### PR TITLE
Resolve compiler warnings

### DIFF
--- a/test/syscalls/linux/pipe.cc
+++ b/test/syscalls/linux/pipe.cc
@@ -71,13 +71,13 @@ class PipeTest : public ::testing::TestWithParam<PipeCreator> {
   // Returns true iff the pipe represents a named pipe.
   bool IsNamedPipe() const { return named_pipe_; }
 
-  int Size() const {
+  size_t Size() const {
     int s1 = fcntl(rfd_.get(), F_GETPIPE_SZ);
     int s2 = fcntl(wfd_.get(), F_GETPIPE_SZ);
     EXPECT_GT(s1, 0);
     EXPECT_GT(s2, 0);
     EXPECT_EQ(s1, s2);
-    return s1;
+    return static_cast<size_t>(s1);
   }
 
   static void TearDownTestSuite() {
@@ -568,7 +568,7 @@ TEST_P(PipeTest, Streaming) {
   DisableSave ds;
 
   // Size() requires 2 syscalls, call it once and remember the value.
-  const int pipe_size = Size();
+  const size_t pipe_size = Size();
   const size_t streamed_bytes = 4 * pipe_size;
 
   absl::Notification notify;
@@ -576,7 +576,7 @@ TEST_P(PipeTest, Streaming) {
     std::vector<char> buf(1024);
     // Don't start until it's full.
     notify.WaitForNotification();
-    ssize_t total = 0;
+    size_t total = 0;
     while (total < streamed_bytes) {
       ASSERT_THAT(read(rfd_.get(), buf.data(), buf.size()),
                   SyscallSucceedsWithValue(buf.size()));
@@ -593,7 +593,7 @@ TEST_P(PipeTest, Streaming) {
   // page) for the check for notify.Notify() below to be correct.
   std::vector<char> buf(1024);
   RandomizeBuffer(buf.data(), buf.size());
-  ssize_t total = 0;
+  size_t total = 0;
   while (total < streamed_bytes) {
     ASSERT_THAT(write(wfd_.get(), buf.data(), buf.size()),
                 SyscallSucceedsWithValue(buf.size()));

--- a/test/syscalls/linux/proc_net.cc
+++ b/test/syscalls/linux/proc_net.cc
@@ -420,14 +420,14 @@ TEST(ProcNetSnmp, CheckNetStat) {
   int name_count = 0;
   int value_count = 0;
   std::vector<absl::string_view> lines = absl::StrSplit(contents, '\n');
-  for (int i = 0; i + 1 < lines.size(); i += 2) {
+  for (long unsigned int i = 0; i + 1 < lines.size(); i += 2) {
     std::vector<absl::string_view> names =
         absl::StrSplit(lines[i], absl::ByAnyChar("\t "));
     std::vector<absl::string_view> values =
         absl::StrSplit(lines[i + 1], absl::ByAnyChar("\t "));
     EXPECT_EQ(names.size(), values.size()) << " mismatch in lines '" << lines[i]
                                            << "' and '" << lines[i + 1] << "'";
-    for (int j = 0; j < names.size() && j < values.size(); ++j) {
+    for (long unsigned int j = 0; j < names.size() && j < values.size(); ++j) {
       if (names[j] == "TCPOrigDataSent" || names[j] == "TCPSynRetrans" ||
           names[j] == "TCPDSACKRecv" || names[j] == "TCPDSACKOfoRecv") {
         ++name_count;
@@ -457,14 +457,14 @@ TEST(ProcNetSnmp, CheckSnmp) {
   int name_count = 0;
   int value_count = 0;
   std::vector<absl::string_view> lines = absl::StrSplit(contents, '\n');
-  for (int i = 0; i + 1 < lines.size(); i += 2) {
+  for (long unsigned int i = 0; i + 1 < lines.size(); i += 2) {
     std::vector<absl::string_view> names =
         absl::StrSplit(lines[i], absl::ByAnyChar("\t "));
     std::vector<absl::string_view> values =
         absl::StrSplit(lines[i + 1], absl::ByAnyChar("\t "));
     EXPECT_EQ(names.size(), values.size()) << " mismatch in lines '" << lines[i]
                                            << "' and '" << lines[i + 1] << "'";
-    for (int j = 0; j < names.size() && j < values.size(); ++j) {
+    for (long unsigned int j = 0; j < names.size() && j < values.size(); ++j) {
       if (names[j] == "RetransSegs") {
         ++name_count;
         int64_t val;

--- a/test/syscalls/linux/proc_net_unix.cc
+++ b/test/syscalls/linux/proc_net_unix.cc
@@ -181,7 +181,7 @@ PosixErrorOr<std::vector<UnixEntry>> ProcNetUnixEntries() {
 // Returns true on match, and sets 'match' to point to the matching entry.
 bool FindBy(std::vector<UnixEntry> entries, UnixEntry* match,
             std::function<bool(const UnixEntry&)> predicate) {
-  for (int i = 0; i < entries.size(); ++i) {
+  for (long unsigned int i = 0; i < entries.size(); ++i) {
     if (predicate(entries[i])) {
       *match = entries[i];
       return true;

--- a/test/syscalls/linux/proc_pid_uid_gid_map.cc
+++ b/test/syscalls/linux/proc_pid_uid_gid_map.cc
@@ -203,7 +203,7 @@ TEST_P(ProcSelfUidGidMapTest, IdentityMapOwnID) {
   EXPECT_THAT(
       InNewUserNamespaceWithMapFD([&](int fd) {
         DenySelfSetgroups();
-        TEST_PCHECK(write(fd, line.c_str(), line.size()) == line.size());
+        TEST_PCHECK(static_cast<long unsigned int>(write(fd, line.c_str(), line.size())) == line.size());
       }),
       IsPosixErrorOkAndHolds(0));
 }
@@ -220,7 +220,7 @@ TEST_P(ProcSelfUidGidMapTest, TrailingNewlineAndNULIgnored) {
         DenySelfSetgroups();
         // The write should return the full size of the write, even though
         // characters after the NUL were ignored.
-        TEST_PCHECK(write(fd, line.c_str(), line.size()) == line.size());
+        TEST_PCHECK(static_cast<long unsigned int>(write(fd, line.c_str(), line.size())) == line.size());
       }),
       IsPosixErrorOkAndHolds(0));
 }
@@ -233,7 +233,7 @@ TEST_P(ProcSelfUidGidMapTest, NonIdentityMapOwnID) {
   EXPECT_THAT(
       InNewUserNamespaceWithMapFD([&](int fd) {
         DenySelfSetgroups();
-        TEST_PCHECK(write(fd, line.c_str(), line.size()) == line.size());
+        TEST_PCHECK(static_cast<long unsigned int>(write(fd, line.c_str(), line.size())) == line.size());
       }),
       IsPosixErrorOkAndHolds(0));
 }

--- a/test/syscalls/linux/semaphore.cc
+++ b/test/syscalls/linux/semaphore.cc
@@ -600,7 +600,7 @@ TEST(SemaphoreTest, SemopGetzcnt) {
   buf.sem_num = 0;
   buf.sem_op = 0;
   constexpr size_t kLoops = 10;
-  for (auto i = 0; i < kLoops; i++) {
+  for (size_t i = 0; i < kLoops; i++) {
     auto child_pid = fork();
     if (child_pid == 0) {
       TEST_PCHECK(RetryEINTR(semop)(sem.get(), &buf, 1) == 0);
@@ -707,7 +707,7 @@ TEST(SemaphoreTest, SemopGetncnt) {
   buf.sem_num = 0;
   buf.sem_op = -1;
   constexpr size_t kLoops = 10;
-  for (auto i = 0; i < kLoops; i++) {
+  for (size_t i = 0; i < kLoops; i++) {
     auto child_pid = fork();
     if (child_pid == 0) {
       TEST_PCHECK(RetryEINTR(semop)(sem.get(), &buf, 1) == 0);

--- a/test/syscalls/linux/socket.cc
+++ b/test/syscalls/linux/socket.cc
@@ -46,7 +46,7 @@ TEST(SocketTest, ProtocolUnix) {
       {AF_UNIX, SOCK_SEQPACKET, PF_UNIX},
       {AF_UNIX, SOCK_DGRAM, PF_UNIX},
   };
-  for (int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
+  for (long unsigned int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
     ASSERT_NO_ERRNO_AND_VALUE(
         Socket(tests[i].domain, tests[i].type, tests[i].protocol));
   }
@@ -59,7 +59,7 @@ TEST(SocketTest, ProtocolInet) {
       {AF_INET, SOCK_DGRAM, IPPROTO_UDP},
       {AF_INET, SOCK_STREAM, IPPROTO_TCP},
   };
-  for (int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
+  for (long unsigned int i = 0; i < ABSL_ARRAYSIZE(tests); i++) {
     ASSERT_NO_ERRNO_AND_VALUE(
         Socket(tests[i].domain, tests[i].type, tests[i].protocol));
   }
@@ -87,7 +87,7 @@ TEST(SocketTest, UnixSocketStat) {
   ASSERT_THAT(stat(addr.sun_path, &statbuf), SyscallSucceeds());
 
   // Mode should be S_IFSOCK.
-  EXPECT_EQ(statbuf.st_mode, S_IFSOCK | sock_perm & ~mask);
+  EXPECT_EQ(statbuf.st_mode, S_IFSOCK | (sock_perm & ~mask));
 
   // Timestamps should be equal and non-zero.
   // TODO(b/158882152): Sockets currently don't implement timestamps.

--- a/test/syscalls/linux/socket_bind_to_device_distribution.cc
+++ b/test/syscalls/linux/socket_bind_to_device_distribution.cc
@@ -168,7 +168,7 @@ TEST_P(BindToDeviceDistributionTest, Tcp) {
   std::vector<std::unique_ptr<ScopedThread>> listen_threads(
       listener_fds.size());
 
-  for (int i = 0; i < listener_fds.size(); i++) {
+  for (long unsigned int i = 0; i < listener_fds.size(); i++) {
     listen_threads[i] = absl::make_unique<ScopedThread>(
         [&listener_fds, &accept_counts, &connects_received, i,
          kConnectAttempts]() {
@@ -235,7 +235,7 @@ TEST_P(BindToDeviceDistributionTest, Tcp) {
     listen_thread->Join();
   }
   // Check that connections are distributed correctly among listening sockets.
-  for (int i = 0; i < accept_counts.size(); i++) {
+  for (long unsigned int i = 0; i < accept_counts.size(); i++) {
     EXPECT_THAT(
         accept_counts[i],
         EquivalentWithin(static_cast<int>(kConnectAttempts *
@@ -308,7 +308,7 @@ TEST_P(BindToDeviceDistributionTest, Udp) {
   std::vector<std::unique_ptr<ScopedThread>> receiver_threads(
       listener_fds.size());
 
-  for (int i = 0; i < listener_fds.size(); i++) {
+  for (long unsigned int i = 0; i < listener_fds.size(); i++) {
     receiver_threads[i] = absl::make_unique<ScopedThread>(
         [&listener_fds, &packets_per_socket, &packets_received, i]() {
           do {
@@ -366,7 +366,7 @@ TEST_P(BindToDeviceDistributionTest, Udp) {
     receiver_thread->Join();
   }
   // Check that packets are distributed correctly among listening sockets.
-  for (int i = 0; i < packets_per_socket.size(); i++) {
+  for (long unsigned int i = 0; i < packets_per_socket.size(); i++) {
     EXPECT_THAT(
         packets_per_socket[i],
         EquivalentWithin(static_cast<int>(kConnectAttempts *

--- a/test/syscalls/linux/socket_ip_udp_generic.cc
+++ b/test/syscalls/linux/socket_ip_udp_generic.cc
@@ -493,7 +493,7 @@ TEST_P(UDPSocketPairTest, TClassRecvMismatch) {
   // This should only test AF_INET6 sockets for the mismatch behavior.
   SKIP_IF(GetParam().domain != AF_INET6);
   // IPV6_RECVTCLASS is only valid for SOCK_DGRAM and SOCK_RAW.
-  SKIP_IF(GetParam().type != SOCK_DGRAM | GetParam().type != SOCK_RAW);
+  SKIP_IF((GetParam().type != SOCK_DGRAM) | (GetParam().type != SOCK_RAW));
 
   auto sockets = ASSERT_NO_ERRNO_AND_VALUE(NewSocketPair());
 

--- a/test/syscalls/linux/socket_ipv4_udp_unbound_netlink.cc
+++ b/test/syscalls/linux/socket_ipv4_udp_unbound_netlink.cc
@@ -177,7 +177,7 @@ TEST_P(IPv4UDPUnboundSocketNetlinkTest, ReuseAddrSubnetDirectedBroadcast) {
 
   // Broadcasts from each socket should be received by every socket (including
   // the sending socket).
-  for (int w = 0; w < socks.size(); w++) {
+  for (long unsigned int w = 0; w < socks.size(); w++) {
     auto& w_sock = socks[w];
     ASSERT_THAT(
         RetryEINTR(sendto)(w_sock->get(), send_buf, kSendBufSize, 0,
@@ -187,7 +187,7 @@ TEST_P(IPv4UDPUnboundSocketNetlinkTest, ReuseAddrSubnetDirectedBroadcast) {
         << "write socks[" << w << "]";
 
     // Check that we received the packet on all sockets.
-    for (int r = 0; r < socks.size(); r++) {
+    for (long unsigned int r = 0; r < socks.size(); r++) {
       auto& r_sock = socks[r];
 
       struct pollfd poll_fd = {r_sock->get(), POLLIN, 0};

--- a/test/syscalls/linux/tuntap.cc
+++ b/test/syscalls/linux/tuntap.cc
@@ -324,8 +324,9 @@ TEST_F(TuntapTest, PingKernel) {
   };
   while (1) {
     inpkt r = {};
-    int n = read(fd.get(), &r, sizeof(r));
-    EXPECT_THAT(n, SyscallSucceeds());
+    int nread = read(fd.get(), &r, sizeof(r));
+    EXPECT_THAT(nread, SyscallSucceeds());
+    long unsigned int n = static_cast<long unsigned int>(nread);
 
     if (n < sizeof(pihdr)) {
       std::cerr << "Ignored packet, protocol: " << r.pi.pi_protocol
@@ -383,8 +384,9 @@ TEST_F(TuntapTest, SendUdpTriggersArpResolution) {
   };
   while (1) {
     inpkt r = {};
-    int n = read(fd.get(), &r, sizeof(r));
-    EXPECT_THAT(n, SyscallSucceeds());
+    int nread = read(fd.get(), &r, sizeof(r));
+    EXPECT_THAT(nread, SyscallSucceeds());
+    long unsigned int n = static_cast<long unsigned int>(nread);
 
     if (n < sizeof(pihdr)) {
       std::cerr << "Ignored packet, protocol: " << r.pi.pi_protocol


### PR DESCRIPTION
The buildkite syscall tests start with a lot of C++ warnings. This
cleans that up a little.