### PR TITLE
watchdog: fix deschedule discount number

### DIFF
--- a/pkg/sentry/watchdog/watchdog.go
+++ b/pkg/sentry/watchdog/watchdog.go
@@ -289,7 +289,7 @@ func (w *Watchdog) runTurn() {
 	// is off, it will discount the entire duration since last run from 'lastUpdateTime'.
 	discount := time.Duration(0)
 	if now.Sub(w.lastRun.Add(w.period)) > descheduleThreshold {
-		discount = now.Sub(w.lastRun)
+		discount = now.Sub(w.lastRun.Add(w.period))
 	}
 	w.lastRun = now
 


### PR DESCRIPTION
The bug will delay watchdog w.period time to find
the stuck task. For example， watchdog is supposed to
find the stuck task at time A, but it actually find it
at "A + w.period", the default value of w.period is 45 seconds.

Signed-off-by: Hang SU <darcy.sh@antfin.com>