### PR TITLE
Fix all compiler warnings.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,6 +68,16 @@ go_repository(
 
 # Load C++ rules.
 http_archive(
+    name = "com_google_absl",
+    sha256 = "84c9f1312d36546e07b8135143319f0f63f577ca4719286e9e0a0986bfc1b898",
+    strip_prefix = "abseil-cpp-c51510d1d87ebce8615ae1752fd5aca912f6cf4c",
+    urls = [
+        "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/c51510d1d87ebce8615ae1752fd5aca912f6cf4c.tar.gz",
+        "https://github.com/abseil/abseil-cpp/archive/c51510d1d87ebce8615ae1752fd5aca912f6cf4c.tar.gz",
+    ],
+)
+
+http_archive(
     name = "rules_cc",
     sha256 = "67412176974bfce3f4cf8bdaff39784a72ed709fc58def599d1f68710b58d68b",
     strip_prefix = "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
@@ -162,11 +172,11 @@ http_archive(
 
 http_archive(
     name = "com_google_benchmark",
-    sha256 = "3c6a165b6ecc948967a1ead710d4a181d7b0fbcaa183ef7ea84604994966221a",
-    strip_prefix = "benchmark-1.5.0",
+    sha256 = "7c1eea9f1626a2e1303d6a367f4b200718722b01ec46573b1a3c469d8d063cd2",
+    strip_prefix = "benchmark-ecc1685340f58f7fe6b707036bc0bb1fccabb0c1",
     urls = [
-        "https://mirror.bazel.build/github.com/google/benchmark/archive/v1.5.0.tar.gz",
-        "https://github.com/google/benchmark/archive/v1.5.0.tar.gz",
+        "https://mirror.bazel.build/github.com/google/benchmark/archive/ecc1685340f58f7fe6b707036bc0bb1fccabb0c1.tar.gz",
+        "https://github.com/google/benchmark/archive/ecc1685340f58f7fe6b707036bc0bb1fccabb0c1.tar.gz",
     ],
 )
 

--- a/test/perf/linux/fork_benchmark.cc
+++ b/test/perf/linux/fork_benchmark.cc
@@ -58,7 +58,7 @@ void BM_CPUBoundAsymmetric(benchmark::State& state) {
   const size_t max = state.max_iterations;
   pid_t child = fork();
   if (child == 0) {
-    for (int i = 0; i < max; i++) {
+    for (unsigned int i = 0; i < max; i++) {
       busy(kBusyMax);
     }
     _exit(0);
@@ -95,7 +95,7 @@ void BM_CPUBoundSymmetric(benchmark::State& state) {
     }
     pid_t child = fork();
     if (child == 0) {
-      for (int i = 0; i < cur; i++) {
+      for (unsigned int i = 0; i < cur; i++) {
         busy(kBusyMax);
       }
       _exit(0);
@@ -296,7 +296,7 @@ void BM_ThreadStart(benchmark::State& state) {
 
     state.ResumeTiming();
 
-    for (size_t i = 0; i < num_threads; ++i) {
+    for (int i = 0; i < num_threads; ++i) {
       threads.emplace_back(std::make_unique<ScopedThread>([barrier] {
         if (barrier->Block()) {
           delete barrier;
@@ -326,7 +326,7 @@ void BM_ProcessLifecycle(benchmark::State& state) {
 
   std::vector<pid_t> pids(num_procs);
   for (auto _ : state) {
-    for (size_t i = 0; i < num_procs; ++i) {
+    for (int i = 0; i < num_procs; ++i) {
       int pid = fork();
       if (pid == 0) {
         _exit(0);

--- a/test/perf/linux/futex_benchmark.cc
+++ b/test/perf/linux/futex_benchmark.cc
@@ -162,7 +162,7 @@ void BM_FutexRoundtripDelayed(benchmark::State& state) {
   constexpr int64_t kBeforeWakeDelayNs = 500;
   std::atomic<int32_t> v(0);
   ScopedThread t([&] {
-    for (int i = 0; i < state.max_iterations; i++) {
+    for (unsigned int i = 0; i < state.max_iterations; i++) {
       SpinNanos(delay_ns);
       while (v.load(std::memory_order_acquire) == 0) {
         FutexWait(&v, 0);

--- a/test/perf/linux/pipe_benchmark.cc
+++ b/test/perf/linux/pipe_benchmark.cc
@@ -40,7 +40,7 @@ void BM_Pipe(benchmark::State& state) {
 
   ScopedThread t([&] {
     auto const fd = fds[1];
-    for (int i = 0; i < state.max_iterations; i++) {
+    for (unsigned int i = 0; i < state.max_iterations; i++) {
       TEST_CHECK(WriteFd(fd, wbuf.data(), wbuf.size()) == size);
     }
   });

--- a/test/perf/linux/seqwrite_benchmark.cc
+++ b/test/perf/linux/seqwrite_benchmark.cc
@@ -46,7 +46,7 @@ void BM_SeqWrite(benchmark::State& state) {
   uint64_t offset = 0;
   for (auto _ : state) {
     TEST_CHECK(PwriteFd(fd.get(), buf.data(), buf.size(), offset) ==
-               buf.size());
+               static_cast<ssize_t>(buf.size()));
     offset += buf.size();
     // Wrap around if going above the maximum file size.
     if (offset >= kMaxFile) {

--- a/test/syscalls/linux/futex.cc
+++ b/test/syscalls/linux/futex.cc
@@ -694,7 +694,7 @@ TEST_P(PrivateAndSharedFutexTest, PIWaiters) {
 
   // Wait until the thread blocks on the futex, setting the waiters bit.
   auto start = absl::Now();
-  while (a.load() != (FUTEX_WAITERS | gettid())) {
+  while (a.load() != int(FUTEX_WAITERS | gettid())) {
     ASSERT_LT(absl::Now() - start, absl::Seconds(5));
     absl::SleepFor(absl::Milliseconds(100));
   }

--- a/test/syscalls/linux/proc_net_unix.cc
+++ b/test/syscalls/linux/proc_net_unix.cc
@@ -181,7 +181,7 @@ PosixErrorOr<std::vector<UnixEntry>> ProcNetUnixEntries() {
 // Returns true on match, and sets 'match' to point to the matching entry.
 bool FindBy(std::vector<UnixEntry> entries, UnixEntry* match,
             std::function<bool(const UnixEntry&)> predicate) {
-  for (int i = 0; i < entries.size(); ++i) {
+  for (unsigned int i = 0; i < entries.size(); ++i) {
     if (predicate(entries[i])) {
       *match = entries[i];
       return true;

--- a/test/syscalls/linux/proc_pid_uid_gid_map.cc
+++ b/test/syscalls/linux/proc_pid_uid_gid_map.cc
@@ -203,7 +203,7 @@ TEST_P(ProcSelfUidGidMapTest, IdentityMapOwnID) {
   EXPECT_THAT(
       InNewUserNamespaceWithMapFD([&](int fd) {
         DenySelfSetgroups();
-        TEST_PCHECK(write(fd, line.c_str(), line.size()) == line.size());
+        TEST_PCHECK(write(fd, line.c_str(), line.size()) == static_cast<ssize_t>(line.size()));
       }),
       IsPosixErrorOkAndHolds(0));
 }
@@ -220,7 +220,7 @@ TEST_P(ProcSelfUidGidMapTest, TrailingNewlineAndNULIgnored) {
         DenySelfSetgroups();
         // The write should return the full size of the write, even though
         // characters after the NUL were ignored.
-        TEST_PCHECK(write(fd, line.c_str(), line.size()) == line.size());
+        TEST_PCHECK(write(fd, line.c_str(), line.size()) == static_cast<ssize_t>(line.size()));
       }),
       IsPosixErrorOkAndHolds(0));
 }
@@ -233,7 +233,7 @@ TEST_P(ProcSelfUidGidMapTest, NonIdentityMapOwnID) {
   EXPECT_THAT(
       InNewUserNamespaceWithMapFD([&](int fd) {
         DenySelfSetgroups();
-        TEST_PCHECK(write(fd, line.c_str(), line.size()) == line.size());
+        TEST_PCHECK(write(fd, line.c_str(), line.size()) == static_cast<ssize_t>(line.size()));
       }),
       IsPosixErrorOkAndHolds(0));
 }

--- a/test/syscalls/linux/socket.cc
+++ b/test/syscalls/linux/socket.cc
@@ -46,7 +46,7 @@ TEST(SocketTest, ProtocolUnix) {
       {AF_UNIX, SOCK_SEQPACKET, PF_UNIX},
       {AF_UNIX, SOCK_DGRAM, PF_UNIX},
   };
-  for (int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
+  for (unsigned int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
     ASSERT_NO_ERRNO_AND_VALUE(
         Socket(tests[i].domain, tests[i].type, tests[i].protocol));
   }
@@ -59,7 +59,7 @@ TEST(SocketTest, ProtocolInet) {
       {AF_INET, SOCK_DGRAM, IPPROTO_UDP},
       {AF_INET, SOCK_STREAM, IPPROTO_TCP},
   };
-  for (int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
+  for (unsigned int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
     ASSERT_NO_ERRNO_AND_VALUE(
         Socket(tests[i].domain, tests[i].type, tests[i].protocol));
   }

--- a/test/syscalls/linux/socket_bind_to_device_distribution.cc
+++ b/test/syscalls/linux/socket_bind_to_device_distribution.cc
@@ -168,7 +168,7 @@ TEST_P(BindToDeviceDistributionTest, Tcp) {
   std::vector<std::unique_ptr<ScopedThread>> listen_threads(
       listener_fds.size());
 
-  for (int i = 0; i < listener_fds.size(); i++) {
+  for (unsigned int i = 0; i < listener_fds.size(); i++) {
     listen_threads[i] = absl::make_unique<ScopedThread>(
         [&listener_fds, &accept_counts, &connects_received, i,
          kConnectAttempts]() {
@@ -235,7 +235,7 @@ TEST_P(BindToDeviceDistributionTest, Tcp) {
     listen_thread->Join();
   }
   // Check that connections are distributed correctly among listening sockets.
-  for (int i = 0; i < accept_counts.size(); i++) {
+  for (unsigned int i = 0; i < accept_counts.size(); i++) {
     EXPECT_THAT(
         accept_counts[i],
         EquivalentWithin(static_cast<int>(kConnectAttempts *
@@ -308,7 +308,7 @@ TEST_P(BindToDeviceDistributionTest, Udp) {
   std::vector<std::unique_ptr<ScopedThread>> receiver_threads(
       listener_fds.size());
 
-  for (int i = 0; i < listener_fds.size(); i++) {
+  for (unsigned int i = 0; i < listener_fds.size(); i++) {
     receiver_threads[i] = absl::make_unique<ScopedThread>(
         [&listener_fds, &packets_per_socket, &packets_received, i]() {
           do {
@@ -366,7 +366,7 @@ TEST_P(BindToDeviceDistributionTest, Udp) {
     receiver_thread->Join();
   }
   // Check that packets are distributed correctly among listening sockets.
-  for (int i = 0; i < packets_per_socket.size(); i++) {
+  for (unsigned int i = 0; i < packets_per_socket.size(); i++) {
     EXPECT_THAT(
         packets_per_socket[i],
         EquivalentWithin(static_cast<int>(kConnectAttempts *

--- a/test/syscalls/linux/socket_netlink_route.cc
+++ b/test/syscalls/linux/socket_netlink_route.cc
@@ -658,7 +658,10 @@ TEST(NetlinkRouteTest, GetRouteRequest) {
 
   req.nla.nla_len = 8;
   req.nla.nla_type = RTA_DST;
-  inet_aton("127.0.0.2", &req.sin_addr);
+
+  struct in_addr in_addr;
+  inet_aton("127.0.0.2", &in_addr);
+  req.sin_addr = in_addr;
 
   bool rtDstFound = false;
   ASSERT_NO_ERRNO(NetlinkRequestResponseSingle(

--- a/test/syscalls/linux/tuntap.cc
+++ b/test/syscalls/linux/tuntap.cc
@@ -327,14 +327,14 @@ TEST_F(TuntapTest, PingKernel) {
     int n = read(fd.get(), &r, sizeof(r));
     EXPECT_THAT(n, SyscallSucceeds());
 
-    if (n < sizeof(pihdr)) {
+    if (n < int(sizeof(pihdr))) {
       std::cerr << "Ignored packet, protocol: " << r.pi.pi_protocol
                 << " len: " << n << std::endl;
       continue;
     }
 
     // Process ARP packet.
-    if (n >= sizeof(arp_pkt) && r.pi.pi_protocol == htons(ETH_P_ARP)) {
+    if (n >= int(sizeof(arp_pkt)) && r.pi.pi_protocol == htons(ETH_P_ARP)) {
       // Respond with canned ARP reply.
       EXPECT_THAT(write(fd.get(), arp_rep.data(), arp_rep.size()),
                   SyscallSucceedsWithValue(arp_rep.size()));
@@ -345,7 +345,7 @@ TEST_F(TuntapTest, PingKernel) {
     }
 
     // Process ping response packet.
-    if (n >= sizeof(ping_pkt) && r.pi.pi_protocol == ping_req.pi.pi_protocol &&
+    if (n >= int(sizeof(ping_pkt)) && r.pi.pi_protocol == ping_req.pi.pi_protocol &&
         r.ping.ip.protocol == ping_req.ip.protocol &&
         !memcmp(&r.ping.ip.saddr, &ping_req.ip.daddr, kIPLen) &&
         !memcmp(&r.ping.ip.daddr, &ping_req.ip.saddr, kIPLen) &&
@@ -386,13 +386,13 @@ TEST_F(TuntapTest, SendUdpTriggersArpResolution) {
     int n = read(fd.get(), &r, sizeof(r));
     EXPECT_THAT(n, SyscallSucceeds());
 
-    if (n < sizeof(pihdr)) {
+    if (n < int(sizeof(pihdr))) {
       std::cerr << "Ignored packet, protocol: " << r.pi.pi_protocol
                 << " len: " << n << std::endl;
       continue;
     }
 
-    if (n >= sizeof(arp_pkt) && r.pi.pi_protocol == htons(ETH_P_ARP)) {
+    if (n >= int(sizeof(arp_pkt)) && r.pi.pi_protocol == htons(ETH_P_ARP)) {
       break;
     }
   }


### PR DESCRIPTION
Staring at bazel build logs with compiler warnings makes me crazy. This
eliminates all possible compiler warnings. Though some still remain,
they are sane: e.g. a warning about static linking for runsc-race.