### PR TITLE
Update abseil dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1253,6 +1253,17 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
+# System Call test dependencies.
+http_archive(
+    name = "com_google_absl",
+    sha256 = "1764491a199eb9325b177126547f03d244f86b4ff28f16f206c7b3e7e4f777ec",
+    strip_prefix = "abseil-cpp-278e0a071885a22dcd2fd1b5576cc44757299343",
+    urls = [
+        "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/278e0a071885a22dcd2fd1b5576cc44757299343.tar.gz",
+        "https://github.com/abseil/abseil-cpp/archive/278e0a071885a22dcd2fd1b5576cc44757299343.tar.gz"
+    ],
+)
+
 # Load C++ grpc rules.
 http_archive(
     name = "com_github_grpc_grpc",
@@ -1271,16 +1282,6 @@ load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
 
-# System Call test dependencies.
-http_archive(
-    name = "com_google_absl",
-    sha256 = "56775f1283a59e6274c28d99981a9717ff4e0b1161e9129fdb2fcf22531d8d93",
-    strip_prefix = "abseil-cpp-a0d1e098c2f99694fa399b175a7ccf920762030e",
-    urls = [
-        "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/a0d1e098c2f99694fa399b175a7ccf920762030e.tar.gz",
-        "https://github.com/abseil/abseil-cpp/archive/a0d1e098c2f99694fa399b175a7ccf920762030e.tar.gz",
-    ],
-)
 
 http_archive(
     name = "com_google_googletest",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1254,6 +1254,9 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
 # System Call test dependencies.
+# grpc also has a dependency on abseil but as this is before grpc dependency 
+# declaration, it will take precedence over grpc's one
+# Version LTS 20210324.2
 http_archive(
     name = "com_google_absl",
     sha256 = "1764491a199eb9325b177126547f03d244f86b4ff28f16f206c7b3e7e4f777ec",


### PR DESCRIPTION
When trying to compile the a syscall test using gcc 11, I get this error:
```
bazel test //test/syscalls:exit_test_native
INFO: Analyzed target //test/syscalls:exit_test_native (18 packages loaded, 3659 targets configured).
INFO: Found 1 test target...
ERROR: /home/esteban/.cache/bazel/_bazel_esteban/c255f9c894dd2f447ce001dac56022de/external/com_google_absl/absl/synchronization/BUILD.bazel:30:11: Compiling absl/synchronization/internal/graphcycles.cc failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 32 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 32 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
external/com_google_absl/absl/synchronization/internal/graphcycles.cc: In member function 'void absl::synchronization_internal::GraphCycles::RemoveNode(void*)':
external/com_google_absl/absl/synchronization/internal/graphcycles.cc:450:26: error: 'numeric_limits' is not a member of 'std'
  450 |   if (x->version == std::numeric_limits<uint32_t>::max()) {
      |                          ^~~~~~~~~~~~~~
external/com_google_absl/absl/synchronization/internal/graphcycles.cc:450:49: error: expected primary-expression before '>' token
  450 |   if (x->version == std::numeric_limits<uint32_t>::max()) {
      |                                                 ^
external/com_google_absl/absl/synchronization/internal/graphcycles.cc:450:52: error: '::max' has not been declared; did you mean 'std::max'?
  450 |   if (x->version == std::numeric_limits<uint32_t>::max()) {
      |                                                    ^~~
      |                                                    std::max
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/algorithm:62,
                 from external/com_google_absl/absl/synchronization/internal/graphcycles.cc:38:
/usr/lib/gcc/x86_64-pc-linux-gnu/11.1.0/../../../../include/c++/11.1.0/bits/stl_algo.h:3467:5: note: 'std::max' declared here
 3467 |     max(initializer_list<_Tp> __l, _Compare __comp)
      |     ^~~
Target //test/syscalls:exit_test_native failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 16.203s, Critical Path: 6.00s
INFO: 70 processes: 10 internal, 60 linux-sandbox.
FAILED: Build did NOT complete successfully
//test/syscalls:exit_test_native                                FAILED TO BUILD

FAILED: Build did NOT complete successfully
```

This is due to an out of date version of abseil