### PR TITLE
Add test/util/save_util_linux.cc:MaybeSave to support arm64

### DIFF
--- a/test/util/save_util_linux.cc
+++ b/test/util/save_util_linux.cc
@@ -18,13 +18,25 @@
 
 #include "test/util/save_util.h"
 
+#if defined(__x86_64__) || defined(__i386__)
+#define SYS_TRIGGER_SAVE SYS_create_module
+#elif defined(__aarch64__)
+#define SYS_TRIGGER_SAVE SYS_finit_module
+#else
+#error "Unknown architecture"
+#endif
+
 namespace gvisor {
 namespace testing {
 
 void MaybeSave() {
   if (internal::ShouldSave()) {
     int orig_errno = errno;
-    syscall(SYS_create_module, nullptr, 0);
+    // We use it to trigger saving the sentry state
+    // when this syscall is called.
+    // Notice: this needs to be a valid syscall
+    // that is not used in any of the syscall tests.
+    syscall(SYS_TRIGGER_SAVE, nullptr, 0);
     errno = orig_errno;
   }
 }


### PR DESCRIPTION
There is no syscall_create_module on Arm64.
And the errno also can be set as ENOSYS by syscall(-1) on amd64/arm64.
So, syscall_create_module can be replaced by syscall(-1) in my opinion.

My test command:
bazel test --test_tag_filters=runsc_ptrace //test/syscalls/... --test_output=streamed --action_env=GVISOR_COOPERATIVE_SAVE_TEST=1

Signed-off-by: Bin Lu <bin.lu@arm.com>