### PR TITLE
[deb package] use "systemctl is-active" instead of "systemctl status"

### DIFF
--- a/debian/postinst.sh
+++ b/debian/postinst.sh
@@ -21,7 +21,7 @@ fi
 # Update docker configuration.
 if [ -f /etc/docker/daemon.json ]; then
   runsc install
-  if systemctl status docker 2>/dev/null; then
+  if systemctl is-active -q docker; then
     systemctl restart docker || echo "unable to restart docker; you must do so manually." >&2
   fi
 fi


### PR DESCRIPTION
In some cases, `systemctl status docker` in the debian package's post install script stucks because of waiting for any inputs to a pager process.
Using systemctl with `--no-pager` resolves this problem, but I think `systemctl is-active` is better in this case.
