### PR TITLE
support some command of ioctl for hostnetwork mode

### DIFF
--- a/pkg/sentry/socket/hostinet/stack.go
+++ b/pkg/sentry/socket/hostinet/stack.go
@@ -29,6 +29,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/marshal/primitive"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
@@ -159,6 +160,8 @@ func ExtractHostInterfaces(links []syscall.NetlinkMessage, addrs []syscall.Netli
 				inetIF.Addr = attr.Value
 			case unix.IFLA_IFNAME:
 				inetIF.Name = string(attr.Value[:len(attr.Value)-1])
+			case unix.IFLA_MTU:
+				inetIF.MTU = hostarch.ByteOrder.Uint32(attr.Value)
 			}
 		}
 		interfaces[ifinfo.Index] = &inetIF

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -3371,8 +3371,9 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 				continue
 			}
 			copy(ifr.Data[4:8], addr.Addr)
-			break
+			return nil
 		}
+		return syserr.ErrAddressNotAvailable
 
 	case linux.SIOCGIFMETRIC:
 		// Gets the metric of the device. As per netdevice(7), this
@@ -3413,8 +3414,9 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 			// Netmask is expected to be returned as a big endian
 			// value.
 			binary.BigEndian.PutUint32(ifr.Data[4:8], mask)
-			break
+			return nil
 		}
+		return syserr.ErrAddressNotAvailable
 
 	case linux.SIOCETHTOOL:
 		// Stubbed out for now, Ideally we should implement the required


### PR DESCRIPTION
support ioctl SIOCGIFINDEX,SIOCGIFADDR,SIOCGIFMTU,SIOCGIFNETMASK,SIOCGIFHWADDR for hostnetwork mode.

This commit can fix some ioctl exception from java.net.NetworkInterface API, and fix problem that we can not get ipv4 net address, mtu, netmask, and mac address when calling 'ifconfig' inside hostnetwork mode gvisor container. 

Signed-off-by: Tan Yifeng <yiftan@163.com>