### PR TITLE
 Fix errors for noescape cases

### DIFF
--- a/pkg/sentry/platform/kvm/bluepill_arm64.go
+++ b/pkg/sentry/platform/kvm/bluepill_arm64.go
@@ -25,29 +25,6 @@ import (
 var (
 	// The action for bluepillSignal is changed by sigaction().
 	bluepillSignal = unix.SIGILL
-
-	// vcpuSErrBounce is the event of system error for bouncing KVM.
-	vcpuSErrBounce = kvmVcpuEvents{
-		exception: exception{
-			sErrPending: 1,
-		},
-	}
-
-	// vcpuSErrNMI is the event of system error to trigger sigbus.
-	vcpuSErrNMI = kvmVcpuEvents{
-		exception: exception{
-			sErrPending: 1,
-			sErrHasEsr:  1,
-			sErrEsr:     _ESR_ELx_SERR_NMI,
-		},
-	}
-
-	// vcpuExtDabt is the event of ext_dabt.
-	vcpuExtDabt = kvmVcpuEvents{
-		exception: exception{
-			extDabtPending: 1,
-		},
-	}
 )
 
 // getTLS returns the value of TPIDR_EL0 register.

--- a/pkg/sentry/platform/kvm/bluepill_arm64_unsafe.go
+++ b/pkg/sentry/platform/kvm/bluepill_arm64_unsafe.go
@@ -80,11 +80,18 @@ func getHypercallID(addr uintptr) int {
 //
 //go:nosplit
 func bluepillStopGuest(c *vCPU) {
+	// vcpuSErrBounce is the event of system error for bouncing KVM.
+	vcpuSErrBounce := &kvmVcpuEvents{
+		exception: exception{
+			sErrPending: 1,
+		},
+	}
+
 	if _, _, errno := unix.RawSyscall( // escapes: no.
 		unix.SYS_IOCTL,
 		uintptr(c.fd),
 		_KVM_SET_VCPU_EVENTS,
-		uintptr(unsafe.Pointer(&vcpuSErrBounce))); errno != 0 {
+		uintptr(unsafe.Pointer(vcpuSErrBounce))); errno != 0 {
 		throw("bounce sErr injection failed")
 	}
 }
@@ -93,12 +100,21 @@ func bluepillStopGuest(c *vCPU) {
 //
 //go:nosplit
 func bluepillSigBus(c *vCPU) {
+	// vcpuSErrNMI is the event of system error to trigger sigbus.
+	vcpuSErrNMI := &kvmVcpuEvents{
+		exception: exception{
+			sErrPending: 1,
+			sErrHasEsr:  1,
+			sErrEsr:     _ESR_ELx_SERR_NMI,
+		},
+	}
+
 	// Host must support ARM64_HAS_RAS_EXTN.
 	if _, _, errno := unix.RawSyscall( // escapes: no.
 		unix.SYS_IOCTL,
 		uintptr(c.fd),
 		_KVM_SET_VCPU_EVENTS,
-		uintptr(unsafe.Pointer(&vcpuSErrNMI))); errno != 0 {
+		uintptr(unsafe.Pointer(vcpuSErrNMI))); errno != 0 {
 		if errno == unix.EINVAL {
 			throw("No ARM64_HAS_RAS_EXTN feature in host.")
 		}
@@ -110,11 +126,18 @@ func bluepillSigBus(c *vCPU) {
 //
 //go:nosplit
 func bluepillExtDabt(c *vCPU) {
+	// vcpuExtDabt is the event of ext_dabt.
+	vcpuExtDabt := &kvmVcpuEvents{
+		exception: exception{
+			extDabtPending: 1,
+		},
+	}
+
 	if _, _, errno := unix.RawSyscall( // escapes: no.
 		unix.SYS_IOCTL,
 		uintptr(c.fd),
 		_KVM_SET_VCPU_EVENTS,
-		uintptr(unsafe.Pointer(&vcpuExtDabt))); errno != 0 {
+		uintptr(unsafe.Pointer(vcpuExtDabt))); errno != 0 {
 		throw("ext_dabt injection failed")
 	}
 }

--- a/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
+++ b/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
@@ -140,22 +140,15 @@ func (c *vCPU) initArchState() error {
 
 	// vbar_el1
 	reg.id = _KVM_ARM64_REGS_VBAR_EL1
-
-	fromLocation := reflect.ValueOf(ring0.Vectors).Pointer()
-	offset := fromLocation & (1<<11 - 1)
-	if offset != 0 {
-		offset = 1<<11 - offset
-	}
-
-	toLocation := fromLocation + offset
-	data = uint64(ring0.KernelStartAddress | toLocation)
+	vectorLocation := reflect.ValueOf(ring0.Vectors).Pointer()
+	data = uint64(ring0.KernelStartAddress | vectorLocation)
 	if err := c.setOneRegister(&reg); err != nil {
 		return err
 	}
 
 	// Use the address of the exception vector table as
 	// the MMIO address base.
-	arm64HypercallMMIOBase = toLocation
+	arm64HypercallMMIOBase = vectorLocation
 
 	// Initialize the PCID database.
 	if hasGuestPCID {


### PR DESCRIPTION
In the event injecting functions, the heap-allocate method should be avoided to reduce the pressure of gc.

Signed-off-by: Robin Luk <lubin.lu@antgroup.com>

