### PR TITLE
Support empty device name in TUNSETIFF

### DIFF
--- a/pkg/abi/linux/netdevice.go
+++ b/pkg/abi/linux/netdevice.go
@@ -57,7 +57,9 @@ func (ifr *IFReq) Name() string {
 
 // SetName sets the name.
 func (ifr *IFReq) SetName(name string) {
-	n := copy(ifr.IFName[:], []byte(name))
+	// Note that name should never exceed len(ifr.IFName)-1
+	// to preserve null terminator
+	n := copy(ifr.IFName[:len(ifr.IFName)-1], []byte(name))
 	for i := n; i < len(ifr.IFName); i++ {
 		ifr.IFName[i] = 0
 	}

--- a/pkg/sentry/devices/tundev/tundev.go
+++ b/pkg/sentry/devices/tundev/tundev.go
@@ -16,6 +16,7 @@
 package tundev
 
 import (
+	"fmt"
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/hostarch"
@@ -64,6 +65,15 @@ type tunFD struct {
 	device tun.Device
 }
 
+func ifaceNameExists(name string, stack *netstack.Stack) bool {
+	for _, iface := range stack.Interfaces() {
+		if iface.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 // Ioctl implements vfs.FileDescriptionImpl.Ioctl.
 func (fd *tunFD) Ioctl(ctx context.Context, uio usermem.IO, args arch.SyscallArguments) (uintptr, error) {
 	request := args[1].Uint()
@@ -94,6 +104,41 @@ func (fd *tunFD) Ioctl(ctx context.Context, uio usermem.IO, args arch.SyscallArg
 		if err != nil {
 			return 0, err
 		}
+
+		if req.Name() == "" {
+			var prefixFmt string
+			if flags.TUN {
+				prefixFmt = "tun%d"
+			} else if flags.TAP {
+				prefixFmt = "tap%d"
+			} else {
+				return 0, syserror.EINVAL
+			}
+
+			for i := 0; i < len(stack.Interfaces())+1; i++ {
+				dev := fmt.Sprintf(prefixFmt, i)
+				if !ifaceNameExists(dev, stack) {
+					req.SetName(dev)
+					break
+				}
+			}
+
+			// Populate if_name with the new name: Note that the character pointer becomes
+			// overwritten with the real device name (e.g. "tun0")
+			_, err := req.CopyOut(t, data)
+			if err != nil {
+				return 0, err
+			}
+		}
+
+		// Note that this check is also required if req.Name() == "",
+		// in case the %d somehow exceeds the buffer size and therefore "chopped"
+		// to the buffer length, which causes the resulted name to be equal to an existed
+		// interface name.
+		if ifaceNameExists(req.Name(), stack) {
+			return 0, syserror.EINVAL
+		}
+
 		return 0, fd.device.SetIff(stack.Stack, req.Name(), flags)
 
 	case linux.TUNGETIFF:


### PR DESCRIPTION
In Linux there is a common practice of invoking TUNSETIFF request with an empty ifr_name.
The Linux behavior is to populate the ifr_name buffer with a newly generated name, i.e. tun%d or tap%d, based  on the requested device type. The %d is replaced with the first available index starting from zero.

Currently gVisor does not support this feature and uses the empty ifr_name "as-is", which could be considered a bug, as empty interface names are not allowed in Linux.

Fixes #6034.