### PR TITLE
passed the kvm test case of "TestKernelFault" on Arm64 platform

### DIFF
--- a/pkg/sentry/platform/ring0/entry_arm64.s
+++ b/pkg/sentry/platform/ring0/entry_arm64.s
@@ -385,6 +385,16 @@ TEXT ·El1_sync(SB),NOSPLIT,$0
 	B el1_invalid
 
 el1_da:
+	WORD $0xd538d092     //MRS   TPIDR_EL1, R18
+	WORD $0xd538601a     //MRS   FAR_EL1, R26
+
+	MOVD R26, CPU_FAULT_ADDR(RSV_REG)
+
+	MOVD $0, CPU_ERROR_TYPE(RSV_REG)
+
+	MOVD $PageFault, R3
+	MOVD R3, CPU_VECTOR_CODE(RSV_REG)
+
 	B ·Halt(SB)
 
 el1_ia:


### PR DESCRIPTION
For test case "TestKernelFault", memory-fault in guest kernel level will be trapped in el1_da. 
And in el1_da, we use mmio_exit to leave the KVM guest.

Signed-off-by: Bin Lu <bin.lu@arm.com>