### PR TITLE
benchmarks: add total cpu utilization metric

### DIFF
--- a/pkg/test/dockerutil/BUILD
+++ b/pkg/test/dockerutil/BUILD
@@ -11,6 +11,7 @@ go_library(
         "exec.go",
         "network.go",
         "profile.go",
+        "stats.go",
     ],
     visibility = ["//:sandbox"],
     deps = [

--- a/pkg/test/dockerutil/stats.go
+++ b/pkg/test/dockerutil/stats.go
@@ -1,0 +1,110 @@
+// Copyright 2022 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dockerutil
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/runsc/cgroup"
+)
+
+const (
+	clockTicksPerSecond  = 100
+	nanoSecondsPerSecond = 1e9
+	cgroupPath           = "/sys/fs/cgroup"
+)
+
+func containerCpuUsage(id string) (uint64, error) {
+	var path string
+	var value uint64
+
+	useSystemd, err := UsingSystemdCgroup()
+	if err != nil {
+		return 0, fmt.Errorf("check systemd cgroup failed: %v", err)
+	}
+
+	if cgroup.IsOnlyV2() {
+		path = filepath.Join(cgroupPath, "docker", id, "cpu.stat")
+		if useSystemd {
+			path = filepath.Join(cgroupPath, "system.slice/docker-"+id+".scope", "cpu.stat")
+		}
+
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return 0, err
+		}
+
+		lines := strings.Split(string(content), "\n")
+		for _, line := range lines {
+			parts := strings.Fields(line)
+			if parts[0] == "usage_usec" {
+				value, err = strconv.ParseUint(parts[1], 10, 64)
+				if err != nil {
+					return 0, fmt.Errorf("Unable to convert value %s to uint64: %s", parts[1], err)
+				}
+			}
+		}
+
+		return value * 1000, nil
+	}
+
+	path = filepath.Join(cgroupPath, "cpu/docker", id, "cpuacct.usage")
+	if useSystemd {
+		path = filepath.Join(cgroupPath, "cpu/system.slice/docker-"+id+".scope", "cpuacct.usage")
+	}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	value, err = strconv.ParseUint(strings.TrimSuffix(string(content), "\n"), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("Unable to convert value %s to uint64: %s", string(content), err)
+	}
+	return value, nil
+}
+
+func systemStatTime() (uint64, error) {
+	content, err := ioutil.ReadFile("/proc/stat")
+	if err != nil {
+		return 0, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for _, line := range lines {
+		parts := strings.Fields(line)
+		switch parts[0] {
+		case "cpu":
+			if len(parts) < 8 {
+				return 0, fmt.Errorf("invalid number of cpu fields")
+			}
+			var totalClockTicks uint64
+			for _, i := range parts[1:8] {
+				v, err := strconv.ParseUint(i, 10, 64)
+				if err != nil {
+					return 0, fmt.Errorf("Unable to convert value %s to int: %s", i, err)
+				}
+				totalClockTicks += v
+			}
+			return (totalClockTicks * nanoSecondsPerSecond) /
+				clockTicksPerSecond, nil
+		}
+	}
+	return 0, fmt.Errorf("invalid stat format. Error trying to parse the '/proc/stat' file")
+}

--- a/test/benchmarks/base/hackbench_test.go
+++ b/test/benchmarks/base/hackbench_test.go
@@ -76,7 +76,7 @@ func BenchmarkHackbench(b *testing.B) {
 			if err != nil {
 				b.Fatalf("failed to run hackbench: %v, logs:%s", err, out)
 			}
-			tc.Report(b, out)
+			tc.Report(b, out, container)
 		})
 	}
 }

--- a/test/benchmarks/base/sysbench_test.go
+++ b/test/benchmarks/base/sysbench_test.go
@@ -109,16 +109,23 @@ func BenchmarkSysbench(b *testing.B) {
 			sysbench := machine.GetContainer(ctx, b)
 			defer sysbench.CleanUp(ctx)
 
+			if err := sysbench.Spawn(
+				ctx, dockerutil.RunOpts{
+					Image: "benchmarks/sysbench",
+				},
+				"sleep", "24h",
+			); err != nil {
+				b.Fatalf("run failed with: %v", err)
+			}
+
 			cmd := tc.test.MakeCmd(b)
 			b.ResetTimer()
-			out, err := sysbench.Run(ctx, dockerutil.RunOpts{
-				Image: "benchmarks/sysbench",
-			}, cmd...)
+			out, err := sysbench.Exec(ctx, dockerutil.ExecOpts{}, cmd...)
 			if err != nil {
 				b.Fatalf("failed to run sysbench: %v: logs:%s", err, out)
 			}
 			b.StopTimer()
-			tc.test.Report(b, out)
+			tc.test.Report(b, out, sysbench)
 		})
 	}
 }

--- a/test/benchmarks/base/syscallbench_test.go
+++ b/test/benchmarks/base/syscallbench_test.go
@@ -60,5 +60,11 @@ func BenchmarkSyscallbench(b *testing.B) {
 		if err != nil {
 			b.Fatalf("failed to run syscallbench: %v, logs:%s", err, out)
 		}
+		b.StopTimer()
+		cpuUtilization, err := container.TotalCpuUtilization()
+		if err != nil {
+			b.Fatalf("parsing total cpu utilization failed: %v", err)
+		}
+		tools.ReportCustomMetric(b, cpuUtilization, "total_cpu_utilization" /*metric name*/, "percentage" /*unit*/)
 	})
 }

--- a/test/benchmarks/tools/BUILD
+++ b/test/benchmarks/tools/BUILD
@@ -18,6 +18,9 @@ go_library(
         "tools.go",
     ],
     visibility = ["//:sandbox"],
+    deps = [
+        "//pkg/test/dockerutil",
+    ],
 )
 
 go_test(


### PR DESCRIPTION
In addition to performance, cpu utilization is also an important metric, which can be used to measure the extra cpu overhead brought by gvisor.

Signed-off-by: Chen Hui <cedriccchen@tencent.com>