### PR TITLE
make: specify /dev/null for the tail tool

### DIFF
--- a/tools/bazel.mk
+++ b/tools/bazel.mk
@@ -131,7 +131,7 @@ bazel-server-start: bazel-image ## Starts the bazel server.
 		--workdir "$(CURDIR)" \
 		$(FULL_DOCKER_RUN_OPTIONS) \
 		$(BUILDER_IMAGE) \
-		sh -c "tail -f --pid=\$$($(BAZEL) info server_pid)"
+		sh -c "tail -f --pid=\$$($(BAZEL) info server_pid) /dev/null"
 .PHONY: bazel-server-start
 
 bazel-shutdown: ## Shuts down a running bazel server.


### PR DESCRIPTION
In travis, if we don't specify /dev/null, tail exits immediately, then its parent process
which is the init process exits too and kills the bazel server.