### PR TITLE
make/release: Sign a package only once

### DIFF
--- a/tools/make_apt.sh
+++ b/tools/make_apt.sh
@@ -107,7 +107,9 @@ for pkg in "$@"; do
   cp -a -L "$(dirname "${pkg}")/${name}.deb" "${destdir}"
   cp -a -L "$(dirname "${pkg}")/${name}.changes" "${destdir}"
   chmod 0644 "${destdir}"/"${name}".*
+  # Sign a package only if it isn't signed yet.
   # We use [*] here to expand the gpg_opts array into a single shell-word.
+  dpkg-sig -g "${gpg_opts[*]}" --verify "${destdir}/${name}.deb" ||
   dpkg-sig -g "${gpg_opts[*]}" --sign builder "${destdir}/${name}.deb"
 done
 


### PR DESCRIPTION
We can generate more than one apt repo for the same package.  If we will
sign a package again, its file will be changed and all hashes that have
been generated before will be invalid.