### PR TITLE
Delete unnecessary function.

### DIFF
--- a/pkg/sentry/fsimpl/cgroupfs/cgroupfs.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cgroupfs.go
@@ -383,11 +383,6 @@ func (d *dir) DecRef(ctx context.Context) {
 	d.dirRefs.DecRef(func() { d.Destroy(ctx) })
 }
 
-// StatFS implements kernfs.Inode.StatFS.
-func (d *dir) StatFS(ctx context.Context, fs *vfs.Filesystem) (linux.Statfs, error) {
-	return vfs.GenericStatFS(linux.CGROUP_SUPER_MAGIC), nil
-}
-
 // controllerFile represents a generic control file that appears within a cgroup
 // directory.
 //


### PR DESCRIPTION
Since cgroupfs.dir embedes cgroupfs.implStatFS, and dir.StatFS and
implStatFS.StatFS are identical, dir.StatFS is not needed.