### PR TITLE
Networking.md: removing stale link to netstack repo

### DIFF
--- a/g3doc/user_guide/networking.md
+++ b/g3doc/user_guide/networking.md
@@ -2,7 +2,7 @@
 
 [TOC]
 
-gVisor implements its own network stack called [netstack][netstack]. All aspects
+gVisor implements its own network stack called netstack. All aspects
 of the network stack are handled inside the Sentry — including TCP connection
 state, control messages, and packet assembly — keeping it isolated from the host
 network stack. Data link layer packets are written directly to the virtual
@@ -82,4 +82,3 @@ Offload (GSO) to run with a kernel that is newer than 3.17. Add the
 }
 ```
 
-[netstack]: https://github.com/google/netstack


### PR DESCRIPTION
Removing the link to the netstack repo as the netstack code is now part of gVisor.

