### PR TITLE
ARM64 kvm: force a flush on Tlb when SwitchToUser

### DIFF
--- a/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
+++ b/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
@@ -226,9 +226,8 @@ func (c *vCPU) SwitchToUser(switchOpts ring0.SwitchOpts, info *arch.SignalInfo) 
 
 	// Assign PCIDs.
 	if c.PCIDs != nil {
-		var requireFlushPCID bool // Force a flush?
-		switchOpts.UserASID, requireFlushPCID = c.PCIDs.Assign(switchOpts.PageTables)
-		switchOpts.Flush = switchOpts.Flush || requireFlushPCID
+		switchOpts.UserASID, _ = c.PCIDs.Assign(switchOpts.PageTables)
+		switchOpts.Flush = true // Force a flush
 	}
 
 	var vector ring0.Vector


### PR DESCRIPTION
Avoid random unhandle memory fault caused by
unflushed TLB when doing SwitchToUser.

This case appears when pagetables already exist
in PCIDs.cache[] and c.PCIDs.Assign(switchOpts.PageTables) 
return false
