### PR TITLE
Fix gracefully stop container doesn't work

### DIFF
--- a/pkg/sentry/kernel/task_start.go
+++ b/pkg/sentry/kernel/task_start.go
@@ -238,6 +238,9 @@ func (ts *TaskSet) assignTIDsLocked(t *Task) error {
 		}
 		allocatedTIDs = append(allocatedTIDs, allocatedTID{ns, tid})
 	}
+	if t.tg.pidns.tgids[t.tg] == 1 {
+		t.tg.reaper = true
+	}
 	return nil
 }
 

--- a/pkg/sentry/kernel/thread_group.go
+++ b/pkg/sentry/kernel/thread_group.go
@@ -238,6 +238,10 @@ type ThreadGroup struct {
 	// execed is protected by the TaskSet mutex.
 	execed bool
 
+	// reaper indicates this is the first ThreadGroup of the PIDNamespace
+	// (with PID==1). This field is immutable.
+	reaper bool
+
 	// oldRSeqCritical is the thread group's old rseq critical region.
 	oldRSeqCritical atomic.Value `state:".(*OldRSeqCriticalRegion)"`
 

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -373,7 +373,7 @@ func TestLifecycle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error waiting on container: %v", err)
 			}
-			if got, want := ws.Signal(), syscall.SIGTERM; got != want {
+			if got, want := ws.Signal(), syscall.SIGKILL; got != want {
 				t.Fatalf("got signal %v, want %v", got, want)
 			}
 			wg.Done()
@@ -383,8 +383,8 @@ func TestLifecycle(t *testing.T) {
 		// container before we signal.
 		<-ch
 		time.Sleep(100 * time.Millisecond)
-		// Send the container a SIGTERM which will cause it to stop.
-		if err := c.SignalContainer(syscall.SIGTERM, false); err != nil {
+		// Send the container a SIGKILL which will cause it to stop.
+		if err := c.SignalContainer(syscall.SIGKILL, false); err != nil {
 			t.Fatalf("error sending signal %v to container: %v", syscall.SIGTERM, err)
 		}
 		// Wait for it to die.


### PR DESCRIPTION
When stop a container, a SIGTERM will be send to
container at first, which allow application to
gracefully stop service, then SIGKILL signal will
be send to container to stop all the appliation
processes.
Currently runsc will forward SIGTERM to every
process inside container, this will cause the
initial process quit, and then the whole container
quit, so gracefully stop doesn't works.
To fix the issue, here follow the linux way,
block unblockable signal for reaper process, if
the signal action is SIG_DEF.