### PR TITLE
platform/kvm: allow KVM_{G,S}ET_REGS in seccomp filters

### DIFF
--- a/pkg/sentry/platform/kvm/filters.go
+++ b/pkg/sentry/platform/kvm/filters.go
@@ -34,6 +34,14 @@ func (k *KVM) SyscallFilters() seccomp.SyscallRules {
 				seccomp.MatchAny{},
 				seccomp.EqualTo(_KVM_SET_USER_MEMORY_REGION),
 			},
+			{
+				seccomp.MatchAny{},
+				seccomp.EqualTo(_KVM_GET_REGS),
+			},
+			{
+				seccomp.MatchAny{},
+				seccomp.EqualTo(_KVM_SET_REGS),
+			},
 		},
 		unix.SYS_MEMBARRIER: []seccomp.Rule{
 			{


### PR DESCRIPTION
They are used in bluepillReadyStopGuest to ajust rflags.

Fixes: #7600