### PR TITLE
Fix #5052 backwards compatibility for cgroup ownership check

### DIFF
--- a/runsc/cgroup/cgroup_test.go
+++ b/runsc/cgroup/cgroup_test.go
@@ -30,10 +30,11 @@ func TestUninstallEnoent(t *testing.T) {
 		// set a non-existent name
 		Name: "runsc-test-uninstall-656e6f656e740a",
 	}
-	c.Own = make(map[string]bool)
+	own := make(map[string]bool)
 	for key := range controllers {
-		c.Own[key] = true
+		own[key] = true
 	}
+	c.Own = own
 	if err := c.Uninstall(); err != nil {
 		t.Errorf("Uninstall() failed: %v", err)
 	}


### PR DESCRIPTION
Fixes issue #5052 for compability when handling /var/run/runsc/*.state
files where Cgroup.Own type varies. This adds type assertions to handle
old and new formats.