### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module gvisor.googlesource.com/gvisor
 go 1.12
 
 require (
-	github.com/cenkalti/backoff v2.2.0
+	github.com/cenkalti/backoff v0.0.0-20190506075156-2146c9339422
 	github.com/gofrs/flock v0.6.1-0.20180915234121-886344bea079
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.1
@@ -16,6 +16,6 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2
 	github.com/vishvananda/netlink v1.0.1-0.20190318003149-adb577d4a45e
 	github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936
-	golang.org/x/net v0.0.0-20180404174746-b3c676e531a6
-	golang.org/x/sys v0.0.0-20171117071000-0dd5e194bbf5
+	golang.org/x/net v0.0.0-20190311183353-d8887717615a
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
 )


### PR DESCRIPTION
Okay -- different standards apply to building locally vs remotely.  Go
refuses to transitively fetch the package via 'go get' because the
backoff package is still not working. Why? For v2+, you must include the
major version number in the package name itself. We can still refer to
the v2.2.0 commit, but must drop the v2.2.0 line from go.mod and just
refer to v0.

Change-Id: I1e17771248ef6789b648780e48d0904f3c81133d