### PR TITLE
arm64 kvm: use TLBI with "Inner Shareable" instead of IPI operation

### DIFF
--- a/pkg/ring0/pagetables/pcids.go
+++ b/pkg/ring0/pagetables/pcids.go
@@ -93,6 +93,18 @@ func (p *PCIDs) Assign(pt *PageTables) (uint16, bool) {
 	return 0, false
 }
 
+// GetPCID returns the cached PCID.
+func (p *PCIDs) GetPCID(pt *PageTables) uint16 {
+	p.mu.Lock()
+	value, ok := p.cache[pt]
+	p.mu.Unlock()
+
+	if !ok {
+		value = 0
+	}
+	return value
+}
+
 // Drop drops references to a set of page tables.
 func (p *PCIDs) Drop(pt *PageTables) {
 	p.mu.Lock()

--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -6,6 +6,8 @@ go_library(
     name = "kvm",
     srcs = [
         "address_space.go",
+        "address_space_amd64.go",
+        "address_space_arm64.go",
         "bluepill.go",
         "bluepill_allocator.go",
         "bluepill_amd64.go",

--- a/pkg/sentry/platform/kvm/address_space.go
+++ b/pkg/sentry/platform/kvm/address_space.go
@@ -85,15 +85,6 @@ type addressSpace struct {
 	dirtySet *dirtySet
 }
 
-// invalidate is the implementation for Invalidate.
-func (as *addressSpace) invalidate() {
-	as.dirtySet.forEach(as.machine, func(c *vCPU) {
-		if c.active.get() == as { // If this happens to be active,
-			c.BounceToKernel() // ... force a kernel transition.
-		}
-	})
-}
-
 // Invalidate interrupts all dirty contexts.
 func (as *addressSpace) Invalidate() {
 	as.mu.Lock()

--- a/pkg/sentry/platform/kvm/address_space_amd64.go
+++ b/pkg/sentry/platform/kvm/address_space_amd64.go
@@ -1,0 +1,24 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+// invalidate is the implementation for Invalidate.
+func (as *addressSpace) invalidate() {
+	as.dirtySet.forEach(as.machine, func(c *vCPU) {
+		if c.active.get() == as { // If this happens to be active,
+			c.BounceToKernel() // ... force a kernel transition.
+		}
+	})
+}

--- a/pkg/sentry/platform/kvm/address_space_arm64.go
+++ b/pkg/sentry/platform/kvm/address_space_arm64.go
@@ -1,0 +1,38 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+import (
+	"gvisor.dev/gvisor/pkg/ring0"
+)
+
+// invalidate is the implementation for Invalidate.
+func (as *addressSpace) invalidate() {
+	asids := map[uint16]byte{} // Store unique primary keys
+
+	as.dirtySet.forEach(as.machine, func(c *vCPU) {
+		if c.active.get() == as { // If this happens to be active,
+			asid := c.PCIDs.GetPCID(as.pageTables)
+			if asid != 0 {
+				_, ok := asids[asid]
+				if !ok {
+					bluepill(as.pageTables.Allocator.(*allocator).cpu)
+					ring0.FlushTlbByASID(uintptr(asid))
+				}
+				asids[asid] = 1
+			}
+		}
+	})
+}


### PR DESCRIPTION
When I do the java benchmark testing(https://github.com/linksgo2011/jmh-reports), 
I can see there are so much bound-s,  these operations greatly affect performance.
So, I changed the logic in invalidate().

on Arm64 platform, we can use TLBI with 'IS' instead of IPI operation.

According to my understanding, the logic in invalidate() is much like
an IPI operation.

On Arm64, we can simply perform inner-shareable invalidation here, not
use IPI.

I think using FlushTlbByVA here is a better way. Maybe I can deliver it in another PR.

Signed-off-by: Robin Luk <lubin.lu@antgroup.com>