### PR TITLE
vfs: Don't allow to splice in all types of file descriptors

### DIFF
--- a/pkg/sentry/devices/memdev/full.go
+++ b/pkg/sentry/devices/memdev/full.go
@@ -47,6 +47,7 @@ type fullFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.SpliceInFD
 }
 
 // Release implements vfs.FileDescriptionImpl.Release.

--- a/pkg/sentry/devices/memdev/null.go
+++ b/pkg/sentry/devices/memdev/null.go
@@ -48,6 +48,7 @@ type nullFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.SpliceInFD
 }
 
 // Release implements vfs.FileDescriptionImpl.Release.

--- a/pkg/sentry/devices/memdev/random.go
+++ b/pkg/sentry/devices/memdev/random.go
@@ -53,6 +53,7 @@ type randomFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.SpliceInFD
 
 	// off is the "file offset". off is accessed using atomic memory
 	// operations.

--- a/pkg/sentry/devices/memdev/zero.go
+++ b/pkg/sentry/devices/memdev/zero.go
@@ -50,6 +50,7 @@ type zeroFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.SpliceInFD
 }
 
 // Release implements vfs.FileDescriptionImpl.Release.

--- a/pkg/sentry/devices/tundev/tundev.go
+++ b/pkg/sentry/devices/tundev/tundev.go
@@ -60,6 +60,7 @@ type tunFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.SpliceInFD
 
 	device tun.Device
 }

