### PR TITLE
Fallback to legacy system time logic when host does not have TSC_CONTROL

### DIFF
--- a/pkg/sentry/platform/kvm/kvm_const.go
+++ b/pkg/sentry/platform/kvm/kvm_const.go
@@ -66,6 +66,7 @@ const (
 	_KVM_CAP_ARM_VM_IPA_SIZE       = 0xa5
 	_KVM_CAP_VCPU_EVENTS           = 0x29
 	_KVM_CAP_ARM_INJECT_SERROR_ESR = 0x9e
+	_KVM_CAP_TSC_CONTROL           = 0x3c
 )
 
 // KVM limits.

--- a/pkg/sentry/platform/kvm/machine_amd64.go
+++ b/pkg/sentry/platform/kvm/machine_amd64.go
@@ -213,6 +213,11 @@ func (c *vCPU) setSystemTime() error {
 	// capabilities as it is emulated in KVM. We don't actually use this
 	// capability, but it means that this method should be robust to
 	// different hardware configurations.
+
+	// if tsc scaling is not supported, fallback to legacy mode
+	if !c.machine.tscControl {
+		return c.setSystemTimeLegacy()
+	}
 	rawFreq, err := c.getTSCFreq()
 	if err != nil {
 		return c.setSystemTimeLegacy()


### PR DESCRIPTION
If the host doesn't have TSC scaling feature, then scaling down TSC to
the lowest value will fail, and we will fall back to legacy logic
anyway, but we leave an ugly log message in host's kernel log.

  kernel: user requested TSC rate below hardware speed

Instead, check for KVM_CAP_TSC_CONTROL when initializing KVM, and fall
back to legacy logic early if host's cpu doesn't support that.

Signed-off-by: Daniel Dao <dqminh89@gmail.com>