### PR TITLE
hostinet: fix not specifying family field

### DIFF
--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -708,6 +708,6 @@ func (p *socketProvider) Pair(t *kernel.Task, stype linux.SockType, protocol int
 func init() {
 	for _, family := range []int{syscall.AF_INET, syscall.AF_INET6} {
 		socket.RegisterProvider(family, &socketProvider{family})
-		socket.RegisterProviderVFS2(family, &socketProviderVFS2{})
+		socket.RegisterProviderVFS2(family, &socketProviderVFS2{family})
 	}
 }


### PR DESCRIPTION
Creating sockets by hostinet with VFS2 fails due to triggerring a
seccomp violation. In essence, we fails to pass down the field of
family.

We fix this by passing down this field, family.

Fixes #3141

Signed-off-by: Jianfeng Tan <henry.tjf@antfin.com>

* [ ] Have you followed the guidelines in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)?
* [ ] Have you formatted and linted your code?
* [ ] Have you added relevant tests?
* [ ] Have you added appropriate Fixes & Updates references?
* [ ] If yes, please erase all these lines!
