### PR TITLE
PROT_NONE should be specially treated in the step of mapPhysical

### DIFF
--- a/pkg/sentry/platform/kvm/machine_arm64.go
+++ b/pkg/sentry/platform/kvm/machine_arm64.go
@@ -60,6 +60,12 @@ func rdonlyRegionsForSetMem() (phyRegions []physicalRegion) {
 		if !vr.accessType.Write && vr.accessType.Read {
 			rdonlyRegions = append(rdonlyRegions, vr.region)
 		}
+
+		// TODO(gvisor.dev/issue/2686): PROT_NONE should be specially treated.
+		// Workaround: treated as rdonly temporarily.
+		if !vr.accessType.Write && !vr.accessType.Read && !vr.accessType.Execute {
+			rdonlyRegions = append(rdonlyRegions, vr.region)
+		}
 	})
 
 	for _, r := range rdonlyRegions {


### PR DESCRIPTION
It's a workaround to treat PROT_NONE as RDONLY temporarily.

TODO(https://github.com/google/gvisor/issues/2686): PROT_NONE should be specially treated.

Signed-off-by: Bin Lu <bin.lu@arm.com>

