### PR TITLE
runsc: Add the --ignore-cgroups option

### DIFF
--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -208,6 +208,9 @@ type Config struct {
 	// Mounts the cgroup filesystem backed by the sentry's cgroupfs.
 	Cgroupfs bool `flag:"cgroupfs"`
 
+	// Don't configure cgroups.
+	IgnoreCgroups bool `flag:"ignore-cgroups"`
+
 	// TestOnlyAllowRunAsCurrentUserWithoutChroot should only be used in
 	// tests. It allows runsc to start the sandbox process as the current
 	// user, and without chrooting the sandbox process. This can be

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -84,6 +84,7 @@ func RegisterFlags() {
 		flag.Bool("fuse", false, "TEST ONLY; use while FUSE in VFSv2 is landing. This allows the use of the new experimental FUSE filesystem.")
 		flag.Bool("lisafs", false, "Enables lisafs protocol instead of 9P. This is only effective with VFS2.")
 		flag.Bool("cgroupfs", false, "Automatically mount cgroupfs.")
+		flag.Bool("ignore-cgroups", false, "don't configure cgroups.")
 
 		// Flags that control sandbox runtime behavior: network related.
 		flag.Var(networkTypePtr(NetworkSandbox), "network", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")


### PR DESCRIPTION
If it is specified, runsc doesn't configure cgroups and starts a
container in a current cgroup set.

This can be used as a workaround for hosts with cgroupv2.