### PR TITLE
platform/kvm: Don't handle safecopy regions from bluepillHandler

### DIFF
--- a/pkg/safecopy/safecopy_test.go
+++ b/pkg/safecopy/safecopy_test.go
@@ -115,6 +115,13 @@ func TestZeroOutSuccess(t *testing.T) {
 	}
 }
 
+func BenchmarkSwapUint64(b *testing.B) {
+	val := uint64(0)
+	for i := uint64(0); i < uint64(b.N); i++ {
+		SwapUint64(unsafe.Pointer(&val), i)
+	}
+}
+
 func TestSwapUint32Success(t *testing.T) {
 	// Test that SwapUint32 does not return an error when the page is
 	// accessible.

--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -89,6 +89,7 @@ go_test(
         "//pkg/sentry/platform",
         "//pkg/sentry/platform/kvm/testutil",
         "//pkg/sentry/time",
+	"//pkg/memutil",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -83,6 +83,7 @@ go_test(
         "//pkg/hostarch",
         "//pkg/ring0",
         "//pkg/ring0/pagetables",
+        "//pkg/safecopy",
         "//pkg/sentry/arch",
         "//pkg/sentry/arch/fpu",
         "//pkg/sentry/platform",


### PR DESCRIPTION
safecopy handles faults from a signal handler, but all signals are
blocked in bluepillHandler.

Reported-by: syzbot+fdf75441d9785299ce95@syzkaller.appspotmail.com