### PR TITLE
implement TCSETSF for master/slave tty

### DIFF
--- a/pkg/sentry/fs/tty/master.go
+++ b/pkg/sentry/fs/tty/master.go
@@ -167,6 +167,8 @@ func (mf *masterFileOperations) Ioctl(ctx context.Context, _ *fs.File, io userme
 	case linux.TCSETSW:
 		// TODO(b/29356795): This should drain the output queue first.
 		return mf.t.ld.setTermios(ctx, io, args)
+	case linux.TCSETSF:
+		return mf.t.ld.setTermiosFlush(ctx, io, args)
 	case linux.TIOCGPTN:
 		_, err := usermem.CopyObjectOut(ctx, io, args[2].Pointer(), uint32(mf.t.n), usermem.IOOpts{
 			AddressSpaceActive: true,

--- a/pkg/sentry/fs/tty/queue.go
+++ b/pkg/sentry/fs/tty/queue.go
@@ -143,6 +143,16 @@ func (q *queue) read(ctx context.Context, dst usermem.IOSequence, l *lineDiscipl
 	return int64(n), nPushed > 0, nil
 }
 
+// discardPending all pending readable data in the queue
+func (q *queue) discardPending(ctx context.Context) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.readBuf = nil
+	q.waitBuf = nil
+	q.waitBufLen = 0
+	q.readable = false
+}
+
 // write writes to q from userspace.
 //
 // Preconditions:

--- a/pkg/sentry/fs/tty/slave.go
+++ b/pkg/sentry/fs/tty/slave.go
@@ -147,6 +147,8 @@ func (sf *slaveFileOperations) Ioctl(ctx context.Context, _ *fs.File, io usermem
 	case linux.TCSETSW:
 		// TODO(b/29356795): This should drain the output queue first.
 		return sf.si.t.ld.setTermios(ctx, io, args)
+	case linux.TCSETSF:
+		return sf.si.t.ld.setTermiosFlush(ctx, io, args)
 	case linux.TIOCGPTN:
 		_, err := usermem.CopyObjectOut(ctx, io, args[2].Pointer(), uint32(sf.si.t.n), usermem.IOOpts{
 			AddressSpaceActive: true,


### PR DESCRIPTION
Fix #2335

I'm unsure if discardPendingInput is the most correct thing, but this seems to work.

Signed-off-by: Daniel Dao <dqminh89@gmail.com>