### PR TITLE
Avoid random failure case on x86/arm64:udp_socket_test_runsc_ptrace_h…

### DIFF
--- a/test/syscalls/linux/udp_socket_test_cases.h
+++ b/test/syscalls/linux/udp_socket_test_cases.h
@@ -21,9 +21,6 @@
 namespace gvisor {
 namespace testing {
 
-// The initial port to be be used on gvisor.
-constexpr int TestPort = 40000;
-
 // Fixture for tests parameterized by the address family to use (AF_INET and
 // AF_INET6) when creating sockets.
 class UdpSocketTest
@@ -42,6 +39,9 @@ class UdpSocketTest
     }
   }
 
+  // The port to be be used on gvisor.
+  int test_port_;
+
   // First UDP socket.
   int s_;
 
@@ -51,7 +51,7 @@ class UdpSocketTest
   // The length of the socket address.
   socklen_t addrlen_;
 
-  // Initialized address pointing to loopback and port TestPort+i.
+  // Initialized address pointing to loopback and port test_port_+i.
   struct sockaddr* addr_[3];
 
   // Initialize "any" address.


### PR DESCRIPTION
To prevent port conflicts in concurrent tests, I think using random
port will greatly reduce this probability.

Without this patch, there is a random issue, the log is like following:

test/syscalls/linux/udp_socket_test_cases.cc:1056: Failure
Value of: bind(s_, addr_[0], addrlen_)
Expected: not -1 (success)
  Actual: -1 (of type int), with errno PosixError(errno=98 Address already in use)
[  FAILED  ] AllInetTests/UdpSocketTest.BoundaryPreserved_SendMsgRecvMsg/2, where GetParam() = 4-byte object <03-00 00-00> (0 ms)
[----------] 1 test from AllInetTests/UdpSocketTest (0 ms total)



Signed-off-by: Bin Lu <bin.lu@arm.com>

