### PR TITLE
Container mounting of host Unix Domain Socket support

### DIFF
--- a/pkg/fd/BUILD
+++ b/pkg/fd/BUILD
@@ -7,6 +7,9 @@ go_library(
     srcs = ["fd.go"],
     importpath = "gvisor.dev/gvisor/pkg/fd",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/unet",
+    ],
 )
 
 go_test(

--- a/pkg/fd/fd.go
+++ b/pkg/fd/fd.go
@@ -17,12 +17,12 @@ package fd
 
 import (
 	"fmt"
+	"gvisor.dev/gvisor/pkg/unet"
 	"io"
 	"os"
 	"runtime"
 	"sync/atomic"
 	"syscall"
-	"gvisor.dev/gvisor/pkg/unet"
 )
 
 // ReadWriter implements io.ReadWriter, io.ReaderAt, and io.WriterAt for fd. It
@@ -186,8 +186,8 @@ func OpenAt(dir *FD, path string, flags int, mode uint32) (*FD, error) {
 	return New(f), nil
 }
 
-// OpenUnix Open a Unix Domain Socket and return the file descriptor for it.
-func OpenUnix(path string) (*FD, error) {
+// DialUnix connects to a Unix Domain Socket and return the file descriptor.
+func DialUnix(path string) (*FD, error) {
 	socket, err := unet.Connect(path, false)
 	return New(socket.FD()), err
 }

--- a/pkg/fd/fd.go
+++ b/pkg/fd/fd.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"sync/atomic"
 	"syscall"
+	"net"
 )
 
 // ReadWriter implements io.ReadWriter, io.ReaderAt, and io.WriterAt for fd. It
@@ -183,6 +184,21 @@ func OpenAt(dir *FD, path string, flags int, mode uint32) (*FD, error) {
 		return nil, err
 	}
 	return New(f), nil
+}
+
+// OpenUnix TODO: DOC
+func OpenUnix(path string) (*FD, error) {
+	addr, _ := net.ResolveUnixAddr("unix", path)
+	f, err := net.DialUnix("unix", nil, addr); if err != nil {
+		return nil, fmt.Errorf("unable to open socket: %q, err: %v", path, err)
+	}
+	fConnd, err := f.File(); if err != nil {
+		return nil, fmt.Errorf("unable to convert to os.File: %q, err: %v", path, err)
+	}
+	fdConnd, err := NewFromFile(fConnd); if err != nil {
+		return nil, fmt.Errorf("unable to convert os.File to fd.FD: %q, err: %v", path, err)
+	}
+	return fdConnd, nil
 }
 
 // Close closes the file descriptor contained in the FD.

