### PR TITLE
gopath: switch to the archive mode

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -24,7 +24,7 @@ function install_pkgs() {
 }
 install_pkgs make linux-libc-dev graphviz jq curl binutils gnupg gnupg-agent \
   gcc pkg-config apt-transport-https ca-certificates \
-  software-properties-common rsync kmod systemd
+  software-properties-common rsync kmod systemd unzip
 
 # Install headers, only if available.
 if test -n "$(apt-cache search --names-only "^linux-headers-$(uname -r)$")"; then

--- a/BUILD
+++ b/BUILD
@@ -120,7 +120,7 @@ build_test(
 # The files in this tree are symlinks to the true sources.
 go_path(
     name = "gopath",
-    mode = "link",
+    mode = "archive",
     deps = [
         # Main binaries.
         #

--- a/tools/go_branch.sh
+++ b/tools/go_branch.sh
@@ -45,13 +45,10 @@ origpwd=$(pwd)
 othersrc=("go.mod" "go.sum" "AUTHORS" "LICENSE")
 readonly module origpwd othersrc
 
-# Build a full gopath. Before copying, this scans the generated directory
-# and removes broken symbolic links. It's not clear what conditions this bug
-# is hit with bazel, but it happens on occasion.
+# Build a full gopath.
 declare -r go_output="${tmp_dir}/output"
 make build BAZEL_OPTIONS="" TARGETS="//:gopath"
-find bazel-bin/gopath/ -xtype l -delete # See above.
-rsync --recursive --delete --copy-links bazel-bin/gopath/ "${go_output}"
+unzip bazel-bin/gopath.zip -d "${go_output}"
 
 # We expect to have an existing go branch that we will use as the basis for this
 # commit. That branch may be empty, but it must exist. We search for this branch


### PR DESCRIPTION
With the link mode, we see stale files from previous runs in bazel-bin/gopath.