### PR TITLE
Enable fault() syscall test on arm64.

### DIFF
--- a/test/syscalls/linux/fault.cc
+++ b/test/syscalls/linux/fault.cc
@@ -37,6 +37,9 @@ int GetPcFromUcontext(ucontext_t* uc, uintptr_t* pc) {
 #elif defined(__i386__)
   *pc = uc->uc_mcontext.gregs[REG_EIP];
   return 1;
+#elif defined(__aarch64__)
+  *pc = uc->uc_mcontext.pc;
+  return 1;
 #else
   return 0;
 #endif


### PR DESCRIPTION
Signed-off-by: Haibo Xu <haibo.xu@arm.com>
Change-Id: I9b2b2e0d84946c10cf136abeef6c60642fa3b6ec