### PR TITLE
Truncate the output buffer to outLen size when getsockopt with TCP_INFO.

### DIFF
--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -410,6 +410,10 @@ func (s *socketOpsCommon) GetSockOpt(t *kernel.Task, level int, name int, optVal
 			optlen = sizeofInt32
 		case linux.TCP_INFO:
 			optlen = linux.SizeOfTCPInfo
+			// Truncate the output buffer to outLen size.
+			if optlen > outLen {
+				optlen = outLen
+			}
 		case linux.TCP_CONGESTION:
 			optlen = outLen
 		}


### PR DESCRIPTION
This will fix error that gvisor returned EINVAL in hostnetwork mode
if outLen of user process passed in is less than length of linux.SizeOfTCPInfo in gvisor.

Signed-off-by: Tan Yifeng <yiftan@163.com>