### PR TITLE
fixed to use NewUDPConn instead of NewTCPConn

### DIFF
--- a/pkg/tcpip/adapters/gonet/gonet_test.go
+++ b/pkg/tcpip/adapters/gonet/gonet_test.go
@@ -410,7 +410,7 @@ func TestUDPForwarder(t *testing.T) {
 		}
 		defer ep.Close()
 
-		c := NewTCPConn(&wq, ep)
+		c := NewUDPConn(s, &wq, ep)
 
 		buf := make([]byte, 256)
 		n, e := c.Read(buf)


### PR DESCRIPTION
I fixed to use `UDPConn` instead of `TCPConn` in `udp.NewForwarder` callback