### PR TITLE
Allow packet forwarding with address-less interfaces

### DIFF
--- a/pkg/tcpip/stack/route.go
+++ b/pkg/tcpip/stack/route.go
@@ -132,7 +132,7 @@ func (r *Route) fieldsLocked() RouteInfo {
 //
 // Returns an empty route if validation fails.
 func constructAndValidateRoute(netProto tcpip.NetworkProtocolNumber, addressEndpoint AssignableAddressEndpoint, localAddressNIC, outgoingNIC *nic, gateway, localAddr, remoteAddr tcpip.Address, handleLocal, multicastLoop bool) *Route {
-	if len(localAddr) == 0 {
+	if addressEndpoint != nil && len(localAddr) == 0 {
 		localAddr = addressEndpoint.AddressWithPrefix().Address
 	}
 
@@ -168,7 +168,7 @@ func makeRoute(netProto tcpip.NetworkProtocolNumber, gateway, localAddr, remoteA
 		panic(fmt.Sprintf("cannot create a route with NICs from different stacks"))
 	}
 
-	if len(localAddr) == 0 {
+	if localAddressEndpoint != nil && len(localAddr) == 0 {
 		localAddr = localAddressEndpoint.AddressWithPrefix().Address
 	}
 
@@ -184,8 +184,10 @@ func makeRoute(netProto tcpip.NetworkProtocolNumber, gateway, localAddr, remoteA
 			loop |= PacketLoop
 		} else if remoteAddr == header.IPv4Broadcast {
 			loop |= PacketLoop
-		} else if subnet := localAddressEndpoint.AddressWithPrefix().Subnet(); subnet.IsBroadcast(remoteAddr) {
-			loop |= PacketLoop
+		} else if localAddressEndpoint != nil {
+			if subnet := localAddressEndpoint.AddressWithPrefix().Subnet(); subnet.IsBroadcast(remoteAddr) {
+				loop |= PacketLoop
+			}
 		}
 	}
 

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -1169,7 +1169,7 @@ func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, n
 			}
 
 			plen := route.Destination.Mask().Prefix()
-			if plen <= bestPrefixLen {
+			if plen < bestPrefixLen {
 				continue
 			}
 
@@ -1182,7 +1182,7 @@ func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, n
 
 					if r := constructAndValidateRoute(netProto, addressEndpoint, nic /* outgoingNIC */, nic /* outgoingNIC */, gateway, localAddr, remoteAddr, s.handleLocal, multicastLoop); r == nil {
 						panic(fmt.Sprintf("non-forwarding route validation failed with route table entry = %#v, id = %d, localAddr = %s, remoteAddr = %s", route, id, localAddr, remoteAddr))
-					} else if plen > bestPrefixLen {
+					} else if plen >= bestPrefixLen {
 						bestRoute, bestPrefixLen = r, plen
 					}
 				} else {
@@ -1191,7 +1191,7 @@ func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, n
 					// construct a route that uses the remote address as the gateway.
 					if r := constructAndValidateRoute(netProto, nil, nic /* outgoingNIC */, nic /* outgoingNIC */, remoteAddr, localAddr, remoteAddr, s.handleLocal, multicastLoop); r == nil {
 						panic(fmt.Sprintf("non-forwarding route validation failed with route table entry = %#v, id = %d, localAddr = %s, remoteAddr = %s", route, id, localAddr, remoteAddr))
-					} else if plen > bestPrefixLen {
+					} else if plen >= bestPrefixLen {
 						bestRoute, bestPrefixLen = r, plen
 					}
 				}

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -1151,6 +1151,13 @@ func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, n
 		s.routeMu.RLock()
 		defer s.routeMu.RUnlock()
 
+		// We want to find the route that has the longest prefix length,
+		// so that more specific routes will win.
+		// TODO: Probably should have additional tie-breaks here so that
+		// the result is always deterministic.
+		var bestPrefixLen int
+		var bestRoute *Route
+
 		for _, route := range s.routeTable {
 			if len(remoteAddr) != 0 && !route.Destination.Contains(remoteAddr) {
 				continue
@@ -1161,17 +1168,32 @@ func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, n
 				continue
 			}
 
+			plen := route.Destination.Mask().Prefix()
+			if plen <= bestPrefixLen {
+				continue
+			}
+
 			if id == 0 || id == route.NIC {
 				if addressEndpoint := s.getAddressEP(nic, localAddr, remoteAddr, netProto); addressEndpoint != nil {
 					var gateway tcpip.Address
 					if needRoute {
 						gateway = route.Gateway
 					}
-					r := constructAndValidateRoute(netProto, addressEndpoint, nic /* outgoingNIC */, nic /* outgoingNIC */, gateway, localAddr, remoteAddr, s.handleLocal, multicastLoop)
-					if r == nil {
+
+					if r := constructAndValidateRoute(netProto, addressEndpoint, nic /* outgoingNIC */, nic /* outgoingNIC */, gateway, localAddr, remoteAddr, s.handleLocal, multicastLoop); r == nil {
 						panic(fmt.Sprintf("non-forwarding route validation failed with route table entry = %#v, id = %d, localAddr = %s, remoteAddr = %s", route, id, localAddr, remoteAddr))
+					} else if plen > bestPrefixLen {
+						bestRoute, bestPrefixLen = r, plen
 					}
-					return r
+				} else {
+					// There's no local address on the NIC but this route suggests that
+					// we can still reach this destination address via this NIC, so just
+					// construct a route that uses the remote address as the gateway.
+					if r := constructAndValidateRoute(netProto, nil, nic /* outgoingNIC */, nic /* outgoingNIC */, remoteAddr, localAddr, remoteAddr, s.handleLocal, multicastLoop); r == nil {
+						panic(fmt.Sprintf("non-forwarding route validation failed with route table entry = %#v, id = %d, localAddr = %s, remoteAddr = %s", route, id, localAddr, remoteAddr))
+					} else if plen > bestPrefixLen {
+						bestRoute, bestPrefixLen = r, plen
+					}
 				}
 			}
 
@@ -1187,7 +1209,7 @@ func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, n
 			}
 		}
 
-		return nil
+		return bestRoute // might be nil
 	}(); r != nil {
 		return r, nil
 	}


### PR DESCRIPTION
This should fix #7184 by allowing packet forwarding to take place even if the interface doesn't have an address assigned.

This is done by:
1. accepting the route, using the remote address as a gateway, if there's no address endpoint;
2. ensuring that we find the route with the longest prefix length, given that there might be more than one route available that covers the address — we always want the most specific route;
3. making finding the local address endpoint optional in a couple of places so we don't panic if it is `nil`.

First PR here — go easy on me. 😄 

cc @hbhasker 