### PR TITLE
passed the kvm test case of "TestApplicationFault" on Arm64 platform

### DIFF
--- a/pkg/sentry/platform/ring0/entry_arm64.s
+++ b/pkg/sentry/platform/ring0/entry_arm64.s
@@ -444,6 +444,17 @@ el0_svc:
 	B ·Halt(SB)
 
 el0_da:
+	WORD $0xd538d092     //MRS   TPIDR_EL1, R18
+	WORD $0xd538601a     //MRS   FAR_EL1, R26
+
+	MOVD R26, CPU_FAULT_ADDR(RSV_REG)
+
+	MOVD $1, R3
+	MOVD R3, CPU_ERROR_TYPE(RSV_REG) // Set error type to user.
+
+	MOVD $PageFault, R3
+	MOVD R3, CPU_VECTOR_CODE(RSV_REG)
+
 	B ·Halt(SB)
 
 el0_ia:


### PR DESCRIPTION
For test case "TestApplicationFault",
Memory-fault in guest user level will be trapped in el0_da.
And in el0_da, we use mmio_exit to leave the KVM guest.

Signed-off-by: Bin Lu <bin.lu@arm.com>