### PR TITLE
Go Test Code for BugId-38962-TCP23.1

### DIFF
--- a/test/packetimpact/tests/BUILD
+++ b/test/packetimpact/tests/BUILD
@@ -28,6 +28,16 @@ packetimpact_go_test(
     ],
 )
 
+packetimpact_go_test(
+    name = "syn_with_same_ip",
+    srcs = ["syn_with_same_ip_test.go"],
+    deps = [
+        "//pkg/tcpip/header",
+        "//test/packetimpact/testbench",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
 sh_binary(
     name = "test_runner",
     srcs = ["test_runner.sh"],

--- a/test/packetimpact/tests/syn_with_same_ip_test.go
+++ b/test/packetimpact/tests/syn_with_same_ip_test.go
@@ -1,0 +1,57 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syn_with_same_ip_test
+
+import (
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+	"testing"
+	"time"
+)
+
+const ipv4LayerIndex int = 1
+
+func TestSynWithSameLocalRemoteIP(t *testing.T) {
+	dut := tb.NewDUT(t)
+	defer dut.TearDown()
+	listenFd, remotePort := dut.CreateListener(unix.SOCK_STREAM, unix.IPPROTO_TCP, 1)
+	defer dut.Close(listenFd)
+	conn := tb.NewTCPIPv4(t, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+	defer conn.Close()
+
+	frame := conn.CreateFrame(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn)})
+        frame[ipv4LayerIndex].(*tb.IPv4).SrcAddr = frame[ipv4LayerIndex].(*tb.IPv4).DstAddr
+        conn.SendFrame(frame)
+
+	// Expecting No SYN-ACK from DUT.
+	if gotOne := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn | header.TCPFlagAck)}, 3*time.Second); gotOne != nil {
+		t.Fatal("expecting no SYN-ACK packet but got one")
+	} else {
+		println("\nNo response arrived from DUT\n" +
+			"Verifying that DUT is in the LISTEN state\n" +
+			"Sending a TCP packet (SYN) without any option to DUT interface\n")
+
+		conn = tb.NewTCPIPv4(t, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+
+		// Send SYN to DUT.
+		conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn)})
+
+		// Expecting SYN-ACK from DUT
+		if gotOne := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn | header.TCPFlagAck)}, 3*time.Second); gotOne == nil {
+			t.Fatal("received a SYN-ACK packet")
+		}
+	}
+}


### PR DESCRIPTION
**Code changes for BugId-38962-TCP23.1**

source files changed:

	test/packetimpact/testbench/connections.go
	test/packetimpact/testbench/layers.go
	test/packetimpact/tests/BUILD
	test/packetimpact/tests/syn_with_same_ip_test.go

Performed tests and attached logs

[syn_with_same_ip_linux.log](https://github.com/google/gvisor/files/4393692/syn_with_same_ip_linux.log)
[syn_with_same_ip_netstack.log](https://github.com/google/gvisor/files/4393693/syn_with_same_ip_netstack.log)


-------------------------------------------
**March 30th:   Review comments are incorporated:** 

https://github.com/google/gvisor/pull/2273/commits/4a5441ae5661beb506fcba8fe1a1eb881312d70c

**Source files changed:**
test/packetimpact/testbench/connections.go
test/packetimpact/tests/BUILD
test/packetimpact/tests/syn_with_same_ip_test.go

* No change in file "test/packetimpact/testbench/layers.go"

**Tests:** 
Test logs attached

[PresubmitTests.txt](https://github.com/google/gvisor/files/4401804/PresubmitTests.txt)
[syn_with_same_ip_linux_test.txt](https://github.com/google/gvisor/files/4401806/syn_with_same_ip_linux_test.txt)
[syn_with_same_ip_netstack_test.txt](https://github.com/google/gvisor/files/4401807/syn_with_same_ip_netstack_test.txt)
