### PR TITLE
Fix iptables List entries Input interface field

### DIFF
--- a/pkg/sentry/socket/netfilter/ipv4.go
+++ b/pkg/sentry/socket/netfilter/ipv4.go
@@ -80,6 +80,8 @@ func getEntries4(table stack.Table, tablename linux.TableName) (linux.KernelIPTG
 		copy(entry.Entry.IP.SrcMask[:], rule.Filter.SrcMask)
 		copy(entry.Entry.IP.OutputInterface[:], rule.Filter.OutputInterface)
 		copy(entry.Entry.IP.OutputInterfaceMask[:], rule.Filter.OutputInterfaceMask)
+		copy(entry.Entry.IP.InputInterface[:], rule.Filter.InputInterface)
+		copy(entry.Entry.IP.InputInterfaceMask[:], rule.Filter.InputInterfaceMask)
 		if rule.Filter.DstInvert {
 			entry.Entry.IP.InverseFlags |= linux.IPT_INV_DSTIP
 		}

--- a/pkg/sentry/socket/netfilter/ipv6.go
+++ b/pkg/sentry/socket/netfilter/ipv6.go
@@ -80,6 +80,8 @@ func getEntries6(table stack.Table, tablename linux.TableName) (linux.KernelIP6T
 		copy(entry.Entry.IPv6.SrcMask[:], rule.Filter.SrcMask)
 		copy(entry.Entry.IPv6.OutputInterface[:], rule.Filter.OutputInterface)
 		copy(entry.Entry.IPv6.OutputInterfaceMask[:], rule.Filter.OutputInterfaceMask)
+		copy(entry.Entry.IPv6.InputInterface[:], rule.Filter.InputInterface)
+		copy(entry.Entry.IPv6.InputInterfaceMask[:], rule.Filter.InputInterfaceMask)
 		if rule.Filter.DstInvert {
 			entry.Entry.IPv6.InverseFlags |= linux.IP6T_INV_DSTIP
 		}


### PR DESCRIPTION
In Linux, iptables list entries command returns the name of the input interface assigned to the iptable rule.
```
# iptables -S
-A FORWARD -i docker0 -o docker0 -j ACCEPT
```
Meanwhile, in gVsior this interface name is ignored.
```
# iptables -S
-A FORWARD -o docker0 -j ACCEPT
```