### PR TITLE
Multi-container checkpoint/restore

### DIFF
--- a/pkg/sentry/control/proc.go
+++ b/pkg/sentry/control/proc.go
@@ -95,7 +95,11 @@ type ExecArgs struct {
 	urpc.FilePayload
 
 	// ContainerID is the container for the process being executed.
+	// Note: Only ContainerIndex is used inside sentry, ContainerID
+	// here is used in runsc to propagate containerID information to
+	// loader, but it's not used in sentry.
 	ContainerID string
+	ContainerIndex int
 
 	// PIDNamespace is the pid namespace for the process being executed.
 	PIDNamespace *kernel.PIDNamespace
@@ -162,7 +166,7 @@ func (proc *Proc) execAsync(args *ExecArgs) (*kernel.ThreadGroup, kernel.ThreadI
 		UTSNamespace:            proc.Kernel.RootUTSNamespace(),
 		IPCNamespace:            proc.Kernel.RootIPCNamespace(),
 		AbstractSocketNamespace: proc.Kernel.RootAbstractSocketNamespace(),
-		ContainerID:             args.ContainerID,
+		ContainerIndex:          args.ContainerIndex,
 		PIDNamespace:            args.PIDNamespace,
 	}
 	if initArgs.MountNamespace != nil {
@@ -245,7 +249,7 @@ type PsArgs struct {
 // Ps provides a process listing for the running kernel.
 func (proc *Proc) Ps(args *PsArgs, out *string) error {
 	var p []*Process
-	if e := Processes(proc.Kernel, "", &p); e != nil {
+	if e := Processes(proc.Kernel, -1, &p); e != nil {
 		return e
 	}
 	if !args.JSON {
@@ -327,7 +331,7 @@ func PrintPIDsJSON(pl []*Process) (string, error) {
 
 // Processes retrieves information about processes running in the sandbox with
 // the given container id. All processes are returned if 'containerID' is empty.
-func Processes(k *kernel.Kernel, containerID string, out *[]*Process) error {
+func Processes(k *kernel.Kernel, containerIndex int, out *[]*Process) error {
 	ts := k.TaskSet()
 	now := k.RealtimeClock().Now()
 	for _, tg := range ts.Root.ThreadGroups() {
@@ -338,7 +342,7 @@ func Processes(k *kernel.Kernel, containerID string, out *[]*Process) error {
 		if pid == 0 {
 			continue
 		}
-		if containerID != "" && containerID != tg.Leader().ContainerID() {
+		if containerIndex != -1 && containerIndex != tg.Leader().ContainerIndex() {
 			continue
 		}
 

--- a/pkg/sentry/fs/gofer/inode_state.go
+++ b/pkg/sentry/fs/gofer/inode_state.go
@@ -150,7 +150,10 @@ func (i *inodeFileState) afterLoad() {
 		}
 
 		if i.sattr.Type == fs.RegularFile {
-			env, ok := fs.CurrentRestoreEnvironment()
+			var cindex int
+			var notUsed string
+			fmt.Sscanf(i.s.connID, "9pfs-%d%v", &cindex, &notUsed)
+			env, ok := fs.CurrentRestoreEnvironment(cindex)
 			if !ok {
 				return errors.New("missing restore environment")
 			}

--- a/pkg/sentry/fs/gofer/session_state.go
+++ b/pkg/sentry/fs/gofer/session_state.go
@@ -37,7 +37,11 @@ func (s *session) beforeSave() {
 func (s *session) afterLoad() {
 	// The restore environment contains the 9p connection of this mount.
 	fsys := filesystem{}
-	env, ok := fs.CurrentRestoreEnvironment()
+
+	var cindex int
+	var notUsed string
+	fmt.Sscanf(s.connID, "9pfs-%d%v", &cindex, &notUsed)
+	env, ok := fs.CurrentRestoreEnvironment(cindex)
 	if !ok {
 		panic("failed to find restore environment")
 	}

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1444,8 +1444,8 @@ func (k *Kernel) GlobalInit() *ThreadGroup {
 	return k.globalInit
 }
 
-// SetContainerInit sets the thread group with ID 1 in the PID namespace.
-func (k *Kernel) SetContainerInit(tg *ThreadGroup) {
+// AddContainerInit sets the thread group with ID 1 in the PID namespace.
+func (k *Kernel) AddContainerInit(tg *ThreadGroup) {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
 	k.containerInit = append(k.containerInit, tg)

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1408,6 +1408,12 @@ func (k *Kernel) RootUTSNamespace() *UTSNamespace {
 	return k.rootUTSNamespace
 }
 
+// UpdateRootUTSNamespace updates RootUTSNamespace's hostName and domainName
+func (k *Kernel) UpdateRootUTSNamespace(hostName string, domainName string) () {
+	k.rootUTSNamespace.SetHostName(hostName)
+	k.rootUTSNamespace.SetDomainName(domainName)
+}
+
 // RootIPCNamespace takes a reference and returns the root IPCNamespace.
 func (k *Kernel) RootIPCNamespace() *IPCNamespace {
 	k.rootIPCNamespace.IncRef()

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -248,12 +248,12 @@ type Task struct {
 	// k is the Kernel that this task belongs to. The k pointer is immutable.
 	k *Kernel
 
-	// containerID has no equivalent in Linux; it's used by runsc to track all
+	// containerIndex has no equivalent in Linux; it's used by runsc to track all
 	// tasks that belong to a given containers since cgroups aren't implemented.
 	// It's inherited by the children, is immutable, and may be empty.
 	//
 	// NOTE: cgroups can be used to track this when implemented.
-	containerID string
+	containerIndex int
 
 	// mu protects some of the following fields.
 	mu sync.Mutex `state:"nosave"`
@@ -820,9 +820,9 @@ func (t *Task) AbstractSockets() *AbstractSocketNamespace {
 	return t.abstractSockets
 }
 
-// ContainerID returns t's container ID.
-func (t *Task) ContainerID() string {
-	return t.containerID
+// ContainerIndex returns t's container Index.
+func (t *Task) ContainerIndex() int {
+	return t.containerIndex
 }
 
 // OOMScoreAdj gets the task's thread group's OOM score adjustment.

--- a/pkg/sentry/kernel/task_clone.go
+++ b/pkg/sentry/kernel/task_clone.go
@@ -301,7 +301,7 @@ func (t *Task) Clone(opts *CloneOptions) (ThreadID, *SyscallControl, error) {
 		MountNamespaceVFS2:      mntnsVFS2,
 		RSeqAddr:                rseqAddr,
 		RSeqSignature:           rseqSignature,
-		ContainerID:             t.ContainerID(),
+		ContainerIndex:          t.ContainerIndex(),
 	}
 	if opts.NewThreadGroup {
 		cfg.Parent = t

--- a/pkg/sentry/kernel/task_start.go
+++ b/pkg/sentry/kernel/task_start.go
@@ -92,8 +92,8 @@ type TaskConfig struct {
 	// with.
 	RSeqSignature uint32
 
-	// ContainerID is the container the new task belongs to.
-	ContainerID string
+	// ContainerIndex is the container the new task belongs to.
+	ContainerIndex int
 }
 
 // NewTask creates a new task defined by cfg.
@@ -150,7 +150,7 @@ func (ts *TaskSet) newTask(cfg *TaskConfig) (*Task, error) {
 		rseqAddr:           cfg.RSeqAddr,
 		rseqSignature:      cfg.RSeqSignature,
 		futexWaiter:        futex.NewWaiter(),
-		containerID:        cfg.ContainerID,
+		containerIndex:     cfg.ContainerIndex,
 	}
 	t.creds.Store(cfg.Credentials)
 	t.endStopCond.L = &t.tg.signalHandlers.mu

--- a/pkg/sentry/state/state.go
+++ b/pkg/sentry/state/state.go
@@ -109,6 +109,16 @@ type LoadOpts struct {
 	Key []byte
 }
 
+func (opts LoadOpts) GetMetadata() (map[string]string, error) {
+	// Open the file.
+	_, m, err := statefile.NewReader(opts.Source, opts.Key)
+	if err != nil {
+		return nil, ErrStateFile{err}
+	}
+
+	return m, err
+}
+
 // Load loads the given kernel, setting the provided platform and stack.
 func (opts LoadOpts) Load(ctx context.Context, k *kernel.Kernel, n inet.Stack, clocks time.Clocks, vfsOpts *vfs.CompleteRestoreOptions) error {
 	// Open the file.

--- a/pkg/urpc/urpc.go
+++ b/pkg/urpc/urpc.go
@@ -561,6 +561,7 @@ func unmarshal(s *unet.Socket, v interface{}) ([]*os.File, error) {
 
 	// Extract any FDs that may be there.
 	if _, err := r.ReadVec([][]byte{firstByte}); err != nil {
+		log.Debugf("urpc: error reading bytes: %v", err)
 		return nil, err
 	}
 	fds, err := r.ExtractFDs()

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"strconv"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/control/server"
@@ -334,6 +335,15 @@ func (cm *containerManager) Checkpoint(o *control.SaveOpts, _ *struct{}) error {
 		Kernel:   cm.l.k,
 		Watchdog: cm.l.watchdog,
 	}
+
+	num := 0
+	for _, _ = range cm.l.processes {
+		num++
+	}
+	if o.Metadata == nil {
+		o.Metadata = make(map[string]string)
+	}
+	o.Metadata["container_num"] = strconv.Itoa(num)
 	return state.Save(o, nil)
 }
 

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"syscall"
 	"strconv"
+	"syscall"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/control/server"
@@ -183,6 +183,9 @@ type containerManager struct {
 
 	// l is the loader that creates containers and sandboxes.
 	l *Loader
+
+	// cindex is the current index of the containers inside a sandbox
+	cindex int
 }
 
 // StartRoot will start the root container process.
@@ -226,7 +229,11 @@ func (cm *containerManager) Create(args *CreateArgs, _ *struct{}) error {
 			return fmt.Errorf("error dup'ing TTY file: %w", err)
 		}
 	}
-	return cm.l.createContainer(args.CID, tty)
+	err := cm.l.createContainer(args.CID, tty)
+	if err == nil {
+		cm.cindex++
+	}
+	return err
 }
 
 // StartArgs contains arguments to the Start method.

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -218,7 +218,7 @@ func (cm *containerManager) StartRoot(cid *string, _ *struct{}) error {
 // Processes retrieves information about processes running in the sandbox.
 func (cm *containerManager) Processes(cid *string, out *[]*control.Process) error {
 	log.Debugf("containerManager.Processes, cid: %s", *cid)
-	return control.Processes(cm.l.k, *cid, out)
+	return control.Processes(cm.l.k, cm.l.containers[*cid], out)
 }
 
 // CreateArgs contains arguments to the Create method.

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -359,14 +359,10 @@ func (cm *containerManager) Checkpoint(o *control.SaveOpts, _ *struct{}) error {
 		Watchdog: cm.l.watchdog,
 	}
 
-	num := 0
-	for _, _ = range cm.l.processes {
-		num++
-	}
 	if o.Metadata == nil {
 		o.Metadata = make(map[string]string)
 	}
-	o.Metadata["container_num"] = strconv.Itoa(num)
+	o.Metadata["container_num"] = strconv.Itoa(cm.cindex + 1)
 	return state.Save(o, nil)
 }
 

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -362,7 +362,7 @@ func (cm *containerManager) Checkpoint(o *control.SaveOpts, _ *struct{}) error {
 	if o.Metadata == nil {
 		o.Metadata = make(map[string]string)
 	}
-	o.Metadata["container_num"] = strconv.Itoa(cm.cindex + 1)
+	o.Metadata["container_num"] = strconv.Itoa(cm.cindex)
 	return state.Save(o, nil)
 }
 

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -529,6 +529,10 @@ func (cm *containerManager) RootRestore(o *RestoreOpts, _ *struct{}) error {
 	}
 	cm.l.mu.Unlock()
 
+	// Update the restored kernel's rootUTSNamespace according to the restore spec
+	// Loader.spec contains hostname information for the restore root container
+	cm.l.k.UpdateRootUTSNamespace(cm.l.spec.Hostname, cm.l.spec.Hostname)
+
 	// Tell the root container to start and wait for the result.
 	cm.startChan <- struct{}{}
 	if err := <-cm.startResultChan; err != nil {

--- a/runsc/boot/fs.go
+++ b/runsc/boot/fs.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	// Device name for root mount.
-	rootDevice = "9pfs-/"
+	rootDevice = "9pfs"
 
 	// MountPrefix is the annotation prefix for mount hints.
 	MountPrefix = "dev.gvisor.spec.mount."
@@ -64,6 +64,17 @@ const (
 	bind   = "bind"
 	nonefs = "none"
 )
+
+// cindex is used to differentiate session's connID so that on restore,
+// we can figure out to which container the gofer session/inode object belongs to.
+// To serve this purpose, connID is constructed with a specific pattern:
+// 9pfs-cindex/mount_point
+// root will have cindex 0, and child container's cindex starts from 1.
+// This assumes containers are started and restored in exact the same order
+// FIXME: index must be accessed serially, i.e. root container and
+// child containers can't be started/restored at the same time. This
+// seems to be a reasonable assumption.
+var cindex int = 0
 
 // tmpfs has some extra supported options that we must pass through.
 var tmpfsAllowedData = []string{"mode", "uid", "gid"}
@@ -212,7 +223,7 @@ func mountDevice(m specs.Mount) string {
 	if m.Type == bind {
 		// Make a device string that includes the target, which is consistent across
 		// S/R and uniquely identifies the connection.
-		return "9pfs-" + m.Destination
+		return "9pfs-" + strconv.Itoa(cindex) + m.Destination
 	}
 	// All other fs types use device "none".
 	return "none"
@@ -632,6 +643,10 @@ func (c *containerMounter) setupFS(conf *config.Config, procArgs *kernel.CreateP
 	if err := c.mountSubmounts(rootCtx, conf, mns); err != nil {
 		return nil, err
 	}
+
+	// cindex must be incremented after all mount points have been setup
+	// or the submounts could end up with a wrong index value
+	cindex++
 	return mns, nil
 }
 
@@ -739,7 +754,8 @@ func (c *containerMounter) createRootMount(ctx context.Context, conf *config.Con
 		opts = append(opts, "overlayfs_stale_read")
 	}
 
-	rootInode, err := p9FS.Mount(ctx, rootDevice, mf, strings.Join(opts, ","), nil)
+	dev := fmt.Sprintf("%v-%d/", rootDevice, cindex)
+	rootInode, err := p9FS.Mount(ctx, dev, mf, strings.Join(opts, ","), nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating root mount point: %v", err)
 	}
@@ -952,8 +968,9 @@ func (c *containerMounter) createRestoreEnvironment(conf *config.Config) (*fs.Re
 		mf.ReadOnly = true
 	}
 
+	dev := fmt.Sprintf("%v-%d/", rootDevice, cindex)
 	rootMount := fs.MountArgs{
-		Dev:        rootDevice,
+		Dev:        dev,
 		Flags:      mf,
 		DataString: strings.Join(opts, ","),
 	}
@@ -980,6 +997,8 @@ func (c *containerMounter) createRestoreEnvironment(conf *config.Config) (*fs.Re
 			return nil, err
 		}
 	}
+
+	cindex++
 
 	return renv, nil
 }

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -842,6 +842,9 @@ func (l *Loader) createContainerProcess(root bool, cid string, info *containerIn
 		}
 	}
 
+	l.processes[eid].tg = tg
+	l.k.SetContainerInit(tg)
+
 	return tg, ttyFile, ttyFileVFS2, nil
 }
 

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -135,6 +135,11 @@ type Loader struct {
 	// processes is guardded by mu.
 	processes map[execID]*execProcess
 
+	// containers maps container ID to container index
+	// this is needed during restore when we need to know
+	// the index of the child container from its ID
+	containers map[string]int
+
 	// mountHints provides extra information about mounts for containers that
 	// apply to the entire pod.
 	mountHints *podMountHints
@@ -649,6 +654,9 @@ func (l *Loader) createContainer(cid string, tty *fd.FD) error {
 		return fmt.Errorf("container %q already exists", cid)
 	}
 	l.processes[eid] = &execProcess{hostTTY: tty}
+
+	l.ctrl.manager.cindex++
+	l.containers[cid] = l.ctrl.manager.cindex
 	return nil
 }
 

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -408,6 +408,7 @@ func New(args Args) (*Loader, error) {
 		processes:  map[execID]*execProcess{eid: {}},
 		mountHints: mountHints,
 		root:       info,
+		containers: map[string]int{args.ID: 0},
 	}
 
 	// We don't care about child signals; some platforms can generate a

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -385,9 +385,8 @@ func (c *Container) Start(conf *config.Config) error {
 			}
 
 			if conf.RestoreFile != "" {
-				return c.Sandbox.RestoreContainer(c.Spec, conf, c.ID, ioFiles)
-			} else {
-				return c.Sandbox.StartContainer(c.Spec, conf, c.ID, ioFiles)
+				// TODO/TRAVIS: Do we need to pass stdios here?
+				return c.Sandbox.RestoreContainer(c.Spec, conf, c.ID, goferFiles)
 			}
 
 			return c.Sandbox.StartContainer(c.Spec, conf, c.ID, stdios, goferFiles)
@@ -449,7 +448,7 @@ func (c *Container) RestoreRoot(spec *specs.Spec, conf *config.Config, restoreFi
 	return c.saveLocked()
 }
 
-func (c *Container) Restore(spec *specs.Spec, conf *conf.Config, restoreFile string) error {
+func (c *Container) Restore(spec *specs.Spec, conf *config.Config, restoreFile string) error {
 	log.Debugf("Restore container %q", c.ID)
 	if isRoot(spec) {
 		return c.RestoreRoot(spec, conf, restoreFile)

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -385,8 +385,7 @@ func (c *Container) Start(conf *config.Config) error {
 			}
 
 			if conf.RestoreFile != "" {
-				// TODO/TRAVIS: Do we need to pass stdios here?
-				return c.Sandbox.RestoreContainer(c.Spec, conf, c.ID, goferFiles)
+				return c.Sandbox.RestoreContainer(c.Spec, conf, c.ID, stdios, goferFiles)
 			}
 
 			return c.Sandbox.StartContainer(c.Spec, conf, c.ID, stdios, goferFiles)

--- a/runsc/container/state_file.go
+++ b/runsc/container/state_file.go
@@ -305,10 +305,16 @@ func (s *StateFile) saveLocked(v interface{}) error {
 }
 
 func (s *StateFile) load(v interface{}) error {
-	if err := s.lock(); err != nil {
-		return err
-	}
-	defer s.unlock()
+	// FIXME: root container restore will lock the state file
+	// then when child container load root container's state file,
+	// the below s.lock() will need wait till root container's
+	// restore finish. But since root container's restore is also
+	// waiting for child container to appear, this will deadlock.
+	// skip lock for now.
+//	if err := s.lock(); err != nil {
+//		return err
+//	}
+//	defer s.unlock()
 
 	metaBytes, err := ioutil.ReadFile(s.statePath())
 	if err != nil {

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -248,12 +248,12 @@ func (s *Sandbox) StartContainer(spec *specs.Spec, conf *config.Config, cid stri
 }
 
 // Restore sends the restore call for a container in the sandbox.
-func (s *Sandbox) RestoreRoot(cid string, spec *specs.Spec, conf *config.Config, filename string) error {
+func (s *Sandbox) RestoreRoot(cid string, spec *specs.Spec, conf *config.Config, restoreFile string) error {
 	log.Debugf("Restore sandbox %q", s.ID)
 
-	rf, err := os.Open(filename)
+	rf, err := os.Open(restoreFile)
 	if err != nil {
-		return fmt.Errorf("opening restore file %q failed: %v", filename, err)
+		return fmt.Errorf("opening restore file %q failed: %v", restoreFile, err)
 	}
 	defer rf.Close()
 

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -292,7 +292,7 @@ func (s *Sandbox) RestoreRoot(cid string, spec *specs.Spec, conf *config.Config,
 }
 
 // RestoreContainer sends the restore call for a container in the sandbox.
-func (s *Sandbox) RestoreContainer(spec *specs.Spec, conf *boot.Config, cid string, goferFiles []*os.File) error {
+func (s *Sandbox) RestoreContainer(spec *specs.Spec, conf *config.Config, cid string, goferFiles []*os.File) error {
 	log.Debugf("Restore child container %q in sandbox %q.", cid, s.ID)
 
 	// The payload must container stdin/stdout/stderr followed by gofer


### PR DESCRIPTION
This is a functionality I would love to use, so I decided to dust off @aaronlu's old `multicontainer` branch (rebasing an almost year-old branch isn't fun...).

I'm not terribly terribly familiar with the gVisor codebase (or even Go in general, to be honest), so this PR is more draft than anything. If anyone has the time and bandwidth to help me with this (or wants to take it over themselves) I'd be very grateful (I'll buy you a coffee or something for your time).

# What the PR does
It's big, sorry. At a high level, it just changed the existing restore (which only works for the root container) and separates it into _restore-root_ and _restore-container_ specific commands.

For a sandbox running n containers (1 root container and n-1 child containers):
* `RootRestore` does some initial setup (for the root container) and then waits for the n-1 child containers to send a restore _start_ event (via `cm.restoreStartChan`)
* `ContainerRestore` sets up the per-container restore environment
  * This requires restoring an array of restore environments, rather than just one
* `ContainerRestore` sends its _start_ event and then waits for the restore _done_ (which is sent from `RootRestore` via -cm.restoreResultChan`)
*  When all n-1 child containers have sent their _start_ events, `RootRestore` does the normal restore stuff and then sends the restore _done_ event to all the child containers
* `ContainerRestore` then does whatever clean is necessary

## Concerns & questions
This is all predicated on knowing which container is which by assigning each container an index within the sandbox (the root container is index 0). We can't use container id since it might change between checkpoint/restore.
* This requires assuming that the containers will be created and then restored in the same order. I don't know if this is a problematic assumption (especially if you want to use this in conjunction with something like Kubernetes/CRI -- which I personally do). An alternative might be to try to use the container name (via the CRI annotation) and fallback to indices if it's not specified (e.g., outside of CRI environments).

There's currently a TODO in the code about passing `stdios` in `RestoreContainer` (looks like that change was made for `StartContainer` somewhere between April and now, so I think I need to just make sure the logic there is parallel.