### PR TITLE
Add `io_uring_setup` syscall

### DIFF
--- a/pkg/abi/linux/BUILD
+++ b/pkg/abi/linux/BUILD
@@ -35,6 +35,7 @@ go_library(
         "inotify.go",
         "ioctl.go",
         "ioctl_tun.go",
+        "io_uring.go",
         "ip.go",
         "ipc.go",
         "limits.go",

--- a/pkg/abi/linux/io_uring.go
+++ b/pkg/abi/linux/io_uring.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The gVisor Authors.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linux
+
+// IoUringParams represents struct io_uring_params.
+type IoUringParams struct {
+	SqEntries    uint32
+	CqEntries    uint32
+	Flags        uint32
+	SqThreadCPU  uint32
+	SqThreadIDLE uint32
+	Features     uint32
+	WqFd         uint32
+	Resv         [3]uint64
+	//TODO: Fix missing sq_off and cq_off
+}

--- a/pkg/abi/linux/io_uring.go
+++ b/pkg/abi/linux/io_uring.go
@@ -67,7 +67,6 @@ type IoUringParams struct {
 	Resv         [3]uint32
 	SqOff        IoSqringOffsets
 	CqOff        IoCqringOffsets
-	//TODO: Fix missing sq_off and cq_off
 }
 
 // IoUringCqe represents struct io_uring_cqe.
@@ -84,5 +83,14 @@ type IoUringCqe struct {
 //
 // +marshal
 type IoUringSqe struct {
-	Resv [64]uint8
+	opcode    uint8
+	flags     uint8
+	ioprio    uint16
+	fd        int32
+	union1    uint64
+	union2    uint64
+	len       uint32
+	uinon3    uint32
+	user_data uint64
+	union4    [3]uint64
 }

--- a/pkg/abi/linux/io_uring.go
+++ b/pkg/abi/linux/io_uring.go
@@ -14,7 +14,48 @@
 
 package linux
 
+const (
+	IORING_MAX_ENTRIES    = 32768
+	IORING_MAX_CQ_ENTRIES = 2 * IORING_MAX_ENTRIES
+
+	IORING_OFF_SQ_RING = 0
+	IORING_OFF_CQ_RING = 0x8000000
+	IORING_OFF_SQES    = 0x10000000
+)
+
+// IoSqringOffsets represents struct io_sqring_offsets.
+//
+// +marshal
+type IoSqringOffsets struct {
+	Head        uint32
+	Tail        uint32
+	RingMask    uint32
+	RingEntries uint32
+	Flags       uint32
+	Dropped     uint32
+	Array       uint32
+	Resv1       uint32
+	Resv2       uint64
+}
+
+// IoCqringOffsets represents struct io_cqring_offsets.
+//
+// +marshal
+type IoCqringOffsets struct {
+	Head        uint32
+	Tail        uint32
+	RingMask    uint32
+	RingEntries uint32
+	Overflow    uint32
+	Cqes        uint32
+	Flags       uint32
+	Resv1       uint32
+	Resv2       uint64
+}
+
 // IoUringParams represents struct io_uring_params.
+//
+// +marshal
 type IoUringParams struct {
 	SqEntries    uint32
 	CqEntries    uint32
@@ -23,6 +64,8 @@ type IoUringParams struct {
 	SqThreadIDLE uint32
 	Features     uint32
 	WqFd         uint32
-	Resv         [3]uint64
+	Resv         [3]uint32
+	SqOff        IoSqringOffsets
+	CqOff        IoCqringOffsets
 	//TODO: Fix missing sq_off and cq_off
 }

--- a/pkg/abi/linux/io_uring.go
+++ b/pkg/abi/linux/io_uring.go
@@ -69,3 +69,20 @@ type IoUringParams struct {
 	CqOff        IoCqringOffsets
 	//TODO: Fix missing sq_off and cq_off
 }
+
+// IoUringCqe represents struct io_uring_cqe.
+//
+// +marshal
+type IoUringCqe struct {
+	UserData uint64
+	Res      int32
+	Flags    uint32
+}
+
+// IoUringSqe represents struct io_uring_sqe.
+// TODO: this is just a placeholder
+//
+// +marshal
+type IoUringSqe struct {
+	Resv [64]uint8
+}

--- a/pkg/sentry/fsimpl/iouringfs/BUILD
+++ b/pkg/sentry/fsimpl/iouringfs/BUILD
@@ -1,0 +1,26 @@
+load("//tools:defs.bzl", "go_library")
+
+licenses(["notice"])
+
+go_library(
+    name = "iouringfs",
+    srcs = ["iouringfs.go"],
+    visibility = ["//pkg/sentry:internal"],
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/context",
+        "//pkg/safemem",
+        "//pkg/hostarch",
+        "//pkg/fspath",
+        "//pkg/sentry/fsimpl/kernfs",
+        "//pkg/sentry/fs/fsutil",
+        "//pkg/sentry/fs",
+        "//pkg/sentry/kernel/auth",
+        "//pkg/sentry/memmap",
+        "//pkg/sentry/vfs",
+        "//pkg/sentry/pgalloc",
+        "//pkg/sentry/usage",
+        "//pkg/syserror",
+
+    ],
+)

--- a/pkg/sentry/fsimpl/iouringfs/iouringfs.go
+++ b/pkg/sentry/fsimpl/iouringfs/iouringfs.go
@@ -1,0 +1,318 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package iouringfs provides a filesystem implementation for io_uring shared
+// memory region
+package iouringfs
+
+import (
+	"fmt"
+	"io"
+	"unsafe"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/fspath"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/safemem"
+	"gvisor.dev/gvisor/pkg/sentry/fs"
+	"gvisor.dev/gvisor/pkg/sentry/fs/fsutil"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/syserror"
+)
+
+// filesystemType implements vfs.FilesystemType.
+//
+// +stateify savable
+type iouringFSType struct{}
+
+// GetFilesystem implements vfs.FilesystemType.GetFilesystem.
+func (iouringFSType) GetFilesystem(_ context.Context, vfsObj *vfs.VirtualFilesystem, _ *auth.Credentials, _ string, _ vfs.GetFilesystemOptions) (*vfs.Filesystem, *vfs.Dentry, error) {
+	panic("iouringfs.iouringFSType.GetFilesystem should never be called")
+}
+
+// Name implements vfs.FilesystemType.Name.
+//
+// Note that registering sockfs is unnecessary, except for the fact that it
+// will not show up under /proc/filesystems as a result. This is a very minor
+// discrepancy from Linux.
+func (iouringFSType) Name() string {
+	return "iouring"
+}
+
+// Release implements vfs.FilesystemType.Release.
+func (iouringFSType) Release(ctx context.Context) {}
+
+// +stateify savable
+type iouringFS struct {
+	kernfs.Filesystem
+
+	devMinor uint32
+}
+
+// NewFilesystem sets up and returns a new iouring filesystem.
+//
+// Note that there should only ever be one instance of iouring.Filesystem,
+// backing a global io_uring mount.
+func NewFilesystem(vfsObj *vfs.VirtualFilesystem) (*vfs.Filesystem, error) {
+	devMinor, err := vfsObj.GetAnonBlockDevMinor()
+	if err != nil {
+		return nil, err
+	}
+
+	fs := &iouringFS{
+		devMinor: devMinor,
+	}
+
+	fs.Filesystem.VFSFilesystem().Init(vfsObj, iouringFSType{}, fs)
+
+	return fs.Filesystem.VFSFilesystem(), nil
+}
+
+// Release implements vfs.FilesystemImpl.Release.
+func (fs *iouringFS) Release(ctx context.Context) {
+	fs.Filesystem.VFSFilesystem().VirtualFilesystem().PutAnonBlockDevMinor(fs.devMinor)
+	fs.Filesystem.Release(ctx)
+}
+
+// PrependPath implements vfs.FilesystemImpl.PrependPath.
+func (fs *iouringFS) PrependPath(ctx context.Context, vfsroot, vd vfs.VirtualDentry, b *fspath.Builder) error {
+	inode := vd.Dentry().Impl().(*kernfs.Dentry).Inode().(*inode)
+	b.PrependComponent(fmt.Sprintf("iouring:[%d]", inode.InodeAttrs.Ino()))
+	return vfs.PrependPathSyntheticError{}
+}
+
+// MountOptions implements vfs.FilesystemImpl.MountOptions.
+func (fs *iouringFS) MountOptions() string {
+	return ""
+}
+
+// inode implements kernfs.Inode.
+//
+// +stateify savable
+type inode struct {
+	kernfs.InodeAttrs
+	kernfs.InodeNoopRefCount
+	kernfs.InodeNotDirectory
+	kernfs.InodeNotSymlink
+}
+
+// Open implements kernfs.Inode.Open. iouringfs inode can not be opened
+func (i *inode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
+	return nil, syserror.EPERM
+}
+
+// StatFS implements kernfs.Inode.StatFS.
+func (i *inode) StatFS(ctx context.Context, fs *vfs.Filesystem) (linux.Statfs, error) {
+	return vfs.GenericStatFS(linux.SOCKFS_MAGIC), syserror.EPERM
+}
+
+// NewDentry constructs and returns a iouringfs dentry.
+//
+// Preconditions: mnt.Filesystem() must have been returned by NewFilesystem().
+func NewDentry(ctx context.Context, mnt *vfs.Mount) *vfs.Dentry {
+	fs := mnt.Filesystem().Impl().(*iouringFS)
+
+	filemode := linux.FileMode(linux.S_IFREG | 0600)
+	i := &inode{}
+	i.InodeAttrs.Init(ctx, auth.CredentialsFromContext(ctx), linux.UNNAMED_MAJOR, fs.devMinor, fs.Filesystem.NextIno(), filemode)
+
+	d := &kernfs.Dentry{}
+	d.Init(&fs.Filesystem, i)
+	return d.VFSDentry()
+}
+
+// fileDescription is embedded by iouringfs implementations of
+// vfs.FileDescriptionImpl.
+//
+// +stateify savable
+type fileDescription struct {
+	vfsfd vfs.FileDescription
+	vfs.FileDescriptionDefaultImpl
+	vfs.LockFD
+
+	sqEntries, cqEntries uint32
+
+	// memFile is a platform.File used to allocate pages to this regularFile.
+	memFile *pgalloc.MemoryFile `state:"nosave"`
+
+	// memoryUsageKind is the memory accounting category under which pages backing
+	// this regularFile's contents are accounted.
+	memoryUsageKind usage.MemoryKind
+
+	mappings memmap.MappingSet
+
+	data fsutil.FileRangeSet
+
+	size uint64
+
+	writableMappingPages uint64
+
+	locks vfs.FileLocks
+}
+
+// Stat implements vfs.FileDescriptionImpl.Stat.
+func (fd *fileDescription) Stat(ctx context.Context, opts vfs.StatOptions) (linux.Statx, error) {
+	var stat linux.Statx
+	return stat, syserror.EPERM
+}
+
+// SetStat implements vfs.FileDescriptionImpl.SetStat.
+func (fd *fileDescription) SetStat(ctx context.Context, opts vfs.SetStatOptions) error {
+	return syserror.EPERM
+}
+
+// Release implements vfs.FileDescriptionImpl.Release
+func (f *fileDescription) Release(ctx context.Context) {
+}
+
+// ConfigureMMap implements vfs.FileDescriptionImpl.ConfigureMMap.
+func (fd *fileDescription) ConfigureMMap(ctx context.Context, opts *memmap.MMapOpts) error {
+	return vfs.GenericConfigureMMap(&fd.vfsfd, fd, opts)
+}
+
+// AddMapping implements memmap.Mappable.AddMapping.
+func (fd *fileDescription) AddMapping(ctx context.Context, ms memmap.MappingSpace, ar hostarch.AddrRange, offset uint64, writable bool) error {
+	fd.mappings.AddMapping(ms, ar, offset, writable)
+
+	return nil
+}
+
+// RemoveMapping implements memmap.Mappable.RemoveMapping.
+func (fd *fileDescription) RemoveMapping(ctx context.Context, ms memmap.MappingSpace, ar hostarch.AddrRange, offset uint64, writable bool) {
+	fd.mappings.RemoveMapping(ms, ar, offset, writable)
+}
+
+// CopyMapping implements memmap.Mappable.CopyMapping.
+func (fd *fileDescription) CopyMapping(ctx context.Context, ms memmap.MappingSpace, srcAR, dstAR hostarch.AddrRange, offset uint64, writable bool) error {
+	return fd.AddMapping(ctx, ms, dstAR, offset, writable)
+}
+
+// InvalidateUnsavable implements memmap.Mappable.InvalidateUnsavable.
+func (*fileDescription) InvalidateUnsavable(context.Context) error {
+	return nil
+}
+
+func (fd *fileDescription) sqEndOffset() uint64 {
+	// Sizeof need an instance of the type...
+	var forSizeof uint
+	SQEndOff := uint64(fd.sqEntries) * uint64(unsafe.Sizeof(forSizeof))
+	return fs.OffsetPageEnd(int64(linux.IORING_OFF_SQ_RING + SQEndOff))
+}
+
+func (fd *fileDescription) cqEndOffset() uint64 {
+	// Sizeof need an instance of the type...
+	CQEndOff := uint64(fd.cqEntries) * uint64((*linux.IoUringCqe)(nil).SizeBytes())
+	return fs.OffsetPageEnd(int64(linux.IORING_OFF_CQ_RING + CQEndOff))
+}
+
+func (fd *fileDescription) sqeEndOffset() uint64 {
+	// Sizeof need an instance of the type...
+	SQESEndOff := uint64(fd.sqEntries) * uint64((*linux.IoUringSqe)(nil).SizeBytes())
+	return fs.OffsetPageEnd(int64(linux.IORING_OFF_SQES + SQESEndOff))
+}
+
+func (fd *fileDescription) isInRing(maprange memmap.MappableRange) bool {
+	if maprange.IsSupersetOf(memmap.MappableRange{Start: linux.IORING_OFF_SQ_RING, End: fd.sqEndOffset()}) {
+		return true
+	}
+
+	if maprange.IsSupersetOf(memmap.MappableRange{Start: linux.IORING_OFF_CQ_RING, End: fd.cqEndOffset()}) {
+		return true
+	}
+
+	if maprange.IsSupersetOf(memmap.MappableRange{Start: linux.IORING_OFF_SQES, End: fd.sqeEndOffset()}) {
+		return true
+	}
+
+	return false
+
+}
+
+// Translate implements memmap.Mappable.Translate.
+func (fd *fileDescription) Translate(ctx context.Context, required, optional memmap.MappableRange, at hostarch.AccessType) ([]memmap.Translation, error) {
+	// Sq ring, Cq ring or Sqe ring ?
+	if fd.isInRing(required) {
+		cerr := fd.data.Fill(ctx, required, optional, fd.sqeEndOffset(), fd.memFile, fd.memoryUsageKind, func(_ context.Context, dsts safemem.BlockSeq, _ uint64) (uint64, error) {
+			// Newly-allocated pages are zeroed, so we don't need to do anything.
+			return dsts.NumBytes(), nil
+		})
+
+		var ts []memmap.Translation
+		var translatedEnd uint64
+		for seg := fd.data.FindSegment(required.Start); seg.Ok() && seg.Start() < required.End; seg, _ = seg.NextNonEmpty() {
+			segMR := seg.Range().Intersect(optional)
+			ts = append(ts, memmap.Translation{
+				Source: segMR,
+				File:   fd.memFile,
+				Offset: seg.FileRangeOf(segMR).Start,
+				Perms:  hostarch.AnyAccess,
+			})
+			translatedEnd = segMR.End
+		}
+
+		// Don't return the error returned by f.data.Fill if it occurred outside of
+		// required.
+		if translatedEnd < required.End && cerr != nil {
+			return ts, &memmap.BusError{cerr}
+		}
+
+		return ts, nil
+	}
+
+	return nil, &memmap.BusError{io.EOF}
+}
+
+func NewIouringfsFile(ctx context.Context, mnt *vfs.Mount, SqEntries, CqEntries uint32) (*vfs.FileDescription, error) {
+	d := NewDentry(ctx, mnt)
+	defer d.DecRef(ctx)
+
+	fd, err := newfileDescription(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	fd.sqEntries = SqEntries
+	fd.cqEntries = CqEntries
+
+	vfsfd := &fd.vfsfd
+	if err := vfsfd.Init(fd, uint32(linux.O_RDWR), mnt, d, &vfs.FileDescriptionOptions{
+		DenyPRead:         true,
+		DenyPWrite:        true,
+		UseDentryMetadata: false,
+	}); err != nil {
+		return nil, err
+	}
+
+	return vfsfd, nil
+}
+
+func newfileDescription(ctx context.Context) (*fileDescription, error) {
+	fd := &fileDescription{}
+	fd.LockFD.Init(&fd.locks)
+
+	mfp := pgalloc.MemoryFileProviderFromContext(ctx)
+	if mfp == nil {
+		panic("MemoryFileProviderFromContext returned nil")
+	}
+
+	fd.memFile = mfp.MemoryFile()
+
+	return fd, nil
+}

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -249,6 +249,7 @@ go_library(
         "//pkg/sentry/fsimpl/kernfs",
         "//pkg/sentry/fsimpl/pipefs",
         "//pkg/sentry/fsimpl/sockfs",
+        "//pkg/sentry/fsimpl/iouringfs",
         "//pkg/sentry/fsimpl/timerfd",
         "//pkg/sentry/fsimpl/tmpfs",
         "//pkg/sentry/hostcpu",

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -274,7 +274,8 @@ type Kernel struct {
 	// 3. Socket files created by binding Unix sockets to a file path
 	socketMount *vfs.Mount
 
-	// FIXME:doc
+	// iouringMount is the Mount used for `io_uring`s created by the
+	// `io_uring_setup` syscall.
 	iouringMount *vfs.Mount
 
 	// If set to true, report address space activation waits as if the task is in
@@ -437,6 +438,7 @@ func (k *Kernel) Init(args InitKernelArgs) error {
 			return fmt.Errorf("failed to create sockfs mount: %v", err)
 		}
 		k.socketMount = socketMount
+		k.socketsVFS2 = make(map[*vfs.FileDescription]*SocketRecord)
 
 		iouringFilesystem, err := iouringfs.NewFilesystem(&k.vfs)
 		if err != nil {
@@ -448,8 +450,6 @@ func (k *Kernel) Init(args InitKernelArgs) error {
 			return fmt.Errorf("failed to create iouringfs mount: %v", err)
 		}
 		k.iouringMount = iouringMount
-
-		k.socketsVFS2 = make(map[*vfs.FileDescription]*SocketRecord)
 
 		k.cgroupRegistry = newCgroupRegistry()
 	}

--- a/pkg/sentry/syscalls/linux/vfs2/BUILD
+++ b/pkg/sentry/syscalls/linux/vfs2/BUILD
@@ -57,6 +57,7 @@ go_library(
         "//pkg/sentry/fsimpl/signalfd",
         "//pkg/sentry/fsimpl/timerfd",
         "//pkg/sentry/fsimpl/tmpfs",
+        "//pkg/sentry/fsimpl/iouringfs",
         "//pkg/sentry/kernel",
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/kernel/fasync",

--- a/pkg/sentry/syscalls/linux/vfs2/BUILD
+++ b/pkg/sentry/syscalls/linux/vfs2/BUILD
@@ -15,6 +15,7 @@ go_library(
         "getdents.go",
         "inotify.go",
         "ioctl.go",
+        "io_uring.go",
         "lock.go",
         "memfd.go",
         "mmap.go",

--- a/pkg/sentry/syscalls/linux/vfs2/io_uring.go
+++ b/pkg/sentry/syscalls/linux/vfs2/io_uring.go
@@ -16,15 +16,53 @@ package vfs2
 
 import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
-	// "gvisor.dev/gvisor/pkg/syserror"
+	"gvisor.dev/gvisor/pkg/syserror"
+	"unsafe"
 )
+
+// Represent `struct io_uring` as defined in
+// https://elixir.bootlin.com/linux/v5.10.44/source/fs/io_uring.c#L107
+type IoUring struct {
+	Head uint32
+	_    [15]uint32 // Head and tail need to be "____cacheline_aligned_in_smp"
+	Tail uint32
+	_    [15]uint32 // Head and tail need to be "____cacheline_aligned_in_smp"
+}
+
+// Represent `struct io_rings` as defined in
+// https://elixir.bootlin.com/linux/v5.10.44/source/fs/io_uring.c#L119
+type IoRings struct {
+	Sq            IoUring
+	Cq            IoUring
+	SqRingMask    uint32
+	CqRingMask    uint32
+	SqRingEntries uint32
+	CqRingEntries uint32
+	SqDropped     uint32
+	SqFlags       uint32
+	CqFlags       uint32
+	CqOverflow    uint32
+	// TODO: Add cqes array?
+}
 
 // IoUringSetup implements Linux syscall io_uring_setup(2)
 func IoUringSetup(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
-	file, err := tmpfs.NewZeroFile(t, t.Credentials(), t.Kernel().ShmMount(), 0)
+	entries := args[0].Uint()
+	params := args[1].Pointer()
+
+	err := ioUringCreate(t, entries, params)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	// 2 * IORING_OFF_SQES is to have enought space on the tmpfs file. This
+	// should change once we implement `iouringfs`
+	file, err := tmpfs.NewZeroFile(t, t.Credentials(), t.Kernel().ShmMount(),
+		2*linux.IORING_OFF_SQES)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -38,4 +76,55 @@ func IoUringSetup(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.
 
 	return uintptr(fd), nil, nil
 
+}
+
+func ioUringCreate(t *kernel.Task, entries uint32, p hostarch.Addr) error {
+	if entries == 0 {
+		return syserror.EINVAL
+	}
+
+	var params linux.IoUringParams
+
+	_, err := params.CopyIn(t, p)
+	if err != nil {
+		return err
+	}
+
+	if entries > linux.IORING_MAX_ENTRIES {
+		entries = linux.IORING_MAX_ENTRIES
+	}
+
+	params.SqEntries = entries
+	params.CqEntries = 2 * params.SqEntries
+
+	rings := IoRings{}
+
+	params.SqOff.Head = uint32(unsafe.Offsetof(rings.Sq.Head))
+	params.SqOff.Tail = uint32(unsafe.Offsetof(rings.Sq.Tail))
+	params.SqOff.RingMask = uint32(unsafe.Offsetof(rings.SqRingMask))
+	params.SqOff.RingEntries = uint32(unsafe.Offsetof(rings.SqRingEntries))
+	params.SqOff.Flags = uint32(unsafe.Offsetof(rings.SqFlags))
+	params.SqOff.Dropped = uint32(unsafe.Offsetof(rings.SqDropped))
+	params.SqOff.Array = 384 // TODO: Unconstify this
+
+	params.CqOff.Head = uint32(unsafe.Offsetof(rings.Cq) + unsafe.Offsetof(rings.Cq.Head)) // For some reason, directly using Offsetof(rigs.Cq.Head) does not work as excepted (or as in C)
+	params.CqOff.Tail = uint32(unsafe.Offsetof(rings.Cq) + unsafe.Offsetof(rings.Cq.Tail)) // For some reason, directly using Offsetof(rigs.Cq.Head) does not work as excepted (or as in C)
+	params.CqOff.RingMask = uint32(unsafe.Offsetof(rings.CqRingMask))
+	params.CqOff.RingEntries = uint32(unsafe.Offsetof(rings.CqRingEntries))
+	params.CqOff.Overflow = uint32(unsafe.Offsetof(rings.CqOverflow))
+	params.CqOff.Cqes = 320 // TODO: Unconstify this
+	params.CqOff.Flags = uint32(unsafe.Offsetof(rings.CqFlags))
+
+	_, err = params.CopyOut(t, p)
+	return err
+}
+
+func NextPowOf2(n uint32) uint32 {
+	var k uint32 = 1
+
+	for k < n {
+		k = k << 1
+	}
+
+	return k
 }

--- a/pkg/sentry/syscalls/linux/vfs2/io_uring.go
+++ b/pkg/sentry/syscalls/linux/vfs2/io_uring.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vfs2
+
+import (
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/syserror"
+)
+
+// IoUringSetup implements Linux syscall io_uring_setup(2)
+func IoUringSetup(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
+    fd := -1
+    return uintptr(fd), nil, syserror.EINVAL
+
+}

--- a/pkg/sentry/syscalls/linux/vfs2/vfs2.go
+++ b/pkg/sentry/syscalls/linux/vfs2/vfs2.go
@@ -159,6 +159,7 @@ func Override() {
 	s.Table[327] = syscalls.Supported("preadv2", Preadv2)
 	s.Table[328] = syscalls.Supported("pwritev2", Pwritev2)
 	s.Table[332] = syscalls.Supported("statx", Statx)
+	s.Table[425] = syscalls.PartiallySupported("io_uring_setup", IoUringSetup, "This is a just a place holder for the time being", nil)
 	s.Table[441] = syscalls.Supported("epoll_pwait2", EpollPwait2)
 	s.Init()
 
@@ -270,6 +271,7 @@ func Override() {
 	s.Table[286] = syscalls.Supported("preadv2", Preadv2)
 	s.Table[287] = syscalls.Supported("pwritev2", Pwritev2)
 	s.Table[291] = syscalls.Supported("statx", Statx)
+	s.Table[425] = syscalls.PartiallySupported("io_uring_setup", IoUringSetup, "This is a just a place holder for the time being", nil)
 	s.Table[441] = syscalls.Supported("epoll_pwait2", EpollPwait2)
 
 	s.Init()

--- a/pkg/syserror/syserror.go
+++ b/pkg/syserror/syserror.go
@@ -38,6 +38,7 @@ var (
 	ENOSYS   = error(unix.ENOSYS)
 	EPERM    = error(unix.EPERM)
 	EFAULT   = error(unix.EFAULT)
+	EINVAL   = error(unix.EINVAL)
 )
 
 var (

--- a/pkg/syserror/syserror.go
+++ b/pkg/syserror/syserror.go
@@ -36,6 +36,8 @@ var (
 	ENOTSOCK = error(unix.ENOTSOCK)
 	ENOSPC   = error(unix.ENOSPC)
 	ENOSYS   = error(unix.ENOSYS)
+	EPERM    = error(unix.EPERM)
+	EFAULT   = error(unix.EFAULT)
 )
 
 var (

--- a/test/syscalls/BUILD
+++ b/test/syscalls/BUILD
@@ -240,6 +240,10 @@ syscall_test(
 )
 
 syscall_test(
+    test = "//test/syscalls/linux:io_uring_setup_test",
+)
+
+syscall_test(
     test = "//test/syscalls/linux:verity_ioctl_test",
 )
 

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -1032,6 +1032,21 @@ cc_binary(
 )
 
 cc_binary(
+    name = "io_uring_setup_test",
+    testonly = 1,
+    srcs = ["io_uring_setup.cc"],
+    linkstatic = 1,
+    deps = [
+        "//test/util:file_descriptor",
+        "@com_google_absl//absl/time",
+        gtest,
+        "//test/util:test_main",
+        "//test/util:test_util",
+        "//test/util:time_util",
+    ],
+)
+
+cc_binary(
     name = "verity_ioctl_test",
     testonly = 1,
     srcs = ["verity_ioctl.cc"],

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -1043,6 +1043,7 @@ cc_binary(
         "//test/util:test_main",
         "//test/util:test_util",
         "//test/util:time_util",
+        "//test/util:memory_util",
     ],
 )
 

--- a/test/syscalls/linux/io_uring_setup.cc
+++ b/test/syscalls/linux/io_uring_setup.cc
@@ -38,6 +38,14 @@ TEST(IoUringSetupTest, Exist) {
   ASSERT_NE(errno, ENOSYS);
 }
 
+TEST(IoUringSetupTest, ReturnsFd) {
+  struct io_uring_params params = { 0 };
+  const int nb_entries = 2;
+  int fd = io_uring_setup(nb_entries, &params);
+
+  ASSERT_NE(fd , -1);
+}
+
 }  // namespace
 
 }  // namespace testing

--- a/test/syscalls/linux/io_uring_setup.cc
+++ b/test/syscalls/linux/io_uring_setup.cc
@@ -1,0 +1,44 @@
+// Copyright 2021 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/wait.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <errno.h>
+#include <linux/io_uring.h>
+
+#include "gtest/gtest.h"
+
+namespace gvisor {
+namespace testing {
+
+namespace {
+
+int io_uring_setup(unsigned entries, struct io_uring_params *p)
+{
+    return (int) syscall(__NR_io_uring_setup, entries, p);
+}
+
+TEST(IoUringSetupTest, Exist) {
+  struct io_uring_params params;
+  const int nb_entries = 2;
+  io_uring_setup(nb_entries, &params);
+
+  ASSERT_NE(errno, ENOSYS);
+}
+
+}  // namespace
+
+}  // namespace testing
+}  // namespace gvisor


### PR DESCRIPTION
This PR add the `io_uring_setup` syscall.

It setups a shared memory space for communication between gVisor and userland, then fill-in the `struct io_uring_params` given by the user