### PR TITLE
[WIP, diffbased] Support SO_ORIGINAL_DST

### DIFF
--- a/pkg/abi/linux/netfilter.go
+++ b/pkg/abi/linux/netfilter.go
@@ -51,7 +51,7 @@ var VerdictStrings = map[int32]string{
 	NF_RETURN:      "RETURN",
 }
 
-// Socket options. These correspond to values in
+// Socket options for SOL_SOCKET. These correspond to values in
 // include/uapi/linux/netfilter_ipv4/ip_tables.h.
 const (
 	IPT_BASE_CTL            = 64
@@ -64,6 +64,12 @@ const (
 	IPT_SO_GET_REVISION_MATCH  = IPT_BASE_CTL + 2
 	IPT_SO_GET_REVISION_TARGET = IPT_BASE_CTL + 3
 	IPT_SO_GET_MAX             = IPT_SO_GET_REVISION_TARGET
+)
+
+// Socket option for SOL_IP. This corresponds to the value in
+// include/uapi/linux/netfilter_ipv4.h.
+const (
+	SO_ORIGINAL_DST = 80
 )
 
 // Name lengths. These correspond to values in

--- a/pkg/sentry/socket/netfilter/netfilter.go
+++ b/pkg/sentry/socket/netfilter/netfilter.go
@@ -401,8 +401,8 @@ func SetEntries(stk *stack.Stack, optVal []byte) *syserr.Error {
 	switch replace.Name.String() {
 	case stack.TablenameFilter:
 		table = stack.EmptyFilterTable()
-	case stack.TablenameNat:
-		table = stack.EmptyNatTable()
+	case stack.TablenameNAT:
+		table = stack.EmptyNATTable()
 	default:
 		nflog("we don't yet support writing to the %q table (gvisor.dev/issue/170)", replace.Name.String())
 		return syserr.ErrInvalidArgument

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -1505,6 +1505,19 @@ func getSockOptIP(t *kernel.Task, ep commonEndpoint, name, outLen int, family in
 		}
 		return boolToInt32(v), nil
 
+	case linux.SO_ORIGINAL_DST:
+		if outLen < len(linux.InetAddr{}) {
+			return nil, syserr.ErrInvalidArgument
+		}
+
+		var v tcpip.OriginalDestinationOption
+		if err := ep.GetSockOpt(&v); err != nil {
+			return nil, syserr.TranslateNetstackError(err)
+		}
+
+		a, _ := ConvertAddress(linux.AF_INET, tcpip.FullAddress(v))
+		return a.(*linux.SockAddrInet), nil
+
 	default:
 		emitUnimplementedEventIP(t, name)
 	}

--- a/pkg/sentry/strace/socket.go
+++ b/pkg/sentry/strace/socket.go
@@ -521,6 +521,7 @@ var sockOptNames = map[uint64]abi.ValueSet{
 		linux.IP_ROUTER_ALERT:           "IP_ROUTER_ALERT",
 		linux.IP_PKTOPTIONS:             "IP_PKTOPTIONS",
 		linux.IP_MTU:                    "IP_MTU",
+		linux.SO_ORIGINAL_DST:           "SO_ORIGINAL_DST",
 	},
 	linux.SOL_SOCKET: {
 		linux.SO_ERROR:        "SO_ERROR",

--- a/pkg/tcpip/stack/conntrack.go
+++ b/pkg/tcpip/stack/conntrack.go
@@ -16,6 +16,7 @@ package stack
 
 import (
 	"encoding/binary"
+	"fmt"
 	"sync"
 	"time"
 
@@ -39,111 +40,153 @@ const (
 	dirReply
 )
 
-// Status of connection.
-// TODO(gvisor.dev/issue/170): Add other states of connection.
-type connStatus int
-
-const (
-	connNew connStatus = iota
-	connEstablished
-)
-
 // Manipulation type for the connection.
 type manipType int
 
 const (
-	manipDstPrerouting manipType = iota
+	manipNone manipType = iota
+	manipDstPrerouting
 	manipDstOutput
 )
 
 // connTrackMutable is the manipulatable part of the tuple.
 type connTrackMutable struct {
-	// addr is source address of the tuple.
+	// addr is source address of the tuple. It is set according to the NAT
+	// rules, then is immutable.
 	addr tcpip.Address
 
-	// port is source port of the tuple.
+	// port is source port of the tuple. It is set according to the NAT
+	// rules, then is immutable.
 	port uint16
 
-	// protocol is network layer protocol.
+	// protocol is network layer protocol. It is set according to the NAT
+	// rules, then is immutable.
 	protocol tcpip.NetworkProtocolNumber
 }
 
 // connTrackImmutable is the non-manipulatable part of the tuple.
 type connTrackImmutable struct {
-	// addr is destination address of the tuple.
+	// addr is destination address of the tuple. It is set according to the
+	// NAT rules, then is immutable.en is immutable.
 	addr tcpip.Address
 
-	// direction is direction (original or reply) of the tuple.
+	// direction is direction (original or reply) of the tuple. It is set
+	// according to the NAT rules, then is immutable. then is immutable.
 	direction ctDirection
 
-	// port is destination port of the tuple.
+	// port is destination port of the tuple. It is set according to the
+	// NAT rules, then is immutable.
 	port uint16
 
-	// protocol is transport layer protocol.
+	// protocol is transport layer protocol. It is set according to the NAT
+	// rules, then is immutable.
 	protocol tcpip.TransportProtocolNumber
 }
 
 // connTrackTuple represents the tuple which is created from the
 // packet.
 type connTrackTuple struct {
-	// dst is non-manipulatable part of the tuple.
+	// dst is non-manipulatable part of the tuple. It is set according to
+	// the NAT rules, then is immutable.
 	dst connTrackImmutable
 
-	// src is manipulatable part of the tuple.
+	// src is manipulatable part of the tuple. It is set according to the
+	// NAT rules, then is immutable.
 	src connTrackMutable
 }
 
 // connTrackTupleHolder is the container of tuple and connection.
 type ConnTrackTupleHolder struct {
-	// conn is pointer to the connection tracking entry.
+	// conn is pointer to the connection tracking entry. It is set
+	// according to the NAT rules, then is immutable.
 	conn *connTrack
 
-	// tuple is original or reply tuple.
+	// tuple is original or reply tuple. It is set according to the NAT
+	// rules, then is immutable.
 	tuple connTrackTuple
 }
 
 // connTrack is the connection.
 type connTrack struct {
-	// originalTupleHolder contains tuple in original direction.
+	// originalTupleHolder contains tuple in original direction. It is set
+	// according to the NAT rules, then is immutable.
 	originalTupleHolder ConnTrackTupleHolder
 
-	// replyTupleHolder contains tuple in reply direction.
+	// replyTupleHolder contains tuple in reply direction. It is set
+	// according to the NAT rules, then is immutable.
 	replyTupleHolder ConnTrackTupleHolder
 
-	// status indicates connection is new or established.
-	status connStatus
-
-	// timeout indicates the time connection should be active.
-	timeout time.Duration
-
-	// manip indicates if the packet should be manipulated.
+	// manip indicates if the packet should be manipulated. It is set at
+	// initialization, then is immutable.
 	manip manipType
 
-	// tcb is TCB control block. It is used to keep track of states
-	// of tcp connection.
-	tcb tcpconntrack.TCB
-
 	// tcbHook indicates if the packet is inbound or outbound to
-	// update the state of tcb.
+	// update the state of tcb. It is set at initialization and is
+	// immutable.
 	tcbHook Hook
+
+	mu struct {
+		sync.Mutex
+
+		// tcb is TCP control block. It is used to keep track of states
+		// of tcp connection. It is protected by mu.
+		tcb tcpconntrack.TCB
+
+		// lastUsed is the last time the connection saw a relevant
+		// packet, and is updated by each packet on the connection. It
+		// is protected by mu.
+		lastUsed time.Time
+	}
+}
+
+// timedOut returns whether the connection timed out based on its state.
+func (ct *connTrack) timedOut(now time.Time) bool {
+	ct.mu.Lock()
+	defer ct.mu.Unlock()
+	if ct.mu.tcb.State() == tcpconntrack.ResultAlive {
+		// Use the same default as Linux, which doesn't delete
+		// established connections for 5(!) days.
+		return now.Sub(ct.mu.lastUsed) > 5*24*time.Hour
+	}
+	// Use the same default as Linux, which lets connections in most states
+	// other than established remain for <= 120 seconds.
+	return now.Sub(ct.mu.lastUsed) > 120*time.Second
+}
+
+// update the connection tracking state.
+//
+// Precondition: ct.mu must be held if ct is shared between goroutines.
+func (ct *connTrack) update(tcpHeader header.TCP, hook Hook) {
+	// Update the state of tcb. tcb assumes it's always initialized on the
+	// client. However, we only need to know whether the connection is
+	// established or not, so the client/server distinction isn't important.
+	// TODO(gvisor.dev/issue/170): Add support in tcpconntrack to handle
+	// other tcp states.
+	if ct.mu.tcb.IsEmpty() {
+		ct.mu.tcb.Init(tcpHeader)
+	} else if hook == ct.tcbHook {
+		ct.mu.tcb.UpdateStateOutbound(tcpHeader)
+	} else {
+		ct.mu.tcb.UpdateStateInbound(tcpHeader)
+	}
 }
 
 // ConnTrackTable contains a map of all existing connections created for
 // NAT rules.
 type ConnTrackTable struct {
-	// connMu protects connTrackTable.
+	// connMu protects ctMap.
 	connMu sync.RWMutex
 
-	// connTrackTable maintains a map of tuples needed for connection tracking
+	// ctMap maintains a map of tuples needed for connection tracking
 	// for iptables NAT rules. The key for the map is an integer calculated
 	// using seed, source address, destination address, source port and
 	// destination port.
-	CtMap map[uint32]ConnTrackTupleHolder
+	ctMap map[uint32]ConnTrackTupleHolder
 
 	// seed is a one-time random value initialized at stack startup
 	// and is used in calculation of hash key for connection tracking
-	// table.
-	Seed uint32
+	// table. It is immutable.
+	seed uint32
 }
 
 // packetToTuple converts packet to a tuple in original direction.
@@ -186,23 +229,24 @@ func getReplyTuple(tuple connTrackTuple) connTrackTuple {
 	return replyTuple
 }
 
-// makeNewConn creates new connection.
-func makeNewConn(tuple, replyTuple connTrackTuple) connTrack {
+// newConn creates new connection.
+func newConn(tuple, replyTuple connTrackTuple, manip manipType, hook Hook) *connTrack {
 	var conn connTrack
-	conn.status = connNew
+	conn.mu.lastUsed = time.Now()
 	conn.originalTupleHolder.tuple = tuple
 	conn.originalTupleHolder.conn = &conn
 	conn.replyTupleHolder.tuple = replyTuple
 	conn.replyTupleHolder.conn = &conn
-
-	return conn
+	conn.manip = manip
+	conn.tcbHook = hook
+	return &conn
 }
 
 // getTupleHash returns hash of the tuple. The fields used for
 // generating hash are seed (generated once for stack), source address,
 // destination address, source port and destination ports.
 func (ct *ConnTrackTable) getTupleHash(tuple connTrackTuple) uint32 {
-	h := jenkins.Sum32(ct.Seed)
+	h := jenkins.Sum32(ct.seed)
 	h.Write([]byte(tuple.src.addr))
 	h.Write([]byte(tuple.dst.addr))
 	portBuf := make([]byte, 2)
@@ -214,92 +258,81 @@ func (ct *ConnTrackTable) getTupleHash(tuple connTrackTuple) uint32 {
 	return h.Sum32()
 }
 
-// connTrackForPacket returns connTrack for packet.
+// connTrackForPacket gets the connTrack for pkt if it exists, or returns nil
+// if it does not.
 // TODO(gvisor.dev/issue/170): Only TCP packets are supported. Need to support other
 // transport protocols.
-func (ct *ConnTrackTable) connTrackForPacket(pkt *PacketBuffer, hook Hook, createConn bool) (*connTrack, ctDirection) {
-	var dir ctDirection
+func (ct *ConnTrackTable) connTrackForPacket(pkt *PacketBuffer, hook Hook) (*connTrack, ctDirection) {
 	tuple, err := packetToTuple(pkt, hook)
 	if err != nil {
-		return nil, dir
+		return nil, dirOriginal
 	}
-
-	ct.connMu.Lock()
-	defer ct.connMu.Unlock()
-
-	connTrackTable := ct.CtMap
 	hash := ct.getTupleHash(tuple)
 
-	var conn *connTrack
-	switch createConn {
-	case true:
-		// If connection does not exist for the hash, create a new
-		// connection.
-		replyTuple := getReplyTuple(tuple)
-		replyHash := ct.getTupleHash(replyTuple)
-		newConn := makeNewConn(tuple, replyTuple)
-		conn = &newConn
-
-		// Add tupleHolders to the map.
-		// TODO(gvisor.dev/issue/170): Need to support collisions using linked list.
-		ct.CtMap[hash] = conn.originalTupleHolder
-		ct.CtMap[replyHash] = conn.replyTupleHolder
-	default:
-		tupleHolder, ok := connTrackTable[hash]
-		if !ok {
-			return nil, dir
-		}
-
-		// If this is the reply of new connection, set the connection
-		// status as ESTABLISHED.
-		conn = tupleHolder.conn
-		if conn.status == connNew && tupleHolder.tuple.dst.direction == dirReply {
-			conn.status = connEstablished
-		}
-		if tupleHolder.conn == nil {
-			panic("tupleHolder has null connection tracking entry")
-		}
-
-		dir = tupleHolder.tuple.dst.direction
-	}
-	return conn, dir
-}
-
-// SetNatInfo will manipulate the tuples according to iptables NAT rules.
-func (ct *ConnTrackTable) SetNatInfo(pkt *PacketBuffer, rt RedirectTarget, hook Hook) {
-	// Get the connection. Connection is always created before this
-	// function is called.
-	conn, _ := ct.connTrackForPacket(pkt, hook, false)
-	if conn == nil {
-		panic("connection should be created to manipulate tuples.")
-	}
-	replyTuple := conn.replyTupleHolder.tuple
-	replyHash := ct.getTupleHash(replyTuple)
-
-	// TODO(gvisor.dev/issue/170): Support only redirect of ports. Need to
-	// support changing of address for Prerouting.
-
-	// Change the port as per the iptables rule. This tuple will be used
-	// to manipulate the packet in HandlePacket.
-	conn.replyTupleHolder.tuple.src.addr = rt.MinIP
-	conn.replyTupleHolder.tuple.src.port = rt.MinPort
-	newHash := ct.getTupleHash(conn.replyTupleHolder.tuple)
-
-	// Add the changed tuple to the map.
 	ct.connMu.Lock()
 	defer ct.connMu.Unlock()
-	ct.CtMap[newHash] = conn.replyTupleHolder
-	if hook == Output {
-		conn.replyTupleHolder.conn.manip = manipDstOutput
+
+	tupleHolder, ok := ct.ctMap[hash]
+	if !ok {
+		return nil, dirOriginal
 	}
 
-	// Delete the old tuple.
-	delete(ct.CtMap, replyHash)
+	// The connection may have timed out.
+	if tupleHolder.conn.timedOut(time.Now()) {
+		replyTuple := tupleHolder.conn.replyTupleHolder.tuple
+		replyHash := ct.getTupleHash(replyTuple)
+		delete(ct.ctMap, hash)
+		delete(ct.ctMap, replyHash)
+		return nil, dirOriginal
+	}
+
+	return tupleHolder.conn, tupleHolder.tuple.dst.direction
+}
+
+// createConnTrackForPacket creates a new connTrack for pkt.
+func (ct *ConnTrackTable) createConnTrackForPacket(pkt *PacketBuffer, hook Hook, rt RedirectTarget) *connTrack {
+	tuple, err := packetToTuple(pkt, hook)
+	if err != nil {
+		return nil
+	}
+	hash := ct.getTupleHash(tuple)
+
+	// Create a new connection and change the port as per the iptables
+	// rule. This tuple will be used to manipulate the packet in
+	// HandlePacket.
+	replyTuple := getReplyTuple(tuple)
+	replyTuple.src.addr = rt.MinIP
+	replyTuple.src.port = rt.MinPort
+	replyHash := ct.getTupleHash(replyTuple)
+	var manip manipType
+	switch hook {
+	case Prerouting:
+		manip = manipDstPrerouting
+	case Output:
+		manip = manipDstOutput
+	default:
+		panic(fmt.Sprintf("NAT only apples to Prerouting and Output, but found %d", hook))
+	}
+	conn := newConn(tuple, replyTuple, manip, hook)
+
+	// Add the changed tuple to the map.
+	// TODO(gvisor.dev/issue/170): Need to support collisions using linked
+	// list.
+	ct.connMu.Lock()
+	defer ct.connMu.Unlock()
+	ct.ctMap[hash] = conn.originalTupleHolder
+	ct.ctMap[replyHash] = conn.replyTupleHolder
+
+	return conn
 }
 
 // handlePacketPrerouting manipulates ports for packets in Prerouting hook.
-// TODO(gvisor.dev/issue/170): Change address for Prerouting hook..
 func handlePacketPrerouting(pkt *PacketBuffer, conn *connTrack, dir ctDirection) {
+	// If this is a noop entry, don't do anything.
+	if conn.manip == manipNone {
+		return
+	}
+
 	netHeader := header.IPv4(pkt.NetworkHeader)
 	tcpHeader := header.TCP(pkt.TransportHeader)
 
@@ -317,12 +350,22 @@ func handlePacketPrerouting(pkt *PacketBuffer, conn *connTrack, dir ctDirection)
 		netHeader.SetSourceAddress(conn.originalTupleHolder.tuple.dst.addr)
 	}
 
+	// TODO(gvisor.dev/issue/170): TCP checksums aren't usually validated
+	// on inbound packets, so we don't recalculate them. However, we should
+	// support cases when they are validated, e.g. when we can't offload
+	// receive checksumming.
+
 	netHeader.SetChecksum(0)
 	netHeader.SetChecksum(^netHeader.CalculateChecksum())
 }
 
 // handlePacketOutput manipulates ports for packets in Output hook.
 func handlePacketOutput(pkt *PacketBuffer, conn *connTrack, gso *GSO, r *Route, dir ctDirection) {
+	// If this is a noop entry, don't do anything.
+	if conn.manip == manipNone {
+		return
+	}
+
 	netHeader := header.IPv4(pkt.NetworkHeader)
 	tcpHeader := header.TCP(pkt.TransportHeader)
 
@@ -356,33 +399,79 @@ func handlePacketOutput(pkt *PacketBuffer, conn *connTrack, gso *GSO, r *Route, 
 	netHeader.SetChecksum(^netHeader.CalculateChecksum())
 }
 
-// HandlePacket will manipulate the port and address of the packet if the
-// connection exists.
-func (ct *ConnTrackTable) HandlePacket(pkt *PacketBuffer, hook Hook, gso *GSO, r *Route) {
+// MaybeInsertNoop tries to insert a no-op connection entry to keep connections
+// from getting clobbered when replies arrive. It only inserts if there isn't
+// already a connection for pkt.
+//
+// This should be called after traversing iptables rules only, to ensure that
+// pkt.NatDone is set correctly.
+func (ct *ConnTrackTable) MaybeInsertNoop(pkt *PacketBuffer, hook Hook) {
+	// If there were a rule applying to this packet, it would be marked
+	// with NatDone.
 	if pkt.NatDone {
 		return
 	}
 
+	// NAT only works in the Prerouting and Output hookds.
 	if hook != Prerouting && hook != Output {
 		return
 	}
 
-	conn, dir := ct.connTrackForPacket(pkt, hook, false)
-	// Connection or Rule not found for the packet.
-	if conn == nil {
+	// We only track TCP connections.
+	if netHeader := header.IPv4(pkt.NetworkHeader); netHeader == nil || netHeader.TransportProtocol() != header.TCPProtocolNumber || pkt.TransportHeader == nil {
 		return
 	}
 
-	netHeader := header.IPv4(pkt.NetworkHeader)
+	// This is the first packet we're seeing for the TCP connection. Insert
+	// the noop entry (an identity mapping) so that the response doesn't
+	// get NATed, breaking the connection.
+
+	// Get the TCP tuples and hashes uniquely identifying the connection.
+	tuple, err := packetToTuple(pkt, hook)
+	if err != nil {
+		return
+	}
+	hash := ct.getTupleHash(tuple)
+	replyTuple := getReplyTuple(tuple)
+	replyHash := ct.getTupleHash(replyTuple)
+	conn := newConn(tuple, replyTuple, manipNone, hook)
+	conn.update(header.TCP(pkt.TransportHeader), hook)
+
+	// Add tupleHolders to the map. Packets that are a part of this
+	// connection won't be NATed regardless of their direction.
+	ct.connMu.Lock()
+	defer ct.connMu.Unlock()
+	ct.ctMap[hash] = conn.originalTupleHolder
+	ct.ctMap[replyHash] = conn.replyTupleHolder
+}
+
+// HandlePacket will manipulate the port and address of the packet if the
+// connection exists. Returns whether, after the packet traverses the tables,
+// it should create a new entry in the table.
+func (ct *ConnTrackTable) HandlePacket(pkt *PacketBuffer, hook Hook, gso *GSO, r *Route) bool {
+	if pkt.NatDone {
+		return false
+	}
+
+	if hook != Prerouting && hook != Output {
+		return false
+	}
+
+	conn, dir := ct.connTrackForPacket(pkt, hook)
+	// Connection or Rule not found for the packet.
+	if conn == nil {
+		return true
+	}
+
 	// TODO(gvisor.dev/issue/170): Need to support for other transport
 	// protocols as well.
-	if netHeader == nil || netHeader.TransportProtocol() != header.TCPProtocolNumber {
-		return
+	if netHeader := header.IPv4(pkt.NetworkHeader); netHeader == nil || netHeader.TransportProtocol() != header.TCPProtocolNumber {
+		return false
 	}
 
 	tcpHeader := header.TCP(pkt.TransportHeader)
 	if tcpHeader == nil {
-		return
+		return false
 	}
 
 	switch hook {
@@ -390,45 +479,41 @@ func (ct *ConnTrackTable) HandlePacket(pkt *PacketBuffer, hook Hook, gso *GSO, r
 		handlePacketPrerouting(pkt, conn, dir)
 	case Output:
 		handlePacketOutput(pkt, conn, gso, r, dir)
+	default:
+		panic(fmt.Sprintf("NAT only handles the Prerouting and Output hook, but was invoked on hook %d", hook))
 	}
 	pkt.NatDone = true
 
-	// Update the state of tcb.
-	// TODO(gvisor.dev/issue/170): Add support in tcpcontrack to handle
-	// other tcp states.
-	var st tcpconntrack.Result
-	if conn.tcb.IsEmpty() {
-		conn.tcb.Init(tcpHeader)
-		conn.tcbHook = hook
-	} else {
-		switch hook {
-		case conn.tcbHook:
-			st = conn.tcb.UpdateStateOutbound(tcpHeader)
-		default:
-			st = conn.tcb.UpdateStateInbound(tcpHeader)
-		}
-	}
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
 
-	// Delete conntrack if tcp connection is closed.
-	if st == tcpconntrack.ResultClosedByPeer || st == tcpconntrack.ResultClosedBySelf || st == tcpconntrack.ResultReset {
-		ct.deleteConnTrack(conn)
-	}
+	// Mark the connection as having been used recently so it isn't reaped.
+	conn.mu.lastUsed = time.Now()
+	// Update connection state.
+	conn.update(tcpHeader, hook)
+
+	return false
 }
 
-// deleteConnTrack deletes the connection.
-func (ct *ConnTrackTable) deleteConnTrack(conn *connTrack) {
-	if conn == nil {
-		return
-	}
-
-	tuple := conn.originalTupleHolder.tuple
-	hash := ct.getTupleHash(tuple)
-	replyTuple := conn.replyTupleHolder.tuple
-	replyHash := ct.getTupleHash(replyTuple)
+// reap deletes timed out entries from the conntrack map.
+func (ct *ConnTrackTable) reap() {
+	// Find unused connections.
+	// TODO(gvisor.dev/issue/170): This can be more finely controlled, as
+	// it is in Linux via sysctl.
+	now := time.Now()
 
 	ct.connMu.Lock()
 	defer ct.connMu.Unlock()
 
-	delete(ct.CtMap, hash)
-	delete(ct.CtMap, replyHash)
+	var deadConns []uint32
+	for hash, holder := range ct.ctMap {
+		if holder.conn.timedOut(now) {
+			deadConns = append(deadConns, hash)
+		}
+	}
+
+	// Remove unused connections.
+	for _, hash := range deadConns {
+		delete(ct.ctMap, hash)
+	}
 }

--- a/pkg/tcpip/stack/iptables_targets.go
+++ b/pkg/tcpip/stack/iptables_targets.go
@@ -150,11 +150,10 @@ func (rt RedirectTarget) Action(pkt *PacketBuffer, ct *ConnTrackTable, hook Hook
 			return RuleAccept, 0
 		}
 
-		// Set up conection for matching NAT rule.
-		// Only the first packet of the connection comes here.
-		// Other packets will be manipulated in connection tracking.
-		if conn, _ := ct.connTrackForPacket(pkt, hook, true); conn != nil {
-			ct.SetNatInfo(pkt, rt, hook)
+		// Set up conection for matching NAT rule. Only the first
+		// packet of the connection comes here. Other packets will be
+		// manipulated in connection tracking.
+		if conn := ct.createConnTrackForPacket(pkt, hook, rt); conn != nil {
 			ct.HandlePacket(pkt, hook, gso, r)
 		}
 	default:

--- a/pkg/tcpip/stack/iptables_types.go
+++ b/pkg/tcpip/stack/iptables_types.go
@@ -91,7 +91,16 @@ type IPTables struct {
 	// hook. mu needs to be locked for accessing.
 	priorities map[Hook][]string
 
+	// connections tracks connections for the NAT table.
 	connections ConnTrackTable
+
+	// once prevents connectionReaperDone from being signalled more than
+	// once.
+	once sync.Once
+
+	// connectionReaperDone can be signalled to stop the connection reaper
+	// goroutine.
+	connectionReaperDone chan struct{}
 }
 
 // A Table defines a set of chains and hooks into the network stack. It is

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -813,6 +813,12 @@ type OutOfBandInlineOption int
 // a default TTL.
 type DefaultTTLOption uint8
 
+// type OriginalDestinationOption struct {
+// 	Addr Address
+// 	Port uint16
+// }
+type OriginalDestinationOption FullAddress
+
 // IPPacketInfo is the message struture for IP_PKTINFO.
 //
 // +stateify savable

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -1982,6 +1982,17 @@ func (e *endpoint) GetSockOpt(opt interface{}) *tcpip.Error {
 		*o = tcpip.TCPDeferAcceptOption(e.deferAccept)
 		e.UnlockUser()
 
+	case *tcpip.OriginalDestinationOption:
+		ipt := e.stack.IPTables()
+		addr, port, err := ipt.OriginalDst(e.ID)
+		if err != nil {
+			return err
+		}
+		*o = tcpip.OriginalDestinationOption{
+			Addr: addr,
+			Port: port,
+		}
+
 	default:
 		return tcpip.ErrUnknownProtocolOption
 	}

--- a/pkg/tcpip/transport/tcpconntrack/tcp_conntrack.go
+++ b/pkg/tcpip/transport/tcpconntrack/tcp_conntrack.go
@@ -106,6 +106,11 @@ func (t *TCB) UpdateStateOutbound(tcp header.TCP) Result {
 	return st
 }
 
+// State returns the current state of the TCB.
+func (t *TCB) State() Result {
+	return t.state
+}
+
 // IsAlive returns true as long as the connection is established(Alive)
 // or connecting state.
 func (t *TCB) IsAlive() bool {

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -259,6 +259,13 @@ func TestNATPreRedirectTCPPort(t *testing.T) {
 	singleTest(t, NATPreRedirectTCPPort{})
 }
 
+func TestNATPreRedirectTCPOutgoing(t *testing.T) {
+	singleTest(t, NATPreRedirectTCPOutgoing{})
+}
+
+func TestNATOutRedirectTCPIncoming(t *testing.T) {
+	singleTest(t, NATOutRedirectTCPIncoming{})
+}
 func TestNATOutRedirectUDPPort(t *testing.T) {
 	singleTest(t, NATOutRedirectUDPPort{})
 }

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -321,3 +321,19 @@ func TestInputSource(t *testing.T) {
 func TestInputInvertSource(t *testing.T) {
 	singleTest(t, FilterInputInvertSource{})
 }
+
+func TestNATPreOriginalDst(t *testing.T) {
+	singleTest(t, NATPreOriginalDst{})
+}
+
+func TestNATOutOriginalDst(t *testing.T) {
+	singleTest(t, NATOutOriginalDst{})
+}
+
+// func TestNATPreOriginalDstUnchanged(t *testing.T) {
+// 	singleTest(t, NATPreOriginalDstUnchanged{})
+// }
+
+// func TestNATOutOriginalDstUnchanged(t *testing.T) {
+// 	singleTest(t, NATOutOriginalDstUnchanged{})
+// }

--- a/test/iptables/iptables_util.go
+++ b/test/iptables/iptables_util.go
@@ -15,9 +15,12 @@
 package iptables
 
 import (
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"os/exec"
+	"strings"
 	"time"
 
 	"gvisor.dev/gvisor/pkg/test/testutil"
@@ -172,15 +175,43 @@ func localAddrs() ([]string, error) {
 
 // getInterfaceName returns the name of the interface other than loopback.
 func getInterfaceName() (string, bool) {
-	var ifname string
+	iface, ok := getNonLoopbackInterface()
+	if !ok {
+		return "", false
+	}
+	return iface.Name, true
+}
+
+func getInterfaceAddr() ([]byte, error) {
+	iface, ok := getNonLoopbackInterface()
+	if !ok {
+		return []byte{}, errors.New("no non-loopback interface found")
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return []byte{}, err
+	}
+	if len(addrs) != 1 {
+		return []byte{}, fmt.Errorf("wanted exactly 1 non-loopback interface, but found %d", len(addrs))
+	}
+	// Get the address as a string, cut off the mask, and make sure it's a
+	// 4-byte slice.
+	return net.ParseIP(strings.Split(addrs[0].String(), "/")[0]).To4(), nil
+}
+
+func getNonLoopbackInterface() (net.Interface, bool) {
 	if interfaces, err := net.Interfaces(); err == nil {
 		for _, intf := range interfaces {
 			if intf.Name != "lo" {
-				ifname = intf.Name
-				break
+				return intf, true
 			}
 		}
 	}
+	return net.Interface{}, false
+}
 
-	return ifname, ifname != ""
+func htons(x uint16) uint16 {
+	buf := make([]byte, 2)
+	binary.BigEndian.PutUint16(buf, x)
+	return binary.LittleEndian.Uint16(buf)
 }

--- a/test/iptables/nat.go
+++ b/test/iptables/nat.go
@@ -28,6 +28,8 @@ const (
 func init() {
 	RegisterTestCase(NATPreRedirectUDPPort{})
 	RegisterTestCase(NATPreRedirectTCPPort{})
+	RegisterTestCase(NATPreRedirectTCPOutgoing{})
+	RegisterTestCase(NATOutRedirectTCPIncoming{})
 	RegisterTestCase(NATOutRedirectUDPPort{})
 	RegisterTestCase(NATOutRedirectTCPPort{})
 	RegisterTestCase(NATDropUDP{})
@@ -89,6 +91,56 @@ func (NATPreRedirectTCPPort) ContainerAction(ip net.IP) error {
 // LocalAction implements TestCase.LocalAction.
 func (NATPreRedirectTCPPort) LocalAction(ip net.IP) error {
 	return connectTCP(ip, dropPort, sendloopDuration)
+}
+
+// NATPreRedirectTCPOutgoing verifies that outgoing TCP connections aren't
+// affected by PREROUTING connection tracking.
+type NATPreRedirectTCPOutgoing struct{}
+
+// Name implements TestCase.Name.
+func (NATPreRedirectTCPOutgoing) Name() string {
+	return "NATPreRedirectTCPOutgoing"
+}
+
+// ContainerAction implements TestCase.ContainerAction.
+func (NATPreRedirectTCPOutgoing) ContainerAction(ip net.IP) error {
+	// Redirect all incoming TCP traffic to a closed port.
+	if err := natTable("-A", "PREROUTING", "-p", "tcp", "-j", "REDIRECT", "--to-ports", fmt.Sprintf("%d", dropPort)); err != nil {
+		return err
+	}
+
+	// Establish a connection to the host process.
+	return connectTCP(ip, acceptPort, sendloopDuration)
+}
+
+// LocalAction implements TestCase.LocalAction.
+func (NATPreRedirectTCPOutgoing) LocalAction(ip net.IP) error {
+	return listenTCP(acceptPort, sendloopDuration)
+}
+
+// NATOutRedirectTCPIncoming verifies that incoming TCP connections aren't
+// affected by OUTPUT connection tracking.
+type NATOutRedirectTCPIncoming struct{}
+
+// Name implements TestCase.Name.
+func (NATOutRedirectTCPIncoming) Name() string {
+	return "NATOutRedirectTCPIncoming"
+}
+
+// ContainerAction implements TestCase.ContainerAction.
+func (NATOutRedirectTCPIncoming) ContainerAction(ip net.IP) error {
+	// Redirect all incoming TCP traffic to a closed port.
+	if err := natTable("-A", "OUTPUT", "-p", "tcp", "-j", "REDIRECT", "--to-ports", fmt.Sprintf("%d", dropPort)); err != nil {
+		return err
+	}
+
+	// Establish a connection to the host process.
+	return listenTCP(acceptPort, sendloopDuration)
+}
+
+// LocalAction implements TestCase.LocalAction.
+func (NATOutRedirectTCPIncoming) LocalAction(ip net.IP) error {
+	return connectTCP(ip, acceptPort, sendloopDuration)
 }
 
 // NATOutRedirectUDPPort tests that packets are redirected to different port.

--- a/test/syscalls/linux/socket_ip_tcp_generic.cc
+++ b/test/syscalls/linux/socket_ip_tcp_generic.cc
@@ -953,5 +953,17 @@ TEST_P(TCPSocketPairTest, TCPResetDuringClose_NoRandomSave) {
   }
 }
 
+TEST_P(TCPSocketPairTest, OriginalDstErrors) {
+  auto sockets = ASSERT_NO_ERRNO_AND_VALUE(NewSocketPair());
+
+  // Sockets not affected by NAT should fail to find an original destination.
+  struct sockaddr_in *sin = {};
+  socklen_t addr_len = 0;
+  EXPECT_THAT(getsockopt(sockets->first_fd(), SOL_IP, SO_ORIGINAL_DST, &opt,
+                         &optLen), SyscallFailsWithErrno(EFAULT));
+  EXPECT_THAT(getsockopt(sockets->second_fd(), SOL_IP, SO_ORIGINAL_DST, &opt,
+                         &optLen), SyscallFailsWithErrno(EFAULT));
+}
+
 }  // namespace testing
 }  // namespace gvisor


### PR DESCRIPTION
Envoy (#170) uses this to get the original destination of redirected
packets.