### PR TITLE
Support pread/pwrite for VFSv1 procfs seqfiles and task files with generic seek

### DIFF
--- a/pkg/sentry/fs/proc/exec_args.go
+++ b/pkg/sentry/fs/proc/exec_args.go
@@ -71,6 +71,7 @@ func newExecArgInode(t *kernel.Task, msrc *fs.MountSource, arg execArgType) *fs.
 
 // GetFile implements fs.InodeOperations.GetFile.
 func (i *execArgInode) GetFile(ctx context.Context, dirent *fs.Dirent, flags fs.FileFlags) (*fs.File, error) {
+	flags.Pread = true
 	return fs.NewFile(ctx, dirent, flags, &execArgFile{
 		arg: i.arg,
 		t:   i.t,

--- a/pkg/sentry/fs/proc/seqfile/seqfile.go
+++ b/pkg/sentry/fs/proc/seqfile/seqfile.go
@@ -149,6 +149,7 @@ func (s *SeqFile) UnstableAttr(ctx context.Context, inode *fs.Inode) (fs.Unstabl
 
 // GetFile implements fs.InodeOperations.GetFile.
 func (s *SeqFile) GetFile(ctx context.Context, dirent *fs.Dirent, flags fs.FileFlags) (*fs.File, error) {
+	flags.Pread = true
 	return fs.NewFile(ctx, dirent, flags, &seqFileOperations{seqFile: s}), nil
 }
 

--- a/pkg/sentry/fs/proc/task.go
+++ b/pkg/sentry/fs/proc/task.go
@@ -841,6 +841,7 @@ func (c *comm) Check(ctx context.Context, inode *fs.Inode, p fs.PermMask) bool {
 
 // GetFile implements fs.InodeOperations.GetFile.
 func (c *comm) GetFile(ctx context.Context, dirent *fs.Dirent, flags fs.FileFlags) (*fs.File, error) {
+	flags.Pread = true
 	return fs.NewFile(ctx, dirent, flags, &commFile{t: c.t}), nil
 }
 
@@ -898,6 +899,7 @@ func newAuxvec(t *kernel.Task, msrc *fs.MountSource) *fs.Inode {
 
 // GetFile implements fs.InodeOperations.GetFile.
 func (a *auxvec) GetFile(ctx context.Context, dirent *fs.Dirent, flags fs.FileFlags) (*fs.File, error) {
+	flags.Pread = true
 	return fs.NewFile(ctx, dirent, flags, &auxvecFile{t: a.t}), nil
 }
 
@@ -996,6 +998,8 @@ func (*oomScoreAdj) Truncate(context.Context, *fs.Inode, int64) error {
 
 // GetFile implements fs.InodeOperations.GetFile.
 func (o *oomScoreAdj) GetFile(ctx context.Context, dirent *fs.Dirent, flags fs.FileFlags) (*fs.File, error) {
+	flags.Pread = true
+	flags.Pwrite = true
 	return fs.NewFile(ctx, dirent, flags, &oomScoreAdjFile{t: o.t}), nil
 }
 

--- a/pkg/sentry/fs/proc/uid_gid_map.go
+++ b/pkg/sentry/fs/proc/uid_gid_map.go
@@ -77,6 +77,8 @@ func newIDMap(t *kernel.Task, msrc *fs.MountSource, gids bool) *fs.Inode {
 
 // GetFile implements fs.InodeOperations.GetFile.
 func (imio *idMapInodeOperations) GetFile(ctx context.Context, dirent *fs.Dirent, flags fs.FileFlags) (*fs.File, error) {
+	flags.Pread = true
+	flags.Pwrite = true
 	return fs.NewFile(ctx, dirent, flags, &idMapFileOperations{
 		iops: imio,
 	}), nil

--- a/pkg/sentry/fs/proc/uptime.go
+++ b/pkg/sentry/fs/proc/uptime.go
@@ -51,6 +51,7 @@ func newUptime(ctx context.Context, msrc *fs.MountSource) *fs.Inode {
 
 // GetFile implements fs.InodeOperations.GetFile.
 func (u *uptime) GetFile(ctx context.Context, dirent *fs.Dirent, flags fs.FileFlags) (*fs.File, error) {
+	flags.Pread = true
 	return fs.NewFile(ctx, dirent, flags, &uptimeFile{startTime: u.startTime}), nil
 }
 


### PR DESCRIPTION
This fix enables pread/pwrite support for all seqfiles in procfs as well as other file implementations in `sentry/fs/proc` which use `fsutil.FileGenericSeek` and should resolve both #4798 and #4565.
