### PR TITLE
code clean in arch module

### DIFF
--- a/pkg/sentry/arch/arch_aarch64.go
+++ b/pkg/sentry/arch/arch_aarch64.go
@@ -274,7 +274,7 @@ const (
 func (s *State) PtraceGetRegSet(regset uintptr, dst io.Writer, maxlen int) (int, error) {
 	switch regset {
 	case _NT_PRSTATUS:
-		if maxlen < ptraceRegsSize {
+		if maxlen < registersSize {
 			return 0, syserror.EFAULT
 		}
 		return s.PtraceGetRegs(dst)
@@ -287,7 +287,7 @@ func (s *State) PtraceGetRegSet(regset uintptr, dst io.Writer, maxlen int) (int,
 func (s *State) PtraceSetRegSet(regset uintptr, src io.Reader, maxlen int) (int, error) {
 	switch regset {
 	case _NT_PRSTATUS:
-		if maxlen < ptraceRegsSize {
+		if maxlen < registersSize {
 			return 0, syserror.EFAULT
 		}
 		return s.PtraceSetRegs(src)


### PR DESCRIPTION
Test steps:
cd pkg/sentry/arch/
bazel build .

The error log is below:

/root/.cache/bazel/_bazel_root/f3b369e7325850c58bec1b7d63bbc49c/sandbox/linux-sandbox/588/execroot/__main__/pkg/sentry/arch/arch_aarch64.go:277:15: undefined: ptraceRegsSize
/root/.cache/bazel/_bazel_root/f3b369e7325850c58bec1b7d63bbc49c/sandbox/linux-sandbox/588/execroot/__main__/pkg/sentry/arch/arch_aarch64.go:290:15: undefined: ptraceRegsSize


Signed-off-by: Bin Lu <bin.lu@arm.com>

