### PR TITLE
Fix repository build scripts

### DIFF
--- a/scripts/common_bazel.sh
+++ b/scripts/common_bazel.sh
@@ -48,7 +48,8 @@ fi
 
 # Wrap bazel.
 function build() {
-  bazel build "${BAZEL_RBE_FLAGS[@]}" "${BAZEL_RBE_AUTH_FLAGS[@]}" "${BAZEL_FLAGS[@]}" "$@"
+  bazel build "${BAZEL_RBE_FLAGS[@]}" "${BAZEL_RBE_AUTH_FLAGS[@]}" "${BAZEL_FLAGS[@]}" "$@" 2>&1 |
+    tee /dev/fd/2 | grep -E '^  bazel-bin/' | awk '{ print $1; }'
 }
 
 function test() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -26,9 +26,13 @@ if ! [[ -v KOKORO_RELEASE_TAG ]]; then
   exit 1
 fi
 
+# Unless an explicit releaser is provided, use the bot e-mail.
+declare -r KOKORO_RELEASE_AUTHOR=${KOKORO_RELEASE_AUTHOR:-gvisor-bot}
+declare -r EMAIL=${EMAIL:-${KOKORO_RELEASE_AUTHOR}@google.com}
+
 # Ensure we have an appropriate configuration for the tag.
 git config --get user.name || git config user.name "gVisor-bot"
-git config --get user.email || git config user.email "gvisor-bot@google.com"
+git config --get user.email || git config user.email "${EMAIL}"
 
 # Run the release tool, which pushes to the origin repository.
 tools/tag_release.sh "${KOKORO_RELEASE_COMMIT}" "${KOKORO_RELEASE_TAG}"

--- a/tools/make_repository.sh
+++ b/tools/make_repository.sh
@@ -37,10 +37,10 @@ cleanup() {
   rm -f "${keyring}"
 }
 trap cleanup EXIT
-gpg --no-default-keyring --keyring "${keyring}" --import "${private_key}"
+gpg --no-default-keyring --keyring "${keyring}" --import "${private_key}" >&2
 
 # Export the public key from the keyring.
-gpg --no-default-keyring --keyring "${keyring}" --armor --export "${signer}" > "${tmpdir}"/keyFile
+gpg --no-default-keyring --keyring "${keyring}" --armor --export "${signer}" > "${tmpdir}"/keyFile >&2
 
 # Copy the packages, and ensure permissions are correct.
 cp -a "$@" "${tmpdir}" && chmod 0644 "${tmpdir}"/*
@@ -52,7 +52,7 @@ find "${tmpdir}" -type l -exec rm -f {} \;
 
 # Sign all packages.
 for file in "${tmpdir}"/*.deb; do
-  dpkg-sig -g "--no-default-keyring --keyring ${keyring}" --sign builder "${file}"
+  dpkg-sig -g "--no-default-keyring --keyring ${keyring}" --sign builder "${file}" >&2
 done
 
 # Build the package list.
@@ -62,8 +62,8 @@ done
 (cd "${tmpdir}" && apt-ftparchive release . > Release)
 
 # Sign the release.
-(cd "${tmpdir}" && gpg --no-default-keyring --keyring "${keyring}" --clearsign -o InRelease Release)
-(cd "${tmpdir}" && gpg --no-default-keyring --keyring "${keyring}" -abs -o Release.gpg Release)
+(cd "${tmpdir}" && gpg --no-default-keyring --keyring "${keyring}" --clearsign -o InRelease Release >&2)
+(cd "${tmpdir}" && gpg --no-default-keyring --keyring "${keyring}" -abs -o Release.gpg Release >&2)
 
 # Show the results.
 echo "${tmpdir}"


### PR DESCRIPTION
This has the following fixes:

* Packages are passed to the tools/make_repository.sh command.
* All matching tags are built, for commits with multiple.
* The binary path is generated by the build command.
* Output from signing the repository is supressed.
* The output path is cleaned for artifact copying.

Change-Id: I2d08954ba76e35612f352be99d5bb99080f80892