### PR TITLE
apply bitmap for fd_table

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1322,6 +1322,12 @@ http_file(
 # pins that we have in go.mod or below. So order actually matters here.
 
 go_repository(
+    name = "com_github_RoaringBitmap_roaring",
+    importpath = "github.com/RoaringBitmap/roaring",
+    commit = "8316baf1c9c3b58455ae1fd92c31250fc64d918c",
+)
+
+go_repository(
     name = "com_github_sirupsen_logrus",
     importpath = "github.com/sirupsen/logrus",
     sum = "h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=",

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -282,6 +282,7 @@ go_library(
         "//pkg/usermem",
         "//pkg/waiter",
         "@org_golang_x_sys//unix:go_default_library",
+        "@com_github_RoaringBitmap_roaring//:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Apply roaring bitmap in fd_table to record open file fd
It can accelerate the speed of allocating or removing fd from
fdtable

Detailed test and performance analysis in #6136

Signed-off-by: Howard Zhang <howard.zhang@arm.com>
