### PR TITLE
hostinet: allow getsockopt(SO_RCVTIMEO) and getsockopt(SO_SNDTIMEO)

### DIFF
--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -401,6 +401,8 @@ func (s *socketOpsCommon) GetSockOpt(t *kernel.Task, level int, name int, optVal
 			optlen = sizeofInt32
 		case linux.SO_LINGER:
 			optlen = unix.SizeofLinger
+		case linux.SO_RCVTIMEO, linux.SO_SNDTIMEO:
+			optlen = linux.SizeOfTimeval
 		}
 	case linux.SOL_TCP:
 		switch name {

--- a/runsc/boot/filter/config.go
+++ b/runsc/boot/filter/config.go
@@ -476,6 +476,16 @@ func hostInetFilters() seccomp.SyscallRules {
 			},
 			{
 				seccomp.MatchAny{},
+				seccomp.EqualTo(unix.SOL_SOCKET),
+				seccomp.EqualTo(unix.SO_RCVTIMEO),
+			},
+			{
+				seccomp.MatchAny{},
+				seccomp.EqualTo(unix.SOL_SOCKET),
+				seccomp.EqualTo(unix.SO_SNDTIMEO),
+			},
+			{
+				seccomp.MatchAny{},
 				seccomp.EqualTo(unix.SOL_TCP),
 				seccomp.EqualTo(unix.TCP_NODELAY),
 			},


### PR DESCRIPTION
Fixes #6603