--- a/runsc/boot/config.go
+++ b/runsc/boot/config.go
@@ -138,6 +138,9 @@ type Config struct {
 	// Overlay is whether to wrap the root filesystem in an overlay.
 	Overlay bool
 
+	// fsGoferHostUDSAllowed enables the gofer to mount a host UDS
+	FSGoferHostUDSAllowed bool
+
 	// Network indicates what type of network to use.
 	Network NetworkType
 

--- a/runsc/boot/config.go
+++ b/runsc/boot/config.go
@@ -138,8 +138,8 @@ type Config struct {
 	// Overlay is whether to wrap the root filesystem in an overlay.
 	Overlay bool
 
-	// FSGoferHostUDSAllowed enables the gofer to mount a host UDS.
-	FSGoferHostUDSAllowed bool
+	// FSGoferHostUDS enables the gofer to mount a host UDS.
+	FSGoferHostUDS bool
 
 	// Network indicates what type of network to use.
 	Network NetworkType
@@ -217,6 +217,7 @@ func (c *Config) ToFlags() []string {
 		"--debug-log-format=" + c.DebugLogFormat,
 		"--file-access=" + c.FileAccess.String(),
 		"--overlay=" + strconv.FormatBool(c.Overlay),
+		"--fsgofer-host-uds=" + strconv.FormatBool(c.FSGoferHostUDS),
 		"--network=" + c.Network.String(),
 		"--log-packets=" + strconv.FormatBool(c.LogPackets),
 		"--platform=" + c.Platform,

--- a/runsc/boot/config.go
+++ b/runsc/boot/config.go
@@ -138,7 +138,7 @@ type Config struct {
 	// Overlay is whether to wrap the root filesystem in an overlay.
 	Overlay bool
 
-	// fsGoferHostUDSAllowed enables the gofer to mount a host UDS
+	// FSGoferHostUDSAllowed enables the gofer to mount a host UDS.
 	FSGoferHostUDSAllowed bool
 
 	// Network indicates what type of network to use.

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -56,10 +56,11 @@ var goferCaps = &specs.LinuxCapabilities{
 // Gofer implements subcommands.Command for the "gofer" command, which starts a
 // filesystem gofer.  This command should not be called directly.
 type Gofer struct {
-	bundleDir string
-	ioFDs     intFlags
-	applyCaps bool
-	setUpRoot bool
+	bundleDir      string
+	ioFDs          intFlags
+	applyCaps      bool
+	hostUDSAllowed bool
+	setUpRoot      bool
 
 	panicOnWrite bool
 	specFD       int
@@ -86,6 +87,7 @@ func (g *Gofer) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&g.bundleDir, "bundle", "", "path to the root of the bundle directory, defaults to the current directory")
 	f.Var(&g.ioFDs, "io-fds", "list of FDs to connect 9P servers. They must follow this order: root first, then mounts as defined in the spec")
 	f.BoolVar(&g.applyCaps, "apply-caps", true, "if true, apply capabilities to restrict what the Gofer process can do")
+	f.BoolVar(&g.hostUDSAllowed, "host-uds-allowed", false, "if true, allow the Gofer to mount a host UDS")
 	f.BoolVar(&g.panicOnWrite, "panic-on-write", false, "if true, panics on attempts to write to RO mounts. RW mounts are unnaffected")
 	f.BoolVar(&g.setUpRoot, "setup-root", true, "if true, set up an empty root for the process")
 	f.IntVar(&g.specFD, "spec-fd", -1, "required fd with the container spec")
@@ -180,8 +182,9 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...interface{})
 	for _, m := range spec.Mounts {
 		if specutils.Is9PMount(m) {
 			cfg := fsgofer.Config{
-				ROMount:      isReadonlyMount(m.Options),
-				PanicOnWrite: g.panicOnWrite,
+				ROMount:        isReadonlyMount(m.Options),
+				PanicOnWrite:   g.panicOnWrite,
+				HostUDSAllowed: g.hostUDSAllowed,
 			}
 			ap, err := fsgofer.NewAttachPoint(m.Destination, cfg)
 			if err != nil {
@@ -200,8 +203,14 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...interface{})
 		Fatalf("too many FDs passed for mounts. mounts: %d, FDs: %d", mountIdx, len(g.ioFDs))
 	}
 
-	if err := filter.Install(); err != nil {
-		Fatalf("installing seccomp filters: %v", err)
+	if g.hostUDSAllowed {
+		if err := filter.InstallUDS(); err != nil {
+			Fatalf("installing UDS seccomp filters: %v", err)
+		}
+	} else {
+		if err := filter.Install(); err != nil {
+			Fatalf("installing seccomp filters: %v", err)
+		}
 	}
 
 	runServers(ats, g.ioFDs)

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -204,13 +204,11 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...interface{})
 	}
 
 	if g.hostUDSAllowed {
-		if err := filter.InstallUDS(); err != nil {
-			Fatalf("installing UDS seccomp filters: %v", err)
-		}
-	} else {
-		if err := filter.Install(); err != nil {
-			Fatalf("installing seccomp filters: %v", err)
-		}
+		filter.InstallUDSFilters()
+	}
+
+	if err := filter.Install(); err != nil {
+		Fatalf("installing seccomp filters: %v", err)
 	}
 
 	runServers(ats, g.ioFDs)

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -941,6 +941,11 @@ func (c *Container) createGoferProcess(spec *specs.Spec, conf *boot.Config, bund
 		args = append(args, "--panic-on-write=true")
 	}
 
+	// Add support for mounting host UDS in the gofer
+	if conf.FSGoferHostUDSAllowed {
+		args = append(args, "--host-uds-allowed=true")
+	}
+
 	// Open the spec file to donate to the sandbox.
 	specFile, err := specutils.OpenSpec(bundleDir)
 	if err != nil {

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -941,11 +941,6 @@ func (c *Container) createGoferProcess(spec *specs.Spec, conf *boot.Config, bund
 		args = append(args, "--panic-on-write=true")
 	}
 
-	// Add support for mounting host UDS in the gofer
-	if conf.FSGoferHostUDSAllowed {
-		args = append(args, "--host-uds-allowed=true")
-	}
-
 	// Open the spec file to donate to the sandbox.
 	specFile, err := specutils.OpenSpec(bundleDir)
 	if err != nil {

--- a/runsc/fsgofer/filter/config.go
+++ b/runsc/fsgofer/filter/config.go
@@ -83,10 +83,6 @@ var allowedSyscalls = seccomp.SyscallRules{
 			seccomp.AllowAny{},
 			seccomp.AllowValue(syscall.F_GETFD),
 		},
-		{
-			seccomp.AllowAny{},
-			seccomp.AllowValue(syscall.F_DUPFD_CLOEXEC),
-		},
 	},
 	syscall.SYS_FSTAT:     {},
 	syscall.SYS_FSTATFS:   {},

--- a/runsc/fsgofer/filter/config.go
+++ b/runsc/fsgofer/filter/config.go
@@ -39,6 +39,8 @@ var allowedSyscalls = seccomp.SyscallRules{
 	syscall.SYS_SETSOCKOPT: []seccomp.Rule{
 		{
 			seccomp.AllowAny{},
+			seccomp.AllowValue(syscall.SOL_SOCKET),
+			seccomp.AllowValue(syscall.SO_BROADCAST),
 		},
 	},
 	syscall.SYS_GETSOCKNAME: []seccomp.Rule{
@@ -110,6 +112,7 @@ var allowedSyscalls = seccomp.SyscallRules{
 		},
 		{
 			seccomp.AllowAny{},
+			seccomp.AllowValue(syscall.F_DUPFD_CLOEXEC),
 		},
 	},
 	syscall.SYS_FSTAT:     {},

--- a/runsc/fsgofer/filter/config.go
+++ b/runsc/fsgofer/filter/config.go
@@ -36,23 +36,6 @@ var allowedSyscalls = seccomp.SyscallRules{
 			seccomp.AllowAny{},
 		},
 	},
-	syscall.SYS_SETSOCKOPT: []seccomp.Rule{
-		{
-			seccomp.AllowAny{},
-			seccomp.AllowValue(syscall.SOL_SOCKET),
-			seccomp.AllowValue(syscall.SO_BROADCAST),
-		},
-	},
-	syscall.SYS_GETSOCKNAME: []seccomp.Rule{
-		{
-			seccomp.AllowAny{},
-		},
-	},
-	syscall.SYS_GETPEERNAME: []seccomp.Rule{
-		{
-			seccomp.AllowAny{},
-		},
-	},
 	syscall.SYS_ARCH_PRCTL: []seccomp.Rule{
 		{seccomp.AllowValue(linux.ARCH_GET_FS)},
 		{seccomp.AllowValue(linux.ARCH_SET_FS)},

--- a/runsc/fsgofer/filter/config.go
+++ b/runsc/fsgofer/filter/config.go
@@ -26,16 +26,6 @@ import (
 // allowedSyscalls is the set of syscalls executed by the gofer.
 var allowedSyscalls = seccomp.SyscallRules{
 	syscall.SYS_ACCEPT: {},
-	syscall.SYS_SOCKET: []seccomp.Rule{
-		{
-			seccomp.AllowValue(syscall.AF_UNIX),
-		},
-	},
-	syscall.SYS_CONNECT: []seccomp.Rule{
-		{
-			seccomp.AllowAny{},
-		},
-	},
 	syscall.SYS_ARCH_PRCTL: []seccomp.Rule{
 		{seccomp.AllowValue(linux.ARCH_GET_FS)},
 		{seccomp.AllowValue(linux.ARCH_SET_FS)},
@@ -193,4 +183,17 @@ var allowedSyscalls = seccomp.SyscallRules{
 	syscall.SYS_UNLINKAT:  {},
 	syscall.SYS_UTIMENSAT: {},
 	syscall.SYS_WRITE:     {},
+}
+
+var udsSyscalls = seccomp.SyscallRules{
+	syscall.SYS_SOCKET: []seccomp.Rule{
+		{
+			seccomp.AllowValue(syscall.AF_UNIX),
+		},
+	},
+	syscall.SYS_CONNECT: []seccomp.Rule{
+		{
+			seccomp.AllowAny{},
+		},
+	},
 }

--- a/runsc/fsgofer/filter/config.go
+++ b/runsc/fsgofer/filter/config.go
@@ -26,6 +26,31 @@ import (
 // allowedSyscalls is the set of syscalls executed by the gofer.
 var allowedSyscalls = seccomp.SyscallRules{
 	syscall.SYS_ACCEPT: {},
+	syscall.SYS_SOCKET: []seccomp.Rule{
+		{
+			seccomp.AllowValue(syscall.AF_UNIX),
+		},
+	},
+	syscall.SYS_CONNECT: []seccomp.Rule{
+		{
+			seccomp.AllowAny{},
+		},
+	},
+	syscall.SYS_SETSOCKOPT: []seccomp.Rule{
+		{
+			seccomp.AllowAny{},
+		},
+	},
+	syscall.SYS_GETSOCKNAME: []seccomp.Rule{
+		{
+			seccomp.AllowAny{},
+		},
+	},
+	syscall.SYS_GETPEERNAME: []seccomp.Rule{
+		{
+			seccomp.AllowAny{},
+		},
+	},
 	syscall.SYS_ARCH_PRCTL: []seccomp.Rule{
 		{seccomp.AllowValue(linux.ARCH_GET_FS)},
 		{seccomp.AllowValue(linux.ARCH_SET_FS)},
@@ -82,6 +107,9 @@ var allowedSyscalls = seccomp.SyscallRules{
 		{
 			seccomp.AllowAny{},
 			seccomp.AllowValue(syscall.F_GETFD),
+		},
+		{
+			seccomp.AllowAny{},
 		},
 	},
 	syscall.SYS_FSTAT:     {},

--- a/runsc/fsgofer/filter/filter.go
+++ b/runsc/fsgofer/filter/filter.go
@@ -30,8 +30,8 @@ func Install() error {
 	return seccomp.Install(allowedSyscalls)
 }
 
-// InstallUDSFilters installs the seccomp filters required to let the gofer connect
-// to a host UDS.
+// InstallUDSFilters extends the allowed syscalls to include those necessary for
+// connecting to a host UDS.
 func InstallUDSFilters() {
 	// Add additional filters required for connecting to the host's sockets.
 	allowedSyscalls.Merge(udsSyscalls)

--- a/runsc/fsgofer/filter/filter.go
+++ b/runsc/fsgofer/filter/filter.go
@@ -23,23 +23,16 @@ import (
 
 // Install installs seccomp filters.
 func Install() error {
-	s := allowedSyscalls
-
 	// Set of additional filters used by -race and -msan. Returns empty
 	// when not enabled.
-	s.Merge(instrumentationFilters())
+	allowedSyscalls.Merge(instrumentationFilters())
 
-	return seccomp.Install(s)
+	return seccomp.Install(allowedSyscalls)
 }
 
-// InstallUDS installs the standard Gofer seccomp filters along with filters
-// allowing the gofer to connect to a host UDS.
-func InstallUDS() error {
-	// Use the base syscall
-	s := allowedSyscalls
-
+// InstallUDSFilters installs the seccomp filters required to let the gofer connect
+// to a host UDS.
+func InstallUDSFilters() {
 	// Add additional filters required for connecting to the host's sockets.
-	s.Merge(udsSyscalls)
-
-	return seccomp.Install(s)
+	allowedSyscalls.Merge(udsSyscalls)
 }

--- a/runsc/fsgofer/filter/filter.go
+++ b/runsc/fsgofer/filter/filter.go
@@ -31,3 +31,15 @@ func Install() error {
 
 	return seccomp.Install(s)
 }
+
+// InstallUDS installs the standard Gofer seccomp filters along with filters
+// allowing the gofer to connect to a host UDS.
+func InstallUDS() error {
+	// Use the base syscall
+	s := allowedSyscalls
+
+	// Add additional filters required for connecting to the host's sockets.
+	s.Merge(udsSyscalls)
+
+	return seccomp.Install(s)
+}

--- a/runsc/fsgofer/fsgofer.go
+++ b/runsc/fsgofer/fsgofer.go
@@ -21,6 +21,7 @@
 package fsgofer
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -86,7 +87,7 @@ type Config struct {
 	// PanicOnWrite panics on attempts to write to RO mounts.
 	PanicOnWrite bool
 
-	// HostUDS prevents
+	// HostUDSAllowed signals whether the gofer can mount a host's UDS.
 	HostUDSAllowed bool
 }
 
@@ -131,23 +132,23 @@ func (a *attachPoint) Attach() (p9.File, error) {
 		return nil, fmt.Errorf("stat file %q, err: %v", a.prefix, err)
 	}
 
-	// Acquire the attach point lock
+	// Acquire the attach point lock.
 	a.attachedMu.Lock()
 	defer a.attachedMu.Unlock()
 
-	// Hold the file descriptor we are converting into a p9.File
+	// Hold the file descriptor we are converting into a p9.File.
 	var f *fd.FD
 
-	// Apply the S_IFMT bitmask so we can detect file type appropriately
-	switch fmtStat := stat.Mode & syscall.S_IFMT; {
-	case fmtStat == syscall.S_IFSOCK:
-		// Check to see if the CLI option has been set to allow the UDS mount
+	// Apply the S_IFMT bitmask so we can detect file type appropriately.
+	switch fmtStat := stat.Mode & syscall.S_IFMT; fmtStat {
+	case syscall.S_IFSOCK:
+		// Check to see if the CLI option has been set to allow the UDS mount.
 		if !a.conf.HostUDSAllowed {
-			return nil, fmt.Errorf("host UDS support is disabled")
+			return nil, errors.New("host UDS support is disabled")
 		}
 
 		// Attempt to open a connection. Bubble up the failures.
-		f, err = fd.OpenUnix(a.prefix)
+		f, err = fd.DialUnix(a.prefix)
 		if err != nil {
 			return nil, err
 		}
@@ -1058,7 +1059,7 @@ func (l *localFile) Flush() error {
 
 // Connect implements p9.File.
 func (l *localFile) Connect(p9.ConnectFlags) (*fd.FD, error) {
-	return fd.OpenUnix(l.hostPath)
+	return fd.DialUnix(l.hostPath)
 }
 
 // Close implements p9.File.

--- a/runsc/fsgofer/fsgofer.go
+++ b/runsc/fsgofer/fsgofer.go
@@ -87,8 +87,8 @@ type Config struct {
 	// PanicOnWrite panics on attempts to write to RO mounts.
 	PanicOnWrite bool
 
-	// HostUDSAllowed signals whether the gofer can mount a host's UDS.
-	HostUDSAllowed bool
+	// HostUDS signals whether the gofer can mount a host's UDS.
+	HostUDS bool
 }
 
 type attachPoint struct {
@@ -143,7 +143,7 @@ func (a *attachPoint) Attach() (p9.File, error) {
 	switch fmtStat := stat.Mode & syscall.S_IFMT; fmtStat {
 	case syscall.S_IFSOCK:
 		// Check to see if the CLI option has been set to allow the UDS mount.
-		if !a.conf.HostUDSAllowed {
+		if !a.conf.HostUDS {
 			return nil, errors.New("host UDS support is disabled")
 		}
 
@@ -1059,6 +1059,10 @@ func (l *localFile) Flush() error {
 
 // Connect implements p9.File.
 func (l *localFile) Connect(p9.ConnectFlags) (*fd.FD, error) {
+	// Check to see if the CLI option has been set to allow the UDS mount.
+	if !l.attachPoint.conf.HostUDS {
+		return nil, errors.New("host UDS support is disabled")
+	}
 	return fd.DialUnix(l.hostPath)
 }
 

--- a/runsc/fsgofer/fsgofer.go
+++ b/runsc/fsgofer/fsgofer.go
@@ -131,30 +131,30 @@ func (a *attachPoint) Attach() (p9.File, error) {
 	// Hold the file descriptor we are converting into a p9.File
 	var f *fd.FD
 
-  // Apply the S_IFMT bitmask so we can detect file type appropriately
+	// Apply the S_IFMT bitmask so we can detect file type appropriately
 	switch fmtStat := stat.Mode & syscall.S_IFMT; {
 	case fmtStat == syscall.S_IFSOCK:
-			// Attempt to open a connection. Bubble up the failures.
-			f, err = fd.OpenUnix(a.prefix)
-			if err != nil {
-				return nil, err
-			}
+		// Attempt to open a connection. Bubble up the failures.
+		f, err = fd.OpenUnix(a.prefix)
+		if err != nil {
+			return nil, err
+		}
 
-		default:
-			// Default to Read/Write permissions.
-			mode := syscall.O_RDWR
+	default:
+		// Default to Read/Write permissions.
+		mode := syscall.O_RDWR
 
-			// If the configuration is Read Only & the mount point is a directory,
-			// set the mode to Read Only.
-			if a.conf.ROMount || fmtStat == syscall.S_IFDIR {
-				mode = syscall.O_RDONLY
-			}
+		// If the configuration is Read Only & the mount point is a directory,
+		// set the mode to Read Only.
+		if a.conf.ROMount || fmtStat == syscall.S_IFDIR {
+			mode = syscall.O_RDONLY
+		}
 
-			// Open the mount point & capture the FD.
-			f, err = fd.Open(a.prefix, openFlags|mode, 0)
-			if err != nil {
-				return nil, fmt.Errorf("unable to open file %q, err: %v", a.prefix, err)
-			}
+		// Open the mount point & capture the FD.
+		f, err = fd.Open(a.prefix, openFlags|mode, 0)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open file %q, err: %v", a.prefix, err)
+		}
 	}
 
 	// Close the connection if the UDS is already attached.

--- a/runsc/main.go
+++ b/runsc/main.go
@@ -63,17 +63,18 @@ var (
 	straceLogSize  = flag.Uint("strace-log-size", 1024, "default size (in bytes) to log data argument blobs")
 
 	// Flags that control sandbox runtime behavior.
-	platformName       = flag.String("platform", "ptrace", "specifies which platform to use: ptrace (default), kvm")
-	network            = flag.String("network", "sandbox", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")
-	gso                = flag.Bool("gso", true, "enable generic segmenation offload")
-	fileAccess         = flag.String("file-access", "exclusive", "specifies which filesystem to use for the root mount: exclusive (default), shared. Volume mounts are always shared.")
-	overlay            = flag.Bool("overlay", false, "wrap filesystem mounts with writable overlay. All modifications are stored in memory inside the sandbox.")
-	watchdogAction     = flag.String("watchdog-action", "log", "sets what action the watchdog takes when triggered: log (default), panic.")
-	panicSignal        = flag.Int("panic-signal", -1, "register signal handling that panics. Usually set to SIGUSR2(12) to troubleshoot hangs. -1 disables it.")
-	profile            = flag.Bool("profile", false, "prepares the sandbox to use Golang profiler. Note that enabling profiler loosens the seccomp protection added to the sandbox (DO NOT USE IN PRODUCTION).")
-	netRaw             = flag.Bool("net-raw", false, "enable raw sockets. When false, raw sockets are disabled by removing CAP_NET_RAW from containers (`runsc exec` will still be able to utilize raw sockets). Raw sockets allow malicious containers to craft packets and potentially attack the network.")
-	numNetworkChannels = flag.Int("num-network-channels", 1, "number of underlying channels(FDs) to use for network link endpoints.")
-	rootless           = flag.Bool("rootless", false, "it allows the sandbox to be started with a user that is not root. Sandbox and Gofer processes may run with same privileges as current user.")
+	platformName          = flag.String("platform", "ptrace", "specifies which platform to use: ptrace (default), kvm")
+	network               = flag.String("network", "sandbox", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")
+	gso                   = flag.Bool("gso", true, "enable generic segmenation offload")
+	fileAccess            = flag.String("file-access", "exclusive", "specifies which filesystem to use for the root mount: exclusive (default), shared. Volume mounts are always shared.")
+	fsGoferHostUDSAllowed = flag.Bool("fsgofer-host-uds-allowed", false, "Allow the gofer to mount Unix Domain Sockets.")
+	overlay               = flag.Bool("overlay", false, "wrap filesystem mounts with writable overlay. All modifications are stored in memory inside the sandbox.")
+	watchdogAction        = flag.String("watchdog-action", "log", "sets what action the watchdog takes when triggered: log (default), panic.")
+	panicSignal           = flag.Int("panic-signal", -1, "register signal handling that panics. Usually set to SIGUSR2(12) to troubleshoot hangs. -1 disables it.")
+	profile               = flag.Bool("profile", false, "prepares the sandbox to use Golang profiler. Note that enabling profiler loosens the seccomp protection added to the sandbox (DO NOT USE IN PRODUCTION).")
+	netRaw                = flag.Bool("net-raw", false, "enable raw sockets. When false, raw sockets are disabled by removing CAP_NET_RAW from containers (`runsc exec` will still be able to utilize raw sockets). Raw sockets allow malicious containers to craft packets and potentially attack the network.")
+	numNetworkChannels    = flag.Int("num-network-channels", 1, "number of underlying channels(FDs) to use for network link endpoints.")
+	rootless              = flag.Bool("rootless", false, "it allows the sandbox to be started with a user that is not root. Sandbox and Gofer processes may run with same privileges as current user.")
 
 	// Test flags, not to be used outside tests, ever.
 	testOnlyAllowRunAsCurrentUserWithoutChroot = flag.Bool("TESTONLY-unsafe-nonroot", false, "TEST ONLY; do not ever use! This skips many security measures that isolate the host from the sandbox.")
@@ -171,27 +172,28 @@ func main() {
 
 	// Create a new Config from the flags.
 	conf := &boot.Config{
-		RootDir:            *rootDir,
-		Debug:              *debug,
-		LogFilename:        *logFilename,
-		LogFormat:          *logFormat,
-		DebugLog:           *debugLog,
-		DebugLogFormat:     *debugLogFormat,
-		FileAccess:         fsAccess,
-		Overlay:            *overlay,
-		Network:            netType,
-		GSO:                *gso,
-		LogPackets:         *logPackets,
-		Platform:           platformType,
-		Strace:             *strace,
-		StraceLogSize:      *straceLogSize,
-		WatchdogAction:     wa,
-		PanicSignal:        *panicSignal,
-		ProfileEnable:      *profile,
-		EnableRaw:          *netRaw,
-		NumNetworkChannels: *numNetworkChannels,
-		Rootless:           *rootless,
-		AlsoLogToStderr:    *alsoLogToStderr,
+		RootDir:               *rootDir,
+		Debug:                 *debug,
+		LogFilename:           *logFilename,
+		LogFormat:             *logFormat,
+		DebugLog:              *debugLog,
+		DebugLogFormat:        *debugLogFormat,
+		FileAccess:            fsAccess,
+		FSGoferHostUDSAllowed: *fsGoferHostUDSAllowed,
+		Overlay:               *overlay,
+		Network:               netType,
+		GSO:                   *gso,
+		LogPackets:            *logPackets,
+		Platform:              platformType,
+		Strace:                *strace,
+		StraceLogSize:         *straceLogSize,
+		WatchdogAction:        wa,
+		PanicSignal:           *panicSignal,
+		ProfileEnable:         *profile,
+		EnableRaw:             *netRaw,
+		NumNetworkChannels:    *numNetworkChannels,
+		Rootless:              *rootless,
+		AlsoLogToStderr:       *alsoLogToStderr,
 
 		TestOnlyAllowRunAsCurrentUserWithoutChroot: *testOnlyAllowRunAsCurrentUserWithoutChroot,
 	}

--- a/runsc/main.go
+++ b/runsc/main.go
@@ -63,18 +63,18 @@ var (
 	straceLogSize  = flag.Uint("strace-log-size", 1024, "default size (in bytes) to log data argument blobs")
 
 	// Flags that control sandbox runtime behavior.
-	platformName          = flag.String("platform", "ptrace", "specifies which platform to use: ptrace (default), kvm")
-	network               = flag.String("network", "sandbox", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")
-	gso                   = flag.Bool("gso", true, "enable generic segmenation offload")
-	fileAccess            = flag.String("file-access", "exclusive", "specifies which filesystem to use for the root mount: exclusive (default), shared. Volume mounts are always shared.")
-	fsGoferHostUDSAllowed = flag.Bool("fsgofer-host-uds-allowed", false, "Allow the gofer to mount Unix Domain Sockets.")
-	overlay               = flag.Bool("overlay", false, "wrap filesystem mounts with writable overlay. All modifications are stored in memory inside the sandbox.")
-	watchdogAction        = flag.String("watchdog-action", "log", "sets what action the watchdog takes when triggered: log (default), panic.")
-	panicSignal           = flag.Int("panic-signal", -1, "register signal handling that panics. Usually set to SIGUSR2(12) to troubleshoot hangs. -1 disables it.")
-	profile               = flag.Bool("profile", false, "prepares the sandbox to use Golang profiler. Note that enabling profiler loosens the seccomp protection added to the sandbox (DO NOT USE IN PRODUCTION).")
-	netRaw                = flag.Bool("net-raw", false, "enable raw sockets. When false, raw sockets are disabled by removing CAP_NET_RAW from containers (`runsc exec` will still be able to utilize raw sockets). Raw sockets allow malicious containers to craft packets and potentially attack the network.")
-	numNetworkChannels    = flag.Int("num-network-channels", 1, "number of underlying channels(FDs) to use for network link endpoints.")
-	rootless              = flag.Bool("rootless", false, "it allows the sandbox to be started with a user that is not root. Sandbox and Gofer processes may run with same privileges as current user.")
+	platformName       = flag.String("platform", "ptrace", "specifies which platform to use: ptrace (default), kvm")
+	network            = flag.String("network", "sandbox", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")
+	gso                = flag.Bool("gso", true, "enable generic segmenation offload")
+	fileAccess         = flag.String("file-access", "exclusive", "specifies which filesystem to use for the root mount: exclusive (default), shared. Volume mounts are always shared.")
+	fsGoferHostUDS     = flag.Bool("fsgofer-host-uds", false, "Allow the gofer to mount Unix Domain Sockets.")
+	overlay            = flag.Bool("overlay", false, "wrap filesystem mounts with writable overlay. All modifications are stored in memory inside the sandbox.")
+	watchdogAction     = flag.String("watchdog-action", "log", "sets what action the watchdog takes when triggered: log (default), panic.")
+	panicSignal        = flag.Int("panic-signal", -1, "register signal handling that panics. Usually set to SIGUSR2(12) to troubleshoot hangs. -1 disables it.")
+	profile            = flag.Bool("profile", false, "prepares the sandbox to use Golang profiler. Note that enabling profiler loosens the seccomp protection added to the sandbox (DO NOT USE IN PRODUCTION).")
+	netRaw             = flag.Bool("net-raw", false, "enable raw sockets. When false, raw sockets are disabled by removing CAP_NET_RAW from containers (`runsc exec` will still be able to utilize raw sockets). Raw sockets allow malicious containers to craft packets and potentially attack the network.")
+	numNetworkChannels = flag.Int("num-network-channels", 1, "number of underlying channels(FDs) to use for network link endpoints.")
+	rootless           = flag.Bool("rootless", false, "it allows the sandbox to be started with a user that is not root. Sandbox and Gofer processes may run with same privileges as current user.")
 
 	// Test flags, not to be used outside tests, ever.
 	testOnlyAllowRunAsCurrentUserWithoutChroot = flag.Bool("TESTONLY-unsafe-nonroot", false, "TEST ONLY; do not ever use! This skips many security measures that isolate the host from the sandbox.")
@@ -172,28 +172,28 @@ func main() {
 
 	// Create a new Config from the flags.
 	conf := &boot.Config{
-		RootDir:               *rootDir,
-		Debug:                 *debug,
-		LogFilename:           *logFilename,
-		LogFormat:             *logFormat,
-		DebugLog:              *debugLog,
-		DebugLogFormat:        *debugLogFormat,
-		FileAccess:            fsAccess,
-		FSGoferHostUDSAllowed: *fsGoferHostUDSAllowed,
-		Overlay:               *overlay,
-		Network:               netType,
-		GSO:                   *gso,
-		LogPackets:            *logPackets,
-		Platform:              platformType,
-		Strace:                *strace,
-		StraceLogSize:         *straceLogSize,
-		WatchdogAction:        wa,
-		PanicSignal:           *panicSignal,
-		ProfileEnable:         *profile,
-		EnableRaw:             *netRaw,
-		NumNetworkChannels:    *numNetworkChannels,
-		Rootless:              *rootless,
-		AlsoLogToStderr:       *alsoLogToStderr,
+		RootDir:            *rootDir,
+		Debug:              *debug,
+		LogFilename:        *logFilename,
+		LogFormat:          *logFormat,
+		DebugLog:           *debugLog,
+		DebugLogFormat:     *debugLogFormat,
+		FileAccess:         fsAccess,
+		FSGoferHostUDS:     *fsGoferHostUDS,
+		Overlay:            *overlay,
+		Network:            netType,
+		GSO:                *gso,
+		LogPackets:         *logPackets,
+		Platform:           platformType,
+		Strace:             *strace,
+		StraceLogSize:      *straceLogSize,
+		WatchdogAction:     wa,
+		PanicSignal:        *panicSignal,
+		ProfileEnable:      *profile,
+		EnableRaw:          *netRaw,
+		NumNetworkChannels: *numNetworkChannels,
+		Rootless:           *rootless,
+		AlsoLogToStderr:    *alsoLogToStderr,
 
 		TestOnlyAllowRunAsCurrentUserWithoutChroot: *testOnlyAllowRunAsCurrentUserWithoutChroot,
 	}


### PR DESCRIPTION
## Description
This pull request adds the ability for mounting a Unix Domain Socket (UDS) from the host, and using the mounted socket from the container. The feature required implementing the `Connect` callback for the Gofer filesystem, adding the supported filetypes, and changing the implementation of the `Attach` point. Additionally, further `seccomp` permissions were added to allow for the filesystem process to connect to a host UDS.

This functionality operates as expected under circumstances where no networking is allowed.

Example output has been included below.
```
vagrant@ubuntu-xenial:/vagrant$ bazel build runsc && sudo systemctl restart docker && sudo docker run --runtime=runsc -it -v /home/vagrant/uds_socket:/uds_socket:rw gvisor_test bashINFO: Analyzed target //runsc:runsc (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //runsc:runsc up-to-date:
  bazel-bin/runsc/linux_amd64_pure_stripped/runsc
INFO: Elapsed time: 1.087s, Critical Path: 0.45s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
root@d178235204fa:/# curl --unix-socket ./uds_socket https://www.example.com/
<!doctype html>
<html>
<head>
    <title>Example Domain</title>

    <meta charset="utf-8" />
    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <style type="text/css">
    body {
        background-color: #f0f0f2;
        margin: 0;
        padding: 0;
        font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;

    }
    div {
        width: 600px;
        margin: 5em auto;
        padding: 50px;
        background-color: #fff;
        border-radius: 1em;
    }
    a:link, a:visited {
        color: #38488f;
        text-decoration: none;
    }
    @media (max-width: 700px) {
        body {
            background-color: #fff;
        }
        div {
            width: auto;
            margin: 0 auto;
            border-radius: 0;
            padding: 1em;
        }
    }
    </style>
</head>

<body>
<div>
    <h1>Example Domain</h1>
    <p>This domain is established to be used for illustrative examples in documents. You may use this
    domain in examples without prior coordination or asking for permission.</p>
    <p><a href="http://www.iana.org/domains/example">More information...</a></p>
</div>
</body>
</html>
```

```
vagrant@ubuntu-xenial:~$ socat -d -d UNIX-LISTEN:./uds_socket,fork TCP4-CONNECT:www.example.com:443
2019/08/27 21:05:35 socat[21177] N listening on AF=1 "./uds_socket"
2019/08/27 21:05:41 socat[21177] N accepting connection from AF=1 "<anon>" on AF=1 "./uds_socket"
2019/08/27 21:05:41 socat[21177] N forked off child process 21668
2019/08/27 21:05:41 socat[21177] N listening on AF=1 "./uds_socket"
2019/08/27 21:05:42 socat[21668] N opening connection to AF=2 93.184.216.34:443
2019/08/27 21:05:42 socat[21668] N successfully connected from local address AF=2 10.0.2.15:51164
2019/08/27 21:05:42 socat[21668] N starting data transfer loop with FDs [6,6] and [5,5]
2019/08/27 21:06:02 socat[21177] N accepting connection from AF=1 "<anon>" on AF=1 "./uds_socket"
2019/08/27 21:06:02 socat[21177] N forked off child process 21701
2019/08/27 21:06:02 socat[21177] N listening on AF=1 "./uds_socket"
2019/08/27 21:06:02 socat[21701] N opening connection to AF=2 93.184.216.34:443
2019/08/27 21:06:02 socat[21701] N successfully connected from local address AF=2 10.0.2.15:51166
2019/08/27 21:06:02 socat[21701] N starting data transfer loop with FDs [6,6] and [5,5]
2019/08/27 21:06:02 socat[21701] N socket 1 (fd 6) is at EOF
2019/08/27 21:06:02 socat[21701] E write(6, 0x1b51e00, 24): Broken pipe
2019/08/27 21:06:02 socat[21701] N exit(1)
2019/08/27 21:06:02 socat[21177] N childdied(): handling signal 17
2019/08/27 21:06:02 socat[21177] W waitpid(): child 21701 exited with status 1
2019/08/27 21:06:43 socat[21668] N socket 2 (fd 5) is at EOF
2019/08/27 21:06:43 socat[21668] N exiting with status 0
2019/08/27 21:06:43 socat[21177] N childdied(): handling signal 17
```

## Testing & acceptance
Currently, tests are not implemented for this functionality, as direction is required from the upstream maintainers on how to properly implement the testing to be in accordance with the rest of the GVisor test suite. This feature requires testing on both the host and container level, since changes transit these boundaries.

Seccomp permissions also need to be reviewed to ensure they are properly restrictive, given the filesystem process requires more permissions to open a file descriptor to a host UDS.

## Related issues
The discussions related to the requirements of this feature can be found in issue #235 . 