### PR TITLE
fix missing SIGTTOU signal in SetForegroundProcessGroup

### DIFF
--- a/pkg/sentry/kernel/thread_group.go
+++ b/pkg/sentry/kernel/thread_group.go
@@ -489,11 +489,6 @@ func (tg *ThreadGroup) SetForegroundProcessGroup(tty *TTY, pgid ProcessGroupID) 
 	tg.signalHandlers.mu.Lock()
 	defer tg.signalHandlers.mu.Unlock()
 
-	// TODO(gvisor.dev/issue/6148): "If tcsetpgrp() is called by a member of a
-	// background process group in its session, and the calling process is not
-	// blocking or ignoring SIGTTOU, a SIGTTOU signal is sent to all members of
-	// this background process group."
-
 	// tty must be the controlling terminal.
 	if tg.tty != tty {
 		return -1, linuxerr.ENOTTY
@@ -514,6 +509,11 @@ func (tg *ThreadGroup) SetForegroundProcessGroup(tty *TTY, pgid ProcessGroupID) 
 	// pg must be part of this process's session.
 	if tg.processGroup.session != pg.session {
 		return -1, linuxerr.EPERM
+	}
+
+	//if the calling process is a member of a background group, a SIGTTOU signal is sent to all members of this group.
+	if tg.processGroup.session.foreground.id != tg.processGroup.id {
+		tg.processGroup.SendSignal(&linux.SignalInfo{Signo: int32(linux.SIGTTOU)})
 	}
 
 	tg.processGroup.session.foreground.id = pgid


### PR DESCRIPTION
SetForegroundProcessGroup now send a SIGTTOU signal if called by a process belonging to a background group. Fixes #6148