### PR TITLE
benchmarks: add and fix some benchmarks

### DIFF
--- a/images/benchmarks/hackbench/Dockerfile
+++ b/images/benchmarks/hackbench/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:18.04
+
+RUN set -x \
+        && apt-get update \
+        && apt-get install -y rt-tests \
+        && rm -rf /var/lib/apt/lists/*

--- a/images/benchmarks/syscallbench/Dockerfile
+++ b/images/benchmarks/syscallbench/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+RUN set -x \
+        && apt-get update \
+        && apt-get install -y \
+            gcc \
+        && rm -rf /var/lib/apt/lists/*
+
+COPY ./syscallbench.c /
+RUN gcc /syscallbench.c -o /usr/bin/syscallbench

--- a/images/benchmarks/syscallbench/syscallbench.c
+++ b/images/benchmarks/syscallbench/syscallbench.c
@@ -1,0 +1,79 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdio.h>
+#include <sys/time.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <getopt.h>
+
+static int loops = 10000000;
+
+static void show_usage(const char *cmd)
+{
+	fprintf(stderr, "Usage: %s [options]\n"
+		"-l, --loops <num>\t\t Number of syscall loops, default 10000000\n", cmd);
+	exit(1);
+}
+
+int main(int argc, char *argv[])
+{
+	struct timeval start, stop, diff;
+	unsigned long long result_nsec = 0;
+	int i;
+	int c;
+	struct option long_options[] = {
+		{"loops", required_argument, 0, 'l'},
+		{0, 0, 0, 0}};
+	int option_index = 0;
+
+	while ((c = getopt_long(argc, argv, "l:", long_options, &option_index)) != -1) {
+		switch (c) {
+		case 'l':
+			loops = atoi(optarg);
+			if (loops <= 0) {
+				show_usage(argv[0]);
+				exit(0);
+			}
+			break;
+		default:
+			show_usage(argv[0]);
+			exit(0);
+		}
+	}
+
+	gettimeofday(&start, NULL);
+
+	for (i = 0; i < loops; i++)
+		syscall(SYS_getpid);
+
+	gettimeofday(&stop, NULL);
+	timersub(&stop, &start, &diff);
+
+	printf("# Executed %'d getpid() calls\n", loops);
+
+	result_nsec = diff.tv_sec * 1000000000;
+	result_nsec += diff.tv_usec * 1000;
+
+	printf(" %14s: %lu.%03lu [sec]\n\n", "Total time",
+	       diff.tv_sec, (unsigned long) (diff.tv_usec/1000));
+
+	printf(" %14lf ns/syscall\n",
+	       (double)result_nsec / (double)loops);
+	printf(" %'14d syscalls/sec\n",
+	       (int)((double)loops / ((double)result_nsec / (double)1000000000)));
+	return 0;
+}

--- a/test/benchmarks/base/BUILD
+++ b/test/benchmarks/base/BUILD
@@ -48,3 +48,14 @@ benchmark_test(
         "//test/benchmarks/tools",
     ],
 )
+
+benchmark_test(
+    name = "syscallbench_test",
+    srcs = ["syscallbench_test.go"],
+    visibility = ["//:sandbox"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/benchmarks/harness",
+        "//test/benchmarks/tools",
+    ],
+)

--- a/test/benchmarks/base/BUILD
+++ b/test/benchmarks/base/BUILD
@@ -59,3 +59,14 @@ benchmark_test(
         "//test/benchmarks/tools",
     ],
 )
+
+benchmark_test(
+    name = "hackbench_test",
+    srcs = ["hackbench_test.go"],
+    visibility = ["//:sandbox"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/benchmarks/harness",
+        "//test/benchmarks/tools",
+    ],
+)

--- a/test/benchmarks/base/hackbench_test.go
+++ b/test/benchmarks/base/hackbench_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hackbench_test
+
+import (
+	"context"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/benchmarks/harness"
+	"gvisor.dev/gvisor/test/benchmarks/tools"
+)
+
+// BenchmarHackbench runs hackbench on the runtime.
+func BenchmarkHackbench(b *testing.B) {
+	testCases := []tools.Hackbench{
+		{
+			IpcMode:     "pipe",
+			ProcessMode: "thread",
+		},
+		{
+			IpcMode:     "socket",
+			ProcessMode: "process",
+		},
+	}
+
+	machine, err := harness.GetMachine()
+	if err != nil {
+		b.Fatalf("failed to get machine: %v", err)
+	}
+	defer machine.CleanUp()
+
+	for _, tc := range testCases {
+		ipcMode := tools.Parameter{
+			Name:  "ipcMode",
+			Value: tc.IpcMode,
+		}
+		processMode := tools.Parameter{
+			Name:  "processMode",
+			Value: tc.ProcessMode,
+		}
+		name, err := tools.ParametersToName(ipcMode, processMode)
+		if err != nil {
+			b.Fatalf("Failed to parse params: %v", err)
+		}
+		b.Run(name, func(b *testing.B) {
+			ctx := context.Background()
+			container := machine.GetContainer(ctx, b)
+			defer container.CleanUp(ctx)
+
+			cmd := tc.MakeCmd(b)
+			b.ResetTimer()
+			out, err := container.Run(ctx, dockerutil.RunOpts{
+				Image: "benchmarks/hackbench",
+			}, cmd...)
+			if err != nil {
+				b.Fatalf("failed to run hackbench: %v: logs:%s", err, out)
+			}
+			b.StopTimer()
+			tc.Report(b, out)
+		})
+	}
+}

--- a/test/benchmarks/base/sysbench_test.go
+++ b/test/benchmarks/base/sysbench_test.go
@@ -16,6 +16,7 @@ package sysbench_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/test/dockerutil"
@@ -24,15 +25,17 @@ import (
 )
 
 type testCase struct {
-	name string
-	test tools.Sysbench
+	name    string
+	threads int
+	test    tools.Sysbench
 }
 
 // BenchmarSysbench runs sysbench on the runtime.
 func BenchmarkSysbench(b *testing.B) {
 	testCases := []testCase{
 		{
-			name: "CPU",
+			name:    "CPU",
+			threads: 1,
 			test: &tools.SysbenchCPU{
 				SysbenchBase: tools.SysbenchBase{
 					Threads: 1,
@@ -40,7 +43,17 @@ func BenchmarkSysbench(b *testing.B) {
 			},
 		},
 		{
-			name: "Memory",
+			name:    "CPU",
+			threads: 16,
+			test: &tools.SysbenchCPU{
+				SysbenchBase: tools.SysbenchBase{
+					Threads: 16,
+				},
+			},
+		},
+		{
+			name:    "Memory",
+			threads: 1,
 			test: &tools.SysbenchMemory{
 				SysbenchBase: tools.SysbenchBase{
 					Threads: 1,
@@ -48,7 +61,17 @@ func BenchmarkSysbench(b *testing.B) {
 			},
 		},
 		{
-			name: "Mutex",
+			name:    "Memory",
+			threads: 16,
+			test: &tools.SysbenchMemory{
+				SysbenchBase: tools.SysbenchBase{
+					Threads: 16,
+				},
+			},
+		},
+		{
+			name:    "Mutex",
+			threads: 8,
 			test: &tools.SysbenchMutex{
 				SysbenchBase: tools.SysbenchBase{
 					Threads: 8,
@@ -68,7 +91,11 @@ func BenchmarkSysbench(b *testing.B) {
 			Name:  "testname",
 			Value: tc.name,
 		}
-		name, err := tools.ParametersToName(param)
+		threads := tools.Parameter{
+			Name:  "threads",
+			Value: fmt.Sprintf("%d", tc.threads),
+		}
+		name, err := tools.ParametersToName(param, threads)
 		if err != nil {
 			b.Fatalf("Failed to parse params: %v", err)
 		}

--- a/test/benchmarks/base/syscallbench_test.go
+++ b/test/benchmarks/base/syscallbench_test.go
@@ -1,0 +1,62 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syscallbench_test
+
+import (
+	"context"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/benchmarks/harness"
+	"gvisor.dev/gvisor/test/benchmarks/tools"
+)
+
+// BenchmarSyscallbench runs syscallbench on the runtime.
+func BenchmarkSyscallbench(b *testing.B) {
+	machine, err := harness.GetMachine()
+	if err != nil {
+		b.Fatalf("failed to get machine: %v", err)
+	}
+	defer machine.CleanUp()
+
+	param := tools.Parameter{
+		Name:  "syscall",
+		Value: "getpid",
+	}
+	name, err := tools.ParametersToName(param)
+	if err != nil {
+		b.Fatalf("Failed to parse params: %v", err)
+	}
+	b.Run(name, func(b *testing.B) {
+		ctx := context.Background()
+		container := machine.GetContainer(ctx, b)
+		defer container.CleanUp(ctx)
+
+		syscallbench := tools.Syscallbench{
+			Loops: b.N, // total number of loops
+		}
+
+		cmd := syscallbench.MakeCmd(b)
+		b.ResetTimer()
+		out, err := container.Run(ctx, dockerutil.RunOpts{
+			Image: "benchmarks/syscallbench",
+		}, cmd...)
+		if err != nil {
+			b.Fatalf("failed to run syscallbench: %v: logs:%s", err, out)
+		}
+		b.StopTimer()
+		syscallbench.Report(b, out)
+	})
+}

--- a/test/benchmarks/fs/fio_test.go
+++ b/test/benchmarks/fs/fio_test.go
@@ -126,7 +126,7 @@ func BenchmarkFio(b *testing.B) {
 
 				// For reads, we need a file to read so make one inside the container.
 				if strings.Contains(tc.Test, "read") {
-					fallocateCmd := fmt.Sprintf("fallocate -l %dK %s", tc.Size, outfile)
+					fallocateCmd := fmt.Sprintf("fallocate -l %dM %s", tc.Size, outfile)
 					if out, err := container.Exec(ctx, dockerutil.ExecOpts{},
 						strings.Split(fallocateCmd, " ")...); err != nil {
 						b.Fatalf("failed to create readable file on mount: %v, %s", err, out)

--- a/test/benchmarks/fs/fio_test.go
+++ b/test/benchmarks/fs/fio_test.go
@@ -39,12 +39,22 @@ func BenchmarkFio(b *testing.B) {
 		},
 		{
 			Test:      "write",
+			BlockSize: 64,
+			IODepth:   4,
+		},
+		{
+			Test:      "write",
 			BlockSize: 1024,
 			IODepth:   4,
 		},
 		{
 			Test:      "read",
 			BlockSize: 4,
+			IODepth:   4,
+		},
+		{
+			Test:      "read",
+			BlockSize: 64,
 			IODepth:   4,
 		},
 		{

--- a/test/benchmarks/network/iperf_test.go
+++ b/test/benchmarks/network/iperf_test.go
@@ -41,6 +41,8 @@ func BenchmarkIperf(b *testing.B) {
 	ctx := context.Background()
 	for _, bm := range []struct {
 		name       string
+		length     int
+		parallel   int
 		clientFunc func(context.Context, testutil.Logger) *dockerutil.Container
 		serverFunc func(context.Context, testutil.Logger) *dockerutil.Container
 	}{
@@ -49,11 +51,85 @@ func BenchmarkIperf(b *testing.B) {
 		// server.
 		{
 			name:       "Upload",
+			length:     4,
+			parallel:   1,
+			clientFunc: clientMachine.GetContainer,
+			serverFunc: serverMachine.GetNativeContainer,
+		},
+		{
+			name:       "Upload",
+			length:     64,
+			parallel:   1,
+			clientFunc: clientMachine.GetContainer,
+			serverFunc: serverMachine.GetNativeContainer,
+		},
+		{
+			name:       "Upload",
+			length:     1024,
+			parallel:   1,
+			clientFunc: clientMachine.GetContainer,
+			serverFunc: serverMachine.GetNativeContainer,
+		},
+		{
+			name:       "Upload",
+			length:     4,
+			parallel:   16,
+			clientFunc: clientMachine.GetContainer,
+			serverFunc: serverMachine.GetNativeContainer,
+		},
+		{
+			name:       "Upload",
+			length:     64,
+			parallel:   16,
+			clientFunc: clientMachine.GetContainer,
+			serverFunc: serverMachine.GetNativeContainer,
+		},
+		{
+			name:       "Upload",
+			length:     1024,
+			parallel:   16,
 			clientFunc: clientMachine.GetContainer,
 			serverFunc: serverMachine.GetNativeContainer,
 		},
 		{
 			name:       "Download",
+			length:     4,
+			parallel:   1,
+			clientFunc: clientMachine.GetNativeContainer,
+			serverFunc: serverMachine.GetContainer,
+		},
+		{
+			name:       "Download",
+			length:     64,
+			parallel:   1,
+			clientFunc: clientMachine.GetNativeContainer,
+			serverFunc: serverMachine.GetContainer,
+		},
+		{
+			name:       "Download",
+			length:     1024,
+			parallel:   1,
+			clientFunc: clientMachine.GetNativeContainer,
+			serverFunc: serverMachine.GetContainer,
+		},
+		{
+			name:       "Download",
+			length:     4,
+			parallel:   16,
+			clientFunc: clientMachine.GetNativeContainer,
+			serverFunc: serverMachine.GetContainer,
+		},
+		{
+			name:       "Download",
+			length:     64,
+			parallel:   16,
+			clientFunc: clientMachine.GetNativeContainer,
+			serverFunc: serverMachine.GetContainer,
+		},
+		{
+			name:       "Download",
+			length:     1024,
+			parallel:   16,
 			clientFunc: clientMachine.GetNativeContainer,
 			serverFunc: serverMachine.GetContainer,
 		},
@@ -61,6 +137,12 @@ func BenchmarkIperf(b *testing.B) {
 		name, err := tools.ParametersToName(tools.Parameter{
 			Name:  "operation",
 			Value: bm.name,
+		}, tools.Parameter{
+			Name:  "length",
+			Value: fmt.Sprintf("%dK", bm.length),
+		}, tools.Parameter{
+			Name:  "parallel",
+			Value: fmt.Sprintf("%d", bm.parallel),
 		})
 		if err != nil {
 			b.Fatalf("Failed to parse parameters: %v", err)
@@ -87,7 +169,9 @@ func BenchmarkIperf(b *testing.B) {
 			}
 
 			iperf := tools.Iperf{
-				Num: b.N, // KB for the client to send.
+				Num:      b.N,       // KB for the client to send.
+				Length:   bm.length, // KB for length.
+				Parallel: bm.parallel,
 			}
 
 			// Run the client.

--- a/test/benchmarks/tools/BUILD
+++ b/test/benchmarks/tools/BUILD
@@ -14,6 +14,7 @@ go_library(
         "parser_util.go",
         "redis.go",
         "sysbench.go",
+        "syscallbench.go",
         "tools.go",
     ],
     visibility = ["//:sandbox"],

--- a/test/benchmarks/tools/BUILD
+++ b/test/benchmarks/tools/BUILD
@@ -15,6 +15,7 @@ go_library(
         "redis.go",
         "sysbench.go",
         "syscallbench.go",
+        "hackbench.go",
         "tools.go",
     ],
     visibility = ["//:sandbox"],

--- a/test/benchmarks/tools/hackbench.go
+++ b/test/benchmarks/tools/hackbench.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// Hackbench makes 'hackbench' commands and parses their output.
+type Hackbench struct {
+	IpcMode     string // ipc mode: pipe, socket(default)
+	ProcessMode string // process mode: thread, process(default)
+}
+
+// MakeCmd makes commands for Hackbench.
+func (s *Hackbench) MakeCmd(b *testing.B) []string {
+	cmd := []string{"hackbench"}
+	// ipc mode
+	if s.IpcMode == "pipe" {
+		cmd = append(cmd, fmt.Sprintf("--pipe"))
+	}
+	// group num
+	cmd = append(cmd, fmt.Sprintf("--groups=10"))
+	// process mode
+	if s.ProcessMode == "thread" {
+		cmd = append(cmd, fmt.Sprintf("--threads"))
+	} else {
+		cmd = append(cmd, fmt.Sprintf("--process"))
+	}
+	// loops
+	cmd = append(cmd, fmt.Sprintf("--loops=1000"))
+	return cmd
+}
+
+// Report reports the relevant metrics for Hackbench.
+func (s *Hackbench) Report(b *testing.B, output string) {
+	b.Helper()
+	result, err := s.parseResult(output)
+	if err != nil {
+		b.Fatalf("parsing result from %s failed: %v", output, err)
+	}
+	ReportCustomMetric(b, result, "execution_time" /*metric name*/, "s" /*unit*/)
+}
+
+var hackbenchRegexp = regexp.MustCompile(`Time:\s*(\d*.?\d*)\n`)
+
+func (s *Hackbench) parseResult(data string) (float64, error) {
+	match := hackbenchRegexp.FindStringSubmatch(data)
+	if len(match) < 2 {
+		return 0.0, fmt.Errorf("could not find Time: %s", data)
+	}
+	return strconv.ParseFloat(match[1], 64)
+}

