### PR TITLE
Optimize to share upper half page table

### DIFF
--- a/pkg/sentry/platform/kvm/kvm.go
+++ b/pkg/sentry/platform/kvm/kvm.go
@@ -117,15 +117,7 @@ func (*KVM) MaxUserAddress() usermem.Addr {
 func (k *KVM) NewAddressSpace(_ interface{}) (platform.AddressSpace, <-chan struct{}, error) {
 	// Allocate page tables and install system mappings.
 	pageTables := pagetables.New(newAllocator())
-	applyPhysicalRegions(func(pr physicalRegion) bool {
-		// Map the kernel in the upper half.
-		pageTables.Map(
-			usermem.Addr(ring0.KernelStartAddress|pr.virtual),
-			pr.length,
-			pagetables.MapOpts{AccessType: usermem.AnyAccess},
-			pr.physical)
-		return true // Keep iterating.
-	})
+	pageTables.MirrorKernelPageTable()
 
 	// Return the new address space.
 	return &addressSpace{

--- a/pkg/sentry/platform/kvm/machine.go
+++ b/pkg/sentry/platform/kvm/machine.go
@@ -194,6 +194,8 @@ func newMachine(vm int) (*machine, error) {
 	}
 	log.Debugf("The maximum number of vCPUs is %d.", m.maxVCPUs)
 
+	m.kernel.PageTables.SetKernelPageTable()
+
 	// Apply the physical mappings. Note that these mappings may point to
 	// guest physical addresses that are not actually available. These
 	// physical pages are mapped on demand, see kernel_unsafe.go.

--- a/pkg/sentry/platform/ring0/pagetables/BUILD
+++ b/pkg/sentry/platform/ring0/pagetables/BUILD
@@ -89,7 +89,7 @@ go_library(
         "//pkg/sentry/platform/kvm:__subpackages__",
         "//pkg/sentry/platform/ring0:__subpackages__",
     ],
-    deps = ["//pkg/sentry/usermem"],
+    deps = ["//pkg/sentry/usermem","//pkg/sentry/platform/safecopy"],
 )
 
 go_test(

--- a/pkg/sentry/platform/ring0/pagetables/walker_amd64.go
+++ b/pkg/sentry/platform/ring0/pagetables/walker_amd64.go
@@ -63,7 +63,7 @@ type Walker struct {
 // non-canonical ranges. If they do, a panic will result.
 //
 //go:nosplit
-func (w *Walker) iterateRange(start, end uintptr) {
+func (w *Walker) iterateRange(pageTables *PageTables, start, end uintptr) {
 	if start%pteSize != 0 {
 		panic("unaligned start")
 	}
@@ -83,7 +83,9 @@ func (w *Walker) iterateRange(start, end uintptr) {
 				panic("alloc spans non-canonical range")
 			}
 			w.iterateRangeCanonical(start, lowerTop)
-			w.iterateRangeCanonical(upperBottom, end)
+			if pageTables == kPageTable {
+				w.iterateRangeCanonical(upperBottom, end)
+			}
 		}
 	} else if start < upperBottom {
 		if end <= upperBottom {
@@ -94,7 +96,9 @@ func (w *Walker) iterateRange(start, end uintptr) {
 			if w.visitor.requiresAlloc() {
 				panic("alloc spans non-canonical range")
 			}
-			w.iterateRangeCanonical(upperBottom, end)
+			if pageTables == kPageTable {
+				w.iterateRangeCanonical(upperBottom, end)
+			}
 		}
 	} else {
 		w.iterateRangeCanonical(start, end)


### PR DESCRIPTION
Sentry split memory address space into bottom half
and upper half, kernel address space will be mapped
into both ranges.
And sentry will setup kernel address space map at
upper half in every user task page table.
Optimize is done to share the kernel upper half
address space page table between sentry kernel and
user task, this will reduce the user task page table
memory consume and speed up user task initialize.