### PR TITLE
arm64 kvm:use TLBI with "Inner Shareable" instead of IPI operation

### DIFF
--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -6,6 +6,8 @@ go_library(
     name = "kvm",
     srcs = [
         "address_space.go",
+        "address_space_amd64.go",
+        "address_space_arm64.go",
         "bluepill.go",
         "bluepill_allocator.go",
         "bluepill_amd64.go",

--- a/pkg/sentry/platform/kvm/address_space.go
+++ b/pkg/sentry/platform/kvm/address_space.go
@@ -85,15 +85,6 @@ type addressSpace struct {
 	dirtySet *dirtySet
 }
 
-// invalidate is the implementation for Invalidate.
-func (as *addressSpace) invalidate() {
-	as.dirtySet.forEach(as.machine, func(c *vCPU) {
-		if c.active.get() == as { // If this happens to be active,
-			c.BounceToKernel() // ... force a kernel transition.
-		}
-	})
-}
-
 // Invalidate interrupts all dirty contexts.
 func (as *addressSpace) Invalidate() {
 	as.mu.Lock()

--- a/pkg/sentry/platform/kvm/address_space_amd64.go
+++ b/pkg/sentry/platform/kvm/address_space_amd64.go
@@ -1,0 +1,24 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+// invalidate is the implementation for Invalidate.
+func (as *addressSpace) invalidate() {
+	as.dirtySet.forEach(as.machine, func(c *vCPU) {
+		if c.active.get() == as { // If this happens to be active,
+			c.BounceToKernel() // ... force a kernel transition.
+		}
+	})
+}

--- a/pkg/sentry/platform/kvm/address_space_arm64.go
+++ b/pkg/sentry/platform/kvm/address_space_arm64.go
@@ -1,0 +1,25 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kvm
+
+import (
+	"gvisor.dev/gvisor/pkg/ring0"
+)
+
+// invalidate is the implementation for Invalidate.
+func (as *addressSpace) invalidate() {
+	bluepill(as.pageTables.Allocator.(*allocator).cpu)
+	ring0.FlushTlbAll()
+}


### PR DESCRIPTION
on Arm64 platform, we can use TLBI with 'IS' instead of IPI operation.

According to my understanding, the logic in invalidate() is much like
an IPI operation.

On Arm64, we can simply perform vmalle1is invalidation here, not
use IPI.

Reference:
https://github.com/torvalds/linux/blob/v5.12/arch/arm64/kvm/mmu.c#L81

* [x]  Tested on Ampere N1, @zhlhahaha
* [x]  Tested on my arm server.

Signed-off-by: Robin Luk <lubin.lu@antgroup.com>