### PR TITLE
slight changes to ring0&pagetables for Arm64

### DIFF
--- a/pkg/sentry/platform/ring0/entry_arm64.s
+++ b/pkg/sentry/platform/ring0/entry_arm64.s
@@ -554,6 +554,10 @@ TEXT ·Vectors(SB),NOSPLIT,$0
 	B ·El0_error_invalid(SB)
 	nop31Instructions()
 
+	// The exception-vector-table is required to be 11-bits aligned.
+	// Please see Linux source code as reference: arch/arm64/kernel/entry.s.
+	// For gvisor, I defined it as 4K in length, filled the 2nd 2K part with NOPs.
+	// So that, I can safely move the 1st 2K part into the address with 11-bits alignment.
 	WORD $0xd503201f	//nop
 	nop31Instructions()
 	WORD $0xd503201f

--- a/pkg/sentry/platform/ring0/lib_arm64.s
+++ b/pkg/sentry/platform/ring0/lib_arm64.s
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "funcdata.h"
+#include "textflag.h"
+
 TEXT ·CPACREL1(SB),NOSPLIT,$0-8
 	WORD $0xd5381041 	// MRS CPACR_EL1, R1
 	MOVD R1, ret+0(FP)
 	RET
 
-TEXT ·FPCR(SB),NOSPLIT,$0-8
+TEXT ·GetFPCR(SB),NOSPLIT,$0-8
 	WORD $0xd53b4201    	// MRS NZCV, R1
 	MOVD R1, ret+0(FP)
 	RET
@@ -27,7 +30,7 @@ TEXT ·GetFPSR(SB),NOSPLIT,$0-8
 	MOVD R1, ret+0(FP)
 	RET
 
-TEXT ·FPCR(SB),NOSPLIT,$0-8
+TEXT ·SetFPCR(SB),NOSPLIT,$0-8
 	MOVD addr+0(FP), R1
 	WORD $0xd51b4201  	// MSR R1, NZCV
 	RET

--- a/pkg/sentry/platform/ring0/pagetables/BUILD
+++ b/pkg/sentry/platform/ring0/pagetables/BUILD
@@ -11,7 +11,10 @@ config_setting(
 
 go_template(
     name = "generic_walker",
-    srcs = ["walker_amd64.go"],
+    srcs = select({
+           ":aarch64": ["walker_arm64.go",],
+           "//conditions:default": ["walker_amd64.go",],
+    }),
     opt_types = [
         "Visitor",
     ],


### PR DESCRIPTION
There are 2 jobs have been finished in this patch:
1, a comment was added to explain the purpose of the extra NOPs in Vectors().
2, some merge errors were fixed.

Signed-off-by: Bin Lu <bin.lu@arm.com>