### PR TITLE
vfs-arm64-2:Solve a specific symlink bug

### DIFF
--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -784,6 +784,18 @@ afterTrailingSymlink:
 		start = parent
 		goto afterTrailingSymlink
 	}
+
+	// If still not done, resolves rp to an existing file
+	for !rp.Done() {
+		child.dirMu.Lock()
+		next, err := fs.stepLocked(ctx, rp, child, true, &ds)
+		child.dirMu.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		child = next
+	}
+
 	return child.openLocked(ctx, rp, &opts)
 }
 


### PR DESCRIPTION
There is a bug when dealing with a special form of symlink.
Just like following:
 ll /x/test.txt
 /x/test.txt -> y/z/test.txt

The logic of the current code only deals with the parent's child
based on rp->Final()/followsymlink/issymlink.
For this situation, the final result based on the current code
will be /x/test.txt -> /x/y

So, I added a workaround for it:
if still not done, resolves rp to an existing file.

Signed-off-by: Bin Lu <bin.lu@arm.com>

* [ ] Have you followed the guidelines in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)?
* [ ] Have you formatted and linted your code?
* [ ] Have you added relevant tests?
* [ ] Have you added appropriate Fixes & Updates references?
* [ ] If yes, please erase all these lines!
