### PR TITLE
Fix race condition in shmat and shmctl

### DIFF
--- a/pkg/sentry/kernel/shm/shm.go
+++ b/pkg/sentry/kernel/shm/shm.go
@@ -522,7 +522,7 @@ type AttachOpts struct {
 func (s *Shm) ConfigureAttach(ctx context.Context, addr usermem.Addr, opts AttachOpts) (memmap.MMapOpts, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.pendingDestruction && s.ReadRefs() == 0 {
+	if s.pendingDestruction {
 		return memmap.MMapOpts{}, syserror.EIDRM
 	}
 


### PR DESCRIPTION
When two process operating the same share memory segment via shmat and shmctl,
race condition may happens, the process invoking shmat may operating the
segment deleted by shmctl, then cause sentry crash.

Task1 [shmget]Create share memory segment A
      [reference of segment is 0]
Task1 [shmctl]Destroy share memory segment A (before remove the key) [interrupted by Task2]
      [reference of segment is 0]
Task2 [shmget]Find share memory segment A
      [reference of segment is 0]
Task2 [shmat]Attach share memory segment A (before got segment lock) [interrupted by Task1]
      [reference of segment is 0]
Task1 [Continue] Destroy share memory segment A
      [reference of segment is -1]
Task2 [Continue] Attach share memory segment A
      panic when increment the ref of segment

Fixes #1513

Reported-by: antkaller+59c6639c08309a7e9669@antfin.com
Signed-off-by: Yong He <chenglang.hy@antfin.com>