### PR TITLE
runner: fix goroutine leak

### DIFF
--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -204,7 +204,7 @@ func runRunsc(tc gtest.TestCase, spec *specs.Spec) error {
 			return
 		}
 		log.Warningf("%s: Got signal: %v", name, s)
-		done := make(chan bool)
+		done := make(chan bool, 1)
 		dArgs := append([]string{}, args...)
 		dArgs = append(dArgs, "-alsologtostderr=true", "debug", "--stacks", id)
 		go func(dArgs []string) {


### PR DESCRIPTION
Signed-off-by: Gaurav Singh <gaurav1086@gmail.com>

* [y ] Have you followed the guidelines in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)?
* [ y] Have you formatted and linted your code?
* [n ] Have you added relevant tests?
* [y ] Have you added appropriate Fixes & Updates references?
* [- ] If yes, please erase all these lines!

the channel done need to be buffered to prevent the goroutine from hanging indefinitely
when the select statement reads something other than the one the goroutine sends on. i.e. timeouts