### PR TITLE
arm64: enable DZE bit in SCTLR to make EL0 can use DC ZVA

### DIFF
--- a/pkg/sentry/platform/ring0/entry_arm64.s
+++ b/pkg/sentry/platform/ring0/entry_arm64.s
@@ -46,10 +46,11 @@
 #define SCTLR_M         1 << 0
 #define SCTLR_C         1 << 2
 #define SCTLR_I         1 << 12
+#define SCTLR_DZE       1 << 14
 #define SCTLR_UCT       1 << 15
 #define SCTLR_UCI       1 << 26
 
-#define SCTLR_EL1_DEFAULT       (SCTLR_M | SCTLR_C | SCTLR_I | SCTLR_UCT | SCTLR_UCI)
+#define SCTLR_EL1_DEFAULT       (SCTLR_M | SCTLR_C | SCTLR_I | SCTLR_UCT | SCTLR_UCI | SCTLR_DZE)
 
 // cntkctl_el1: counter-timer kernel control register el1.
 #define CNTKCTL_EL0PCTEN 	1 << 0


### PR DESCRIPTION
Some application (like java) may need DC ZVA.

```
root@i85b08054:~/work/gvisor# pouch run --runtime=runsc -it --net=none arm64v8/openjdk:latest
OpenJDK 64-Bit Server VM warning: DC ZVA is not available on this CPU
Oct 10, 2020 8:48:33 AM java.util.prefs.FileSystemPreferences$1 run
INFO: Created user preferences directory.
|  Welcome to JShell -- Version 11.0.2
|  For an introduction type: /help intro

jshell> 

```
With this patch

```
root@i85b08054:~/work/gvisor# pouch run --runtime=runsc -it --net=none arm64v8/openjdk:latest
Oct 10, 2020 8:54:17 AM java.util.prefs.FileSystemPreferences$1 run
INFO: Created user preferences directory.
|  Welcome to JShell -- Version 11.0.2
|  For an introduction type: /help intro

jshell> 

```