### PR TITLE
kvm: use syscall.RawSyscall to fit the nosplit stack limit.

### DIFF
--- a/pkg/sentry/platform/kvm/machine_unsafe.go
+++ b/pkg/sentry/platform/kvm/machine_unsafe.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"runtime"
 	"sync/atomic"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -55,7 +56,8 @@ func (m *machine) setMemoryRegion(slot int, physical, length, virtual uintptr, f
 	}
 
 	// Set the region.
-	_, _, errno := unix.RawSyscall(
+	// Note: syscall.RawSyscall is used to fit the nosplit stack limit.
+	_, _, errno := syscall.RawSyscall(
 		unix.SYS_IOCTL,
 		uintptr(m.fd),
 		_KVM_SET_USER_MEMORY_REGION,


### PR DESCRIPTION
unix.RawSyscall is a wrapper of syscall.RawSyscall:

gvisor.dev/gvisor/pkg/sentry/platform/kvm.sigsysHandler: nosplit stack over 792 byte limit gvisor.dev/gvisor/pkg/sentry/platform/kvm.sigsysHandler<0>
    grows 16 bytes, calls gvisor.dev/gvisor/pkg/sentry/platform/kvm.seccompMmapHandler<0>
        grows 32 bytes, calls gvisor.dev/gvisor/pkg/sentry/platform/kvm.seccompMmapHandler<1>
            grows 144 bytes, calls gvisor.dev/gvisor/pkg/sentry/platform/kvm.(*machine).mapPhysical<1>
                grows 96 bytes, calls gvisor.dev/gvisor/pkg/sentry/platform/kvm.handleBluepillFault<1>
                    grows 128 bytes, calls gvisor.dev/gvisor/pkg/sentry/platform/kvm.(*machine).setMemoryRegion<1>
                        grows 160 bytes, calls golang.org/x/sys/unix.RawSyscall<0>
                            grows 0 bytes, calls syscall.RawSyscall<0>
                                grows 80 bytes, calls syscall.RawSyscall<1>
                                    grows 80 bytes, calls syscall.RawSyscall6<1>
                                        grows 96 bytes, calls runtime/internal/syscall.Syscall6<0>
                                        40 bytes over limit