### PR TITLE
get correct path information for unix domain socket

### DIFF
--- a/pkg/sentry/fs/dirent.go
+++ b/pkg/sentry/fs/dirent.go
@@ -246,6 +246,10 @@ func NewNegativeDirent(name string) *Dirent {
 	return newDirent(nil, name)
 }
 
+func (d *Dirent) BecameInvisible() {
+	allDirents.remove(d)
+}
+
 // IsRoot returns true if d is a root Dirent.
 func (d *Dirent) IsRoot() bool {
 	return d.parent == nil

--- a/pkg/sentry/fs/dirent.go
+++ b/pkg/sentry/fs/dirent.go
@@ -117,6 +117,13 @@ type Dirent struct {
 	// parent is protected by renameMu.
 	parent *Dirent
 
+	// In gofer, the Dirent created by Bind() is used to fetch full path information
+	// during checkpoint in fillPathMap() but since it is not returned in overlayBind(),
+	// it didn't have parent set and lacks path information. For this reason, the Dirent
+	// returned in overlayBind() is stored here named Overlay to fetch path information.
+	// It may also serve other purposes in overlay case for other upper layer FS.
+	Overlay *Dirent
+
 	// deleted may be set atomically when removed.
 	deleted int32
 

--- a/pkg/sentry/fs/inode_overlay.go
+++ b/pkg/sentry/fs/inode_overlay.go
@@ -474,6 +474,7 @@ func overlayBind(ctx context.Context, o *overlayEntry, parent *Dirent, name stri
 	// will have to be taken care of by upper layer when it DecRef() d.
 	if d.ReadRefs() > 1 {
 		overlayd.IncRef()
+		d.BecameInvisible()
 	}
 	d.DecRef()
 	return overlayd, nil

--- a/pkg/sentry/fs/save.go
+++ b/pkg/sentry/fs/save.go
@@ -37,10 +37,7 @@ func SaveInodeMappings() {
 	}
 
 	for dirent := range allDirents.dirents {
-		// skip upper layer's dirents if they have overlay dirent set
-		// as upper layer's dirents do not have parent set and will be
-		// incorrectly regarded as root path in d.Fullname().
-		if dirent.Inode != nil && dirent.Overlay == nil {
+		if dirent.Inode != nil {
 			// We cannot trust the root provided in the mount due
 			// to the overlay. We can trust the overlay to delegate
 			// SaveInodeMappings to the right underlying

--- a/pkg/sentry/fs/save.go
+++ b/pkg/sentry/fs/save.go
@@ -37,7 +37,10 @@ func SaveInodeMappings() {
 	}
 
 	for dirent := range allDirents.dirents {
-		if dirent.Inode != nil {
+		// skip upper layer's dirents if they have overlay dirent set
+		// as upper layer's dirents do not have parent set and will be
+		// incorrectly regarded as root path in d.Fullname().
+		if dirent.Inode != nil && dirent.Overlay == nil {
 			// We cannot trust the root provided in the mount due
 			// to the overlay. We can trust the overlay to delegate
 			// SaveInodeMappings to the right underlying


### PR DESCRIPTION
The gofer backed rootfs is layered on top of ramfs so when bind()ing an
unix domain socket, the overlayBind() is called and then gofer's bind().
In gofer's bind(), a Dirent called childDir is created and it's supposed
to provide path information on checkpoint to session's overrides pathMap.

Problem is, in overlayBind(), the dirent returned from upper layer
(childDir in gofer's case) isn't returned to caller and wouldn't have
its parent set by d.finishCreate(). Instead, a new dirent is created
with the overlay inode and gets returned. This caused the problem of
childDir's path information being totally wrong and would be regarded
as "/" in d.FullName() since it doesn't have parent.

Then during checkpoint, in fs.SaveInodeMapping(), childDir's incorrect
root path is sent to gofer's SaveInodeMapping and gofer session's
inodeMappings will record childDir's InodeID with root path...Now we
have two InodeIDs(one is childDir's, the other is the real root's)
having the same root path recorded. This will cause panic on restore
when gofer's inode afterLoad() sees two InodeIDs having the same key
(the same key is derived from the same root path of the two different
files). The error message is like(InodeID 42 is the childDir's inode but
it's getting the same key as root inode, which is 1):
$./restore.sh
running container: starting container: restoring container
"newrootbash": restore failed due to external file system state in
corruption: gofer device key{device: 0, sdevice: 9pfs-/, inode: 631952}
-> 42 conflict in gofer device mappings: cache{key{device: 0, sdevice:
9pfs-/, inode: 3146948} -> 6, key{device: 0, sdevice: 9pfs-/, inode:
632044} -> 13, key{device: 0, sdevice: 9pfs-/etc/hostname, inode:
546130} -> 7, key{device: 0, sdevice: 9pfs-/, inode: 631957} -> 8,
key{device: 0, sdevice: 9pfs-/, inode: 632032} -> 3, key{device: 0,
sdevice: 9pfs-/, inode: 632039} -> 10, key{device: 0, sdevice: 9pfs-/,
inode: 632021} -> 16, key{device: 0, sdevice: 9pfs-/, inode: 632038} ->
4, key{device: 0, sdevice: 9pfs-/, inode: 546130} -> 9, key{device: 0,
sdevice: 9pfs-/, inode: 618348} -> 17, key{device: 0, sdevice: 9pfs-/,
inode: 618570} -> 21, key{device: 0, sdevice: 9pfs-/mnt, inode: 3146948}
-> 5, key{device: 0, sdevice: 9pfs-/, inode: 530086} -> 29, key{device:
0, sdevice: 9pfs-/, inode: 632040} -> 12, key{device: 0, sdevice:
9pfs-/, inode: 631952} -> 1, key{device: 0, sdevice: 9pfs-/, inode:
632042} -> 19, }

Normally, the upper layer returned dirent(childDir) is supposed to be
destroyed by d.DecRef() in overlayBind() but since gofer's bind() has
IncRef()ed it, it will stay. Gofer's bind() did this because the said
reason above: it's needed to provide path information during checkpoint.

So the problem to solve is: in overlay case, how can we make the saved
dirent in gofer's session.overrides providing correct path information.

If we can replace the gofer's saved dirent with the one created in
overlayBind(), problem will be solved. But I don't see a clean way of
doing this. Also, it doesn't appear we can skip creating a new dirent
using the overlayInode and return the upper layer's dirent. And setting
parent for childDir doesn't seem like a correct thing to do since the
dirent returned from overlayBind() will also get that same parent set.

For these reasons, I'm adding one more field to fs.Dirent named Overlay
so that I can set the dirent which has parent set as Overlay for gofer
returned dirent(childDir) and when gofer needs to find the path
information from its saved dirent, it can refer to its Overlay dirent.
Also, childDir shall be skipped in fs.SaveInodeMappings() since it
doesn't have the correct path information and its Overlay dirent will go
through that path.

Fixes #2300.

Reported-by: Wang Yu <yuwang.yuwang@alibaba-inc.com>
Signed-off-by: Aaron Lu <ziqian.lzq@antfin.com>