### PR TITLE
return root pids with runsc ps

### DIFF
--- a/pkg/sentry/control/proc.go
+++ b/pkg/sentry/control/proc.go
@@ -334,8 +334,8 @@ func PrintPIDsJSON(pl []*Process) (string, error) {
 func Processes(k *kernel.Kernel, containerID string, out *[]*Process) error {
 	ts := k.TaskSet()
 	now := k.RealtimeClock().Now()
-	for _, tg := range ts.Root.ThreadGroups() {
-		pidns := tg.PIDNamespace()
+	pidns := ts.Root
+	for _, tg := range pidns.ThreadGroups() {
 		pid := pidns.IDOfThreadGroup(tg)
 
 		// If tg has already been reaped ignore it.

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -203,7 +203,7 @@ func TestMultiPIDNS(t *testing.T) {
 				t.Errorf("failed to wait for sleep to start: %v", err)
 			}
 			expectedPL = []*control.Process{
-				newProcessBuilder().PID(1).Cmd("sleep").Process(),
+				newProcessBuilder().PID(2).Cmd("sleep").Process(),
 			}
 			if err := waitForProcessList(containers[1], expectedPL); err != nil {
 				t.Errorf("failed to wait for sleep to start: %v", err)
@@ -291,14 +291,16 @@ func TestMultiPIDNSPath(t *testing.T) {
 			if err := waitForProcessList(containers[0], expectedPL); err != nil {
 				t.Errorf("failed to wait for sleep to start: %v", err)
 			}
-			if err := waitForProcessList(containers[2], expectedPL); err != nil {
-				t.Errorf("failed to wait for sleep to start: %v", err)
-			}
-
 			expectedPL = []*control.Process{
 				newProcessBuilder().PID(2).PPID(0).Cmd("sleep").Process(),
 			}
 			if err := waitForProcessList(containers[1], expectedPL); err != nil {
+				t.Errorf("failed to wait for sleep to start: %v", err)
+			}
+			expectedPL = []*control.Process{
+				newProcessBuilder().PID(3).PPID(0).Cmd("sleep").Process(),
+			}
+			if err := waitForProcessList(containers[2], expectedPL); err != nil {
 				t.Errorf("failed to wait for sleep to start: %v", err)
 			}
 
@@ -371,14 +373,13 @@ func TestMultiPIDNSKill(t *testing.T) {
 			const processes = 3
 			testSpecs, ids := createSpecs(cmd, cmd)
 
-			// TODO: Uncomment after https://github.com/google/gvisor/pull/5519.
-			//testSpecs[1].Linux = &specs.Linux{
-			//	Namespaces: []specs.LinuxNamespace{
-			//		{
-			//			Type: "pid",
-			//		},
-			//	},
-			//}
+			testSpecs[1].Linux = &specs.Linux{
+				Namespaces: []specs.LinuxNamespace{
+					{
+						Type: "pid",
+					},
+				},
+			}
 
 			containers, cleanup, err := startContainers(conf, testSpecs, ids)
 			if err != nil {


### PR DESCRIPTION
`runsc ps` currently return pid for a task's immediate pid namespace,
which is confusing when there're multiple pid namespaces. We should
return only pids in the root namespace.

Before:

```
1000      1         0         0         ?         02:24     250ms     chrome
1000      1         0         0         ?         02:24     40ms      dumb-init
1000      1         0         0         ?         02:24     240ms     chrome
1000      2         1         0         ?         02:24     2.78s     node
```

After:

```
UID       PID       PPID      C         TTY       STIME     TIME      CMD
1000      1         0         0         ?         12:35     0s        dumb-init
1000      2         1         7         ?         12:35     240ms     node
1000      13        2         21        ?         12:35     2.33s     chrome
1000      27        13        3         ?         12:35     260ms     chrome
```

Signed-off-by: Daniel Dao <dqminh@cloudflare.com>