### PR TITLE
container: use sighandling package

### DIFF
--- a/runsc/container/BUILD
+++ b/runsc/container/BUILD
@@ -15,8 +15,10 @@ go_library(
         "//test:__subpackages__",
     ],
     deps = [
+        "//pkg/abi/linux",
         "//pkg/log",
         "//pkg/sentry/control",
+        "//pkg/sentry/sighandling",
         "//pkg/sync",
         "//runsc/boot",
         "//runsc/cgroup",


### PR DESCRIPTION
Use the sighandling package for Container.ForwardSignals, for
consistency with other signal forwarding.

Fixes #2546
