### PR TITLE
github: Don't build the Go branch for feature branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - feature/**
   pull_request:
     branches:
       - master


### PR DESCRIPTION
We can't actually push the Go branch on pushes to feature branches.
