### PR TITLE
Add support for pause/resume in containerd shim

### DIFF
--- a/pkg/shim/runsc/runsc.go
+++ b/pkg/shim/runsc/runsc.go
@@ -169,14 +169,14 @@ func (r *Runsc) Create(context context.Context, id, bundle string, opts *CreateO
 
 func (r *Runsc) Pause(context context.Context, id string) error {
 	if _, err := cmdOutput(r.command(context, "pause", id), true); err != nil {
-		return fmt.Errorf("unable to pause: %s", err)
+		return fmt.Errorf("unable to pause: %w", err)
 	}
 	return nil
 }
 
 func (r *Runsc) Resume(context context.Context, id string) error {
-	if _, err := cmdOutput(r.command(context, "pause", id), true); err != nil {
-		return fmt.Errorf("unable to resume: %s", err)
+	if _, err := cmdOutput(r.command(context, "resume", id), true); err != nil {
+		return fmt.Errorf("unable to resume: %w", err)
 	}
 	return nil
 }

--- a/pkg/shim/runsc/runsc.go
+++ b/pkg/shim/runsc/runsc.go
@@ -167,6 +167,20 @@ func (r *Runsc) Create(context context.Context, id, bundle string, opts *CreateO
 	return err
 }
 
+func (r *Runsc) Pause(context context.Context, id string) error {
+	if _, err := cmdOutput(r.command(context, "pause", id), true); err != nil {
+		return fmt.Errorf("unable to pause: %s", err)
+	}
+	return nil
+}
+
+func (r *Runsc) Resume(context context.Context, id string) error {
+	if _, err := cmdOutput(r.command(context, "pause", id), true); err != nil {
+		return fmt.Errorf("unable to resume: %s", err)
+	}
+	return nil
+}
+
 // Start will start an already created container.
 func (r *Runsc) Start(context context.Context, id string, cio runc.IO) error {
 	cmd := r.command(context, "start", id)

--- a/pkg/shim/service.go
+++ b/pkg/shim/service.go
@@ -612,13 +612,15 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (*taskAPI.
 // Pause the container.
 func (s *service) Pause(ctx context.Context, r *taskAPI.PauseRequest) (*types.Empty, error) {
 	log.L.Debugf("Pause, id: %s", r.ID)
-	return empty, errdefs.ToGRPC(errdefs.ErrNotImplemented)
+	err := s.task.Runtime().Pause(ctx, r.ID)
+	return empty, err
 }
 
 // Resume the container.
 func (s *service) Resume(ctx context.Context, r *taskAPI.ResumeRequest) (*types.Empty, error) {
 	log.L.Debugf("Resume, id: %s", r.ID)
-	return empty, errdefs.ToGRPC(errdefs.ErrNotImplemented)
+	err := s.task.Runtime().Resume(ctx, r.ID)
+	return empty, err
 }
 
 // Kill a process with the provided signal.

--- a/pkg/shim/service.go
+++ b/pkg/shim/service.go
@@ -612,15 +612,29 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (*taskAPI.
 // Pause the container.
 func (s *service) Pause(ctx context.Context, r *taskAPI.PauseRequest) (*types.Empty, error) {
 	log.L.Debugf("Pause, id: %s", r.ID)
+	if s.task == nil {
+		log.L.Debugf("Pause error, id: %s: container not created", r.ID)
+		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	}
 	err := s.task.Runtime().Pause(ctx, r.ID)
-	return empty, err
+	if err != nil {
+		return nil, err
+	}
+	return empty, nil
 }
 
 // Resume the container.
 func (s *service) Resume(ctx context.Context, r *taskAPI.ResumeRequest) (*types.Empty, error) {
 	log.L.Debugf("Resume, id: %s", r.ID)
+	if s.task == nil {
+		log.L.Debugf("Resume error, id: %s: container not created", r.ID)
+		return nil, errdefs.ToGRPCf(errdefs.ErrFailedPrecondition, "container must be created")
+	}
 	err := s.task.Runtime().Resume(ctx, r.ID)
-	return empty, err
+	if err != nil {
+		return nil, err
+	}
+	return empty, nil
 }
 
 // Kill a process with the provided signal.


### PR DESCRIPTION
Happy to add tests if necessary (not sure where those would go at this point).

Tested by `ctr t pause` and `ctr t resume`-ing a container.

This seems to be necessary to implement checkpoint/restore for containerd (containerd calls pause before checkpointing, then resumes it -- even though that's not strictly necessary for gVisor).