### PR TITLE
Accelerate byte lookup in string with `bytealg/indexbyte`

### DIFF
--- a/pkg/sentry/usermem/usermem.go
+++ b/pkg/sentry/usermem/usermem.go
@@ -16,6 +16,7 @@
 package usermem
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"strconv"
@@ -270,11 +271,10 @@ func CopyStringIn(ctx context.Context, uio IO, addr Addr, maxlen int, opts IOOpt
 		n, err := uio.CopyIn(ctx, addr, buf[done:done+readlen], opts)
 		// Look for the terminating zero byte, which may have occurred before
 		// hitting err.
-		for i, c := range buf[done : done+n] {
-			if c == 0 {
-				return stringFromImmutableBytes(buf[:done+i]), nil
-			}
+		if i := bytes.IndexByte(buf[done:done+n], byte(0)); i >= 0 {
+			return stringFromImmutableBytes(buf[:done+i]), nil
 		}
+
 		done += n
 		if err != nil {
 			return stringFromImmutableBytes(buf[:done]), err


### PR DESCRIPTION
`bytealg/indexbyte` will use AVX or SSE instruction set, if possible,
which could accelerate `CopyStringIn` function by 28%.

In worst case(CPU doesn't support SSE), `bytealg/indexbyte`
will degenerate to traversal lookup. When dealing with
short strings, `bytealg/indexbyte` has the same performance level as
before.

Signed-off-by: Jianfeng Tan <henry.tjf@antfin.com>
Signed-off-by: Hang Su <darcy.sh@antfin.com>