### PR TITLE
Deleting the maxSendBufferSize from fs/host

### DIFF
--- a/pkg/sentry/fs/host/socket.go
+++ b/pkg/sentry/fs/host/socket.go
@@ -22,7 +22,6 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/fd"
 	"gvisor.dev/gvisor/pkg/fdnotifier"
-	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fs"
 	"gvisor.dev/gvisor/pkg/sentry/socket/control"
@@ -38,11 +37,6 @@ import (
 )
 
 // LINT.IfChange
-
-// maxSendBufferSize is the maximum host send buffer size allowed for endpoint.
-//
-// N.B. 8MB is the default maximum on Linux (2 * sysctl_wmem_max).
-const maxSendBufferSize = 8 << 20
 
 // ConnectedEndpoint is a host FD backed implementation of
 // transport.ConnectedEndpoint and transport.Receiver.
@@ -102,10 +96,6 @@ func (c *ConnectedEndpoint) init() *syserr.Error {
 	sndbuf, err := syscall.GetsockoptInt(c.file.FD(), syscall.SOL_SOCKET, syscall.SO_SNDBUF)
 	if err != nil {
 		return syserr.FromError(err)
-	}
-	if sndbuf > maxSendBufferSize {
-		log.Warningf("Socket send buffer too large: %d", sndbuf)
-		return syserr.ErrInvalidEndpointState
 	}
 
 	c.stype = linux.SockType(stype)


### PR DESCRIPTION
    When I do high-performance networking,
    the value of wmem_max is often set very high,
    specially for 10/25/50 Gigabit NIC.

    I think maybe this restriction is not suitable.

Signed-off-by: Bin Lu <bin.lu@arm.com>

