### PR TITLE
Initialize CPU frequency in the background

### DIFF
--- a/pkg/cpuid/cpuid_arm64.go
+++ b/pkg/cpuid/cpuid_arm64.go
@@ -312,6 +312,10 @@ func HostFeatureSet() *FeatureSet {
 	}
 }
 
+// InitWait does nothing.
+func InitWait() {
+}
+
 // Reads bogomips from host /proc/cpuinfo. Must run before syscall filter
 // installation. This value is used to create the fake /proc/cpuinfo from a
 // FeatureSet.

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -22,6 +22,7 @@ import (
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/control/server"
+	"gvisor.dev/gvisor/pkg/cpuid"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/control"
 	"gvisor.dev/gvisor/pkg/sentry/fs"
@@ -373,6 +374,9 @@ func (cm *containerManager) Restore(o *RestoreOpts, _ *struct{}) error {
 		// installing seccomp filters.
 		pprof.Initialize()
 	}
+
+	// Wait for pre-filter initialization.
+	cpuid.WaitForInit()
 
 	// Seccomp filters have to be applied before parsing the state file.
 	if err := cm.l.installSeccompFilters(); err != nil {

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -542,6 +542,9 @@ func (l *Loader) run() error {
 			pprof.Initialize()
 		}
 
+		// Wait for pre-filter initialization.
+		cpuid.WaitForInit()
+
 		// Finally done with all configuration. Setup filters before user code
 		// is loaded.
 		if err := l.installSeccompFilters(); err != nil {


### PR DESCRIPTION
This package cpuid init function is typically taking ~20ms to complete,
in large part because open of /proc/cpuinfo typically includes an
explicit 10ms sleep in the kernel (see
arch/x86/kernel/cpu/aperfmperf.c:arch_freq_prepare_all).

Since we must open cpuinfo before filter installation we can't move this
wholesale to a sync.Once, but we can start reading asychronously in init
and only wait on completion before filter installation. In practice,
this is reducing runsc run startup be ~30ms.

```
name           old time/op    new time/op    delta
GVisorStartup  201ms ±15%     173ms ± 8%     -14.19%  (p=0.008 n=5+5)
```

Fixes #3056
