### PR TITLE
context: initialize and use bgContext once

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -260,6 +260,8 @@ func Log() *BasicLogger {
 //
 // This is not thread safe and shouldn't be called concurrently with any
 // logging calls.
+//
+// SetTarget should be called before any instances of log.Log() to avoid race conditions
 func SetTarget(target Emitter) {
 	logMu.Lock()
 	defer logMu.Unlock()


### PR DESCRIPTION
bgContext is set during package initialization. However, the global
logger's SetTarget() method doesn't apply to instances of
context.Background() loaded after the first one.

See https://github.com/google/gvisor/issues/7795