### PR TITLE
Use consistent thread configuration for sandbox go runtime

### DIFF
--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -282,6 +282,7 @@ func New(args Args) (*Loader, error) {
 		args.NumCPU = runtime.NumCPU()
 	}
 	log.Infof("CPUs: %d", args.NumCPU)
+	runtime.GOMAXPROCS(args.NumCPU)
 
 	if args.TotalMem > 0 {
 		// Adjust the total memory returned by the Sentry so that applications that


### PR DESCRIPTION
With cgroups configured NumCPU is correct, however GOMAXPROCS is still derived from total host core count and ignores cgroup restrictions. This can lead to different and undesired behavior across different hosts.
For example, the total number of threads in the guest process will be larger on machines with more cores.

This change configures the go runtime for the sandbox to only use the number of threads consistent with its restrictions.