--- a/pkg/sentry/fsimpl/devpts/master.go
+++ b/pkg/sentry/fsimpl/devpts/master.go
@@ -90,6 +90,7 @@ type masterFileDescription struct {
 	vfsfd vfs.FileDescription
 	vfs.FileDescriptionDefaultImpl
 	vfs.LockFD
+	vfs.NoSpliceInFD
 
 	inode *masterInode
 	t     *Terminal

--- a/pkg/sentry/fsimpl/devpts/replica.go
+++ b/pkg/sentry/fsimpl/devpts/replica.go
@@ -102,6 +102,7 @@ type replicaFileDescription struct {
 	vfsfd vfs.FileDescription
 	vfs.FileDescriptionDefaultImpl
 	vfs.LockFD
+	vfs.NoSpliceInFD
 
 	inode *replicaInode
 }

--- a/pkg/sentry/fsimpl/eventfd/eventfd.go
+++ b/pkg/sentry/fsimpl/eventfd/eventfd.go
@@ -42,6 +42,7 @@ type EventFileDescription struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.NoSpliceInFD
 
 	// queue is used to notify interested parties when the event object
 	// becomes readable or writable.

--- a/pkg/sentry/fsimpl/fuse/dev.go
+++ b/pkg/sentry/fsimpl/fuse/dev.go
@@ -57,6 +57,7 @@ type DeviceFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.SpliceInFD
 
 	// nextOpID is used to create new requests.
 	nextOpID linux.FUSEOpID

--- a/pkg/sentry/fsimpl/fuse/directory.go
+++ b/pkg/sentry/fsimpl/fuse/directory.go
@@ -28,6 +28,7 @@ import (
 
 type directoryFD struct {
 	fileDescription
+	vfs.NoSpliceInFD
 }
 
 // Allocate implements directoryFD.Allocate.

--- a/pkg/sentry/fsimpl/fuse/regular_file.go
+++ b/pkg/sentry/fsimpl/fuse/regular_file.go
@@ -29,6 +29,7 @@ import (
 
 type regularFileFD struct {
 	fileDescription
+	vfs.SpliceInFD
 
 	// off is the file offset.
 	off int64

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -2443,6 +2443,7 @@ type fileDescription struct {
 	vfsfd vfs.FileDescription
 	vfs.FileDescriptionDefaultImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	lockLogging sync.Once `state:"nosave"`
 }

--- a/pkg/sentry/fsimpl/gofer/regular_file.go
+++ b/pkg/sentry/fsimpl/gofer/regular_file.go
@@ -45,6 +45,7 @@ func (d *dentry) isRegularFile() bool {
 // +stateify savable
 type regularFileFD struct {
 	fileDescription
+	vfs.SpliceInFD
 
 	// off is the file offset. off is protected by mu.
 	mu  sync.Mutex `state:"nosave"`

--- a/pkg/sentry/fsimpl/host/host.go
+++ b/pkg/sentry/fsimpl/host/host.go
@@ -649,6 +649,7 @@ type fileDescription struct {
 	vfsfd vfs.FileDescription
 	vfs.FileDescriptionDefaultImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	// inode is vfsfd.Dentry().Impl().(*kernfs.Dentry).Inode().(*inode), but
 	// cached to reduce indirections and casting. fileDescription does not hold

--- a/pkg/sentry/fsimpl/kernfs/dynamic_bytes_file.go
+++ b/pkg/sentry/fsimpl/kernfs/dynamic_bytes_file.go
@@ -89,6 +89,7 @@ type DynamicBytesFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DynamicBytesFileDescriptionImpl
 	vfs.LockFD
+	vfs.NoSpliceInFD
 
 	vfsfd vfs.FileDescription
 	inode Inode

--- a/pkg/sentry/fsimpl/mqfs/queue.go
+++ b/pkg/sentry/fsimpl/mqfs/queue.go
@@ -61,6 +61,7 @@ type queueFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DynamicBytesFileDescriptionImpl
 	vfs.LockFD
+	vfs.NoSpliceInFD
 
 	vfsfd vfs.FileDescription
 	inode kernfs.Inode

--- a/pkg/sentry/fsimpl/overlay/regular_file.go
+++ b/pkg/sentry/fsimpl/overlay/regular_file.go
@@ -50,6 +50,7 @@ func (d *dentry) readlink(ctx context.Context) (string, error) {
 // +stateify savable
 type regularFileFD struct {
 	fileDescription
+	vfs.SpliceInFD
 
 	// If copiedUp is false, cachedFD represents
 	// fileDescription.dentry().lowerVDs[0]; otherwise, cachedFD represents

--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -434,6 +434,7 @@ type memFD struct {
 	vfsfd vfs.FileDescription
 	vfs.FileDescriptionDefaultImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	inode *memInode
 
@@ -678,6 +679,7 @@ type statusFD struct {
 	statusFDLowerBase
 	vfs.DynamicBytesFileDescriptionImpl
 	vfs.LockFD
+	vfs.NoSpliceInFD
 
 	vfsfd vfs.FileDescription
 
@@ -1173,6 +1175,7 @@ func (i *namespaceInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *ker
 type namespaceFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.LockFD
+	vfs.NoSpliceInFD
 
 	vfsfd vfs.FileDescription
 	inode *namespaceInode

--- a/pkg/sentry/fsimpl/signalfd/signalfd.go
+++ b/pkg/sentry/fsimpl/signalfd/signalfd.go
@@ -34,6 +34,7 @@ type SignalFileDescription struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.NoSpliceInFD
 
 	// target is the original signal target task.
 	//

--- a/pkg/sentry/fsimpl/sys/kcov.go
+++ b/pkg/sentry/fsimpl/sys/kcov.go
@@ -67,6 +67,7 @@ func (i *kcovInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernfs.D
 type kcovFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.NoLockFD
+	vfs.SpliceInFD
 
 	vfsfd vfs.FileDescription
 	inode *kcovInode

--- a/pkg/sentry/fsimpl/timerfd/timerfd.go
+++ b/pkg/sentry/fsimpl/timerfd/timerfd.go
@@ -36,6 +36,7 @@ type TimerFileDescription struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.NoLockFD
+	vfs.NoSpliceInFD
 
 	events waiter.Queue
 	timer  *ktime.Timer

--- a/pkg/sentry/fsimpl/tmpfs/regular_file.go
+++ b/pkg/sentry/fsimpl/tmpfs/regular_file.go
@@ -332,6 +332,7 @@ func (*regularFile) InvalidateUnsavable(context.Context) error {
 // +stateify savable
 type regularFileFD struct {
 	fileDescription
+	vfs.SpliceInFD
 
 	// off is the file offset. off is accessed using atomic memory operations.
 	// offMu serializes operations that may mutate off.

--- a/pkg/sentry/fsimpl/verity/verity.go
+++ b/pkg/sentry/fsimpl/verity/verity.go
@@ -989,6 +989,7 @@ func (d *dentry) readlink(ctx context.Context) (string, error) {
 type fileDescription struct {
 	vfsfd vfs.FileDescription
 	vfs.FileDescriptionDefaultImpl
+	vfs.NoSpliceInFD
 
 	// d is the corresponding dentry to the fileDescription.
 	d *dentry

--- a/pkg/sentry/kernel/pipe/vfs.go
+++ b/pkg/sentry/kernel/pipe/vfs.go
@@ -186,6 +186,7 @@ type VFSPipeFD struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	pipe *Pipe
 }

--- a/pkg/sentry/socket/hostinet/socket_vfs2.go
+++ b/pkg/sentry/socket/hostinet/socket_vfs2.go
@@ -36,6 +36,7 @@ type socketVFS2 struct {
 	vfsfd vfs.FileDescription
 	vfs.FileDescriptionDefaultImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	// We store metadata for hostinet sockets internally. Technically, we should
 	// access metadata (e.g. through stat, chmod) on the host for correctness,

--- a/pkg/sentry/socket/netlink/socket_vfs2.go
+++ b/pkg/sentry/socket/netlink/socket_vfs2.go
@@ -43,6 +43,7 @@ type SocketVFS2 struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	socketOpsCommon
 }

--- a/pkg/sentry/socket/netstack/netstack_vfs2.go
+++ b/pkg/sentry/socket/netstack/netstack_vfs2.go
@@ -41,6 +41,7 @@ type SocketVFS2 struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	socketOpsCommon
 }

--- a/pkg/sentry/socket/unix/unix_vfs2.go
+++ b/pkg/sentry/socket/unix/unix_vfs2.go
@@ -44,6 +44,7 @@ type SocketVFS2 struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.DentryMetadataFileDescriptionImpl
 	vfs.LockFD
+	vfs.SpliceInFD
 
 	socketVFS2Refs
 	socketOpsCommon

--- a/pkg/sentry/syscalls/linux/vfs2/splice.go
+++ b/pkg/sentry/syscalls/linux/vfs2/splice.go
@@ -70,6 +70,9 @@ func Splice(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Syscal
 	if !inFile.IsReadable() || !outFile.IsWritable() {
 		return 0, nil, linuxerr.EBADF
 	}
+	if !outFile.Impl().SpliceInSupported() {
+		return 0, nil, linuxerr.EINVAL
+	}
 
 	// The operation is non-blocking if anything is non-blocking.
 	//
@@ -213,6 +216,9 @@ func Tee(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallCo
 	if !inFile.IsReadable() || !outFile.IsWritable() {
 		return 0, nil, linuxerr.EBADF
 	}
+	if !outFile.Impl().SpliceInSupported() {
+		return 0, nil, linuxerr.EINVAL
+	}
 
 	// The operation is non-blocking if anything is non-blocking.
 	//
@@ -284,6 +290,9 @@ func Sendfile(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Sysc
 	defer outFile.DecRef(t)
 	if !outFile.IsWritable() {
 		return 0, nil, linuxerr.EBADF
+	}
+	if !outFile.Impl().SpliceInSupported() {
+		return 0, nil, linuxerr.EINVAL
 	}
 
 	// Verify that the outFile Append flag is not set.

--- a/pkg/sentry/syscalls/linux/vfs2/splice.go
+++ b/pkg/sentry/syscalls/linux/vfs2/splice.go
@@ -380,7 +380,11 @@ func Sendfile(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.Sysc
 		}
 	} else {
 		// Read inFile to buffer, then write the contents to outFile.
-		buf := make([]byte, count)
+		bufSize := count
+		if count > pipe.DefaultPipeSize {
+			bufSize = count
+		}
+		buf := make([]byte, bufSize)
 		for {
 			var readN int64
 			if offset != -1 {

--- a/pkg/sentry/vfs/epoll.go
+++ b/pkg/sentry/vfs/epoll.go
@@ -34,6 +34,7 @@ type EpollInstance struct {
 	FileDescriptionDefaultImpl
 	DentryMetadataFileDescriptionImpl
 	NoLockFD
+	NoSpliceInFD
 
 	// q holds waiters on this EpollInstance.
 	q waiter.Queue

--- a/pkg/sentry/vfs/file_description.go
+++ b/pkg/sentry/vfs/file_description.go
@@ -473,6 +473,9 @@ type FileDescriptionImpl interface {
 
 	// TestPOSIX returns information about whether the specified lock can be held, in the style of the F_GETLK fcntl.
 	TestPOSIX(ctx context.Context, uid lock.UniqueID, t lock.LockType, r lock.LockRange) (linux.Flock, error)
+
+	// SpliceInSupported returns true if splice into this descriptor is allowed.
+	SpliceInSupported() bool
 }
 
 // Dirent holds the information contained in struct linux_dirent64.

--- a/pkg/sentry/vfs/file_description_impl_util.go
+++ b/pkg/sentry/vfs/file_description_impl_util.go
@@ -199,6 +199,11 @@ func (DirectoryFileDescriptionDefaultImpl) Write(ctx context.Context, src userme
 	return 0, linuxerr.EISDIR
 }
 
+// SpliceInSupported implements FileDescriptionImpl.SpliceInSupported.
+func (DirectoryFileDescriptionDefaultImpl) SpliceInSupported() bool {
+	return false
+}
+
 // DentryMetadataFileDescriptionImpl may be embedded by implementations of
 // FileDescriptionImpl for which FileDescriptionOptions.UseDentryMetadata is
 // true to obtain implementations of Stat and SetStat that panic.
@@ -529,4 +534,26 @@ func (BadLockFD) UnlockPOSIX(ctx context.Context, uid fslock.UniqueID, r fslock.
 // TestPOSIX implements FileDescriptionImpl.TestPOSIX.
 func (BadLockFD) TestPOSIX(ctx context.Context, uid fslock.UniqueID, t fslock.LockType, r fslock.LockRange) (linux.Flock, error) {
 	return linux.Flock{}, linuxerr.EBADF
+}
+
+// SpliceInFD implements SpliceInSupported of FileDescriptionImpl interface
+// returning true.
+//
+// +stateify savable
+type SpliceInFD struct{}
+
+// SpliceInSupported implements FileDescriptionImpl.SpliceInSupported.
+func (SpliceInFD) SpliceInSupported() bool {
+	return true
+}
+
+// NoSpliceInFD implements SpliceInSupported of FileDescriptionImpl interface
+// returning false.
+//
+// +stateify savable
+type NoSpliceInFD struct{}
+
+// SpliceInSupported implements FileDescriptionImpl.SpliceInSupported.
+func (NoSpliceInFD) SpliceInSupported() bool {
+	return false
 }

--- a/pkg/sentry/vfs/file_description_impl_util_test.go
+++ b/pkg/sentry/vfs/file_description_impl_util_test.go
@@ -34,6 +34,7 @@ type fileDescription struct {
 	vfsfd FileDescription
 	FileDescriptionDefaultImpl
 	NoLockFD
+	NoSpliceInFD
 }
 
 // genCount contains the number of times its DynamicBytesSource.Generate()

--- a/pkg/sentry/vfs/inotify.go
+++ b/pkg/sentry/vfs/inotify.go
@@ -58,6 +58,7 @@ type Inotify struct {
 	FileDescriptionDefaultImpl
 	DentryMetadataFileDescriptionImpl
 	NoLockFD
+	NoSpliceInFD
 
 	// Unique identifier for this inotify instance. We don't just reuse the
 	// inotify fd because fds can be duped. These should not be exposed to the

--- a/pkg/sentry/vfs/opath.go
+++ b/pkg/sentry/vfs/opath.go
@@ -31,6 +31,7 @@ type opathFD struct {
 	vfsfd FileDescription
 	FileDescriptionDefaultImpl
 	BadLockFD
+	NoSpliceInFD
 }
 
 // Release implements FileDescriptionImpl.Release.


### PR DESCRIPTION
We want to avoid unneeded side effects, so let's specify what file descriptors
allow to splice data in. Linux does the same thing.

For example, Splicing a big amout of data to eventfd can be slow, because
eventfd can consume only 8 bytes at once.

Reported-by: syzbot+b9610cff22c10d9bead4@syzkaller.appspotmail.com