### PR TITLE
passed the syscall test case 'fpsig_nested' on Arm64 platform

### DIFF
--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -849,10 +849,7 @@ cc_binary(
 cc_binary(
     name = "fpsig_nested_test",
     testonly = 1,
-    srcs = select_arch(
-        amd64 = ["fpsig_nested.cc"],
-        arm64 = [],
-    ),
+    srcs = ["fpsig_nested.cc"],
     linkstatic = 1,
     deps = [
         gtest,

--- a/test/syscalls/linux/fpsig_fork.cc
+++ b/test/syscalls/linux/fpsig_fork.cc
@@ -37,11 +37,11 @@ namespace {
 #define __stringify_1(x...) #x
 #define __stringify(x...) __stringify_1(x)
 #define GET_FPREG(var, regname) \
-  asm volatile("str "__stringify(regname) ", %0" : "=m"(var))
+  asm volatile("str " __stringify(regname) ", %0" : "=m"(var))
 #define SET_FPREG(var, regname) \
-  asm volatile("ldr "__stringify(regname) ", %0" : "=m"(var))
+  asm volatile("ldr " __stringify(regname) ", %0" : "=m"(var))
 #define GET_FP0(var) GET_FPREG(var, d0)
-#define SET_FP0(var) GET_FPREG(var, d0)
+#define SET_FP0(var) SET_FPREG(var, d0)
 #endif
 
 int parent, child;


### PR DESCRIPTION
Some functions were added for Arm64 platform:
a, get_fp/set_fp
b, inline_tgkill

Test step:
bazel test //test/syscalls:fpsig_nested_test_runsc_ptrace

Signed-off-by: Bin Lu <bin.lu@arm.com>

