### PR TITLE
kvm-tls-2:add the preservation of user-TLS in the Arm64 kvm platform

### DIFF
--- a/pkg/sentry/arch/arch_amd64.go
+++ b/pkg/sentry/arch/arch_amd64.go
@@ -129,37 +129,37 @@ func (c *context64) Fork() Context {
 
 // Return returns the current syscall return value.
 func (c *context64) Return() uintptr {
-	return uintptr(c.Regs.Rax)
+	return uintptr(c.Regs.PtraceRegs().Rax)
 }
 
 // SetReturn sets the syscall return value.
 func (c *context64) SetReturn(value uintptr) {
-	c.Regs.Rax = uint64(value)
+	c.Regs.PtraceRegs().Rax = uint64(value)
 }
 
 // IP returns the current instruction pointer.
 func (c *context64) IP() uintptr {
-	return uintptr(c.Regs.Rip)
+	return uintptr(c.Regs.PtraceRegs().Rip)
 }
 
 // SetIP sets the current instruction pointer.
 func (c *context64) SetIP(value uintptr) {
-	c.Regs.Rip = uint64(value)
+	c.Regs.PtraceRegs().Rip = uint64(value)
 }
 
 // Stack returns the current stack pointer.
 func (c *context64) Stack() uintptr {
-	return uintptr(c.Regs.Rsp)
+	return uintptr(c.Regs.PtraceRegs().Rsp)
 }
 
 // SetStack sets the current stack pointer.
 func (c *context64) SetStack(value uintptr) {
-	c.Regs.Rsp = uint64(value)
+	c.Regs.PtraceRegs().Rsp = uint64(value)
 }
 
 // TLS returns the current TLS pointer.
 func (c *context64) TLS() uintptr {
-	return uintptr(c.Regs.Fs_base)
+	return uintptr(c.Regs.PtraceRegs().Fs_base)
 }
 
 // SetTLS sets the current TLS pointer. Returns false if value is invalid.
@@ -168,14 +168,14 @@ func (c *context64) SetTLS(value uintptr) bool {
 		return false
 	}
 
-	c.Regs.Fs = 0
-	c.Regs.Fs_base = uint64(value)
+	c.Regs.PtraceRegs().Fs = 0
+	c.Regs.PtraceRegs().Fs_base = uint64(value)
 	return true
 }
 
 // SetOldRSeqInterruptedIP implements Context.SetOldRSeqInterruptedIP.
 func (c *context64) SetOldRSeqInterruptedIP(value uintptr) {
-	c.Regs.R10 = uint64(value)
+	c.Regs.PtraceRegs().R10 = uint64(value)
 }
 
 // Native returns the native type for the given val.

--- a/pkg/sentry/arch/arch_arm64.go
+++ b/pkg/sentry/arch/arch_arm64.go
@@ -112,37 +112,38 @@ func (c *context64) Fork() Context {
 
 // Return returns the current syscall return value.
 func (c *context64) Return() uintptr {
-	return uintptr(c.Regs.Regs[0])
+	return uintptr(c.Regs.PtraceRegs().Regs[0])
 }
 
 // SetReturn sets the syscall return value.
 func (c *context64) SetReturn(value uintptr) {
-	c.Regs.Regs[0] = uint64(value)
+	c.Regs.PtraceRegs().Regs[0] = uint64(value)
 }
 
 // IP returns the current instruction pointer.
 func (c *context64) IP() uintptr {
-	return uintptr(c.Regs.Pc)
+	return uintptr(c.Regs.PtraceRegs().Pc)
 }
 
 // SetIP sets the current instruction pointer.
 func (c *context64) SetIP(value uintptr) {
-	c.Regs.Pc = uint64(value)
+	c.Regs.PtraceRegs().Pc = uint64(value)
 }
 
 // Stack returns the current stack pointer.
 func (c *context64) Stack() uintptr {
-	return uintptr(c.Regs.Sp)
+	return uintptr(c.Regs.PtraceRegs().Sp)
 }
 
 // SetStack sets the current stack pointer.
 func (c *context64) SetStack(value uintptr) {
-	c.Regs.Sp = uint64(value)
+	c.Regs.PtraceRegs().Sp = uint64(value)
 }
 
 // TLS returns the current TLS pointer.
 func (c *context64) TLS() uintptr {
-	return uintptr(c.TPValue)
+	tlsReg := c.Regs.TlsRegs()
+	return uintptr(*tlsReg)
 }
 
 // SetTLS sets the current TLS pointer. Returns false if value is invalid.
@@ -151,13 +152,16 @@ func (c *context64) SetTLS(value uintptr) bool {
 		return false
 	}
 
-	c.TPValue = uint64(value)
+	tlsReg := c.Regs.TlsRegs()
+	if *tlsReg != uint64(value) {
+		*tlsReg = uint64(value)
+	}
 	return true
 }
 
 // SetOldRSeqInterruptedIP implements Context.SetOldRSeqInterruptedIP.
 func (c *context64) SetOldRSeqInterruptedIP(value uintptr) {
-	c.Regs.Regs[3] = uint64(value)
+	c.Regs.PtraceRegs().Regs[3] = uint64(value)
 }
 
 // Native returns the native type for the given val.

