### PR TITLE
add /dev/kmsg support for gvisor

### DIFF
--- a/pkg/sentry/devices/memdev/BUILD
+++ b/pkg/sentry/devices/memdev/BUILD
@@ -10,9 +10,12 @@ go_library(
         "null.go",
         "random.go",
         "zero.go",
+        "kmsg.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [
+        "//pkg/sentry/kernel",
+        "//pkg/sentry/kernel/auth",
         "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/rand",
@@ -24,5 +27,6 @@ go_library(
         "//pkg/sentry/vfs",
         "//pkg/syserror",
         "//pkg/usermem",
+        "//pkg/waiter",
     ],
 )

--- a/pkg/sentry/devices/memdev/kmsg.go
+++ b/pkg/sentry/devices/memdev/kmsg.go
@@ -1,0 +1,106 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package memdev
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/syserror"
+	"gvisor.dev/gvisor/pkg/usermem"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+const kmsgDevMinor = 11
+
+// kmsgDevice implements vfs.Device for /dev/kmsg.
+type kmsgDevice struct{}
+
+// Open implements vfs.Device.Open.
+func (kmsgDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
+	creds := auth.CredentialsFromContext(ctx)
+	k := kernel.KernelFromContext(ctx)
+	if opts.Flags&linux.O_ACCMODE != linux.O_RDONLY &&
+		!creds.HasCapabilityIn(linux.CAP_SYSLOG, k.RootUserNamespace()) &&
+		!creds.HasCapabilityIn(linux.CAP_SYS_ADMIN, k.RootUserNamespace()) {
+		return nil, syserror.EPERM
+	}
+	fd := &kmsgFD{
+		kernel:   k,
+		index:    k.Syslog().FirstIndex(),
+		sequence: k.Syslog().FirstSequence(),
+	}
+	if err := fd.vfsfd.Init(fd, opts.Flags, mnt, vfsd, &vfs.FileDescriptionOptions{
+		UseDentryMetadata: true,
+	}); err != nil {
+		return nil, err
+	}
+	return &fd.vfsfd, nil
+}
+
+// kmsgFD implements vfs.FileDescriptionImpl for /dev/kmsg.
+type kmsgFD struct {
+	vfsfd vfs.FileDescription
+	vfs.FileDescriptionDefaultImpl
+	vfs.DentryMetadataFileDescriptionImpl
+	vfs.NoLockFD
+
+	kernel *kernel.Kernel
+
+	// sequence is sequence number of syslog record for current kmsg fd.
+	sequence uint64
+	// index is index of syslog record for current kmsg fd.
+	index uint32
+}
+
+// Release implements vfs.FileDescriptionImpl.Release.
+func (fd *kmsgFD) Release() {}
+
+// Read implements vfs.FileDescriptionImpl.Read.
+func (fd *kmsgFD) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
+	seq, idx, bytesCopied, err := fd.kernel.Syslog().DevKmsgRead(ctx, fd.sequence, fd.index, dst, fd.vfsfd.StatusFlags())
+	fd.sequence = seq
+	fd.index = idx
+	if err != nil {
+		return 0, err
+	}
+	return bytesCopied, nil
+}
+
+// Write implements vfs.FileDescriptionImpl.Write.
+func (fd *kmsgFD) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
+	return fd.kernel.Syslog().DevKmsgWrite(ctx, src)
+}
+
+// Seek implements vfs.FileDescriptionImpl.Seek.
+func (fd *kmsgFD) Seek(ctx context.Context, offset int64, whence int32) (int64, error) {
+	if offset != 0 {
+		return 0, syserror.ESPIPE
+	}
+	seq, idx, err := fd.kernel.Syslog().DevKmsgSeek(ctx, whence)
+	if err != nil {
+		return 0, err
+	}
+	fd.sequence = seq
+	fd.index = idx
+	return 0, nil
+}
+
+// Readiness implements waiter.Waitable.Readiness.
+func (fd *kmsgFD) Readiness(mask waiter.EventMask) waiter.EventMask {
+	return fd.kernel.Syslog().DevKmsgReadiness(fd.sequence, mask)
+}

