### PR TITLE
Move seccomp ruleset for SYS_TIME to arch-specific file.

### DIFF
--- a/pkg/sentry/platform/ptrace/subprocess_arm64.go
+++ b/pkg/sentry/platform/ptrace/subprocess_arm64.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"syscall"
 
+	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/seccomp"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
@@ -160,6 +161,13 @@ func enableCpuidFault() {
 
 // appendArchSeccompRules append architecture specific seccomp rules when creating BPF program.
 // Ref attachedThread() for more detail.
-func appendArchSeccompRules(rules []seccomp.RuleSet) []seccomp.RuleSet {
+func appendArchSeccompRules(rules []seccomp.RuleSet, defaultAction linux.BPFAction) []seccomp.RuleSet {
+	rules = append(rules, seccomp.RuleSet{
+		Rules: seccomp.SyscallRules{
+			unix.SYS_GETCPU: {}, // No vsyscall support for SYS_GETCPU on arm64.
+		},
+		Action: linux.SECCOMP_RET_TRAP,
+	})
+
 	return rules
 }

--- a/pkg/sentry/platform/ptrace/subprocess_linux.go
+++ b/pkg/sentry/platform/ptrace/subprocess_linux.go
@@ -128,8 +128,6 @@ func attachedThread(flags uintptr, defaultAction linux.BPFAction) (*thread, erro
 		{
 			Rules: seccomp.SyscallRules{
 				syscall.SYS_GETTIMEOFDAY: {},
-				syscall.SYS_TIME:         {},
-				unix.SYS_GETCPU:          {}, // SYS_GETCPU was not defined in package syscall on amd64.
 			},
 			Action:   linux.SECCOMP_RET_TRAP,
 			Vsyscall: true,
@@ -173,9 +171,10 @@ func attachedThread(flags uintptr, defaultAction linux.BPFAction) (*thread, erro
 			},
 			Action: linux.SECCOMP_RET_ALLOW,
 		})
-
-		rules = appendArchSeccompRules(rules)
 	}
+
+	rules = appendArchSeccompRules(rules, defaultAction)
+
 	instrs, err := seccomp.BuildProgram(rules, defaultAction)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
System call time(2) is not supported on arm64.

Signed-off-by: Haibo Xu <haibo.xu@arm.com>
Change-Id: I658e1bc47e34977c8be50a4ad07deaaf543fe5ea