### PR TITLE
Add support for /proc/[pid]/limits

### DIFF
--- a/pkg/sentry/fsimpl/proc/task.go
+++ b/pkg/sentry/fsimpl/proc/task.go
@@ -64,6 +64,7 @@ func (fs *filesystem) newTaskInode(ctx context.Context, task *kernel.Task, pidns
 		"fdinfo":    fs.newFDInfoDirInode(ctx, task),
 		"gid_map":   fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0644, &idMapData{task: task, gids: true}),
 		"io":        fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0400, newIO(task, isThreadGroup)),
+		"limits":    fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, &limitsData{task: task}),
 		"maps":      fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, &mapsData{task: task}),
 		"mem":       fs.newMemInode(ctx, task, fs.NextIno(), 0400),
 		"mountinfo": fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, &mountInfoData{fs: fs, task: task}),

--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -539,12 +539,13 @@ type limitsData struct {
 }
 
 func (d *limitsData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	taskLimits := d.task.Limits()
 	// formatting matches the kernel output from linux/fs/proc/base.c:proc_pid_limits()
 	fmt.Fprintf(buf, "Limit                     Soft Limit           Hard Limit           Units     \n")
 	for _, lt := range limits.AllLimitTypes {
 		fmt.Fprintf(buf, "%-25s ", lt.Name())
 
-		l := d.task.Limits().Get(lt)
+		l := taskLimits.Get(lt)
 		if l.Cur == limits.Infinity {
 			fmt.Fprintf(buf, "%-20s ", "unlimited")
 		} else {

--- a/pkg/sentry/fsimpl/proc/tasks_test.go
+++ b/pkg/sentry/fsimpl/proc/tasks_test.go
@@ -78,6 +78,7 @@ var (
 		"fdinfo":        linux.DT_DIR,
 		"gid_map":       linux.DT_REG,
 		"io":            linux.DT_REG,
+		"limits":        linux.DT_REG,
 		"maps":          linux.DT_REG,
 		"mem":           linux.DT_REG,
 		"mountinfo":     linux.DT_REG,

--- a/pkg/sentry/limits/limits.go
+++ b/pkg/sentry/limits/limits.go
@@ -43,6 +43,103 @@ const (
 	Rttime
 )
 
+var AllLimitTypes = []LimitType{
+	CPU,
+	FileSize,
+	Data,
+	Stack,
+	Core,
+	Rss,
+	ProcessCount,
+	NumberOfFiles,
+	MemoryLocked,
+	AS,
+	Locks,
+	SignalsPending,
+	MessageQueueBytes,
+	Nice,
+	RealTimePriority,
+	Rttime,
+}
+
+// Name returns the kernel name of the limit
+func (lt LimitType) Name() string {
+	switch lt {
+	case CPU:
+		return "Max cpu time"
+	case FileSize:
+		return "Max file size"
+	case Data:
+		return "Max data size"
+	case Stack:
+		return "Max stack size"
+	case Core:
+		return "Max core file size"
+	case Rss:
+		return "Max resident set"
+	case ProcessCount:
+		return "Max processes"
+	case NumberOfFiles:
+		return "Max open files"
+	case MemoryLocked:
+		return "Max locked memory"
+	case AS:
+		return "Max address space"
+	case Locks:
+		return "Max file locks"
+	case SignalsPending:
+		return "Max pending signals"
+	case MessageQueueBytes:
+		return "Max msgqueue size"
+	case Nice:
+		return "Max nice priority"
+	case RealTimePriority:
+		return "Max realtime priority"
+	case Rttime:
+		return "Max realtime timeout"
+	}
+	return "unknown"
+}
+
+// Unit returns the unit string for a limit
+func (lt LimitType) Unit() string {
+	switch lt {
+	case CPU:
+		return "seconds"
+	case FileSize:
+		return "bytes"
+	case Data:
+		return "bytes"
+	case Stack:
+		return "bytes"
+	case Core:
+		return "bytes"
+	case Rss:
+		return "bytes"
+	case ProcessCount:
+		return "processes"
+	case NumberOfFiles:
+		return "files"
+	case MemoryLocked:
+		return "bytes"
+	case AS:
+		return "bytes"
+	case Locks:
+		return "locks"
+	case SignalsPending:
+		return "signals"
+	case MessageQueueBytes:
+		return "bytes"
+	case Nice:
+		return ""
+	case RealTimePriority:
+		return ""
+	case Rttime:
+		return "us"
+	}
+	return ""
+}
+
 // Infinity is a constant representing a resource with no limit.
 const Infinity = ^uint64(0)
 

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -2139,6 +2139,7 @@ cc_binary(
     linkstatic = 1,
     deps = [
         "//test/util:capability_util",
+        "//test/util:proc_util",
         "//test/util:test_main",
         "//test/util:test_util",
         "//test/util:thread_util",

--- a/test/util/proc_util.h
+++ b/test/util/proc_util.h
@@ -195,6 +195,49 @@ MATCHER_P(ContainsMappings, mappings,
   return all_present;
 }
 
+// LimitType is an rlimit type
+enum class LimitType {
+	CPU,
+	FileSize,
+	Data,
+	Stack,
+	Core,
+	RSS,
+	ProcessCount,
+	NumberOfFiles,
+	MemoryLocked,
+	AS,
+	Locks,
+	SignalsPending,
+	MessageQueueBytes,
+	Nice,
+	RealTimePriority,
+	Rttime,
+};
+
+// ProcLimitsEntry contains the data from a single line in /proc/xxx/limits.
+struct ProcLimitsEntry {
+    LimitType limit_type;
+    uint64_t cur_limit;
+    uint64_t max_limit;
+};
+
+// Parses a single line from /proc/xxx/limits
+PosixErrorOr<ProcLimitsEntry> ParseProcLimitsLine(absl::string_view line);
+
+// Parses an entire /proc/xxx/limits file into lines
+PosixErrorOr<std::vector<ProcLimitsEntry>> ParseProcLimits(absl::string_view contents);
+
+// Printer for ProcLimitsEntry.
+std::ostream& operator<<(std::ostream& os, const ProcLimitsEntry& entry);
+
+// Printer for std::vector<ProcLimitsEntry>.
+std::ostream& operator<<(std::ostream& os, const std::vector<ProcLimitsEntry>& vec);
+
+// GMock printer for std::vector<ProcLimitsEntry>.
+inline void PrintTo(const std::vector<ProcLimitsEntry>& vec, std::ostream* os) {
+  *os << vec;
+}
 }  // namespace testing
 }  // namespace gvisor
 


### PR DESCRIPTION
This adds support for the `/proc/[pid]/limits` file to view information from `ulimit` or `setrlimit`. It prints the output in the exact format that the Linux kernel uses, which is hand-spaced columns instead of tabs or a columnar printer. In order to support the file format, helpers have been added to get the textual names and units for the limit types.