### PR TITLE
Test Code for BugId-38899:11.28 and 38962-23.1

### DIFF
--- a/test/packetimpact/testbench/connections.go
+++ b/test/packetimpact/testbench/connections.go
@@ -36,6 +36,8 @@ var remoteIPv4 = flag.String("remote_ipv4", "", "remote IPv4 address for test pa
 var localMAC = flag.String("local_mac", "", "local mac address for test packets")
 var remoteMAC = flag.String("remote_mac", "", "remote mac address for test packets")
 
+var SetSameLocalRemoteIP = 0
+
 // TCPIPv4 maintains state about a TCP/IPv4 connection.
 type TCPIPv4 struct {
 	outgoing     Layers
@@ -95,6 +97,11 @@ func NewTCPIPv4(t *testing.T, dut DUT, outgoingTCP, incomingTCP TCP) TCPIPv4 {
 	if err != nil {
 		t.Fatalf("can't pick a port: %s", err)
 	}
+
+    if(SetSameLocalRemoteIP == 1) {
+        *localIPv4 = *remoteIPv4
+    }
+
 	lIP := tcpip.Address(net.ParseIP(*localIPv4).To4())
 	rIP := tcpip.Address(net.ParseIP(*remoteIPv4).To4())
 

--- a/test/packetimpact/tests/fin_wait2_reset_test.go
+++ b/test/packetimpact/tests/fin_wait2_reset_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fin_wait2_reset_test
+
+import (
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+	"testing"
+	"time"
+)
+
+func TestFinWait2_RST(t *testing.T) {
+	dut := tb.NewDUT(t)
+	listenFd, remotePort := dut.CreateListener(unix.SOCK_STREAM, unix.IPPROTO_TCP, 1)
+	defer dut.Close(listenFd)
+	conn := tb.NewTCPIPv4(t, dut, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+	defer conn.Close()
+	conn.Handshake()
+
+	acceptFd, _ := dut.Accept(listenFd)
+	tv := unix.Timeval{Sec: 1, Usec: 0}
+	dut.SetSockOptTimeval(acceptFd, unix.SOL_TCP, unix.TCP_LINGER2, &tv)
+	// Initiate Termination of Connection from DUT - Triggers FIN-ACK towards Test Bench.
+	dut.Close(acceptFd)
+
+	// Expecting FIN-ACK from DUT.
+	if gotOne := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagFin | header.TCPFlagAck)}, time.Second); gotOne == nil {
+		t.Fatal("expected a FIN-ACK within 1 second but got none")
+	}
+
+	// Send ACK to DUT.
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)})
+
+	// Send RST-ACK to DUT - This should initiate connection Termination at DUT
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck | header.TCPFlagRst)})
+	time.Sleep(3 * time.Second)
+
+	println("\nSent RST-ACK to DUT\nCheck the status of the connection by sending SYN to DUT\n")
+
+	// Send SYN to DUT for checking connection status.
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn)})
+
+	// Expecting SYN-ACK from DUT to confirm previous connection has been closed.
+	if gotOne := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn | header.TCPFlagAck)}, time.Second); gotOne == nil {
+		t.Fatal("expected a Syn-Ack packet but got Ack")
+	} else {
+		println("\nReceived SYN-ACK from DUT - confirms previous connection closure\n")
+	}
+}

--- a/test/packetimpact/tests/syn_with_same_ip_test.go
+++ b/test/packetimpact/tests/syn_with_same_ip_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syn_with_same_ip_test
+
+import (
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+	"testing"
+	"time"
+)
+
+func TestSynWithSameLocalRemoteIP(t *testing.T) {
+	dut := tb.NewDUT(t)
+	listenFd, remotePort := dut.CreateListener(unix.SOCK_STREAM, unix.IPPROTO_TCP, 1)
+	defer dut.Close(listenFd)
+
+	// Set flag to have same LocalIP Address as RemoteIP.
+	tb.SetSameLocalRemoteIP = 1
+
+	conn := tb.NewTCPIPv4(t, dut, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+	defer conn.Close()
+
+	// Send SYN to DUT.
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn)})//, tb.IPv4{SrcAddr: })
+
+	// Expecting No SYN-ACK from DUT.
+	if gotOne := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn | header.TCPFlagAck)}, 3*time.Second); gotOne != nil {
+		t.Fatal("expecting no SYN-ACK packet but got one")
+		// Clear flag before exiting.
+		tb.SetSameLocalRemoteIP = 0
+	} else {
+		println("\nNo response arrived from DUT\nVerifying that DUT is in the LISTEN state\nSending a TCP packet (SYN) without any option to DUT interface\n")
+		// Clear flag to have different LocalIP Address and RemoteIP.
+		tb.SetSameLocalRemoteIP = 0
+
+		conn = tb.NewTCPIPv4(t, dut, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+
+		// Send SYN to DUT.
+		conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn)})
+
+		// Expecting SYN-ACK from DUT
+		if gotOne := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn | header.TCPFlagAck)}, time.Second); gotOne == nil {
+			t.Fatal("received a SYN-ACK packet")
+		}
+	}
+}


### PR DESCRIPTION
GO Test Code:

**1) BugId-38899:11.28**
    test/packetimpact/tests/fin_wait2_reset_test.go

**2) BugId-38962-23.1**
    test/packetimpact/testbench/connections.go
    test/packetimpact/tests/syn_with_same_ip_test.go
