### PR TITLE
Add huge page info to /proc/meminfo

### DIFF
--- a/pkg/sentry/fs/proc/meminfo.go
+++ b/pkg/sentry/fs/proc/meminfo.go
@@ -87,11 +87,11 @@ func (d *meminfoData) ReadSeqFileData(ctx context.Context, h seqfile.SeqHandle) 
 	fmt.Fprintf(&buf, "AnonPages:      %8d kB\n", anon/1024)
 	fmt.Fprintf(&buf, "Mapped:         %8d kB\n", file/1024) // doesn't count mapped tmpfs, which we don't know
 	fmt.Fprintf(&buf, "Shmem:          %8d kB\n", snapshot.Tmpfs/1024)
-	fmt.Fprintf(&buf, "HugePages_Total:     100\n")
-	fmt.Fprintf(&buf, "HugePages_Free:      100\n")
+	fmt.Fprintf(&buf, "HugePages_Total:     0\n")
+	fmt.Fprintf(&buf, "HugePages_Free:      0\n")
 	fmt.Fprintf(&buf, "HugePages_Rsvd:      0\n")
 	fmt.Fprintf(&buf, "HugePages_Surp:      0\n")
-	fmt.Fprintf(&buf, "Hugepagesize:        2048 kB\n")
+	fmt.Fprintf(&buf, "Hugepagesize:        %8d kB\n", hostarch.HugePageSize)
 	return []seqfile.SeqData{{Buf: buf.Bytes(), Handle: (*meminfoData)(nil)}}, 0
 }
 

--- a/pkg/sentry/fs/proc/meminfo.go
+++ b/pkg/sentry/fs/proc/meminfo.go
@@ -87,6 +87,11 @@ func (d *meminfoData) ReadSeqFileData(ctx context.Context, h seqfile.SeqHandle) 
 	fmt.Fprintf(&buf, "AnonPages:      %8d kB\n", anon/1024)
 	fmt.Fprintf(&buf, "Mapped:         %8d kB\n", file/1024) // doesn't count mapped tmpfs, which we don't know
 	fmt.Fprintf(&buf, "Shmem:          %8d kB\n", snapshot.Tmpfs/1024)
+	fmt.Fprintf(&buf, "HugePages_Total:     100\n")
+	fmt.Fprintf(&buf, "HugePages_Free:      100\n")
+	fmt.Fprintf(&buf, "HugePages_Rsvd:      0\n")
+	fmt.Fprintf(&buf, "HugePages_Surp:      0\n")
+	fmt.Fprintf(&buf, "Hugepagesize:        2048 kB\n")
 	return []seqfile.SeqData{{Buf: buf.Bytes(), Handle: (*meminfoData)(nil)}}, 0
 }
 

--- a/pkg/sentry/fsimpl/proc/tasks_files.go
+++ b/pkg/sentry/fsimpl/proc/tasks_files.go
@@ -304,6 +304,11 @@ func (*meminfoData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	fmt.Fprintf(buf, "AnonPages:      %8d kB\n", anon/1024)
 	fmt.Fprintf(buf, "Mapped:         %8d kB\n", file/1024) // doesn't count mapped tmpfs, which we don't know
 	fmt.Fprintf(buf, "Shmem:          %8d kB\n", snapshot.Tmpfs/1024)
+	fmt.Fprintf(buf, "HugePages_Total:     0\n")
+	fmt.Fprintf(buf, "HugePages_Free:      0\n")
+	fmt.Fprintf(buf, "HugePages_Rsvd:      0\n")
+	fmt.Fprintf(buf, "HugePages_Surp:      0\n")
+	fmt.Fprintf(buf, "Hugepagesize:        %8d kB\n", hostarch.HugePageSize)
 	return nil
 }
 


### PR DESCRIPTION
Add huge page info to /proc/meminfo, so that MySQL could use large pages.

According to my tests using sysbench, QPS increased by 832.6% and the average response time dropped by about 89.3% when MySQL enabled large pages in gVisor.

MySQL large pages needs huge page info in /proc/meminfo, otherwise it will get a "failed to determine large page size" error.