### PR TITLE
fuse: add padding to fuse open out request structure

### DIFF
--- a/pkg/abi/linux/fuse.go
+++ b/pkg/abi/linux/fuse.go
@@ -156,9 +156,9 @@ const (
 
 // Constants relevant to FUSE operations.
 const (
-	FUSE_NAME_MAX       = 1024
-	FUSE_PAGE_SIZE      = 4096
-	FUSE_DIRENT_ALIGN   = 8
+	FUSE_NAME_MAX     = 1024
+	FUSE_PAGE_SIZE    = 4096
+	FUSE_DIRENT_ALIGN = 8
 )
 
 // FUSEInitIn is the request sent by the kernel to the daemon,
@@ -402,6 +402,8 @@ type FUSEOpenOut struct {
 
 	// OpenFlag for the opened file.
 	OpenFlag uint32
+
+	_ uint32
 }
 
 // FUSE_READ flags, consistent with the ones in include/uapi/linux/fuse.h.


### PR DESCRIPTION
The padding on open out structure is probably lost in rebasing and merging, this fixes the issue.