### PR TITLE
Hold taskset.mu when getting tty

### DIFF
--- a/pkg/sentry/kernel/tty.go
+++ b/pkg/sentry/kernel/tty.go
@@ -33,6 +33,8 @@ type TTY struct {
 // TTY returns the thread group's controlling terminal. If nil, there is no
 // controlling terminal.
 func (tg *ThreadGroup) TTY() *TTY {
+	tg.pidns.owner.mu.RLock()
+	defer tg.pidns.owner.mu.RUnlock()
 	tg.signalHandlers.mu.Lock()
 	defer tg.signalHandlers.mu.Unlock()
 	return tg.tty


### PR DESCRIPTION
If we don't hold taskset.mu in TTY(), it may cause a "unlock of
unlocked mutex" problem, since signalHandlers may be replaced by
CopyForExec() in runSyscallAfterExecStop after TTY() holds the
signalHandlers.mu.

The problem is easy to recur with keeping to do "runsc ps".

The crash log is :

```
fatal error: sync: unlock of unlocked mutex

goroutine 5801304 [running]:
runtime.throw(0xfd019c, 0x1e)
        GOROOT/src/runtime/panic.go:774 +0x72 fp=0xc001ba47b0 sp=0xc001ba4780 pc=0x431702
sync.throw(0xfd019c, 0x1e)
        GOROOT/src/runtime/panic.go:760 +0x35 fp=0xc001ba47d0 sp=0xc001ba47b0 pc=0x431685
sync.(*Mutex).unlockSlow(0xc00cf94a30, 0xc0ffffffff)
        GOROOT/src/sync/mutex.go:196 +0xd6 fp=0xc001ba47f8 sp=0xc001ba47d0 pc=0x4707d6
sync.(*Mutex).Unlock(0xc00cf94a30)
        GOROOT/src/sync/mutex.go:190 +0x48 fp=0xc001ba4818 sp=0xc001ba47f8 pc=0x4706e8
gvisor.dev/gvisor/pkg/sentry/kernel.(*ThreadGroup).TTY(0xc011a9e800, 0x0)
        pkg/sentry/kernel/tty.go:38 +0x88 fp=0xc001ba4868 sp=0xc001ba4818 pc=0x835fa8
gvisor.dev/gvisor/pkg/sentry/control.Processes(0xc00025ae00, 0xc013e397c0, 0x40, 0xc0137b9800, 0x1, 0x7f292e9a4cc0)
        pkg/sentry/control/proc.go:366 +0x355 fp=0xc001ba49a0 sp=0xc001ba4868 pc=0x9ac4a5
gvisor.dev/gvisor/runsc/boot.(*containerManager).Processes(0xc0003b62c0, 0xc0051423d0, 0xc0137b9800, 0x0, 0x0)
        runsc/boot/controller.go:228 +0xdf fp=0xc001ba49e8 sp=0xc001ba49a0 pc=0xaf06cf
runtime.call64(0xc0091d4a50, 0xc0000dea90, 0xc0053000c0, 0x1800000028)
```

Signed-off-by: chris.zn <chris.zn@antfin.com>