### PR TITLE
runsc: Fix the data race

### DIFF
--- a/runsc/cmd/capability_test.go
+++ b/runsc/cmd/capability_test.go
@@ -112,7 +112,7 @@ func TestCapabilities(t *testing.T) {
 	}
 
 	// Check that sandbox and gofer have the proper capabilities.
-	if err := checkProcessCaps(c.Sandbox.Pid, spec.Process.Capabilities); err != nil {
+	if err := checkProcessCaps(c.Sandbox.Getpid(), spec.Process.Capabilities); err != nil {
 		t.Error(err)
 	}
 	if err := checkProcessCaps(c.GoferPid, goferCaps); err != nil {

--- a/runsc/cmd/debug.go
+++ b/runsc/cmd/debug.go
@@ -139,13 +139,14 @@ func (d *Debug) Execute(_ context.Context, f *flag.FlagSet, args ...interface{})
 	if !c.IsSandboxRunning() {
 		return Errorf("container sandbox is not running")
 	}
-	log.Infof("Found sandbox %q, PID: %d", c.Sandbox.ID, c.Sandbox.Pid)
+	log.Infof("Found sandbox %q, PID: %d", c.Sandbox.ID, c.Sandbox.Getpid())
 
 	// Perform synchronous actions.
 	if d.signal > 0 {
-		log.Infof("Sending signal %d to process: %d", d.signal, c.Sandbox.Pid)
-		if err := unix.Kill(c.Sandbox.Pid, unix.Signal(d.signal)); err != nil {
-			return Errorf("failed to send signal %d to processs %d", d.signal, c.Sandbox.Pid)
+		pid := c.Sandbox.Getpid()
+		log.Infof("Sending signal %d to process: %d", d.signal, pid)
+		if err := unix.Kill(pid, unix.Signal(d.signal)); err != nil {
+			return Errorf("failed to send signal %d to processs %d", d.signal, pid)
 		}
 	}
 	if d.stacks {

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -514,13 +514,13 @@ func (c *Container) Event() (*boot.EventOut, error) {
 	return event, nil
 }
 
-// SandboxPid returns the Pid of the sandbox the container is running in, or -1 if the
+// SandboxPid returns the Getpid of the sandbox the container is running in, or -1 if the
 // container is not running.
 func (c *Container) SandboxPid() int {
 	if err := c.requireStatus("get PID", Created, Running, Paused); err != nil {
 		return -1
 	}
-	return c.Sandbox.Pid
+	return c.Sandbox.Getpid()
 }
 
 // Wait waits for the container to exit, and returns its WaitStatus.
@@ -1145,7 +1145,7 @@ func adjustSandboxOOMScoreAdj(s *sandbox.Sandbox, spec *specs.Spec, rootDir stri
 	}
 
 	// Set the lowest of all containers oom_score_adj to the sandbox.
-	return setOOMScoreAdj(s.Pid, lowScore)
+	return setOOMScoreAdj(s.Getpid(), lowScore)
 }
 
 // setOOMScoreAdj sets oom_score_adj to the given value for the given PID.

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -1938,7 +1938,7 @@ func doGoferExitTest(t *testing.T, vfs2 bool) {
 	}
 
 	// Kill sandbox and expect gofer to exit on its own.
-	sandboxProc, err := os.FindProcess(c.Sandbox.Pid)
+	sandboxProc, err := os.FindProcess(c.Sandbox.Getpid())
 	if err != nil {
 		t.Fatalf("error finding sandbox process: %v", err)
 	}

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -694,7 +694,7 @@ func TestMultiContainerSignal(t *testing.T) {
 				t.Errorf("error waiting for gofer to exit: %v", err)
 			}
 
-			err = blockUntilWaitable(containers[0].Sandbox.Pid)
+			err = blockUntilWaitable(containers[0].Sandbox.Getpid())
 			if err != nil && err != unix.ECHILD {
 				t.Errorf("error waiting for sandbox to exit: %v", err)
 			}

--- a/test/root/oom_score_adj_test.go
+++ b/test/root/oom_score_adj_test.go
@@ -102,7 +102,7 @@ func TestOOMScoreAdjSingle(t *testing.T) {
 				//
 				// The sandbox should be the same for all containers so just use
 				// the first one.
-				sandboxPid := c.Sandbox.Pid
+				sandboxPid := c.Sandbox.Getpid()
 				sandboxScore, err := specutils.GetOOMScoreAdj(sandboxPid)
 				if err != nil {
 					t.Fatalf("error reading sandbox oom_score_adj: %v", err)
@@ -254,7 +254,7 @@ func TestOOMScoreAdjMulti(t *testing.T) {
 			//
 			// The sandbox should be the same for all containers so just use
 			// the first one.
-			sandboxPid := containers[0].Sandbox.Pid
+			sandboxPid := containers[0].Sandbox.Getpid()
 			if testCase.Expected != nil {
 				score, err := specutils.GetOOMScoreAdj(sandboxPid)
 				if err != nil {


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write at 0x00c000115be0 by main goroutine:
  gvisor.dev/gvisor/runsc/sandbox.(*Sandbox).waitForStopped()
      runsc/sandbox/sandbox.go:1275 +0x24b
  gvisor.dev/gvisor/runsc/sandbox.(*Sandbox).Wait()
      runsc/sandbox/sandbox.go:823 +0xa2c
  gvisor.dev/gvisor/runsc/container.(*Container).Wait()
      runsc/container/container.go:524 +0x131
  gvisor.dev/gvisor/runsc/cmd.startContainerAndWait()
      runsc/cmd/do.go:398 +0xa18
  gvisor.dev/gvisor/runsc/cmd.(*Do).Execute()
      runsc/cmd/do.go:156 +0xc16
  github.com/google/subcommands.(*Commander).Execute()
      external/com_github_google_subcommands/subcommands.go:200 +0x66b
  github.com/google/subcommands.Execute()
      external/com_github_google_subcommands/subcommands.go:481 +0x2096
  gvisor.dev/gvisor/runsc/cli.Main()
      runsc/cli/main.go:243 +0x1fb4
  main.main()
      runsc/main.go:23 +0x56

Previous read at 0x00c000115be0 by goroutine 9:
  gvisor.dev/gvisor/runsc/sandbox.(*Sandbox).connError()
      runsc/sandbox/sandbox.go:387 +0x1e9
  gvisor.dev/gvisor/runsc/sandbox.(*Sandbox).sandboxConnect()
      runsc/sandbox/sandbox.go:381 +0x291
  gvisor.dev/gvisor/runsc/sandbox.(*Sandbox).SignalProcess()
      runsc/sandbox/sandbox.go:932 +0x135
  gvisor.dev/gvisor/runsc/container.(*Container).ForwardSignals.func1()
      runsc/container/container.go:591 +0x267
  gvisor.dev/gvisor/pkg/sentry/sighandling.handleSignals()
      pkg/sentry/sighandling/sighandling.go:63 +0x4f8

Goroutine 9 (running) created at:
  gvisor.dev/gvisor/pkg/sentry/sighandling.StartSignalForwarding()
      pkg/sentry/sighandling/sighandling.go:96 +0x284
  gvisor.dev/gvisor/runsc/container.(*Container).ForwardSignals()
      runsc/container/container.go:589 +0x21d
  gvisor.dev/gvisor/runsc/cmd.startContainerAndWait()
      runsc/cmd/do.go:395 +0x9d0
  gvisor.dev/gvisor/runsc/cmd.(*Do).Execute()
      runsc/cmd/do.go:156 +0xc16
  github.com/google/subcommands.(*Commander).Execute()
      external/com_github_google_subcommands/subcommands.go:200 +0x66b
  github.com/google/subcommands.Execute()
      external/com_github_google_subcommands/subcommands.go:481 +0x2096
  gvisor.dev/gvisor/runsc/cli.Main()
      runsc/cli/main.go:243 +0x1fb4
  main.main()
      runsc/main.go:23 +0x56
==================
Found 1 data race(s)
```