--- a/test/benchmarks/tools/iperf.go
+++ b/test/benchmarks/tools/iperf.go
@@ -21,11 +21,11 @@ import (
 	"testing"
 )
 
-const length = 64 * 1024
-
 // Iperf is for the client side of `iperf`.
 type Iperf struct {
-	Num int // Number of bytes to send in KB.
+	Num      int // Number of bytes to send in KB.
+	Length   int // Length in KB.
+	Parallel int // Number of parallel threads.
 }
 
 // MakeCmd returns a iperf client command.
@@ -35,9 +35,10 @@ func (i *Iperf) MakeCmd(host string, port int) []string {
 		"--format", "K", // Output in KBytes.
 		"--realtime",                       // Measured in realtime.
 		"--num", fmt.Sprintf("%dK", i.Num), // Number of bytes to send in KB.
-		"--length", fmt.Sprintf("%d", length),
+		"--len", fmt.Sprintf("%dK", i.Length), // Length in KB.
 		"--client", host,
 		"--port", fmt.Sprintf("%d", port),
+		"--parallel", fmt.Sprintf("%d", i.Parallel),
 	}
 }
 
@@ -49,7 +50,7 @@ func (i *Iperf) Report(b *testing.B, output string) {
 	if err != nil {
 		b.Fatalf("failed to parse bandwitdth from %s: %v", output, err)
 	}
-	b.SetBytes(length) // Measure Bytes/sec for b.N, although below is iperf output.
+	b.SetBytes(int64(i.Length) * 1024) // Measure Bytes/sec for b.N, although below is iperf output.
 	ReportCustomMetric(b, bW*1024, "bandwidth" /*metric name*/, "bytes_per_second" /*unit*/)
 }
 

