### PR TITLE
runsc: allow rootless mode for runsc run

### DIFF
--- a/runsc/cmd/run.go
+++ b/runsc/cmd/run.go
@@ -68,7 +68,14 @@ func (r *Run) Execute(_ context.Context, f *flag.FlagSet, args ...interface{}) s
 	waitStatus := args[1].(*unix.WaitStatus)
 
 	if conf.Rootless {
-		return Errorf("Rootless mode not supported with %q", r.Name())
+		if conf.Network == config.NetworkSandbox {
+			return Errorf("sandbox network isn't supported with --rootless, use --network=none or --network=host")
+		}
+
+		if err := specutils.MaybeRunAsRoot(); err != nil {
+			return Errorf("Error executing inside namespace: %v", err)
+		}
+		// Execution will continue here if no more capabilities are needed...
 	}
 
 	bundleDir := r.bundleDir


### PR DESCRIPTION
Rootless mode seems to work fine for simple containers with runsc run,
so allow its use.

Since runsc run is more widely used, require a workable --network option
is passed rather than automatically switching like runsc do does.

Fixes #3036