### PR TITLE
Cross-compile gvsior for arm64 cpp

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -58,3 +58,7 @@ build:results-local --spawn_strategy=local
 build:results-local --remote_cache=remotebuildexecution.googleapis.com
 build:results-local --remote_timeout=3600
 build:results-local --bes_results_url="https://source.cloud.google.com/results/invocations/"
+
+# Set flags for aarch64.
+build:aarch64 --crosstool_top=@crosstool//:toolchains
+build:aarch64 --cpu=aarch64

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -330,3 +330,15 @@ http_archive(
         "https://github.com/google/googletest/archive/565f1b848215b77c3732bca345fe76a0431d8b34.tar.gz",
     ],
 )
+
+http_archive(
+    name = "coral_crosstool",
+    sha256 = "75e177abc39a2a283b61077a0c2f9934394c95393fda9d8629a0e5a83b7bb929",
+    strip_prefix = "crosstool-edf312a5a0a31bbdfb0e204d3ed77394ea723812",
+    urls = [
+        "https://github.com/google-coral/crosstool/archive/edf312a5a0a31bbdfb0e204d3ed77394ea723812.tar.gz",
+    ],
+)
+
+load("@coral_crosstool//:configure.bzl", "cc_crosstool")
+cc_crosstool(name = "crosstool")


### PR DESCRIPTION
Signed-off-by: Bin Lu <bin.lu@arm.com>

My test steps:
1, apt-get install -y build-essential crossbuild-essential-arm64
2, bazel build --config=aarch64 //vdso:vdso
3, check
root@entos-dell:/go/src/gvisor.dev/gvisor# file bazel-bin/vdso/vdso.so
bazel-bin/vdso/vdso.so: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=2e6fd24a3b166da9a6b240bf3288e8828135b1f1, not stripped
