### PR TITLE
Add debug.SetTraceback for runsc-gofer

### DIFF
--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/google/subcommands"
@@ -98,6 +99,9 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...interface{})
 	}
 
 	conf := args[0].(*config.Config)
+
+	// Set traceback level
+	debug.SetTraceback(conf.Traceback)
 
 	specFile := os.NewFile(uintptr(g.specFD), "spec file")
 	defer specFile.Close()


### PR DESCRIPTION
The -traceback flag sets the Debug.SetTraceback for runsc-sandbox.
We need this for gofer too. Fixes #7583