### PR TITLE
Disable cgo by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,6 +21,12 @@ build --cxxopt=-std=c++17
 # Display the current git revision in the info block.
 build --stamp --workspace_status_command tools/workspace_status.sh
 
+build:race --@io_bazel_rules_go//go/config:race --@io_bazel_rules_go//go/config:pure=false
+test:race --@io_bazel_rules_go//go/config:race --@io_bazel_rules_go//go/config:pure=false
+
+build --@io_bazel_rules_go//go/config:pure
+test --@io_bazel_rules_go//go/config:pure
+
 # Set flags for x86_64.
 build:x86_64 --crosstool_top=@crosstool//:toolchains
 build:x86_64 --cpu=k8

--- a/tools/bazel.mk
+++ b/tools/bazel.mk
@@ -47,7 +47,7 @@ BRANCH_NAME := $(shell (git branch --show-current 2>/dev/null || \
   git rev-parse --abbrev-ref HEAD 2>/dev/null) | \
   xargs -n 1 basename 2>/dev/null)
 BUILD_ROOTS := bazel-bin/ bazel-out/
-RACE_FLAGS := --@io_bazel_rules_go//go/config:race
+RACE_FLAGS := --config=race
 
 # Bazel container configuration (see below).
 USER := $(shell whoami)


### PR DESCRIPTION
* We build all binaries in a build container but then we execute them in
  another evironments, so we don't want to have a dependency on glibc.

* runsc is build without cgo, so it looks reasonable to build tests with
  the same flags.

* If we build all packeges with the same flags, they all shares the same
  cache.

This change adds the race config to build with the race detector