### PR TITLE
kvm: use safecopy to handle KVM_EXIT_MMIO

### DIFF
--- a/pkg/abi/linux/signal.go
+++ b/pkg/abi/linux/signal.go
@@ -476,6 +476,8 @@ func (s *SignalInfo) Addr() uint64 {
 }
 
 // SetAddr sets the si_addr field.
+//
+//go:nosplit
 func (s *SignalInfo) SetAddr(val uint64) {
 	hostarch.ByteOrder.PutUint64(s.Fields[0:8], val)
 }

--- a/pkg/safecopy/memcpy_amd64.s
+++ b/pkg/safecopy/memcpy_amd64.s
@@ -44,8 +44,8 @@ TEXT handleMemcpyFault(SB), NOSPLIT, $0-36
 //
 // The code is derived from the forward copying part of runtime.memmove.
 //
-// func memcpy(dst, src unsafe.Pointer, n uintptr) (fault unsafe.Pointer, sig int32)
-TEXT ·memcpy(SB), NOSPLIT, $0-36
+// func Memcpy(dst, src unsafe.Pointer, n uintptr) (fault unsafe.Pointer, sig int32)
+TEXT ·Memcpy(SB), NOSPLIT, $0-36
 	// Store 0 as the returned signal number. If we run to completion,
 	// this is the value the caller will see; if a signal is received,
 	// handleMemcpyFault will store a different value in this address.
@@ -220,6 +220,6 @@ move_129through256:
 
 // func addrOfMemcpy() uintptr
 TEXT ·addrOfMemcpy(SB), $0-8
-	MOVQ	$·memcpy(SB), AX
+	MOVQ	$·Memcpy(SB), AX
 	MOVQ	AX, ret+0(FP)
 	RET

--- a/pkg/safecopy/memcpy_arm64.s
+++ b/pkg/safecopy/memcpy_arm64.s
@@ -15,7 +15,7 @@ TEXT handleMemcpyFault(SB), NOSPLIT, $0-36
 	MOVW R1, sig+32(FP)
 	RET
 
-// memcpy copies data from src to dst. If a SIGSEGV or SIGBUS signal is received
+// Memcpy copies data from src to dst. If a SIGSEGV or SIGBUS signal is received
 // during the copy, it returns the address that caused the fault and the number
 // of the signal that was received. Otherwise, it returns an unspecified address
 // and a signal number of 0.
@@ -26,8 +26,8 @@ TEXT handleMemcpyFault(SB), NOSPLIT, $0-36
 //
 // The code is derived from the Go source runtime.memmove.
 //
-// func memcpy(dst, src unsafe.Pointer, n uintptr) (fault unsafe.Pointer, sig int32)
-TEXT ·memcpy(SB), NOSPLIT, $-8-36
+// func Memcpy(dst, src unsafe.Pointer, n uintptr) (fault unsafe.Pointer, sig int32)
+TEXT ·Memcpy(SB), NOSPLIT, $-8-36
 	// Store 0 as the returned signal number. If we run to completion,
 	// this is the value the caller will see; if a signal is received,
 	// handleMemcpyFault will store a different value in this address.
@@ -79,6 +79,6 @@ forwardtailloop:
 
 // func addrOfMemcpy() uintptr
 TEXT ·addrOfMemcpy(SB), $0-8
-	MOVD	$·memcpy(SB), R0
+	MOVD	$·Memcpy(SB), R0
 	MOVD	R0, ret+0(FP)
 	RET

