### PR TITLE
Handling IP Options and ICMP Parameter Problem

### DIFF
--- a/pkg/tcpip/header/icmpv4.go
+++ b/pkg/tcpip/header/icmpv4.go
@@ -97,6 +97,11 @@ func (b ICMPv4) SetChecksum(checksum uint16) {
 	binary.BigEndian.PutUint16(b[icmpv4ChecksumOffset:], checksum)
 }
 
+// SetPointer sets the ICMP pointer field.
+func (b ICMPv4) SetPointer(pointer []byte) {
+	copy(b[4:], pointer)
+}
+
 // SourcePort implements Transport.SourcePort.
 func (ICMPv4) SourcePort() uint16 {
 	return 0

--- a/pkg/tcpip/header/ipv4.go
+++ b/pkg/tcpip/header/ipv4.go
@@ -33,6 +33,7 @@ const (
 	checksum           = 10
 	srcAddr            = 12
 	dstAddr            = 16
+	options            = 20
 )
 
 // IPv4Fields contains the fields of an IPv4 packet. It is used to describe the
@@ -70,6 +71,9 @@ type IPv4Fields struct {
 
 	// DstAddr is the "destination ip address" of an IPv4 packet.
 	DstAddr tcpip.Address
+
+	// Options is the "ip options" of an IPv4 packet.
+	Options []byte
 }
 
 // IPv4 represents an ipv4 header stored in a byte array.
@@ -189,6 +193,11 @@ func (b IPv4) DestinationAddress() tcpip.Address {
 	return tcpip.Address(b[dstAddr : dstAddr+IPv4AddressSize])
 }
 
+// Options returns the "IP option" field of thr ipv4 header.
+func (b IPv4) Options(optlen int) []byte {
+	return b[options : options+optlen]
+}
+
 // TransportProtocol implements Network.TransportProtocol.
 func (b IPv4) TransportProtocol() tcpip.TransportProtocolNumber {
 	return tcpip.TransportProtocolNumber(b.Protocol())
@@ -245,6 +254,11 @@ func (b IPv4) SetSourceAddress(addr tcpip.Address) {
 // header.
 func (b IPv4) SetDestinationAddress(addr tcpip.Address) {
 	copy(b[dstAddr:dstAddr+IPv4AddressSize], addr)
+}
+
+// SetOptions sets the "IP option" field of the ipv4 header.
+func (b IPv4) SetOptions(opt []byte) {
+	copy(b[options:options+len(opt)], opt)
 }
 
 // CalculateChecksum calculates the checksum of the ipv4 header.


### PR DESCRIPTION
If datagram arrives with incorrect arguments in an IP Option, DUT should discard the packet and notify the sender by sending ICMP Parameter problem message with Pointer field set and and
it contains the exactly same Internet Header and 64 bits of Original Datagram.

While Testing Fuchsia (on Intel NUC) networking stack by using
IxANVL tool, four of the test cases are failed related to IP_Options
and ICMP Parameter Problem.

This CL adds a fix to send ICMP Parameter problem message whenever
a datagram is arrived with incorrect arguments in an IP Option.

Testing : Updated ip_test.go by adding test for ip_options as part of test

[0001-IP_Options-Handling-and-ICMP-parameter-Problem.txt](https://github.com/google/gvisor/files/3841699/0001-IP_Options-Handling-and-ICMP-parameter-Problem.txt)
