### PR TITLE
arm64: fix tlb and memory map issue

### DIFF
--- a/pkg/sentry/platform/ring0/entry_arm64.s
+++ b/pkg/sentry/platform/ring0/entry_arm64.s
@@ -461,6 +461,14 @@ TEXT ·kernelExitToEl0(SB),NOSPLIT,$0
 	MOVD PTRACE_PSTATE(RSV_REG_APP), R1
 	WORD $0xd5184001  //MSR R1, SPSR_EL1
 
+	// need use kernel space address to excute below code, since
+	// after SWITCH_TO_APP_PAGETABLE the ASID is changed to app's
+	// ASID.
+	WORD $0x10000061		// ADR R1, do_exit_to_el0
+	ORR $0xffff000000000000, R1, R1
+	JMP (R1)
+
+do_exit_to_el0:
 	// RSV_REG & RSV_REG_APP will be loaded at the end.
 	REGISTERS_LOAD(RSV_REG_APP, 0)
 


### PR DESCRIPTION
@lubinszARM 
The patch has been test based on our own codebase, I have not test it on KVM, since our kernel is 4.19 (KVM has some issue on this kernel for gvisor). But I think it also works on KVM, without this patch the sentry will hang randomly on our ARM64 platform. I see currently the ASID is changed to TTBR1_EL1, with this patches, I think the ASID can still in TTBR0_EL1 and the kernel address space can be mapped as global.