### PR TITLE
Make mount type optional for bind mounts

### DIFF
--- a/pkg/sentry/fs/filesystems.go
+++ b/pkg/sentry/fs/filesystems.go
@@ -144,6 +144,10 @@ type MountSourceFlags struct {
 	// NoExec corresponds to mount(2)'s "MS_NOEXEC" and indicates that
 	// binaries from this file system can't be executed.
 	NoExec bool
+
+	// Bind corresponds to mount(2)'s MS_BIND and indicates that
+	// the filesystem should be bind mounted.
+	Bind bool
 }
 
 // GenericMountSourceOptions splits a string containing comma separated tokens of the

--- a/pkg/sentry/fs/filesystems.go
+++ b/pkg/sentry/fs/filesystems.go
@@ -144,10 +144,6 @@ type MountSourceFlags struct {
 	// NoExec corresponds to mount(2)'s "MS_NOEXEC" and indicates that
 	// binaries from this file system can't be executed.
 	NoExec bool
-
-	// Bind corresponds to mount(2)'s MS_BIND and indicates that
-	// the filesystem should be bind mounted.
-	Bind bool
 }
 
 // GenericMountSourceOptions splits a string containing comma separated tokens of the

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -1523,6 +1523,28 @@ func TestReadonlyMount(t *testing.T) {
 	}
 }
 
+func TestBindMountByOption(t *testing.T) {
+	for _, conf := range configs(t, overlay) {
+		t.Logf("Running test with conf: %+v", conf)
+
+		dir, err := ioutil.TempDir(testutil.TmpDir(), "bind-mount")
+		spec := testutil.NewSpecWithArgs("/bin/touch", path.Join(dir, "file"))
+		if err != nil {
+			t.Fatalf("ioutil.TempDir() failed: %v", err)
+		}
+		spec.Mounts = append(spec.Mounts, specs.Mount{
+			Destination: dir,
+			Source:      dir,
+			Type:        "none",
+			Options:     []string{"rw", "bind"},
+		})
+
+		if err := run(spec, conf); err != nil {
+			t.Fatalf("error running sandbox: %v", err)
+		}
+	}
+}
+
 // TestAbbreviatedIDs checks that runsc supports using abbreviated container
 // IDs in place of full IDs.
 func TestAbbreviatedIDs(t *testing.T) {

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -1394,7 +1394,7 @@ func TestMultiContainerSharedMountUnsupportedOptions(t *testing.T) {
 		Destination: "/mydir/test",
 		Source:      "/some/dir",
 		Type:        "tmpfs",
-		Options:     []string{"rw", "rbind", "relatime"},
+		Options:     []string{"rw", "relatime"},
 	}
 	podSpec[0].Mounts = append(podSpec[0].Mounts, mnt0)
 

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -311,7 +311,19 @@ func capsFromNames(names []string, skipSet map[linux.Capability]struct{}) (auth.
 
 // Is9PMount returns true if the given mount can be mounted as an external gofer.
 func Is9PMount(m specs.Mount) bool {
-	return m.Type == "bind" && m.Source != "" && IsSupportedDevMount(m)
+	var isBind bool
+	switch m.Type {
+	case "bind":
+		isBind = true
+	default:
+		for _, opt := range m.Options {
+			if opt == "bind" || opt == "rbind" {
+				isBind = true
+				break
+			}
+		}
+	}
+	return isBind && m.Source != "" && IsSupportedDevMount(m)
 }
 
 // IsSupportedDevMount returns true if the mount is a supported /dev mount.


### PR DESCRIPTION
## Description
This fixes behavior of `getMountNameAndOptions` func based on OCI runtime spec(https://github.com/opencontainers/runtime-spec/blob/master/config.md#posix-platform-mounts).
In detail, if the mount type is equal to "none" or other dummy string and the mount option includes either "bind" or  "rbind",  `getMountNameAndOptions` behave as the mount type is equal to "bind".

## Relevant issue
Fix: https://github.com/google/gvisor/issues/2330

Signed-off-by: moricho <ikeda.morito@gmail.com>