### PR TITLE
fix wrong SizeOfTCPInfo

### DIFF
--- a/pkg/abi/linux/socket.go
+++ b/pkg/abi/linux/socket.go
@@ -352,7 +352,7 @@ type TCPInfo struct {
 }
 
 // SizeOfTCPInfo is the binary size of a TCPInfo struct.
-const SizeOfTCPInfo = 104
+const SizeOfTCPInfo = 192
 
 // Control message types, from linux/socket.h.
 const (


### PR DESCRIPTION
Below command under hostinet network will lead to panic:

  $ cat /proc/net/tcp

It's caused by the wrong SizeOfTCPInfo.

  #0 runtime.panicindex()
  #1 encoding/binary.littleEndian.Uint64
  #2 encoding/binary.(*littleEndian).Uint64
  #3 gvisor.dev/gvisor/pkg/binary.unmarshal
  #4 gvisor.dev/gvisor/pkg/binary.unmarshal
  #5 gvisor.dev/gvisor/pkg/binary.Unmarshal
  #6 gvisor.dev/gvisor/pkg/sentry/socket/hostinet.(*socketOperations).State
  #7 gvisor.dev/gvisor/pkg/sentry/fs/proc.(*netTCP).ReadSeqFileData

Correct SizeOfTCPInfo from 104 to 192 to fix it.

Signed-off-by: Jianfeng Tan <henry.tjf@antfin.com>