### PR TITLE
Elide WriteGS if the GS is already correct.

### DIFF
--- a/pkg/sentry/platform/ring0/defs_amd64.go
+++ b/pkg/sentry/platform/ring0/defs_amd64.go
@@ -102,6 +102,13 @@ type CPUArchState struct {
 
 	// tss is the CPU's task state.
 	tss TaskState64
+
+	// GS is the cached GS segment value.
+	//
+	// This is saved to avoid having to reset the GS segment on each
+	// transition. This is an expensive operation since the full pipeline
+	// must be flushed since the swapgs is still in progress.
+	GS uintptr
 }
 
 // ErrorCode returns the last error code.

--- a/pkg/sentry/platform/ring0/kernel_amd64.go
+++ b/pkg/sentry/platform/ring0/kernel_amd64.go
@@ -191,9 +191,12 @@ func (c *CPU) SwitchToUser(switchOpts SwitchOpts) (vector Vector) {
 	regs.Ss = uint64(Udata)   // Ditto.
 
 	// Perform the switch.
-	swapgs()                                         // GS will be swapped on return.
-	WriteFS(uintptr(regs.Fs_base))                   // Set application FS.
-	WriteGS(uintptr(regs.Gs_base))                   // Set application GS.
+	swapgs()                       // GS will be swapped on return.
+	WriteFS(uintptr(regs.Fs_base)) // Set application FS.
+	if c.GS != uintptr(regs.Gs_base) {
+		WriteGS(uintptr(regs.Gs_base)) // Set application GS.
+		c.GS = uintptr(regs.Gs_base)   // Save cached value.
+	}
 	LoadFloatingPoint(switchOpts.FloatingPointState) // Copy in floating point.
 	jumpToKernel()                                   // Switch to upper half.
 	writeCR3(uintptr(userCR3))                       // Change to user address space.


### PR DESCRIPTION
This caches the GS value in the ring0.CPU struct, in order to avoid a
full pipeline flush in the switch path.

Fixes #2010