### PR TITLE
set correct Checksum for rules_go-v0.24.10.tar.gz

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,7 +40,7 @@ http_archive(
         # binaries of symbols, which we don't want.
         "//tools:rules_go.patch",
     ],
-    sha256 = "a515569b4903776eae90ac2696b34ee1dd45600cf9dfd7d16475e2df32867521",
+    sha256 = "8e9434015ff8f3d6962cb8f016230ea7acc1ac402b760a8d66ff54dc11673ca6",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.10/rules_go-v0.24.10.tar.gz",
         "https://github.com/bazelbuild/rules_go/releases/download/v0.24.10/rules_go-v0.24.10.tar.gz",


### PR DESCRIPTION
When doing bazel http_archive, there is a error which shows following information
`Download from https://github.com/bazelbuild/rules_go/releases/download/v0.24.10/rules_go-v0.24.10.tar.gz failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Checksum was 8e9434015ff8f3d6962cb8f016230ea7acc1ac402b760a8d66ff54dc11673ca6 but wanted a515569b4903776eae90ac2696b34ee1dd45600cf9dfd7d16475e2df32867521`
Change the checksum of rules_go-v0.24.10.tar.gz from a515569b4903776eae90ac2696b34ee1dd45600cf9dfd7d16475e2df32867521 to 8e9434015ff8f3d6962cb8f016230ea7acc1ac402b760a8d66ff54dc11673ca6 

Signed-off-by: Howard Zhang <howard.zhang@arm.com>