### PR TITLE
tunning hasSlot function and fix store wrong value in usedSlots

### DIFF
--- a/pkg/sentry/platform/kvm/bluepill_fault.go
+++ b/pkg/sentry/platform/kvm/bluepill_fault.go
@@ -101,7 +101,7 @@ func handleBluepillFault(m *machine, physical uintptr, phyRegions []physicalRegi
 		// Store the physical address in the slot. This is used to
 		// avoid calls to handleBluepillFault in the future (see
 		// machine.mapPhysical).
-		atomic.StoreUintptr(&m.usedSlots[slot], physical)
+		atomic.StoreUintptr(&m.usedSlots[slot], physicalStart)
 		// Successfully added region; we can increment nextSlot and
 		// allow another set to proceed here.
 		atomic.StoreUint32(&m.nextSlot, slot+1)


### PR DESCRIPTION
1. Currently, setMemoryRegion is triggered every time, even if the memory region has mapped.
It is supposed to store `physicalStart` in `usedSlot` rather than `physical`.

2. Make `hasSlot` scan allocated slot, rather than the whole slice.

Performance is tuned by applying this PR. e.g.
1. `test/perf/mapping_benchmark`
Before #6358 
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_MapUnmap/1/real_time                32812 ns        33089 ns        21457
BM_MapUnmap/8/real_time                33095 ns        32898 ns        22798
BM_MapUnmap/64/real_time               40419 ns        40751 ns        20122
BM_MapUnmap/512/real_time              59843 ns        60000 ns        10000
BM_MapUnmap/4096/real_time              2224 ns         2237 ns       326386
BM_MapUnmap/32768/real_time             2143 ns         2140 ns       345727
BM_MapUnmap/131072/real_time            2217 ns         2223 ns       341854
BM_MapTouchUnmap/1/real_time           42512 ns        42866 ns        16330
BM_MapTouchUnmap/8/real_time           58479 ns        58772 ns        12591
BM_MapTouchUnmap/64/real_time         188771 ns       187999 ns         3883
BM_MapTouchUnmap/512/real_time       1123581 ns      1121495 ns          642
BM_MapTouchUnmap/4096/real_time      8455231 ns      8554217 ns           83
BM_MapTouchUnmap/32768/real_time    67366990 ns     67272727 ns           11
BM_MapTouchUnmap/131072/real_time  282513698 ns    283333333 ns            3
BM_MapTouchMany/1/real_time            39390 ns        39022 ns        18451 bytes_per_second=99.1677M/s
BM_MapTouchMany/8/real_time           285528 ns       286533 ns         2443 bytes_per_second=109.446M/s
BM_MapTouchMany/64/real_time         2027092 ns      2015707 ns          382 bytes_per_second=123.329M/s
BM_MapTouchMany/512/real_time       15745603 ns     15777778 ns           45 bytes_per_second=127.02M/s
BM_MapTouchMany/4096/real_time     173398316 ns    175000000 ns            4 bytes_per_second=92.2731M/s
BM_PageFault/real_time                 24694 ns        24736 ns        27895
```

On #6358 
```
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_MapUnmap/1/real_time                13531 ns        13584 ns        80239
BM_MapUnmap/8/real_time                 9655 ns         9583 ns       106434
BM_MapUnmap/64/real_time                9877 ns         9821 ns       105894
BM_MapUnmap/512/real_time              21955 ns        21993 ns        34557
BM_MapUnmap/4096/real_time              2452 ns         2445 ns       306716
BM_MapUnmap/32768/real_time             2401 ns         2379 ns       353131
BM_MapUnmap/131072/real_time            2447 ns         2450 ns       293864
BM_MapTouchUnmap/1/real_time           17314 ns        17237 ns        60916
BM_MapTouchUnmap/8/real_time           40533 ns        40168 ns        21161
BM_MapTouchUnmap/64/real_time         190584 ns       191702 ns         3495
BM_MapTouchUnmap/512/real_time       1193934 ns      1187500 ns          640
BM_MapTouchUnmap/4096/real_time      8462374 ns      8433735 ns           83
BM_MapTouchUnmap/32768/real_time    66902529 ns     66363636 ns           11
BM_MapTouchUnmap/131072/real_time  273673932 ns    273333333 ns            3
BM_MapTouchMany/1/real_time            15852 ns        15897 ns        54727 bytes_per_second=246.425M/s
BM_MapTouchMany/8/real_time           112965 ns       112801 ns         5851 bytes_per_second=276.634M/s
BM_MapTouchMany/64/real_time          805882 ns       807720 ns         1399 bytes_per_second=310.219M/s
BM_MapTouchMany/512/real_time        6690979 ns      6637931 ns          116 bytes_per_second=298.91M/s
BM_MapTouchMany/4096/real_time      99162281 ns     98750000 ns            8 bytes_per_second=161.352M/s
BM_PageFault/real_time                  2459 ns         2604 ns       218902
```

2. Time for running `ls` 1000 times in runsc,

| without the PR | with the PR |
| --- | --- |
| 38.4s| 34.3s|




BTW, in most cases, `usedSlots[]` is read rather than writen, and it stored unsorted physical addresses. So the function `hasSlot` is relatively less effective. Is it better to use hashmap to store the mapped physical address, thus we can have O(1) when search mapped physical addresses?