### PR TITLE
Use syserror.EPERM for semctl(IPC_SET) and semctl(IPC_RMID).

### DIFF
--- a/pkg/sentry/kernel/semaphore/semaphore.go
+++ b/pkg/sentry/kernel/semaphore/semaphore.go
@@ -252,7 +252,7 @@ func (r *Registry) RemoveID(id int32, creds *auth.Credentials) error {
 	// "The effective user ID of the calling process must match the creator or
 	// owner of the semaphore set, or the caller must be privileged."
 	if !set.checkCredentials(creds) && !set.checkCapability(creds) {
-		return syserror.EACCES
+		return syserror.EPERM
 	}
 
 	delete(r.semaphores, set.ID)
@@ -370,7 +370,7 @@ func (s *Set) Change(ctx context.Context, creds *auth.Credentials, owner fs.File
 	// "The effective UID of the calling process must match the owner or creator
 	// of the semaphore set, or the caller must be privileged."
 	if !s.checkCredentials(creds) && !s.checkCapability(creds) {
-		return syserror.EACCES
+		return syserror.EPERM
 	}
 
 	s.owner = owner


### PR DESCRIPTION
The man page for semctl(2) specifies that EPERM should be used for
permission errors when cmd argument is IPC_SET or IPC_RMID, with EACCES
being used for all other operations.