### PR TITLE
Enable "make packetimpact-tests" to work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,6 @@ swgso-tests: load-basic-images
 	@$(call submake,install-test-runtime RUNTIME="swgso" ARGS="--software-gso=true --gso=false")
 	@$(call submake,test-runtime RUNTIME="swgso" TARGETS="$(INTEGRATION_TARGETS)")
 .PHONY: swgso-tests
-
 hostnet-tests: load-basic-images
 	@$(call submake,install-test-runtime RUNTIME="hostnet" ARGS="--network=host")
 	@$(call submake,test-runtime RUNTIME="hostnet" OPTIONS="--test_arg=-checkpoint=false" TARGETS="$(INTEGRATION_TARGETS)")
@@ -211,8 +210,9 @@ packetdrill-tests: load-packetdrill
 .PHONY: packetdrill-tests
 
 packetimpact-tests: load-packetimpact
+	@sudo modprobe iptable_filter ip6table_filter
 	@$(call submake,install-test-runtime RUNTIME="packetimpact")
-	@$(call submake,test-runtime RUNTIME="packetimpact" TARGETS="$(shell $(MAKE) query TARGETS='attr(tags, packetimpact, tests(//...))')")
+	@$(call submake,test-runtime OPTIONS="--jobs=HOST_CPUS*3 --local_test_jobs=HOST_CPUS*3" RUNTIME="packetimpact" TARGETS="$(shell $(MAKE) query TARGETS='attr(tags, packetimpact, tests(//...))')")
 .PHONY: packetimpact-tests
 
 root-tests: load-basic-images

--- a/test/packetimpact/runner/defs.bzl
+++ b/test/packetimpact/runner/defs.bzl
@@ -61,12 +61,12 @@ PACKETIMPACT_TAGS = [
     "packetimpact",
 ]
 
-def packetimpact_linux_test(
+def packetimpact_native_test(
         name,
         testbench_binary,
         expect_failure = False,
         **kwargs):
-    """Add a packetimpact test on linux.
+    """Add a native packetimpact test.
 
     Args:
         name: name of the test
@@ -76,9 +76,9 @@ def packetimpact_linux_test(
     """
     expect_failure_flag = ["--expect_failure"] if expect_failure else []
     _packetimpact_test(
-        name = name + "_linux_test",
+        name = name + "_native_test",
         testbench_binary = testbench_binary,
-        flags = ["--dut_platform", "linux"] + expect_failure_flag,
+        flags = ["--native"] + expect_failure_flag,
         tags = PACKETIMPACT_TAGS,
         **kwargs
     )
@@ -102,21 +102,21 @@ def packetimpact_netstack_test(
     _packetimpact_test(
         name = name + "_netstack_test",
         testbench_binary = testbench_binary,
-        # This is the default runtime unless
-        # "--test_arg=--runtime=OTHER_RUNTIME" is used to override the value.
-        flags = ["--dut_platform", "netstack", "--runtime=runsc-d"] + expect_failure_flag,
+        # Note that a distinct runtime must be provided in the form
+        # --test_arg=--runtime=other when invoking bazel.
+        flags = expect_failure_flag,
         tags = PACKETIMPACT_TAGS,
         **kwargs
     )
 
-def packetimpact_go_test(name, size = "small", pure = True, expect_linux_failure = False, expect_netstack_failure = False, **kwargs):
+def packetimpact_go_test(name, size = "small", pure = True, expect_native_failure = False, expect_netstack_failure = False, **kwargs):
     """Add packetimpact tests written in go.
 
     Args:
         name: name of the test
         size: size of the test
         pure: make a static go binary
-        expect_linux_failure: the test must fail for Linux
+        expect_native_failure: the test must fail natively
         expect_netstack_failure: the test must fail for Netstack
         **kwargs: all the other args, forwarded to go_test
     """
@@ -131,9 +131,9 @@ def packetimpact_go_test(name, size = "small", pure = True, expect_linux_failure
         ],
         **kwargs
     )
-    packetimpact_linux_test(
+    packetimpact_native_test(
         name = name,
-        expect_failure = expect_linux_failure,
+        expect_failure = expect_native_failure,
         testbench_binary = testbench_binary,
     )
     packetimpact_netstack_test(

--- a/test/packetimpact/testbench/testbench.go
+++ b/test/packetimpact/testbench/testbench.go
@@ -27,8 +27,8 @@ import (
 )
 
 var (
-	// DUTType is the type of device under test.
-	DUTType = ""
+	// Native indicates that the test is being run natively.
+	Native = false
 	// Device is the local device on the test network.
 	Device = ""
 
@@ -81,7 +81,7 @@ func RegisterFlags(fs *flag.FlagSet) {
 	fs.StringVar(&RemoteIPv6, "remote_ipv6", RemoteIPv6, "remote IPv6 address for test packets")
 	fs.StringVar(&RemoteMAC, "remote_mac", RemoteMAC, "remote mac address for test packets")
 	fs.StringVar(&Device, "device", Device, "local device for test packets")
-	fs.StringVar(&DUTType, "dut_type", DUTType, "type of device under test")
+	fs.BoolVar(&Native, "native", Native, "whether the test is running natively")
 	fs.Uint64Var(&RemoteInterfaceID, "remote_interface_id", RemoteInterfaceID, "remote interface ID for test packets")
 }
 

--- a/test/packetimpact/tests/tcp_reordering_test.go
+++ b/test/packetimpact/tests/tcp_reordering_test.go
@@ -54,13 +54,13 @@ func TestReorderingWindow(t *testing.T) {
 	acceptFd, _ := dut.Accept(t, listenFd)
 	defer dut.Close(t, acceptFd)
 
-	if tb.DUTType == "linux" {
+	if tb.Native {
 		// Linux has changed its handling of reordering, force the old behavior.
 		dut.SetSockOpt(t, acceptFd, unix.IPPROTO_TCP, unix.TCP_CONGESTION, []byte("reno"))
 	}
 
 	pls := dut.GetSockOptInt(t, acceptFd, unix.IPPROTO_TCP, unix.TCP_MAXSEG)
-	if tb.DUTType == "netstack" {
+	if !tb.Native {
 		// netstack does not impliment TCP_MAXSEG correctly. Fake it
 		// here. Netstack uses the max SACK size which is 32. The MSS
 		// option is 8 bytes, making the total 36 bytes.
@@ -141,7 +141,7 @@ func TestReorderingWindow(t *testing.T) {
 		}
 	}
 
-	if tb.DUTType == "netstack" {
+	if !tb.Native {
 		// The window should now be halved, so we should receive any
 		// more, even if we send them.
 		dut.Send(t, acceptFd, payload, 0)


### PR DESCRIPTION
This required minor fixes to the bazel wrapper. The "dut_platform" is
also changed to "native" to line-up with the system call tests and
remove the hard-coded "linux" and "netstack" strings.