### PR TITLE
iptables: support gid match for owner matching.

### DIFF
--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -167,6 +167,26 @@ func TestFilterOutputOwnerFail(t *testing.T) {
 	singleTest(t, FilterOutputOwnerFail{})
 }
 
+func TestFilterOutputAcceptGIDOwner(t *testing.T) {
+	singleTest(t, FilterOutputAcceptGIDOwner{})
+}
+
+func TestFilterOutputDropGIDOwner(t *testing.T) {
+	singleTest(t, FilterOutputDropGIDOwner{})
+}
+
+func TestFilterOutputInvertGIDOwner(t *testing.T) {
+	singleTest(t, FilterOutputInvertGIDOwner{})
+}
+
+func TestFilterOutputInvertUIDOwner(t *testing.T) {
+	singleTest(t, FilterOutputInvertUIDOwner{})
+}
+
+func TestFilterOutputInvertUIDAndGIDOwner(t *testing.T) {
+	singleTest(t, FilterOutputInvertUIDAndGIDOwner{})
+}
+
 func TestFilterOutputInterfaceAccept(t *testing.T) {
 	singleTest(t, FilterOutputInterfaceAccept{})
 }


### PR DESCRIPTION
- Added support for matching gid owner and invert flag for uid
and gid.
$ iptables -A OUTPUT -p tcp -m owner --gid-owner root -j ACCEPT
$ iptables -A OUTPUT -p tcp -m owner ! --uid-owner root -j ACCEPT
$ iptables -A OUTPUT -p tcp -m owner ! --gid-owner root -j DROP

- Added tests for uid, gid and invert flags.