### PR TITLE
recreate file on checkpoint to make restore work for deleted file

### DIFF
--- a/pkg/sentry/fs/dirent_state.go
+++ b/pkg/sentry/fs/dirent_state.go
@@ -15,10 +15,10 @@
 package fs
 
 import (
-	"fmt"
 	"sync/atomic"
 
 	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/refs"
 )
 
@@ -39,7 +39,7 @@ func (d *Dirent) beforeSave() {
 	// execution, it may become allowed to save again.
 	if !d.Inode.IsVirtual() && atomic.LoadInt32(&d.deleted) != 0 {
 		n, _ := d.FullName(nil /* root */)
-		panic(ErrSaveRejection{fmt.Errorf("deleted file %q still has open fds", n)})
+		log.Warningf("Dirent.beforeSave: deleted file %q still has open fds", n)
 	}
 }
 


### PR DESCRIPTION
Some application has the behaviour of: open() -> mmap() -> close() -> unlink().
After the above operation, application can continue to access the file
through the pointer returned from mmap() but the file disappears from
filesystem now.

This is OK in the normal case, but in checkpoint/restore, since the file
is gone it's impossible to re-open it on restore by gofer and connect
things up to the File/Dirent/Inode/etc. and when the app access the mmap()ed
region, it's impossible to make things work anymore.

We can ask the application developer to refine their code so that this
behaviour is avoided, but sometimes, application developer doesn't want
to change their code or they are using some 3rd party library that has
such behaviour which makes it impossible to change this behaviour.

For this reason, I think it's worth to support such behaviour so that
checkpoint/restore continue to work.

To solve this problem, the 'deleted' file is recreated on checkpoint(so
that it re-appears on file system and on restore, the file can be
re-opened) and removed(make it disappear from filesystem) again after
restore is done(but before apps are started).

XXX: ideally, only unlinked-but-still-present fs.File needs to be
recorded but since unlink() works at fd.Dirent level and there is no way
of getting fs.File from fs.Dirent(FileOperation is needed to do file
copy), so all files are recorded, i.e. globalFileMap is an overhead
introduced by this patch.

XXX: I thought I have to take an extra ref on the recreated file before
removing it after restore, or the file will be permanently gone from the
system, rendering application not being able to use it. But it turns out
I do not need to do this extra ref and application can work fine. It's
not entirely clear to me why at the moment.

The below test code is used:
https://github.com/aaronlu/misc/blob/master/open_mmap_close_unlink.c

Reported-and-tested-by: Zhongxing Liang <zhongxing.lzx@antgroup.com>
Reported-by: Wang Yu <yuwang.yuwang@antgroup.com>