### PR TITLE
Add tooling for Go-compatible branch.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,7 @@
 package(licenses = ["notice"])  # Apache 2.0
 
 load("@io_bazel_rules_go//go:def.bzl", "go_path")
+load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # The sandbox filegroup is used for sandbox-internal dependencies.
 package_group(
@@ -22,3 +23,9 @@ go_path(
         "//runsc",
     ],
 )
+
+# gazelle is a set of build tools.
+#
+# To update the WORKSPACE from go.mod, use:
+#   bazel run //:gazelle -- update-repos -from_file=go.mod
+gazelle(name = "gazelle")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,6 +6,7 @@ http_archive(
     sha256 = "a82a352bffae6bee4e95f68a8d80a70e87f42c4741e6a448bec11998fcc82329",
     url = "https://github.com/bazelbuild/rules_go/releases/download/0.18.5/rules_go-0.18.5.tar.gz",
 )
+
 http_archive(
     name = "bazel_gazelle",
     sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
@@ -37,86 +38,86 @@ http_archive(
 # External repositories, in sorted order.
 go_repository(
     name = "com_github_cenkalti_backoff",
-    commit = "66e726b43552c0bab0539b28e640b89fd6862115",
     importpath = "github.com/cenkalti/backoff",
+    tag = "v2.0.1-0.20180725110945-66e726b43552",
 )
 
 go_repository(
     name = "com_github_gofrs_flock",
-    commit = "886344bea0798d02ff3fae16a922be5f6b26cee0",
+    commit = "886344bea079",
     importpath = "github.com/gofrs/flock",
 )
 
 go_repository(
     name = "com_github_golang_mock",
-    commit = "600781dde9cca80734169b9e969d9054ccc57937",
     importpath = "github.com/golang/mock",
+    tag = "v1.3.1",
 )
 
 go_repository(
     name = "com_github_google_go-cmp",
-    commit = "3af367b6b30c263d47e8895973edcca9a49cf029",
     importpath = "github.com/google/go-cmp",
+    tag = "v0.2.0",
 )
 
 go_repository(
     name = "com_github_google_subcommands",
-    commit = "ce3d4cfc062faac7115d44e5befec8b5a08c3faa",
+    commit = "ce3d4cfc062f",
     importpath = "github.com/google/subcommands",
 )
 
 go_repository(
     name = "com_github_google_uuid",
-    commit = "dec09d789f3dba190787f8b4454c7d3c936fed9e",
+    commit = "dec09d789f3d",
     importpath = "github.com/google/uuid",
 )
 
 go_repository(
     name = "com_github_kr_pty",
-    commit = "282ce0e5322c82529687d609ee670fac7c7d917c",
     importpath = "github.com/kr/pty",
+    tag = "v1.1.1",
 )
 
 go_repository(
     name = "com_github_opencontainers_runtime-spec",
-    commit = "b2d941ef6a780da2d9982c1fb28d77ad97f54fc7",
+    commit = "b2d941ef6a78",
     importpath = "github.com/opencontainers/runtime-spec",
 )
 
 go_repository(
     name = "com_github_syndtr_gocapability",
-    commit = "d98352740cb2c55f81556b63d4a1ec64c5a319c2",
+    commit = "d98352740cb2",
     importpath = "github.com/syndtr/gocapability",
 )
 
 go_repository(
     name = "com_github_vishvananda_netlink",
-    commit = "adb577d4a45e341da53c4d9196ad4222c9a23e69",
+    commit = "adb577d4a45e",
     importpath = "github.com/vishvananda/netlink",
 )
 
 go_repository(
     name = "com_github_vishvananda_netns",
-    commit = "be1fbeda19366dea804f00efff2dd73a1642fdcc",
+    commit = "be1fbeda1936",
     importpath = "github.com/vishvananda/netns",
 )
 
 go_repository(
     name = "org_golang_x_net",
-    commit = "b3c676e531a6dc479fa1b35ac961c13f5e2b4d2e",
+    commit = "d8887717615a",
     importpath = "golang.org/x/net",
 )
 
 go_repository(
     name = "org_golang_x_sys",
-    commit = "0dd5e194bbf5eb84a39666eb4c98a4d007e4203a",
+    commit = "d0b11bdaac8a",
     importpath = "golang.org/x/sys",
 )
 
 go_repository(
     name = "com_github_google_btree",
-    commit = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306",
     importpath = "github.com/google/btree",
+    tag = "v1.0.0",
 )
 
 # System Call test dependencies.
@@ -148,4 +149,34 @@ http_archive(
         "https://mirror.bazel.build/github.com/google/googletest/archive/61cdca569b1f7e4629f8b949f0a9606c28281a6b.tar.gz",
         "https://github.com/google/googletest/archive/61cdca569b1f7e4629f8b949f0a9606c28281a6b.tar.gz",
     ],
+)
+
+go_repository(
+    name = "com_github_golang_protobuf",
+    importpath = "github.com/golang/protobuf",
+    tag = "v1.3.1",
+)
+
+go_repository(
+    name = "org_golang_x_crypto",
+    commit = "c2843e01d9a2",
+    importpath = "golang.org/x/crypto",
+)
+
+go_repository(
+    name = "org_golang_x_sync",
+    commit = "112230192c58",
+    importpath = "golang.org/x/sync",
+)
+
+go_repository(
+    name = "org_golang_x_text",
+    importpath = "golang.org/x/text",
+    tag = "v0.3.0",
+)
+
+go_repository(
+    name = "org_golang_x_tools",
+    commit = "36563e24a262",
+    importpath = "golang.org/x/tools",
 )

--- a/cloudbuild/go.yaml
+++ b/cloudbuild/go.yaml
@@ -1,0 +1,9 @@
+steps:
+- name: gcr.io/cloud-builders/git
+  args: ['fetch', '--unshallow']
+- name: gcr.io/cloud-builders/bazel
+  args: ['build', ':gopath']
+- name: gcr.io/cloud-builders/git
+  cmd:  ['tools/go_branch.sh']
+- name: gcr.io/cloud-builders/git
+  args: ['push', 'origin', 'go:go']

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,20 @@
+module gvisor.googlesource.com/gvisor
+go 1.12
+
+require (
+	github.com/cenkalti/backoff v2.0.1-0.20180725110945-66e726b43552+incompatible
+	github.com/gofrs/flock v0.6.1-0.20180915234121-886344bea079
+	github.com/golang/mock v1.3.1
+	github.com/golang/protobuf v1.3.1
+	github.com/google/btree v1.0.0
+	github.com/google/go-cmp v0.2.0
+	github.com/google/subcommands v0.0.0-20170224175846-ce3d4cfc062f
+	github.com/google/uuid v0.0.0-20171129191014-dec09d789f3d
+	github.com/kr/pty v1.1.1
+	github.com/opencontainers/runtime-spec v0.1.2-0.20171211145439-b2d941ef6a78
+	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
+	github.com/vishvananda/netlink v1.0.1-0.20190318003149-adb577d4a45e
+	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936
+	golang.org/x/net v0.0.0-20180404174746-b3c676e531a6
+	golang.org/x/sys v0.0.0-20171117071000-0dd5e194bbf5
+)

--- a/kokoro/run_tests.sh
+++ b/kokoro/run_tests.sh
@@ -44,7 +44,7 @@ use_bazel.sh latest
 which bazel
 bazel version
 
-# Load the kvm module
+# Load the kvm module.
 sudo -n -E modprobe kvm
 
 # General Bazel build/test flags.
@@ -67,6 +67,12 @@ BAZEL_BUILD_RBE_FLAGS=(
 ####################
 # Helper Functions #
 ####################
+
+sanity_checks() {
+  cd ${WORKSPACE_DIR}
+  bazel run //:gazelle -- update-repos -from_file=go.mod
+  git diff --exit-code WORKSPACE
+}
 
 build_everything() {
   FLAVOR="${1}"
@@ -235,6 +241,7 @@ main() {
   trap finish EXIT
 
   # Build and run the simple tests.
+  sanity_checks
   build_everything opt
   run_simple_tests
 

--- a/tools/go_branch.sh
+++ b/tools/go_branch.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# Discovery the package name from the go.mod file.
+declare -r gomod="$(pwd)/go.mod"
+declare -r module=$(cat "${gomod}" | grep -E "^module" | cut -d' ' -f2)
+
+# Check that gopath has been built.
+declare -r gopath_dir="$(pwd)/bazel-bin/gopath/src/${module}"
+if ! [ -d "${gopath_dir}" ]; then
+  echo "No gopath directory found; build the :gopath target." >&2
+  exit 1
+fi
+
+# Create a temporary working directory, and ensure that this directory and all
+# subdirectories are cleaned up upon exit.
+declare -r tmp_dir=$(mktemp -d)
+finish() {
+  cd # Leave tmp_dir.
+  rm -rf "${tmp_dir}"
+}
+trap finish EXIT
+
+# Record the current working commit.
+declare -r head=$(git describe --always)
+
+# We expect to have an existing go branch that we will use as the basis for
+# this commit. That branch may be empty, but it must exist.
+declare -r go_branch=$(git show-ref --heads --hash go)
+
+# Clone the current repository to the temporary directory, and check out the
+# current go_branch directory. We move to the new repository for convenience.
+declare -r repo_orig="$(pwd)"
+declare -r repo_new="${tmp_dir}/repository"
+git clone . "${repo_new}"
+cd "${repo_new}"
+git checkout go
+
+# Start working on a merge commit that combines the previous history with the
+# current history. Note that we don't actually want any changes yet.
+git merge --allow-unrelated-histories --no-commit --strategy ours ${head}
+
+# Sync the entire gopath_dir and go.mod.
+rsync --recursive --verbose --delete --exclude .git --exclude README.md -L "${gopath_dir}/" .
+cp "${gomod}" .
+
+# There are a few solitary files that can get left behind due to the way bazel
+# constructs the gopath target. Note that we don't find all Go files here
+# because they may correspond to unused templates, etc.
+cp "${repo_orig}"/runsc/*.go runsc/
+
+# Update the current working set and commit.
+git add . && git commit -m "Merge ${head} (automated)"
+
+# Push the branch back to the original repository.
+git remote add orig "${repo_orig}" && git push orig go:go


### PR DESCRIPTION
The WORKSPACE go_repositories can be generated from a standard go.mod file. Add
the necessary gazelle hooks to do so, and include a test that sanity checks
there are no changes. This go.mod file will be used in a subsequent commit to
generate a go gettable branch of the repository.

This commit also adds a tools/go_branch.sh script, which given an existing go
branch in the repository, will add an additional synthetic change to the branch
bringing it up-to-date with HEAD.

As a final step, a cloudbuild script is included, which can be used to automate
the process for every change pushed to the repository.