### PR TITLE
Fix a bug in PCIDs.Assign

### DIFF
--- a/pkg/sentry/platform/ring0/pagetables/pcids_x86.go
+++ b/pkg/sentry/platform/ring0/pagetables/pcids_x86.go
@@ -64,6 +64,7 @@ func (p *PCIDs) Assign(pt *PageTables) (uint16, bool) {
 	if len(p.avail) > 0 {
 		pcid := p.avail[len(p.avail)-1]
 		p.avail = p.avail[:len(p.avail)-1]
+		p.cache[pt] = pcid
 
 		// We need to flush because while this is in the available
 		// pool, it may have been used previously.


### PR DESCRIPTION
Store the new assigned pcid in p.cache[pt].

Signed-off-by: ShiruRen <renshiru2000@gmail.com>

Thanks for contributing to gVisor!

gVisor development happens on Gerrit rather than GitHub, so we don't accept pull requests here. Gerrit can be found here: https://gvisor-review.googlesource.com

Please see the contributing guidelines for more information: https://github.com/google/gvisor/blob/master/CONTRIBUTING.md
