### PR TITLE
Arm64 kvm: support cpuid related instructions

### DIFF
--- a/pkg/sentry/platform/kvm/kvm_const_arm64.go
+++ b/pkg/sentry/platform/kvm/kvm_const_arm64.go
@@ -156,6 +156,22 @@ const (
 	_ESR_ELx_SERR_NMI = 0x1
 )
 
+// ARM Architecture Reference Manual for ARMv8 Profile-A, Issue A.a
+// Section C3.1 "A64 instruction index by encoding":
+// AArch64 main encoding table
+const (
+	_AARCH64_INSN_FUNCS_MASK = 0xfff00000
+	_AARCH64_INSN_FUNCS_MRS  = 0xd5300000
+
+	_AARCH64_INSN_SYSREG_MIDR   = (0x3 << 19)
+	_AARCH64_INSN_SYSREG_MPIDR  = (0x3 << 19) | (0x5 << 5)
+	_AARCH64_INSN_SYSREG_REVIDR = (0x3 << 19) | (0x6 << 5)
+	_AARCH64_INSN_SYSREG_MASK   = 0xffff
+	_AARCH64_INSN_SYSREG_SHIFT  = 0x5
+
+	_AARCH64_INSN_COMMONREG_MASK = 0xf
+)
+
 // Arm64: MMIO base address used to dispatch hypercalls.
 const (
 	// on Arm64, the MMIO address must be 64-bit aligned.

--- a/pkg/sentry/platform/kvm/machine_arm64.go
+++ b/pkg/sentry/platform/kvm/machine_arm64.go
@@ -144,6 +144,27 @@ func isWriteFault(code uint64) bool {
 	return (code & _ESR_ELx_WNR) != 0
 }
 
+// getFunc returns function id by decoding instruction value.
+//
+//go:nosplit
+func getFunc(insn uint32) uint32 {
+	return (insn & _AARCH64_INSN_FUNCS_MASK)
+}
+
+// getSysReg returns sysreg id by decoding instruction value.
+//
+//go:nosplit
+func getSysReg(insn uint32) uint32 {
+	return ((insn >> _AARCH64_INSN_SYSREG_SHIFT) & _AARCH64_INSN_SYSREG_MASK) << _AARCH64_INSN_SYSREG_SHIFT
+}
+
+// getReg returns common register id by decoding instruction value.
+//
+//go:nosplit
+func getReg(insn uint32) uint32 {
+	return (insn & _AARCH64_INSN_COMMONREG_MASK)
+}
+
 // fault generates an appropriate fault return.
 //
 //go:nosplit

--- a/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
+++ b/pkg/sentry/platform/kvm/machine_arm64_unsafe.go
@@ -262,6 +262,19 @@ func (c *vCPU) SwitchToUser(switchOpts ring0.SwitchOpts, info *arch.SignalInfo) 
 	case ring0.Vector(bounce): // ring0.VirtualizationException
 		return usermem.NoAccess, platform.ErrContextInterrupt
 	case ring0.El0SyncUndef:
+		var p uintptr = uintptr(switchOpts.Registers.Pc)
+		var insp uint32 = *(*uint32)(unsafe.Pointer(p))
+		var funcId uint32 = getFunc(insp)
+		if funcId == _AARCH64_INSN_FUNCS_MRS {
+			var sysReg uint32 = getSysReg(insp)
+			if sysReg == _AARCH64_INSN_SYSREG_MIDR ||
+				sysReg == _AARCH64_INSN_SYSREG_MPIDR ||
+				sysReg == _AARCH64_INSN_SYSREG_REVIDR {
+				// Got CPUID:MIDR/MPIDR/REVIDR.
+				return usermem.AccessType{}, platform.ErrContextSignalCPUID
+			}
+		}
+
 		return c.fault(int32(syscall.SIGILL), info)
 	default:
 		panic(fmt.Sprintf("unexpected vector: 0x%x", vector))


### PR DESCRIPTION
For platforms before arm8.4, cpuid related instructions will be trapped
in el0_undef.

Functions related to checking cpuid are added to this patch.
Reference code: https://github.com/torvalds/linux/blob/v5.10-rc7/arch/arm64/kernel/traps.c#L531

Signed-off-by: Robin Luk <lubin.lu@antgroup.com>
