### PR TITLE
use `--no-install-recommends` in `apt-get` in dockerfiles to save space

### DIFF
--- a/images/basic/hostoverlaytest/Dockerfile
+++ b/images/basic/hostoverlaytest/Dockerfile
@@ -3,6 +3,6 @@ FROM ubuntu:bionic
 WORKDIR /root
 COPY . .
 
-RUN apt-get update && apt-get install -y gcc
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates gcc
 RUN gcc -O2 -o test_copy_up test_copy_up.c
 RUN gcc -O2 -o test_rewinddir test_rewinddir.c

--- a/images/basic/linktest/Dockerfile
+++ b/images/basic/linktest/Dockerfile
@@ -3,5 +3,5 @@ FROM ubuntu:bionic
 WORKDIR /root
 COPY . .
 
-RUN apt-get update && apt-get install -y gcc
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates gcc
 RUN gcc -O2 -o link_test link_test.c

--- a/images/benchmarks/ab/Dockerfile
+++ b/images/benchmarks/ab/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             apache2-utils \
         && rm -rf /var/lib/apt/lists/*

--- a/images/benchmarks/absl/Dockerfile
+++ b/images/benchmarks/absl/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             wget \
             git \
             pkg-config \

--- a/images/benchmarks/ffmpeg/Dockerfile
+++ b/images/benchmarks/ffmpeg/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             ffmpeg \
         && rm -rf /var/lib/apt/lists/*
 WORKDIR /media

--- a/images/benchmarks/fio/Dockerfile
+++ b/images/benchmarks/fio/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             fio \
         && rm -rf /var/lib/apt/lists/*

--- a/images/benchmarks/hey/Dockerfile
+++ b/images/benchmarks/hey/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
            wget \
         && rm -rf /var/lib/apt/lists/*
 

--- a/images/benchmarks/httpd/Dockerfile
+++ b/images/benchmarks/httpd/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             apache2 \
         && rm -rf /var/lib/apt/lists/*
 

--- a/images/benchmarks/iperf/Dockerfile
+++ b/images/benchmarks/iperf/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             iperf \
         && rm -rf /var/lib/apt/lists/*
 

--- a/images/benchmarks/runsc/Dockerfile
+++ b/images/benchmarks/runsc/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             wget \
             git \
             pkg-config \

--- a/images/benchmarks/sysbench/Dockerfile
+++ b/images/benchmarks/sysbench/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:18.04
 
 RUN set -x \
         && apt-get update \
-        && apt-get install -y \
+        && apt-get --no-install-recommends install -y apt-utils ca-certificates \
             sysbench \
         && rm -rf /var/lib/apt/lists/*

--- a/images/benchmarks/tensorflow/Dockerfile
+++ b/images/benchmarks/tensorflow/Dockerfile
@@ -1,7 +1,7 @@
 FROM tensorflow/tensorflow:1.13.2
 
 RUN apt-get update \
-    && apt-get install -y git
+    && apt-get --no-install-recommends install -y apt-utils ca-certificates git
 RUN git clone --depth 1 https://github.com/aymericdamien/TensorFlow-Examples.git
 RUN python -m pip install -U pip setuptools
 RUN python -m pip install matplotlib

--- a/images/benchmarks/util/Dockerfile
+++ b/images/benchmarks/util/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:bionic
 
-RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates wget

--- a/images/packetdrill/Dockerfile
+++ b/images/packetdrill/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-RUN apt-get update && apt-get install -y net-tools git iptables iputils-ping \
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates net-tools git iptables iputils-ping \
         netcat tcpdump jq tar bison flex make
 # Pick up updated git.
 RUN hash -r

--- a/images/packetimpact/Dockerfile
+++ b/images/packetimpact/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:focal
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -y apt-utils ca-certificates \
         # iptables to disable OS native packet processing.
         iptables \
         # nc to check that the posix_server is running.

--- a/images/runtimes/java11/Dockerfile
+++ b/images/runtimes/java11/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
   autoconf \
   build-essential \
   curl \

--- a/images/runtimes/nodejs12.4.0/Dockerfile
+++ b/images/runtimes/nodejs12.4.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
   curl \
   dumb-init \
   g++ \

--- a/images/runtimes/php7.3.6/Dockerfile
+++ b/images/runtimes/php7.3.6/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
   autoconf \
   automake \
   bison \

--- a/images/runtimes/python3.7.3/Dockerfile
+++ b/images/runtimes/python3.7.3/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:bionic
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get --no-install-recommends install -y apt-utils ca-certificates \
   curl \
   gcc \
   libbz2-dev \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get"
system installs recommended but not suggested packages .

By passing "--no-install-recommends" option,
the user lets apt-get know not to consider
recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog]
(https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow because "apt-utils" not installed

2. to avoid build to exits with error without having certificate

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>
