### PR TITLE
Fix typo of arg name on assembly files in the safecopy package

### DIFF
--- a/pkg/safecopy/atomic_amd64.s
+++ b/pkg/safecopy/atomic_amd64.s
@@ -24,12 +24,12 @@ TEXT handleSwapUint32Fault(SB), NOSPLIT, $0-24
   MOVL DI, sig+20(FP)
   RET
 
-// swapUint32 atomically stores new into *addr and returns (the previous *addr
+// swapUint32 atomically stores new into *ptr and returns (the previous ptr*
 // value, 0). If a SIGSEGV or SIGBUS signal is received during the swap, the
 // value of old is unspecified, and sig is the number of the signal that was
 // received.
 //
-// Preconditions: addr must be aligned to a 4-byte boundary.
+// Preconditions: ptr must be aligned to a 4-byte boundary.
 //
 //func swapUint32(ptr unsafe.Pointer, new uint32) (old uint32, sig int32)
 TEXT ·swapUint32(SB), NOSPLIT, $0-24
@@ -38,7 +38,7 @@ TEXT ·swapUint32(SB), NOSPLIT, $0-24
   // handleSwapUint32Fault will store a different value in this address.
   MOVL $0, sig+20(FP)
 
-  MOVQ addr+0(FP), DI
+  MOVQ ptr+0(FP), DI
   MOVL new+8(FP), AX
   XCHGL AX, 0(DI)
   MOVL AX, old+16(FP)
@@ -60,12 +60,12 @@ TEXT handleSwapUint64Fault(SB), NOSPLIT, $0-28
   MOVL DI, sig+24(FP)
   RET
 
-// swapUint64 atomically stores new into *addr and returns (the previous *addr
+// swapUint64 atomically stores new into *ptr and returns (the previous *ptr
 // value, 0). If a SIGSEGV or SIGBUS signal is received during the swap, the
 // value of old is unspecified, and sig is the number of the signal that was
 // received.
 //
-// Preconditions: addr must be aligned to a 8-byte boundary.
+// Preconditions: ptr must be aligned to a 8-byte boundary.
 //
 //func swapUint64(ptr unsafe.Pointer, new uint64) (old uint64, sig int32)
 TEXT ·swapUint64(SB), NOSPLIT, $0-28
@@ -74,7 +74,7 @@ TEXT ·swapUint64(SB), NOSPLIT, $0-28
   // handleSwapUint64Fault will store a different value in this address.
   MOVL $0, sig+24(FP)
 
-  MOVQ addr+0(FP), DI
+  MOVQ ptr+0(FP), DI
   MOVQ new+8(FP), AX
   XCHGQ AX, 0(DI)
   MOVQ AX, old+16(FP)
@@ -97,11 +97,11 @@ TEXT handleCompareAndSwapUint32Fault(SB), NOSPLIT, $0-24
   RET
 
 // compareAndSwapUint32 is like sync/atomic.CompareAndSwapUint32, but returns
-// (the value previously stored at addr, 0). If a SIGSEGV or SIGBUS signal is
+// (the value previously stored at ptr, 0). If a SIGSEGV or SIGBUS signal is
 // received during the operation, the value of prev is unspecified, and sig is
 // the number of the signal that was received.
 //
-// Preconditions: addr must be aligned to a 4-byte boundary.
+// Preconditions: ptr must be aligned to a 4-byte boundary.
 //
 //func compareAndSwapUint32(ptr unsafe.Pointer, old, new uint32) (prev uint32, sig int32)
 TEXT ·compareAndSwapUint32(SB), NOSPLIT, $0-24
@@ -111,7 +111,7 @@ TEXT ·compareAndSwapUint32(SB), NOSPLIT, $0-24
   // address.
   MOVL $0, sig+20(FP)
 
-  MOVQ addr+0(FP), DI
+  MOVQ ptr+0(FP), DI
   MOVL old+8(FP), AX
   MOVL new+12(FP), DX
   LOCK
@@ -135,11 +135,11 @@ TEXT handleLoadUint32Fault(SB), NOSPLIT, $0-16
   MOVL DI, sig+12(FP)
   RET
 
-// loadUint32 atomically loads *addr and returns it. If a SIGSEGV or SIGBUS
+// loadUint32 atomically loads *ptr and returns it. If a SIGSEGV or SIGBUS
 // signal is received, the value returned is unspecified, and sig is the number
 // of the signal that was received.
 //
