### PR TITLE
platform/kvm/x86: restore mxcsr when switching from guest to sentry

### DIFF
--- a/pkg/ring0/kernel_amd64.go
+++ b/pkg/ring0/kernel_amd64.go
@@ -250,6 +250,7 @@ func (c *CPU) SwitchToUser(switchOpts SwitchOpts) (vector Vector) {
 	}
 	SaveFloatingPoint(switchOpts.FloatingPointState.BytePointer()) // escapes: no. Copy out floating point.
 	WriteFS(uintptr(c.registers.Fs_base))                          // escapes: no. Restore kernel FS.
+	ldmxcsr(&kernelMXCSR)                                          // escapes: no. Restore kernel MXCSR.
 	return
 }
 
@@ -320,4 +321,14 @@ func SetCPUIDFaulting(on bool) bool {
 //go:nosplit
 func ReadCR2() uintptr {
 	return readCR2()
+}
+
+// kernelMXCSR is the value of the mxcsr register in the Sentry.
+//
+// The MXCSR control configuration is initialized once and never changed. Look
+// at src/cmd/compile/abi-internal.md in the golang sources for more details.
+var kernelMXCSR uint32
+
+func init() {
+	stmxcsr(&kernelMXCSR)
 }

--- a/pkg/ring0/lib_amd64.go
+++ b/pkg/ring0/lib_amd64.go
@@ -61,6 +61,12 @@ func wrgsbase(addr uintptr)
 // wrgsmsr writes to the GS_BASE MSR.
 func wrgsmsr(addr uintptr)
 
+// stmxcsr reads the MXCSR control and status register.
+func stmxcsr(addr *uint32)
+
+// ldmxcsr writes to the MXCSR control and status register.
+func ldmxcsr(addr *uint32)
+
 // readCR2 reads the current CR2 value.
 func readCR2() uintptr
 

--- a/pkg/ring0/lib_amd64.s
+++ b/pkg/ring0/lib_amd64.s
@@ -198,3 +198,15 @@ TEXT ·rdmsr(SB),NOSPLIT,$0-16
 	MOVL AX, ret+8(FP)
 	MOVL DX, ret+12(FP)
 	RET
+
+// stmxcsr reads the MXCSR control and status register.
+TEXT ·stmxcsr(SB),NOSPLIT,$0-8
+	MOVQ addr+0(FP), SI
+	STMXCSR (SI)
+	RET
+
+// ldmxcsr writes to the MXCSR control and status register.
+TEXT ·ldmxcsr(SB),NOSPLIT,$0-8
+	MOVQ addr+0(FP), SI
+	LDMXCSR (SI)
+	RET

--- a/pkg/sentry/arch/fpu/fpu_amd64.go
+++ b/pkg/sentry/arch/fpu/fpu_amd64.go
@@ -219,6 +219,11 @@ func (s *State) PtraceSetXstateRegs(src io.Reader, maxlen int, featureSet *cpuid
 	return copy(*s, f), nil
 }
 
+// SetMXCSR sets the MXCSR control/status register in the state.
+func (s *State) SetMXCSR(mxcsr uint32) {
+	hostarch.ByteOrder.PutUint32((*s)[mxcsrOffset:], mxcsr)
+}
+
 // BytePointer returns a pointer to the first byte of the state.
 //
 //go:nosplit

--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -66,6 +66,7 @@ go_test(
     srcs = [
         "kvm_amd64_test.go",
         "kvm_arm64_test.go",
+        "kvm_amd64_test.s",
         "kvm_test.go",
         "virtual_map_test.go",
     ],

--- a/pkg/sentry/platform/kvm/kvm_amd64_test.s
+++ b/pkg/sentry/platform/kvm/kvm_amd64_test.s
@@ -1,0 +1,21 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "textflag.h"
+
+// stmxcsr reads the MXCSR control and status register.
+TEXT ·stmxcsr(SB),NOSPLIT,$0-8
+	MOVQ addr+0(FP), SI
+	STMXCSR (SI)
+	RET


### PR DESCRIPTION
Goruntime sets mxcsr once and never changes it.

Reported-by: syzbot+ec55cea6e57ec083b7a6@syzkaller.appspotmail.com
Fixes: #5754