### PR TITLE
(docs) use node.k8s.io/v1/RuntimeClass for Kubernetes set up

### DIFF
--- a/g3doc/user_guide/containerd/quick_start.md
+++ b/g3doc/user_guide/containerd/quick_start.md
@@ -151,7 +151,7 @@ Install the RuntimeClass for gVisor:
 
 ```shell
 cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: gvisor


### PR DESCRIPTION
Signed-off-by: Naoki Oketani <okepy.naoki@gmail.com>

closes #6212