### PR TITLE
Fix udp_socket test build issue on arm64.

### DIFF
--- a/test/syscalls/linux/udp_socket_test_cases.cc
+++ b/test/syscalls/linux/udp_socket_test_cases.cc
@@ -33,6 +33,11 @@
 namespace gvisor {
 namespace testing {
 
+// In case build on some environment with old header file.
+#ifndef SIOCGSTAMP
+#define SIOCGSTAMP 0x8906
+#endif
+
 // Gets a pointer to the port component of the given address.
 uint16_t* Port(struct sockaddr_storage* addr) {
   switch (addr->ss_family) {


### PR DESCRIPTION
The SIOCGSTAMP macro was missing on some arm64 platform which
will result in build errors:
test/syscalls/linux/udp_socket_test_cases.cc:1263:25: error:
'SIOCGSTAMP' was not declared in this scope
   ASSERT_THAT(ioctl(s_, SIOCGSTAMP, &tv),
SyscallFailsWithErrno(ENOENT));

Signed-off-by: Haibo Xu <haibo.xu@arm.com>
Change-Id: I894655f55282308012d64afd54c88dabc014cada