### PR TITLE
ip6tables: handle both IPv4 and v6 addresses

### DIFF
--- a/test/iptables/filter_input.go
+++ b/test/iptables/filter_input.go
@@ -618,7 +618,7 @@ func (FilterInputDestination) Name() string {
 
 // ContainerAction implements TestCase.ContainerAction.
 func (FilterInputDestination) ContainerAction(ip net.IP) error {
-	addrs, err := localAddrs()
+	addrs, err := localAddrs(false)
 	if err != nil {
 		return err
 	}

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -17,6 +17,7 @@ package iptables
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/test/dockerutil"
@@ -314,4 +315,29 @@ func TestInputSource(t *testing.T) {
 
 func TestInputInvertSource(t *testing.T) {
 	singleTest(t, FilterInputInvertSource{})
+}
+
+func TestFilterAddrs(t *testing.T) {
+	tcs := []struct {
+		ipv6  bool
+		addrs []string
+		want  []string
+	}{
+		{
+			ipv6:  false,
+			addrs: []string{"192.168.0.1", "192.168.0.2/24", "::1", "::2/128"},
+			want:  []string{"192.168.0.1", "192.168.0.2"},
+		},
+		{
+			ipv6:  true,
+			addrs: []string{"192.168.0.1", "192.168.0.2/24", "::1", "::2/128"},
+			want:  []string{"::1", "::2"},
+		},
+	}
+
+	for _, tc := range tcs {
+		if got := filterAddrs(tc.addrs, tc.ipv6); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%v with IPv6 %t: got %v, but wanted %v", tc.addrs, tc.ipv6, got, tc.want)
+		}
+	}
 }

--- a/test/iptables/nat.go
+++ b/test/iptables/nat.go
@@ -241,7 +241,7 @@ func (NATPreRedirectIP) Name() string {
 
 // ContainerAction implements TestCase.ContainerAction.
 func (NATPreRedirectIP) ContainerAction(ip net.IP) error {
-	addrs, err := localAddrs()
+	addrs, err := localAddrs(false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Enabling IPv6 in Docker caused IPv4 tests to fail because localAddrs
didn't distinguish between address types. Example failure:
https://source.cloud.google.com/results/invocations/203b2401-3333-4bec-9a56-72cc53d68ddd/log