### PR TITLE
Fix `runsc --version` and add a test.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Display the current git revision in the info block.
-build --workspace_status_command tools/workspace_status.sh
+build --stamp --workspace_status_command tools/workspace_status.sh
 
 # Enable remote execution so actions are performed on the remote systems.
 build:remote --remote_executor=grpcs://remotebuildexecution.googleapis.com

--- a/runsc/BUILD
+++ b/runsc/BUILD
@@ -13,7 +13,7 @@ go_binary(
     visibility = [
         "//visibility:public",
     ],
-    x_defs = {"main.version": "{VERSION}"},
+    x_defs = {"main.version": "{STABLE_VERSION}"},
     deps = [
         "//pkg/log",
         "//pkg/refs",
@@ -46,7 +46,7 @@ go_binary(
     visibility = [
         "//visibility:public",
     ],
-    x_defs = {"main.version": "{VERSION}"},
+    x_defs = {"main.version": "{STABLE_VERSION}"},
     deps = [
         "//pkg/log",
         "//pkg/refs",
@@ -100,4 +100,11 @@ pkg_deb(
     visibility = [
         "//visibility:public",
     ],
+)
+
+sh_test(
+    name = "version_test",
+    data = [":runsc"],
+    size = "small",
+    srcs = ["version_test.sh"],
 )

--- a/runsc/version.go
+++ b/runsc/version.go
@@ -15,4 +15,4 @@
 package main
 
 // version is set during linking.
-var version = ""
+var version = "VERSION_MISSING"

--- a/runsc/version_test.sh
+++ b/runsc/version_test.sh
@@ -14,5 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The STABLE_ prefix will triger a re-link if it changes.
-echo STABLE_VERSION $(git describe --always --tags --abbrev=12 --dirty)
+set -euf -x -o pipefail
+
+readonly runsc="${TEST_SRCDIR}/__main__/runsc/linux_amd64_pure_stripped/runsc"
+readonly version=$($runsc --version)
+
+# Version should should not match VERSION, which is the default and which will
+# also appear if something is wrong with workspace_status.sh script.
+if [[ $version =~ "VERSION" ]]; then
+  echo "Got bad version $version"
+  exit 1
+fi
+
+echo "Got OK version $version"
+exit 0


### PR DESCRIPTION
We need to include the `--stamp` flag in `tools/workspace_status.sh` for
the version to be picked up by the linker. Not sure why.

Also changes the VERSION string to STABLE_VERSION, which will cause the
program to be re-linked if the string changes.

Fixes #830