### PR TITLE
arm64 test: add exceptions related test cases

### DIFF
--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -621,10 +621,7 @@ cc_binary(
 cc_binary(
     name = "exceptions_test",
     testonly = 1,
-    srcs = select_arch(
-        amd64 = ["exceptions.cc"],
-        arm64 = [],
-    ),
+    srcs = ["exceptions.cc"],
     linkstatic = 1,
     deps = [
         gtest,


### PR DESCRIPTION
For now, I only added a halt test case for Arm64.

Signed-off-by: Robin Luk <lubin.lu@antgroup.com>
