### PR TITLE
Allocate auxv with better capacity while loading stack

### DIFF
--- a/pkg/sentry/arch/stack.go
+++ b/pkg/sentry/arch/stack.go
@@ -190,7 +190,7 @@ func (s *Stack) Load(args []string, env []string, aux Auxv) (StackLayout, error)
 	// NOTE: We need an extra zero here per spec.
 	// The Push function will automatically terminate
 	// strings and arrays with a single null value.
-	auxv := make([]hostarch.Addr, 0, len(aux))
+	auxv := make([]hostarch.Addr, 0, len(aux)*2+1)
 	for _, a := range aux {
 		auxv = append(auxv, hostarch.Addr(a.Key), a.Value)
 	}


### PR DESCRIPTION
`auxv` in `arch/stack.go` is initialized with the capacity of `len(aux)` but `len(aux)*2+1` elements are appended.