### PR TITLE
packet_buffer: reset packet buffer state in Clone

### DIFF
--- a/pkg/tcpip/stack/packet_buffer.go
+++ b/pkg/tcpip/stack/packet_buffer.go
@@ -329,6 +329,7 @@ func (pk *PacketBuffer) headerView(typ headerType) tcpipbuffer.View {
 // shared. Hence, no modifications is done to underlying packet payload.
 func (pk *PacketBuffer) Clone() *PacketBuffer {
 	newPk := pkPool.Get().(*PacketBuffer)
+	newPk.reset()
 	newPk.PacketBufferEntry = pk.PacketBufferEntry
 	newPk.buf = pk.buf.Clone()
 	newPk.reserved = pk.reserved


### PR DESCRIPTION
The reset may be defensive, however, the code as-is is missing a clone
of EgressRoute, and was previously also missing the should-not-be-set
PreserveObject. The reset provides clarity of intent and safety against
missing field assignments.