### PR TITLE
avoid the random memory barrier issue in mmap testing on Arm64

### DIFF
--- a/test/syscalls/linux/mmap.cc
+++ b/test/syscalls/linux/mmap.cc
@@ -589,6 +589,11 @@ TEST_F(MMapTest, ProtExec) {
 
   memcpy(reinterpret_cast<void*>(addr), machine_code, sizeof(machine_code));
 
+#if defined(__aarch64__)
+  // We use this as a memory barrier for Arm64.
+  ASSERT_THAT(Protect(addr, kPageSize, PROT_READ | PROT_EXEC), SyscallSucceeds());
+#endif
+
   func = reinterpret_cast<uint32_t (*)(void)>(addr);
 
   EXPECT_EQ(42, func());


### PR DESCRIPTION
There is a new random issue on some Arm64 machines.
This scene can be summarized as following:
sometimes, the content pointed to by the function pointer is still 0 opcode, then sigill was generated.
The probability of this kind of issue is very low,
currently only available on some machines.

After inserting a simple memory barrier, this issue was gone.

The code to directly use the memory barrier is as follows:
  memcpy(reinterpret_cast<void*>(addr), machine_code, sizeof(machine_code));
############MEMORY BARRIER#######
  isb()
#################################
  func = reinterpret_cast<uint32_t (*)(void)>(addr);

Signed-off-by: Bin Lu <bin.lu@arm.com>
