### PR TITLE
pipe_opener_test: fix data race

### DIFF
--- a/pkg/sentry/fs/fdpipe/pipe_opener_test.go
+++ b/pkg/sentry/fs/fdpipe/pipe_opener_test.go
@@ -421,7 +421,6 @@ func TestPipeHangup(t *testing.T) {
 			hangupSelf: true,
 		},
 	} {
-		test := test // re-create a local copy to avoid data race in the goroutine below
 		if test.flags.Read == test.flags.Write {
 			t.Errorf("%s: test requires a single reader or writer", test.desc)
 			continue
@@ -440,7 +439,7 @@ func TestPipeHangup(t *testing.T) {
 		// fd once we expect this partner routine to succeed, so we can manifest
 		// hangup events more directly.
 		fdchan := make(chan int, 1)
-		go func() {
+		go func(test interface{}) {
 			// Be explicit about the flags to protect the test from
 			// misconfiguration.
 			var flags int
@@ -454,7 +453,7 @@ func TestPipeHangup(t *testing.T) {
 				t.Logf("Open(%q, %o, 0666) partner failed: %v", name, flags, err)
 			}
 			fdchan <- fd
-		}()
+		}(test)
 
 		// Open our end in a blocking way to ensure that we coordinate.
 		opener := &hostOpener{name: name}

--- a/pkg/sentry/fs/fdpipe/pipe_opener_test.go
+++ b/pkg/sentry/fs/fdpipe/pipe_opener_test.go
@@ -421,6 +421,7 @@ func TestPipeHangup(t *testing.T) {
 			hangupSelf: true,
 		},
 	} {
+		test := test // re-create a local copy to avoid data race in the goroutine below
 		if test.flags.Read == test.flags.Write {
 			t.Errorf("%s: test requires a single reader or writer", test.desc)
 			continue

--- a/pkg/sentry/fs/fdpipe/pipe_opener_test.go
+++ b/pkg/sentry/fs/fdpipe/pipe_opener_test.go
@@ -421,6 +421,7 @@ func TestPipeHangup(t *testing.T) {
 			hangupSelf: true,
 		},
 	} {
+		test := test		// To avoid data race in goroutine
 		if test.flags.Read == test.flags.Write {
 			t.Errorf("%s: test requires a single reader or writer", test.desc)
 			continue
@@ -439,7 +440,7 @@ func TestPipeHangup(t *testing.T) {
 		// fd once we expect this partner routine to succeed, so we can manifest
 		// hangup events more directly.
 		fdchan := make(chan int, 1)
-		go func(test interface{}) {
+		go func() {
 			// Be explicit about the flags to protect the test from
 			// misconfiguration.
 			var flags int
@@ -453,7 +454,7 @@ func TestPipeHangup(t *testing.T) {
 				t.Logf("Open(%q, %o, 0666) partner failed: %v", name, flags, err)
 			}
 			fdchan <- fd
-		}(test)
+		}()
 
 		// Open our end in a blocking way to ensure that we coordinate.
 		opener := &hostOpener{name: name}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

* [y ] Have you followed the guidelines in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)?
* [y ] Have you formatted and linted your code?
* [n ] Have you added relevant tests?
* [ y] Have you added appropriate Fixes & Updates references?
* [- ] If yes, please erase all these lines!

The iterator variable test will cause a data race in the goroutine since all the goroutines are scheduled after the control gets out of the for loop, hence only the last value in the for loop is picked up by all the goroutines. To avoid this issue, this PR creates a local copy of the iterator variable.