-// Preconditions: addr must be aligned to a 4-byte boundary.
+// Preconditions: ptr must be aligned to a 4-byte boundary.
 //
 //func loadUint32(ptr unsafe.Pointer) (val uint32, sig int32)
 TEXT ·loadUint32(SB), NOSPLIT, $0-16
@@ -148,7 +148,7 @@ TEXT ·loadUint32(SB), NOSPLIT, $0-16
   // handleLoadUint32Fault will store a different value in this address.
   MOVL $0, sig+12(FP)
 
-  MOVQ addr+0(FP), AX
+  MOVQ ptr+0(FP), AX
   MOVL (AX), BX
   MOVL BX, val+8(FP)
   RET

--- a/pkg/safecopy/atomic_arm64.s
+++ b/pkg/safecopy/atomic_arm64.s
@@ -25,7 +25,7 @@ TEXT ·swapUint32(SB), NOSPLIT, $0-24
 	// handleSwapUint32Fault will store a different value in this address.
 	MOVW $0, sig+20(FP)
 again:
-	MOVD addr+0(FP), R0
+	MOVD ptr+0(FP), R0
 	MOVW new+8(FP), R1
 	LDAXRW (R0), R2
 	STLXRW R1, (R0), R3
@@ -60,7 +60,7 @@ TEXT ·swapUint64(SB), NOSPLIT, $0-28
 	// handleSwapUint64Fault will store a different value in this address.
 	MOVW $0, sig+24(FP)
 again:
-	MOVD addr+0(FP), R0
+	MOVD ptr+0(FP), R0
 	MOVD new+8(FP), R1
 	LDAXR (R0), R2
 	STLXR R1, (R0), R3
@@ -96,7 +96,7 @@ TEXT ·compareAndSwapUint32(SB), NOSPLIT, $0-24
 	// address.
 	MOVW $0, sig+20(FP)
 
-	MOVD addr+0(FP), R0
+	MOVD ptr+0(FP), R0
 	MOVW old+8(FP), R1
 	MOVW new+12(FP), R2
 again:
@@ -125,11 +125,11 @@ TEXT handleLoadUint32Fault(SB), NOSPLIT, $0-16
 	MOVW R1, sig+12(FP)
 	RET
 
-// loadUint32 atomically loads *addr and returns it. If a SIGSEGV or SIGBUS
+// loadUint32 atomically loads *ptr and returns it. If a SIGSEGV or SIGBUS
 // signal is received, the value returned is unspecified, and sig is the number
 // of the signal that was received.
 //
-// Preconditions: addr must be aligned to a 4-byte boundary.
+// Preconditions: ptr must be aligned to a 4-byte boundary.
 //
 //func loadUint32(ptr unsafe.Pointer) (val uint32, sig int32)
 TEXT ·loadUint32(SB), NOSPLIT, $0-16
@@ -138,7 +138,7 @@ TEXT ·loadUint32(SB), NOSPLIT, $0-16
 	// handleLoadUint32Fault will store a different value in this address.
 	MOVW $0, sig+12(FP)
 
-	MOVD addr+0(FP), R0
+	MOVD ptr+0(FP), R0
 	LDARW (R0), R1
 	MOVW R1, val+8(FP)
 	RET

--- a/pkg/safecopy/memcpy_amd64.s
+++ b/pkg/safecopy/memcpy_amd64.s
@@ -51,8 +51,8 @@ TEXT ·memcpy(SB), NOSPLIT, $0-36
 	// handleMemcpyFault will store a different value in this address.
 	MOVL	$0, sig+32(FP)
 
-	MOVQ	to+0(FP), DI
-	MOVQ	from+8(FP), SI
+	MOVQ	dst+0(FP), DI
+	MOVQ	src+8(FP), SI
 	MOVQ	n+16(FP), BX
 
 tail:

--- a/pkg/safecopy/memcpy_arm64.s
+++ b/pkg/safecopy/memcpy_arm64.s
@@ -33,8 +33,8 @@ TEXT ·memcpy(SB), NOSPLIT, $-8-36
 	// handleMemcpyFault will store a different value in this address.
 	MOVW $0, sig+32(FP)
 
-	MOVD to+0(FP), R3
-	MOVD from+8(FP), R4
+	MOVD dst+0(FP), R3
+	MOVD src+8(FP), R4
 	MOVD n+16(FP), R5
 	CMP $0, R5
 	BNE check


### PR DESCRIPTION
Fix typo of arg name on assembly files.

In the `safecopy` package, wrong arg name on assembler files. actually `ptr` but documentation and assembly code both of `addr`.