### PR TITLE
Allow aggressive cache filling and reclaimation in read operations

### DIFF
--- a/pkg/sentry/fs/fsutil/BUILD
+++ b/pkg/sentry/fs/fsutil/BUILD
@@ -94,6 +94,7 @@ go_library(
         "//pkg/state",
         "//pkg/syserror",
         "//pkg/waiter",
+        "//third_party/gvsync",
     ],
 )
 

--- a/pkg/sentry/fs/fsutil/BUILD
+++ b/pkg/sentry/fs/fsutil/BUILD
@@ -73,11 +73,13 @@ go_library(
         "host_mappable.go",
         "inode.go",
         "inode_cached.go",
+        "cache_reclaim.go",
     ],
     importpath = "gvisor.dev/gvisor/pkg/sentry/fs/fsutil",
     visibility = ["//pkg/sentry:internal"],
     deps = [
         "//pkg/abi/linux",
+        "//pkg/ilist",
         "//pkg/log",
         "//pkg/sentry/arch",
         "//pkg/sentry/context",

--- a/pkg/sentry/fs/fsutil/cache_reclaim.go
+++ b/pkg/sentry/fs/fsutil/cache_reclaim.go
@@ -1,0 +1,332 @@
+package fsutil
+
+import (
+        "sync"
+        "sync/atomic"
+        "time"
+        "runtime"
+
+        "gvisor.dev/gvisor/pkg/ilist"
+        "gvisor.dev/gvisor/pkg/log"
+        "gvisor.dev/gvisor/pkg/sentry/context"
+        "gvisor.dev/gvisor/pkg/sentry/memmap"
+        "gvisor.dev/gvisor/pkg/sentry/pgalloc"
+        "gvisor.dev/gvisor/pkg/sentry/platform"
+        "gvisor.dev/gvisor/pkg/sentry/usermem"
+)
+
+const (
+        LRU_ACTIVE_LIST = 0
+        LRU_INACTIVE_LIST = 1
+        LRU_LIST_NUM = 2
+)
+
+type LruEntry struct {
+	ilist.Entry
+	fr platform.FileRange
+	mr memmap.MappableRange
+	c *CachingInodeOperations
+	accessed bool
+	lru int
+}
+
+type LruManager struct {
+	destroyed bool
+
+	// LRULists store the current file ranges consumed by all the files
+        // with the minimum granularity of 4K
+        // LRUMap records the mappings from the start of file range to its entry
+        //
+        // LRULists and LRUMap are protected by LRUMapMu
+        lists [LRU_LIST_NUM]ilist.List
+	length [LRU_LIST_NUM]int
+        mappings map[uint64]*LruEntry
+        lruMu sync.RWMutex
+}
+
+func NewLruEntry(fr platform.FileRange, mr memmap.MappableRange, c *CachingInodeOperations) *LruEntry {
+        return &LruEntry{fr: fr, mr: mr, c: c, accessed: true, lru: LRU_ACTIVE_LIST}
+}
+
+func update(e *LruEntry, fr platform.FileRange, mr memmap.MappableRange, c *CachingInodeOperations) {
+	e.fr = fr
+	e.mr = mr
+	e.c = c
+	e.accessed = true
+}
+
+var mgrMu sync.Mutex
+var mgrMap map[*pgalloc.MemoryFile]*LruManager = make(map[*pgalloc.MemoryFile]*LruManager)
+
+func NewLruManager(interval time.Duration, f *pgalloc.MemoryFile) *LruManager {
+	// Created only once for each MemoryFile
+	if manager, ok := mgrMap[f]; ok {
+		return manager
+	}
+
+	mgrMu.Lock()
+	lru := &LruManager {
+		destroyed: false,
+		mappings: make(map[uint64]*LruEntry),
+	}
+	for i := 0; i < LRU_LIST_NUM; i++ {
+		lru.lists[i].Reset()
+		lru.length[i] = 0
+	}
+
+	go lru.run(interval)
+	mgrMap[f] = lru
+	mgrMu.Unlock()
+	return lru
+}
+
+func (m *LruManager) shrinkActiveListLocked(maxHarvest int) (*ilist.List, int) {
+	var out ilist.List
+	reclaimed := 0
+	for e := m.lists[LRU_ACTIVE_LIST].Front(); e != nil && m.length[LRU_ACTIVE_LIST] > m.length[LRU_INACTIVE_LIST] && reclaimed < maxHarvest; {
+		next := e.Next()
+		if !e.(*LruEntry).accessed {
+			// Second chance
+			m.lists[LRU_ACTIVE_LIST].Remove(e)
+			m.length[LRU_ACTIVE_LIST]--
+			out.PushBack(e)
+			reclaimed++
+		} else {
+			e.(*LruEntry).accessed = false
+		}
+		e = next
+	}
+
+	return &out, reclaimed
+}
+
+func (m *LruManager) shrinkInactiveListLocked(maxHarvest int) (*ilist.List, int) {
+	var out ilist.List
+	reclaimed := 0
+	for e := m.lists[LRU_INACTIVE_LIST].Front(); e != nil && reclaimed < maxHarvest; {
+		next := e.Next()
+		if e.(*LruEntry).accessed {
+			e.(*LruEntry).accessed = false
+			m.lists[LRU_INACTIVE_LIST].Remove(e)
+			m.length[LRU_INACTIVE_LIST]--
+			// Repush in the front as this might be an occasional access
+			//m.lists[LRU_ACTIVE_LIST].PushFront(e)
+			m.lists[LRU_ACTIVE_LIST].PushBack(e)
+			m.length[LRU_ACTIVE_LIST]++
+		} else {
+			m.lists[LRU_INACTIVE_LIST].Remove(e)
+			m.length[LRU_INACTIVE_LIST]--
+			out.PushBack(e)
+		}
+		reclaimed++
+		e = next
+	}
+
+	return &out, reclaimed
+}
+
+func (m *LruManager) doReclaim(maxHarvest int) {
+	m.lruMu.Lock()
+	active, reclaimedActive := m.shrinkActiveListLocked(maxHarvest)
+	inactive, _ := m.shrinkInactiveListLocked(maxHarvest)
+
+	// reinsert items in active  to global inactive lru list
+	m.lists[LRU_INACTIVE_LIST].PushBackList(active)
+	m.length[LRU_INACTIVE_LIST] += reclaimedActive
+	m.lruMu.Unlock()
+
+	// free the harvested inactive elements
+	var backup ilist.List
+	for e := inactive.Front(); e != nil; e = e.Next() {
+		le := e.(*LruEntry)
+		c := le.c
+		c.mapsMu.Lock()
+		c.dataMu.Lock()
+		// writeback data if this range is dirty
+		err := SyncDirty(context.Background(), le.mr, &c.cache, &c.dirty, uint64(c.attr.Size), c.mfp.MemoryFile(), c.backingFile.WriteFromBlocksAt)
+		if err == nil {
+			c.cache.Drop(le.mr, c.mfp.MemoryFile())
+		} else {
+			backup.PushBack(e)
+		}
+		c.dataMu.Unlock()
+		c.mapsMu.Unlock()
+	}
+
+	if backup.Empty() {
+		return
+	}
+	m.lruMu.Lock()
+	for e := backup.Front(); e != nil; e = e.Next() {
+		m.lists[LRU_INACTIVE_LIST].PushFront(e)
+	}
+	m.lruMu.Unlock()
+}
+
+func (m *LruManager) run(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	// TODO. aribitrarily chosen
+	maxHarvest := 64
+	for !m.destroyed {
+		select {
+		case <- ticker.C:
+			m.doReclaim(maxHarvest)
+		default:
+			runtime.Gosched()
+		}
+	}
+}
+
+func (m *LruManager) Access(fr platform.FileRange) {
+	m.lruMu.RLock()
+	if entry, ok := m.mappings[fr.Start &^ (usermem.PageSize - 1)]; ok {
+		// TODO. should we use atomic instead?
+		entry.accessed = true
+	}
+	m.lruMu.RUnlock()
+}
+
+func (m *LruManager) Insert(e *LruEntry) {
+	lru := e.lru
+	fr := e.fr
+	mr := e.mr
+	c := e.c
+
+	// fast path for inclusive ranges
+	m.lruMu.RLock()
+	if entry, ok := m.mappings[fr.Start &^ (usermem.PageSize - 1)]; ok {
+		update(entry, fr, e.mr, c)
+		m.lruMu.RUnlock()
+		return
+	}
+	m.lruMu.RUnlock()
+
+	m.lruMu.Lock()
+	if entry, ok := m.mappings[fr.Start &^ (usermem.PageSize - 1)]; ok {
+		update(entry, fr, mr, c)
+	} else {
+		m.lists[lru].PushBack(e)
+		m.mappings[fr.Start &^ (usermem.PageSize - 1)] = e
+		m.length[lru]++
+	}
+	m.lruMu.Unlock()
+}
+
+func (m *LruManager) Remove(e *LruEntry) {
+	lru := e.lru
+	m.lruMu.Lock()
+	m.lists[lru].Remove(e)
+	m.length[lru]--
+	m.lruMu.Unlock()
+}
+
+func (m *LruManager) Destroyed() bool {
+	return m.destroyed
+}
+
+func (m *LruManager) Destroy() {
+	m.lruMu.Lock()
+	m.destroyed = true
+	for i := 0; i < LRU_LIST_NUM; i++ {
+		m.lists[i].Reset()
+		m.length[i] = 0
+	}
+	m.mappings = make(map[uint64]*LruEntry)
+	m.lruMu.Unlock()
+}
+
+// PeriodicFlusher periodically flushes the dirty file ranges of each inode into memfd
+// in the host. But we only do call SyncDirty here, not including fsync
+type PeriodicFlusher struct {
+	inodeList ilist.List
+	inodeMu sync.RWMutex
+
+	forceWriteback bool
+	runnable bool
+}
+
+var pdfInited = int32(0)
+var globalPDF *PeriodicFlusher = nil
+
+func NewPeriodicFlusher(interval time.Duration) *PeriodicFlusher {
+	if pdfInited != 0 || !atomic.CompareAndSwapInt32(&pdfInited, 0, 1) {
+		for globalPDF == nil {
+			runtime.Gosched()
+		}
+		return globalPDF;
+	}
+
+	globalPDF = &PeriodicFlusher{
+		forceWriteback: false,
+		runnable: false,
+	}
+	globalPDF.inodeList.Reset()
+	globalPDF.Start(interval)
+
+	return globalPDF
+}
+
+func (pdf *PeriodicFlusher) Start(interval time.Duration) {
+	pdf.inodeList.Reset()
+	pdf.runnable = true
+	go pdf.run(interval)
+}
+
+func (pdf *PeriodicFlusher) Stop() {
+	pdf.runnable = false
+}
+
+func (pdf *PeriodicFlusher) Kick() {
+	pdf.forceWriteback = true
+}
+
+func (pdf *PeriodicFlusher) Attach(c *CachingInodeOperations) {
+	pdf.inodeMu.Lock()
+	pdf.inodeList.PushBack(c)
+	pdf.inodeMu.Unlock()
+}
+
+func (pdf *PeriodicFlusher) Detach(c *CachingInodeOperations) {
+	pdf.inodeMu.Lock()
+	pdf.inodeList.Remove(c)
+	pdf.inodeMu.Unlock()
+}
+
+func (pdf *PeriodicFlusher) flushDirty() {
+	pdf.inodeMu.RLock()
+	for e := pdf.inodeList.Front(); e != nil; e = e.Next() {
+		c := e.(*CachingInodeOperations)
+		if !c.dirtyAttr.Size {
+			continue
+		}
+		// CachingInodeOperations.WriteOut does not use inode param
+		if err := c.WriteOut(context.Background(), nil); err != nil {
+			log.Debugf("Writeback cache failed in pdf = %v", pdf)
+		}
+	}
+	pdf.inodeMu.RUnlock()
+}
+
+func (pdf *PeriodicFlusher) run(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	for pdf.runnable {
+		if pdf.inodeList.Empty() {
+			runtime.Gosched()
+			continue
+		}
+
+		if pdf.forceWriteback {
+			pdf.forceWriteback = false
+			pdf.flushDirty()
+			continue
+		}
+
+		select {
+		case <- ticker.C:
+			pdf.flushDirty()
+		default:
+			runtime.Gosched()
+			continue
+		}
+	}
+}

--- a/pkg/sentry/fs/fsutil/inode_cached.go
+++ b/pkg/sentry/fs/fsutil/inode_cached.go
@@ -32,6 +32,9 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/usermem"
 )
 
