### PR TITLE
test/runner: use proper filters for test cases and benchmarks

### DIFF
--- a/test/runner/gtest/gtest.go
+++ b/test/runner/gtest/gtest.go
@@ -66,13 +66,12 @@ func (tc TestCase) Args() []string {
 	}
 	if tc.benchmark {
 		return []string{
-			fmt.Sprintf("%s=^$", filterTestFlag),
 			fmt.Sprintf("%s=^%s$", filterBenchmarkFlag, tc.Name),
+			fmt.Sprintf("%s=", filterTestFlag),
 		}
 	}
 	return []string{
-		fmt.Sprintf("%s=^%s$", filterTestFlag, tc.FullName()),
-		fmt.Sprintf("%s=^$", filterBenchmarkFlag),
+		fmt.Sprintf("%s=%s", filterTestFlag, tc.FullName()),
 	}
 }
 
@@ -146,6 +145,8 @@ func ParseTestCases(testBin string, benchmarks bool, extraArgs ...string) ([]Tes
 		}
 		return nil, fmt.Errorf("could not enumerate gtest benchmarks: %v\nstderr\n%s", err, exitErr.Stderr)
 	}
+
+	out = []byte(strings.Trim(string(out), "\n"))
 
 	// Parse benchmark output.
 	for _, line := range strings.Split(string(out), "\n") {

--- a/test/syscalls/linux/tuntap_hostinet.cc
+++ b/test/syscalls/linux/tuntap_hostinet.cc
@@ -26,6 +26,7 @@ namespace {
 
 TEST(TuntapHostInetTest, NoNetTun) {
   SKIP_IF(!IsRunningOnGvisor());
+  SKIP_IF(!IsRunningWithHostinet());
 
   struct stat statbuf;
   ASSERT_THAT(stat("/dev/net/tun", &statbuf), SyscallFailsWithErrno(ENOENT));


### PR DESCRIPTION
The benchmark_filter options accepts regex-s, but
the gtest-filter option accepts shell-like wildcards.

Fixes #2034

Signed-off-by: Andrei Vagin <avagin@gmail.com>