### PR TITLE
hostinet: fix return type of GetSockName and GetPeerName

### DIFF
--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -41,6 +41,10 @@ const (
 	// sizeofSockaddr is the size in bytes of the largest sockaddr type
 	// supported by this package.
 	sizeofSockaddr = syscall.SizeofSockaddrInet6 // sizeof(sockaddr_in6) > sizeof(sockaddr_in)
+
+	sockAddrInetSize = uint32(syscall.SizeofSockaddrInet4)
+
+	sockAddrInet6Size = uint32(syscall.SizeofSockaddrInet6)
 )
 
 // socketOperations implements fs.FileOperations and socket.Socket for a socket


### PR DESCRIPTION
Commit 94a6bfab5d0a ("Implement /proc/net/tcp.") implements a way to
lookup tcp stream information. But hostinet fails with the wrong type
assertion (linux.SockAddrInet) for the return of GetSockName and
GetPeerName.

This patch fixes it by returning the correct address format.

Fixes #639

Signed-off-by: Jianfeng Tan <henry.tjf@antfin.com>