### PR TITLE
arm64 test: enabled Fault() function

### DIFF
--- a/test/util/signal_util.h
+++ b/test/util/signal_util.h
@@ -88,7 +88,7 @@ inline void FixupFault(ucontext_t* ctx) {
 #elif __aarch64__
 inline void Fault() {
   // Zero and dereference x0.
-  asm("mov xzr, x0\r\n"
+  asm("mov x0, xzr\r\n"
       "str xzr, [x0]\r\n"
       :
       :


### PR DESCRIPTION
Currently, this Fault() function does not work properly on the arm platform.

After modification, sigaltstack_test_runsc_kvm can be passed on
Arm64.

Signed-off-by: Bin Lu <bin.lu@arm.com>