--- a/pkg/sentry/devices/memdev/memdev.go
+++ b/pkg/sentry/devices/memdev/memdev.go
@@ -31,6 +31,7 @@ func Register(vfsObj *vfs.VirtualFilesystem) error {
 		fullDevMinor:    fullDevice{},
 		randomDevMinor:  randomDevice{},
 		urandomDevMinor: randomDevice{},
+		kmsgDevMinor:    kmsgDevice{},
 	} {
 		if err := vfsObj.RegisterDevice(vfs.CharDevice, linux.MEM_MAJOR, minor, dev, &vfs.RegisterDeviceOptions{
 			GroupName: "mem",
@@ -50,6 +51,7 @@ func CreateDevtmpfsFiles(ctx context.Context, dev *devtmpfs.Accessor) error {
 		fullDevMinor:    "full",
 		randomDevMinor:  "random",
 		urandomDevMinor: "urandom",
+		kmsgDevMinor:    "kmsg",
 	} {
 		if err := dev.CreateDeviceFile(ctx, name, vfs.CharDevice, linux.MEM_MAJOR, minor, 0666 /* mode */); err != nil {
 			return err

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -149,6 +149,7 @@ go_library(
     visibility = ["//:sandbox"],
     deps = [
         ":uncaught_signal_go_proto",
+        "//pkg/buffer",
         "//pkg/abi",
         "//pkg/abi/linux",
         "//pkg/amutex",

--- a/test/syscalls/linux/dev.cc
+++ b/test/syscalls/linux/dev.cc
@@ -61,6 +61,17 @@ TEST(DevTest, LseekDevFull) {
   EXPECT_THAT(lseek(fd.get(), 123, SEEK_END), SyscallSucceedsWithValue(0));
 }
 
+TEST(DevTest, LseekDevKmsg) {
+  SKIP_IF(IsRunningWithVFS1());
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/kmsg", O_RDONLY));
+  EXPECT_THAT(lseek(fd.get(), 0, SEEK_CUR), SyscallFailsWithErrno(EINVAL));
+  EXPECT_THAT(lseek(fd.get(), 1, SEEK_SET), SyscallFailsWithErrno(ESPIPE));
+  EXPECT_THAT(lseek(fd.get(), 0, SEEK_SET), SyscallSucceedsWithValue(0));
+  EXPECT_THAT(lseek(fd.get(), 0, SEEK_END), SyscallSucceedsWithValue(0));
+  EXPECT_THAT(lseek(fd.get(), 0, SEEK_DATA), SyscallSucceedsWithValue(0));
+}
+
 TEST(DevTest, LseekDevNullFreshFile) {
   // Seeks to /dev/null always return 0.
   const FileDescriptor fd1 =
@@ -85,6 +96,9 @@ TEST(DevTest, OpenTruncate) {
       Open("/dev/zero", O_CREAT | O_TRUNC | O_WRONLY, 0644));
   ASSERT_NO_ERRNO_AND_VALUE(
       Open("/dev/full", O_CREAT | O_TRUNC | O_WRONLY, 0644));
+  SKIP_IF(IsRunningWithVFS1());
+  ASSERT_NO_ERRNO_AND_VALUE(
+      Open("/dev/kmsg", O_CREAT | O_TRUNC | O_WRONLY, 0644));
 }
 
 TEST(DevTest, Pread64DevNull) {
@@ -144,6 +158,73 @@ TEST(DevTest, WriteDevFull) {
   const FileDescriptor fd =
       ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/full", O_WRONLY));
   EXPECT_THAT(WriteFd(fd.get(), "a", 1), SyscallFailsWithErrno(ENOSPC));
+}
+
+TEST(DevTest, ReadWriteDevKmsg) {
+  SKIP_IF(IsRunningWithVFS1());
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/kmsg", O_RDWR));
+
+  constexpr int bufferSize = 1024;
+  std::vector<char> oversizeBuffer(bufferSize*2);
+  EXPECT_THAT(WriteFd(fd.get(), oversizeBuffer.data(), bufferSize*2),
+              SyscallFailsWithErrno(EINVAL));
+  std::vector<char> writeBuffer(bufferSize);
+  RandomizeBuffer(writeBuffer.data(), writeBuffer.size());
+  EXPECT_THAT(WriteFd(fd.get(), writeBuffer.data(), bufferSize),
+              SyscallSucceedsWithValue(bufferSize));
+
+  std::vector<char> readBuffer(bufferSize);
+  EXPECT_THAT(ReadFd(fd.get(), readBuffer.data(), bufferSize/2),
+              SyscallFailsWithErrno(EINVAL));
+  EXPECT_THAT(ReadFd(fd.get(), readBuffer.data(), bufferSize),
+              SyscallSucceedsWithValue(bufferSize));
+  EXPECT_EQ(writeBuffer, readBuffer);
+  EXPECT_THAT(ReadFd(fd.get(), readBuffer.data(), bufferSize),
+              SyscallFailsWithErrno(EAGAIN));
+}
+
+TEST(DevTest, OverwriteDevKmsgBuffer) {
+  SKIP_IF(IsRunningWithVFS1());
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/kmsg", O_RDWR));
+
+  constexpr int overwriteAmount = 10;
+  constexpr int bufferEntryMax = 512;
+  for (int i = 0; i < bufferEntryMax + overwriteAmount ; i++){
+    EXPECT_THAT(WriteFd(fd.get(), &i, 1), SyscallSucceedsWithValue(1));
+  }
+  std::vector<int> buf(1);
+  EXPECT_THAT(ReadFd(fd.get(), buf.data(), 1), SyscallFailsWithErrno(EPIPE));
+  EXPECT_THAT(ReadFd(fd.get(), buf.data(), 1), SyscallSucceedsWithValue(1));
+  EXPECT_EQ(overwriteAmount, buf.front());
+}
+
+TEST(DevTest, MultipleOpenAccessKmsg) {
+  SKIP_IF(IsRunningWithVFS1());
+  FileDescriptor writeFd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/kmsg", O_RDWR));
+  constexpr int bufferSize = 1024;
+  std::vector<char> writeBuffer(bufferSize);
+  RandomizeBuffer(writeBuffer.data(), writeBuffer.size());
+  EXPECT_THAT(WriteFd(writeFd.get(), writeBuffer.data(), bufferSize),
+              SyscallSucceedsWithValue(bufferSize));
+  EXPECT_THAT(close(writeFd.release()), SyscallSucceeds());
+
+  FileDescriptor readFd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/kmsg", O_RDWR));
+  std::vector<char> readBuffer(bufferSize);
+  EXPECT_THAT(ReadFd(readFd.get(), readBuffer.data(), bufferSize),
+              SyscallSucceedsWithValue(bufferSize));
+  EXPECT_EQ(writeBuffer, readBuffer);
+}
+
+TEST(DevTest, NonblockReadDevKmsg) {
+  SKIP_IF(IsRunningWithVFS1());
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/kmsg", O_RDWR & O_NONBLOCK));
+  std::vector<char> buf(1);
+  EXPECT_THAT(ReadFd(fd.get(), buf.data(), 1), SyscallFailsWithErrno(EAGAIN));
 }
 
 TEST(DevTest, TTYExists) {


### PR DESCRIPTION
implemented /dev/kmsg support for gvisor

Related issue: [Implement /dev/kmsg inside gVisor #2290](https://github.com/google/gvisor/issues/2290)