### PR TITLE
support file backend tmpfs mount for volumes.

### DIFF
--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -60,6 +60,9 @@ type Boot struct {
 	// overlay's upper tmpfs mount for all containers.
 	overlayFilestoreFD int
 
+	// VolumeBackFDs is the list of host FDs that will back the tmpfs of volume mount.
+	VolumeBackFDs intFlags
+
 	// stdioFDs are the fds for stdin, stdout, and stderr. They must be
 	// provided in that order.
 	stdioFDs intFlags
@@ -147,6 +150,7 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.Var(&b.ioFDs, "io-fds", "list of FDs to connect gofer clients. They must follow this order: root first, then mounts as defined in the spec")
 	f.Var(&b.stdioFDs, "stdio-fds", "list of FDs containing sandbox stdin, stdout, and stderr in that order")
 	f.IntVar(&b.overlayFilestoreFD, "overlay-filestore-fd", -1, "FD to a regular file which will be used to back the overlay's tmpfs upper mount.")
+	f.Var(&b.VolumeBackFDs, "volume-backend-fds", "list of FDs that will back the tmpfs of volume mount.")
 	f.IntVar(&b.userLogFD, "user-log-fd", 0, "file descriptor to write user logs to. 0 means no logging.")
 	f.IntVar(&b.startSyncFD, "start-sync-fd", -1, "required FD to used to synchronize sandbox startup")
 	f.IntVar(&b.mountsFD, "mounts-fd", -1, "mountsFD is the file descriptor to read list of mounts after they have been resolved (direct paths, no symlinks).")
@@ -315,6 +319,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		GoferFDs:           b.ioFDs.GetArray(),
 		StdioFDs:           b.stdioFDs.GetArray(),
 		OverlayFilestoreFD: b.overlayFilestoreFD,
+		VolumeBackFDs:      b.VolumeBackFDs,
 		NumCPU:             b.cpuNum,
 		TotalMem:           b.totalMem,
 		UserLogFD:          b.userLogFD,

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -160,6 +160,10 @@ type Args struct {
 	// mount in the overlay mounts.
 	OverlayFilestoreFile *os.File
 
+	// VolumeBackFiles is the list of regular files that will back the tmpfs
+	// of volume mount.
+	VolumeBackFiles []*os.File
+
 	// MountsFile is a file container mount information from the spec. It's
 	// equivalent to the mounts from the spec, except that all paths have been
 	// resolved to their final absolute location.
@@ -596,6 +600,7 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	// If there is a gofer, sends all socket ends to the sandbox.
 	donations.DonateAndClose("io-fds", args.IOFiles...)
 	donations.DonateAndClose("overlay-filestore-fd", args.OverlayFilestoreFile)
+	donations.DonateAndClose("volume-backend-fds", args.VolumeBackFiles...)
 	donations.DonateAndClose("mounts-fd", args.MountsFile)
 	donations.Donate("start-sync-fd", startSyncFile)
 	if err := donations.OpenAndDonate("user-log-fd", args.UserLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND); err != nil {


### PR DESCRIPTION
Necessary annotation:
dev.gvisor.spec.mount.volumename.share: "pod"
dev.gvisor.spec.mount.volumename.type: "tmpfs"

For emptydir, add such annotation to back tmpfs mount with file:
dev.gvisor.spec.mount.volumename.backend: "file"

For hostpath, you should specify hostpath source in annotation:
dev.gvisor.spec.mount.volumename.source: "/data/somepath"

Based on #7874,  many pods have exclusive emptydir or hostpath to store temporary data,
so mount the whole rootfs with overlay2 is not necessary, and handling whiteout file in overlay filesystem
may take some performance loss, remount such volumes by tmpfs with file backend is enough. 


Signed-off-by: Tan Yifeng <yiftan@tencent.com>