### PR TITLE
Add regression test for #128 (fixed in ab6774ce)

### DIFF
--- a/test/syscalls/linux/getdents.cc
+++ b/test/syscalls/linux/getdents.cc
@@ -437,6 +437,19 @@ TYPED_TEST(GetdentsTest, SeekResetsCursor) {
   EXPECT_EQ(expect, this->ReadAndCountAllEntries(&dirents));
 }
 
+// Test that getdents() after SEEK_END succeeds.
+// This is a regression test for #128.
+TYPED_TEST(GetdentsTest, Issue128ProcSeekEnd) {
+  auto fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/proc/self", O_RDONLY | O_DIRECTORY));
+  typename TestFixture::DirentBufferType dirents(256);
+
+  ASSERT_THAT(lseek(fd.get(), 0, SEEK_END), SyscallSucceeds());
+  ASSERT_THAT(RetryEINTR(syscall)(this->SyscallNum(), fd.get(), dirents.Data(),
+                                  dirents.Size()),
+              SyscallSucceeds());
+}
+
 // Some tests using the glibc readdir interface.
 TEST(ReaddirTest, OpenDir) {
   DIR* dev;


### PR DESCRIPTION
Tests run at HEAD (35719d52):
```
$ bazel test $(bazel query 'filter(".*getdents.*", //test/syscalls:all)')
<snip>
//test/syscalls:getdents_test_native                                     PASSED in 0.3s
//test/syscalls:getdents_test_runsc_ptrace                               PASSED in 4.9s
//test/syscalls:getdents_test_runsc_ptrace_overlay                       PASSED in 4.7s
//test/syscalls:getdents_test_runsc_ptrace_shared                        PASSED in 5.2s
//test/syscalls:getdents_test_runsc_kvm                                  FAILED in 4.0s
```

Tests run at ab6774ce~1 (6f933a93):
```
$ bazel test $(bazel query 'filter(".*getdents.*", //test/syscalls:all)')
//test/syscalls:getdents_test_native                                     PASSED in 0.2s
//test/syscalls:getdents_test_runsc_kvm                                  FAILED in 4.2s
  /usr/local/google/home/brb/.cache/bazel/_bazel_brb/967240a6aae7d353a221d73f4375e038/execroot/__main__/bazel-out/k8-fastbuild/testlogs/test/syscalls/getdents_test_runsc_kvm/test.log
//test/syscalls:getdents_test_runsc_ptrace                               FAILED in 5.3s
  /usr/local/google/home/brb/.cache/bazel/_bazel_brb/967240a6aae7d353a221d73f4375e038/execroot/__main__/bazel-out/k8-fastbuild/testlogs/test/syscalls/getdents_test_runsc_ptrace/test.log
//test/syscalls:getdents_test_runsc_ptrace_overlay                       FAILED in 4.9s
  /usr/local/google/home/brb/.cache/bazel/_bazel_brb/967240a6aae7d353a221d73f4375e038/execroot/__main__/bazel-out/k8-fastbuild/testlogs/test/syscalls/getdents_test_runsc_ptrace_overlay/test.log
//test/syscalls:getdents_test_runsc_ptrace_shared                        FAILED in 5.2s
  /usr/local/google/home/brb/.cache/bazel/_bazel_brb/967240a6aae7d353a221d73f4375e038/execroot/__main__/bazel-out/k8-fastbuild/testlogs/test/syscalls/getdents_test_runsc_ptrace_shared/test.log
```

(I think all runsc_kvm tests are broken on my machine -- I'll rerun them
if you can point me at the documentation to set it up)