### PR TITLE
Fix deadlock in overlay bind

### DIFF
--- a/pkg/sentry/fs/inode_overlay.go
+++ b/pkg/sentry/fs/inode_overlay.go
@@ -436,7 +436,7 @@ func overlayRename(ctx context.Context, o *overlayEntry, oldParent *Dirent, rena
 }
 
 func overlayBind(ctx context.Context, o *overlayEntry, parent *Dirent, name string, data transport.BoundEndpoint, perm FilePermissions) (*Dirent, error) {
-	if err := copyUp(ctx, parent); err != nil {
+	if err := copyUpLockedForRename(ctx, parent); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Copy up parent when binding UDS on overlayfs is supported in commit
02ab1f187cd24c67b754b004229421d189cee264.
But the using of copyUp in overlayBind will cause sentry stuck, reason
is dead lock in renameMu.

1 [Process A] Invoke a Unix socket bind operation
  renameMu is hold in fs.(*Dirent).genericCreate by process A
2 [Process B] Invoke a read syscall on /proc/task/mounts
  waitng on Lock of renameMu in fs.(*MountNamespace).FindMount
3 [Process A] Continue Unix socket bind operation
  wating on RLock of renameMu in fs.copyUp

Root cause is recursive reading lock of reanmeMu in bind call trace,
if there are writing lock between the two reading lock, then deadlock
occured.

Fixes #1397