### PR TITLE
Arm64 signal#1: add arch-specific feature into mm

### DIFF
--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -84,6 +84,7 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 		dumpability:        mm.dumpability,
 		aioManager:         aioManager{contexts: make(map[uint64]*AIOContext)},
 		sleepForActivation: mm.sleepForActivation,
+		vdsoSigReturnAddr : mm.vdsoSigReturnAddr,
 	}
 
 	// Copy vmas.

--- a/pkg/sentry/mm/metadata.go
+++ b/pkg/sentry/mm/metadata.go
@@ -167,3 +167,17 @@ func (mm *MemoryManager) SetExecutable(file fsbridge.File) {
 		orig.DecRef()
 	}
 }
+
+// VDSOSigReturn returns the address of vdso_sigreturn.
+func (mm *MemoryManager) VDSOSigReturn() uint64 {
+	mm.metadataMu.Lock()
+	defer mm.metadataMu.Unlock()
+	return mm.vdsoSigReturnAddr
+}
+
+// SetVDSOSigReturn sets the address of vdso_sigreturn.
+func (mm *MemoryManager) SetVDSOSigReturn(addr uint64) {
+	mm.metadataMu.Lock()
+	defer mm.metadataMu.Unlock()
+	mm.vdsoSigReturnAddr = addr
+}

--- a/pkg/sentry/mm/mm.go
+++ b/pkg/sentry/mm/mm.go
@@ -231,6 +231,9 @@ type MemoryManager struct {
 	// before trying to activate the address space. When set to true, delays in
 	// activation are not reported as stuck tasks by the watchdog.
 	sleepForActivation bool
+
+	// vdsoSigReturnAddr is the address of 'vdso_sigreturn'.
+	vdsoSigReturnAddr uint64
 }
 
 // vma represents a virtual memory area.


### PR DESCRIPTION
Store the arch-specific vdso features directly in the MemoryManager.

I stored the address of the VDSO_Sigreturn into MemoryManager directly.
So that, I can copy the address of vdso_sigreturn into R30 in setup_return().
This method is same with Linux cdoe.

Please see the linux code as reference:
https://github.com/torvalds/linux/blob/master/arch/arm64/kernel/signal.c#L735

Signed-off-by: Bin Lu <bin.lu@arm.com>
Related PR-s: 
Arm64 signal#2: VDSO support for signal #1818
Arm64 signal#3: signal support in arch module #1819
