### PR TITLE
iptables: ready tests to be enabled in kokoro

### DIFF
--- a/scripts/iptables_tests.sh
+++ b/scripts/iptables_tests.sh
@@ -19,9 +19,12 @@ source $(dirname $0)/common.sh
 install_runsc_for_test iptables
 
 # Build the docker image for the test.
-run //test/iptables/runner-image --norun
+run //test/iptables/runner:runner-image --norun
 
-# TODO(gvisor.dev/issue/170): Also test this on runsc once iptables are better
-# supported
-test //test/iptables:iptables_test "--test_arg=--runtime=runc" \
+test //test/iptables:iptables_test \
+  "--test_arg=--runtime=runc" \
+  "--test_arg=--image=bazel/test/iptables/runner:runner-image"
+
+test //test/iptables:iptables_test \
+  "--test_arg=--runtime=runsc" \
   "--test_arg=--image=bazel/test/iptables/runner:runner-image"

--- a/test/iptables/filter_output.go
+++ b/test/iptables/filter_output.go
@@ -24,7 +24,8 @@ func init() {
 	RegisterTestCase(FilterOutputDropTCPSrcPort{})
 }
 
-// FilterOutputDropTCPDestPort tests that connections are not accepted on specified source ports.
+// FilterOutputDropTCPDestPort tests that connections are not accepted on
+// specified source ports.
 type FilterOutputDropTCPDestPort struct{}
 
 // Name implements TestCase.Name.
@@ -48,14 +49,15 @@ func (FilterOutputDropTCPDestPort) ContainerAction(ip net.IP) error {
 
 // LocalAction implements TestCase.LocalAction.
 func (FilterOutputDropTCPDestPort) LocalAction(ip net.IP) error {
-	if err := connectTCP(ip, acceptPort, dropPort, sendloopDuration); err == nil {
+	if err := connectTCP(ip, acceptPort, sendloopDuration); err == nil {
 		return fmt.Errorf("connection on port %d should not be accepted, but got accepted", dropPort)
 	}
 
 	return nil
 }
 
-// FilterOutputDropTCPSrcPort tests that connections are not accepted on specified source ports.
+// FilterOutputDropTCPSrcPort tests that connections are not accepted on
+// specified source ports.
 type FilterOutputDropTCPSrcPort struct{}
 
 // Name implements TestCase.Name.
@@ -79,7 +81,7 @@ func (FilterOutputDropTCPSrcPort) ContainerAction(ip net.IP) error {
 
 // LocalAction implements TestCase.LocalAction.
 func (FilterOutputDropTCPSrcPort) LocalAction(ip net.IP) error {
-	if err := connectTCP(ip, dropPort, acceptPort, sendloopDuration); err == nil {
+	if err := connectTCP(ip, dropPort, sendloopDuration); err == nil {
 		return fmt.Errorf("connection destined to port %d should not be accepted, but got accepted", dropPort)
 	}
 

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -191,24 +191,28 @@ func TestFilterInputDropOnlyUDP(t *testing.T) {
 }
 
 func TestNATRedirectUDPPort(t *testing.T) {
+	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	if err := singleTest(NATRedirectUDPPort{}); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestNATRedirectTCPPort(t *testing.T) {
+	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	if err := singleTest(NATRedirectTCPPort{}); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestNATDropUDP(t *testing.T) {
+	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	if err := singleTest(NATDropUDP{}); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestNATAcceptAll(t *testing.T) {
+	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	if err := singleTest(NATAcceptAll{}); err != nil {
 		t.Fatal(err)
 	}
@@ -251,12 +255,14 @@ func TestFilterInputReturnUnderflow(t *testing.T) {
 }
 
 func TestFilterOutputDropTCPDestPort(t *testing.T) {
+	t.Skip("filter OUTPUT isn't supported yet (gvisor.dev/issue/170).")
 	if err := singleTest(FilterOutputDropTCPDestPort{}); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestFilterOutputDropTCPSrcPort(t *testing.T) {
+	t.Skip("filter OUTPUT isn't supported yet (gvisor.dev/issue/170).")
 	if err := singleTest(FilterOutputDropTCPSrcPort{}); err != nil {
 		t.Fatal(err)
 	}

--- a/test/iptables/iptables_util.go
+++ b/test/iptables/iptables_util.go
@@ -125,26 +125,23 @@ func listenTCP(port int, timeout time.Duration) error {
 	return nil
 }
 
-// connectTCP connects the TCP server over specified local port, server IP and remote/server port.
-func connectTCP(ip net.IP, remotePort, localPort int, timeout time.Duration) error {
+// connectTCP connects to the given IP and port from an ephemeral local address.
+func connectTCP(ip net.IP, port int, timeout time.Duration) error {
 	contAddr := net.TCPAddr{
 		IP:   ip,
-		Port: remotePort,
+		Port: port,
 	}
 	// The container may not be listening when we first connect, so retry
 	// upon error.
 	callback := func() error {
-		localAddr := net.TCPAddr{
-			Port: localPort,
-		}
-		conn, err := net.DialTCP("tcp4", &localAddr, &contAddr)
+		conn, err := net.DialTCP("tcp4", nil, &contAddr)
 		if conn != nil {
 			conn.Close()
 		}
 		return err
 	}
 	if err := testutil.Poll(callback, timeout); err != nil {
-		return fmt.Errorf("timed out waiting to send IP, most recent error: %v", err)
+		return fmt.Errorf("timed out waiting to connect IP, most recent error: %v", err)
 	}
 
 	return nil

--- a/test/iptables/nat.go
+++ b/test/iptables/nat.go
@@ -76,7 +76,7 @@ func (NATRedirectTCPPort) ContainerAction(ip net.IP) error {
 
 // LocalAction implements TestCase.LocalAction.
 func (NATRedirectTCPPort) LocalAction(ip net.IP) error {
-	return connectTCP(ip, dropPort, acceptPort, sendloopDuration)
+	return connectTCP(ip, dropPort, sendloopDuration)
 }
 
 // NATDropUDP tests that packets are not received in ports other than redirect port.


### PR DESCRIPTION
Fixed flakes (tested via --runs_per_test=100) and added skips for
not-yet-implemented features. Once submitted, the iptables tests will be
ready to enable in kokoro.