### PR TITLE
Deprecating apt-key

### DIFF
--- a/g3doc/user_guide/install.md
+++ b/g3doc/user_guide/install.md
@@ -51,18 +51,17 @@ sudo apt-get install -y \
     apt-transport-https \
     ca-certificates \
     curl \
-    gnupg-agent \
-    software-properties-common
+    gnupg
 ```
 
 Next, configure the key used to sign archives and the repository.
 
 NOTE: The key was updated on 2021-07-13 to replace the expired key. If you get
-errors about the key being expired, run the `apt-key add` command below again.
+errors about the key being expired, run the `curl` command below again.
 
 ```bash
-curl -fsSL https://gvisor.dev/archive.key | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64,arm64] https://storage.googleapis.com/gvisor/releases release main"
+curl -fsSL https://gvisor.dev/archive.key | sudo gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" | sudo tee /etc/apt/sources.list.d/gvisor.list > /dev/null
 ```
 
 Now the runsc package can be installed:


### PR DESCRIPTION
As apt-key got deprecated in Debian 11 and will be deleted from Debian 12
Replace apt-key by the supported keyring + signed-by method

Related : docker/docker.github.io#11625
Debian wiki : https://wiki.debian.org/DebianRepository/UseThirdParty

Signed-off-by: Nicolas stig124 FORMICHELLA <stigpro@outlook.fr>
