### PR TITLE
Build stopfd for all linux architectures

### DIFF
--- a/pkg/tcpip/link/stopfd/stopfd.go
+++ b/pkg/tcpip/link/stopfd/stopfd.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build (linux && amd64) || (linux && arm64)
-// +build linux,amd64 linux,arm64
+//go:build linux
+// +build linux
 
 // Package stopfd provides an type that can be used to signal the stop of a dispatcher.
 package stopfd


### PR DESCRIPTION
f18c6daa563267e79f4625182268456c79d574b9 breaks fdbased on non-amd/arm64 devices.