--- a/pkg/safecopy/safecopy_unsafe.go
+++ b/pkg/safecopy/safecopy_unsafe.go
@@ -28,7 +28,7 @@ import (
 // (for memclr) before proceeding.
 const maxRegisterSize = 16
 
-// memcpy copies data from src to dst. If a SIGSEGV or SIGBUS signal is received
+// Memcpy copies data from src to dst. If a SIGSEGV or SIGBUS signal is received
 // during the copy, it returns the address that caused the fault and the number
 // of the signal that was received. Otherwise, it returns an unspecified address
 // and a signal number of 0.
@@ -38,7 +38,7 @@ const maxRegisterSize = 16
 // successfully copied.
 //
 //go:noescape
-func memcpy(dst, src uintptr, n uintptr) (fault uintptr, sig int32)
+func Memcpy(dst, src uintptr, n uintptr) (fault uintptr, sig int32)
 
 // memclr sets the n bytes following ptr to zeroes. If a SIGSEGV or SIGBUS
 // signal is received during the write, it returns the address that caused the
@@ -117,7 +117,7 @@ func copyIn(dst []byte, src uintptr) (int, error) {
 		return 0, nil
 	}
 
-	fault, sig := memcpy(uintptr(unsafe.Pointer(&dst[0])), src, toCopy)
+	fault, sig := Memcpy(uintptr(unsafe.Pointer(&dst[0])), src, toCopy)
 	if sig == 0 {
 		return len(dst), nil
 	}
@@ -157,7 +157,7 @@ func copyOut(dst uintptr, src []byte) (int, error) {
 		return 0, nil
 	}
 
-	fault, sig := memcpy(dst, uintptr(unsafe.Pointer(&src[0])), toCopy)
+	fault, sig := Memcpy(dst, uintptr(unsafe.Pointer(&src[0])), toCopy)
 	if sig == 0 {
 		return len(src), nil
 	}
@@ -200,7 +200,7 @@ func copyN(dst, src uintptr, toCopy uintptr) (uintptr, error) {
 		return 0, nil
 	}
 
-	fault, sig := memcpy(dst, src, toCopy)
+	fault, sig := Memcpy(dst, src, toCopy)
 	if sig == 0 {
 		return toCopy, nil
 	}

--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -81,8 +81,10 @@ go_test(
     deps = [
         "//pkg/abi/linux",
         "//pkg/hostarch",
+        "//pkg/memutil",
         "//pkg/ring0",
         "//pkg/ring0/pagetables",
+        "//pkg/safecopy",
         "//pkg/sentry/arch",
         "//pkg/sentry/arch/fpu",
         "//pkg/sentry/platform",

--- a/pkg/sentry/platform/kvm/filters_amd64.go
+++ b/pkg/sentry/platform/kvm/filters_amd64.go
@@ -35,6 +35,14 @@ func (*KVM) SyscallFilters() seccomp.SyscallRules {
 		unix.SYS_MMAP:            {},
 		unix.SYS_RT_SIGSUSPEND:   {},
 		unix.SYS_RT_SIGTIMEDWAIT: {},
-		0xffffffffffffffff:       {}, // KVM uses syscall -1 to transition to host.
+		unix.SYS_RT_TGSIGQUEUEINFO: {
+			{
+				seccomp.EqualTo(pid),
+				seccomp.MatchAny{},
+				seccomp.MatchAny{},
+				seccomp.MatchAny{},
+			},
+		},
+		0xffffffffffffffff: {}, // KVM uses syscall -1 to transition to host.
 	}
 }

--- a/pkg/sentry/platform/kvm/kvm.go
+++ b/pkg/sentry/platform/kvm/kvm.go
@@ -59,6 +59,14 @@ type runData struct {
 	data [32]uint64
 }
 
+// mmioData mirrors kvm_run.mmio (linux/kvm.h).
+type mmioData struct {
+	physical uint64
+	data     [8]uint8
+	length   uint32
+	isWrite  uint8
+}
+
 // KVM represents a lightweight VM context.
 type KVM struct {
 	platform.NoCPUPreemptionDetection

--- a/pkg/sentry/platform/kvm/kvm_test.go
+++ b/pkg/sentry/platform/kvm/kvm_test.go
@@ -467,6 +467,7 @@ func TestRdtsc(t *testing.T) {
 	})
 }
 
+// testSafecopy creates big file mappings to trigger KVM_EXIT_MMIO.`
 func testSafecopy(t *testing.T, mapSize uintptr, fileSize uintptr, testFunc func(t *testing.T, c *vCPU, addr uintptr)) {
 	memfd, err := memutil.CreateMemFD(fmt.Sprintf("kvm_test_%d", os.Getpid()), 0)
 	if err != nil {
@@ -504,6 +505,9 @@ func testSafecopy(t *testing.T, mapSize uintptr, fileSize uintptr, testFunc func
 	})
 }
 
+// TestSafecopySigbus creates a file mapping and call safecopy.CopyIn to an
+// address that is beyond the file size. In this case, CopyIn has to return the
+// BusError.
 func TestSafecopySigbus(t *testing.T) {
 	mapSize := uintptr(faultBlockSize)
 	fileSize := mapSize - hostarch.PageSize
@@ -518,6 +522,8 @@ func TestSafecopySigbus(t *testing.T) {
 	})
 }
 
