### PR TITLE
ci: update GitHub Actions to avoid set-output deprecation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,9 +23,9 @@ jobs:
     - id: setup
       run: |
         if ! [[ -z "${{ secrets.GO_TOKEN }}" ]]; then
-          echo ::set-output name=has_token::true
+          echo has_token=true >> $GITHUB_OUTPUT
         else
-          echo ::set-output name=has_token::false
+          echo has_token=false >> $GITHUB_OUTPUT
         fi
     - run: |
         jq -nc '{"state": "pending", "context": "go tests"}' | \


### PR DESCRIPTION
Starting 1st June 2023 (planned) workflows, `::set-output name...::` syntax cannot be used. You can see the example warnings here: https://github.com/google/gvisor/actions/runs/3791389619

ref. [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR fixes the issue by using the `GITHUB_OUTPUT` environment variable as instructed in the above article.
