### PR TITLE
limit numbers of negative children to avoid infinitely increment of memory

### DIFF
--- a/pkg/sentry/fsimpl/gofer/BUILD
+++ b/pkg/sentry/fsimpl/gofer/BUILD
@@ -4,6 +4,18 @@ load("//tools/go_generics:defs.bzl", "go_template_instance")
 licenses(["notice"])
 
 go_template_instance(
+    name = "string_list",
+    out = "string_list.go",
+    package = "gofer",
+    prefix = "string",
+    template = "//pkg/ilist:generic_list",
+    types = {
+        "Element": "*stringListElem",
+        "Linker": "*stringListElem",
+    },
+)
+
+go_template_instance(
     name = "dentry_list",
     out = "dentry_list.go",
     package = "gofer",
@@ -41,6 +53,7 @@ go_template_instance(
 go_library(
     name = "gofer",
     srcs = [
+        "string_list.go",
         "dentry_list.go",
         "directory.go",
         "filesystem.go",

--- a/pkg/sentry/fsimpl/gofer/gofer_test.go
+++ b/pkg/sentry/fsimpl/gofer/gofer_test.go
@@ -65,3 +65,25 @@ func TestDestroyIdempotent(t *testing.T) {
 	child.checkCachingLocked(ctx, true /* renameMuWriteLocked */)
 	child.checkCachingLocked(ctx, true /* renameMuWriteLocked */)
 }
+
+func TestStringFixedCache(t *testing.T) {
+	names := []string{"a", "b", "c"}
+	cache := stringFixedCache{}
+
+	cache.init(uint64(len(names)))
+	if inited := cache.isInited(); !inited {
+		t.Fatalf("cache.isInited(): %v, want: true", inited)
+	}
+	for _, s := range names {
+		victim := cache.add(s)
+		if victim != "" {
+			t.Fatalf("cache.add(): %v, want: \"\"", victim)
+		}
+	}
+	for _, s := range names {
+		victim := cache.add("something")
+		if victim != s {
+			t.Fatalf("cache.add(): %v, want: %v", victim, s)
+		}
+	}
+}


### PR DESCRIPTION
Fix issue #8267
when create and remove file, dentry.children will cache the name to speedup file access,
memory will increse infinitely if we remove huge amount of different files,
limit the length of negative file names is necessary since most of removed files will never access again.

Signed-off-by: Tan Yifeng <yiftan@tencent.com>