### PR TITLE
Disconnect call-chain between sighandler() and bluepill().

### DIFF
--- a/pkg/sentry/platform/kvm/bluepill_amd64.s
+++ b/pkg/sentry/platform/kvm/bluepill_amd64.s
@@ -37,7 +37,15 @@ TEXT ·bluepill(SB),NOSPLIT,$0
 begin:
 	MOVQ vcpu+0(FP), AX
 	LEAQ VCPU_CPU(AX), BX
+
+	// The gorountine stack will be changed in guest which renders
+	// the frame pointer outdated and misleads perf tools.
+	// Disconnect the frame-chain with the zeroed frame pointer
+	// when it is saved in the frame in bluepillHandler().
+	MOVQ BP, CX
+	MOVQ $0, BP
 	BYTE CLI;
+	MOVQ CX, BP
 check_vcpu:
 	MOVQ ENTRY_CPU_SELF(GS), CX
 	CMPQ BX, CX


### PR DESCRIPTION
When sentry is running in guest ring0, the goroutine stack is changing
and it will not be the stack when bluepill() is called.

If PMU interrupt hits when the CPU is in host ring 0, the perf handler
will try to get the stack of the kernel and the userspace(sentry).  It
can travel back to sighandler() and try to continue to the stack of
the goroutine with the outdated frame pointer if sentry has been running
in the guest.  The perf handler can't record correct addresses
from the outdated and wrong frames.  Those addresses are often
irresolvable, and even if it is resolvable accidentally, it would
be misleading names.

To fix the problem, we just set the frame pointer(%RBP) to zero and
disconnect the link when the zeroed frame pointer is saved in the
frame in bluepillHandler().

Signed-off-by: Lai Jiangshan <jiangshan.ljs@antfin.com>