+// TestSafecopy checks that safecopy calls work properly for memory regions
+// that are not mapped to the guest yet.
 func TestSafecopy(t *testing.T) {
 	mapSize := uintptr(faultBlockSize)
 	fileSize := mapSize

--- a/pkg/sentry/platform/kvm/kvm_test.go
+++ b/pkg/sentry/platform/kvm/kvm_test.go
@@ -15,17 +15,22 @@
 package kvm
 
 import (
+	"fmt"
 	"math/rand"
+	"os"
 	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/memutil"
 	"gvisor.dev/gvisor/pkg/ring0"
 	"gvisor.dev/gvisor/pkg/ring0/pagetables"
+	"gvisor.dev/gvisor/pkg/safecopy"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/arch/fpu"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
@@ -459,6 +464,78 @@ func TestRdtsc(t *testing.T) {
 		}
 		i++
 		return i < 100
+	})
+}
+
+func testSafecopy(t *testing.T, mapSize uintptr, fileSize uintptr, testFunc func(t *testing.T, c *vCPU, addr uintptr)) {
+	memfd, err := memutil.CreateMemFD(fmt.Sprintf("kvm_test_%d", os.Getpid()), 0)
+	if err != nil {
+		t.Errorf("error creating memfd: %v", err)
+	}
+
+	memfile := os.NewFile(uintptr(memfd), "kvm_test")
+	memfile.Truncate(int64(fileSize))
+	kvmTest(t, nil, func(c *vCPU) bool {
+		const n = 10
+		mappings := make([]uintptr, n)
+		defer func() {
+			for i := 0; i < n && mappings[i] != 0; i++ {
+				unix.RawSyscall(
+					unix.SYS_MUNMAP,
+					mappings[i], mapSize, 0)
+			}
+		}()
+		for i := 0; i < n; i++ {
+			addr, _, errno := unix.RawSyscall6(
+				unix.SYS_MMAP,
+				0,
+				mapSize,
+				unix.PROT_READ|unix.PROT_WRITE,
+				unix.MAP_SHARED|unix.MAP_FILE,
+				uintptr(memfile.Fd()),
+				0)
+			if errno != 0 {
+				t.Errorf("error mapping file: %v", errno)
+			}
+			mappings[i] = addr
+			testFunc(t, c, addr)
+		}
+		return false
+	})
+}
+
+func TestSafecopySigbus(t *testing.T) {
+	mapSize := uintptr(faultBlockSize)
+	fileSize := mapSize - hostarch.PageSize
+	buf := make([]byte, hostarch.PageSize)
+	testSafecopy(t, mapSize, fileSize, func(t *testing.T, c *vCPU, addr uintptr) {
+		want := safecopy.BusError{addr + fileSize}
+		bluepill(c)
+		_, err := safecopy.CopyIn(buf, unsafe.Pointer(addr+fileSize))
+		if err != want {
+			t.Errorf("expected error: got %v, want %v", err, want)
+		}
+	})
+}
+
+func TestSafecopy(t *testing.T) {
+	mapSize := uintptr(faultBlockSize)
+	fileSize := mapSize
+	testSafecopy(t, mapSize, fileSize, func(t *testing.T, c *vCPU, addr uintptr) {
+		want := uint32(0x12345678)
+		bluepill(c)
+		_, err := safecopy.SwapUint32(unsafe.Pointer(addr+fileSize-8), want)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		bluepill(c)
+		val, err := safecopy.LoadUint32(unsafe.Pointer(addr + fileSize - 8))
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if val != want {
+			t.Errorf("incorrect value: got %x, want %x", val, want)
+		}
 	})
 }
 

--- a/pkg/sentry/platform/kvm/machine.go
+++ b/pkg/sentry/platform/kvm/machine.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 
 	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/log"
@@ -142,6 +143,10 @@ type vCPU struct {
 
 	// dieState holds state related to vCPU death.
 	dieState dieState
+
+	// safecopySiginfo is an information about a signal that has been
+	// trigered by one of safecopy calls in the guest mode.
+	safecopySiginfo linux.SignalInfo
 }
 
 type dieState struct {


### PR DESCRIPTION
KVM_EXIT_MMIO can be triggered when the Sentry reads user memory with
safecopy. In this case, the SIGBUS signal can be triggered and safecopy
knows how to handle it.

KVM_EXIT_MMIO is handled from the bluepillHandler signal handler where
sigbus is blocked. It means that if bluepillHandler triggers the signal, the
kernel kills the Sentry process.

Jamie suggested to:
- unmask SIGBUS in sigaction::sa_mask for the bluepill signal handler so
  that safecopy can function from within bluepillHandler()
- in the KVM_EXIT_MMIO handler, use safecopy instead of performing the
  read/write directly
- if safecopy fails, call bluepillSigBus() to re-inject the safecopy
  failure as a SIGBUS in the guest

This patch implements this scheme, but SIGBUS is unlocked and locked
back in bluepillHandler, because we don't know where and why it was
blocked.