### PR TITLE
calibrate defaultOverheadCycles for ARM64

### DIFF
--- a/pkg/sentry/time/BUILD
+++ b/pkg/sentry/time/BUILD
@@ -25,6 +25,8 @@ go_library(
         "muldiv_arm64.s",
         "parameters.go",
         "sampler.go",
+        "sampler_amd64.go",
+        "sampler_arm64.go",
         "sampler_unsafe.go",
         "seqatomic_parameters_unsafe.go",
         "tsc_amd64.s",

--- a/pkg/sentry/time/sampler.go
+++ b/pkg/sentry/time/sampler.go
@@ -21,13 +21,6 @@ import (
 )
 
 const (
-	// defaultOverheadTSC is the default estimated syscall overhead in TSC cycles.
-	// It is further refined as syscalls are made.
-	defaultOverheadCycles = 1 * 1000
-
-	// maxOverheadCycles is the maximum allowed syscall overhead in TSC cycles.
-	maxOverheadCycles = 100 * defaultOverheadCycles
-
 	// maxSampleLoops is the maximum number of times to try to get a clock sample
 	// under the expected overhead.
 	maxSampleLoops = 5

--- a/pkg/sentry/time/sampler_amd64.go
+++ b/pkg/sentry/time/sampler_amd64.go
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "textflag.h"
+//+build amd64
 
-TEXT ·Rdtsc(SB),NOSPLIT,$0-8
-	// Get the virtual counter.
-	ISB	$15
-	WORD	$0xd53be040     //MRS	CNTVCT_EL0, R0
-	MOVD	R0, ret+0(FP)
-	RET
+package time
 
-TEXT ·getCNTFRQ(SB),NOSPLIT,$0-8
-	// Get the virtual counter frequency.
-	WORD	$0xd53be000     //MRS	CNTFRQ_EL0, R0
-	MOVD	R0, ret+0(FP)
-	RET
+const(
+	// defaultOverheadTSC is the default estimated syscall overhead in TSC cycles.
+	// It is further refined as syscalls are made.
+	defaultOverheadCycles = 1 * 1000
+
+	// maxOverheadCycles is the maximum allowed syscall overhead in TSC cycles.
+	maxOverheadCycles = 100 * defaultOverheadCycles
+)

--- a/pkg/sentry/time/sampler_arm64.go
+++ b/pkg/sentry/time/sampler_arm64.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build arm64
+
+package time
+
+// getCNTFRQ get ARM counter-timer frequency
+func getCNTFRQ() TSCValue
+
+// getDefaultArchOverheadCycles get default OverheadCycles based on
+// ARM counter-timer frequency. Usually ARM counter-timer frequency
+// is range from 1-50Mhz which is much less than that on x86, so we
+// calibrate defaultOverheadCycles for ARM.
+func getDefaultArchOverheadCycles() TSCValue {
+	// estimated the clock frequency on x86 is 1Ghz.
+	// 1Ghz devided by counter-timer frequency of ARM to get
+	// frqRatio. defaultOverheadCycles of ARM equals to that on
+	// x86 devided by frqRatio
+	cntfrq := getCNTFRQ()
+	frqRatio := 1000000000 / cntfrq
+	overheadCycles := ( 1 * 1000 ) / frqRatio
+	return overheadCycles
+}
+
+// defaultOverheadTSC is the default estimated syscall overhead in TSC cycles.
+// It is further refined as syscalls are made.
+var defaultOverheadCycles = getDefaultArchOverheadCycles()
+
+// maxOverheadCycles is the maximum allowed syscall overhead in TSC cycles.
+var maxOverheadCycles = 100 * defaultOverheadCycles


### PR DESCRIPTION
Usually ARM counter-timer frequency is range from 1-50Mhz which is
much less than that on x86, so we calibrate defaultOverheadCycles
for ARM.

Signed-off-by: howard zhang <howard.zhang@arm.com>