### PR TITLE
sync/lockdep: use RangeRepeatable instead of Range

### DIFF
--- a/pkg/sync/locking/lockdep.go
+++ b/pkg/sync/locking/lockdep.go
@@ -70,7 +70,7 @@ func checkLock(class *MutexClass, prevClass *MutexClass, chain []*MutexClass) {
 		}
 		panic(b.String())
 	}
-	prevClass.ancestors.Range(func(parentClass *MutexClass, stacks *string) bool {
+	prevClass.ancestors.RangeRepeatable(func(parentClass *MutexClass, stacks *string) bool {
 		// The recursion is fine here. If it fails, you need to reduce
 		// a number of nested locks.
 		checkLock(class, parentClass, chain)


### PR DESCRIPTION
It is lockless and so it guarantes to avoid nested locks (deadlocks).

Reported-by: syzbot+7f2b94fef2e1109bcd40@syzkaller.appspotmail.com