--- a/test/benchmarks/tools/syscallbench.go
+++ b/test/benchmarks/tools/syscallbench.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tools
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// Syscallbench makes 'syscallbench' commands and parses output.
+type Syscallbench struct {
+	Loops int // total number of loops
+}
+
+// MakeCmd makes commands for Syscallbench.
+func (s *Syscallbench) MakeCmd(b *testing.B) []string {
+	cmd := []string{"syscallbench"}
+	cmd = append(cmd, fmt.Sprintf("--loops=%d", s.Loops))
+	return cmd
+}
+
+// Report reports the relevant metrics for Syscallbench.
+func (s *Syscallbench) Report(b *testing.B, output string) {
+	b.Helper()
+	result, err := s.parseResult(output)
+	if err != nil {
+		b.Fatalf("parsing result from %s failed: %v", output, err)
+	}
+	ReportCustomMetric(b, result, "per_syscall_time" /*metric name*/, "ns" /*unit*/)
+}
+
+var syscallbenchRegexp = regexp.MustCompile(`(\d*.?\d*)\s*ns/syscall\n`)
+
+// parseResult reports the per_syscall_time in ns.
+func (s *Syscallbench) parseResult(data string) (float64, error) {
+	match := syscallbenchRegexp.FindStringSubmatch(data)
+	if len(match) < 2 {
+		return 0.0, fmt.Errorf("could not find ns/syscall: %s", data)
+	}
+	return strconv.ParseFloat(match[1], 64)
+}


### PR DESCRIPTION
benchmarks: add and fix some benchmarks
1. add syscallbench benchmark for syscall performance
2. add hackbench benchmark for scheduler performance
3. add more threads arguments for sysbench benchmark
4. fix wrong file size for fio read
5. add more blocksize arguments for fio benchmark
6. add length and parallel options for iperf benchmark