### PR TITLE
Support pidns inode number

### DIFF
--- a/pkg/sentry/fs/proc/inode.go
+++ b/pkg/sentry/fs/proc/inode.go
@@ -134,4 +134,18 @@ func newProcInode(ctx context.Context, iops fs.InodeOperations, msrc *fs.MountSo
 	return fs.NewInode(ctx, iops, msrc, sattr)
 }
 
+// newProcNsInode creates a new inode from the given inode operations.
+func newProcNsInode(ctx context.Context, iops fs.InodeOperations, msrc *fs.MountSource, typ fs.InodeType, t *kernel.Task, inodeID uint64) *fs.Inode {
+	sattr := fs.StableAttr{
+		DeviceID:  device.ProcDevice.DeviceID(),
+		InodeID:   inodeID,
+		BlockSize: usermem.PageSize,
+		Type:      typ,
+	}
+	if t != nil {
+		iops = &taskOwnedInodeOps{iops, t}
+	}
+	return fs.NewInode(ctx, iops, msrc, sattr)
+}
+
 // LINT.ThenChange(../../fsimpl/proc/tasks.go)

--- a/pkg/sentry/kernel/task_start.go
+++ b/pkg/sentry/kernel/task_start.go
@@ -243,6 +243,11 @@ func (ts *TaskSet) assignTIDsLocked(t *Task) error {
 		}
 		allocatedTIDs = append(allocatedTIDs, allocatedTID{ns, tid})
 	}
+	if t.tg.pidns.tgids[t.tg] == 1 {
+		if rootns := t.k.RootPIDNamespace(); rootns != nil {
+			t.tg.pidns.inum = uint64(rootns.tids[t]) + 0xF0000000
+		}
+	}
 	return nil
 }
 

--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -169,6 +169,10 @@ type PIDNamespace struct {
 	// exiting indicates that the namespace's init process is exiting or has
 	// exited.
 	exiting bool
+
+	// inum is the 'inode number' of the pid namespace, inum is set as reaper
+	// process id in root pid namespace. The inum is immutable.
+	inum uint64
 }
 
 func newPIDNamespace(ts *TaskSet, parent *PIDNamespace, userns *auth.UserNamespace) *PIDNamespace {
@@ -468,4 +472,9 @@ func (t *Task) Parent() *Task {
 // dead, ThreadID returns 0.
 func (t *Task) ThreadID() ThreadID {
 	return t.tg.pidns.IDOfTask(t)
+}
+
+// Pidns returns task pid namespace inum.
+func (t *Task) Pidns() uint64 {
+	return t.tg.pidns.inum
 }


### PR DESCRIPTION
In sentry, pidns inode number of every process is set as differet inode
number. This will cause 'killall' can not stop process in the same pid
namespace.

Compared to linux implementation, all namespace inode number is under
IDR mangement (proc_alloc_inum in file fs/proc/generic.c and under idr
management in /lib/idr.c).

To support killall, we implement pid namespace inode number in a simple
way: set pid namespace inode number as reaper process id in root pid
namespace.