### PR TITLE
gonet PacketConn.RemoteAddr() incorrectly returns *net.TCPAddr, shouldd be *net.UDPAddr

### DIFF
--- a/pkg/tcpip/adapters/gonet/gonet.go
+++ b/pkg/tcpip/adapters/gonet/gonet.go
@@ -622,7 +622,7 @@ func (c *PacketConn) RemoteAddr() net.Addr {
 	if err != nil {
 		return nil
 	}
-	return fullToTCPAddr(a)
+	return fullToUDPAddr(a)
 }
 
 // Read implements net.Conn.Read


### PR DESCRIPTION

PacketConn.LocalAddr() already returns *net.UDPAddr correctly.