### PR TITLE
memory_events: use buffered channel to avoid leak

### DIFF
--- a/pkg/sentry/kernel/memevent/memory_events.go
+++ b/pkg/sentry/kernel/memevent/memory_events.go
@@ -52,7 +52,7 @@ func New(k *kernel.Kernel, period time.Duration) *MemoryEvents {
 	return &MemoryEvents{
 		k:      k,
 		period: period,
-		stop:   make(chan struct{}),
+		stop:   make(chan struct{}, 1),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

* [ y] Have you followed the guidelines in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)?
* [y ] Have you formatted and linted your code?
* [ n] Have you added relevant tests?
* [y ] Have you added appropriate Fixes & Updates references?
* [- ] If yes, please erase all these lines!

Fixes a goroutine leak. Explanation: stop needs to have a reader since the goroutine (Line 73: go m.run()) doing the work needs to send to it even if it times out: 

```
 for {
        select {
        case <-m.stop:
            return
        case <-ticker.C:
            totalTicks.Increment()
            m.emit()
        }
    }  
```

A simple fix is to add buffer of size 1 to the stop to not have the goroutine block for a reader.
