### PR TITLE
hostinet: fix parsing route netlink message

### DIFF
--- a/pkg/sentry/socket/hostinet/stack.go
+++ b/pkg/sentry/socket/hostinet/stack.go
@@ -203,8 +203,14 @@ func ExtractHostRoutes(routeMsgs []syscall.NetlinkMessage) ([]inet.Route, error)
 				inetRoute.DstAddr = attr.Value
 			case syscall.RTA_SRC:
 				inetRoute.SrcAddr = attr.Value
-			case syscall.RTA_OIF:
+			case syscall.RTA_GATEWAY:
 				inetRoute.GatewayAddr = attr.Value
+			case syscall.RTA_OIF:
+				expected := int(binary.Size(inetRoute.OutputInterface))
+				if len(attr.Value) != expected {
+					return nil, fmt.Errorf("invalid RTA_OIF length in RTM_NEWROUTE message (got %d bytes, expected %d bytes)", len(attr.Value), expected)
+				}
+				binary.Unmarshal(attr.Value, usermem.ByteOrder, &inetRoute.OutputInterface)
 			}
 		}
 


### PR DESCRIPTION
We wrongly parses output interface as gateway address.
The fix is straightforward.

Fixes #638

Signed-off-by: Jianfeng Tan <henry.tjf@antfin.com>
Change-Id: Ia4bab31f3c238b0278ea57ab22590fad00eaf061