### PR TITLE
fuse: Fix FUSE integration test failed with ECONNREFUSED

### DIFF
--- a/test/fuse/linux/fuse_base.cc
+++ b/test/fuse/linux/fuse_base.cc
@@ -25,9 +25,9 @@
 
 #include <iostream>
 
+#include "absl/strings/str_format.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/strings/str_format.h"
 #include "test/util/posix_error.h"
 #include "test/util/test_util.h"
 
@@ -100,8 +100,11 @@ PosixError FuseTest::ConsumeFuseInit() {
       .error = 0,
       .unique = 2,
   };
-  // Returns an empty init out payload since this is just a test.
-  struct fuse_init_out out_payload;
+  // Returns a fake fuse_init_out with 7.0 version to avoid ECONNREFUSED
+  // error in the initialization of FUSE connection.
+  struct fuse_init_out out_payload = {
+      .major = 7,
+  };
   iov_out[0].iov_len = sizeof(out_header);
   iov_out[0].iov_base = &out_header;
   iov_out[1].iov_len = sizeof(out_payload);


### PR DESCRIPTION
The newer version of FUSE_INIT checks the response from the FUSE server if its major number is equal to 7. If it's not, then FUSE_INIT fails and further filesystem operations will get ECONNREFUSED. To mitigate this issue, we can send back a response with major version equals to 7 when consuming the first FUSE_INIT request.

Fixes #3500