+var AggressiveCache bool
+var CacheCapacity uint64
+
 // Lock order (compare the lock order model in mm/mm.go):
 //
 // CachingInodeOperations.attrMu ("fs locks")

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//pkg/sentry/control",
         "//pkg/sentry/fs",
         "//pkg/sentry/fs/dev",
+        "//pkg/sentry/fs/fsutil",
         "//pkg/sentry/fs/gofer",
         "//pkg/sentry/fs/host",
         "//pkg/sentry/fs/proc",

--- a/runsc/boot/config.go
+++ b/runsc/boot/config.go
@@ -201,6 +201,12 @@ type Config struct {
 
 	// AlsoLogToStderr allows to send log messages to stderr.
 	AlsoLogToStderr bool
+
+	// AggressiveCache enables page cache filling during read/write
+	AggressiveCache bool
+
+	// CacheCapacity controls the maximum size(KB) of used page cache
+	CacheCapacity uint64
 }
 
 // ToFlags returns a slice of flags that correspond to the given Config.
@@ -227,6 +233,8 @@ func (c *Config) ToFlags() []string {
 		"--num-network-channels=" + strconv.Itoa(c.NumNetworkChannels),
 		"--rootless=" + strconv.FormatBool(c.Rootless),
 		"--alsologtostderr=" + strconv.FormatBool(c.AlsoLogToStderr),
+		"--aggressive-cache=" + strconv.FormatBool(c.AggressiveCache),
+		"--cache-capacity=" + strconv.FormatUint(c.CacheCapacity, 10),
 	}
 	if c.TestOnlyAllowRunAsCurrentUserWithoutChroot {
 		// Only include if set since it is never to be used by users.

--- a/runsc/boot/fs.go
+++ b/runsc/boot/fs.go
@@ -25,6 +25,7 @@ import (
 
 	// Include filesystem types that OCI spec might mount.
 	_ "gvisor.dev/gvisor/pkg/sentry/fs/dev"
+	"gvisor.dev/gvisor/pkg/sentry/fs/fsutil"
 	"gvisor.dev/gvisor/pkg/sentry/fs/gofer"
 	_ "gvisor.dev/gvisor/pkg/sentry/fs/host"
 	_ "gvisor.dev/gvisor/pkg/sentry/fs/proc"
@@ -288,6 +289,11 @@ func adjustDirentCache(k *kernel.Kernel) error {
 		}
 	}
 	return nil
+}
+
+func configPageCache(args Args) {
+	fsutil.AggressiveCache = args.AggressiveCache
+	fsutil.CacheCapacity = args.CacheCapacity << 10
 }
 
 type fdDispenser struct {

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -177,6 +177,10 @@ type Args struct {
 	TotalMem uint64
 	// UserLogFD is the file descriptor to write user logs to.
 	UserLogFD int
+	// AggressiveCache is set to true if page cache filling in read/write is enabled
+	AggressiveCache bool
+	// CacheCapacity is the maximum allowed volume(KB) of used page cache
+	CacheCapacity uint64
 }
 
 // New initializes a new kernel loader configured by spec.
@@ -290,6 +294,7 @@ func New(args Args) (*Loader, error) {
 	if err := adjustDirentCache(k); err != nil {
 		return nil, err
 	}
+	configPageCache(args)
 
 	// Turn on packet logging if enabled.
 	if args.Conf.LogPackets {

--- a/runsc/main.go
+++ b/runsc/main.go
@@ -74,6 +74,10 @@ var (
 	numNetworkChannels = flag.Int("num-network-channels", 1, "number of underlying channels(FDs) to use for network link endpoints.")
 	rootless           = flag.Bool("rootless", false, "it allows the sandbox to be started with a user that is not root. Sandbox and Gofer processes may run with same privileges as current user.")
 
+	// Flags that control the page cache behavior in fs
+	aggressiveCache    = flag.Bool("aggressive-cache", false, "allows caching of file contents in normal IO operations apart from mmap")
+	cacheCapacity      = flag.Uint64("cache-capacity", 8192, "maximum allowed size(KB) of page cache")
+
 	// Test flags, not to be used outside tests, ever.
 	testOnlyAllowRunAsCurrentUserWithoutChroot = flag.Bool("TESTONLY-unsafe-nonroot", false, "TEST ONLY; do not ever use! This skips many security measures that isolate the host from the sandbox.")
 )
@@ -191,6 +195,8 @@ func main() {
 		NumNetworkChannels: *numNetworkChannels,
 		Rootless:           *rootless,
 		AlsoLogToStderr:    *alsoLogToStderr,
+		AggressiveCache:    *aggressiveCache,
+		CacheCapacity:      *cacheCapacity,
 
 		TestOnlyAllowRunAsCurrentUserWithoutChroot: *testOnlyAllowRunAsCurrentUserWithoutChroot,
 	}

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -415,6 +415,10 @@ func (s *Sandbox) createSandboxProcess(conf *boot.Config, args *Args, startSyncF
 		nextFD++
 	}
 
+	// Inherit page cache configuration from runsc
+	cmd.Args = append(cmd.Args, "--aggressive-cache="+strconv.FormatBool(conf.AggressiveCache))
+	cmd.Args = append(cmd.Args, "--cache-capacity="+strconv.FormatUint(conf.CacheCapacity, 10))
+
 	// The current process' stdio must be passed to the application via the
 	// --stdio-fds flag. The stdio of the sandbox process itself must not
 	// be connected to the same FDs, otherwise we risk leaking sandbox


### PR DESCRIPTION
## Background

The read operation in cached inode does not actively fill the page cache unless we explicitly choose not to use host page cache. However, there are a few issues about current implementation of [ReadToBlocks][1]
1. When `fillCache` is set to true, the read operations becomes exclusive as well, destroying the benefit of rwlock. Therefore we might consider using `DowngradableRWMutex` to downgrade the lock when cache is found.
2. No active reclaimation. This might be ok if application has a short lifecycle, but not memory friendly when application needs to run much longer time.
3. Does not allow user to choose whether to enable sentry cache and limit the size of page cache.

## About the patch set
The patch set aims at providing active reclaimation and allowing user to limit page cache capacity(per-MemoryFile).

### 1. Reclaimation at FileRange level, instead of block level
There was a previous patch that attempted to reclaim blocks from MemoryFile. This was doable, but it makes things more complicated because each block might contain one or more FileRanges that belong to different inode. But the book-keeping data is inside each inode, which requires some kinds of complicated reverse mapping.

Therefore, this patch set choose to reclaim FileRange rather than blocks, for the following reasons
* it makes dirty page flushing in each inode more convenient
* less synchronization of metadata between different inodes and memory file
* finer granularity (compared with 16M in blocks)

To make reclamation more effective, we should track all cache usage in lru lists to avoid reclaim hot caches as much as possible.

One main problem is that **length of FileRange is not fixed**. So we define a minimal length `usermem.PageSize` and a max length `usermem.HugePageSize`. Any length that falls within `[usermem.PageSize, usermem.HugePageSize]` (page-aligned of course, as cache.Fill requires it) can be inserted into the lru list. Larger length must be splited to chunks of size `HugePageSize`. **Note that the split only happens at lru level**, the cache FileRangeSet is not affected.

### 2. Relcaimation and flush interval
The interval of cache reclaimation and dirty page flushing are both 30 seconds by default, which is arbitrarily chosen. Each scan in lru list will reclaim at most 64 items (128 if memory is above threshold).

### 3. Reclaimation strategy
Ideally, we should take strict lru policy and leverages per-cpu storage to reduce contention, like linux does. Unfortunately, go does not have P-local storage. As an alternative, we adjust the policy to a clock-like algorithm.

When a cache entry is accessed, only item is affected rather than the list itself. The list will be modified only when we started reclaimation. By doing so we can greatly reduce the contention of lru lists.

### 4. ReadAhead
Similar to linux readaread window, but simplified. But async readahead does not really spawn a goroutine to read caches. The reason is that we cannot control the lifecycle of a new goroutine, when the goroutine is executing, a new request might be processed, which makes things complicated. From my own experience, putting things into goroutine did not improve much performance (if you find it does, please let me know).

### 5. User-controllable
We allow users to control whether to enable aggressive cache with `--cache-aggressive` in runtime flag, and `--cache-capacity=` to specify the capacity of cache.

Why do we need a dedicated `AggressiveCache` flag? Because we don't want to affect mmap-ed file which also uses cache. Instead, we only decide whether to fill cache in read operations.

To avoid the synchronization of cache in multiple sentry instance, we currently only allow aggressive cache on read operations. All write operations, unless with mmap, go directly into host.

## Very rough evaluation

To simply indicate that the patch does provide performance improvement. We performed following evaluation.

**1. Cycle of each read syscall**

comparison | wo/ cache |  w/ cache | reduced
-|-|-|-
Cycle of each read syscall | 26984.21 | 8943.84 | 66.8%

**2. nginx**
`wrk -t8 -c1024 -d120s --script=./wrk.lua --latency http://localhost:8087` (port remapping of container)

nginx througput | wo/ cache |  w/ cache  | speedup
-|-|-|-
throughput(MB/s) | 1.38 | 2.95 | 113.7%
requests/second | 1703.79 | 3642.26  reqs/s | 113.7%

**3. redis**
`./src/redis-benchmark -q`
Honestly, I wasn't expecting at all that there was improvement for redis because it is 'in-memory', but the results shows that there is indeed some speedup for most operations. I guess redis might have used something like tmpfs? (NOT confirmed at all)

operations    | wo/ cache (reqs/s) | w/ cache (reqs/s) | speedup
-|-|-|-
PING_INLINE | 10642.83 | 11900.51 | 11.8%
PING_BULK | 11599.58 | 12459.51 | 7.4%
SET | 10397.17 | 11849.75 | 13.9%
GET | 10096.93 | 12263.92 | 21.4%
INCR | 11164.45 | 11831.52 | 5.9%
LPUSH | 10371.29 | 12661.43 | 22.0%
RPUSH | 10835.41 | 11844.13 | 9.3%
LPOP | 9883.38 | 12729.12 | 28.7%
RPOP | 10143.02 | 11784.12 | 16.1%
SADD | 11210.76 | 12227.93 | 9.0%
HSET | 9422.41 | 11596.89 | 23.0%
SPOP | 10857.76 | 11759.17 | 8.3%
LPUSH (needed to benchmark LRANGE) | 11527.38 | 12292.56 | 6.6%
LRANGE_100 (first 100 elements) | 8153.28 | 11021.71 | 35.1%
LRANGE_300 (first 300 elements) | 190.12 | 191.07 | 0.4%
LRANGE_500 (first 450 elements) | 138.09 | 138.18 | 0.06%
LRANGE_600 (first 600 elements) | 107.43 | 108.11 | 0.6%
MSET (10 keys) | 8991.19 | 11496.90 | 27.8%
```

## Summary
This patch set is just a first-step implementation, requesting for reviews and comments. The current architecture of gvisor makes things not so intuitive, therefore it is not quite easy to make codes beautiful.