### PR TITLE
BUILD: Use runsc to generate version

### DIFF
--- a/runsc/BUILD
+++ b/runsc/BUILD
@@ -84,7 +84,8 @@ pkg_tar(
 genrule(
     name = "deb-version",
     outs = ["version.txt"],
-    cmd = "cat bazel-out/volatile-status.txt | grep VERSION | sed 's/^[^0-9]*//' >$@",
+    cmd = "$(location :runsc) -version | head -n 1 | cut -d' ' -f3 >$@",
+    tools = [":runsc"],
     stamp = 1,
 )
 


### PR DESCRIPTION
Using bazel-out directly from a genrule appears to be broken in some cases
(perhaps with remote execution?). We can safely use runsc itself to extract the
version.