### PR TITLE
iptables: Mark OUTPUT tests as TODO

### DIFF
--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -228,10 +228,14 @@ func TestInputInvertDestination(t *testing.T) {
 }
 
 func TestOutputDestination(t *testing.T) {
+	// TODO(gvisor.dev/issue/170): Enable when supported.
+	t.Skip("OUTPUT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, FilterOutputDestination{})
 }
 
 func TestOutputInvertDestination(t *testing.T) {
+	// TODO(gvisor.dev/issue/170): Enable when supported.
+	t.Skip("OUTPUT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, FilterOutputInvertDestination{})
 }
 


### PR DESCRIPTION
These tests were erroneously passing because of an error writing
iptables rules. We now check explicitly that underflow rules and rules
in unsupported chains are truly unconditional (no machers, no IP
filter).