### PR TITLE
support set or get tcpsockopt TCP_MAXSEG, TCP_CONGESTION for hostnetwork.

### DIFF
--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -406,10 +406,12 @@ func (s *socketOpsCommon) GetSockOpt(t *kernel.Task, level int, name int, optVal
 		}
 	case linux.SOL_TCP:
 		switch name {
-		case linux.TCP_NODELAY:
+		case linux.TCP_NODELAY, linux.TCP_MAXSEG:
 			optlen = sizeofInt32
 		case linux.TCP_INFO:
 			optlen = linux.SizeOfTCPInfo
+		case linux.TCP_CONGESTION:
+			optlen = outLen
 		}
 	}
 
@@ -461,8 +463,10 @@ func (s *socketOpsCommon) SetSockOpt(t *kernel.Task, level int, name int, opt []
 		}
 	case linux.SOL_TCP:
 		switch name {
-		case linux.TCP_NODELAY, linux.TCP_INQ:
+		case linux.TCP_NODELAY, linux.TCP_INQ, linux.TCP_MAXSEG:
 			optlen = sizeofInt32
+		case linux.TCP_CONGESTION:
+			optlen = len(opt)
 		}
 	}
 

--- a/runsc/boot/filter/config.go
+++ b/runsc/boot/filter/config.go
@@ -504,6 +504,16 @@ func hostInetFilters() seccomp.SyscallRules {
 				seccomp.EqualTo(unix.SOL_TCP),
 				seccomp.EqualTo(linux.TCP_INQ),
 			},
+			{
+				seccomp.MatchAny{},
+				seccomp.EqualTo(unix.SOL_TCP),
+				seccomp.EqualTo(linux.TCP_MAXSEG),
+			},
+			{
+				seccomp.MatchAny{},
+				seccomp.EqualTo(unix.SOL_TCP),
+				seccomp.EqualTo(linux.TCP_CONGESTION),
+			},
 		},
 		unix.SYS_IOCTL: []seccomp.Rule{
 			{
@@ -571,6 +581,18 @@ func hostInetFilters() seccomp.SyscallRules {
 				seccomp.EqualTo(linux.TCP_INQ),
 				seccomp.MatchAny{},
 				seccomp.EqualTo(4),
+			},
+			{
+				seccomp.MatchAny{},
+				seccomp.EqualTo(unix.SOL_TCP),
+				seccomp.EqualTo(linux.TCP_MAXSEG),
+				seccomp.MatchAny{},
+				seccomp.EqualTo(4),
+			},
+			{
+				seccomp.MatchAny{},
+				seccomp.EqualTo(unix.SOL_TCP),
+				seccomp.EqualTo(linux.TCP_CONGESTION),
 			},
 			{
 				seccomp.MatchAny{},


### PR DESCRIPTION
Support set or get tcpsockopt TCP_MAXSEG, TCP_CONGESTION for hostnetwork mode.

This will fix iperf3 3.9 version running error.

Signed-off-by: Tan Yifeng <yiftan@163.com>