### PR TITLE
runsc: fix the local timezone support in logs

### DIFF
--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -284,8 +284,12 @@ func setupRootFS(spec *specs.Spec, conf *config.Config) error {
 		}
 
 		// Prepare tree structure for pivot_root(2).
-		os.Mkdir("/proc/proc", 0755)
-		os.Mkdir("/proc/root", 0755)
+		if err := os.Mkdir("/proc/proc", 0755); err != nil {
+			Fatalf("error creating /proc/proc: %v", err)
+		}
+		if err := os.Mkdir("/proc/root", 0755); err != nil {
+			Fatalf("error creating /proc/root: %v", err)
+		}
 		// This cannot use SafeMount because there's no available procfs. But we
 		// know that /proc is an empty tmpfs mount, so this is safe.
 		if err := unix.Mount("runsc-proc", "/proc/proc", "proc", flags|unix.MS_RDONLY, ""); err != nil {

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -290,10 +290,16 @@ func setupRootFS(spec *specs.Spec, conf *config.Config) error {
 		if err := os.Mkdir("/proc/root", 0755); err != nil {
 			Fatalf("error creating /proc/root: %v", err)
 		}
+		if err := os.Mkdir("/proc/etc", 0755); err != nil {
+			Fatalf("error creating /proc/etc: %v", err)
+		}
 		// This cannot use SafeMount because there's no available procfs. But we
 		// know that /proc is an empty tmpfs mount, so this is safe.
 		if err := unix.Mount("runsc-proc", "/proc/proc", "proc", flags|unix.MS_RDONLY, ""); err != nil {
 			Fatalf("error mounting proc: %v", err)
+		}
+		if err := copyFile("/proc/etc/localtime", "/etc/localtime"); err != nil {
+			log.Warningf("Failed to copy /etc/localtime: %v. UTC timezone will be used.", err)
 		}
 		root = "/proc/root"
 		procPath = "/proc/proc"


### PR DESCRIPTION
This patch fixes the local timezone support in logs by creating
etc/localtime in the rootfs of sandbox process and gofer process
based on the current /etc/localtime on host.

Before this patch, the timestamps in sandbox and gofer logs will
fallback to UTC timezone after execving "/proc/self/exe" which
may not be very convenient for users to analyse the logs:

I0708 15:37:43.825100       1 chroot.go:69] Setting up sandbox chroot in "/tmp"
I0708 15:37:43.825189       1 chroot.go:31] Mounting "proc" at "/tmp/proc"
......
I0708 15:37:43.850926       1 cmd.go:73] Execve "/proc/self/exe" again, bye!
I0708 07:37:43.856719       1 main.go:218] ***************************
I0708 07:37:43.856751       1 main.go:219] Args: [runsc-sandbox --root=/run/...]
I0708 07:37:43.856785       1 main.go:220] Version release-20210628.0-27-g02fec8dba5a6
I0708 07:37:43.856795       1 main.go:221] GOOS: linux
I0708 07:37:43.856803       1 main.go:222] GOARCH: amd64
......

Fixes #1984

Signed-off-by: Tiwei Bie <tiwei.btw@antgroup.com>