### PR TITLE
iptables - filter packets using outgoing interface.

### DIFF
--- a/pkg/abi/linux/netfilter.go
+++ b/pkg/abi/linux/netfilter.go
@@ -146,7 +146,7 @@ type IPTIP struct {
 	// OutputInterface is the output network interface.
 	OutputInterface [IFNAMSIZ]byte
 
-	// InputInterfaceMask is the intput interface mask.
+	// InputInterfaceMask is the input interface mask.
 	InputInterfaceMask [IFNAMSIZ]byte
 
 	// OuputInterfaceMask is the output interface mask.

--- a/pkg/tcpip/stack/iptables_types.go
+++ b/pkg/tcpip/stack/iptables_types.go
@@ -158,6 +158,19 @@ type IPHeaderFilter struct {
 	// true the filter will match packets that fail the destination
 	// comparison.
 	DstInvert bool
+
+	// OutputInterface matches the name of the outgoing interface for the
+	// packet.
+	OutputInterface string
+
+	// OutputInterfaceMask masks the characters of the interface name when
+	// comparing with OutputInterface.
+	OutputInterfaceMask string
+
+	// OutputInterfaceInvert inverts the meaning of outgoing interface check,
+	// i.e. when true the filter will match packets that fail the outgoing
+	// interface comparison.
+	OutputInterfaceInvert bool
 }
 
 // A Matcher is the interface for matching packets.

--- a/pkg/tcpip/stack/nic.go
+++ b/pkg/tcpip/stack/nic.go
@@ -1233,7 +1233,7 @@ func (n *NIC) DeliverNetworkPacket(linkEP LinkEndpoint, remote, local tcpip.Link
 		// iptables filtering.
 		ipt := n.stack.IPTables()
 		address := n.primaryAddress(protocol)
-		if ok := ipt.Check(Prerouting, &pkt, nil, nil, address.Address); !ok {
+		if ok := ipt.Check(Prerouting, &pkt, nil, nil, address.Address, ""); !ok {
 			// iptables is telling us to drop the packet.
 			return
 		}

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -1898,9 +1898,23 @@ func (s *Stack) FindNetworkEndpoint(netProto tcpip.NetworkProtocolNumber, addres
 			nic.mu.RLock()
 			defer nic.mu.RUnlock()
 
-			// An endpoint with this id exists, check if it can be used and return it.
+			// An endpoint with this id exists, check if it can be
+			// used and return it.
 			return ref.ep, nil
 		}
 	}
 	return nil, tcpip.ErrBadAddress
+}
+
+// FindNICNameFromID returns the name of the nic for the given NICID.
+func (s *Stack) FindNICNameFromID(id tcpip.NICID) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	nic, ok := s.nics[id]
+	if !ok {
+		return ""
+	}
+
+	return nic.Name()
 }

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -167,6 +167,30 @@ func TestFilterOutputOwnerFail(t *testing.T) {
 	singleTest(t, FilterOutputOwnerFail{})
 }
 
+func TestFilterOutputInterfaceAccept(t *testing.T) {
+	singleTest(t, FilterOutputInterfaceAccept{})
+}
+
+func TestFilterOutputInterfaceDrop(t *testing.T) {
+	singleTest(t, FilterOutputInterfaceDrop{})
+}
+
+func TestFilterOutputInterface(t *testing.T) {
+	singleTest(t, FilterOutputInterface{})
+}
+
+func TestFilterOutputInterfaceBeginsWith(t *testing.T) {
+	singleTest(t, FilterOutputInterfaceBeginsWith{})
+}
+
+func TestFilterOutputInterfaceInvertDrop(t *testing.T) {
+	singleTest(t, FilterOutputInterfaceInvertDrop{})
+}
+
+func TestFilterOutputInterfaceInvertAccept(t *testing.T) {
+	singleTest(t, FilterOutputInterfaceInvertAccept{})
+}
+
 func TestJumpSerialize(t *testing.T) {
 	singleTest(t, FilterInputSerializeJump{})
 }

--- a/test/iptables/iptables_util.go
+++ b/test/iptables/iptables_util.go
@@ -169,3 +169,18 @@ func localAddrs() ([]string, error) {
 	}
 	return addrStrs, nil
 }
+
+// getInterfaceName returns the name of the interface other than loopback.
+func getInterfaceName() (string, bool) {
+	var ifname string
+	if interfaces, err := net.Interfaces(); err == nil {
+		for _, intf := range interfaces {
+			if intf.Name != "lo" {
+				ifname = intf.Name
+				break
+			}
+		}
+	}
+
+	return ifname, ifname != ""
+}


### PR DESCRIPTION
Enables commands with -o (--out-interface) for iptables rules.
$ iptables -A OUTPUT -o eth0 -j ACCEPT
