### PR TITLE
Draft: RfC: Make netstack compile on 32-bit Linux, Rebase from #814

### DIFF
--- a/pkg/tcpip/link/fdbased/endpoint.go
+++ b/pkg/tcpip/link/fdbased/endpoint.go
@@ -287,9 +287,11 @@ func createInboundDispatcher(e *endpoint, fd int, isSocket bool) (linkDispatcher
 			// enable PACKET_FANOUT mode is the underlying socket is
 			// of type AF_PACKET.
 			const fanoutType = 0x8000 // PACKET_FANOUT_HASH | PACKET_FANOUT_FLAG_DEFRAG
-			fanoutArg := fanoutID | fanoutType<<16
-			if err := syscall.SetsockoptInt(fd, syscall.SOL_PACKET, unix.PACKET_FANOUT, fanoutArg); err != nil {
-				return nil, fmt.Errorf("failed to enable PACKET_FANOUT option: %v", err)
+			// This const will overflow a 32 bit int and won't compile. Variable
+			// type conversion from 32 bit uint to 32 bit int will overflow correctly.
+			var fanoutArg uint = (fanoutID | fanoutType<<16)
+			if err := syscall.SetsockoptInt(fd, syscall.SOL_PACKET, unix.PACKET_FANOUT, int(fanoutArg)); err != nil {
+					return nil, fmt.Errorf("failed to enable PACKET_FANOUT option: %v", err)
 			}
 		}
 

--- a/pkg/tcpip/link/fdbased/iovlen_linux32.go
+++ b/pkg/tcpip/link/fdbased/iovlen_linux32.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+// +build 386 arm mips mipsle
+
+package fdbased
+
+import (
+	"syscall"
+)
+
+func setIovlen(h *syscall.Msghdr, iovlen int) {
+	h.Iovlen = uint32(iovlen)
+}

--- a/pkg/tcpip/link/fdbased/iovlen_linux64.go
+++ b/pkg/tcpip/link/fdbased/iovlen_linux64.go
@@ -1,0 +1,26 @@
+// Copyright 2019 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build linux
+// +build arm64 amd64 mips64 mips64le ppc64le ppc64 s390x
+
+package fdbased
+
+import (
+	"syscall"
+)
+
+func setIovlen(h *syscall.Msghdr, iovlen int) {
+	h.Iovlen = uint64(iovlen)
+}

--- a/pkg/tcpip/link/fdbased/packet_dispatchers.go
+++ b/pkg/tcpip/link/fdbased/packet_dispatchers.go
@@ -67,10 +67,8 @@ func (d *readVDispatcher) allocateViews(bufConfig []int) {
 		// The kernel adds virtioNetHdr before each packet, but
 		// we don't use it, so so we allocate a buffer for it,
 		// add it in iovecs but don't add it in a view.
-		d.iovecs[0] = syscall.Iovec{
-			Base: &vnetHdr[0],
-			Len:  uint64(virtioNetHdrSize),
-		}
+		d.iovecs[0].Base = &vnetHdr[0]
+		d.iovecs[0].SetLen(virtioNetHdrSize)
 		vnetHdrOff++
 	}
 	for i := 0; i < len(bufConfig); i++ {
@@ -79,10 +77,8 @@ func (d *readVDispatcher) allocateViews(bufConfig []int) {
 		}
 		b := buffer.NewView(bufConfig[i])
 		d.views[i] = b
-		d.iovecs[i+vnetHdrOff] = syscall.Iovec{
-			Base: &b[0],
-			Len:  uint64(len(b)),
-		}
+		d.iovecs[i+vnetHdrOff].Base = &b[0]
+		d.iovecs[i+vnetHdrOff].SetLen(len(b))
 	}
 }
 
@@ -206,7 +202,7 @@ func newRecvMMsgDispatcher(fd int, e *endpoint) (linkDispatcher, error) {
 	d.msgHdrs = make([]rawfile.MMsgHdr, MaxMsgsPerRecv)
 	for i := range d.msgHdrs {
 		d.msgHdrs[i].Msg.Iov = &d.iovecs[i][0]
-		d.msgHdrs[i].Msg.Iovlen = uint64(iovLen)
+		setIovlen(&d.msgHdrs[i].Msg, iovLen)
 	}
 	return d, nil
 }
@@ -231,10 +227,8 @@ func (d *recvMMsgDispatcher) allocateViews(bufConfig []int) {
 			// The kernel adds virtioNetHdr before each packet, but
 			// we don't use it, so so we allocate a buffer for it,
 			// add it in iovecs but don't add it in a view.
-			d.iovecs[k][0] = syscall.Iovec{
-				Base: &vnetHdr[0],
-				Len:  uint64(virtioNetHdrSize),
-			}
+			d.iovecs[k][0].Base = &vnetHdr[0]
+			d.iovecs[k][0].SetLen(virtioNetHdrSize)
 			vnetHdrOff++
 		}
 		for i := 0; i < len(bufConfig); i++ {
@@ -243,10 +237,8 @@ func (d *recvMMsgDispatcher) allocateViews(bufConfig []int) {
 			}
 			b := buffer.NewView(bufConfig[i])
 			d.views[k][i] = b
-			d.iovecs[k][i+vnetHdrOff] = syscall.Iovec{
-				Base: &b[0],
-				Len:  uint64(len(b)),
-			}
+			d.iovecs[k][i+vnetHdrOff].Base = &b[0]
+			d.iovecs[k][i+vnetHdrOff].SetLen(len(b))
 		}
 	}
 }

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -29,6 +29,8 @@ import (
 )
 
 const (
+	// maxInt is the largest representable value of type int.
+	maxInt = int(^uint(0) >> 1)
 	// MinRTO is the minimum allowed value for the retransmit timeout.
 	MinRTO = 200 * time.Millisecond
 
@@ -314,7 +316,7 @@ func newSender(ep *endpoint, iss, irs seqnum.Value, sndWnd seqnum.Size, mss uint
 // their initial values.
 func (s *sender) initCongestionControl(congestionControlName tcpip.CongestionControlOption) congestionControl {
 	s.sndCwnd = InitialCwnd
-	s.sndSsthresh = math.MaxInt64
+	s.sndSsthresh = maxInt
 
 	switch congestionControlName {
 	case ccCubic:


### PR DESCRIPTION
RfC: Make netstack compile on 32-bit Linux, Rebase from #814

Some syscall interfaces have uint32 on 32-bit systems such as
GOARCH=386 and GOARCH=arm, while having uint64 on 64-bit
systems. This fixes locations that assumed 64-bit, and
also some that assume that int is the same as int64.

* [ ] Have you followed the guidelines in [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md)?
* [ ] Have you formatted and linted your code?
* [ ] Have you added relevant tests?
* [ ] Have you added appropriate Fixes & Updates references?
* [ ] If yes, please erase all these lines!
