### PR TITLE
Device major number greater than 2 digits in /proc/self/maps on N1

### DIFF
--- a/pkg/sentry/platform/kvm/virtual_map.go
+++ b/pkg/sentry/platform/kvm/virtual_map.go
@@ -34,7 +34,7 @@ type virtualRegion struct {
 }
 
 // mapsLine matches a single line from /proc/PID/maps.
-var mapsLine = regexp.MustCompile("([0-9a-f]+)-([0-9a-f]+) ([r-][w-][x-][sp]) ([0-9a-f]+) [0-9a-f]{2}:[0-9a-f]{2,} [0-9]+\\s+(.*)")
+var mapsLine = regexp.MustCompile("([0-9a-f]+)-([0-9a-f]+) ([r-][w-][x-][sp]) ([0-9a-f]+) [0-9a-f]{2,3}:[0-9a-f]{2,} [0-9]+\\s+(.*)")
 
 // excludeRegion returns true if these regions should be excluded from the
 // physical map. Virtual regions need to be excluded if get_user_pages will


### PR DESCRIPTION
The device major number may greater than 2 digits in /proc/self/maps on Arm64 N1 machine.
Please see the following as reference:

root@entos-ampere:/tmp/runsc# cat /proc/self/maps 
aaaabc438000-aaaabc440000 r-xp 00000000 103:04 30670923                  /bin/cat
aaaabc44f000-aaaabc450000 r--p 00007000 103:04 30670923                  /bin/cat
aaaabc450000-aaaabc451000 rw-p 00008000 103:04 30670923                  /bin/cat
aaaacc27b000-aaaacc29c000 rw-p 00000000 00:00 0                          [heap]
ffff8ad3b000-ffff8ad5d000 rw-p 00000000 00:00 0 
ffff8ad5d000-ffff8b2cd000 r--p 00000000 103:04 29098157                  /usr/lib/locale/locale-archive
ffff8b2cd000-ffff8b426000 r-xp 00000000 103:04 2884566                   /lib/aarch64-linux-gnu/libc-2.30.so
ffff8b426000-ffff8b436000 ---p 00159000 103:04 2884566                   /lib/aarch64-linux-gnu/libc-2.30.so
ffff8b436000-ffff8b439000 r--p 00159000 103:04 2884566                   /lib/aarch64-linux-gnu/libc-2.30.so
ffff8b439000-ffff8b43c000 rw-p 0015c000 103:04 2884566                   /lib/aarch64-linux-gnu/libc-2.30.so
ffff8b43c000-ffff8b43f000 rw-p 00000000 00:00 0 
ffff8b450000-ffff8b470000 r-xp 00000000 103:04 2883605                   /lib/aarch64-linux-gnu/ld-2.30.so
ffff8b47c000-ffff8b47e000 rw-p 00000000 00:00 0 
ffff8b47e000-ffff8b47f000 r--p 00000000 00:00 0                          [vvar]
ffff8b47f000-ffff8b480000 r-xp 00000000 00:00 0                          [vdso]
ffff8b480000-ffff8b481000 r--p 00020000 103:04 2883605                   /lib/aarch64-linux-gnu/ld-2.30.so
ffff8b481000-ffff8b483000 rw-p 00021000 103:04 2883605                   /lib/aarch64-linux-gnu/ld-2.30.so
ffffff733000-ffffff754000 rw-p 00000000 00:00 0                          [stack]

Signed-off-by: Bin Lu <bin.lu@arm.com>

