### PR TITLE
tcpip/transport/raw: check MTU before copying a buffer from user memory

### DIFF
--- a/pkg/tcpip/transport/internal/network/endpoint.go
+++ b/pkg/tcpip/transport/internal/network/endpoint.go
@@ -235,6 +235,10 @@ type WriteContext struct {
 	tos   uint8
 }
 
+func (c *WriteContext) MTU() uint32 {
+	return c.route.MTU()
+}
+
 // Release releases held resources.
 func (c *WriteContext) Release() {
 	c.route.Release()

--- a/pkg/tcpip/transport/raw/endpoint.go
+++ b/pkg/tcpip/transport/raw/endpoint.go
@@ -345,6 +345,10 @@ func (e *endpoint) write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcp
 		return 0, err
 	}
 
+	if p.Len() > int(ctx.MTU()) {
+		return 0, &tcpip.ErrMessageTooLong{}
+	}
+
 	// TODO(https://gvisor.dev/issue/6538): Avoid this allocation.
 	payloadBytes := make([]byte, p.Len())
 	if _, err := io.ReadFull(p, payloadBytes); err != nil {


### PR DESCRIPTION
Reported-by: syzbot+5cccbb7c0511ad1aa175@syzkaller.appspotmail.com