### PR TITLE
Go Test Code for BugId-38847

### DIFF
--- a/test/packetimpact/tests/BUILD
+++ b/test/packetimpact/tests/BUILD
@@ -51,6 +51,16 @@ packetimpact_go_test(
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )
+packetimpact_go_test(
+    name = "close_wait_state_ack",
+    srcs = ["close_wait_state_ack_test.go"],
+    deps = [
+        "//pkg/tcpip/header",
+        "//pkg/tcpip/seqnum",
+        "//test/packetimpact/testbench",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
 
 sh_binary(
     name = "test_runner",

--- a/test/packetimpact/tests/close_wait_state_ack_test.go
+++ b/test/packetimpact/tests/close_wait_state_ack_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package close_wait_state_Ack_test
+
+import (
+	"testing"
+	"time"
+
+	"fmt"
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/seqnum"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+)
+
+func TestTCPCloseWaitStateAck(t *testing.T) {
+	for _, tt := range []struct {
+		description string
+		isSeqNum    bool
+	}{
+		{"SEQNUM", true},
+		{"ACKNUM", false},
+	} {
+		t.Run(fmt.Sprintf("%s", tt.description), func(t *testing.T) {
+			println("\nCASE \n")
+			if tt.isSeqNum == true {
+				println("\nCASE OOW SEQNUM\n")
+			} else {
+				println("\nCASE UNACCEPT ACKNUM\n")
+			}
+			dut := tb.NewDUT(t)
+			defer dut.TearDown()
+			listenFd, remotePort := dut.CreateListener(unix.SOCK_STREAM, unix.IPPROTO_TCP, 1)
+			defer dut.Close(listenFd)
+			conn := tb.NewTCPIPv4(t, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+			defer conn.Close()
+			conn.Handshake()
+			acceptFd, _ := dut.Accept(listenFd)
+
+			// Send FIN-ACK to DUT.
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagFin | header.TCPFlagAck)})
+			// Expecting ACK from DUT
+			if _, err := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)}, 3*time.Second); err != nil {
+				t.Fatal("expected an ACK packet within 3 seconds but got nonei")
+			}
+			fmt.Println("In CLOSED_WAIT STATE")
+			if tt.isSeqNum == true {
+				conn.Send(tb.TCP{
+					SeqNum: tb.Uint32(uint32(conn.LocalSeqNum.Add(seqnum.Size(*conn.SynAck.WindowSize) + 2))),
+					Flags:  tb.Uint8(header.TCPFlagAck),
+				}, []tb.Layer{&tb.Payload{Bytes: []byte("abcdef12345")}}...)
+			} else {
+				conn.Send(tb.TCP{
+					AckNum: tb.Uint32(uint32(conn.LocalSeqNum.Add(seqnum.Size(*conn.SynAck.WindowSize) + 2))),
+					Flags:  tb.Uint8(header.TCPFlagAck),
+				}, []tb.Layer{&tb.Payload{Bytes: []byte("abcdef12345")}}...)
+			}
+
+			_, err := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)}, 3*time.Second)
+			if err != nil {
+				t.Fatal("expected an ACK packet within 3 seconds but got none")
+			}
+			// Verifying that DUT is in the CLOSE-WAIT state Causing DUT to issue a CLOSE call
+			dut.Close(acceptFd)
+			if _, err := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagFin | header.TCPFlagAck)}, time.Second); err != nil {
+				t.Fatal("expected an FIN-ACK packet within a second but got none")
+			}
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)})
+
+			// Sending a TCP data packet to DUT and Expecting RST response from DUT
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)}, []tb.Layer{&tb.Payload{Bytes: []byte("sample data")}}...)
+			if _, err := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagRst)}, time.Second); err != nil {
+				t.Fatal("expected an RSTpacket within a second but got none")
+			}
+			conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagRst | header.TCPFlagAck)})
+		})
+	}
+}


### PR DESCRIPTION
Testcase: TCP 3.23

Description:  TCP, in CLOSE-WAIT state, MUST return ACK with proper SEQ and ACK numbers after receiving  a segment with out of window SEQ number (or) unacceptible ACK number, and remain in same state.
 
sequence:
    1. DUT bind()
    2. DUT listen()
    3. TCP Handshake
       Send SYN
       Receive SYN-ACK
       Send ACK
    4. DUT accept()
    5. Move DUT to CLOSE-WAIT state

    6.TEST CASE
        case a:
                    a) <TESTBENCH> will send segment with out of window SEQ number.
                    b)expected ACK from DUT side.
        
         case b:
                    a) <TESTBENCH> will send segment with out of window SEQ number.
                    b)expected ACK from DUT side.

    8.verifying DUT in close-wait state

Flow-Diagram:

![Screenshot from 2020-04-05 19-55-59](https://user-images.githubusercontent.com/54174113/79231669-0ef5e400-7e84-11ea-9032-355bc64e86fa.png)

![Screenshot from 2020-04-05 19-54-12](https://user-images.githubusercontent.com/54174113/79231609-f71e6000-7e83-11ea-9d54-bfca38261fe6.png)

Modified files:
    test/packetimpact/tests/BUILD
    test/packetimpact/tests/close_wait_state_ack_test.go

Log files:
[tcp-3.23-linux.log](https://github.com/google/gvisor/files/4475684/tcp-3.23-linux.log)
[tcp-3.23-netstack.log](https://github.com/google/gvisor/files/4475685/tcp-3.23-netstack.log)
[unit_test_tcp3.23.log](https://github.com/google/gvisor/files/4475686/unit_test_tcp3.23.log)

