### PR TITLE
Test Code for BugId-38932

### DIFF
--- a/test/packetimpact/tests/BUILD
+++ b/test/packetimpact/tests/BUILD
@@ -96,6 +96,16 @@ packetimpact_go_test(
     ],
 )
 
+packetimpact_go_test(
+    name = "tcp_retransmission",
+    srcs = ["tcp_retransmission_test.go"],
+    deps = [
+        "//pkg/tcpip/header",
+        "//test/packetimpact/testbench",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
 sh_binary(
     name = "test_runner",
     srcs = ["test_runner.sh"],

--- a/test/packetimpact/tests/tcp_retransmission_test.go
+++ b/test/packetimpact/tests/tcp_retransmission_test.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcp_retransmission_test
+
+import (
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	tb "gvisor.dev/gvisor/test/packetimpact/testbench"
+	"testing"
+	"time"
+)
+
+func TestTcpRetransmission(t *testing.T) {
+	dut := tb.NewDUT(t)
+	listenFd, remotePort := dut.CreateListener(unix.SOCK_STREAM, unix.IPPROTO_TCP, 1)
+	defer dut.Close(listenFd)
+
+	conn := tb.NewTCPIPv4(t, tb.TCP{DstPort: &remotePort}, tb.TCP{SrcPort: &remotePort})
+	defer conn.Close()
+	conn.Handshake()
+
+	acceptFd, _ := dut.Accept(listenFd)
+	defer dut.Close(acceptFd)
+
+	//DUT send data segment.
+	buf := []byte("Hi I am DUT sending Data")
+	bufPayload := &tb.Payload{Bytes: buf}
+	dut.Send(acceptFd, buf, 0)
+	layers, _ := conn.ExpectData(&tb.TCP{}, bufPayload, time.Second)
+	id1 := *layers[1].(*tb.IPv4).ID
+
+	//Send data segment to DUT.
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagAck)}, []tb.Layer{&tb.Payload{Bytes: []byte("hellooooooooooo")}}...)
+
+	//DUT Retransmit data segment with ACK.
+	dut.Send(acceptFd, buf, 16)
+	layers, _ = conn.ExpectData(&tb.TCP{}, bufPayload, time.Second)
+	id2 := *layers[1].(*tb.IPv4).ID
+
+	//Send ACK+RST to close the connection.
+	conn.Send(tb.TCP{Flags: tb.Uint8(header.TCPFlagRst | header.TCPFlagAck)})
+
+	//Check the IP Identification field.
+	if id1 != id2 {
+		t.Fatal("ID for packet and retransmitted packet are different")
+	}
+}


### PR DESCRIPTION
Test case: TCP-15.21

Test case description: If a re-transmitted packet differs from the original packet in the acknowledgement field, the same IP identification field MUST NOT be used.

If a re-transmitted packet is identical to the original packet (which implies not only that the data boundaries have not changed, but also that the window and acknowledgement fields of the header have not changed), then the same IP Identification field MAY be used (as per rfc 1122 page no 90).

Test case sequence:

1. DUT listen() state.
2. Testbench sends SYN.
3. DUT send SYN-ACK.
4. Testbench sends ACK.
5. DUT send data segment.
6. Extract a IP Identification field from an Ethernet header from a packet sent by DUT.
7. Testbench sends data segments to DUT.
8. DUT sends a Data segment with ACK.
9. Extract a IP Identification field from an Ethernet header from a packet sent by DUT.
10. Compare saved IP Identification fields.

Flow diagram :
![image](https://user-images.githubusercontent.com/54174113/80406039-12a45480-88e1-11ea-9075-a56f971c16b2.png)

Modified files:
test/packetimpact/tests/BUILD
test/packetimpact/tests/tcp_retransmission_test.go

log files:
[tcp-15.21-linux.log](https://github.com/google/gvisor/files/4541363/tcp-15.21-linux.log)
[tcp-15.21-netstack.log](https://github.com/google/gvisor/files/4541364/tcp-15.21-netstack.log)
[tcp-15.21-unit-test.log](https://github.com/google/gvisor/files/4541365/tcp-15.21-unit-test.log)
