### PR TITLE
optimize the tools code to avoid some build errors

### DIFF
--- a/tools/go_marshal/gomarshal/generator.go
+++ b/tools/go_marshal/gomarshal/generator.go
@@ -120,7 +120,7 @@ func (g *Generator) writeHeader() error {
 
 	// Emit build tags.
 	if t := tags.Aggregate(g.inputs); len(t) > 0 {
-		b.emit(strings.Join(t.Lines(), "\n"))
+		b.emit(strings.Join(t.AggregateLines(), "\n"))
 		b.emit("\n\n")
 	}
 

--- a/tools/go_stateify/main.go
+++ b/tools/go_stateify/main.go
@@ -230,7 +230,7 @@ func main() {
 
 	// Emit build tags.
 	if t := tags.Aggregate(flag.Args()); len(t) > 0 {
-		fmt.Fprintf(outputFile, "%s\n\n", strings.Join(t.Lines(), "\n"))
+		fmt.Fprintf(outputFile, "%s\n\n", strings.Join(t.AggregateLines(), "\n"))
 	}
 
 	// Emit the package name.

--- a/tools/tags/tags.go
+++ b/tools/tags/tags.go
@@ -44,6 +44,40 @@ func (and AndSet) Lines() (ls []string) {
 	return
 }
 
+// AggregateLines aggregates all tags from a set of files into one line, and remove duplicate tags.
+func (and AndSet) AggregateLines() (ls []string) {
+	var tags []string
+
+	// Aggregates all tags from a set of files, and remove duplicate tags.
+	for _, or := range and {
+		for i := 0; i < len(or); i++ {
+			dup := 0
+
+			for _, tag := range tags {
+				if tag == or[i] {
+					dup = 1
+					break
+				}
+			}
+
+			if dup == 0 {
+				tags = append(tags, or[i])
+			}
+		}
+	}
+
+	// Return one line.
+	line := "// +build"
+	for _, tag := range tags {
+		line += " "
+		line += tag
+	}
+
+	ls = append(ls, line)
+
+	return
+}
+
 // Join joins this AndSet with another.
 func (and AndSet) Join(other AndSet) AndSet {
 	return append(and, other...)


### PR DESCRIPTION
Currently, I found that if a file has the specific tag codes,
the file can not be compiled on Arm64.
Such as:

In ./aarch64-fastbuild/bin/pkg/sentry/arch/arch_abi_autogen_unsafe.go:
The tag is like following:
// +build amd64 386
// +build amd64 386
// +build 386 amd64 arm64

After applying my patch, the tag will be like following:
// +build amd64 386 arm64

And this file with my modified tag can be compiled on Arm64.

The test step is like following:

cd pkg/sentry/syscalls/linux
bazel build .

And the error log is like following:

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: error running subcommand: exit status 2
/root/.cache/bazel/_bazel_root/36b1ee2f901aa84ae46b26c6f7ea4048/sandbox/linux-sandbox/793/execroot/__main__/pkg/sentry/arch/signal_arm64.go:68:9: cannot use &SignalAct literal (type *SignalAct) as type NativeSignalAct in return argument:
        *SignalAct does not implement NativeSignalAct (missing CopyIn method)
/root/.cache/bazel/_bazel_root/36b1ee2f901aa84ae46b26c6f7ea4048/sandbox/linux-sandbox/793/execroot/__main__/pkg/sentry/arch/signal_arm64.go:73:9: cannot use &SignalStack literal (type *SignalStack) as type NativeSignalStack in return argument:
        *SignalStack does not implement NativeSignalStack (missing CopyIn method)
Target //pkg/sentry/syscalls/linux:linux failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 5.282s, Critical Path: 2.06s
INFO: 292 processes: 292 linux-sandbox.
FAILED: Build did NOT complete successfully

Signed-off-by: Bin Lu <bin.lu@arm.com>


