### PR TITLE
Fuse init

### DIFF
--- a/pkg/abi/linux/BUILD
+++ b/pkg/abi/linux/BUILD
@@ -29,6 +29,7 @@ go_library(
         "file_amd64.go",
         "file_arm64.go",
         "fs.go",
+        "fuse.go",
         "futex.go",
         "inotify.go",
         "ioctl.go",

--- a/pkg/abi/linux/fuse.go
+++ b/pkg/abi/linux/fuse.go
@@ -14,6 +14,58 @@
 
 package linux
 
+// +marshal
+type FUSEOpcode uint32
+
+// +marshal
+type FUSEOpID uint64
+
+// Opcodes for FUSE operations. Analogous to the opcodes in include/linux/fuse.h.
+const (
+	FUSE_LOOKUP FUSEOpcode = iota + 1
+	FUSE_FORGET            /* no reply */
+	FUSE_GETATTR
+	FUSE_SETATTR
+	FUSE_READLINK
+	FUSE_SYMLINK
+	_
+	FUSE_MKNOD
+	FUSE_MKDIR
+	FUSE_UNLINK
+	FUSE_RMDIR
+	FUSE_RENAME
+	FUSE_LINK
+	FUSE_OPEN
+	FUSE_READ
+	FUSE_WRITE
+	FUSE_STATFS
+	FUSE_RELEASE
+	_
+	FUSE_FSYNC
+	FUSE_SETXATTR
+	FUSE_GETXATTR
+	FUSE_LISTXATTR
+	FUSE_REMOVEXATTR
+	FUSE_FLUSH
+	FUSE_INIT
+	FUSE_OPENDIR
+	FUSE_READDIR
+	FUSE_RELEASEDIR
+	FUSE_FSYNCDIR
+	FUSE_GETLK
+	FUSE_SETLK
+	FUSE_SETLKW
+	FUSE_ACCESS
+	FUSE_CREATE
+	FUSE_INTERRUPT
+	FUSE_BMAP
+	FUSE_DESTROY
+	FUSE_IOCTL
+	FUSE_POLL
+	FUSE_NOTIFY_REPLY
+	FUSE_BATCH_FORGET
+)
+
 // FUSEHeaderIn is the header read by the daemon with each request.
 //
 // +marshal
@@ -22,10 +74,10 @@ type FUSEHeaderIn struct {
 	Len uint32
 
 	// Opcode specifies the kind of operation of the request.
-	Opcode uint32
+	Opcode FUSEOpcode
 
 	// Unique specifies the unique identifier for this request.
-	Unique uint32
+	Unique FUSEOpID
 
 	// NodeID is the ID of the filesystem object being operated on.
 	NodeID uint64
@@ -37,7 +89,7 @@ type FUSEHeaderIn struct {
 	GID uint32
 
 	// PID is the PID of the requesting process.
-	PID     uint32
+	PID uint32
 
 	padding uint32
 }
@@ -55,5 +107,5 @@ type FUSEHeaderOut struct {
 	Error int32
 
 	// Unique specifies the unique identifier of the corresponding request.
-	Unique uint32
+	Unique FUSEOpID
 }

--- a/pkg/abi/linux/fuse.go
+++ b/pkg/abi/linux/fuse.go
@@ -1,0 +1,59 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linux
+
+// FUSEHeaderIn is the header read by the daemon with each request.
+//
+// +marshal
+type FUSEHeaderIn struct {
+	// Len specifies the total length of the data, including this header.
+	Len uint32
+
+	// Opcode specifies the kind of operation of the request.
+	Opcode uint32
+
+	// Unique specifies the unique identifier for this request.
+	Unique uint32
+
+	// NodeID is the ID of the filesystem object being operated on.
+	NodeID uint64
+
+	// UID is the UID of the requesting process.
+	UID uint32
+
+	// GID is the GID of the requesting process.
+	GID uint32
+
+	// PID is the PID of the requesting process.
+	PID     uint32
+
+	padding uint32
+}
+
+// FUSEHeaderOut is the header written by the daemon when it processes
+// a request and wants to send a reply (almost all operations require a
+// reply; if they do not, this will be explicitly documented).
+//
+// +marshal
+type FUSEHeaderOut struct {
+	// Len specifies the total length of the data, including this header.
+	Len uint32
+
+	// Error specifies the error that occurred (0 if none).
+	Error int32
+
+	// Unique specifies the unique identifier of the corresponding request.
+	Unique uint32
+}

--- a/pkg/abi/linux/fuse.go
+++ b/pkg/abi/linux/fuse.go
@@ -109,3 +109,102 @@ type FUSEHeaderOut struct {
 	// Unique specifies the unique identifier of the corresponding request.
 	Unique FUSEOpID
 }
+
+// FUSE_INIT flags, from include/uapi/linux/fuse.h.
+const (
+	FUSE_ASYNC_READ          = 1 << 0
+	FUSE_POSIX_LOCKS         = 1 << 1
+	FUSE_FILE_OPS            = 1 << 2
+	FUSE_ATOMIC_O_TRUNC      = 1 << 3
+	FUSE_EXPORT_SUPPORT      = 1 << 4
+	FUSE_BIG_WRITES          = 1 << 5
+	FUSE_DONT_MASK           = 1 << 6
+	FUSE_SPLICE_WRITE        = 1 << 7
+	FUSE_SPLICE_MOVE         = 1 << 8
+	FUSE_SPLICE_READ         = 1 << 9
+	FUSE_FLOCK_LOCKS         = 1 << 10
+	FUSE_HAS_IOCTL_DIR       = 1 << 11
+	FUSE_AUTO_INVAL_DATA     = 1 << 12
+	FUSE_DO_READDIRPLUS      = 1 << 13
+	FUSE_READDIRPLUS_AUTO    = 1 << 14
+	FUSE_ASYNC_DIO           = 1 << 15
+	FUSE_WRITEBACK_CACHE     = 1 << 16
+	FUSE_NO_OPEN_SUPPORT     = 1 << 17
+	FUSE_PARALLEL_DIROPS     = 1 << 18
+	FUSE_HANDLE_KILLPRIV     = 1 << 19
+	FUSE_POSIX_ACL           = 1 << 20
+	FUSE_ABORT_ERROR         = 1 << 21
+	FUSE_MAX_PAGES           = 1 << 22
+	FUSE_CACHE_SYMLINKS      = 1 << 23
+	FUSE_NO_OPENDIR_SUPPORT  = 1 << 24
+	FUSE_EXPLICIT_INVAL_DATA = 1 << 25
+	FUSE_MAP_ALIGNMENT       = 1 << 26
+)
+
+// const version numbers from include/uapi/linux/fuse.h.
+const (
+	FUSE_KERNEL_VERSION = 7
+	FUSE_KERNEL_MINOR_VERSION = 31
+)
+
+// FUSEInitIn is the request sent by the kernel to the daemon,
+// to negotiate the version and flags.
+//
+// +marshal
+type FUSEInitIn struct {
+	// Major version supported by kernel.
+	Major uint32
+
+	// Minor version supported by the kernel.
+	Minor uint32
+
+	// MaxReadahead is the maximum number of bytes to read-ahead.
+	MaxReadahead uint32
+
+	// Flags of init_in request.
+	Flags uint32
+}
+
+// FUSEInitOut is the reply sent by the daemon to the kernel
+// for FUSEInitIn.
+//
+// +marshal
+type FUSEInitOut struct {
+	// Major version supported by daemon.
+	Major uint32
+
+	// Minor version supported by daemon.
+	Minor uint32
+
+	// MaxReadahead is the maximum number of bytes to read-ahead.
+	MaxReadahead uint32
+
+	// Flags of init_out reply.
+	Flags uint32
+
+	// MaxBackground is the maximum number of pending "background" requests.
+	MaxBackground uint16
+
+	// CongestionThreshold parameter used by the kernel.
+	// FUSE mark the filesystem as "congested" when the number of pending
+	// background requests exceeds this threshold.
+	CongestionThreshold uint16
+
+	// MaxWrite the maximum size of a write buffer.
+	// Minmum value is FUSE_MIN_MAX_WRITE.
+	MaxWrite uint32
+
+	// TimeGran is the time granularity for mtime and ctime supported by the filesystem.
+	// Values should be power of 10 and unit is nanosecond.
+	// 1 indicates full nanosecond granularity support.
+	TimeGran uint32
+
+	// MaxPages the maximum number of pages for one write operation.
+	// Maximum value is FUSE_MAX_MAX_PAGES.
+	MaxPages uint16
+
+	// MapAlignment is an unknown field and not used at this moment.
+	MapAlignment uint16
+
+	unused [8]uint32
+}

--- a/pkg/sentry/fsimpl/fuse/BUILD
+++ b/pkg/sentry/fsimpl/fuse/BUILD
@@ -1,12 +1,28 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
+load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 licenses(["notice"])
+
+go_template_instance(
+    name = "request_list",
+    out = "request_list.go",
+    package = "fuse",
+    prefix = "request",
+    template = "//pkg/ilist:generic_list",
+    types = {
+        "Element": "*Request",
+        "Linker": "*Request",
+    },
+)
 
 go_library(
     name = "fuse",
     srcs = [
+        "connection.go",
         "dev.go",
         "fusefs.go",
+        "register.go",
+        "request_list.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [
@@ -18,8 +34,33 @@ go_library(
         "//pkg/sentry/kernel",
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/vfs",
+        "//pkg/sync",
         "//pkg/syserror",
         "//pkg/usermem",
+        "//pkg/waiter",
+        "//tools/go_marshal/marshal",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
+go_test(
+    name = "dev_test",
+    size = "small",
+    srcs = ["dev_test.go"],
+    library = ":fuse",
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/context",
+        "//pkg/log",
+        "//pkg/sentry/fsimpl/testutil",
+        "//pkg/sentry/fsimpl/tmpfs",
+        "//pkg/sentry/kernel",
+        "//pkg/sentry/kernel/auth",
+        "//pkg/sentry/vfs",
+        "//pkg/sync",
+        "//pkg/syserror",
+        "//pkg/usermem",
+        "//tools/go_marshal/marshal",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/sentry/fsimpl/fuse/BUILD
+++ b/pkg/sentry/fsimpl/fuse/BUILD
@@ -21,6 +21,7 @@ go_library(
         "connection.go",
         "dev.go",
         "fusefs.go",
+        "init.go",
         "register.go",
         "request_list.go",
     ],

--- a/pkg/sentry/fsimpl/fuse/BUILD
+++ b/pkg/sentry/fsimpl/fuse/BUILD
@@ -6,14 +6,20 @@ go_library(
     name = "fuse",
     srcs = [
         "dev.go",
+        "fusefs.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [
         "//pkg/abi/linux",
         "//pkg/context",
+        "//pkg/log",
         "//pkg/sentry/fsimpl/devtmpfs",
+        "//pkg/sentry/fsimpl/kernfs",
+        "//pkg/sentry/kernel",
+        "//pkg/sentry/kernel/auth",
         "//pkg/sentry/vfs",
         "//pkg/syserror",
         "//pkg/usermem",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/sentry/fsimpl/fuse/connection.go
+++ b/pkg/sentry/fsimpl/fuse/connection.go
@@ -1,0 +1,209 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuse
+
+import (
+	"fmt"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/tools/go_marshal/marshal"
+	"syscall"
+)
+
+// TODO: configure this properly.
+const MaxInFlightRequests = 1000
+
+// Request represents a FUSE operation request that hasn't been sent to the
+// server yet.
+//
+// +stateify savable
+type Request struct {
+	requestEntry
+
+	id   linux.FUSEOpID
+	hdr  *linux.FUSEHeaderIn
+	data []byte
+}
+
+// FutureResponse represents an in-flight request, that may or may not have
+// completed yet. Convert it to a resolved Response by calling Resolve, but note
+// that this may block.
+//
+// +stateify savable
+type FutureResponse struct {
+	ch   chan struct{}
+	hdr  *linux.FUSEHeaderOut
+	data []byte
+}
+
+// Connection is the struct by which the sentry communicates with the FUSE server daemon.
+type Connection struct {
+	fd *DeviceFD
+}
+
+// NewFUSEConnection creates a FUSE connection to fd
+func NewFUSEConnection(ctx context.Context, fd *vfs.FileDescription) *Connection {
+	// Mark the device as ready so it can be used. /dev/fuse can only be used if the FD was used to
+	// mount a FUSE filesystem.
+	fuseFD := fd.Impl().(*DeviceFD)
+	fuseFD.mounted = true
+
+	// Create the writeBuf for the header to be stored in.
+	hdrLen := uint32((*linux.FUSEHeaderOut)(nil).SizeBytes())
+	fuseFD.writeBuf = make([]byte, hdrLen)
+	fuseFD.completions = make(map[linux.FUSEOpID]*FutureResponse)
+	fuseFD.waitCh = make(chan struct{}, MaxInFlightRequests)
+	fuseFD.writeCursor = 0
+	fuseFD.readCursor = 0
+
+	return &Connection{fd: fuseFD}
+}
+
+// NewRequest creates a new request that can be sent to the FUSE server.
+func (conn *Connection) NewRequest(creds *auth.Credentials, pid uint32, ino uint64, opcode linux.FUSEOpcode, payload marshal.Marshallable) (*Request, error) {
+	conn.fd.mu.Lock()
+	defer conn.fd.mu.Unlock()
+
+	hdrLen := (*linux.FUSEHeaderIn)(nil).SizeBytes()
+	hdr := linux.FUSEHeaderIn{
+		Len:    uint32(hdrLen + payload.SizeBytes()),
+		Opcode: opcode,
+		Unique: conn.fd.nextOpID,
+		NodeID: ino,
+		UID:    uint32(creds.EffectiveKUID),
+		GID:    uint32(creds.EffectiveKGID),
+		PID:    pid,
+	}
+	conn.fd.nextOpID++
+
+	buf := make([]byte, hdr.Len)
+	hdr.MarshalUnsafe(buf[:hdrLen])
+	payload.MarshalUnsafe(buf[hdrLen:])
+
+	return &Request{
+		id:   hdr.Unique,
+		hdr:  &hdr,
+		data: buf,
+	}, nil
+}
+
+// Call makes a request to the server and blocks the invoking task until a
+// server responds with a response.
+func (conn *Connection) Call(t *kernel.Task, r *Request) (*Response, error) {
+	fut, err := conn.callFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return fut.resolve(t)
+}
+
+// CallTaskNonBlock makes a request to the server and blocks the invoking
+// goroutine until a server responds with a response. Doesn't block
+// a kernel.Task.
+func (conn *Connection) CallTaskNonBlock(r *Request) (*Response, error) {
+	fut, err := conn.callFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: Consider allowing a timeout to unblock the process. Unclear if this
+	// is required yet.
+	select {
+	case <-fut.ch:
+	}
+
+	// A response is ready. Resolve and return it.
+	return &Response{
+		hdr:  *fut.hdr,
+		data: fut.data,
+	}, nil
+}
+
+// callFuture makes a request to the server and returns a future response.
+// Call resolve() when the response needs to be fulfilled.
+func (conn *Connection) callFuture(r *Request) (*FutureResponse, error) {
+	conn.fd.mu.Lock()
+	conn.fd.queue.PushBack(r)
+	fut := newFutureResponse()
+	conn.fd.completions[r.id] = fut
+	conn.fd.mu.Unlock()
+
+	// Signal a reader notifying them about a queued request. This
+	// might block if the number of in flight requests exceed
+	// MaxInFlightRequests.
+	//
+	// TODO: Consider possible starvation here if the waitCh is
+	// continuously full. Will go channels respect FIFO order when
+	// unblocking threads?
+	conn.fd.waitCh <- struct{}{}
+
+	return fut, nil
+}
+
+// newFutureResponse creates a future response to a FUSE request.
+func newFutureResponse() *FutureResponse {
+	return &FutureResponse{
+		ch: make(chan struct{}),
+	}
+}
+
+// resolve blocks the task until the server responds to its corresponding request,
+// then returns a resolved response.
+func (r *FutureResponse) resolve(t *kernel.Task) (*Response, error) {
+	if err := t.Block(r.ch); err != nil {
+		return nil, err
+	}
+
+	return &Response{
+		hdr:  *r.hdr,
+		data: r.data,
+	}, nil
+}
+
+// Response represents an actual response from the server, including the
+// response payload.
+//
+// +stateify savable
+type Response struct {
+	hdr  linux.FUSEHeaderOut
+	data []byte
+}
+
+func (r *Response) Error() error {
+	errno := r.hdr.Error
+	if errno >= 0 {
+		return nil
+	}
+
+	sysErrNo := syscall.Errno(-errno)
+	return error(sysErrNo)
+}
+
+func (r *Response) UnmarshalPayload(m marshal.Marshallable) error {
+	hdrLen := r.hdr.SizeBytes()
+	haveDataLen := r.hdr.Len - uint32(hdrLen)
+	wantDataLen := uint32(m.SizeBytes())
+
+	if haveDataLen < wantDataLen {
+		return fmt.Errorf("payload too small. Minimum data lenth required: %d,  but got data length %d", wantDataLen, haveDataLen)
+	}
+
+	m.UnmarshalUnsafe(r.data[hdrLen:])
+	return nil
+}

--- a/pkg/sentry/fsimpl/fuse/connection.go
+++ b/pkg/sentry/fsimpl/fuse/connection.go
@@ -16,13 +16,16 @@ package fuse
 
 import (
 	"fmt"
+	"syscall"
+	"sync"
+	"sync/atomic"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/tools/go_marshal/marshal"
-	"syscall"
 )
 
 // TODO: configure this properly.
@@ -32,6 +35,20 @@ var (
 	// Ordinary requests have even IDs, while interrupts IDs are odd.
 	FUSE_INIT_REQ_BIT uint64 = 1
 	FUSE_REQ_ID_STEP  uint64 = 2
+)
+
+const (
+	// FUSE_DEFAULT_MAX_BACKGROUND is the maximum number of outstanding background requests.
+	// From fs/fuse/inode.c.
+	FUSE_DEFAULT_MAX_BACKGROUND = 12
+
+	// FUSE_DEFAULT_CONGESTION_THRESHOLD is 75% of default maximum.
+	// From fs/fuse/inode.c.
+	FUSE_DEFAULT_CONGESTION_THRESHOLD = (FUSE_DEFAULT_MAX_BACKGROUND * 3 / 4)
+
+	// FUSE_DEFAULT_MAX_PAGES_PER_REQ is the maximum number of pages that can be used in a single read request.
+	// From fs/fuse/fuse_i.h.
+	FUSE_DEFAULT_MAX_PAGES_PER_REQ = 32
 )
 
 // Request represents a FUSE operation request that hasn't been sent to the
@@ -60,24 +77,260 @@ type FutureResponse struct {
 // Connection is the struct by which the sentry communicates with the FUSE server daemon.
 type Connection struct {
 	fd *DeviceFD
+
+	// MaxRead size in bytes.
+	MaxRead uint32
+
+	// MaxWrite size in bytes.
+	MaxWrite uint32
+
+	// MaxPages is the maximum number of pages for a single request to use.
+	MaxPages uint16
+
+	// MaxBackground is the maximum number of outstanding background requests.
+	MaxBackground uint16
+
+	// CongestionThreshold for number of background requests.
+	CongestionThreshold uint16
+
+	// NumberBackground is the number of requests in background.
+	NumBackground uint16
+
+	// ActiveBackground requests number currently queued for userspace.
+	ActiveBackground uint16
+
+	// TODO: BgQuque
+	// some queue for background queued requests.
+
+	// BgLock protects:
+	// MaxBackground, CongestionThreshold, NumBackground,
+	// ActiveBackground, BgQueue, Blocked.
+	BgLock sync.Mutex
+
+	// Initialized if INIT reply has been received.
+	// Until it's set, suspend sending FUSE requests.
+	Initialized bool
+
+	// protects Initialized.
+	initializedLock sync.Mutex
+
+	// Blocked when:
+	// before the INIT reply is received,
+	// and if there are too many outstading backgrounds requests.
+	// TODO: use a channel to block.
+	Blocked bool
+
+	// Connected if connection established.
+	// Unset when umount, connection abort and device release.
+	Connected bool
+
+	// Aborted via sysfs.
+	Aborted bool
+
+	// ConnError if connection failed (version mismatch).
+	// Only set in INIT,
+	// before any other request,
+	// never unset.
+	// Cannot race with other flags.
+	ConnError bool
+
+	// ConnInit if connection successful.
+	// Only set in INIT.
+	ConnInit bool
+
+	// AsyncRead if read pages asynchronously.
+	// Only set in INIT.
+	AsyncRead bool
+
+	// AbortErr is true when FUSE will return an unique read error after abort.
+	// Only set in INIT.
+	AbortErr bool
+
+	// AtomicOTrunc is true when FUSE does not send a separate SETATTR request
+	// before open with O_TRUNC flag.
+	AtomicOTrunc bool
+
+	// ExportSupport is true if Filesystem supports NFS exporting.
+	// Only set in INIT.
+	ExportSupport bool
+
+	// WritebackCache is true if using write-back cache policy,
+	// false if using write-through policy.
+	WritebackCache bool
+
+	// ParallelDirops is true if allowing lookup and readdir in parallel,
+	// false if serialized.
+	ParallelDirops bool
+
+	// HandleKillpriv if fs handls killing suid/sgid/cap on write/chown/trunc.
+	HandleKillpriv bool
+
+	// CacheSymlinks if cache READLINK responses in page cache.
+	CacheSymlinks bool
+
+	/* Setting races on the following optimization-purpose flags are safe */
+
+	// NoOpen if open/release not implemented by fs.
+	NoOpen bool
+
+	// NoOpendir if opendir/releasedir not implemented by fs.
+	NoOpendir bool
+
+	// NoFsync if fsync not implemented by fs.
+	NoFsync bool
+
+	// NoFsyncdir if fsyncdir not implemented by fs.
+	NoFsyncdir bool
+
+	// NoFlush if flush not implemented by fs.
+	NoFlush bool
+
+	// NoSetxattr if setxattr not implemented by fs.
+	NoSetxattr bool
+
+	// NoGetxattr if getxattr not implemented by fs.
+	NoGetxattr bool
+
+	// NoListxattr if listxattr not implemented by fs.
+	NoListxattr bool
+
+	// NoRemovexattr if removexattr not implemented by fs.
+	NoRemovexattr bool
+
+	// NoLock if posix file locking primitives not implemented by fs.
+	NoLock bool
+
+	// NoAccess if access not implemented by fs.
+	NoAccess bool
+
+	// NoCreate if create not implemented by fs.
+	NoCreate bool
+
+	// NoInterrupt if interrupt not implemented by fs.
+	NoInterrupt bool
+
+	// NoBmap if bmap not implemented by fs.
+	NoBmap bool
+
+	// NoPoll if poll not implemented by fs.
+	NoPoll bool
+
+	// BigWrites if doing multi-page cached writes.
+	BigWrites bool
+
+	// DontMask don't apply umask to creation modes.
+	DontMask bool
+
+	// NoFLock if BSD file locking primitives not implemented by fs.
+	NoFLock bool
+
+	// NoFallocate if fallocate not implemented by fs.
+	NoFallocate bool
+
+	// NoRename2 if rename with flags not implemented by fs.
+	NoRename2 bool
+
+	// AutoInvalData use enhanced/automatic page cache invalidation.
+	AutoInvalData bool
+
+	// ExplicitInvalData Filesystem is fully reponsible for page cache invalidation.
+	ExplicitInvalData bool
+
+	// DoReaddirplus if the filesystem supports readdirplus.
+	DoReaddirplus bool
+
+	// ReaddirplusAuto if the filesystem wants adaptive readdirplus.
+	ReaddirplusAuto bool
+
+	// AsyncDio if the filesystem supports asynchronous direct-IO submission.
+	AsyncDio bool
+
+	// NoLseek if lseek() not implemented by fs.
+	NoLseek bool
+
+	// PosixACL if the filesystem supports posix acls.
+	PosixACL bool
+
+	// DefaultPermissions if to check permissions based on the file mode.
+	DefaultPermissions bool
+
+	// AllowOther user who is not the mounter to access the filesystem.
+	AllowOther bool
+
+	// NoCopyFileRange if the filesystem not supports copy_file_range.
+	NoCopyFileRange bool
+
+	// Destroy request will be sent.
+	Destroy bool
+
+	// DeleteStable dentries.
+	DeleteStable bool
+
+	// NoControl if not create entry in fusectl fs.
+	NonControl bool
+
+	// NoForceUmount if not allow MNT_FORCE umount.
+	NoForceUmount bool
+
+	// NoMountOptions if not show mount options.
+	NoMountOptions bool
+
+	// NumWating requests waiting for completion.
+	NumWaiting uint32
+
+	// Minor version negotiated.
+	Minor uint32
 }
 
-// NewFUSEConnection creates a FUSE connection to fd
+// NewFUSEConnection creates a FUSE connection to fd.
 func NewFUSEConnection(ctx context.Context, fd *vfs.FileDescription) *Connection {
+	conn := &Connection{}
+
 	// Mark the device as ready so it can be used. /dev/fuse can only be used if the FD was used to
 	// mount a FUSE filesystem.
-	fuseFD := fd.Impl().(*DeviceFD)
-	fuseFD.mounted = true
+	conn.fd = fd.Impl().(*DeviceFD)
+	conn.fd.mounted = true
 
 	// Create the writeBuf for the header to be stored in.
 	hdrLen := uint32((*linux.FUSEHeaderOut)(nil).SizeBytes())
-	fuseFD.writeBuf = make([]byte, hdrLen)
-	fuseFD.completions = make(map[linux.FUSEOpID]*FutureResponse)
-	fuseFD.waitCh = make(chan struct{}, MaxInFlightRequests)
-	fuseFD.writeCursor = 0
-	fuseFD.readCursor = 0
+	conn.fd.writeBuf = make([]byte, hdrLen)
+	conn.fd.completions = make(map[linux.FUSEOpID]*FutureResponse)
+	conn.fd.waitCh = make(chan struct{}, MaxInFlightRequests)
+	conn.fd.writeCursor = 0
+	conn.fd.readCursor = 0
 
-	return &Connection{fd: fuseFD}
+	// Initialize other member fields.
+
+	atomic.StoreUint32(&conn.NumWaiting, 0)
+
+	conn.MaxBackground = FUSE_DEFAULT_MAX_BACKGROUND
+	conn.CongestionThreshold = FUSE_DEFAULT_CONGESTION_THRESHOLD
+
+	conn.Blocked = false
+	conn.Initialized = false
+	conn.Connected = true
+
+	conn.MaxPages = FUSE_DEFAULT_MAX_PAGES_PER_REQ
+
+	return conn
+}
+
+// called in Init before wake up all blocked requests.
+// Analogous to inode.c:fuse_set_initialized().
+func (conn *Connection) setInitialized() {
+	conn.initializedLock.Lock()
+	defer conn.initializedLock.Unlock()
+
+	conn.Initialized = true
+}
+
+// check if the connection is initialized,
+// pairs with setInitialized().
+func (conn *Connection) isInitialized() bool {
+	conn.initializedLock.Lock()
+	defer conn.initializedLock.Unlock()
+
+	return conn.Initialized
 }
 
 // NewRequest creates a new request that can be sent to the FUSE server.

--- a/pkg/sentry/fsimpl/fuse/dev.go
+++ b/pkg/sentry/fsimpl/fuse/dev.go
@@ -46,6 +46,9 @@ type DeviceFD struct {
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
 
+	// mounted specifies whether a FUSE filesystem was mounted using the DeviceFD.
+	mounted bool
+
 	// TODO(gvisor.dev/issue/2987): Add all the data structures needed to enqueue
 	// and deque requests, control synchronization and establish communication
 	// between the FUSE kernel module and the /dev/fuse character device.
@@ -56,26 +59,51 @@ func (fd *DeviceFD) Release() {}
 
 // PRead implements vfs.FileDescriptionImpl.PRead.
 func (fd *DeviceFD) PRead(ctx context.Context, dst usermem.IOSequence, offset int64, opts vfs.ReadOptions) (int64, error) {
+	// Operations on /dev/fuse don't make sense until a FUSE filesystem is mounted.
+	if !fd.mounted {
+		return 0, syserror.EPERM
+	}
+
 	return 0, syserror.ENOSYS
 }
 
 // Read implements vfs.FileDescriptionImpl.Read.
 func (fd *DeviceFD) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
+	// Operations on /dev/fuse don't make sense until a FUSE filesystem is mounted.
+	if !fd.mounted {
+		return 0, syserror.EPERM
+	}
+
 	return 0, syserror.ENOSYS
 }
 
 // PWrite implements vfs.FileDescriptionImpl.PWrite.
 func (fd *DeviceFD) PWrite(ctx context.Context, src usermem.IOSequence, offset int64, opts vfs.WriteOptions) (int64, error) {
+	// Operations on /dev/fuse don't make sense until a FUSE filesystem is mounted.
+	if !fd.mounted {
+		return 0, syserror.EPERM
+	}
+
 	return 0, syserror.ENOSYS
 }
 
 // Write implements vfs.FileDescriptionImpl.Write.
 func (fd *DeviceFD) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
+	// Operations on /dev/fuse don't make sense until a FUSE filesystem is mounted.
+	if !fd.mounted {
+		return 0, syserror.EPERM
+	}
+
 	return 0, syserror.ENOSYS
 }
 
 // Seek implements vfs.FileDescriptionImpl.Seek.
 func (fd *DeviceFD) Seek(ctx context.Context, offset int64, whence int32) (int64, error) {
+	// Operations on /dev/fuse don't make sense until a FUSE filesystem is mounted.
+	if !fd.mounted {
+		return 0, syserror.EPERM
+	}
+
 	return 0, syserror.ENOSYS
 }
 

--- a/pkg/sentry/fsimpl/fuse/dev_test.go
+++ b/pkg/sentry/fsimpl/fuse/dev_test.go
@@ -73,6 +73,10 @@ func TestCallAndResolve(t *testing.T) {
 			t.Fatalf("CallTaskNonBlock failed: %v", err)
 		}
 
+		if err = resp.Error(); err != nil {
+			t.Fatalf("Server responded with an error: %v", err)
+		}
+
 		var newTestObject testObject
 		if err := resp.UnmarshalPayload(&newTestObject); err != nil {
 			t.Fatalf("Unmarshalling payload error: %v", err)

--- a/pkg/sentry/fsimpl/fuse/dev_test.go
+++ b/pkg/sentry/fsimpl/fuse/dev_test.go
@@ -1,0 +1,246 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuse
+
+import (
+	"fmt"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/testutil"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/usermem"
+	"gvisor.dev/gvisor/tools/go_marshal/marshal"
+	"io"
+	"testing"
+)
+
+const testOpcode linux.FUSEOpcode = 1000
+
+type testObject struct {
+	opcode linux.FUSEOpcode
+}
+
+func TestCallAndResolve(t *testing.T) {
+	s := setup(t)
+	defer s.Destroy()
+
+	k := kernel.KernelFromContext(s.Ctx)
+	creds := auth.CredentialsFromContext(s.Ctx)
+
+	fuseConn, fd, err := newTestConnection(s, k)
+	if err != nil {
+		t.Fatalf("newTestConnection: %v", err)
+	}
+
+	// Queue up a request.
+	testObj := &testObject{
+		opcode: testOpcode,
+	}
+	testPid := uint32(1)
+	testInode := uint64(1)
+
+	// Create the tasks that the server and clients will be using.
+	tc := k.NewThreadGroup(nil, k.RootPIDNamespace(), kernel.NewSignalHandlers(), linux.SIGCHLD, k.GlobalInit().Limits())
+
+	clientDone := make(chan struct{})
+	serverDone := make(chan struct{})
+
+	// FUSE client.
+	go func() {
+		req, err := fuseConn.NewRequest(creds, testPid, testInode, testOpcode, testObj)
+		if err != nil {
+			t.Fatalf("NewRequest creation failed: %v", err)
+		}
+
+		// CallTaskNonBlock is used by asyc calls and tests. Other FUSE operation impls will use
+		// Call to make a blocking call to the server with the same behaviour.
+		resp, err := fuseConn.CallTaskNonBlock(req)
+		if err != nil {
+			t.Fatalf("CallTaskNonBlock failed: %v", err)
+		}
+
+		var newTestObject testObject
+		if err := resp.UnmarshalPayload(&newTestObject); err != nil {
+			t.Fatalf("Unmarshalling payload error: %v", err)
+		}
+
+		if newTestObject.opcode != testOpcode || resp.hdr.Unique != req.hdr.Unique {
+			t.Fatalf("read incorrect data. Payload: %v, Req: %+v, Resp: %+v", newTestObject, req.hdr, resp.hdr)
+		}
+
+		clientDone <- struct{}{}
+	}()
+
+	// FUSE server.
+	go func() {
+		serverTask, err := testutil.CreateTask(s.Ctx, fmt.Sprintf("fuse-server"), tc, s.MntNs, s.Root, s.Root)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Read the request.
+		inHdrLen := uint32((*linux.FUSEHeaderIn)(nil).SizeBytes())
+		payloadLen := uint32(testObj.SizeBytes())
+		inBuf := make([]byte, inHdrLen+payloadLen)
+		inIOseq := usermem.BytesIOSequence(inBuf)
+
+		// Emulate the blocking for when no requests are available. We can't really
+		// block a task during test and so this way we guarantee the fast path of
+		// task.Block() (when no wait is required) is hit.
+		waitChan := fd.Impl().(*DeviceFD).waitCh
+		select {
+		case signal := <-waitChan:
+
+			// Make sure there is something for Read to find.
+			waitChan <- signal
+		}
+
+		// Perform a non blocking read.
+		n, err := fd.Read(serverTask, inIOseq, vfs.ReadOptions{})
+		if err != nil {
+			t.Fatalf("Read failed :%v", err)
+		}
+
+		if n <= 0 {
+			t.Fatalf("Read read no bytes")
+		}
+
+		var readFUSEHeaderIn linux.FUSEHeaderIn
+		var readPayload testObject
+		readFUSEHeaderIn.UnmarshalUnsafe(inBuf[:inHdrLen])
+		readPayload.UnmarshalUnsafe(inBuf[inHdrLen:])
+
+		if readPayload.opcode != testOpcode || readFUSEHeaderIn.Opcode != testOpcode {
+			t.Fatalf("read incorrect data. Header: %v, Payload: %v", readFUSEHeaderIn, readPayload)
+		}
+
+		// Write the response.
+		outHdrLen := uint32((*linux.FUSEHeaderOut)(nil).SizeBytes())
+		outBuf := make([]byte, outHdrLen+payloadLen)
+		outHeader := linux.FUSEHeaderOut{
+			Len:    outHdrLen + payloadLen,
+			Error:  0,
+			Unique: readFUSEHeaderIn.Unique,
+		}
+
+		// Echo the payload back.
+		outHeader.MarshalUnsafe(outBuf[:outHdrLen])
+		readPayload.MarshalUnsafe(outBuf[outHdrLen:])
+		outIOseq := usermem.BytesIOSequence(outBuf)
+
+		n, err = fd.Write(s.Ctx, outIOseq, vfs.WriteOptions{})
+		if err != nil {
+			t.Fatalf("Write failed :%v", err)
+		}
+
+		serverDone <- struct{}{}
+	}()
+
+	<-serverDone
+	<-clientDone
+}
+
+// SizeBytes implements marshal.Marshallable.SizeBytes.
+func (t *testObject) SizeBytes() int {
+	return (*linux.FUSEOpcode)(nil).SizeBytes()
+}
+
+// MarshalBytes implements marshal.Marshallable.MarshalBytes.
+func (t *testObject) MarshalBytes(dst []byte) {
+	t.opcode.MarshalBytes(dst[:t.opcode.SizeBytes()])
+}
+
+// UnmarshalBytes implements marshal.Marshallable.UnmarshalBytes.
+func (t *testObject) UnmarshalBytes(src []byte) {
+	t.opcode.UnmarshalBytes(src[:t.opcode.SizeBytes()])
+}
+
+// Packed implements marshal.Marshallable.Packed.
+func (t *testObject) Packed() bool {
+	return t.opcode.Packed()
+}
+
+// MarshalUnsafe implements marshal.Marshallable.MarshalUnsafe.
+func (t *testObject) MarshalUnsafe(dst []byte) {
+	t.MarshalBytes(dst)
+}
+
+// UnmarshalUnsafe implements marshal.Marshallable.UnmarshalUnsafe.
+func (t *testObject) UnmarshalUnsafe(src []byte) {
+	t.UnmarshalBytes(src)
+}
+
+// CopyOutN implements marshal.Marshallable.CopyOutN.
+func (t *testObject) CopyOutN(task marshal.Task, addr usermem.Addr, limit int) (int, error) {
+	panic("not implemented")
+}
+
+// CopyOut implements marshal.Marshallable.CopyOut.
+func (t *testObject) CopyOut(task marshal.Task, addr usermem.Addr) (int, error) {
+	panic("not implemented")
+}
+
+// CopyIn implements marshal.Marshallable.CopyIn.
+func (t *testObject) CopyIn(task marshal.Task, addr usermem.Addr) (int, error) {
+	panic("not implemented")
+}
+
+// WriteTo implements io.WriterTo.WriteTo.
+func (t *testObject) WriteTo(w io.Writer) (int64, error) {
+	panic("not implemented")
+}
+
+func setup(t *testing.T) *testutil.System {
+	k, err := testutil.Boot()
+	if err != nil {
+		t.Fatalf("Error creating kernel: %v", err)
+	}
+
+	ctx := k.SupervisorContext()
+	creds := auth.CredentialsFromContext(ctx)
+
+	k.VFS().MustRegisterFilesystemType(Name, &FilesystemType{}, &vfs.RegisterFilesystemTypeOptions{
+		AllowUserList:  true,
+		AllowUserMount: true,
+	})
+
+	mntns, err := k.VFS().NewMountNamespace(ctx, creds, "", tmpfs.Name, &vfs.GetFilesystemOptions{})
+	if err != nil {
+		t.Fatalf("NewMountNamespace(): %v", err)
+	}
+
+	return testutil.NewSystem(ctx, t, k.VFS(), mntns)
+}
+
+// newTestConnection creates a fuse connection that the sentry can communicate with
+// and the FD for the server to communicate with.
+func newTestConnection(system *testutil.System, k *kernel.Kernel) (*Connection, *vfs.FileDescription, error) {
+	vfsObj := &vfs.VirtualFilesystem{}
+	fuseDev := &DeviceFD{}
+
+	if err := vfsObj.Init(); err != nil {
+		return nil, nil, err
+	}
+
+	vd := vfsObj.NewAnonVirtualDentry("genCountFD")
+	defer vd.DecRef()
+	if err := fuseDev.vfsfd.Init(fuseDev, linux.O_RDWR|linux.O_CREAT, vd.Mount(), vd.Dentry(), &vfs.FileDescriptionOptions{}); err != nil {
+		return nil, nil, err
+	}
+
+	return NewFUSEConnection(system.Ctx, &fuseDev.vfsfd), &fuseDev.vfsfd, nil
+}

--- a/pkg/sentry/fsimpl/fuse/fusefs.go
+++ b/pkg/sentry/fsimpl/fuse/fusefs.go
@@ -1,0 +1,204 @@
+// Copyright 2019 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fuse implements fusefs.
+package fuse
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/syserror"
+	"strconv"
+)
+
+// Name is the default filesystem name.
+const Name = "fuse"
+
+// FilesystemType implements vfs.FilesystemType.
+type FilesystemType struct{}
+
+type filesystemOptions struct {
+	// userID specifies the numeric uid of the mount owner.
+	// This option should not be specified by the filesystem owner.
+	// It is set by libfuse (or, if libfuse is not used, must be set
+	// by the filesystem itself). For more information, see man page
+	// for fuse(8)
+	userID uint32
+
+	// groupID specifies the numeric uid of the mount owner.
+	// This option should not be specified by the filesystem owner.
+	// It is set by libfuse (or, if libfuse is not used, must be set
+	// by the filesystem itself). For more information, see man page
+	// for fuse(8)
+	groupID uint32
+
+	// rootMode specifies the the file mode of the filesystem's root.
+	rootMode linux.FileMode
+}
+
+// filesystem implements vfs.FilesystemImpl.
+type filesystem struct {
+	kernfs.Filesystem
+	devMinor uint32
+
+	// fuseFD is the FD returned when opening /dev/fuse. It is used for communication
+	// between the FUSE server daemon and the sentry fusefs.
+	fuseFD *DeviceFD
+
+	// opts is the options the fusefs is initialized with.
+	opts filesystemOptions
+}
+
+// Name implements vfs.FilesystemType.Name.
+func (FilesystemType) Name() string {
+	return Name
+}
+
+// GetFilesystem implements vfs.FilesystemType.GetFilesystem.
+func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.VirtualFilesystem, creds *auth.Credentials, source string, opts vfs.GetFilesystemOptions) (*vfs.Filesystem, *vfs.Dentry, error) {
+	devMinor, err := vfsObj.GetAnonBlockDevMinor()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var fsopts filesystemOptions
+	mopts := vfs.GenericParseMountOptions(opts.Data)
+	deviceDescriptorStr, ok := mopts["fd"]
+	if !ok {
+		log.Warningf("fusefs.FilesystemType.GetFilesystem: communication file descriptor N (obtained by opening /dev/fuse) must be specified as 'fd=N'")
+		return nil, nil, syserror.EINVAL
+	}
+	delete(mopts, "fd")
+
+	deviceDescriptor, err := strconv.ParseInt(deviceDescriptorStr, 10 /* base */, 32 /* bitSize */)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	taskCtxKey := kernel.CtxTask
+	taskCtxValue := ctx.Value(taskCtxKey)
+	if taskCtxValue == nil {
+		log.Warningf("fusefs.FilesystemType.GetFilesystem: couldn't get kernel task from context")
+		return nil, nil, syserror.EINVAL
+	}
+	kernelTask := taskCtxValue.(*kernel.Task)
+	fuseFd := kernelTask.GetFileVFS2(int32(deviceDescriptor))
+
+	// Parse and set all the other supported FUSE mount options.
+	// TODO: Expand the supported mount options.
+	if userIDStr, ok := mopts["user_id"]; ok {
+		delete(mopts, "user_id")
+		userID, err := strconv.ParseUint(userIDStr, 10, 32)
+		if err != nil {
+			log.Warningf("fusefs.FilesystemType.GetFilesystem: invalid user_id: user_id=%s", userIDStr)
+			return nil, nil, syserror.EINVAL
+		}
+		fsopts.userID = uint32(userID)
+	}
+
+	if groupIDStr, ok := mopts["group_id"]; ok {
+		delete(mopts, "group_id")
+		groupID, err := strconv.ParseUint(groupIDStr, 10, 32)
+		if err != nil {
+			log.Warningf("fusefs.FilesystemType.GetFilesystem: invalid group_id: group_id=%s", groupIDStr)
+			return nil, nil, syserror.EINVAL
+		}
+		fsopts.groupID = uint32(groupID)
+	}
+
+	rootMode := linux.FileMode(0777)
+	modeStr, ok := mopts["rootmode"]
+	if ok {
+		delete(mopts, "rootmode")
+		mode, err := strconv.ParseUint(modeStr, 8, 32)
+		if err != nil {
+			ctx.Warningf("fusefs.FilesystemType.GetFilesystem: invalid mode: %q", modeStr)
+			return nil, nil, syserror.EINVAL
+		}
+		rootMode = linux.FileMode(mode & 07777)
+	}
+	fsopts.rootMode = rootMode
+
+	// Check for unparsed options.
+	if len(mopts) != 0 {
+		log.Warningf("fusefs.FilesystemType.GetFilesystem: unknown options: %v", mopts)
+		return nil, nil, syserror.EINVAL
+	}
+
+	// Mark the device as ready so it can be used. /dev/fuse can only be used if the FD was used to
+	// mount a FUSE filesystem.
+	fuseFD := fuseFd.Impl().(*DeviceFD)
+	fuseFD.mounted = true
+
+	fs := &filesystem{
+		devMinor: devMinor,
+		fuseFD:   fuseFD,
+		opts: fsopts,
+	}
+
+	fs.VFSFilesystem().Init(vfsObj, &fsType, fs)
+
+	// TODO: dispatch a FUSE_INIT request to the FUSE daemon server before
+	//  returning. Mount will not block on this dispatched request.
+
+	// root is the fusefs root directory.
+	defaultFusefsDirMode := linux.FileMode(0755)
+	root := fs.newInode(creds, defaultFusefsDirMode)
+
+	return fs.VFSFilesystem(), root.VFSDentry(), nil
+}
+
+// Release implements vfs.FilesystemImpl.Release.
+func (fs *filesystem) Release() {
+	fs.Filesystem.VFSFilesystem().VirtualFilesystem().PutAnonBlockDevMinor(fs.devMinor)
+	fs.Filesystem.Release()
+}
+
+// Inode implements kernfs.Inode.
+type Inode struct {
+	// TODO: Change these directory inode implementations once fusefs is more fleshed out.
+	kernfs.InodeAttrs
+	kernfs.InodeNoDynamicLookup
+	kernfs.InodeNotSymlink
+	kernfs.InodeDirectoryNoNewChildren
+	kernfs.OrderedChildren
+
+	locks vfs.FileLocks
+
+	dentry kernfs.Dentry
+}
+
+func (fs *filesystem) newInode(creds *auth.Credentials, mode linux.FileMode) *kernfs.Dentry {
+	i := &Inode{}
+	i.InodeAttrs.Init(creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), linux.ModeDirectory|0755)
+	i.OrderedChildren.Init(kernfs.OrderedChildrenOptions{})
+	i.dentry.Init(i)
+
+	return &i.dentry
+}
+
+// Open implements kernfs.Inode.Open.
+func (i *Inode) Open(ctx context.Context, rp *vfs.ResolvingPath, vfsd *vfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
+	fd, err := kernfs.NewGenericDirectoryFD(rp.Mount(), vfsd, &i.OrderedChildren, &i.locks, &opts)
+	if err != nil {
+		return nil, err
+	}
+	return fd.VFSFileDescription(), nil
+}
+

--- a/pkg/sentry/fsimpl/fuse/init.go
+++ b/pkg/sentry/fsimpl/fuse/init.go
@@ -1,0 +1,311 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuse
+
+import (
+	"math"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+const (
+	// FUSE_MAX_MAX_PAGES is the maximum value for MaxPages received in InitOut
+	// From fs/fuse/fuse_i.h.
+	FUSE_MAX_MAX_PAGES = 256
+
+	// max value for the time granularity for file time stamps, 1s.
+	// From a magic number in fs/fuse/inode.c.
+	fuseMaxTimeGranNs = 1000000000
+
+	// min value for MaxWrite.
+	// From a magic number in fs/fuse/inode.c.
+	fuseMinMaxWrite = 4096
+
+	// Temporary default value for max readahead, 128kb
+	fuseDefaultMaxReadahead = 131072
+)
+
+// Adjustable maximums for Connection's cogestion control parameters.
+// Used as the upperbound of the config values.
+// TODO: add adjust support.
+var (
+	MaxUserBackgroundRequest uint16 = FUSE_DEFAULT_MAX_BACKGROUND
+	MaxUserCongestionThreshold uint16 = FUSE_DEFAULT_CONGESTION_THRESHOLD
+)
+
+// Init sends a FUSE_INIT request, waits for the reply, and processes it.
+func (fs *filesystem) Init(creds *auth.Credentials, k *kernel.Kernel, pid uint32) error {
+	req, err := fs.initBuildRequest(creds, pid)
+	if err != nil {
+		return err
+	}
+
+	res, err := fs.fuseConn.CallTaskNonBlock(req)
+	if err != nil {
+		return err
+	}
+	if err := res.Error(); err != nil {
+		return err
+	}
+
+	var out linux.FUSEInitOut
+	if err := res.UnmarshalPayload(&out); err != nil {
+		return err
+	}
+
+	return fs.initProcessReply(k, creds, &out)
+}
+
+// Builds a FUSE_INIT request.
+//
+// Analogous to fuse_send_init() in fs/fuse/inode.c.
+func (fs *filesystem) initBuildRequest(creds *auth.Credentials, pid uint32) (*Request, error) {
+	in := linux.FUSEInitIn{
+		Major: linux.FUSE_KERNEL_VERSION,
+		Minor: linux.FUSE_KERNEL_MINOR_VERSION,
+		// TODO: find appropriate way to calculate this
+		MaxReadahead: fuseDefaultMaxReadahead, 
+		Flags: linux.FUSE_ASYNC_READ |
+			linux.FUSE_POSIX_LOCKS |
+			linux.FUSE_ATOMIC_O_TRUNC |
+			linux.FUSE_EXPORT_SUPPORT |
+			linux.FUSE_BIG_WRITES |
+			linux.FUSE_DONT_MASK |
+			linux.FUSE_SPLICE_WRITE |
+			linux.FUSE_SPLICE_MOVE |
+			linux.FUSE_SPLICE_READ |
+			linux.FUSE_FLOCK_LOCKS |
+			linux.FUSE_HAS_IOCTL_DIR |
+			linux.FUSE_AUTO_INVAL_DATA |
+			linux.FUSE_DO_READDIRPLUS |
+			linux.FUSE_READDIRPLUS_AUTO |
+			linux.FUSE_ASYNC_DIO |
+			linux.FUSE_WRITEBACK_CACHE |
+			linux.FUSE_NO_OPEN_SUPPORT |
+			linux.FUSE_PARALLEL_DIROPS |
+			linux.FUSE_HANDLE_KILLPRIV |
+			linux.FUSE_POSIX_ACL |
+			linux.FUSE_ABORT_ERROR |
+			linux.FUSE_MAX_PAGES |
+			linux.FUSE_CACHE_SYMLINKS |
+			linux.FUSE_NO_OPENDIR_SUPPORT |
+			linux.FUSE_EXPLICIT_INVAL_DATA,
+	}
+
+	return fs.fuseConn.NewRequest(creds, pid, 0, linux.FUSE_INIT, &in)
+}
+
+// Process the FUSE_INIT reply from the FUSE server.
+//
+// Analogous to process_init_reply() in fs/fuse/inode.c.
+func (fs *filesystem) initProcessReply(k *kernel.Kernel, creds *auth.Credentials, out *linux.FUSEInitOut) error {
+	// No support for old major fuse versions.
+	// This behaves the same as the Linux kernel (currently v5.8).
+	if out.Major != linux.FUSE_KERNEL_VERSION {
+		fs.fuseConn.ConnError = true
+	} else {
+		// TODO: figure out how to use ra_pages
+		// var ra_pages uint32
+
+		// No support for limits before minor version 13.
+		if out.Minor >= 13 {
+			fs.initProcessLimits(k, creds, out)
+		}
+
+		// No support for the following flags before minor version 6.
+		if out.Minor >= 6 {
+			// ra_pages = reply.max_readahead / PAGE_SIZE
+			if out.Flags&linux.FUSE_ASYNC_READ != 0 {
+				fs.fuseConn.AsyncRead = true
+			}
+
+			if out.Flags&linux.FUSE_POSIX_LOCKS == 0 {
+				fs.fuseConn.NoLock = true
+			}
+
+			// No support for FLOCK flag before minor version 17.
+			if out.Minor >= 17 {
+				if out.Flags & linux.FUSE_FLOCK_LOCKS == 0 {
+					fs.fuseConn.NoFLock = true
+				}
+			} else {
+				if out.Flags & linux.FUSE_POSIX_LOCKS == 0 {
+					fs.fuseConn.NoFLock = true
+				}
+			}
+
+			if out.Flags & linux.FUSE_ATOMIC_O_TRUNC != 0 {
+				fs.fuseConn.AtomicOTrunc = true
+			}
+
+			// No support for EXPORT flag before minor version 9.
+			if out.Minor >= 9 {
+				if out.Flags & linux.FUSE_EXPORT_SUPPORT != 0 {
+					fs.fuseConn.ExportSupport = true
+				}
+			}
+
+			if out.Flags & linux.FUSE_BIG_WRITES != 0 {
+				fs.fuseConn.BigWrites = true
+			}
+
+			if out.Flags & linux.FUSE_DONT_MASK != 0 {
+				fs.fuseConn.DontMask = true
+			}
+
+			if out.Flags & linux.FUSE_AUTO_INVAL_DATA != 0 {
+				fs.fuseConn.AutoInvalData = true
+			} else if out.Flags & linux.FUSE_EXPLICIT_INVAL_DATA != 0 {
+				fs.fuseConn.ExplicitInvalData = true
+			}
+
+			if out.Flags & linux.FUSE_DO_READDIRPLUS != 0 {
+				fs.fuseConn.DoReaddirplus = true
+				if out.Flags & linux.FUSE_READDIRPLUS_AUTO != 0 {
+					fs.fuseConn.ReaddirplusAuto = true
+				}
+			}
+
+			if out.Flags & linux.FUSE_ASYNC_DIO != 0 {
+				fs.fuseConn.AsyncDio = true
+			}
+
+			if out.Flags & linux.FUSE_WRITEBACK_CACHE != 0 {
+				fs.fuseConn.WritebackCache = true
+			}
+
+			if out.Flags & linux.FUSE_PARALLEL_DIROPS != 0 {
+				fs.fuseConn.ParallelDirops = true
+			}
+
+			if out.Flags & linux.FUSE_HANDLE_KILLPRIV != 0 {
+				fs.fuseConn.HandleKillpriv = true
+			}
+
+			if out.TimeGran > 0 && out.TimeGran <= fuseMaxTimeGranNs {
+				// TODO: figure out how to use this
+				// superBlock.s_time_gran = reply.TimeGran
+			}
+
+			if out.Flags & linux.FUSE_POSIX_ACL != 0 {
+				fs.fuseConn.DefaultPermissions = true
+				fs.fuseConn.PosixACL = true
+				// TODO: add xattr handler support
+				// superBlock.s_xattr = fuse_acl_xattr_handlers
+			}
+
+			if out.Flags & linux.FUSE_CACHE_SYMLINKS != 0 {
+				fs.fuseConn.CacheSymlinks = true
+			}
+
+			if out.Flags & linux.FUSE_ABORT_ERROR != 0 {
+				fs.fuseConn.AbortErr = true
+			}
+
+			if out.Flags & linux.FUSE_MAX_PAGES != 0 {
+				maxPages := out.MaxPages
+				if maxPages < 1 {
+					maxPages = 1
+				}
+				if maxPages > FUSE_MAX_MAX_PAGES {
+					maxPages = FUSE_MAX_MAX_PAGES
+				}
+				fs.fuseConn.MaxPages = maxPages
+			}
+		} else {
+			// raPages = fc->max_read / PAGE_SIZE
+			fs.fuseConn.NoLock = true
+			fs.fuseConn.NoFLock = true
+		}
+
+		// fc->sb->s_bdi->ra_pages =
+		// 		min(fc->sb->s_bdi->ra_pages, ra_pages)
+		fs.fuseConn.Minor = out.Minor
+
+		// No support for max_write before minor version 5.
+		if out.Minor < 5 {
+			fs.fuseConn.MaxWrite = fuseMinMaxWrite
+		} else {
+			fs.fuseConn.MaxWrite = out.MaxWrite
+		}
+		if fs.fuseConn.MaxWrite < fuseMinMaxWrite {
+			fs.fuseConn.MaxWrite = fuseMinMaxWrite
+		}
+
+		fs.fuseConn.ConnInit = true
+	}
+
+	fs.fuseConn.setInitialized()
+
+	// TODO: unblock all blocked requests so far
+	// wake_up_all(fs.fussConn.blockedWaitq)
+
+	return nil
+}
+
+// Updates the MaxBackground and CongestionThreshold after negoiation.
+// Supported after FUSE protocol version 7.13.
+//
+// Analogous to inode.c:process_init_limits().
+func (fs *filesystem) initProcessLimits(k *kernel.Kernel, creds *auth.Credentials, out *linux.FUSEInitOut) {
+	isCapable := creds.HasCapabilityIn(linux.CAP_SYS_ADMIN, k.RootUserNamespace())
+
+	totalSize := k.MemoryFile().TotalSize()
+	sanitizeFuseBgLimit(totalSize, &MaxUserBackgroundRequest)
+	sanitizeFuseBgLimit(totalSize, &MaxUserCongestionThreshold)
+
+	fs.fuseConn.BgLock.Lock()
+	defer fs.fuseConn.BgLock.Unlock()
+
+	if out.MaxBackground > 0 {
+		fs.fuseConn.MaxBackground = out.MaxBackground
+
+		if !isCapable &&
+			fs.fuseConn.MaxBackground > MaxUserBackgroundRequest {
+			fs.fuseConn.MaxBackground = MaxUserBackgroundRequest
+		}
+	}
+	if out.CongestionThreshold > 0 {
+		fs.fuseConn.CongestionThreshold = out.CongestionThreshold
+
+		if !isCapable &&
+			fs.fuseConn.CongestionThreshold > MaxUserCongestionThreshold {
+			fs.fuseConn.CongestionThreshold = MaxUserCongestionThreshold
+		}
+	}
+}
+
+// Calculates a value for one maximum limit (for MaxUserBackgroundRequest and MaxUserCongestionThreshold)
+// if the current value is 0.
+//
+// Analogous to sanitize_global_limit() from inode.c.
+func sanitizeFuseBgLimit(totalSize uint64, limit *uint16) {
+	// Assume request has 392 bytes
+	const requsetSize = 392
+	// Magic number from unix code
+	const memoryFraction = 13
+
+	// Calculate default number of async request
+	// to be 1/2^13 of total memory
+	if *limit == 0 {
+		newLimit := (totalSize >> memoryFraction) / requsetSize
+		if newLimit > math.MaxUint16 {
+			newLimit = math.MaxUint16
+		}
+		*limit = uint16(newLimit)
+	}
+}

--- a/pkg/sentry/fsimpl/fuse/register.go
+++ b/pkg/sentry/fsimpl/fuse/register.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fuse
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/devtmpfs"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+)
+
+// Register registers the FUSE device with vfsObj.
+func Register(vfsObj *vfs.VirtualFilesystem) error {
+	if err := vfsObj.RegisterDevice(vfs.CharDevice, linux.MISC_MAJOR, fuseDevMinor, fuseDevice{}, &vfs.RegisterDeviceOptions{
+		GroupName: "misc",
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateDevtmpfsFile creates a device special file in devtmpfs.
+func CreateDevtmpfsFile(ctx context.Context, dev *devtmpfs.Accessor) error {
+	if err := dev.CreateDeviceFile(ctx, "fuse", vfs.CharDevice, linux.MISC_MAJOR, fuseDevMinor, 0666 /* mode */); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/sentry/syscalls/linux/vfs2/mount.go
+++ b/pkg/sentry/syscalls/linux/vfs2/mount.go
@@ -77,8 +77,7 @@ func Mount(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscall
 
 	// Silently allow MS_NOSUID, since we don't implement set-id bits
 	// anyway.
-	const unsupportedFlags = linux.MS_NODEV |
-		linux.MS_NODIRATIME | linux.MS_STRICTATIME
+	const unsupportedFlags = linux.MS_NODIRATIME | linux.MS_STRICTATIME
 
 	// Linux just allows passing any flags to mount(2) - it won't fail when
 	// unknown or unsupported flags are passed. Since we don't implement
@@ -93,6 +92,12 @@ func Mount(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscall
 	}
 	if flags&linux.MS_NOEXEC == linux.MS_NOEXEC {
 		opts.Flags.NoExec = true
+	}
+	if flags&linux.MS_NODEV == linux.MS_NODEV {
+		opts.Flags.NoDev = true
+	}
+	if flags&linux.MS_NOSUID == linux.MS_NOSUID {
+		opts.Flags.NoSUID = true
 	}
 	if flags&linux.MS_RDONLY == linux.MS_RDONLY {
 		opts.ReadOnly = true

--- a/pkg/sentry/vfs/options.go
+++ b/pkg/sentry/vfs/options.go
@@ -79,6 +79,15 @@ type MountFlags struct {
 	// NoATime is equivalent to MS_NOATIME and indicates that the
 	// filesystem should not update access time in-place.
 	NoATime bool
+
+	// NoDev is equivalent to MS_NODEV and indicates that the
+	// filesystem should not allow access to devices (special files).
+	NoDev bool
+
+	// NoSUID is equivalent to MS_NOSUID and indicates that the
+	// filesystem should not honor set-user-ID and set-group-ID bits or
+	// file capabilities when executing programs.
+	NoSUID bool
 }
 
 // MountOptions contains options to VirtualFilesystem.MountAt().

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -73,6 +73,10 @@ func registerFilesystems(ctx context.Context, vfsObj *vfs.VirtualFilesystem, cre
 		AllowUserMount: true,
 		AllowUserList:  true,
 	})
+	vfsObj.MustRegisterFilesystemType(fuse.Name, &fuse.FilesystemType{}, &vfs.RegisterFilesystemTypeOptions{
+		AllowUserMount: true,
+		AllowUserList:  true,
+	})
 
 	// Setup files in devtmpfs.
 	if err := memdev.Register(vfsObj); err != nil {
@@ -81,7 +85,6 @@ func registerFilesystems(ctx context.Context, vfsObj *vfs.VirtualFilesystem, cre
 	if err := ttydev.Register(vfsObj); err != nil {
 		return fmt.Errorf("registering ttydev: %w", err)
 	}
-
 	if err := fuse.Register(vfsObj); err != nil {
 		return fmt.Errorf("registering fusedev: %w", err)
 	}
@@ -109,6 +112,7 @@ func registerFilesystems(ctx context.Context, vfsObj *vfs.VirtualFilesystem, cre
 	if err := fuse.CreateDevtmpfsFile(ctx, a); err != nil {
 		return fmt.Errorf("creating fusedev devtmpfs files: %w", err)
 	}
+
 	return nil
 }
 

--- a/test/syscalls/linux/dev.cc
+++ b/test/syscalls/linux/dev.cc
@@ -161,6 +161,18 @@ TEST(DevTest, OpenDevFuse) {
   ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/fuse", O_RDONLY));
 }
 
+TEST(DevTest, ReadDevFuseWithoutMount) {
+  // Note(gvisor.dev/issue/3076) This won't work in the sentry until the new
+  // device registration is complete.
+  SKIP_IF(IsRunningWithVFS1() || IsRunningOnGvisor());
+
+  const FileDescriptor fd =
+    ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/fuse", O_RDONLY));
+
+  std::vector<char> buf(1);
+  EXPECT_THAT(ReadFd(fd.get(), buf.data(), sizeof(buf)), SyscallFailsWithErrno(EPERM));
+}
+
 }  // namespace
 }  // namespace testing
 

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -321,6 +321,34 @@ TEST(MountTest, RenameRemoveMountPoint) {
   ASSERT_THAT(rmdir(dir.path().c_str()), SyscallFailsWithErrno(EBUSY));
 }
 
+TEST(MountTest, MountFuseFilesystemNoDevice) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // Note(gvisor.dev/issue/3076) This won't work in the sentry until the new
+  // device registration is complete.
+  SKIP_IF(IsRunningWithVFS1() || IsRunningOnGvisor());
+
+  auto const dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  EXPECT_THAT(mount("", dir.path().c_str(), "fuse", 0, ""),
+              SyscallFailsWithErrno(EINVAL));
+}
+
+TEST(MountTest, MountFuseFilesystem) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // Note(gvisor.dev/issue/3076) This won't work in the sentry until the new
+  // device registration is complete.
+  SKIP_IF(IsRunningWithVFS1() || IsRunningOnGvisor());
+
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/fuse", O_WRONLY));
+  std::string mopts = "fd=" + std::to_string(fd.get());
+
+  auto const dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  auto const mount =
+      ASSERT_NO_ERRNO_AND_VALUE(Mount("", dir.path(), "fuse", 0, mopts, 0));
+}
+
 }  // namespace
 
 }  // namespace testing


### PR DESCRIPTION
This pull request adds the FUSE_INIT to the existing FUSE code:  #3097 and is based on #3083

This change allows the sentry to send FUSE_INIT request and process
the reply. It adds the corresponding structs, employs the fuse
device to send and read the message, and updates the system
parameters after negotiation.