### PR TITLE
kvm-tls-2:adding the preservation of user-TLS in the Arm64 kvm platform

### DIFF
--- a/pkg/sentry/platform/kvm/context.go
+++ b/pkg/sentry/platform/kvm/context.go
@@ -62,6 +62,7 @@ func (c *context) Switch(as platform.AddressSpace, ac arch.Context, _ int32) (*a
 	switchOpts := ring0.SwitchOpts{
 		Registers:          &ac.StateData().Regs,
 		FloatingPointState: (*byte)(ac.FloatingPointData()),
+		Tls:                &ac.StateData().TPValue, // Only used on Arm64.
 		PageTables:         localAS.pageTables,
 		Flush:              localAS.Touch(cpu),
 		FullRestore:        ac.FullRestore(),

--- a/pkg/sentry/platform/ring0/defs.go
+++ b/pkg/sentry/platform/ring0/defs.go
@@ -95,6 +95,9 @@ type SwitchOpts struct {
 	// saved and restored.
 	FloatingPointState *byte
 
+	// TLS is the user TLS state.
+	Tls *uint64
+
 	// PageTables are the application page tables.
 	PageTables *pagetables.PageTables
 

--- a/pkg/sentry/platform/ring0/kernel_arm64.go
+++ b/pkg/sentry/platform/ring0/kernel_arm64.go
@@ -58,7 +58,15 @@ func (c *CPU) SwitchToUser(switchOpts SwitchOpts) (vector Vector) {
 
 	regs.Pstate &= ^uint64(UserFlagsClear)
 	regs.Pstate |= UserFlagsSet
+
+	tls := switchOpts.Tls
+
+	SetTLS(*tls)
+
 	kernelExitToEl0()
+
+	*tls = GetTLS()
+
 	vector = c.vecCode
 
 	// Perform the switch.


### PR DESCRIPTION
This patch load/save TLS for the container application on Arm64 kvm platform.

Signed-off-by: Bin Lu <bin.lu@arm.com>

