### PR TITLE
Add tools/go_stateify to support Arm64

### DIFF
--- a/pkg/sentry/arch/arch_amd64.go
+++ b/pkg/sentry/arch/arch_amd64.go
@@ -101,7 +101,7 @@ const (
 
 // context64 represents an AMD64 context.
 //
-// +stateify savable
+// +stateify savable_amd64
 type context64 struct {
 	State
 	sigFPState []x86FPState // fpstate to be restored on sigreturn.

--- a/pkg/sentry/arch/arch_state_x86.go
+++ b/pkg/sentry/arch/arch_state_x86.go
@@ -89,7 +89,7 @@ func (s *State) afterLoad() {
 	copy(s.x86FPState, old)
 }
 
-// +stateify savable
+// +stateify savable_amd64
 type syscallPtraceRegs struct {
 	R15      uint64
 	R14      uint64

--- a/pkg/sentry/arch/arch_x86.go
+++ b/pkg/sentry/arch/arch_x86.go
@@ -154,7 +154,7 @@ func NewFloatingPointData() *FloatingPointData {
 // State contains the common architecture bits for X86 (the build tag of this
 // file ensures it's only built on x86).
 //
-// +stateify savable
+// +stateify savable_amd64
 type State struct {
 	// The system registers.
 	Regs syscall.PtraceRegs `state:".(syscallPtraceRegs)"`

--- a/pkg/sentry/arch/signal_amd64.go
+++ b/pkg/sentry/arch/signal_amd64.go
@@ -29,7 +29,7 @@ import (
 // SignalAct represents the action that should be taken when a signal is
 // delivered, and is equivalent to struct sigaction on 64-bit x86.
 //
-// +stateify savable
+// +stateify savable_amd64
 type SignalAct struct {
 	Handler  uint64
 	Flags    uint64
@@ -50,7 +50,7 @@ func (s *SignalAct) DeserializeTo(other *SignalAct) {
 // SignalStack represents information about a user stack, and is equivalent to
 // stack_t on 64-bit x86.
 //
-// +stateify savable
+// +stateify savable_amd64
 type SignalStack struct {
 	Addr  uint64
 	Flags uint32
@@ -71,7 +71,7 @@ func (s *SignalStack) DeserializeTo(other *SignalStack) {
 // SignalInfo represents information about a signal being delivered, and is
 // equivalent to struct siginfo on 64-bit x86.
 //
-// +stateify savable
+// +stateify savable_amd64
 type SignalInfo struct {
 	Signo int32 // Signal number
 	Errno int32 // Errno value

--- a/tools/go_stateify/defs.bzl
+++ b/tools/go_stateify/defs.bzl
@@ -44,6 +44,7 @@ def _go_stateify_impl(ctx):
     # Run the stateify command.
     args = ["-output=%s" % output.path]
     args += ["-pkg=%s" % ctx.attr.package]
+    args += ["-arch=%s" % ctx.attr.arch]
     if ctx.attr._statepkg:
         args += ["-statepkg=%s" % ctx.attr._statepkg]
     if ctx.attr.imports:
@@ -83,6 +84,10 @@ for statified types.
             doc = "The package name for the input sources.",
             mandatory = True,
         ),
+        "arch": attr.string(
+            doc = "Target platform.",
+            mandatory = True,
+        ),
         "out": attr.output(
             doc = """
 The name of the generated file output. This must not conflict with any other
@@ -118,6 +123,10 @@ def go_library(name, srcs, deps = [], imports = [], **kwargs):
             srcs = [src for src in srcs if src.endswith(".go")],
             imports = imports,
             package = name,
+            arch = select({
+                   "@bazel_tools//src/conditions:linux_aarch64": "arm64",
+                   "//conditions:default": "amd64",
+            }),
             out = name + "_state_autogen.go",
         )
         all_srcs = srcs + [name + "_state_autogen.go"]

--- a/tools/go_stateify/main.go
+++ b/tools/go_stateify/main.go
@@ -33,6 +33,7 @@ var (
 	imports  = flag.String("imports", "", "extra imports for the output file")
 	output   = flag.String("output", "", "output file")
 	statePkg = flag.String("statepkg", "", "state import package; defaults to empty")
+	arch     = flag.String("arch", "", "specify the target platform")
 )
 
 // resolveTypeName returns a qualified type name.
@@ -318,8 +319,8 @@ func main() {
 			}
 
 			// Only generate code for types marked
-			// "// +stateify savable" in one of the proceeding
-			// comment lines.
+			// "// +stateify savable" or "// +stateify savable_amd64" or "// +stateify savable_arm64"
+			// in one of the proceeding comment lines.
 			if d.Doc == nil {
 				continue
 			}
@@ -328,6 +329,18 @@ func main() {
 				if l.Text == "// +stateify savable" {
 					savable = true
 					break
+				}
+				// Currently, only 2 target platforms were supported: amd64, arm64.
+				if *arch == "arm64" {
+					if l.Text == "// +stateify savable_arm64" {
+						savable = true
+						break
+					}
+				} else {
+					if l.Text == "// +stateify savable_amd64" {
+						savable = true
+						break
+					}
 				}
 			}
 			if !savable {


### PR DESCRIPTION
2 jobs were finished in this patch:
  1, add a new attribute to specify the target platform.
  2, add 2 extra rules to generate codes for different target platforms.
Signed-off-by: Bin Lu <bin.lu@arm.com>