### PR TITLE
fix the failed test target //pkg/cpuid:cpuid_test on arm64.

### DIFF
--- a/pkg/cpuid/cpuid_arm64.go
+++ b/pkg/cpuid/cpuid_arm64.go
@@ -491,4 +491,5 @@ func init() {
 	initCPUInfo()
 	initHwCap()
 	initFeaturesFromString()
+	hostFeatureSet = getHostFeatureSet()
 }


### PR DESCRIPTION
Target //pkg/cpuid:cpuid_test  fails on arm64 which shows 

exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //pkg/cpuid:cpuid_test
-----------------------------------------------------------------------------
--- FAIL: TestHostFeatureSet (0.00s)
    cpuid_arm64_test.go:32: Got invalid feature set &{map[] 0 0 0 0 0} from HostFeatureSet()
FAIL
