### PR TITLE
Add common Cgroup interface

### DIFF
--- a/runsc/cgroup/cgroup_test.go
+++ b/runsc/cgroup/cgroup_test.go
@@ -59,7 +59,7 @@ var dindMountinfo = `
 `
 
 func TestUninstallEnoent(t *testing.T) {
-	c := Cgroup{
+	c := cgroupV1{
 		// Use a non-existent name.
 		Name: "runsc-test-uninstall-656e6f656e740a",
 		Own:  make(map[string]bool),


### PR DESCRIPTION
This is part of cgroupv2 patch set. Here we add a Cgroup interface that
both v1 and v2 need to conform to, and port cgroupv1 to use that first.