### PR TITLE
test/syscall: run hostnet tests in separate network namespaces

### DIFF
--- a/test/runner/defs.bzl
+++ b/test/runner/defs.bzl
@@ -93,6 +93,7 @@ def _syscall_test(
     # we figure out how to request ipv4 sockets on Guitar machines.
     if network == "host":
         tags.append("noguitar")
+        tags.append("block-network")
 
     # Disable off-host networking.
     tags.append("requires-net:loopback")


### PR DESCRIPTION
A few tests use hard coded port numbers, so we need to guarantee that
these ports will not be used for something else.

