### PR TITLE
GoTest Code for BugId-38814

### DIFF
--- a/test/packetimpact/proto/posix_server.proto
+++ b/test/packetimpact/proto/posix_server.proto
@@ -163,6 +163,18 @@ message RecvResponse {
   bytes buf = 3;
 }
 
+message SendToRequest {
+  int32 sockfd = 1;
+  string buf = 2;
+  int32 length = 3;
+  Sockaddr addr = 4;
+}
+
+message SendToResponse {
+  int32 ret = 1;
+  int32 errno_ = 3;
+}
+
 service Posix {
   // Call accept() on the DUT.
   rpc Accept(AcceptRequest) returns (AcceptResponse);
@@ -190,4 +202,6 @@ service Posix {
   rpc Socket(SocketRequest) returns (SocketResponse);
   // Call recv() on the DUT.
   rpc Recv(RecvRequest) returns (RecvResponse);
+  // Call SendTo() on DUT
+  rpc SendTo(SendToRequest) returns (SendToResponse);
 }

--- a/test/packetimpact/tests/BUILD
+++ b/test/packetimpact/tests/BUILD
@@ -52,6 +52,18 @@ packetimpact_go_test(
     ],
 )
 
+packetimpact_go_test(
+    name = "udp_ipoption",
+    srcs = ["udp_ipoptions_test.go"],
+    netstack = True,
+    deps = [
+        "//pkg/tcpip",
+        "//pkg/tcpip/header",
+        "//test/packetimpact/testbench",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
 sh_binary(
     name = "test_runner",
     srcs = ["test_runner.sh"],

--- a/test/packetimpact/tests/udp_ipoptions_test.go
+++ b/test/packetimpact/tests/udp_ipoptions_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package udp_dut
+
+import (
+	"golang.org/x/sys/unix"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+	"net"
+	"testing"
+	"time"
+	"fmt"
+)
+
+const (
+	IP_OPT_TIME_STAMP = 68
+)
+func TestUDP_timestamp(t *testing.T) {
+	dut := tb.NewDUT(t)
+	defer dut.TearDown()
+	boundFD, remotePort := dut.CreateBoundSocket(unix.SOCK_DGRAM, unix.IPPROTO_UDP, net.ParseIP("0.0.0.0"))
+	/*socket option enabled for ip option timestamp
+	here 68 is ip timestamp option value*/
+	dut.SetSockOpt(boundFD, unix.IPPROTO_IP, unix.IP_OPTIONS, []byte{IP_OPT_TIME_STAMP, 4, 5, 0})
+
+	conn := tb.NewUDPIPv4(t, tb.UDP{DstPort: &remotePort}, tb.UDP{SrcPort: &remotePort})
+
+	/*getting sockaddr information*/
+	newSockAddr, _ := unix.Getsockname(conn.PortPickerFD)
+	defer conn.Close()
+
+	/*Send UDP packet from dut to testbench with IP option TIMESTAMP set*/
+	dut.SendTo(boundFD, []byte("Hello"), int32(len("Hello")), newSockAddr)
+
+	/*check for IPv4 IP_OPTION TIMESTAMP
+	ExpectIPv4 returns pointer to options(ipheader+minlenght(20)) field*/
+        ipOptions := conn.ExpectIPv4(time.Second)
+        if ipOptions == nil {
+                t.Fatal("expected received packet contains IP Option is set to <IP_OPT_TIME_STAMP> but got none")
+        }
+
+	/*checking for first byte is TIMESTAMP option value (68) */
+	if ipOptions[0] == IP_OPT_TIME_STAMP {
+		fmt.Println("Received packet with IP option <IP_OPT_TIME_STAMP> set")
+        } else {
+                t.Fatal("expected IP Option is set to <IP_OPT_TIME_STAMP> but no IP option")
+	}
+}


### PR DESCRIPTION


Description: UDP6.6 testcase in which An application MUST be able to specify IP options to be sent from DUT to testbench  in its UDP datagrams, and UDP MUST pass these options to the IP layer.

Files changed:  
test/packetimpact/dut/posix_server.cc 
test/packetimpact/proto/posix_server.proto 
test/packetimpact/testbench/connections.go 
test/packetimpact/testbench/dut.go 
test/packetimpact/tests/BUILD 
test/packetimpact/tests/udp_ipoptions_test.go

[presubmit_test.log](https://github.com/google/gvisor/files/4475616/presubmit_test.log)

[udp_ipoption_linux_test.log](https://github.com/google/gvisor/files/4475651/udp_ipoption_linux_test.log)
[udp_ipoption_netstack_test.log](https://github.com/google/gvisor/files/4475652/udp_ipoption_netstack_test.log)

Testing: logs attached