### PR TITLE
Skip tid allocation which is used by process group

### DIFF
--- a/pkg/sentry/kernel/task_start.go
+++ b/pkg/sentry/kernel/task_start.go
@@ -249,8 +249,20 @@ func (ns *PIDNamespace) allocateTID() (ThreadID, error) {
 		}
 
 		// Is it available?
-		_, ok := ns.tasks[tid]
-		if !ok {
+		tidInUse := func() bool {
+			if _, ok := ns.tasks[tid]; ok {
+				return true
+			}
+			if _, ok := ns.processGroups[ProcessGroupID(tid)]; ok {
+				return true
+			}
+			if _, ok := ns.sessions[SessionID(tid)]; ok {
+				return true
+			}
+			return false
+		} ()
+
+		if !tidInUse {
 			ns.last = tid
 			return tid, nil
 		}


### PR DESCRIPTION
When leader of process group exit, the process
group ID is holding by other processes in the
process group, so the process group ID can not
be reused.
If reusing the process group ID as new process
group ID for new process, this will cause session
create failed, and later runsc crash when access
process group.
The fix skip the tid if it is using by a process
group when allocating a new tid.

We could easily reproduce the runsc crash follow
these steps:

1. build loop program

int main(int argc, char *argv[])
{
	while(1) {
		usleep(1);
	}
	return 0;
}

2. build hello program

int main(int argc, char *argv[])
{
	printf("Current PID is %ld\n", (long) getpid());
	return 0;
}

3. run script in container which run loop inside container
/test/loop &
ps -aef

4. run script on host which run hello inside container,
you can speed up the test with set TasksLimit as lower
value.
for (( i=0; i<65535; i++ ))
do
	docker exec 01a1688d3ffe /test/hello
done

5. when hello process reusing the process group of loop process,
runsc will crash.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x79f0c8]

goroutine 612475 [running]:
gvisor.googlesource.com/gvisor/pkg/sentry/kernel.(*ProcessGroup).decRefWithParent(0x0, 0x0)
        pkg/sentry/kernel/sessions.go:160 +0x78
gvisor.googlesource.com/gvisor/pkg/sentry/kernel.(*Task).exitNotifyLocked(0xc000663500, 0x0)
        pkg/sentry/kernel/task_exit.go:672 +0x2b7
gvisor.googlesource.com/gvisor/pkg/sentry/kernel.(*runExitNotify).execute(0x0, 0xc000663500, 0x0, 0x0)
        pkg/sentry/kernel/task_exit.go:542 +0xc4
gvisor.googlesource.com/gvisor/pkg/sentry/kernel.(*Task).run(0xc000663500, 0xc)
        pkg/sentry/kernel/task_run.go:91 +0x194
created by gvisor.googlesource.com/gvisor/pkg/sentry/kernel.(*Task).Start
        pkg/sentry/kernel/task_start.go:286 +0xfe