### PR TITLE
Fix typo of Syncutil to sync on sync packages README

### DIFF
--- a/pkg/sync/README.md
+++ b/pkg/sync/README.md
@@ -1,4 +1,4 @@
-# Syncutil
+# sync
 
 This package provides additional synchronization primitives not provided by the
 Go stdlib 'sync' package. It is partially derived from the upstream 'sync'


### PR DESCRIPTION
Fix typo of `Syncutil` to `sync` on `sync` packages README.

I assume `Syncutil` is an old name, just fix it to the correct package name.