### PR TITLE
platform/kvm: set physical slots without overlapping

### DIFF
--- a/pkg/sentry/platform/kvm/bluepill_fault.go
+++ b/pkg/sentry/platform/kvm/bluepill_fault.go
@@ -55,11 +55,7 @@ func calculateBluepillFault(physical uintptr, phyRegions []physicalRegion) (virt
 		}
 
 		// Adjust the block to match our size.
-		physicalStart = alignedPhysical & faultBlockMask
-		if physicalStart < pr.physical {
-			// Bound the starting point to the start of the region.
-			physicalStart = pr.physical
-		}
+		physicalStart = pr.physical + (alignedPhysical - pr.physical) & faultBlockMask
 		virtualStart = pr.virtual + (physicalStart - pr.physical)
 		physicalEnd := physicalStart + faultBlockSize
 		if physicalEnd > end {


### PR DESCRIPTION
Right now, the first slot starts with an address of a memory region and its size is faultBlockSize,
but the second slot starts with (physicalStart + faultBlockSize) & faultBlockMask.

It means they will overlap if a start address of a memory region are not aligned to faultBlockSize.

The kernel doesn't allow to add overlapped regions, but we ignore the EEXIST error.

