### PR TITLE
Support for connection tracking of TCP packets.

### DIFF
--- a/pkg/sentry/socket/netfilter/targets.go
+++ b/pkg/sentry/socket/netfilter/targets.go
@@ -15,6 +15,7 @@
 package netfilter
 
 import (
+	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
 
@@ -29,6 +30,6 @@ type JumpTarget struct {
 }
 
 // Action implements stack.Target.Action.
-func (jt JumpTarget) Action(stack.PacketBuffer) (stack.RuleVerdict, int) {
+func (jt JumpTarget) Action(*stack.PacketBuffer, *stack.ConnTrackTable, stack.Hook, *stack.GSO, *stack.Route, tcpip.Address) (stack.RuleVerdict, int) {
 	return stack.RuleJump, jt.RuleNum
 }

--- a/pkg/tcpip/header/tcp.go
+++ b/pkg/tcpip/header/tcp.go
@@ -594,3 +594,20 @@ func AddTCPOptionPadding(options []byte, offset int) int {
 	}
 	return paddingToAdd
 }
+
+// Acceptable checks if a segment that starts at segSeq and has length segLen is
+// "acceptable" for arriving in a receive window that starts at rcvNxt and ends
+// before rcvAcc, according to the table on page 26 and 69 of RFC 793.
+func Acceptable(segSeq seqnum.Value, segLen seqnum.Size, rcvNxt, rcvAcc seqnum.Value) bool {
+	if rcvNxt == rcvAcc {
+		return segLen == 0 && segSeq == rcvNxt
+	}
+	if segLen == 0 {
+		// rcvWnd is incremented by 1 because that is Linux's behavior despite the
+		// RFC.
+		return segSeq.InRange(rcvNxt, rcvAcc.Add(1))
+	}
+	// Page 70 of RFC 793 allows packets that can be made "acceptable" by trimming
+	// the payload, so we'll accept any payload that overlaps the receieve window.
+	return rcvNxt.LessThan(segSeq.Add(segLen)) && segSeq.LessThan(rcvAcc)
+}

--- a/pkg/tcpip/stack/BUILD
+++ b/pkg/tcpip/stack/BUILD
@@ -30,6 +30,7 @@ go_template_instance(
 go_library(
     name = "stack",
     srcs = [
+        "conntrack.go",
         "dhcpv6configurationfromndpra_string.go",
         "forwarder.go",
         "icmp_rate_limit.go",
@@ -62,6 +63,7 @@ go_library(
         "//pkg/tcpip/header",
         "//pkg/tcpip/ports",
         "//pkg/tcpip/seqnum",
+        "//pkg/tcpip/transport/tcpconntrack",
         "//pkg/waiter",
         "@org_golang_x_time//rate:go_default_library",
     ],

--- a/pkg/tcpip/stack/conntrack.go
+++ b/pkg/tcpip/stack/conntrack.go
@@ -1,0 +1,480 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"encoding/binary"
+	"sync"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip/hash/jenkins"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcpconntrack"
+)
+
+// Connection tracking is used to track and manipulate packets for NAT rules.
+// The connection is created for a packet if it does not exist. Every connection
+// contains two tuples (original and reply). The tuples are manipulated if there
+// is a matching NAT rule. The packet is modified by looking at the tuples in the
+// Prerouting and Output hooks.
+
+// Direction of the tuple.
+type ctDirection int
+
+const (
+	dirOriginal ctDirection = iota
+	dirReply
+)
+
+// Status of connection.
+// TODO(gvisor.dev/issue/170): Add other states of connection.
+type connStatus int
+
+const (
+	connNew connStatus = iota
+	connEstablished
+)
+
+// Manipulation type for the connection.
+type manipType int
+
+const (
+	manipDstPrerouting manipType = iota
+	manipDstOutput
+)
+
+// connTrackMutable is the manipulatable part of the tuple.
+type connTrackMutable struct {
+	// addr is source address of the tuple.
+	addr tcpip.Address
+
+	// port is source port of the tuple.
+	port uint16
+
+	// protocol is network layer protocol.
+	protocol tcpip.NetworkProtocolNumber
+}
+
+// connTrackImmutable is the non-manipulatable part of the tuple.
+type connTrackImmutable struct {
+	// addr is destination address of the tuple.
+	addr tcpip.Address
+
+	// direction is direction (original or reply) of the tuple.
+	direction ctDirection
+
+	// port is destination port of the tuple.
+	port uint16
+
+	// protocol is transport layer protocol.
+	protocol tcpip.TransportProtocolNumber
+}
+
+// connTrackTuple represents the tuple which is created from the
+// packet.
+type connTrackTuple struct {
+	// dst is non-manipulatable part of the tuple.
+	dst connTrackImmutable
+
+	// src is manipulatable part of the tuple.
+	src connTrackMutable
+}
+
+// connTrackTupleHolder is the container of tuple and connection.
+type ConnTrackTupleHolder struct {
+	// conn is pointer to the connection tracking entry.
+	conn *connTrack
+
+	// tuple is original or reply tuple.
+	tuple connTrackTuple
+}
+
+// connTrack is the connection.
+type connTrack struct {
+	// originalTupleHolder contains tuple in original direction.
+	originalTupleHolder ConnTrackTupleHolder
+
+	// replyTupleHolder contains tuple in reply direction.
+	replyTupleHolder ConnTrackTupleHolder
+
+	// status indicates connection is new or established.
+	status connStatus
+
+	// timeout indicates the time connection should be active.
+	timeout time.Duration
+
+	// manip indicates if the packet should be manipulated.
+	manip manipType
+
+	// tcb is TCB control block. It is used to keep track of states
+	// of tcp connection.
+	tcb tcpconntrack.TCB
+
+	// tcbHook indicates if the packet is inbound or outbound to
+	// update the state of tcb.
+	tcbHook Hook
+}
+
+// ConnTrackTable contains a map of all existing connections created for
+// NAT rules.
+type ConnTrackTable struct {
+	// connMu protects connTrackTable.
+	connMu sync.RWMutex
+
+	// connTrackTable maintains a map of tuples needed for connection tracking
+	// for iptables NAT rules. The key for the map is an integer calculated
+	// using seed, source address, destination address, source port and
+	// destination port.
+	CtMap map[uint32]ConnTrackTupleHolder
+
+	// seed is a one-time random value initialized at stack startup
+	// and is used in calculation of hash key for connection tracking
+	// table.
+	Seed uint32
+}
+
+// parseHeaders sets headers in the packet.
+func parseHeaders(pkt *PacketBuffer) {
+	newPkt := pkt.Clone()
+
+	// Set network header.
+	hdr, ok := newPkt.Data.PullUp(header.IPv4MinimumSize)
+	if !ok {
+		return
+	}
+	netHeader := header.IPv4(hdr)
+	newPkt.NetworkHeader = hdr
+	length := int(netHeader.HeaderLength())
+
+	// TODO(gvisor.dev/issue/170): Need to support for other
+	// protocols as well.
+	// Set transport header.
+	switch protocol := netHeader.TransportProtocol(); protocol {
+	case header.UDPProtocolNumber:
+		if newPkt.TransportHeader == nil {
+			h, ok := newPkt.Data.PullUp(length + header.UDPMinimumSize)
+			if !ok {
+				return
+			}
+			newPkt.TransportHeader = buffer.View(header.UDP(h[length:]))
+		}
+	case header.TCPProtocolNumber:
+		if newPkt.TransportHeader == nil {
+			h, ok := newPkt.Data.PullUp(length + header.TCPMinimumSize)
+			if !ok {
+				return
+			}
+			newPkt.TransportHeader = buffer.View(header.TCP(h[length:]))
+		}
+	}
+	pkt.NetworkHeader = newPkt.NetworkHeader
+	pkt.TransportHeader = newPkt.TransportHeader
+}
+
+// packetToTuple converts packet to a tuple in original direction.
+func packetToTuple(pkt PacketBuffer, hook Hook) (connTrackTuple, *tcpip.Error) {
+	var tuple connTrackTuple
+
+	netHeader := header.IPv4(pkt.NetworkHeader)
+	// TODO(gvisor.dev/issue/170): Need to support for other
+	// protocols as well.
+	if netHeader == nil || netHeader.TransportProtocol() != header.TCPProtocolNumber {
+		return tuple, tcpip.ErrUnknownProtocol
+	}
+	tcpHeader := header.TCP(pkt.TransportHeader)
+	if tcpHeader == nil {
+		return tuple, tcpip.ErrUnknownProtocol
+	}
+
+	tuple.src.addr = netHeader.SourceAddress()
+	tuple.src.port = tcpHeader.SourcePort()
+	tuple.src.protocol = header.IPv4ProtocolNumber
+
+	tuple.dst.addr = netHeader.DestinationAddress()
+	tuple.dst.port = tcpHeader.DestinationPort()
+	tuple.dst.protocol = netHeader.TransportProtocol()
+
+	return tuple, nil
+}
+
+// getReplyTuple creates reply tuple for the given tuple.
+func getReplyTuple(tuple connTrackTuple) connTrackTuple {
+	var replyTuple connTrackTuple
+	replyTuple.src.addr = tuple.dst.addr
+	replyTuple.src.port = tuple.dst.port
+	replyTuple.src.protocol = tuple.src.protocol
+	replyTuple.dst.addr = tuple.src.addr
+	replyTuple.dst.port = tuple.src.port
+	replyTuple.dst.protocol = tuple.dst.protocol
+	replyTuple.dst.direction = dirReply
+
+	return replyTuple
+}
+
+// makeNewConn creates new connection.
+func makeNewConn(tuple, replyTuple connTrackTuple) connTrack {
+	var conn connTrack
+	conn.status = connNew
+	conn.originalTupleHolder.tuple = tuple
+	conn.originalTupleHolder.conn = &conn
+	conn.replyTupleHolder.tuple = replyTuple
+	conn.replyTupleHolder.conn = &conn
+
+	return conn
+}
+
+// getTupleHash returns hash of the tuple. The fields used for
+// generating hash are seed (generated once for stack), source address,
+// destination address, source port and destination ports.
+func (ct *ConnTrackTable) getTupleHash(tuple connTrackTuple) uint32 {
+	h := jenkins.Sum32(ct.Seed)
+	h.Write([]byte(tuple.src.addr))
+	h.Write([]byte(tuple.dst.addr))
+	portBuf := make([]byte, 2)
+	binary.LittleEndian.PutUint16(portBuf, tuple.src.port)
+	h.Write([]byte(portBuf))
+	binary.LittleEndian.PutUint16(portBuf, tuple.dst.port)
+	h.Write([]byte(portBuf))
+
+	return h.Sum32()
+}
+
+// connTrackForPacket returns connTrack for packet.
+// TODO(gvisor.dev/issue/170): Only TCP packets are supported. Need to support other
+// transport protocols.
+func (ct *ConnTrackTable) connTrackForPacket(pkt *PacketBuffer, hook Hook, createConn bool) (*connTrack, ctDirection) {
+	if hook == Prerouting {
+		// Headers will not be set in Prerouting.
+		// TODO(gvisor.dev/issue/170): Change this after parsing headers
+		// code is added.
+		parseHeaders(pkt)
+	}
+
+	var dir ctDirection
+	tuple, err := packetToTuple(*pkt, hook)
+	if err != nil {
+		return nil, dir
+	}
+
+	ct.connMu.Lock()
+	defer ct.connMu.Unlock()
+
+	connTrackTable := ct.CtMap
+	hash := ct.getTupleHash(tuple)
+
+	var conn *connTrack
+	switch createConn {
+	case true:
+		// If connection does not exist for the hash, create a new
+		// connection.
+		replyTuple := getReplyTuple(tuple)
+		replyHash := ct.getTupleHash(replyTuple)
+		newConn := makeNewConn(tuple, replyTuple)
+		conn = &newConn
+
+		// Add tupleHolders to the map.
+		// TODO(gvisor.dev/issue/170): Need to support collisions using linked list.
+		ct.CtMap[hash] = conn.originalTupleHolder
+		ct.CtMap[replyHash] = conn.replyTupleHolder
+	default:
+		tupleHolder, ok := connTrackTable[hash]
+		if !ok {
+			return nil, dir
+		}
+
+		// If this is the reply of new connection, set the connection
+		// status as ESTABLISHED.
+		conn = tupleHolder.conn
+		if conn.status == connNew && tupleHolder.tuple.dst.direction == dirReply {
+			conn.status = connEstablished
+		}
+		if tupleHolder.conn == nil {
+			panic("tupleHolder has null connection tracking entry")
+		}
+
+		dir = tupleHolder.tuple.dst.direction
+	}
+	return conn, dir
+}
+
+// SetNatInfo will manipulate the tuples according to iptables NAT rules.
+func (ct *ConnTrackTable) SetNatInfo(pkt *PacketBuffer, rt RedirectTarget, hook Hook) {
+	// Get the connection. Connection is always created before this
+	// function is called.
+	conn, _ := ct.connTrackForPacket(pkt, hook, false)
+	if conn == nil {
+		panic("connection should be created to manipulate tuples.")
+	}
+	replyTuple := conn.replyTupleHolder.tuple
+	replyHash := ct.getTupleHash(replyTuple)
+
+	// TODO(gvisor.dev/issue/170): Support only redirect of ports. Need to
+	// support changing of address for Prerouting.
+
+	// Change the port as per the iptables rule. This tuple will be used
+	// to manipulate the packet in HandlePacket.
+	conn.replyTupleHolder.tuple.src.addr = rt.MinIP
+	conn.replyTupleHolder.tuple.src.port = rt.MinPort
+	newHash := ct.getTupleHash(conn.replyTupleHolder.tuple)
+
+	// Add the changed tuple to the map.
+	ct.connMu.Lock()
+	defer ct.connMu.Unlock()
+	ct.CtMap[newHash] = conn.replyTupleHolder
+	if hook == Output {
+		conn.replyTupleHolder.conn.manip = manipDstOutput
+	}
+
+	// Delete the old tuple.
+	delete(ct.CtMap, replyHash)
+}
+
+// handlePacketPrerouting manipulates ports for packets in Prerouting hook.
+// TODO(gvisor.dev/issue/170): Change address for Prerouting hook..
+func handlePacketPrerouting(pkt *PacketBuffer, conn *connTrack, dir ctDirection) {
+	netHeader := header.IPv4(pkt.NetworkHeader)
+	tcpHeader := header.TCP(pkt.TransportHeader)
+
+	// For prerouting redirection, packets going in the original direction
+	// have their destinations modified and replies have their sources
+	// modified.
+	switch dir {
+	case dirOriginal:
+		port := conn.replyTupleHolder.tuple.src.port
+		tcpHeader.SetDestinationPort(port)
+		netHeader.SetDestinationAddress(conn.replyTupleHolder.tuple.src.addr)
+	case dirReply:
+		port := conn.originalTupleHolder.tuple.dst.port
+		tcpHeader.SetSourcePort(port)
+		netHeader.SetSourceAddress(conn.originalTupleHolder.tuple.dst.addr)
+	}
+
+	netHeader.SetChecksum(0)
+	netHeader.SetChecksum(^netHeader.CalculateChecksum())
+}
+
+// handlePacketOutput manipulates ports for packets in Output hook.
+func handlePacketOutput(pkt *PacketBuffer, conn *connTrack, gso *GSO, r *Route, dir ctDirection) {
+	netHeader := header.IPv4(pkt.NetworkHeader)
+	tcpHeader := header.TCP(pkt.TransportHeader)
+
+	// For output redirection, packets going in the original direction
+	// have their destinations modified and replies have their sources
+	// modified. For prerouting redirection, we only reach this point
+	// when replying, so packet sources are modified.
+	if conn.manip == manipDstOutput && dir == dirOriginal {
+		port := conn.replyTupleHolder.tuple.src.port
+		tcpHeader.SetDestinationPort(port)
+		netHeader.SetDestinationAddress(conn.replyTupleHolder.tuple.src.addr)
+	} else {
+		port := conn.originalTupleHolder.tuple.dst.port
+		tcpHeader.SetSourcePort(port)
+		netHeader.SetSourceAddress(conn.originalTupleHolder.tuple.dst.addr)
+	}
+
+	// Calculate the TCP checksum and set it.
+	tcpHeader.SetChecksum(0)
+	hdr := &pkt.Header
+	length := uint16(pkt.Data.Size()+hdr.UsedLength()) - uint16(netHeader.HeaderLength())
+	xsum := r.PseudoHeaderChecksum(header.TCPProtocolNumber, length)
+	if gso != nil && gso.NeedsCsum {
+		tcpHeader.SetChecksum(xsum)
+	} else if r.Capabilities()&CapabilityTXChecksumOffload == 0 {
+		xsum = header.ChecksumVVWithOffset(pkt.Data, xsum, int(tcpHeader.DataOffset()), pkt.Data.Size())
+		tcpHeader.SetChecksum(^tcpHeader.CalculateChecksum(xsum))
+	}
+
+	netHeader.SetChecksum(0)
+	netHeader.SetChecksum(^netHeader.CalculateChecksum())
+}
+
+// HandlePacket will manipulate the port and address of the packet if the
+// connection exists.
+func (ct *ConnTrackTable) HandlePacket(pkt *PacketBuffer, hook Hook, gso *GSO, r *Route) {
+	if pkt.NatDone {
+		return
+	}
+
+	if hook != Prerouting && hook != Output {
+		return
+	}
+
+	conn, dir := ct.connTrackForPacket(pkt, hook, false)
+	// Connection or Rule not found for the packet.
+	if conn == nil {
+		return
+	}
+
+	netHeader := header.IPv4(pkt.NetworkHeader)
+	// TODO(gvisor.dev/issue/170): Need to support for other transport
+	// protocols as well.
+	if netHeader == nil || netHeader.TransportProtocol() != header.TCPProtocolNumber {
+		return
+	}
+
+	tcpHeader := header.TCP(pkt.TransportHeader)
+	if tcpHeader == nil {
+		return
+	}
+
+	switch hook {
+	case Prerouting:
+		handlePacketPrerouting(pkt, conn, dir)
+	case Output:
+		handlePacketOutput(pkt, conn, gso, r, dir)
+	}
+	pkt.NatDone = true
+
+	// Update the state of tcb.
+	// TODO(gvisor.dev/issue/170): Add support in tcpcontrack to handle
+	// other tcp states.
+	var st tcpconntrack.Result
+	if conn.tcb.IsEmpty() {
+		conn.tcb.Init(tcpHeader)
+		conn.tcbHook = hook
+	} else {
+		switch hook {
+		case conn.tcbHook:
+			st = conn.tcb.UpdateStateOutbound(tcpHeader)
+		default:
+			st = conn.tcb.UpdateStateInbound(tcpHeader)
+		}
+	}
+
+	// Delete conntrack if tcp connection is closed.
+	if st == tcpconntrack.ResultClosedByPeer || st == tcpconntrack.ResultClosedBySelf || st == tcpconntrack.ResultReset {
+		ct.deleteConnTrack(conn)
+	}
+}
+
+// deleteConnTrack deletes the connection.
+func (ct *ConnTrackTable) deleteConnTrack(conn *connTrack) {
+	if conn == nil {
+		return
+	}
+
+	tuple := conn.originalTupleHolder.tuple
+	hash := ct.getTupleHash(tuple)
+	replyTuple := conn.replyTupleHolder.tuple
+	replyHash := ct.getTupleHash(replyTuple)
+
+	ct.connMu.Lock()
+	defer ct.connMu.Unlock()
+
+	delete(ct.CtMap, hash)
+	delete(ct.CtMap, replyHash)
+}

--- a/pkg/tcpip/stack/iptables_types.go
+++ b/pkg/tcpip/stack/iptables_types.go
@@ -82,6 +82,8 @@ type IPTables struct {
 	// list is the order in which each table should be visited for that
 	// hook.
 	Priorities map[Hook][]string
+
+	connections ConnTrackTable
 }
 
 // A Table defines a set of chains and hooks into the network stack. It is
@@ -176,5 +178,5 @@ type Target interface {
 	// Action takes an action on the packet and returns a verdict on how
 	// traversal should (or should not) continue. If the return value is
 	// Jump, it also returns the index of the rule to jump to.
-	Action(packet PacketBuffer) (RuleVerdict, int)
+	Action(packet *PacketBuffer, connections *ConnTrackTable, hook Hook, gso *GSO, r *Route, address tcpip.Address) (RuleVerdict, int)
 }

--- a/pkg/tcpip/stack/nic.go
+++ b/pkg/tcpip/stack/nic.go
@@ -1230,8 +1230,10 @@ func (n *NIC) DeliverNetworkPacket(linkEP LinkEndpoint, remote, local tcpip.Link
 
 	// TODO(gvisor.dev/issue/170): Not supporting iptables for IPv6 yet.
 	if protocol == header.IPv4ProtocolNumber {
+		// iptables filtering.
 		ipt := n.stack.IPTables()
-		if ok := ipt.Check(Prerouting, pkt); !ok {
+		address := n.primaryAddress(protocol)
+		if ok := ipt.Check(Prerouting, &pkt, nil, nil, address.Address); !ok {
 			// iptables is telling us to drop the packet.
 			return
 		}

--- a/pkg/tcpip/stack/packet_buffer.go
+++ b/pkg/tcpip/stack/packet_buffer.go
@@ -72,6 +72,10 @@ type PacketBuffer struct {
 	EgressRoute           *Route
 	GSOOptions            *GSO
 	NetworkProtocolNumber tcpip.NetworkProtocolNumber
+
+	// NatDone indicates if the packet has been manipulated as per NAT
+	// iptables rule.
+	NatDone bool
 }
 
 // Clone makes a copy of pk. It clones the Data field, which creates a new

--- a/pkg/tcpip/stack/route.go
+++ b/pkg/tcpip/stack/route.go
@@ -261,3 +261,16 @@ func (r *Route) MakeLoopedRoute() Route {
 func (r *Route) Stack() *Stack {
 	return r.ref.stack()
 }
+
+// ReverseRoute returns new route with given source and destination address.
+func (r *Route) ReverseRoute(src tcpip.Address, dst tcpip.Address) Route {
+	return Route{
+		NetProto:          r.NetProto,
+		LocalAddress:      dst,
+		LocalLinkAddress:  r.RemoteLinkAddress,
+		RemoteAddress:     src,
+		RemoteLinkAddress: r.LocalLinkAddress,
+		ref:               r.ref,
+		Loop:              r.Loop,
+	}
+}

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -1885,3 +1885,22 @@ func generateRandInt64() int64 {
 	}
 	return v
 }
+
+// FindNetworkEndpoint returns the network endpoint for the given address.
+func (s *Stack) FindNetworkEndpoint(netProto tcpip.NetworkProtocolNumber, address tcpip.Address) (NetworkEndpoint, *tcpip.Error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, nic := range s.nics {
+		id := NetworkEndpointID{address}
+
+		if ref, ok := nic.mu.endpoints[id]; ok {
+			nic.mu.RLock()
+			defer nic.mu.RUnlock()
+
+			// An endpoint with this id exists, check if it can be used and return it.
+			return ref.ep, nil
+		}
+	}
+	return nil, tcpip.ErrBadAddress
+}

--- a/pkg/tcpip/transport/tcp/BUILD
+++ b/pkg/tcpip/transport/tcp/BUILD
@@ -115,7 +115,7 @@ go_test(
     size = "small",
     srcs = ["rcv_test.go"],
     deps = [
-        ":tcp",
+        "//pkg/tcpip/header",
         "//pkg/tcpip/seqnum",
     ],
 )

--- a/pkg/tcpip/transport/tcp/rcv.go
+++ b/pkg/tcpip/transport/tcp/rcv.go
@@ -70,24 +70,7 @@ func newReceiver(ep *endpoint, irs seqnum.Value, rcvWnd seqnum.Size, rcvWndScale
 // acceptable checks if the segment sequence number range is acceptable
 // according to the table on page 26 of RFC 793.
 func (r *receiver) acceptable(segSeq seqnum.Value, segLen seqnum.Size) bool {
-	return Acceptable(segSeq, segLen, r.rcvNxt, r.rcvAcc)
-}
-
-// Acceptable checks if a segment that starts at segSeq and has length segLen is
-// "acceptable" for arriving in a receive window that starts at rcvNxt and ends
-// before rcvAcc, according to the table on page 26 and 69 of RFC 793.
-func Acceptable(segSeq seqnum.Value, segLen seqnum.Size, rcvNxt, rcvAcc seqnum.Value) bool {
-	if rcvNxt == rcvAcc {
-		return segLen == 0 && segSeq == rcvNxt
-	}
-	if segLen == 0 {
-		// rcvWnd is incremented by 1 because that is Linux's behavior despite the
-		// RFC.
-		return segSeq.InRange(rcvNxt, rcvAcc.Add(1))
-	}
-	// Page 70 of RFC 793 allows packets that can be made "acceptable" by trimming
-	// the payload, so we'll accept any payload that overlaps the receieve window.
-	return rcvNxt.LessThan(segSeq.Add(segLen)) && segSeq.LessThan(rcvAcc)
+	return header.Acceptable(segSeq, segLen, r.rcvNxt, r.rcvAcc)
 }
 
 // getSendParams returns the parameters needed by the sender when building

--- a/pkg/tcpip/transport/tcp/rcv_test.go
+++ b/pkg/tcpip/transport/tcp/rcv_test.go
@@ -17,8 +17,8 @@ package rcv_test
 import (
 	"testing"
 
+	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/seqnum"
-	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 )
 
 func TestAcceptable(t *testing.T) {
@@ -67,8 +67,8 @@ func TestAcceptable(t *testing.T) {
 		{105, 2, 108, 108, false},
 		{105, 2, 109, 109, false},
 	} {
-		if got := tcp.Acceptable(tt.segSeq, tt.segLen, tt.rcvNxt, tt.rcvAcc); got != tt.want {
-			t.Errorf("tcp.Acceptable(%d, %d, %d, %d) = %t, want %t", tt.segSeq, tt.segLen, tt.rcvNxt, tt.rcvAcc, got, tt.want)
+		if got := header.Acceptable(tt.segSeq, tt.segLen, tt.rcvNxt, tt.rcvAcc); got != tt.want {
+			t.Errorf("header.Acceptable(%d, %d, %d, %d) = %t, want %t", tt.segSeq, tt.segLen, tt.rcvNxt, tt.rcvAcc, got, tt.want)
 		}
 	}
 }

--- a/pkg/tcpip/transport/tcpconntrack/BUILD
+++ b/pkg/tcpip/transport/tcpconntrack/BUILD
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//pkg/tcpip/header",
         "//pkg/tcpip/seqnum",
-        "//pkg/tcpip/transport/tcp",
     ],
 )
 

--- a/pkg/tcpip/transport/tcpconntrack/tcp_conntrack.go
+++ b/pkg/tcpip/transport/tcpconntrack/tcp_conntrack.go
@@ -20,7 +20,6 @@ package tcpconntrack
 import (
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/seqnum"
-	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 )
 
 // Result is returned when the state of a TCB is updated in response to an
@@ -312,7 +311,7 @@ type stream struct {
 // the window is zero, if it's a packet with no payload and sequence number
 // equal to una.
 func (s *stream) acceptable(segSeq seqnum.Value, segLen seqnum.Size) bool {
-	return tcp.Acceptable(segSeq, segLen, s.una, s.end)
+	return header.Acceptable(segSeq, segLen, s.una, s.end)
 }
 
 // closed determines if the stream has already been closed. This happens when
@@ -337,4 +336,17 @@ func logicalLen(tcp header.TCP) seqnum.Size {
 		l++
 	}
 	return l
+}
+
+// IsEmpty returns true if tcb is not initialized.
+func (t *TCB) IsEmpty() bool {
+	if t.inbound != (stream{}) || t.outbound != (stream{}) {
+		return false
+	}
+
+	if t.firstFin != nil || t.state != ResultDrop {
+		return false
+	}
+
+	return true
 }

--- a/test/iptables/filter_output.go
+++ b/test/iptables/filter_output.go
@@ -42,7 +42,7 @@ func (FilterOutputDropTCPDestPort) Name() string {
 
 // ContainerAction implements TestCase.ContainerAction.
 func (FilterOutputDropTCPDestPort) ContainerAction(ip net.IP) error {
-	if err := filterTable("-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", fmt.Sprintf("%d", dropPort), "-j", "DROP"); err != nil {
+	if err := filterTable("-A", "OUTPUT", "-p", "tcp", "-m", "tcp", "--dport", "1024:65535", "-j", "DROP"); err != nil {
 		return err
 	}
 

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -115,30 +115,6 @@ func TestFilterInputDropOnlyUDP(t *testing.T) {
 	singleTest(t, FilterInputDropOnlyUDP{})
 }
 
-func TestNATRedirectUDPPort(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
-	singleTest(t, NATRedirectUDPPort{})
-}
-
-func TestNATRedirectTCPPort(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
-	singleTest(t, NATRedirectTCPPort{})
-}
-
-func TestNATDropUDP(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
-	singleTest(t, NATDropUDP{})
-}
-
-func TestNATAcceptAll(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
-	singleTest(t, NATAcceptAll{})
-}
-
 func TestFilterInputDropTCPDestPort(t *testing.T) {
 	singleTest(t, FilterInputDropTCPDestPort{})
 }
@@ -164,14 +140,10 @@ func TestFilterInputReturnUnderflow(t *testing.T) {
 }
 
 func TestFilterOutputDropTCPDestPort(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("filter OUTPUT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, FilterOutputDropTCPDestPort{})
 }
 
 func TestFilterOutputDropTCPSrcPort(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("filter OUTPUT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, FilterOutputDropTCPSrcPort{})
 }
 
@@ -235,44 +207,54 @@ func TestOutputInvertDestination(t *testing.T) {
 	singleTest(t, FilterOutputInvertDestination{})
 }
 
+func TestNATPreRedirectUDPPort(t *testing.T) {
+	singleTest(t, NATPreRedirectUDPPort{})
+}
+
+func TestNATPreRedirectTCPPort(t *testing.T) {
+	singleTest(t, NATPreRedirectTCPPort{})
+}
+
+func TestNATOutRedirectUDPPort(t *testing.T) {
+	singleTest(t, NATOutRedirectUDPPort{})
+}
+
+func TestNATOutRedirectTCPPort(t *testing.T) {
+	singleTest(t, NATOutRedirectTCPPort{})
+}
+
+func TestNATDropUDP(t *testing.T) {
+	singleTest(t, NATDropUDP{})
+}
+
+func TestNATAcceptAll(t *testing.T) {
+	singleTest(t, NATAcceptAll{})
+}
+
 func TestNATOutRedirectIP(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, NATOutRedirectIP{})
 }
 
 func TestNATOutDontRedirectIP(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, NATOutDontRedirectIP{})
 }
 
 func TestNATOutRedirectInvert(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, NATOutRedirectInvert{})
 }
 
 func TestNATPreRedirectIP(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, NATPreRedirectIP{})
 }
 
 func TestNATPreDontRedirectIP(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, NATPreDontRedirectIP{})
 }
 
 func TestNATPreRedirectInvert(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, NATPreRedirectInvert{})
 }
 
 func TestNATRedirectRequiresProtocol(t *testing.T) {
-	// TODO(gvisor.dev/issue/170): Enable when supported.
-	t.Skip("NAT isn't supported yet (gvisor.dev/issue/170).")
 	singleTest(t, NATRedirectRequiresProtocol{})
 }

--- a/test/iptables/iptables_util.go
+++ b/test/iptables/iptables_util.go
@@ -151,7 +151,7 @@ func connectTCP(ip net.IP, port int, timeout time.Duration) error {
 		return err
 	}
 	if err := testutil.Poll(callback, timeout); err != nil {
-		return fmt.Errorf("timed out waiting to connect IP, most recent error: %v", err)
+		return fmt.Errorf("timed out waiting to connect IP on port %v, most recent error: %v", port, err)
 	}
 
 	return nil


### PR DESCRIPTION
Connection tracking is used to track packets in prerouting and
output hooks of iptables. The NAT rules modify the tuples in
connections. The connection tracking code modifies the packets by
looking at the modified tuples.