--- a/pkg/sentry/arch/syscalls_amd64.go
+++ b/pkg/sentry/arch/syscalls_amd64.go
@@ -27,7 +27,7 @@ func (c *context64) SyscallSaveOrig() {
 
 // SyscallNo returns the syscall number according to the 64-bit convention.
 func (c *context64) SyscallNo() uintptr {
-	return uintptr(c.Regs.Orig_rax)
+	return uintptr(c.Regs.PtraceRegs().Orig_rax)
 }
 
 // SyscallArgs provides syscall arguments according to the 64-bit convention.
@@ -36,24 +36,25 @@ func (c *context64) SyscallNo() uintptr {
 // built in 64-bit mode. So we can just assume the syscall numbers that come
 // back match the expected host system call numbers.
 func (c *context64) SyscallArgs() SyscallArguments {
+	ptRegs := c.Regs.PtraceRegs()
 	return SyscallArguments{
-		SyscallArgument{Value: uintptr(c.Regs.Rdi)},
-		SyscallArgument{Value: uintptr(c.Regs.Rsi)},
-		SyscallArgument{Value: uintptr(c.Regs.Rdx)},
-		SyscallArgument{Value: uintptr(c.Regs.R10)},
-		SyscallArgument{Value: uintptr(c.Regs.R8)},
-		SyscallArgument{Value: uintptr(c.Regs.R9)},
+		SyscallArgument{Value: uintptr(ptRegs.Rdi)},
+		SyscallArgument{Value: uintptr(ptRegs.Rsi)},
+		SyscallArgument{Value: uintptr(ptRegs.Rdx)},
+		SyscallArgument{Value: uintptr(ptRegs.R10)},
+		SyscallArgument{Value: uintptr(ptRegs.R8)},
+		SyscallArgument{Value: uintptr(ptRegs.R9)},
 	}
 }
 
 // RestartSyscall implements Context.RestartSyscall.
 func (c *context64) RestartSyscall() {
-	c.Regs.Rip -= SyscallWidth
-	c.Regs.Rax = c.Regs.Orig_rax
+	c.Regs.PtraceRegs().Rip -= SyscallWidth
+	c.Regs.PtraceRegs().Rax = c.Regs.PtraceRegs().Orig_rax
 }
 
 // RestartSyscallWithRestartBlock implements Context.RestartSyscallWithRestartBlock.
 func (c *context64) RestartSyscallWithRestartBlock() {
-	c.Regs.Rip -= SyscallWidth
-	c.Regs.Rax = uint64(restartSyscallNr)
+	c.Regs.PtraceRegs().Rip -= SyscallWidth
+	c.Regs.PtraceRegs().Rax = uint64(restartSyscallNr)
 }

--- a/pkg/sentry/platform/kvm/bluepill_amd64.go
+++ b/pkg/sentry/platform/kvm/bluepill_amd64.go
@@ -33,7 +33,7 @@ var (
 //go:nosplit
 func bluepillArchEnter(context *arch.SignalContext64) *vCPU {
 	c := vCPUPtr(uintptr(context.Rax))
-	regs := c.CPU.Registers()
+	regs := c.CPU.Registers().PtraceRegs()
 	regs.R8 = context.R8
 	regs.R9 = context.R9
 	regs.R10 = context.R10
@@ -67,7 +67,7 @@ func bluepillArchEnter(context *arch.SignalContext64) *vCPU {
 //
 //go:nosplit
 func (c *vCPU) KernelSyscall() {
-	regs := c.Registers()
+	regs := c.Registers().PtraceRegs()
 	if regs.Rax != ^uint64(0) {
 		regs.Rip -= 2 // Rewind.
 	}
@@ -85,7 +85,7 @@ func (c *vCPU) KernelSyscall() {
 //
 //go:nosplit
 func (c *vCPU) KernelException(vector ring0.Vector) {
-	regs := c.Registers()
+	regs := c.Registers().PtraceRegs()
 	if vector == ring0.Vector(bounce) {
 		// These should not interrupt kernel execution; point the Rip
 		// to zero to ensure that we get a reasonable panic when we
@@ -102,7 +102,7 @@ func (c *vCPU) KernelException(vector ring0.Vector) {
 //
 //go:nosplit
 func bluepillArchExit(c *vCPU, context *arch.SignalContext64) {
-	regs := c.CPU.Registers()
+	regs := c.CPU.Registers().PtraceRegs()
 	context.R8 = regs.R8
 	context.R9 = regs.R9
 	context.R10 = regs.R10

--- a/pkg/sentry/platform/kvm/bluepill_amd64_unsafe.go
+++ b/pkg/sentry/platform/kvm/bluepill_amd64_unsafe.go
@@ -41,7 +41,7 @@ func dieArchSetup(c *vCPU, context *arch.SignalContext64, guestRegs *userRegs) {
 	// If the vCPU is in user mode, we set the stack to the stored stack
 	// value in the vCPU itself. We don't want to unwind the user stack.
 	if guestRegs.RFLAGS&ring0.UserFlagsSet == ring0.UserFlagsSet {
-		regs := c.CPU.Registers()
+		regs := c.CPU.Registers().PtraceRegs()
 		context.Rax = regs.Rax
 		context.Rsp = regs.Rsp
 		context.Rbp = regs.Rbp

--- a/pkg/sentry/platform/kvm/bluepill_arm64.go
+++ b/pkg/sentry/platform/kvm/bluepill_arm64.go
@@ -44,7 +44,7 @@ var (
 //go:nosplit
 func bluepillArchEnter(context *arch.SignalContext64) (c *vCPU) {
 	c = vCPUPtr(uintptr(context.Regs[8]))
-	regs := c.CPU.Registers()
+	regs := c.CPU.Registers().PtraceRegs()
 	regs.Regs = context.Regs
 	regs.Sp = context.Sp
 	regs.Pc = context.Pc
@@ -58,7 +58,7 @@ func bluepillArchEnter(context *arch.SignalContext64) (c *vCPU) {
 //
 //go:nosplit
 func bluepillArchExit(c *vCPU, context *arch.SignalContext64) {
-	regs := c.CPU.Registers()
+	regs := c.CPU.Registers().PtraceRegs()
 	context.Regs = regs.Regs
 	context.Sp = regs.Sp
 	context.Pc = regs.Pc
@@ -81,7 +81,7 @@ func bluepillArchExit(c *vCPU, context *arch.SignalContext64) {
 //
 //go:nosplit
 func (c *vCPU) KernelSyscall() {
-	regs := c.Registers()
+	regs := c.Registers().PtraceRegs()
 	if regs.Regs[8] != ^uint64(0) {
 		regs.Pc -= 4 // Rewind.
 	}
@@ -105,7 +105,7 @@ func (c *vCPU) KernelSyscall() {
 //
 //go:nosplit
 func (c *vCPU) KernelException(vector ring0.Vector) {
-	regs := c.Registers()
+	regs := c.Registers().PtraceRegs()
 	if vector == ring0.Vector(bounce) {
 		regs.Pc = 0
 	}

--- a/pkg/sentry/platform/kvm/bluepill_arm64_unsafe.go
+++ b/pkg/sentry/platform/kvm/bluepill_arm64_unsafe.go
@@ -42,7 +42,7 @@ func dieArchSetup(c *vCPU, context *arch.SignalContext64, guestRegs *userRegs) {
 	// If the vCPU is in user mode, we set the stack to the stored stack
 	// value in the vCPU itself. We don't want to unwind the user stack.
 	if guestRegs.Regs.Pstate&ring0.PSR_MODE_MASK == ring0.PSR_MODE_EL0t {
-		regs := c.CPU.Registers()
+		regs := c.CPU.Registers().PtraceRegs()
 		context.Regs[0] = regs.Regs[0]
 		context.Sp = regs.Sp
 		context.Regs[29] = regs.Regs[29] // stack base address

--- a/pkg/sentry/platform/kvm/kvm_arm64.go
+++ b/pkg/sentry/platform/kvm/kvm_arm64.go
@@ -17,7 +17,7 @@
 package kvm
 
 import (
-	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/sentry/platform/ring0"
 )
 
@@ -39,7 +39,7 @@ type userFpsimdState struct {
 }
 
 type userRegs struct {
-	Regs    arch.Registers
+	Regs    linux.PtraceRegs
 	sp_el1  uint64
 	elr_el1 uint64
 	spsr    [KVM_NR_SPSR]uint64

--- a/pkg/sentry/platform/kvm/machine_amd64_unsafe.go
+++ b/pkg/sentry/platform/kvm/machine_amd64_unsafe.go
@@ -35,14 +35,14 @@ func (c *vCPU) loadSegments(tid uint64) {
 	if _, _, errno := syscall.RawSyscall(
 		syscall.SYS_ARCH_PRCTL,
 		linux.ARCH_GET_FS,
-		uintptr(unsafe.Pointer(&c.CPU.Registers().Fs_base)),
+		uintptr(unsafe.Pointer(&c.CPU.Registers().PtraceRegs().Fs_base)),
 		0); errno != 0 {
 		throw("getting FS segment")
 	}
 	if _, _, errno := syscall.RawSyscall(
 		syscall.SYS_ARCH_PRCTL,
 		linux.ARCH_GET_GS,
-		uintptr(unsafe.Pointer(&c.CPU.Registers().Gs_base)),
+		uintptr(unsafe.Pointer(&c.CPU.Registers().PtraceRegs().Gs_base)),
 		0); errno != 0 {
 		throw("getting GS segment")
 	}

--- a/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
+++ b/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
@@ -228,7 +228,7 @@ func (c *vCPU) setSignalMask() error {
 // SwitchToUser unpacks architectural-details.
 func (c *vCPU) SwitchToUser(switchOpts ring0.SwitchOpts, info *arch.SignalInfo) (usermem.AccessType, error) {
 	// Check for canonical addresses.
-	if regs := switchOpts.Registers; !ring0.IsCanonical(regs.Pc) {
+	if regs := switchOpts.Registers.PtraceRegs(); !ring0.IsCanonical(regs.Pc) {
 		return nonCanonical(regs.Pc, int32(syscall.SIGSEGV), info)
 	} else if !ring0.IsCanonical(regs.Sp) {
 		return nonCanonical(regs.Sp, int32(syscall.SIGBUS), info)

--- a/pkg/sentry/platform/kvm/testutil/testutil_amd64.go
+++ b/pkg/sentry/platform/kvm/testutil/testutil_amd64.go
@@ -27,93 +27,95 @@ func TwiddleSegments()
 
 // SetTestTarget sets the rip appropriately.
 func SetTestTarget(regs *arch.Registers, fn func()) {
-	regs.Rip = uint64(reflect.ValueOf(fn).Pointer())
+	regs.PtraceRegs().Rip = uint64(reflect.ValueOf(fn).Pointer())
 }
 
 // SetTouchTarget sets rax appropriately.
 func SetTouchTarget(regs *arch.Registers, target *uintptr) {
 	if target != nil {
-		regs.Rax = uint64(reflect.ValueOf(target).Pointer())
+		regs.PtraceRegs().Rax = uint64(reflect.ValueOf(target).Pointer())
 	} else {
-		regs.Rax = 0
+		regs.PtraceRegs().Rax = 0
 	}
 }
 
 // RewindSyscall rewinds a syscall RIP.
 func RewindSyscall(regs *arch.Registers) {
-	regs.Rip -= 2
+	regs.PtraceRegs().Rip -= 2
 }
 
 // SetTestRegs initializes registers to known values.
 func SetTestRegs(regs *arch.Registers) {
-	regs.R15 = 0x15
-	regs.R14 = 0x14
-	regs.R13 = 0x13
-	regs.R12 = 0x12
-	regs.Rbp = 0xb9
-	regs.Rbx = 0xb4
-	regs.R11 = 0x11
-	regs.R10 = 0x10
-	regs.R9 = 0x09
-	regs.R8 = 0x08
-	regs.Rax = 0x44
-	regs.Rcx = 0xc4
-	regs.Rdx = 0xd4
-	regs.Rsi = 0x51
-	regs.Rdi = 0xd1
-	regs.Rsp = 0x59
+	ptRegs := regs.PtraceRegs()
+	ptRegs.R15 = 0x15
+	ptRegs.R14 = 0x14
+	ptRegs.R13 = 0x13
+	ptRegs.R12 = 0x12
+	ptRegs.Rbp = 0xb9
+	ptRegs.Rbx = 0xb4
+	ptRegs.R11 = 0x11
+	ptRegs.R10 = 0x10
+	ptRegs.R9 = 0x09
+	ptRegs.R8 = 0x08
+	ptRegs.Rax = 0x44
+	ptRegs.Rcx = 0xc4
+	ptRegs.Rdx = 0xd4
+	ptRegs.Rsi = 0x51
+	ptRegs.Rdi = 0xd1
+	ptRegs.Rsp = 0x59
 }
 
 // CheckTestRegs checks that registers were twiddled per TwiddleRegs.
 func CheckTestRegs(regs *arch.Registers, full bool) (err error) {
-	if need := ^uint64(0x15); regs.R15 != need {
-		err = addRegisterMismatch(err, "R15", regs.R15, need)
+	ptRegs := regs.PtraceRegs()
+	if need := ^uint64(0x15); ptRegs.R15 != need {
+		err = addRegisterMismatch(err, "R15", ptRegs.R15, need)
 	}
-	if need := ^uint64(0x14); regs.R14 != need {
-		err = addRegisterMismatch(err, "R14", regs.R14, need)
+	if need := ^uint64(0x14); ptRegs.R14 != need {
+		err = addRegisterMismatch(err, "R14", ptRegs.R14, need)
 	}
-	if need := ^uint64(0x13); regs.R13 != need {
-		err = addRegisterMismatch(err, "R13", regs.R13, need)
+	if need := ^uint64(0x13); ptRegs.R13 != need {
+		err = addRegisterMismatch(err, "R13", ptRegs.R13, need)
 	}
-	if need := ^uint64(0x12); regs.R12 != need {
-		err = addRegisterMismatch(err, "R12", regs.R12, need)
+	if need := ^uint64(0x12); ptRegs.R12 != need {
+		err = addRegisterMismatch(err, "R12", ptRegs.R12, need)
 	}
-	if need := ^uint64(0xb9); regs.Rbp != need {
-		err = addRegisterMismatch(err, "Rbp", regs.Rbp, need)
+	if need := ^uint64(0xb9); ptRegs.Rbp != need {
+		err = addRegisterMismatch(err, "Rbp", ptRegs.Rbp, need)
 	}
-	if need := ^uint64(0xb4); regs.Rbx != need {
-		err = addRegisterMismatch(err, "Rbx", regs.Rbx, need)
+	if need := ^uint64(0xb4); ptRegs.Rbx != need {
+		err = addRegisterMismatch(err, "Rbx", ptRegs.Rbx, need)
 	}
-	if need := ^uint64(0x10); regs.R10 != need {
-		err = addRegisterMismatch(err, "R10", regs.R10, need)
+	if need := ^uint64(0x10); ptRegs.R10 != need {
+		err = addRegisterMismatch(err, "R10", ptRegs.R10, need)
 	}
-	if need := ^uint64(0x09); regs.R9 != need {
-		err = addRegisterMismatch(err, "R9", regs.R9, need)
+	if need := ^uint64(0x09); ptRegs.R9 != need {
+		err = addRegisterMismatch(err, "R9", ptRegs.R9, need)
 	}
-	if need := ^uint64(0x08); regs.R8 != need {
-		err = addRegisterMismatch(err, "R8", regs.R8, need)
+	if need := ^uint64(0x08); ptRegs.R8 != need {
+		err = addRegisterMismatch(err, "R8", ptRegs.R8, need)
 	}
-	if need := ^uint64(0x44); regs.Rax != need {
-		err = addRegisterMismatch(err, "Rax", regs.Rax, need)
+	if need := ^uint64(0x44); ptRegs.Rax != need {
+		err = addRegisterMismatch(err, "Rax", ptRegs.Rax, need)
 	}
-	if need := ^uint64(0xd4); regs.Rdx != need {
-		err = addRegisterMismatch(err, "Rdx", regs.Rdx, need)
+	if need := ^uint64(0xd4); ptRegs.Rdx != need {
+		err = addRegisterMismatch(err, "Rdx", ptRegs.Rdx, need)
 	}
-	if need := ^uint64(0x51); regs.Rsi != need {
-		err = addRegisterMismatch(err, "Rsi", regs.Rsi, need)
+	if need := ^uint64(0x51); ptRegs.Rsi != need {
+		err = addRegisterMismatch(err, "Rsi", ptRegs.Rsi, need)
 	}
-	if need := ^uint64(0xd1); regs.Rdi != need {
-		err = addRegisterMismatch(err, "Rdi", regs.Rdi, need)
+	if need := ^uint64(0xd1); ptRegs.Rdi != need {
+		err = addRegisterMismatch(err, "Rdi", ptRegs.Rdi, need)
 	}
-	if need := ^uint64(0x59); regs.Rsp != need {
-		err = addRegisterMismatch(err, "Rsp", regs.Rsp, need)
+	if need := ^uint64(0x59); ptRegs.Rsp != need {
+		err = addRegisterMismatch(err, "Rsp", ptRegs.Rsp, need)
 	}
 	// Rcx & R11 are ignored if !full is set.
-	if need := ^uint64(0x11); full && regs.R11 != need {
-		err = addRegisterMismatch(err, "R11", regs.R11, need)
+	if need := ^uint64(0x11); full && ptRegs.R11 != need {
+		err = addRegisterMismatch(err, "R11", ptRegs.R11, need)
 	}
-	if need := ^uint64(0xc4); full && regs.Rcx != need {
-		err = addRegisterMismatch(err, "Rcx", regs.Rcx, need)
+	if need := ^uint64(0xc4); full && ptRegs.Rcx != need {
+		err = addRegisterMismatch(err, "Rcx", ptRegs.Rcx, need)
 	}
 	return
 }
@@ -123,17 +125,17 @@ var gsData uint64 = 0x85
 
 // SetTestSegments initializes segments to known values.
 func SetTestSegments(regs *arch.Registers) {
-	regs.Fs_base = uint64(reflect.ValueOf(&fsData).Pointer())
-	regs.Gs_base = uint64(reflect.ValueOf(&gsData).Pointer())
+	regs.PtraceRegs().Fs_base = uint64(reflect.ValueOf(&fsData).Pointer())
+	regs.PtraceRegs().Gs_base = uint64(reflect.ValueOf(&gsData).Pointer())
 }
 
 // CheckTestSegments checks that registers were twiddled per TwiddleSegments.
 func CheckTestSegments(regs *arch.Registers) (err error) {
-	if regs.Rax != fsData {
-		err = addRegisterMismatch(err, "Rax", regs.Rax, fsData)
+	if regs.PtraceRegs().Rax != fsData {
+		err = addRegisterMismatch(err, "Rax", regs.PtraceRegs().Rax, fsData)
 	}
-	if regs.Rbx != gsData {
-		err = addRegisterMismatch(err, "Rbx", regs.Rcx, gsData)
+	if regs.PtraceRegs().Rbx != gsData {
+		err = addRegisterMismatch(err, "Rbx", regs.PtraceRegs().Rcx, gsData)
 	}
 	return
 }

--- a/pkg/sentry/platform/kvm/testutil/testutil_arm64.go
+++ b/pkg/sentry/platform/kvm/testutil/testutil_arm64.go
@@ -25,35 +25,35 @@ import (
 
 // SetTestTarget sets the rip appropriately.
 func SetTestTarget(regs *arch.Registers, fn func()) {
-	regs.Pc = uint64(reflect.ValueOf(fn).Pointer())
+	regs.PtraceRegs().Pc = uint64(reflect.ValueOf(fn).Pointer())
 }
 
 // SetTouchTarget sets rax appropriately.
 func SetTouchTarget(regs *arch.Registers, target *uintptr) {
 	if target != nil {
-		regs.Regs[8] = uint64(reflect.ValueOf(target).Pointer())
+		regs.PtraceRegs().Regs[8] = uint64(reflect.ValueOf(target).Pointer())
 	} else {
-		regs.Regs[8] = 0
+		regs.PtraceRegs().Regs[8] = 0
 	}
 }
 
 // RewindSyscall rewinds a syscall RIP.
 func RewindSyscall(regs *arch.Registers) {
-	regs.Pc -= 4
+	regs.PtraceRegs().Pc -= 4
 }
 
 // SetTestRegs initializes registers to known values.
 func SetTestRegs(regs *arch.Registers) {
 	for i := 0; i <= 30; i++ {
-		regs.Regs[i] = uint64(i) + 1
+		regs.PtraceRegs().Regs[i] = uint64(i) + 1
 	}
 }
 
 // CheckTestRegs checks that registers were twiddled per TwiddleRegs.
 func CheckTestRegs(regs *arch.Registers, full bool) (err error) {
 	for i := 0; i <= 30; i++ {
-		if need := ^uint64(i + 1); regs.Regs[i] != need {
-			err = addRegisterMismatch(err, fmt.Sprintf("R%d", i), regs.Regs[i], need)
+		if need := ^uint64(i + 1); regs.PtraceRegs().Regs[i] != need {
+			err = addRegisterMismatch(err, fmt.Sprintf("R%d", i), regs.PtraceRegs().Regs[i], need)
 		}
 	}
 	return

--- a/pkg/sentry/platform/ptrace/ptrace_amd64.go
+++ b/pkg/sentry/platform/ptrace/ptrace_amd64.go
@@ -28,7 +28,7 @@ func fpRegSet(useXsave bool) uintptr {
 }
 
 func stackPointer(r *arch.Registers) uintptr {
-	return uintptr(r.Rsp)
+	return uintptr(r.PtraceRegs().Rsp)
 }
 
 // x86 use the fs_base register to store the TLS pointer which can be

--- a/pkg/sentry/platform/ptrace/ptrace_arm64.go
+++ b/pkg/sentry/platform/ptrace/ptrace_arm64.go
@@ -25,5 +25,5 @@ func fpRegSet(_ bool) uintptr {
 }
 
 func stackPointer(r *arch.Registers) uintptr {
-	return uintptr(r.Sp)
+	return uintptr(r.PtraceRegs().Sp)
 }

--- a/pkg/sentry/platform/ptrace/ptrace_unsafe.go
+++ b/pkg/sentry/platform/ptrace/ptrace_unsafe.go
@@ -25,9 +25,10 @@ import (
 
 // getRegs gets the general purpose register set.
 func (t *thread) getRegs(regs *arch.Registers) error {
+	ptRegs := regs.PtraceRegs()
 	iovec := syscall.Iovec{
-		Base: (*byte)(unsafe.Pointer(regs)),
-		Len:  uint64(unsafe.Sizeof(*regs)),
+		Base: (*byte)(unsafe.Pointer(ptRegs)),
+		Len:  uint64(unsafe.Sizeof(*ptRegs)),
 	}
 	_, _, errno := syscall.RawSyscall6(
 		syscall.SYS_PTRACE,
@@ -44,9 +45,10 @@ func (t *thread) getRegs(regs *arch.Registers) error {
 
 // setRegs sets the general purpose register set.
 func (t *thread) setRegs(regs *arch.Registers) error {
+	ptRegs := regs.PtraceRegs()
 	iovec := syscall.Iovec{
-		Base: (*byte)(unsafe.Pointer(regs)),
-		Len:  uint64(unsafe.Sizeof(*regs)),
+		Base: (*byte)(unsafe.Pointer(ptRegs)),
+		Len:  uint64(unsafe.Sizeof(*ptRegs)),
 	}
 	_, _, errno := syscall.RawSyscall6(
 		syscall.SYS_PTRACE,

--- a/pkg/sentry/platform/ring0/BUILD
+++ b/pkg/sentry/platform/ring0/BUILD
@@ -80,6 +80,7 @@ go_library(
         "//pkg/cpuid",
         "//pkg/safecopy",
         "//pkg/sentry/arch",
+        "//pkg/abi/linux",
         "//pkg/sentry/platform/ring0/pagetables",
         "//pkg/usermem",
     ],

--- a/pkg/sentry/platform/ring0/gen_offsets/BUILD
+++ b/pkg/sentry/platform/ring0/gen_offsets/BUILD
@@ -28,6 +28,7 @@ go_binary(
     deps = [
         "//pkg/cpuid",
         "//pkg/sentry/arch",
+        "//pkg/abi/linux",
         "//pkg/sentry/platform/ring0/pagetables",
         "//pkg/usermem",
     ],

--- a/pkg/sentry/platform/ring0/offsets_amd64.go
+++ b/pkg/sentry/platform/ring0/offsets_amd64.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"reflect"
 
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 )
 
@@ -65,7 +66,7 @@ func Emit(w io.Writer) {
 	fmt.Fprintf(w, "#define SyscallInt80               0x%02x\n", SyscallInt80)
 	fmt.Fprintf(w, "#define Syscall                    0x%02x\n", Syscall)
 
-	p := &arch.Registers{}
+	p := &linux.PtraceRegs{}
 	fmt.Fprintf(w, "\n// Ptrace registers.\n")
 	fmt.Fprintf(w, "#define PTRACE_R15      0x%02x\n", reflect.ValueOf(&p.R15).Pointer()-reflect.ValueOf(p).Pointer())
 	fmt.Fprintf(w, "#define PTRACE_R14      0x%02x\n", reflect.ValueOf(&p.R14).Pointer()-reflect.ValueOf(p).Pointer())

--- a/pkg/sentry/platform/ring0/offsets_arm64.go
+++ b/pkg/sentry/platform/ring0/offsets_arm64.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"reflect"
 
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 )
 
@@ -88,7 +89,7 @@ func Emit(w io.Writer) {
 	fmt.Fprintf(w, "#define Syscall 0x%02x\n", Syscall)
 	fmt.Fprintf(w, "#define VirtualizationException 0x%02x\n", VirtualizationException)
 
-	p := &arch.Registers{}
+	p := &linux.PtraceRegs{}
 	fmt.Fprintf(w, "\n// Ptrace registers.\n")
 	fmt.Fprintf(w, "#define PTRACE_R0       0x%02x\n", reflect.ValueOf(&p.Regs[0]).Pointer()-reflect.ValueOf(p).Pointer())
 	fmt.Fprintf(w, "#define PTRACE_R1       0x%02x\n", reflect.ValueOf(&p.Regs[1]).Pointer()-reflect.ValueOf(p).Pointer())


### PR DESCRIPTION
This patch load/save TLS for the container application.

Related issue: full context-switch supporting for Arm64 #1238