### PR TITLE
VFS2: fix /dev/shm mount permissions

### DIFF
--- a/pkg/sentry/fsimpl/devtmpfs/devtmpfs.go
+++ b/pkg/sentry/fsimpl/devtmpfs/devtmpfs.go
@@ -215,16 +215,25 @@ func (a *Accessor) UserspaceInit(ctx context.Context) error {
 		}
 	}
 
-	// systemd: src/core/mount-setup.c:mount_table
-	for _, dir := range []string{
-		"shm",
-		"pts",
+	// systemd: src/shared/mount-setup.c:mount_table
+	for _, dir := range []struct {
+		path string
+		mode linux.FileMode
+	}{
+		{
+			path: "shm",
+			mode: 01777,
+		},
+		{
+			path: "pts",
+			mode: 0755,
+		},
 	} {
-		if err := a.vfsObj.MkdirAt(actx, a.creds, a.pathOperationAt(dir), &vfs.MkdirOptions{
-			// systemd: src/core/mount-setup.c:mount_one()
-			Mode: 0755,
+		if err := a.vfsObj.MkdirAt(actx, a.creds, a.pathOperationAt(dir.path), &vfs.MkdirOptions{
+			// systemd: src/shared/mount-setup.c:mount_one()
+			Mode: dir.mode,
 		}); err != nil {
-			return fmt.Errorf("failed to create directory %q: %v", dir, err)
+			return fmt.Errorf("failed to create directory %q: %v", dir.path, err)
 		}
 	}
 

--- a/pkg/sentry/fsimpl/devtmpfs/devtmpfs_test.go
+++ b/pkg/sentry/fsimpl/devtmpfs/devtmpfs_test.go
@@ -127,9 +127,21 @@ func TestUserspaceInit(t *testing.T) {
 		}
 	}
 
-	dirs := []string{"shm", "pts"}
+	dirs := []struct {
+		path string
+		mode uint16
+	}{
+		{
+			path: "shm",
+			mode: 01777,
+		},
+		{
+			path: "pts",
+			mode: 0755,
+		},
+	}
 	for _, dir := range dirs {
-		abspath := path.Join(devPath, dir)
+		abspath := path.Join(devPath, dir.path)
 		statx, err := vfsObj.StatAt(ctx, creds, &vfs.PathOperation{
 			Root:  root,
 			Start: root,
@@ -141,7 +153,7 @@ func TestUserspaceInit(t *testing.T) {
 			t.Errorf("stat(%q): got error %v ", abspath, err)
 			continue
 		}
-		if want := uint16(0755) | linux.S_IFDIR; statx.Mode != want {
+		if want := dir.mode | linux.S_IFDIR; statx.Mode != want {
 			t.Errorf("stat(%q): got mode %x, want %x", abspath, statx.Mode, want)
 		}
 	}


### PR DESCRIPTION
This fixes #5687 where `/dev/shm` is mounted with `0755` permissions instead of `1777`. 

With this change applied:

```
# gvisor w/ vfs2
root@gvisor:~/gvisor# docker run --rm --runtime=runsc-vfs2 ubuntu:focal stat -c '%a %n' /dev/shm
1777 /dev/shm

# vanilla docker
root@gvisor:~/gvisor# docker run --rm ubuntu:focal stat -c '%a %n' /dev/shm
1777 /dev/shm

# gvisor w/ vfs
root@gvisor:~/gvisor# docker run --rm --runtime=runsc ubuntu:focal stat -c '%a %n' /dev/shm
777 /dev/shm
```

Sidenote: looking at the referenced systemd mount table in [mount-setup.c](https://github.com/systemd/systemd/blob/fee6441601c979165ebcbb35472036439f8dad5f/src/shared/mount-setup.c#L81-L82), `/dev/pts` seems to be mounted with `0620` permissions however that does not line up with what I see locally on a vanilla Docker container without gvisor. `0755` seems to be right mode for it.