### PR TITLE
sentry: use defer wg.Done() unconditionally

### DIFF
--- a/pkg/sentry/kernel/timekeeper.go
+++ b/pkg/sentry/kernel/timekeeper.go
@@ -186,6 +186,7 @@ func (t *Timekeeper) startUpdater() {
 	timer := time.NewTicker(sentrytime.ApproxUpdateInterval)
 	t.wg.Add(1)
 	go func() { // S/R-SAFE: stopped during save.
+		defer t.wg.Done()
 		for {
 			// Start with an update immediately, so the clocks are
 			// ready ASAP.
@@ -220,7 +221,6 @@ func (t *Timekeeper) startUpdater() {
 			select {
 			case <-timer.C:
 			case <-t.stop:
-				t.wg.Done()
 				return
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

* [y ] Have you followed the guidelines in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)?
* [y ] Have you formatted and linted your code?
* [n ] Have you added relevant tests?
* [y ] Have you added appropriate Fixes & Updates references?
* [- ] If yes, please erase all these lines!

The PR moves the t.wg.Done() at the top to be unconditional rather than only on t.Stop() executes.
