### PR TITLE
Add --traceback flag to customize debug.SetTraceback level

### DIFF
--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -131,10 +131,10 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...interface{}) 
 		return subcommands.ExitUsageError
 	}
 
-	// Ensure that if there is a panic, all goroutine stacks are printed.
-	debug.SetTraceback("system")
-
 	conf := args[0].(*config.Config)
+
+	// Set traceback level
+	debug.SetTraceback(conf.Traceback)
 
 	if b.attached {
 		// Ensure this process is killed after parent process terminates when

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	// RootDir is the runtime root directory.
 	RootDir string `flag:"root"`
 
+	// Traceback changes the Go runtime's traceback level.
+	Traceback string `flag:"traceback"`
+
 	// Debug indicates that debug logging should be enabled.
 	Debug bool `flag:"debug"`
 

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -49,6 +49,7 @@ func RegisterFlags() {
 		flag.String("debug-log-format", "text", "log format: text (default), json, or json-k8s.")
 		flag.Bool("alsologtostderr", false, "send log messages to stderr.")
 		flag.Bool("allow-flag-override", false, "allow OCI annotations (dev.gvisor.flag.<name>) to override flags for debugging.")
+		flag.String("traceback", "system", "golang runtime's traceback level")
 
 		// Debugging flags: strace related
 		flag.Bool("strace", false, "enable strace.")


### PR DESCRIPTION
Sometimes we run into an issue in gVisor (or gets killed because of OOM or something) while having tons of goroutines. When gVisor gets killed in these cases, it prints huge amounts of Goroutine traces (more than 10K lines), but it does forbid us to change the traceback level to something lower than `system`.

I propose to add a debugging flag `--traceback` that sets the value used for the `SetTraceback` call in `runsc/cmd/boot.go`.