### PR TITLE
Test Code for BugId-38942

### DIFF
--- a/test/packetimpact/tests/BUILD
+++ b/test/packetimpact/tests/BUILD
@@ -96,6 +96,16 @@ packetimpact_go_test(
     ],
 )
 
+packetimpact_go_test(
+    name = "tcp_window_msb_set",
+    srcs = ["tcp_window_msb_set_test.go"],
+    deps = [
+        "//pkg/tcpip/header",
+        "//test/packetimpact/testbench",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
 sh_binary(
     name = "test_runner",
     srcs = ["test_runner.sh"],

--- a/test/packetimpact/tests/tcp_window_msb_set_test.go
+++ b/test/packetimpact/tests/tcp_window_msb_set_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcp_window_msb_set_test
+
+import (
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+	"testing"
+	"time"
+)
+
+func TestWindowMsb(t *testing.T) {
+	dut := tb.NewDUT(t)
+	listenFd, remotePort := dut.CreateListener(unix.SOCK_STREAM, unix.IPPROTO_TCP, 1)
+	defer dut.Close(listenFd)
+
+	conn := tb.NewTCPIPv4(t, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+	defer conn.Close()
+
+	//Send SYN to DUT.
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn)})
+
+	//Expecting SYN-ACK from DUT.
+	synAck, _ := conn.Expect(tb.TCP{Flags: tb.Uint8(header.TCPFlagSyn | header.TCPFlagAck)}, time.Second)
+	if synAck == nil {
+		t.Fatal("Didn't get SYN-ACK packet")
+	}
+
+	//Send ACK to DUT with window size set as msb.
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck), WindowSize: tb.Uint16(0x8000)})
+
+	//Send a data packet from DUT.
+	acceptFd, _ := dut.Accept(listenFd)
+	defer dut.Close(acceptFd)
+	buf := []byte("Hi I am DUT sending Data")
+	bufPayload := &tb.Payload{Bytes: buf}
+	dut.Send(acceptFd, buf, 0)
+	conn.ExpectData(&tb.TCP{}, bufPayload, time.Second)
+}


### PR DESCRIPTION
Test case: TCP-16.18

Test case description: The windows size MUST be treated as an unsigned number.

The window size must be treated as an unsigned number, or else large window sizes will appear like negative windows and TCP will not work(as per rfc 1122 page no 83). It is recommended that implementations reserve 32-bit fields for the send and receive window sizes in the connection record and do all window computations with 32 bits.

Test case sequence:
1. DUT listen() state.
2. Testbench sends SYN.
3. DUT send SYN-ACK.
4. Testbench sends ACK with a window size having MSB set.
5. DUT send data segment.

Flow diagram :
![image](https://user-images.githubusercontent.com/54174113/80076070-41c96780-8569-11ea-8202-791cf7c75044.png)

Modified files:
test/packetimpact/tests/BUILD
test/packetimpact/tests/tcp_window_msb_set_test.go

log files:
[tcp-16.18-linux.log](https://github.com/google/gvisor/files/4521364/tcp-16.18-linux.log)
[tcp-16.18-netstack.log](https://github.com/google/gvisor/files/4521365/tcp-16.18-netstack.log)
[tcp-16.18-unit-test.log](https://github.com/google/gvisor/files/4521366/tcp-16.18-unit-test.log)
