### PR TITLE
Add terminal support to do, exec and run commands

### DIFF
--- a/pkg/sighandling/sighandling.go
+++ b/pkg/sighandling/sighandling.go
@@ -81,6 +81,9 @@ func StartSignalForwarding(handler func(linux.Signal)) func() {
 	//
 	// External real-time signals are not supported. We rely on the go-runtime
 	// for their handling.
+	//
+	// We do not forward some signals that are likely induced by the behavior
+	// of the forwarding process.
 	var sigchans []chan os.Signal
 	for sig := 1; sig <= numSignals+1; sig++ {
 		sigchan := make(chan os.Signal, 1)
@@ -92,6 +95,10 @@ func StartSignalForwarding(handler func(linux.Signal)) func() {
 		}
 		// SIGPIPE is received when sending to disconnected host pipes/sockets.
 		if sig == int(linux.SIGPIPE) {
+			continue
+		}
+		// SIGCHLD is received when a child of the forwarding process exits.
+		if sig == int(linux.SIGCHLD) {
 			continue
 		}
 		signal.Notify(sigchan, unix.Signal(sig))

--- a/runsc/cmd/do.go
+++ b/runsc/cmd/do.go
@@ -33,6 +33,7 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/console"
 	"gvisor.dev/gvisor/runsc/container"
 	"gvisor.dev/gvisor/runsc/flag"
 	"gvisor.dev/gvisor/runsc/specutils"
@@ -167,6 +168,7 @@ func (c *Do) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcommand
 			Args:         f.Args(),
 			Env:          os.Environ(),
 			Capabilities: specutils.AllCapabilities(),
+			Terminal:     console.IsPty(os.Stdin.Fd()),
 		},
 		Hostname: hostname,
 	}
@@ -445,7 +447,7 @@ func startContainerAndWait(spec *specs.Spec, conf *config.Config, cid string, wa
 	//
 	// N.B. There is a still a window before this where a signal may kill
 	// this process, skipping cleanup.
-	stopForwarding := ct.ForwardSignals(0 /* pid */, false /* fgProcess */)
+	stopForwarding := ct.ForwardSignals(0 /* pid */, spec.Process.Terminal /* fgProcess */)
 	defer stopForwarding()
 
 	ws, err := ct.Wait()

--- a/runsc/cmd/exec.go
+++ b/runsc/cmd/exec.go
@@ -329,7 +329,7 @@ func (ex *Exec) argsFromCLI(argv []string, enableRaw bool) (*control.ExecArgs, e
 		KGID:             ex.user.kgid,
 		ExtraKGIDs:       extraKGIDs,
 		Capabilities:     caps,
-		StdioIsPty:       ex.consoleSocket != "",
+		StdioIsPty:       ex.consoleSocket != "" || console.IsPty(os.Stdin.Fd()),
 		FilePayload:      urpc.FilePayload{[]*os.File{os.Stdin, os.Stdout, os.Stderr}},
 	}, nil
 }

--- a/runsc/console/BUILD
+++ b/runsc/console/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "console",
     srcs = [
         "console.go",
+	"pty_linux.go"
     ],
     visibility = [
         "//runsc:__subpackages__",

--- a/runsc/console/pty_linux.go
+++ b/runsc/console/pty_linux.go
@@ -1,0 +1,26 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+// +build linux
+
+package console
+
+import "golang.org/x/sys/unix"
+
+// IsPty returns true if FD is a PTY.
+func IsPty(fd uintptr) bool {
+	_, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	return err == nil
+}

--- a/runsc/specutils/namespace.go
+++ b/runsc/specutils/namespace.go
@@ -282,6 +282,10 @@ func MaybeRunAsRoot() error {
 
 		// Make sure child is killed when the parent terminates.
 		Pdeathsig: unix.SIGKILL,
+
+		// Detach from session. Otherwise, signals sent to the foreground process
+		// will also be forwarded by this process, resulting in duplicate signals.
+		Setsid: true,
 	}
 
 	cmd.Env = os.Environ()


### PR DESCRIPTION
When executing `runsc` directly inside a host terminal (e.g. using `runsc --ignore-cgroups --network=sandbox --file-access=shared --rootless --host-uds=all do --force-overlay=false -- bash`), `Ctrl+C` currently terminates the sandbox instead of causing the signal to be handled by the terminal in the guest.

Therefore, this commit adds terminal support to the `do`, `exec` and `run` commands.