### PR TITLE
make: Allow to specify bazel startup options.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,10 @@ jobs:
    - os: linux
      arch: arm64
 script:
-   - uname -a && make smoke-test
+   # On arm64, we need to create our own pipes for stderr and stdout,
+   # otherwise we will not be able to open /dev/stderr. This is probably
+   # due to AppArmor rules.
+   - uname -a && make smoke-test 2>&1 | cat
 branches:
   except:
   # Skip copybara branches.

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@
 
 # Described below.
 OPTIONS :=
+STARTUP_OPTIONS :=
 TARGETS := //runsc
 ARGS    :=
 
@@ -24,7 +25,7 @@ default: runsc
 
 ## usage: make <target>
 ##         or
-##        make <build|test|copy|run|sudo> OPTIONS="..." TARGETS="..." ARGS="..."
+##        make <build|test|copy|run|sudo> STARTUP_OPTIONS="..." OPTIONS="..." TARGETS="..." ARGS="..."
 ##
 ## Basic targets.
 ##
@@ -33,6 +34,7 @@ default: runsc
 ##   requirements.
 ##
 ##   There are common arguments that may be passed to targets. These are:
+##     STARTUP_OPTIONS - Bazel startup options.
 ##     OPTIONS - Build or test options.
 ##     TARGETS - The bazel targets.
 ##     ARGS    - Arguments for run or sudo.


### PR DESCRIPTION
And don't parse binary paths for the build target. Without this,
make build TARGETS=''..." always fails.