### PR TITLE
Fix frame pointer is clobbered before saving vet issue on BP register

### DIFF
--- a/pkg/atomicbitops/atomicbitops_amd64.s
+++ b/pkg/atomicbitops/atomicbitops_amd64.s
@@ -16,21 +16,21 @@
 
 #include "textflag.h"
 
-TEXT ·AndUint32(SB),$0-12
+TEXT ·AndUint32(SB),$8-12
   MOVQ  addr+0(FP), BP
   MOVL  val+8(FP), AX
   LOCK
   ANDL   AX, 0(BP)
   RET
 
-TEXT ·OrUint32(SB),$0-12
+TEXT ·OrUint32(SB),$8-12
   MOVQ  addr+0(FP), BP
   MOVL  val+8(FP), AX
   LOCK
   ORL   AX, 0(BP)
   RET
 
-TEXT ·XorUint32(SB),$0-12
+TEXT ·XorUint32(SB),$8-12
   MOVQ  addr+0(FP), BP
   MOVL  val+8(FP), AX
   LOCK
@@ -46,21 +46,21 @@ TEXT ·CompareAndSwapUint32(SB),$0-20
   MOVL  AX, ret+16(FP)
   RET
 
-TEXT ·AndUint64(SB),$0-16
+TEXT ·AndUint64(SB),$8-16
   MOVQ  addr+0(FP), BP
   MOVQ  val+8(FP), AX
   LOCK
   ANDQ   AX, 0(BP)
   RET
 
-TEXT ·OrUint64(SB),$0-16
+TEXT ·OrUint64(SB),$8-16
   MOVQ  addr+0(FP), BP
   MOVQ  val+8(FP), AX
   LOCK
   ORQ   AX, 0(BP)
   RET
 
-TEXT ·XorUint64(SB),$0-16
+TEXT ·XorUint64(SB),$8-16
   MOVQ  addr+0(FP), BP
   MOVQ  val+8(FP), AX
   LOCK

--- a/pkg/atomicbitops/atomicbitops_amd64.s
+++ b/pkg/atomicbitops/atomicbitops_amd64.s
@@ -20,21 +20,21 @@ TEXT ·AndUint32(SB),$0-12
   MOVQ  addr+0(FP), BX
   MOVL  val+8(FP), AX
   LOCK
-  ANDL   AX, 0(BP)
+  ANDL   AX, 0(BX)
   RET
 
 TEXT ·OrUint32(SB),$0-12
   MOVQ  addr+0(FP), BX
   MOVL  val+8(FP), AX
   LOCK
-  ORL   AX, 0(BP)
+  ORL   AX, 0(BX)
   RET
 
 TEXT ·XorUint32(SB),$0-12
   MOVQ  addr+0(FP), BX
   MOVL  val+8(FP), AX
   LOCK
-  XORL   AX, 0(BP)
+  XORL   AX, 0(BX)
   RET
 
 TEXT ·CompareAndSwapUint32(SB),$0-20
@@ -50,21 +50,21 @@ TEXT ·AndUint64(SB),$0-16
   MOVQ  addr+0(FP), BX
   MOVQ  val+8(FP), AX
   LOCK
-  ANDQ   AX, 0(BP)
+  ANDQ   AX, 0(BX)
   RET
 
 TEXT ·OrUint64(SB),$0-16
   MOVQ  addr+0(FP), BX
   MOVQ  val+8(FP), AX
   LOCK
-  ORQ   AX, 0(BP)
+  ORQ   AX, 0(BX)
   RET
 
 TEXT ·XorUint64(SB),$0-16
   MOVQ  addr+0(FP), BX
   MOVQ  val+8(FP), AX
   LOCK
-  XORQ   AX, 0(BP)
+  XORQ   AX, 0(BX)
   RET
 
 TEXT ·CompareAndSwapUint64(SB),$0-32

--- a/pkg/atomicbitops/atomicbitops_amd64.s
+++ b/pkg/atomicbitops/atomicbitops_amd64.s
@@ -16,22 +16,22 @@
 
 #include "textflag.h"
 
-TEXT ·AndUint32(SB),$8-12
-  MOVQ  addr+0(FP), BP
+TEXT ·AndUint32(SB),$0-12
+  MOVQ  addr+0(FP), BX
   MOVL  val+8(FP), AX
   LOCK
   ANDL   AX, 0(BP)
   RET
 
-TEXT ·OrUint32(SB),$8-12
-  MOVQ  addr+0(FP), BP
+TEXT ·OrUint32(SB),$0-12
+  MOVQ  addr+0(FP), BX
   MOVL  val+8(FP), AX
   LOCK
   ORL   AX, 0(BP)
   RET
 
-TEXT ·XorUint32(SB),$8-12
-  MOVQ  addr+0(FP), BP
+TEXT ·XorUint32(SB),$0-12
+  MOVQ  addr+0(FP), BX
   MOVL  val+8(FP), AX
   LOCK
   XORL   AX, 0(BP)
@@ -46,22 +46,22 @@ TEXT ·CompareAndSwapUint32(SB),$0-20
   MOVL  AX, ret+16(FP)
   RET
 
-TEXT ·AndUint64(SB),$8-16
-  MOVQ  addr+0(FP), BP
+TEXT ·AndUint64(SB),$0-16
+  MOVQ  addr+0(FP), BX
   MOVQ  val+8(FP), AX
   LOCK
   ANDQ   AX, 0(BP)
   RET
 
-TEXT ·OrUint64(SB),$8-16
-  MOVQ  addr+0(FP), BP
+TEXT ·OrUint64(SB),$0-16
+  MOVQ  addr+0(FP), BX
   MOVQ  val+8(FP), AX
   LOCK
   ORQ   AX, 0(BP)
   RET
 
-TEXT ·XorUint64(SB),$8-16
-  MOVQ  addr+0(FP), BP
+TEXT ·XorUint64(SB),$0-16
+  MOVQ  addr+0(FP), BX
   MOVQ  val+8(FP), AX
   LOCK
   XORQ   AX, 0(BP)


### PR DESCRIPTION
Fix frame pointer is clobbered before saving vet issue on `BP` register.

`BP` should be callee-save. It will be saved automatically if there is nonzero frame size.

```console
$ go1.16.5 vet -framepointer ./pkg/atomicbitops
# gvisor.dev/gvisor/pkg/atomicbitops
atomicbitops/atomicbitops_amd64.s:20:1: frame pointer is clobbered before saving
atomicbitops/atomicbitops_amd64.s:27:1: frame pointer is clobbered before saving
atomicbitops/atomicbitops_amd64.s:34:1: frame pointer is clobbered before saving
atomicbitops/atomicbitops_amd64.s:50:1: frame pointer is clobbered before saving
atomicbitops/atomicbitops_amd64.s:57:1: frame pointer is clobbered before saving
atomicbitops/atomicbitops_amd64.s:64:1: frame pointer is clobbered before saving
```