### PR TITLE
Expose gonet.NewPacketConn, for parity with gonet.NewConn API

### DIFF
--- a/pkg/tcpip/adapters/gonet/gonet.go
+++ b/pkg/tcpip/adapters/gonet/gonet.go
@@ -556,6 +556,17 @@ type PacketConn struct {
 	wq    *waiter.Queue
 }
 
+// NewPacketConn creates a new PacketConn.
+func NewPacketConn(s *stack.Stack, wq *waiter.Queue, ep tcpip.Endpoint) *PacketConn {
+	c := &PacketConn{
+		stack: s,
+		ep:    ep,
+		wq:    wq,
+	}
+	c.deadlineTimer.init()
+	return c
+}
+
 // DialUDP creates a new PacketConn.
 //
 // If laddr is nil, a local address is automatically chosen.


### PR DESCRIPTION
gonet.Conn can be created with both gonet.NewConn and gonet.Dial.
gonet.PacketConn was created only by gonet.DialUDP. This prevented
us from being able to use PacketConn in udp.NewForwarder() context.

This simple constructor - NewPacketConn, allows user to create
correct structure from that context.