### PR TITLE
atomicbitops, cpuid: fix warnings, lack of atomics on macOS

### DIFF
--- a/pkg/atomicbitops/BUILD
+++ b/pkg/atomicbitops/BUILD
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/cpuid",
         "//pkg/sync",
+	"@org_golang_x_sys//cpu:go_default_library",
     ],
 )
 

--- a/pkg/atomicbitops/atomicbitops_arm64.go
+++ b/pkg/atomicbitops/atomicbitops_arm64.go
@@ -17,6 +17,24 @@
 
 package atomicbitops
 
-import "gvisor.dev/gvisor/pkg/cpuid"
+import (
+	"runtime"
 
-var arm64HasATOMICS = cpuid.HostFeatureSet().HasFeature(cpuid.ARM64FeatureATOMICS)
+	"golang.org/x/sys/cpu"
+	"gvisor.dev/gvisor/pkg/cpuid"
+)
+
+var arm64HasATOMICS bool
+
+func init() {
+	// The gvisor cpuid package only works on Linux.
+	// For all other operating systems, use Go's x/sys/cpu package
+	// to get the one bit we care about here.
+	//
+	// See https://github.com/google/gvisor/issues/7849.
+	if runtime.GOOS == "linux" {
+		arm64HasATOMICS = cpuid.HostFeatureSet().HasFeature(cpuid.ARM64FeatureATOMICS)
+	} else {
+		arm64HasATOMICS = cpu.ARM64.HasATOMICS
+	}
+}

--- a/pkg/cpuid/native_arm64.go
+++ b/pkg/cpuid/native_arm64.go
@@ -20,6 +20,7 @@ package cpuid
 import (
 	"encoding/binary"
 	"io/ioutil"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -46,6 +47,11 @@ func (fs FeatureSet) Fixed() FeatureSet {
 // Must run before syscall filter installation. This value is used to create
 // the fake /proc/cpuinfo from a FeatureSet.
 func initCPUInfo() {
+	if runtime.GOOS != "linux" {
+		// Don't try to read Linux-specific /proc files or
+		// warn about them not existing.
+		return
+	}
 	cpuinfob, err := ioutil.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		// Leave everything at 0, nothing can be done.
@@ -172,6 +178,11 @@ func initCPUInfo() {
 //	0000440                   15      140734614619529
 //	0000460                    0                    0
 func initHwCap() {
+	if runtime.GOOS != "linux" {
+		// Don't try to read Linux-specific /proc files or
+		// warn about them not existing.
+		return
+	}
 	auxv, err := ioutil.ReadFile("/proc/self/auxv")
 	if err != nil {
 		log.Warningf("Could not read /proc/self/auxv: %v", err)

--- a/pkg/tcpip/BUILD
+++ b/pkg/tcpip/BUILD
@@ -69,6 +69,7 @@ deps_test(
 
         # Other deps.
         "@com_github_google_btree//:go_default_library",
+        "@org_golang_x_sys//cpu:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",
         "@org_golang_x_time//rate:go_default_library",
     ],


### PR DESCRIPTION
Updates google/gvisor#7849
