### PR TITLE
Bump the bazel version number.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Make sure the following dependencies are installed:
 
 *   Linux 4.14.77+ ([older linux][old-linux])
 *   [git][git]
-*   [Bazel][bazel] 0.28.0+
+*   [Bazel][bazel] 1.0.0+
 *   [Python][python]
 *   [Docker version 17.09.0 or greater][docker]
 *   Gold linker (e.g. `binutils-gold` package on Ubuntu)


### PR DESCRIPTION
Building with bazel 0.28.1 results in the following error. Updating to
1.0.0 solved the issue:

> bazel build //runsc
INFO: Analyzed target //runsc:runsc (136 packages loaded, 1439 targets
configured).
INFO: Found 1 target...
ERROR:
/home/kevin/.cache/bazel/_bazel_kevin/1e8a83d50be5720dda2541785a340423/external/com_google_protobuf/BUILD:117:1:
undeclared inclusion(s) in rule '@com_google_protobuf//:protobuf_lite':
this rule is missing dependency declarations for the following files
included by
'external/com_google_protobuf/src/google/protobuf/stubs/stringpiece.cc':
  '/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/include/stddef.h'
  '/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/include/stdarg.h'
  '/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/include/stdint.h'
  '/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/include-fixed/limits.h'
  '/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/include-fixed/syslimits.h'
Target //runsc:runsc failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 6.805s, Critical Path: 1.00s
INFO: 0 processes.
FAILED: Build did NOT complete successfully