### PR TITLE
Fix deadloop in proc subtask list

### DIFF
--- a/pkg/sentry/fs/proc/task.go
+++ b/pkg/sentry/fs/proc/task.go
@@ -184,6 +184,7 @@ func (f *subtasksFile) Readdir(ctx context.Context, file *fs.File, ser fs.Dentry
 		taskInts = append(taskInts, int(tid))
 	}
 
+	sort.Sort(sort.IntSlice(taskInts))
 	// Find the task to start at.
 	idx := sort.SearchInts(taskInts, int(offset))
 	if idx == len(taskInts) {


### PR DESCRIPTION
Readdir of /proc/x/task/ will get direntry entries
from tasks of specified taskgroup. Now the tasks
slice is unsorted, use sort.SearchInts search entry
from the slice may cause infinity loops.
The fix is sort the slice before search.
This issue could be easily reproduced via following
steps, revise Readdir in pkg/sentry/fs/proc/task.go,
force set taskInts into test slice
[]int{1, 11, 7, 5, 10, 6, 8, 3, 9, 2, 4},
then run docker image and run ls /proc/1/task, the
command will cause infinity loops.