### PR TITLE
optimize size and time using "--no-cache-dir"

### DIFF
--- a/benchmarks/workloads/tensorflow/Dockerfile
+++ b/benchmarks/workloads/tensorflow/Dockerfile
@@ -3,8 +3,8 @@ FROM tensorflow/tensorflow:1.13.2
 RUN apt-get update \
     && apt-get install -y git
 RUN git clone --depth 1 https://github.com/aymericdamien/TensorFlow-Examples.git
-RUN python -m pip install -U pip setuptools
-RUN python -m pip install matplotlib
+RUN python -m pip install --no-cache-dir -U pip setuptools
+RUN python -m pip install --no-cache-dir matplotlib
 
 WORKDIR /TensorFlow-Examples/examples
 

--- a/images/default/Dockerfile
+++ b/images/default/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora:31
 # Install bazel.
 RUN dnf install -y dnf-plugins-core && dnf copr enable -y vbatts/bazel
 RUN dnf install -y git gcc make golang gcc-c++ glibc-devel python3 which python3-pip python3-devel libffi-devel openssl-devel pkg-config glibc-static libstdc++-static patch diffutils
-RUN pip install pycparser
+RUN pip install --no-cache-dir pycparser
 RUN dnf install -y bazel3
 # Install gcloud.
 RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-289.0.0-linux-x86_64.tar.gz | \

--- a/tools/vm/ubuntu1604/40_kokoro.sh
+++ b/tools/vm/ubuntu1604/40_kokoro.sh
@@ -41,7 +41,7 @@ while true; do
 done
 
 # junitparser is used to merge junit xml files.
-pip install junitparser
+pip install --no-cache-dir junitparser
 
 # We need a kbuilder user, which may already exist.
 useradd -c "kbuilder user" -m -s /bin/bash kbuilder || true


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6
