### PR TITLE
hostinet: translate the error from dst.CopyOutFrom

### DIFF
--- a/pkg/sentry/socket/hostinet/socket_vfs2.go
+++ b/pkg/sentry/socket/hostinet/socket_vfs2.go
@@ -124,7 +124,7 @@ func (s *socketVFS2) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.
 	reader := hostfd.GetReadWriterAt(int32(s.fd), -1, opts.Flags)
 	n, err := dst.CopyOutFrom(ctx, reader)
 	hostfd.PutReadWriterAt(reader)
-	return int64(n), err
+	return int64(n), translateIOSyscallError(err)
 }
 
 // PWrite implements vfs.FileDescriptionImpl.


### PR DESCRIPTION
Though 'EAGAIN' and 'EWOULDBLOCK' is the same number in linux, they are not the same type in go. We need treat this two error as the same.

Closes #8156