### PR TITLE
vdso: support more flags for clock_gettime() vdso interface

### DIFF
--- a/vdso/vdso.cc
+++ b/vdso/vdso.cc
@@ -29,12 +29,18 @@ int __common_clock_gettime(clockid_t clock, struct timespec* ts) {
   int ret;
 
   switch (clock) {
+    case CLOCK_REALTIME_COARSE:
+      // Fallthrough, CLOCK_REALTIME_COARSE is an alias for CLOCK_REALTIME
     case CLOCK_REALTIME:
       ret = ClockRealtime(ts);
       break;
 
     case CLOCK_BOOTTIME:
       // Fallthrough, CLOCK_BOOTTIME is an alias for CLOCK_MONOTONIC
+    case CLOCK_MONOTONIC_RAW:
+      // Fallthrough, CLOCK_MONOTONIC_RAW is an alias for CLOCK_MONOTONIC
+    case CLOCK_MONOTONIC_COARSE:
+      // Fallthrough, CLOCK_MONOTONIC_COARSE is an alias for CLOCK_MONOTONIC
     case CLOCK_MONOTONIC:
       ret = ClockMonotonic(ts);
       break;


### PR DESCRIPTION
Current vdso(implemented by sentry, and used by the real application) is a partial implimentation. More specifically, the clock_gettime() vdso interface only works for CLOCK_REALTIME, CLOCK_BOOTTIME, and CLOCK_MONOTONIC.

So we support more flags for clock_gettime() vdso interface here, like CLOCK_REALTIME_COARSE, CLOCK_MONOTONIC_RAW, and CLOCK_MONOTONIC_COARSE, to accelerate clock_gettime() call of real application.

And their implementations refer to the internal syscall of gvisor. See function getClock() in pkg/sentry/syscalls/linux/sys_time.go.

Signed-off-by: Chen Hui <cedriccchen@tencent.com>