### PR TITLE
passed the syscall test case 'clock_getres' on Arm64 platform

### DIFF
--- a/vdso/vdso.cc
+++ b/vdso/vdso.cc
@@ -126,6 +126,10 @@ extern "C" int __kernel_clock_getres(clockid_t clock, struct timespec* res) {
     case CLOCK_REALTIME:
     case CLOCK_MONOTONIC:
     case CLOCK_BOOTTIME: {
+      if (res == nullptr) {
+        return 0;
+      }
+
       res->tv_sec = 0;
       res->tv_nsec = 1;
       break;


### PR DESCRIPTION
The glibc uses vdso to call getres on Arm64 platform.
Test command:
	bazel test //test/syscalls:clock_getres_test_runsc_ptrace

Signed-off-by: Bin Lu <bin.lu@arm.com>