### PR TITLE
Add support for RTM_NEWROUTE

### DIFF
--- a/pkg/sentry/inet/inet.go
+++ b/pkg/sentry/inet/inet.go
@@ -75,6 +75,9 @@ type Stack interface {
 	// RouteTable returns the network stack's route table.
 	RouteTable() []Route
 
+	// AddRoute adds route to the route table.
+	AddRoute(route Route) error
+
 	// Resume restarts the network stack after restore.
 	Resume()
 

--- a/pkg/sentry/socket/hostinet/stack.go
+++ b/pkg/sentry/socket/hostinet/stack.go
@@ -469,6 +469,11 @@ func (s *Stack) RouteTable() []inet.Route {
 	return append([]inet.Route(nil), s.routes...)
 }
 
+// AddRoute implements inet.Stack.AddRoute.
+func (s *Stack) AddRoute(route inet.Route) error {
+	return syserror.EACCES
+}
+
 // Resume implements inet.Stack.Resume.
 func (s *Stack) Resume() {}
 

--- a/pkg/sentry/socket/netlink/message.go
+++ b/pkg/sentry/socket/netlink/message.go
@@ -50,7 +50,7 @@ func NewMessage(hdr linux.NetlinkMessageHeader) *Message {
 
 // ParseMessage parses the first message seen at buf, returning the rest of the
 // buffer. If message is malformed, ok of false is returned. For last message,
-// padding check is loose, if there isn't enought padding, whole buf is consumed
+// padding check is loose, if there isn't enough padding, whole buf is consumed
 // and ok is set to true.
 func ParseMessage(buf []byte) (msg *Message, rest []byte, ok bool) {
 	b := BytesView(buf)

--- a/pkg/sentry/socket/netlink/route/BUILD
+++ b/pkg/sentry/socket/netlink/route/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/socket/netlink",
         "//pkg/syserr",
+        "//pkg/syserror",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/sentry/socket/netstack/stack.go
+++ b/pkg/sentry/socket/netstack/stack.go
@@ -433,6 +433,20 @@ func (s *Stack) RouteTable() []inet.Route {
 	return routeTable
 }
 
+// AddRoute implements inet.Stack.AddRoute.
+func (s *Stack) AddRoute(route inet.Route) error {
+	address := tcpip.AddressWithPrefix{
+		Address:   tcpip.Address(route.DstAddr),
+		PrefixLen: int(route.DstLen),
+	}
+	rt := tcpip.Route {
+		Destination: address.Subnet(),
+		Gateway:     tcpip.Address(route.GatewayAddr),
+		NIC:         tcpip.NICID(route.OutputInterface),
+	}
+	return syserr.TranslateNetstackError(s.Stack.AddRoute(rt)).ToError()
+}
+
 // IPTables returns the stack's iptables.
 func (s *Stack) IPTables() (*stack.IPTables, error) {
 	return s.Stack.IPTables(), nil

--- a/pkg/syserr/netstack.go
+++ b/pkg/syserr/netstack.go
@@ -52,6 +52,8 @@ var (
 	ErrBadBuffer             = New((&tcpip.ErrBadBuffer{}).String(), linux.EFAULT)
 	ErrMalformedHeader       = New((&tcpip.ErrMalformedHeader{}).String(), linux.EINVAL)
 	ErrInvalidPortRange      = New((&tcpip.ErrInvalidPortRange{}).String(), linux.EINVAL)
+	ErrDuplicateRoute        = New((&tcpip.ErrDuplicateRoute{}).String(), linux.EEXIST)
+	ErrInvalidGateway        = New((&tcpip.ErrInvalidGateway{}).String(), linux.EINVAL)
 )
 
 // TranslateNetstackError converts an error from the tcpip package to a sentry
@@ -138,6 +140,10 @@ func TranslateNetstackError(err tcpip.Error) *Error {
 		return ErrMalformedHeader
 	case *tcpip.ErrInvalidPortRange:
 		return ErrInvalidPortRange
+	case *tcpip.ErrDuplicateRoute:
+		return ErrDuplicateRoute
+	case *tcpip.ErrInvalidGateway:
+		return ErrInvalidGateway
 	default:
 		panic(fmt.Sprintf("unknown error %T", err))
 	}

--- a/pkg/tcpip/errors.go
+++ b/pkg/tcpip/errors.go
@@ -552,4 +552,30 @@ func (*ErrWouldBlock) IgnoreStats() bool {
 }
 func (*ErrWouldBlock) String() string { return "operation would block" }
 
+// ErrDuplicateRoute indicates an attempt to add route that already exists in the route table.
+//
+// +stateify savable
+type ErrDuplicateRoute struct{}
+
+func (*ErrDuplicateRoute) isError() {}
+
+// IgnoreStats implements Error.
+func (*ErrDuplicateRoute) IgnoreStats() bool {
+	return true
+}
+func (*ErrDuplicateRoute) String() string { return "Route already exists in the route table" }
+
+// ErrInvalidGateway indicates an attempt to add route with invalid gateway.
+//
+// +stateify savable
+type ErrInvalidGateway struct{}
+
+func (*ErrInvalidGateway) isError() {}
+
+// IgnoreStats implements Error.
+func (*ErrInvalidGateway) IgnoreStats() bool {
+	return true
+}
+func (*ErrInvalidGateway) String() string { return "Invalid gateway in route" }
+
 // LINT.ThenChange(../syserr/netstack.go)

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -578,6 +579,9 @@ func (s *Stack) SetRouteTable(table []tcpip.Route) {
 	s.route.mu.Lock()
 	defer s.route.mu.Unlock()
 	s.route.mu.table = table
+	sort.Slice(s.route.mu.table, func(i, j int) bool {
+		return s.route.mu.table[i].Destination.Prefix() < s.route.mu.table[j].Destination.Prefix()
+	})
 }
 
 // GetRouteTable returns the route table which is currently in use.
@@ -587,11 +591,44 @@ func (s *Stack) GetRouteTable() []tcpip.Route {
 	return append([]tcpip.Route(nil), s.route.mu.table...)
 }
 
+func (s *Stack) findRouteNic(route tcpip.Route) tcpip.NICID {
+	protocol := header.IPv4ProtocolNumber
+	if len(route.Gateway) == header.IPv6AddressSize {
+		protocol = header.IPv6ProtocolNumber
+	}
+	r, err := s.FindRoute(0, "", route.Gateway, protocol, false)
+	if err != nil {
+		return tcpip.NICID(-1)
+	}
+	return r.NICID()
+}
+
 // AddRoute appends a route to the route table.
-func (s *Stack) AddRoute(route tcpip.Route) {
+func (s *Stack) AddRoute(route tcpip.Route) tcpip.Error {
+	nicID := tcpip.NICID(-1)
+	if len(route.Gateway) != 0 {
+		nicID = s.findRouteNic(route)
+	} else if _, ok := s.nics[route.NIC]; ok {
+		nicID = route.NIC
+	}
+	if nicID == tcpip.NICID(-1) {
+		return &tcpip.ErrInvalidGateway{}
+	}
+	route.NIC = nicID
 	s.route.mu.Lock()
 	defer s.route.mu.Unlock()
-	s.route.mu.table = append(s.route.mu.table, route)
+
+	// Route table sorted insert
+	index := sort.Search(len(s.route.mu.table), func(i int) bool {
+		return route.Destination.Prefix() <= s.route.mu.table[i].Destination.Prefix()
+	})
+	if index < len(s.route.mu.table) && s.route.mu.table[index] == route {
+		return &tcpip.ErrDuplicateRoute{}
+	}
+	s.route.mu.table = append(s.route.mu.table, tcpip.Route{})
+	copy(s.route.mu.table[index+1:], s.route.mu.table[index:])
+	s.route.mu.table[index] = route
+	return nil
 }
 
 // RemoveRoutes removes matching routes from the route table.
@@ -1160,8 +1197,8 @@ func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, n
 	if r := func() *Route {
 		s.route.mu.RLock()
 		defer s.route.mu.RUnlock()
-
-		for _, route := range s.route.mu.table {
+		for i := len(s.route.mu.table)-1; i >= 0; i-- {
+			route := s.route.mu.table[i]
 			if len(remoteAddr) != 0 && !route.Destination.Contains(remoteAddr) {
 				continue
 			}


### PR DESCRIPTION
In Linux RTM_NEWROUTE netlink message allows users to add route entry to the routing table ("ip route add").

This commits adds this feature to gVisor.
In addition it fixes multiple bugs with the route traversal in tcpip/stack/stack.go.

Fixes part of #578 