### PR TITLE
fix missing SIGTTOU signal in SetForegroundProcessGroup

### DIFF
--- a/pkg/sentry/kernel/thread_group.go
+++ b/pkg/sentry/kernel/thread_group.go
@@ -489,11 +489,6 @@ func (tg *ThreadGroup) SetForegroundProcessGroup(tty *TTY, pgid ProcessGroupID) 
 	tg.signalHandlers.mu.Lock()
 	defer tg.signalHandlers.mu.Unlock()
 
-	// TODO(gvisor.dev/issue/6148): "If tcsetpgrp() is called by a member of a
-	// background process group in its session, and the calling process is not
-	// blocking or ignoring SIGTTOU, a SIGTTOU signal is sent to all members of
-	// this background process group."
-
 	// tty must be the controlling terminal.
 	if tg.tty != tty {
 		return -1, linuxerr.ENOTTY
@@ -514,6 +509,11 @@ func (tg *ThreadGroup) SetForegroundProcessGroup(tty *TTY, pgid ProcessGroupID) 
 	// pg must be part of this process's session.
 	if tg.processGroup.session != pg.session {
 		return -1, linuxerr.EPERM
+	}
+
+	//if the calling process is a member of a background group, a SIGTTOU signal is sent to all members of this background process group.
+	if tg.processGroup.session.foreground.id != tg.processGroup.id {
+		tg.processGroup.SendSignal(&linux.SignalInfo{Signo: int32(linux.SIGTTOU)})
 	}
 
 	tg.processGroup.session.foreground.id = pgid

--- a/test/syscalls/linux/pty.cc
+++ b/test/syscalls/linux/pty.cc
@@ -1640,6 +1640,57 @@ TEST_F(JobControlTest, DISABLED_SetForegroundProcessGroup) {
   ASSERT_NO_ERRNO(res);
 }
 
+// This test verify if a SIGTTOU signal is sent to the calling process'group
+// when tcsetpgrp is called by a background process
+TEST_F(JobControlTest, SetForegroundProcessGroupSIGTTOUBackground) {
+  auto res = RunInChild([=]() {
+    setsid();
+    TEST_PCHECK(!ioctl(replica_.get(), TIOCSCTTY, 0));
+    pid_t grandchild = fork();
+    if (!grandchild) {
+        //assign a different pgid to the child so it will result as
+        //a background process
+        setpgid(grandchild, getpid());
+        tcsetpgrp(replica_.get(), getpgid(0));
+          // We should never reach this.
+          _exit(1);
+        }
+    int wstatus;
+    TEST_PCHECK(waitpid(grandchild, &wstatus, WSTOPPED) == grandchild);
+    TEST_PCHECK(WSTOPSIG(wstatus)==SIGTTOU);
+  });
+  ASSERT_NO_ERRNO(res);
+}
+
+// This test verify that a SIGTTOU signal is not delivered to
+// a background process which calls tcsetpgrp and is ignoring SIGTTOU
+TEST_F(JobControlTest, SetForegroundProcessGroupSIGTTOUIgnored) {
+  auto res = RunInChild([=]() {
+    setsid();
+    TEST_PCHECK(!ioctl(replica_.get(), TIOCSCTTY, 0));
+    pid_t grandchild = fork();
+    if (!grandchild) {
+        // ignore SIGTTOU so the child in background won't
+        // be stopped when it will call tcsetpgrp
+        struct sigaction sa = {};
+        sa.sa_handler = SIG_IGN;
+        sa.sa_flags = 0;
+        sigemptyset(&sa.sa_mask);
+        sigaction(SIGTTOU, &sa, NULL);
+        //assign a different pgid to the child so it will result as
+        //a background process
+        setpgid(grandchild, getpid());
+        tcsetpgrp(replica_.get(), getpgid(0));
+        _exit(0);
+        }
+    int wstatus;
+    TEST_PCHECK(waitpid(grandchild, &wstatus, WSTOPPED) == grandchild);
+    TEST_PCHECK(WSTOPSIG(wstatus)!=SIGTTOU);
+    TEST_PCHECK(WIFEXITED(wstatus));
+  });
+  ASSERT_NO_ERRNO(res);
+}
+
 TEST_F(JobControlTest, SetForegroundProcessGroupWrongTTY) {
   pid_t pid = getpid();
   ASSERT_THAT(ioctl(replica_.get(), TIOCSPGRP, &pid),


### PR DESCRIPTION
SetForegroundProcessGroup now send a SIGTTOU signal if called by a process belonging to a background group. Fixes #6148