### PR TITLE
GO Test code for BugId178/TCP8.25

### DIFF
--- a/test/packetimpact/tests/BUILD
+++ b/test/packetimpact/tests/BUILD
@@ -28,6 +28,17 @@ packetimpact_go_test(
     ],
 )
 
+packetimpact_go_test(
+    name = "close_wait_state",
+    srcs = ["close_wait_state_test.go"],
+    deps = [
+        "//pkg/tcpip/header",
+        "//test/packetimpact/testbench",
+        "@org_golang_x_sys//unix:go_default_library",
+        "//pkg/tcpip/seqnum",
+    ],
+)
+
 sh_binary(
     name = "test_runner",
     srcs = ["test_runner.sh"],

--- a/test/packetimpact/tests/close_wait_state_test.go
+++ b/test/packetimpact/tests/close_wait_state_test.go
@@ -1,0 +1,86 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package close_wait_state_test
+
+import (
+	"testing"
+	"time"
+
+	"fmt"
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/seqnum"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+)
+
+func TestTCPCloseWaitState(t *testing.T) {
+	for _, tt := range []struct {
+		description  string
+		tcpFlags     uint8
+		payload      []tb.Layer
+		seqNumOffset seqnum.Size
+	}{
+		{"SYN", header.TCPFlagSyn, nil, 2},
+		{"SYNACK", header.TCPFlagSyn | header.TCPFlagAck, nil, 2},
+		{"ACK", header.TCPFlagAck, nil, 2},
+		{"FIN", header.TCPFlagFin | header.TCPFlagAck, nil, 2},
+		{"Data", header.TCPFlagAck, []tb.Layer{&tb.Payload{Bytes: []byte("abcdef12345")}}, 2},
+	} {
+		t.Run(fmt.Sprintf("%s%d", tt.description, tt.seqNumOffset), func(t *testing.T) {
+			println("\nCASE : ", tt.description, "\n")
+			dut := tb.NewDUT(t)
+			defer dut.TearDown()
+			listenFd, remotePort := dut.CreateListener(unix.SOCK_STREAM, unix.IPPROTO_TCP, 1)
+			defer dut.Close(listenFd)
+			conn := tb.NewTCPIPv4(t, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+			defer conn.Close()
+			conn.Handshake()
+			acceptFd, _ := dut.Accept(listenFd)
+
+			// Send FIN-ACK to DUT.
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagFin | header.TCPFlagAck)})
+
+			// Expecting ACK from DUT
+			if (conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)}, 3*time.Second) == nil) {
+				t.Fatal("expected an ACK packet within 3 seconds but got nonei")
+			}
+
+			println("DUT In CLOSED_WAIT STATE")
+
+			windowSize := seqnum.Size(*conn.SynAck.WindowSize) + tt.seqNumOffset
+			conn.Send(tb.TCP{
+				SeqNum: tb.Uint32(uint32(conn.LocalSeqNum.Add(windowSize))),
+				Flags:  tb.Uint8(tt.tcpFlags),
+			}, tt.payload...)
+
+			gotAck := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)}, 3*time.Second)
+			if gotAck == nil {
+				t.Fatal("expected an ACK packet within 3 seconds but got none")
+			}
+
+			dut.Close(acceptFd)
+			if (conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagFin | header.TCPFlagAck)}, time.Second) == nil) {
+				t.Fatal("expected an FIN-ACK packet within a second but got nonei")
+			}
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)})
+
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)}, []tb.Layer{&tb.Payload{Bytes: []byte("abcdef12345")}}...)
+			if (conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagRst)}, time.Second) == nil) {
+				t.Fatal("expected an RSTpacket within a second but got nonei")
+			}
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagRst | header.TCPFlagAck)})
+		})
+	}
+}


### PR DESCRIPTION
**GO Test code for BugId178/TCP8.25:**

**Test Assertion:**
TCP, in CLOSE-WAIT state, MUST send an ACK with next expected SEQ number after recv any segment with OTW SEQ number and remain in the same state


**Source code files:**
	1) test/packetimpact/tests/BUILD
	2) test/packetimpact/tests/close_wait_state_test.go

**Test Sequence:**
1. DUT bind()
2. DUT listen()
3. TCP Handshake
   a. Send SYN
   b. Receive SYN-ACK
   c. Send ACK
4. DUT accept()
5. Move DUT to CLOSE-WAIT state
6. Do a test case from below.
7. Make DUT close
8. Send ACK
9. Make DUT to RST the connection
10. Send RST-ACK

The test cases are all sent with a sequence number that is the window size plus 2. They
are:
       a. Send SYN
       b. Send SYN,ACK
       c. Send ACK
       d. Send FIN
       e. Send “Sample data” without any options

**Test Results:**
linux      - pass
netstack   - fail

**Test Logs:**
Attached for linux and netstack
[close_wait_state_linux_test_log.txt](https://github.com/google/gvisor/files/4415176/close_wait_state_linux_test_log.txt)
[close_wait_state_netstack_test_log.txt](https://github.com/google/gvisor/files/4415177/close_wait_state_netstack_test_log.txt)
[pre-submit-tests.txt](https://github.com/google/gvisor/files/4415179/pre-submit-tests.txt)

