### PR TITLE
Allow use of IFF_ONE_QUEUE

### DIFF
--- a/pkg/abi/linux/ioctl_tun.go
+++ b/pkg/abi/linux/ioctl_tun.go
@@ -26,4 +26,7 @@ const (
 	IFF_TAP      = 0x0002
 	IFF_NO_PI    = 0x1000
 	IFF_NOFILTER = 0x1000
+
+	// According to linux/if_tun.h "This flag has no real effect"
+	IFF_ONE_QUEUE = 0x2000
 )

--- a/pkg/sentry/socket/netstack/tun.go
+++ b/pkg/sentry/socket/netstack/tun.go
@@ -40,7 +40,7 @@ func LinuxToTUNFlags(flags uint16) (tun.Flags, error) {
 	// Linux adds IFF_NOFILTER (the same value as IFF_NO_PI unfortunately)
 	// when there is no sk_filter. See __tun_chr_ioctl() in
 	// net/drivers/tun.c.
-	if flags&^uint16(linux.IFF_TUN|linux.IFF_TAP|linux.IFF_NO_PI) != 0 {
+	if flags&^uint16(linux.IFF_TUN|linux.IFF_TAP|linux.IFF_NO_PI|linux.IFF_ONE_QUEUE) != 0 {
 		return tun.Flags{}, syserror.EINVAL
 	}
 	return tun.Flags{


### PR DESCRIPTION
Before this fix usage of this flag returns an error.
It affects applications like OpenVPN which sets this flag for legacy reasons. 
According to linux/if_tun.h:
```
/* This flag has no real effect */
#define IFF_ONE_QUEUE	0x2000
```
