### PR TITLE
Support building runsc with legacy GNU linker

### DIFF
--- a/pkg/sentry/platform/systrap/sysmsg/pie.lds.S
+++ b/pkg/sentry/platform/systrap/sysmsg/pie.lds.S
@@ -34,6 +34,6 @@ SECTIONS
         } =0x00000000,
 
         /DISCARD/ : {
-                *(.interp) *(.gnu.hash) *(.hash) *(.dynamic) *(.dynsym) *(.dynstr) *(.rela.dyn) *(.eh_frame)
+                *(.interp) *(.gnu.hash) *(.hash) *(.dynamic) *(.dynsym) *(.dynstr) *(.rela.dyn) *(.eh_frame) *(.note.gnu.property)
         }
 }


### PR DESCRIPTION
Currently, runsc fails to build on systems which still use the legacy GNU linker (i.e. not gold), which is still the default linker on many systems:

```
ERROR: /gvisor/pkg/sentry/platform/systrap/sysmsg/BUILD:62:8: Executing genrule //pkg/sentry/platform/systrap/sysmsg:sighandler.built-in.object failed: (Exit 1): bash failed: error executing command (from target //pkg/sentry/platform/systrap/sysmsg:sighandler.built-in.object) /bin/bash -c ... (remaining 1 argument skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
/usr/bin/ld: section .note.gnu.property LMA [0000000000000000,000000000000002f] overlaps section .crblob LMA [0000000000000000,0000000000005e3f]
/usr/bin/ld: warning: bazel-out/k8-fastbuild/bin/pkg/sentry/platform/systrap/sysmsg/sighandler.built-in.bin.o has a LOAD segment with RWX permissions
Target //runsc:runsc failed to build
```

Therefore, this small change enables building with the legacy GNU linker that emits the `.note.gnu.property` section which conflicts with the `.crblob` section inside the sysmsg linker script.