### PR TITLE
Implement msgget(2) and msgctl(IPC_RMID)

### DIFF
--- a/pkg/abi/linux/BUILD
+++ b/pkg/abi/linux/BUILD
@@ -41,6 +41,7 @@ go_library(
         "linux.go",
         "membarrier.go",
         "mm.go",
+        "msgqueue.go",
         "netdevice.go",
         "netfilter.go",
         "netfilter_ipv6.go",

--- a/pkg/abi/linux/msgqueue.go
+++ b/pkg/abi/linux/msgqueue.go
@@ -1,0 +1,108 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linux
+
+import (
+	"gvisor.dev/gvisor/pkg/marshal/primitive"
+)
+
+// Linux-specific control commands. Source: include/uapi/linux/msg.h
+const (
+	MSG_STAT     = 11
+	MSG_INFO     = 12
+	MSG_STAT_ANY = 13
+)
+
+// msgrcv(2) options. Source: include/uapi/linux/msg.h
+const (
+	MSG_NOERROR = 010000 // No error if message is too big.
+	MSG_EXCEPT  = 020000 // Receive any message except of specified type.
+	MSG_COPY    = 040000 // Copy (not remove) all queue messages.
+)
+
+// System-wide limits for message queues. Source: include/uapi/linux/msg.h
+const (
+	MSGMNI = 32000 // Maximum number of message queue identifiers.
+	MSGMAX = 8192  // Maximum size of message (bytes).
+	MSGMNB = 16384 // Default max size of a message queue.
+)
+
+// System-wide limits. Unused. Source: include/uapi/linux/msg.h
+const (
+	MSGPOOL = (MSGMNI * MSGMNB / 1024)
+	MSGTQL  = MSGMNB
+	MSGMAP  = MSGMNB
+	MSGSSZ  = 16
+
+	// MSGSEG is simplified due to the inexistance of a ternary operator.
+	MSGSEG = (MSGPOOL * 1024) / MSGSSZ
+)
+
+// MsqidDS is equivelant to struct msqid64_ds. Source:
+// include/uapi/asm-generic/shmbuf.h
+//
+// +marshal
+type MsqidDS struct {
+	MsgPerm   IPCPerm // IPC permissions.
+	MsgStime  TimeT   // Last msgsnd time.
+	MsgRtime  TimeT   // Last msgrcv time.
+	MsgCtime  TimeT   // Last change time.
+	MsgCbytes uint64  // Current number of bytes on the queue.
+	MsgQnum   uint64  // Number of messages in the queue.
+	MsgQbytes uint64  // Max number of bytes in the queue.
+	MsgLspid  int32   // PID of last msgsnd.
+	MsgLrpid  int32   // PID of last msgrcv.
+	unused4   uint64
+	unused5   uint64
+}
+
+// MsgBuf is equivelant to struct msgbuf. Source: include/uapi/linux/msg.h
+//
+// +marshal dynamic
+type MsgBuf struct {
+	Type primitive.Int64
+	Text primitive.ByteSlice
+}
+
+// SizeBytes implements marshal.Marshallable.SizeBytes.
+func (b *MsgBuf) SizeBytes() int {
+	return b.Type.SizeBytes() + b.Text.SizeBytes()
+}
+
+// MarshalBytes implements marshal.Marshallable.MarshalBytes.
+func (b *MsgBuf) MarshalBytes(dst []byte) {
+	b.Type.MarshalUnsafe(dst)
+	b.Text.MarshalBytes(dst[b.Type.SizeBytes():])
+}
+
+// UnmarshalBytes implements marshal.Marshallable.UnmarshalBytes.
+func (b *MsgBuf) UnmarshalBytes(src []byte) {
+	b.Type.UnmarshalUnsafe(src)
+	b.Text.UnmarshalBytes(src[b.Type.SizeBytes():])
+}
+
+// MsgInfo is equivelant to struct msginfo. Source: include/uapi/linux/msg.h
+//
+// +marshal
+type MsgInfo struct {
+	MsgPool int32
+	MsgMap  int32
+	MsgMax  int32
+	MsgMnb  int32
+	MsgMni  int32
+	MsgSsz  int32
+	MsgTql  int32
+	MsgSeg  uint16 `marshal:"unaligned"`
+}

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -256,6 +256,7 @@ go_library(
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/kernel/epoll",
         "//pkg/sentry/kernel/futex",
+        "//pkg/sentry/kernel/msgqueue",
         "//pkg/sentry/kernel/sched",
         "//pkg/sentry/kernel/semaphore",
         "//pkg/sentry/kernel/shm",

--- a/pkg/sentry/kernel/ipc/BUILD
+++ b/pkg/sentry/kernel/ipc/BUILD
@@ -6,10 +6,14 @@ go_library(
     name = "ipc",
     srcs = [
         "object.go",
+        "registry.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [
         "//pkg/abi/linux",
+        "//pkg/context",
+        "//pkg/errors/linuxerr",
+        "//pkg/log",
         "//pkg/sentry/fs",
         "//pkg/sentry/kernel/auth",
     ],

--- a/pkg/sentry/kernel/ipc/BUILD
+++ b/pkg/sentry/kernel/ipc/BUILD
@@ -1,0 +1,16 @@
+load("//tools:defs.bzl", "go_library")
+
+package(licenses = ["notice"])
+
+go_library(
+    name = "ipc",
+    srcs = [
+        "object.go",
+    ],
+    visibility = ["//pkg/sentry:internal"],
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/sentry/fs",
+        "//pkg/sentry/kernel/auth",
+    ],
+)

--- a/pkg/sentry/kernel/ipc/object.go
+++ b/pkg/sentry/kernel/ipc/object.go
@@ -1,0 +1,107 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipc defines functionality and utilities common to sysvipc mechanisms.
+package ipc
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/fs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// Key is a user-provided identifier for IPC objects.
+type Key int32
+
+// ID is a kernel identifier for IPC objects.
+type ID int32
+
+// Object represents an abstract IPC object with fields common to all IPC
+// mechanisms.
+type Object struct {
+	// User namespace which owns the IPC namespace which owns the IPC object.
+	// Immutable.
+	UserNS *auth.UserNamespace
+
+	// ID is a kernel identifier for the IPC object. Immutable.
+	ID ID
+
+	// Key is a user-provided identifier for the IPC object. Immutable.
+	Key Key
+
+	// Creator is the user who created the IPC object. Immutable.
+	Creator fs.FileOwner
+
+	// Owner is the current owner of the IPC object.
+	Owner fs.FileOwner
+
+	// Perms is the access permissions the IPC object.
+	Perms fs.FilePermissions
+}
+
+// Mechanism represents a SysV mechanism that holds an IPC object. It can also
+// be looked at as a container for an ipc.Object, which is by definition a fully
+// functional SysV object.
+type Mechanism interface {
+	// Object returns a pointer to the mechanism's ipc.Object. Mechanism.Lock,
+	// and Mechanism.Unlock should be used when the object is used.
+	Object() *Object
+
+	// Lock behaves the same as Mutex.Lock on the mechanism.
+	Lock()
+
+	// Unlock behaves the same as Mutex.Unlock on the mechanism.
+	Unlock()
+}
+
+// NewObject returns a new, initialized ipc.Object.
+func NewObject(un *auth.UserNamespace, id ID, key Key, creator, owner fs.FileOwner, perms fs.FilePermissions) *Object {
+	return &Object{
+		UserNS:  un,
+		ID:      id,
+		Key:     key,
+		Creator: creator,
+		Owner:   owner,
+		Perms:   perms,
+	}
+}
+
+// CheckOwnership verifies whether an IPC object may be accessed using creds as
+// an owner. See ipc/util.c:ipcctl_obtain_check() in Linux.
+func (o *Object) CheckOwnership(creds *auth.Credentials) bool {
+	if o.Owner.UID == creds.EffectiveKUID || o.Creator.UID == creds.EffectiveKUID {
+		return true
+	}
+
+	// Tasks with CAP_SYS_ADMIN may bypass ownership checks. Strangely, Linux
+	// doesn't use CAP_IPC_OWNER for this despite CAP_IPC_OWNER being documented
+	// for use to "override IPC ownership checks".
+	return creds.HasCapabilityIn(linux.CAP_SYS_ADMIN, o.UserNS)
+}
+
+// CheckPermissions verifies whether an IPC object is accessible using creds for
+// access described by req. See ipc/util.c:ipcperms() in Linux.
+func (o *Object) CheckPermissions(creds *auth.Credentials, req fs.PermMask) bool {
+	p := o.Perms.Other
+	if o.Owner.UID == creds.EffectiveKUID {
+		p = o.Perms.User
+	} else if creds.InGroup(o.Owner.GID) {
+		p = o.Perms.Group
+	}
+
+	if p.SupersetOf(req) {
+		return true
+	}
+	return creds.HasCapabilityIn(linux.CAP_IPC_OWNER, o.UserNS)
+}

--- a/pkg/sentry/kernel/ipc/registry.go
+++ b/pkg/sentry/kernel/ipc/registry.go
@@ -1,0 +1,196 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipc
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// Registry is similar to Object, but for registries. It represent an abstract
+// SysV IPC registry with fields common to all SysV registries. Registry is not
+// thread-safe, and should be protected using a mutex.
+//
+// +stateify savable
+type Registry struct {
+	// UserNS owning the IPC namespace this registry belongs to. Immutable.
+	UserNS *auth.UserNamespace
+
+	// objects is a map of IDs to IPC mechanisms.
+	objects map[ID]Mechanism
+
+	// KeysToIDs maps a lookup key to an ID.
+	keysToIDs map[Key]ID
+
+	// lastIDUsed is used to find the next available ID for object creation.
+	lastIDUsed ID
+}
+
+// NewRegistry return a new, initialized ipc.Registry.
+func NewRegistry(userNS *auth.UserNamespace) *Registry {
+	return &Registry{
+		UserNS:    userNS,
+		objects:   make(map[ID]Mechanism),
+		keysToIDs: make(map[Key]ID),
+	}
+}
+
+// Find uses key to search for and return a SysV mechanism. Find returns an
+// error if an object is found by shouldn't be, or if the user doesn't have
+// permission to use the object. If no object is found, Find checks create
+// flag, and returns an error only if it's false.
+func (r *Registry) Find(ctx context.Context, key Key, mode linux.FileMode, create, exclusive bool) (Mechanism, error) {
+	if id, ok := r.keysToIDs[key]; ok {
+		mech := r.objects[id]
+		mech.Lock()
+		defer mech.Unlock()
+
+		obj := mech.Object()
+		creds := auth.CredentialsFromContext(ctx)
+		if !obj.CheckPermissions(creds, fs.PermsFromMode(mode)) {
+			// The [calling process / user] does not have permission to access
+			// the set, and does not have the CAP_IPC_OWNER capability in the
+			// user namespace that governs its IPC namespace.
+			return nil, linuxerr.EACCES
+		}
+
+		if create && exclusive {
+			// IPC_CREAT and IPC_EXCL were specified, but an object already
+			// exists for key.
+			return nil, linuxerr.EEXIST
+		}
+		return mech, nil
+	}
+
+	if !create {
+		// No object exists for key and msgflg did not specify IPC_CREAT.
+		return nil, linuxerr.ENOENT
+	}
+
+	return nil, nil
+}
+
+// Register adds the given object into Registry.Objects, and assigns it a new
+// ID. It returns an error if all IDs are exhausted.
+func (r *Registry) Register(m Mechanism) error {
+	id, err := r.newID()
+	if err != nil {
+		return err
+	}
+
+	obj := m.Object()
+	obj.ID = id
+
+	r.objects[id] = m
+	r.keysToIDs[obj.Key] = id
+
+	return nil
+}
+
+// newID finds the first unused ID in the registry, and returns an error if
+// non is found.
+func (r *Registry) newID() (ID, error) {
+	// Find the next available ID.
+	for id := r.lastIDUsed + 1; id != r.lastIDUsed; id++ {
+		// Handle wrap around.
+		if id < 0 {
+			id = 0
+			continue
+		}
+		if r.objects[id] == nil {
+			r.lastIDUsed = id
+			return id, nil
+		}
+	}
+
+	log.Warningf("ids exhausted, they may be leaking")
+
+	// The man pages for shmget(2) mention that ENOSPC should be used if "All
+	// possible shared memory IDs have been taken (SHMMNI)". Other SysV
+	// mechanisms don't have a specific errno for running out of IDs, but they
+	// return ENOSPC if the max number of objects is exceeded, so we assume that
+	// it's the same case.
+	return 0, linuxerr.ENOSPC
+}
+
+// Remove removes the mechanism with the given id from the registry, and calls
+// mechanism.Destroy to perform mechanism-specific removal.
+func (r *Registry) Remove(id ID, creds *auth.Credentials) error {
+	mech := r.objects[id]
+	if mech == nil {
+		return linuxerr.EINVAL
+	}
+
+	mech.Lock()
+	defer mech.Unlock()
+
+	obj := mech.Object()
+
+	// The effective user ID of the calling process must match the creator or
+	// owner of the [mechanism], or the caller must be privileged.
+	if !obj.CheckOwnership(creds) {
+		return linuxerr.EPERM
+	}
+
+	delete(r.objects, obj.ID)
+	delete(r.keysToIDs, obj.Key)
+	mech.Destroy()
+
+	return nil
+}
+
+// ForAllObjects executes a given function for all given objects.
+func (r *Registry) ForAllObjects(f func(o Mechanism)) {
+	for _, o := range r.objects {
+		f(o)
+	}
+}
+
+// FindByID returns the mechanism with the given ID, nil if non exists.
+func (r *Registry) FindByID(id ID) Mechanism {
+	return r.objects[id]
+}
+
+// DissociateKey removes the association between a mechanism and its key
+// (deletes it from r.keysToIDs), preventing it from being discovered by any new
+// process, but not necessarily destroying it. If the given key doesn't exist,
+// nothing is changed.
+func (r *Registry) DissociateKey(key Key) {
+	delete(r.keysToIDs, key)
+}
+
+// DissociateID removes the association between a mechanism and its ID (deletes
+// it from r.objects). An ID can't be removed unless the associated key is
+// removed already, this is done to prevent the users from acquiring nil a
+// Mechanism.
+//
+// Precondition: must be preceded by a call to r.DissociateKey.
+func (r *Registry) DissociateID(id ID) {
+	delete(r.objects, id)
+}
+
+// ObjectCount returns the number of registered objects.
+func (r *Registry) ObjectCount() int {
+	return len(r.objects)
+}
+
+// LastIDUsed returns the last used ID.
+func (r *Registry) LastIDUsed() ID {
+	return r.lastIDUsed
+}

--- a/pkg/sentry/kernel/ipc_namespace.go
+++ b/pkg/sentry/kernel/ipc_namespace.go
@@ -17,6 +17,7 @@ package kernel
 import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/msgqueue"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/semaphore"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/shm"
 )
@@ -30,6 +31,7 @@ type IPCNamespace struct {
 	// User namespace which owns this IPC namespace. Immutable.
 	userNS *auth.UserNamespace
 
+	queues     *msgqueue.Registry
 	semaphores *semaphore.Registry
 	shms       *shm.Registry
 }
@@ -38,11 +40,17 @@ type IPCNamespace struct {
 func NewIPCNamespace(userNS *auth.UserNamespace) *IPCNamespace {
 	ns := &IPCNamespace{
 		userNS:     userNS,
+		queues:     msgqueue.NewRegistry(userNS),
 		semaphores: semaphore.NewRegistry(userNS),
 		shms:       shm.NewRegistry(userNS),
 	}
 	ns.InitRefs()
 	return ns
+}
+
+// MsgqueueRegistry returns the message queue registry for this namespace.
+func (i *IPCNamespace) MsgqueueRegistry() *msgqueue.Registry {
+	return i.queues
 }
 
 // SemaphoreRegistry returns the semaphore set registry for this namespace.

--- a/pkg/sentry/kernel/msgqueue/BUILD
+++ b/pkg/sentry/kernel/msgqueue/BUILD
@@ -1,0 +1,32 @@
+load("//tools:defs.bzl", "go_library")
+load("//tools/go_generics:defs.bzl", "go_template_instance")
+
+package(licenses = ["notice"])
+
+go_template_instance(
+    name = "message_list",
+    out = "message_list.go",
+    package = "msgqueue",
+    prefix = "msg",
+    template = "//pkg/ilist:generic_list",
+    types = {
+        "Element": "*Message",
+        "Linker": "*Message",
+    },
+)
+
+go_library(
+    name = "msgqueue",
+    srcs = [
+        "msgqueue.go",
+        "message_list.go",
+    ],
+    visibility = ["//pkg/sentry:internal"],
+    deps = [
+        "//pkg/sentry/kernel/auth",
+        "//pkg/sentry/kernel/ipc",
+        "//pkg/sentry/kernel/time",
+        "//pkg/waiter",
+        "//pkg/sync",
+    ],
+)

--- a/pkg/sentry/kernel/msgqueue/BUILD
+++ b/pkg/sentry/kernel/msgqueue/BUILD
@@ -23,10 +23,15 @@ go_library(
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [
+        "//pkg/abi/linux",
+        "//pkg/context",
+        "//pkg/errors/linuxerr",
+        "//pkg/log",
+        "//pkg/sentry/fs",
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/kernel/ipc",
         "//pkg/sentry/kernel/time",
-        "//pkg/waiter",
         "//pkg/sync",
+        "//pkg/waiter",
     ],
 )

--- a/pkg/sentry/kernel/msgqueue/BUILD
+++ b/pkg/sentry/kernel/msgqueue/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/errors/linuxerr",
-        "//pkg/log",
         "//pkg/sentry/fs",
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/kernel/ipc",

--- a/pkg/sentry/kernel/msgqueue/msgqueue.go
+++ b/pkg/sentry/kernel/msgqueue/msgqueue.go
@@ -1,0 +1,111 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package msgqueue implements System V message queues.
+package msgqueue
+
+import (
+	"sync"
+
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/ipc"
+	ktime "gvisor.dev/gvisor/pkg/sentry/kernel/time"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+// Registry contains a set of message queues that can be referenced using keys
+// or IDs.
+//
+// +stateify savable
+type Registry struct {
+	// mu protects all the fields below.
+	mu sync.Mutex `state:"nosave"`
+
+	// reg defines basic fields and operations needed for all SysV registries.
+	reg *ipc.Registry
+}
+
+// Queue represents a SysV message queue, described by sysvipc(7).
+//
+// +stateify savable
+type Queue struct {
+	// registry is the registry owning this queue. Immutable.
+	registry *Registry
+
+	// mu protects all the fields below.
+	mu sync.Mutex `state:"nosave"`
+
+	// obj defines basic fields that should be included in all SysV IPC objects.
+	obj *ipc.Object
+
+	// senders holds a queue of blocked message senders. Senders are notified
+	// when enough space is available in the queue to insert their message.
+	senders waiter.Queue
+
+	// receivers holds a queue of blocked receivers. Receivers are notified
+	// when a new message is inserted into the queue and can be received.
+	receivers waiter.Queue
+
+	// messages is a list of sent messages.
+	messages msgList
+
+	// sendTime is the last time a msgsnd was perfomed.
+	sendTime ktime.Time
+
+	// receiveTime is the last time a msgrcv was performed.
+	receiveTime ktime.Time
+
+	// changeTime is the last time the queue was modified using msgctl.
+	changeTime ktime.Time
+
+	// byteCount is the current number of message bytes in the queue.
+	byteCount uint64
+
+	// messageCount is the current number of messages in the queue.
+	messageCount uint64
+
+	// maxBytes is the maximum allowed number of bytes in the queue, and is also
+	// used as a limit for the number of total possible messages.
+	maxBytes uint64
+
+	// sendPID is the PID of the process that performed the last msgsnd.
+	sendPID int32
+
+	// receivePID is the PID of the process that performed the last msgrcv.
+	receivePID int32
+}
+
+// Message represents a message exchanged through a Queue via msgsnd(2) and
+// msgrcv(2).
+//
+// +stateify savable
+type Message struct {
+	msgEntry
+
+	// mType is an integer representing the type of the sent message.
+	mType int64
+
+	// mText is an untyped block of memory.
+	mText []byte
+
+	// mSize is the size of mText.
+	mSize uint64
+}
+
+// NewRegistry returns a new Registry ready to be used.
+func NewRegistry(userNS *auth.UserNamespace) *Registry {
+	return &Registry{
+		reg: ipc.NewRegistry(userNS),
+	}
+}

--- a/pkg/sentry/kernel/msgqueue/msgqueue.go
+++ b/pkg/sentry/kernel/msgqueue/msgqueue.go
@@ -213,3 +213,8 @@ func (q *Queue) Destroy() {
 	q.senders.Notify(waiter.EventOut)
 	q.receivers.Notify(waiter.EventIn)
 }
+
+// ID returns queue's ID.
+func (q *Queue) ID() ipc.ID {
+	return q.obj.ID
+}

--- a/pkg/sentry/kernel/semaphore/BUILD
+++ b/pkg/sentry/kernel/semaphore/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/log",
         "//pkg/sentry/fs",
         "//pkg/sentry/kernel/auth",
+        "//pkg/sentry/kernel/ipc",
         "//pkg/sentry/kernel/time",
         "//pkg/sync",
         "//pkg/syserror",

--- a/pkg/sentry/kernel/semaphore/BUILD
+++ b/pkg/sentry/kernel/semaphore/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/errors/linuxerr",
-        "//pkg/log",
         "//pkg/sentry/fs",
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/kernel/ipc",
@@ -42,10 +41,11 @@ go_test(
     srcs = ["semaphore_test.go"],
     library = ":semaphore",
     deps = [
-        "//pkg/abi/linux",
-        "//pkg/context",
-        "//pkg/sentry/contexttest",
-        "//pkg/sentry/kernel/auth",
-        "//pkg/syserror",
+        "//pkg/abi/linux",  # keep
+        "//pkg/context",  # keep
+        "//pkg/sentry/contexttest",  # keep
+        "//pkg/sentry/kernel/auth",  # keep
+        "//pkg/sentry/kernel/ipc",  # keep
+        "//pkg/syserror",  # keep
     ],
 )

--- a/pkg/sentry/kernel/semaphore/semaphore_test.go
+++ b/pkg/sentry/kernel/semaphore/semaphore_test.go
@@ -21,6 +21,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/ipc"
 	"gvisor.dev/gvisor/pkg/syserror"
 )
 
@@ -55,7 +56,7 @@ func signalled(ch chan struct{}) bool {
 
 func TestBasic(t *testing.T) {
 	ctx := contexttest.Context(t)
-	set := &Set{ID: 123, sems: make([]sem, 1)}
+	set := &Set{obj: &ipc.Object{ID: 123}, sems: make([]sem, 1)}
 	ops := []linux.Sembuf{
 		{SemOp: 1},
 	}
@@ -76,7 +77,7 @@ func TestBasic(t *testing.T) {
 
 func TestWaitForZero(t *testing.T) {
 	ctx := contexttest.Context(t)
-	set := &Set{ID: 123, sems: make([]sem, 1)}
+	set := &Set{obj: &ipc.Object{ID: 123}, sems: make([]sem, 1)}
 	ops := []linux.Sembuf{
 		{SemOp: 0},
 	}
@@ -115,7 +116,7 @@ func TestWaitForZero(t *testing.T) {
 
 func TestNoWait(t *testing.T) {
 	ctx := contexttest.Context(t)
-	set := &Set{ID: 123, sems: make([]sem, 1)}
+	set := &Set{obj: &ipc.Object{ID: 123}, sems: make([]sem, 1)}
 	ops := []linux.Sembuf{
 		{SemOp: 1},
 	}
@@ -141,8 +142,8 @@ func TestUnregister(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindOrCreate() failed, err: %v", err)
 	}
-	if got := r.FindByID(set.ID); got.ID != set.ID {
-		t.Fatalf("FindById(%d) failed, got: %+v, expected: %+v", set.ID, got, set)
+	if got := r.FindByID(set.obj.ID); got.obj.ID != set.obj.ID {
+		t.Fatalf("FindById(%d) failed, got: %+v, expected: %+v", set.obj.ID, got, set)
 	}
 
 	ops := []linux.Sembuf{
@@ -155,14 +156,14 @@ func TestUnregister(t *testing.T) {
 	}
 
 	creds := auth.CredentialsFromContext(ctx)
-	if err := r.RemoveID(set.ID, creds); err != nil {
-		t.Fatalf("RemoveID(%d) failed, err: %v", set.ID, err)
+	if err := r.RemoveID(set.obj.ID, creds); err != nil {
+		t.Fatalf("RemoveID(%d) failed, err: %v", set.obj.ID, err)
 	}
 	if !set.dead {
 		t.Fatalf("set is not dead: %+v", set)
 	}
-	if got := r.FindByID(set.ID); got != nil {
-		t.Fatalf("FindById(%d) failed, got: %+v, expected: nil", set.ID, got)
+	if got := r.FindByID(set.obj.ID); got != nil {
+		t.Fatalf("FindById(%d) failed, got: %+v, expected: nil", set.obj.ID, got)
 	}
 	for i, ch := range chs {
 		if !signalled(ch) {

--- a/pkg/sentry/kernel/semaphore/semaphore_test.go
+++ b/pkg/sentry/kernel/semaphore/semaphore_test.go
@@ -139,6 +139,7 @@ func TestUnregister(t *testing.T) {
 	ctx := contexttest.Context(t)
 	r := NewRegistry(auth.NewRootUserNamespace())
 	set, err := r.FindOrCreate(ctx, 123, 2, linux.FileMode(0x600), true, true, true)
+
 	if err != nil {
 		t.Fatalf("FindOrCreate() failed, err: %v", err)
 	}
@@ -156,8 +157,8 @@ func TestUnregister(t *testing.T) {
 	}
 
 	creds := auth.CredentialsFromContext(ctx)
-	if err := r.RemoveID(set.obj.ID, creds); err != nil {
-		t.Fatalf("RemoveID(%d) failed, err: %v", set.obj.ID, err)
+	if err := r.Remove(set.obj.ID, creds); err != nil {
+		t.Fatalf("Remove(%d) failed, err: %v", set.obj.ID, err)
 	}
 	if !set.dead {
 		t.Fatalf("set is not dead: %+v", set)

--- a/pkg/sentry/kernel/shm/BUILD
+++ b/pkg/sentry/kernel/shm/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//pkg/sentry/device",
         "//pkg/sentry/fs",
         "//pkg/sentry/kernel/auth",
+        "//pkg/sentry/kernel/ipc",
         "//pkg/sentry/kernel/time",
         "//pkg/sentry/memmap",
         "//pkg/sentry/pgalloc",

--- a/pkg/sentry/syscalls/linux/BUILD
+++ b/pkg/sentry/syscalls/linux/BUILD
@@ -84,6 +84,7 @@ go_library(
         "//pkg/sentry/kernel/epoll",
         "//pkg/sentry/kernel/eventfd",
         "//pkg/sentry/kernel/fasync",
+        "//pkg/sentry/kernel/ipc",
         "//pkg/sentry/kernel/pipe",
         "//pkg/sentry/kernel/sched",
         "//pkg/sentry/kernel/shm",

--- a/pkg/sentry/syscalls/linux/BUILD
+++ b/pkg/sentry/syscalls/linux/BUILD
@@ -25,6 +25,7 @@ go_library(
         "sys_mempolicy.go",
         "sys_mmap.go",
         "sys_mount.go",
+        "sys_msgqueue.go",
         "sys_pipe.go",
         "sys_poll.go",
         "sys_prctl.go",

--- a/pkg/sentry/syscalls/linux/linux64.go
+++ b/pkg/sentry/syscalls/linux/linux64.go
@@ -121,10 +121,10 @@ var AMD64 = &kernel.SyscallTable{
 		65:  syscalls.PartiallySupported("semop", Semop, "Option SEM_UNDO not supported.", nil),
 		66:  syscalls.Supported("semctl", Semctl),
 		67:  syscalls.Supported("shmdt", Shmdt),
-		68:  syscalls.ErrorWithEvent("msgget", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
-		69:  syscalls.ErrorWithEvent("msgsnd", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
-		70:  syscalls.ErrorWithEvent("msgrcv", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
-		71:  syscalls.ErrorWithEvent("msgctl", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
+		68:  syscalls.Supported("msgget", Msgget),
+		69:  syscalls.ErrorWithEvent("msgsnd", linuxerr.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
+		70:  syscalls.ErrorWithEvent("msgrcv", linuxerr.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
+		71:  syscalls.PartiallySupported("msgctl", Msgctl, "Only supports IPC_RMID option.", []string{"gvisor.dev/issue/135"}),
 		72:  syscalls.PartiallySupported("fcntl", Fcntl, "Not all options are supported.", nil),
 		73:  syscalls.PartiallySupported("flock", Flock, "Locks are held within the sandbox only.", nil),
 		74:  syscalls.PartiallySupported("fsync", Fsync, "Full data flush is not guaranteed at this time.", nil),
@@ -616,10 +616,10 @@ var ARM64 = &kernel.SyscallTable{
 		183: syscalls.ErrorWithEvent("mq_timedreceive", syserror.ENOSYS, "", []string{"gvisor.dev/issue/136"}), // TODO(b/29354921)
 		184: syscalls.ErrorWithEvent("mq_notify", syserror.ENOSYS, "", []string{"gvisor.dev/issue/136"}),       // TODO(b/29354921)
 		185: syscalls.ErrorWithEvent("mq_getsetattr", syserror.ENOSYS, "", []string{"gvisor.dev/issue/136"}),   // TODO(b/29354921)
-		186: syscalls.ErrorWithEvent("msgget", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}),          // TODO(b/29354921)
-		187: syscalls.ErrorWithEvent("msgctl", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}),          // TODO(b/29354921)
-		188: syscalls.ErrorWithEvent("msgrcv", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}),          // TODO(b/29354921)
-		189: syscalls.ErrorWithEvent("msgsnd", syserror.ENOSYS, "", []string{"gvisor.dev/issue/135"}),          // TODO(b/29354921)
+		186: syscalls.Supported("msgget", Msgget),
+		187: syscalls.PartiallySupported("msgctl", Msgctl, "Only supports IPC_RMID option.", []string{"gvisor.dev/issue/135"}),
+		188: syscalls.ErrorWithEvent("msgrcv", linuxerr.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
+		189: syscalls.ErrorWithEvent("msgsnd", linuxerr.ENOSYS, "", []string{"gvisor.dev/issue/135"}), // TODO(b/29354921)
 		190: syscalls.Supported("semget", Semget),
 		191: syscalls.Supported("semctl", Semctl),
 		192: syscalls.Supported("semtimedop", Semtimedop),

--- a/pkg/sentry/syscalls/linux/sys_msgqueue.go
+++ b/pkg/sentry/syscalls/linux/sys_msgqueue.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linux
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/ipc"
+)
+
+// Msgget implements msgget(2).
+func Msgget(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
+	key := ipc.Key(args[0].Int())
+	flag := args[1].Int()
+
+	private := key == linux.IPC_PRIVATE
+	create := flag&linux.IPC_CREAT == linux.IPC_CREAT
+	exclusive := flag&linux.IPC_EXCL == linux.IPC_EXCL
+	mode := linux.FileMode(flag & 0777)
+
+	r := t.IPCNamespace().MsgqueueRegistry()
+	queue, err := r.FindOrCreate(t, key, mode, private, create, exclusive)
+	if err != nil {
+		return 0, nil, err
+	}
+	return uintptr(queue.ID()), nil, nil
+}
+
+// Msgctl implements msgctl(2).
+func Msgctl(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
+	id := ipc.ID(args[0].Int())
+	cmd := args[1].Int()
+
+	creds := auth.CredentialsFromContext(t)
+
+	switch cmd {
+	case linux.IPC_RMID:
+		return 0, nil, t.IPCNamespace().MsgqueueRegistry().Remove(id, creds)
+	default:
+		return 0, nil, linuxerr.EINVAL
+	}
+}

--- a/pkg/sentry/syscalls/linux/sys_sem.go
+++ b/pkg/sentry/syscalls/linux/sys_sem.go
@@ -240,7 +240,7 @@ func Semctl(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscal
 func remove(t *kernel.Task, id ipc.ID) error {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	creds := auth.CredentialsFromContext(t)
-	return r.RemoveID(id, creds)
+	return r.Remove(id, creds)
 }
 
 func ipcSet(t *kernel.Task, id ipc.ID, uid auth.UID, gid auth.GID, perms fs.FilePermissions) error {

--- a/pkg/sentry/syscalls/linux/sys_sem.go
+++ b/pkg/sentry/syscalls/linux/sys_sem.go
@@ -26,13 +26,14 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/fs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/ipc"
 )
 
 const opsMax = 500 // SEMOPM
 
 // Semget handles: semget(key_t key, int nsems, int semflg)
 func Semget(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
-	key := args[0].Int()
+	key := ipc.Key(args[0].Int())
 	nsems := args[1].Int()
 	flag := args[2].Int()
 
@@ -46,7 +47,7 @@ func Semget(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscal
 	if err != nil {
 		return 0, nil, err
 	}
-	return uintptr(set.ID), nil, nil
+	return uintptr(set.ID()), nil, nil
 }
 
 // Semtimedop handles: semop(int semid, struct sembuf *sops, size_t nsops, const struct timespec *timeout)
@@ -56,7 +57,7 @@ func Semtimedop(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Sy
 		return Semop(t, args)
 	}
 
-	id := args[0].Int()
+	id := ipc.ID(args[0].Int())
 	sembufAddr := args[1].Pointer()
 	nsops := args[2].SizeT()
 	timespecAddr := args[3].Pointer()
@@ -91,7 +92,7 @@ func Semtimedop(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Sy
 
 // Semop handles: semop(int semid, struct sembuf *sops, size_t nsops)
 func Semop(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
-	id := args[0].Int()
+	id := ipc.ID(args[0].Int())
 	sembufAddr := args[1].Pointer()
 	nsops := args[2].SizeT()
 
@@ -109,7 +110,7 @@ func Semop(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscall
 	return 0, nil, semTimedOp(t, id, ops, false, time.Second)
 }
 
-func semTimedOp(t *kernel.Task, id int32, ops []linux.Sembuf, haveTimeout bool, timeout time.Duration) error {
+func semTimedOp(t *kernel.Task, id ipc.ID, ops []linux.Sembuf, haveTimeout bool, timeout time.Duration) error {
 	set := t.IPCNamespace().SemaphoreRegistry().FindByID(id)
 
 	if set == nil {
@@ -131,7 +132,7 @@ func semTimedOp(t *kernel.Task, id int32, ops []linux.Sembuf, haveTimeout bool, 
 
 // Semctl handles: semctl(int semid, int semnum, int cmd, ...)
 func Semctl(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
-	id := args[0].Int()
+	id := ipc.ID(args[0].Int())
 	num := args[1].Int()
 	cmd := args[2].Int()
 
@@ -210,7 +211,7 @@ func Semctl(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscal
 	case linux.SEM_STAT:
 		arg := args[3].Pointer()
 		// id is an index in SEM_STAT.
-		semid, ds, err := semStat(t, id)
+		semid, ds, err := semStat(t, int32(id))
 		if err != nil {
 			return 0, nil, err
 		}
@@ -222,7 +223,7 @@ func Semctl(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscal
 	case linux.SEM_STAT_ANY:
 		arg := args[3].Pointer()
 		// id is an index in SEM_STAT.
-		semid, ds, err := semStatAny(t, id)
+		semid, ds, err := semStatAny(t, int32(id))
 		if err != nil {
 			return 0, nil, err
 		}
@@ -236,13 +237,13 @@ func Semctl(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscal
 	}
 }
 
-func remove(t *kernel.Task, id int32) error {
+func remove(t *kernel.Task, id ipc.ID) error {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	creds := auth.CredentialsFromContext(t)
 	return r.RemoveID(id, creds)
 }
 
-func ipcSet(t *kernel.Task, id int32, uid auth.UID, gid auth.GID, perms fs.FilePermissions) error {
+func ipcSet(t *kernel.Task, id ipc.ID, uid auth.UID, gid auth.GID, perms fs.FilePermissions) error {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -262,7 +263,7 @@ func ipcSet(t *kernel.Task, id int32, uid auth.UID, gid auth.GID, perms fs.FileP
 	return set.Change(t, creds, owner, perms)
 }
 
-func ipcStat(t *kernel.Task, id int32) (*linux.SemidDS, error) {
+func ipcStat(t *kernel.Task, id ipc.ID) (*linux.SemidDS, error) {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -283,7 +284,7 @@ func semStat(t *kernel.Task, index int32) (int32, *linux.SemidDS, error) {
 	if err != nil {
 		return 0, ds, err
 	}
-	return set.ID, ds, nil
+	return int32(set.ID()), ds, nil
 }
 
 func semStatAny(t *kernel.Task, index int32) (int32, *linux.SemidDS, error) {
@@ -296,10 +297,10 @@ func semStatAny(t *kernel.Task, index int32) (int32, *linux.SemidDS, error) {
 	if err != nil {
 		return 0, ds, err
 	}
-	return set.ID, ds, nil
+	return int32(set.ID()), ds, nil
 }
 
-func setVal(t *kernel.Task, id int32, num int32, val int16) error {
+func setVal(t *kernel.Task, id ipc.ID, num int32, val int16) error {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -310,7 +311,7 @@ func setVal(t *kernel.Task, id int32, num int32, val int16) error {
 	return set.SetVal(t, num, val, creds, int32(pid))
 }
 
-func setValAll(t *kernel.Task, id int32, array hostarch.Addr) error {
+func setValAll(t *kernel.Task, id ipc.ID, array hostarch.Addr) error {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -325,7 +326,7 @@ func setValAll(t *kernel.Task, id int32, array hostarch.Addr) error {
 	return set.SetValAll(t, vals, creds, int32(pid))
 }
 
-func getVal(t *kernel.Task, id int32, num int32) (int16, error) {
+func getVal(t *kernel.Task, id ipc.ID, num int32) (int16, error) {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -335,7 +336,7 @@ func getVal(t *kernel.Task, id int32, num int32) (int16, error) {
 	return set.GetVal(num, creds)
 }
 
-func getValAll(t *kernel.Task, id int32, array hostarch.Addr) error {
+func getValAll(t *kernel.Task, id ipc.ID, array hostarch.Addr) error {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -350,7 +351,7 @@ func getValAll(t *kernel.Task, id int32, array hostarch.Addr) error {
 	return err
 }
 
-func getPID(t *kernel.Task, id int32, num int32) (int32, error) {
+func getPID(t *kernel.Task, id ipc.ID, num int32) (int32, error) {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -369,7 +370,7 @@ func getPID(t *kernel.Task, id int32, num int32) (int32, error) {
 	return int32(tg.ID()), nil
 }
 
-func getZCnt(t *kernel.Task, id int32, num int32) (uint16, error) {
+func getZCnt(t *kernel.Task, id ipc.ID, num int32) (uint16, error) {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {
@@ -379,7 +380,7 @@ func getZCnt(t *kernel.Task, id int32, num int32) (uint16, error) {
 	return set.CountZeroWaiters(num, creds)
 }
 
-func getNCnt(t *kernel.Task, id int32, num int32) (uint16, error) {
+func getNCnt(t *kernel.Task, id ipc.ID, num int32) (uint16, error) {
 	r := t.IPCNamespace().SemaphoreRegistry()
 	set := r.FindByID(id)
 	if set == nil {

--- a/pkg/sentry/syscalls/linux/sys_shm.go
+++ b/pkg/sentry/syscalls/linux/sys_shm.go
@@ -19,12 +19,13 @@ import (
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/ipc"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/shm"
 )
 
 // Shmget implements shmget(2).
 func Shmget(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
-	key := shm.Key(args[0].Int())
+	key := ipc.Key(args[0].Int())
 	size := uint64(args[1].SizeT())
 	flag := args[2].Int()
 
@@ -40,13 +41,13 @@ func Shmget(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscal
 		return 0, nil, err
 	}
 	defer segment.DecRef(t)
-	return uintptr(segment.ID), nil, nil
+	return uintptr(segment.ID()), nil, nil
 }
 
 // findSegment retrives a shm segment by the given id.
 //
 // findSegment returns a reference on Shm.
-func findSegment(t *kernel.Task, id shm.ID) (*shm.Shm, error) {
+func findSegment(t *kernel.Task, id ipc.ID) (*shm.Shm, error) {
 	r := t.IPCNamespace().ShmRegistry()
 	segment := r.FindByID(id)
 	if segment == nil {
@@ -58,7 +59,7 @@ func findSegment(t *kernel.Task, id shm.ID) (*shm.Shm, error) {
 
 // Shmat implements shmat(2).
 func Shmat(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
-	id := shm.ID(args[0].Int())
+	id := ipc.ID(args[0].Int())
 	addr := args[1].Pointer()
 	flag := args[2].Int()
 
@@ -89,7 +90,7 @@ func Shmdt(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscall
 
 // Shmctl implements shmctl(2).
 func Shmctl(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
-	id := shm.ID(args[0].Int())
+	id := ipc.ID(args[0].Int())
 	cmd := args[1].Int()
 	buf := args[2].Pointer()
 

--- a/test/syscalls/BUILD
+++ b/test/syscalls/BUILD
@@ -331,6 +331,10 @@ syscall_test(
 )
 
 syscall_test(
+    test = "//test/syscalls/linux:msgqueue_test",
+)
+
+syscall_test(
     size = "medium",
     test = "//test/syscalls/linux:msync_test",
 )

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4171,6 +4171,18 @@ cc_binary(
 )
 
 cc_binary(
+    name = "msgqueue_test",
+    testonly = 1,
+    srcs = ["msgqueue.cc"],
+    linkstatic = 1,
+    deps = [
+        "//test/util:temp_path",
+        "//test/util:test_main",
+        "//test/util:test_util",
+    ],
+)
+
+cc_binary(
     name = "fadvise64_test",
     testonly = 1,
     srcs = ["fadvise64.cc"],

--- a/test/syscalls/linux/msgqueue.cc
+++ b/test/syscalls/linux/msgqueue.cc
@@ -48,9 +48,6 @@ class Queue {
 
 // Test simple creation and retrieval for msgget(2).
 TEST(MsgqueueTest, MsgGet) {
-  // Don't run test until syscall is implemented.
-  GTEST_SKIP();
-
   const TempPath keyfile = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateFile());
   const key_t key = ftok(keyfile.path().c_str(), 1);
   ASSERT_THAT(key, SyscallSucceeds());
@@ -62,9 +59,6 @@ TEST(MsgqueueTest, MsgGet) {
 
 // Test simple failure scenarios for msgget(2).
 TEST(MsgqueueTest, MsgGetFail) {
-  // Don't run test until syscall is implemented.
-  GTEST_SKIP();
-
   const TempPath keyfile = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateFile());
   const key_t key = ftok(keyfile.path().c_str(), 1);
   ASSERT_THAT(key, SyscallSucceeds());
@@ -79,9 +73,6 @@ TEST(MsgqueueTest, MsgGetFail) {
 
 // Test using msgget(2) with IPC_PRIVATE option.
 TEST(MsgqueueTest, MsgGetIpcPrivate) {
-  // Don't run test until syscall is implemented.
-  GTEST_SKIP();
-
   Queue queue1(msgget(IPC_PRIVATE, 0));
   ASSERT_THAT(queue1.get(), SyscallSucceeds());
 

--- a/test/syscalls/linux/msgqueue.cc
+++ b/test/syscalls/linux/msgqueue.cc
@@ -1,0 +1,96 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/ipc.h>
+#include <sys/msg.h>
+#include <sys/types.h>
+
+#include "test/util/temp_path.h"
+#include "test/util/test_util.h"
+
+namespace gvisor {
+namespace testing {
+namespace {
+
+// Queue is a RAII class used to automatically clean message queues.
+class Queue {
+ public:
+  explicit Queue(int id) : id_(id) {}
+
+  ~Queue() {
+    if (id_ >= 0) {
+      EXPECT_THAT(msgctl(id_, IPC_RMID, nullptr), SyscallSucceeds());
+    }
+  }
+
+  int release() {
+    int old = id_;
+    id_ = -1;
+    return old;
+  }
+
+  int get() { return id_; }
+
+ private:
+  int id_ = -1;
+};
+
+// Test simple creation and retrieval for msgget(2).
+TEST(MsgqueueTest, MsgGet) {
+  // Don't run test until syscall is implemented.
+  GTEST_SKIP();
+
+  const TempPath keyfile = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateFile());
+  const key_t key = ftok(keyfile.path().c_str(), 1);
+  ASSERT_THAT(key, SyscallSucceeds());
+
+  Queue queue(msgget(key, IPC_CREAT));
+  ASSERT_THAT(queue.get(), SyscallSucceeds());
+  EXPECT_THAT(msgget(key, 0), SyscallSucceedsWithValue(queue.get()));
+}
+
+// Test simple failure scenarios for msgget(2).
+TEST(MsgqueueTest, MsgGetFail) {
+  // Don't run test until syscall is implemented.
+  GTEST_SKIP();
+
+  const TempPath keyfile = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateFile());
+  const key_t key = ftok(keyfile.path().c_str(), 1);
+  ASSERT_THAT(key, SyscallSucceeds());
+
+  EXPECT_THAT(msgget(key, 0), SyscallFailsWithErrno(ENOENT));
+
+  Queue queue(msgget(key, IPC_CREAT));
+  ASSERT_THAT(queue.get(), SyscallSucceeds());
+
+  EXPECT_THAT(msgget(key, IPC_CREAT | IPC_EXCL), SyscallFailsWithErrno(EEXIST));
+}
+
+// Test using msgget(2) with IPC_PRIVATE option.
+TEST(MsgqueueTest, MsgGetIpcPrivate) {
+  // Don't run test until syscall is implemented.
+  GTEST_SKIP();
+
+  Queue queue1(msgget(IPC_PRIVATE, 0));
+  ASSERT_THAT(queue1.get(), SyscallSucceeds());
+
+  Queue queue2(msgget(IPC_PRIVATE, 0));
+  ASSERT_THAT(queue2.get(), SyscallSucceeds());
+
+  EXPECT_NE(queue1.get(), queue2.get());
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace gvisor


### PR DESCRIPTION
This implements msgget(2), and the IPC_RMID option for msgctl(2). With this we support creation and deletion of sysv message queues, hopefully to be followed by msgsnd, msgrcv, and msgctl's other options.

The PR is separated into several commits, so I think it'll be easier to review one commit at a time, instead of reviewing it as one whole change.

~Also, the commits in this PR use `ipcutil` which is implemented in #6097. The commit is included here until the PR is reviewed and hopefully merged. When #6097 is merged I'll drop the commit from here and rebase the branch over master.~
#6079 was closed, with `ipc`-related changes included here.

Updates #135