### PR TITLE
[POC] kvm: Introduce watchdog for vCPU

### DIFF
--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -1,4 +1,5 @@
 load("//tools:defs.bzl", "go_library", "go_test")
+load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(licenses = ["notice"])
 
@@ -6,6 +7,7 @@ go_library(
     name = "kvm",
     srcs = [
         "address_space.go",
+        "atomicptr_vcpu_unsafe.go",
         "bluepill.go",
         "bluepill_allocator.go",
         "bluepill_amd64.go",
@@ -81,9 +83,21 @@ go_test(
         "//pkg/sentry/platform",
         "//pkg/sentry/platform/kvm/testutil",
         "//pkg/sentry/time",
+        "//pkg/sync",
         "//pkg/usermem",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_template_instance(
+    name = "atomicptr_vcpu",
+    out = "atomicptr_vcpu_unsafe.go",
+    package = "kvm",
+    suffix = "VCPU",
+    template = "//pkg/sync:generic_atomicptr",
+    types = {
+        "Value": "vCPU",
+    },
 )
 
 genrule(

--- a/pkg/sentry/platform/kvm/address_space.go
+++ b/pkg/sentry/platform/kvm/address_space.go
@@ -42,7 +42,7 @@ func (ds *dirtySet) forEach(m *machine, fn func(c *vCPU)) {
 					continue
 				}
 				id := 64*index + bit
-				fn(m.vCPUsByID[id])
+				fn(m.vCPUsByID[id].Load())
 			}
 		}
 	}

--- a/pkg/sentry/platform/kvm/machine_unsafe.go
+++ b/pkg/sentry/platform/kvm/machine_unsafe.go
@@ -169,3 +169,13 @@ func (c *vCPU) setSignalMask() error {
 
 	return nil
 }
+
+// watchdogTimestamp returns monotonic time in seconds.
+//
+//go:nosplit
+func watchdogTimestamp() int64 {
+	ts := unix.Timespec{}
+	unix.RawSyscall(unix.SYS_CLOCK_GETTIME, uintptr(linux.CLOCK_MONOTONIC), uintptr(unsafe.Pointer(&ts)), 0)
+	return ts.Sec
+
+}


### PR DESCRIPTION
The watchdog prints a warning message if a vCPU is stuck for more than 30 seconds.