### PR TITLE
Added Support for "ICMP Time-to-Live exceeded Error message" 

### DIFF
--- a/pkg/tcpip/network/fragmentation/BUILD
+++ b/pkg/tcpip/network/fragmentation/BUILD
@@ -30,6 +30,8 @@ go_library(
         "//pkg/log",
         "//pkg/tcpip",
         "//pkg/tcpip/buffer",
+        "//pkg/tcpip/stack",
+        "//pkg/tcpip/header",
     ],
 )
 

--- a/pkg/tcpip/network/ipv4/BUILD
+++ b/pkg/tcpip/network/ipv4/BUILD
@@ -24,7 +24,10 @@ go_library(
 go_test(
     name = "ipv4_test",
     size = "small",
-    srcs = ["ipv4_test.go"],
+    srcs = [
+        "ipv4_test.go",
+        "ipv4_frag_test.go",
+    ],
     deps = [
         "//pkg/tcpip",
         "//pkg/tcpip/buffer",
@@ -32,6 +35,7 @@ go_test(
         "//pkg/tcpip/link/channel",
         "//pkg/tcpip/link/sniffer",
         "//pkg/tcpip/network/ipv4",
+        "//pkg/tcpip/network/fragmentation",
         "//pkg/tcpip/stack",
         "//pkg/tcpip/transport/tcp",
         "//pkg/tcpip/transport/udp",

--- a/pkg/tcpip/network/ipv4/ipv4.go
+++ b/pkg/tcpip/network/ipv4/ipv4.go
@@ -376,7 +376,7 @@ func (e *endpoint) HandlePacket(r *stack.Route, pkt tcpip.PacketBuffer) {
 		}
 		var ready bool
 		var err error
-		pkt.Data, ready, err = e.fragmentation.Process(hash.IPv4FragmentHash(h), h.FragmentOffset(), last, more, pkt.Data)
+		pkt.Data, ready, err = e.fragmentation.Process(hash.IPv4FragmentHash(h), h.FragmentOffset(), last, more, pkt.Data, headerView, r)
 		if err != nil {
 			r.Stats().IP.MalformedPacketsReceived.Increment()
 			r.Stats().IP.MalformedFragmentsReceived.Increment()

--- a/pkg/tcpip/network/ipv4/ipv4_frag_test.go
+++ b/pkg/tcpip/network/ipv4/ipv4_frag_test.go
@@ -1,0 +1,136 @@
+// Copyright 2019 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipv4_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/network/fragmentation"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+const (
+	lladdr0 = tcpip.Address("\x10\x00\x00\x01")
+	lladdr1 = tcpip.Address("\x10\x00\x00\x02")
+)
+
+const (
+	// defaultMTU is the loopback MTU value
+	defaultMTU = 65536
+)
+
+type stubLinkEndpoint struct {
+	stack.LinkEndpoint
+}
+
+func (*stubLinkEndpoint) Capabilities() stack.LinkEndpointCapabilities {
+	return 0
+}
+
+func (*stubLinkEndpoint) MaxHeaderLength() uint16 {
+	return 0
+}
+
+func (*stubLinkEndpoint) LinkAddress() tcpip.LinkAddress {
+	return ""
+}
+
+func (*stubLinkEndpoint) WritePacket(*stack.Route, *stack.GSO, tcpip.NetworkProtocolNumber, tcpip.PacketBuffer) *tcpip.Error {
+	return nil
+}
+
+func (*stubLinkEndpoint) Attach(stack.NetworkDispatcher) {
+}
+
+// MTU implements stack.LinkEndpoint.MTU. It just returns a constant that
+// matches the linux loopback MTU.
+func (*stubLinkEndpoint) MTU() uint32 {
+	return defaultMTU
+}
+
+// vv is a helper to build VectorisedView from different strings.
+func vv(size int, pieces ...string) buffer.VectorisedView {
+	views := make([]buffer.View, len(pieces))
+	for i, p := range pieces {
+		views[i] = []byte(p)
+	}
+	return buffer.NewVectorisedView(size, views)
+}
+
+func TestReassemblingTimeout(t *testing.T) {
+	s := stack.New(stack.Options{
+		NetworkProtocols: []stack.NetworkProtocol{ipv4.NewProtocol()},
+	})
+	{
+		if err := s.CreateNIC(1, &stubLinkEndpoint{}); err != nil {
+			t.Fatalf("CreateNIC(_) = %s", err)
+		}
+		if err := s.AddAddress(1, ipv4.ProtocolNumber, lladdr0); err != nil {
+			t.Fatalf("AddAddress(_, %d, %s) = %s", ipv4.ProtocolNumber, lladdr0, err)
+		}
+	}
+	{
+		subnet, err := tcpip.NewSubnet(lladdr1, tcpip.AddressMask(strings.Repeat("\xff", len(lladdr1))))
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.SetRouteTable(
+			[]tcpip.Route{{
+				Destination: subnet,
+				NIC:         1,
+			}},
+		)
+	}
+
+	ra, err := s.FindRoute(1, lladdr0, lladdr1, ipv4.ProtocolNumber, false /* multicastLoop */)
+	if err != nil {
+		t.Fatalf("FindRoute(_) = _, %s, want = _, nil", err)
+	}
+	defer ra.Release()
+
+	totalLen := header.IPv4MinimumSize
+	view := buffer.NewView(totalLen)
+	ip := header.IPv4(view)
+	ip.Encode(&header.IPv4Fields{
+		IHL:         header.IPv4MinimumSize,
+		TotalLength: uint16(totalLen),
+		TTL:         20,
+		Protocol:    10,
+		SrcAddr:     lladdr1,
+		DstAddr:     lladdr0,
+	})
+
+	v1 := view.ToVectorisedView()
+	f := fragmentation.NewFragmentation(1024, 512, time.Second)
+	// Send first fragment with id = 0, first = 0, last = 0, and more = true.
+	f.Process(0, 0, 0, true, vv(1, "0"), v1.First(), &ra)
+	// Sleep more than the timeout.
+	time.Sleep(31 * time.Second)
+	// Send another fragment that completes a packet.
+	// However, no packet should be reassembled because the fragment arrived after the timeout.
+	_, done, err1 := f.Process(0, 1, 1, false, vv(1, "1"), v1.First(), &ra)
+	if err1 != nil {
+		t.Fatalf("f.Process(0, 1, 1, false, vv(1, \"1\")) failed: %v", err1)
+	}
+	if done {
+		t.Errorf("Fragmentation does not respect the reassembling timeout.")
+	}
+}


### PR DESCRIPTION
Added Support for "ICMP Time-to-Live exceeded Error message" while processing ipv4 fragmented datagrams.

Problem Statement: Whenever IP reassembly of IPv4 fragements exceed reassembly time (usually 30sec), It's expected to send an ICMP Error message corresponding to ID of ipv4 fragment that's not received
As per rfc, "ICMP Time-to-Live exceeded Error message (fragment reassembly time exceeded)" should be received

This issue was observed on latest fuchsia code base (commit id : 47a4161aaaa0356001fe7f2932b44cce3534b55f, date : Nov 4), verified on INTEL NUC

Root-cause:
In latest code base of fuchsia, changes to generate "ICMP Time-to-Live exceeded Error message" was not taken care while handling ipv4 datagram fragments

Solution:
If any fragmented ipv4 datagram arrives, Fuchsia Device should check whether the fragment belongs to the same ID (Identification field in ipv4 header) is received within reassembly time (usually 30 sec). If it is not received, we made code changes to take care of generating ICMP error message to notify the sender.

Details of code changes:

File modified : //pkg/tcpip/network/fragmentation/reassembler.go

a) In ipv4 fragment handler,
   -> Start a timer
   -> Invoke a newly added goroutine that will take care of,
	-> notifying after reassembly time (30 sec) expires
	-> Checking whether any fragment is missed or not
	-> If any fragment is missed, Timeout handler gets invoked that generates ICMP Error message.

b) Also, to generate ICMP error message in TimeOut handler, we need details of stack route and IP header. For this, we are passing two more
   arguments in reassembly process function
      -> One of the argument is of type *stack.Route, used to call WritePacket
      -> And one more is of the type buffer.View, used to extract IP header

Testing:

1) We verified our changes on INTEL NUC
   INTEL_NUC   (Fuchsia)   -----  Host_Machine (traffic generator)

   Generate a single fragment (MF bit set) and sent to DUT. Verified that DUT sends a ICMP error message, as it won't receive no more ipv4 fragments from host machine

2) Created ipv4_frag_test.go to generate a Fragmented datagram and verified ICMP TTL error message is received

[0001-Added-Support-for-ICMP-Time-to-Live-exceeded-Error-m.txt](https://github.com/google/gvisor/files/3982014/0001-Added-Support-for-ICMP-Time-to-Live-exceeded-Error-m.txt)

