### PR TITLE
travis: set the pipefail option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
    # On arm64, we need to create our own pipes for stderr and stdout,
    # otherwise we will not be able to open /dev/stderr. This is probably
    # due to AppArmor rules.
-   - uname -a && make smoke-test 2>&1 | cat
+   - bash -xeo pipefail -c 'uname -a && make smoke-test 2>&1 | cat'
 branches:
   except:
   # Skip copybara branches.


### PR DESCRIPTION
The travis job has to fail if make smoke-test fails.

Reported-by: @lubinszARM 

