### PR TITLE
Optimize revalidate for no-caching unstable attrs

### DIFF
--- a/pkg/sentry/fs/gofer/cache_policy.go
+++ b/pkg/sentry/fs/gofer/cache_policy.go
@@ -125,6 +125,12 @@ func (cp cachePolicy) revalidate(ctx context.Context, name string, parent, child
 		return true
 	}
 
+	// If we are not caching unstable attrs, then there is nothing to
+	// update on this inode.
+	if !cp.cacheUAttrs(child) {
+		return false
+	}
+
 	childIops, ok := child.InodeOperations.(*inodeOperations)
 	if !ok {
 		if _, ok := child.InodeOperations.(*fifo); ok {
@@ -153,12 +159,6 @@ func (cp cachePolicy) revalidate(ctx context.Context, name string, parent, child
 	// We must reload.
 	if qids[0].Path != childIops.fileState.key.Inode {
 		return true
-	}
-
-	// If we are not caching unstable attrs, then there is nothing to
-	// update on this inode.
-	if !cp.cacheUAttrs(child) {
-		return false
 	}
 
 	// Update the inode's cached unstable attrs.


### PR DESCRIPTION
In sentry, default cache policy for directory attached via 9p is set as
remote_revalidating, and gofer.cachePolicy.revalidate will try to update
unstable attribute of child inode, this is useless for directory and file
which attched with remote_revalidating via gofer.

This patch check cache poicy before getting attribute from gofer, skip the
useless transaction between gofer and sandbox.