### PR TITLE
passed the syscall test case 'epoll' on Arm64 platform

### DIFF
--- a/pkg/sentry/syscalls/linux/BUILD
+++ b/pkg/sentry/syscalls/linux/BUILD
@@ -16,6 +16,8 @@ go_library(
         "sys_clone_amd64.go",
         "sys_clone_arm64.go",
         "sys_epoll.go",
+        "sys_epoll_amd64.go",
+        "sys_epoll_arm64.go",
         "sys_eventfd.go",
         "sys_file.go",
         "sys_futex.go",

--- a/pkg/sentry/syscalls/linux/sys_epoll_amd64.go
+++ b/pkg/sentry/syscalls/linux/sys_epoll_amd64.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build amd64 i386
+
+package linux
+
+import (
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/epoll"
+	"gvisor.dev/gvisor/pkg/syserror"
+	"gvisor.dev/gvisor/pkg/usermem"
+)
+
+// LINT.IfChange
+
+// copyOutEvents copies epoll events from the kernel to user memory.
+func copyOutEvents(t *kernel.Task, addr usermem.Addr, e []epoll.Event) error {
+	const itemLen = 12
+	buffLen := len(e) * itemLen
+	if _, ok := addr.AddLength(uint64(buffLen)); !ok {
+		return syserror.EFAULT
+	}
+
+	b := t.CopyScratchBuffer(buffLen)
+	for i := range e {
+		usermem.ByteOrder.PutUint32(b[i*itemLen:], e[i].Events)
+		usermem.ByteOrder.PutUint32(b[i*itemLen+4:], uint32(e[i].Data[0]))
+		usermem.ByteOrder.PutUint32(b[i*itemLen+8:], uint32(e[i].Data[1]))
+	}
+
+	if _, err := t.CopyOutBytes(addr, b); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LINT.ThenChange(vfs2/epoll.go)

--- a/pkg/sentry/syscalls/linux/sys_epoll_arm64.go
+++ b/pkg/sentry/syscalls/linux/sys_epoll_arm64.go
@@ -1,0 +1,50 @@
+// Copyright 2019 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build arm64
+
+package linux
+
+import (
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/epoll"
+	"gvisor.dev/gvisor/pkg/syserror"
+	"gvisor.dev/gvisor/pkg/usermem"
+)
+
+// LINT.IfChange
+
+// copyOutEvents copies epoll events from the kernel to user memory.
+func copyOutEvents(t *kernel.Task, addr usermem.Addr, e []epoll.Event) error {
+	const itemLen = 16
+	buffLen := len(e) * itemLen
+	if _, ok := addr.AddLength(uint64(buffLen)); !ok {
+		return syserror.EFAULT
+	}
+
+	b := t.CopyScratchBuffer(buffLen)
+	for i := range e {
+		usermem.ByteOrder.PutUint32(b[i*itemLen:], e[i].Events)
+		usermem.ByteOrder.PutUint32(b[i*itemLen+8:], uint32(e[i].Data[0]))
+		usermem.ByteOrder.PutUint32(b[i*itemLen+12:], uint32(e[i].Data[1]))
+	}
+
+	if _, err := t.CopyOutBytes(addr, b); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// LINT.ThenChange(vfs2/epoll.go)


### PR DESCRIPTION
EpollEvent in linux is not packed on Arm64.
Please see the linux code as reference:
In eventpoll.h
 #ifdef __x86_64__
 #define EPOLL_PACKED __attribute__((packed))
 #else
 #define EPOLL_PACKED
 #endif

Signed-off-by: Bin Lu <bin.lu@arm.com>