### PR TITLE
sentry/kernel: add syslog message

### DIFF
--- a/pkg/sentry/kernel/syslog.go
+++ b/pkg/sentry/kernel/syslog.go
@@ -67,6 +67,7 @@ func (s *syslog) Log() []byte {
 		"Creating process schedule...",
 		"Generating random numbers by fair dice roll...",
 		"Rewriting operating system in Javascript...",
+		"Reticulating splines...",
 		"Consulting tar man page...",
 		"Forking spaghetti code...",
 		"Checking naughty and nice process list...",


### PR DESCRIPTION
It feels like "reticulating splines" is missing from the list of meaningless
syslog messages.