### PR TITLE
Disable mitigate and related test on ARM64

### DIFF
--- a/runsc/cmd/mitigate.go
+++ b/runsc/cmd/mitigate.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"runtime"
 
 	"github.com/google/subcommands"
 	"gvisor.dev/gvisor/pkg/log"
@@ -71,6 +72,11 @@ func (m *Mitigate) SetFlags(f *flag.FlagSet) {
 
 // Execute implements subcommands.Command.Execute.
 func (m *Mitigate) Execute(_ context.Context, f *flag.FlagSet, args ...interface{}) subcommands.ExitStatus {
+	if runtime.GOARCH == "arm64" || runtime.GOARCH == "arm" {
+		log.Warningf("As ARM is not affected by MDS, mitigate does not support")
+		return subcommands.ExitFailure
+	}
+
 	if f.NArg() != 0 {
 		f.Usage()
 		return subcommands.ExitUsageError

--- a/runsc/cmd/mitigate_test.go
+++ b/runsc/cmd/mitigate_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build amd64
+
 package cmd
 
 import (

--- a/runsc/mitigate/mitigate_test.go
+++ b/runsc/mitigate/mitigate_test.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build amd64
+
 package mitigate
 
 import (


### PR DESCRIPTION
As MDS side channel attack does not affect ARM64, we disable
mitigate on ARM64 in case misusage.

For more detail, please refer to:
https://access.redhat.com/security/vulnerabilities/mds

Signed-off-by: Howard Zhang <howard.zhang@arm.com>