### PR TITLE
tcpip/stack: use atomic refs for addressState

### DIFF
--- a/pkg/tcpip/stack/BUILD
+++ b/pkg/tcpip/stack/BUILD
@@ -50,9 +50,21 @@ go_template_instance(
     },
 )
 
+go_template_instance(
+    name = "address_state_refs",
+    out = "address_state_refs.go",
+    package = "stack",
+    prefix = "addressState",
+    template = "//pkg/refs:refs_template",
+    types = {
+        "T": "addressState",
+    },
+)
+
 go_library(
     name = "stack",
     srcs = [
+        "address_state_refs.go",
         "addressable_endpoint_state.go",
         "conntrack.go",
         "gro.go",


### PR DESCRIPTION
In this case, we don't need to take a read-write lock in IncRef and DecRef.