### PR TITLE
Bugfix: non-native tests were tagged as native

### DIFF
--- a/test/runner/defs.bzl
+++ b/test/runner/defs.bzl
@@ -157,7 +157,7 @@ def syscall_test(
         platform = "native",
         use_tmpfs = False,
         add_uds_tree = add_uds_tree,
-        tags = tags,
+        tags = list(tags),
     )
 
     for (platform, platform_tags) in platforms.items():


### PR DESCRIPTION
Copy the list of tags when passing it to _syscall_test.

This caused `make syscall-native-tests` to run and fail kvm tests.