### PR TITLE
Add the /dev/cuda driver with ioctl handler

### DIFF
--- a/pkg/sentry/devices/cudadev/BUILD
+++ b/pkg/sentry/devices/cudadev/BUILD
@@ -1,0 +1,20 @@
+load("//tools:defs.bzl", "go_library")
+
+package(default_applicable_licenses = ["//:license"])
+
+licenses(["notice"])
+
+go_library(
+    name = "cudadev",
+    srcs = ["cudadev.go"],
+    visibility = ["//pkg/sentry:internal"],
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/context",
+        "//pkg/errors/linuxerr",
+        "//pkg/sentry/arch",
+        "//pkg/sentry/fsimpl/devtmpfs",
+        "//pkg/sentry/vfs",
+        "//pkg/usermem",
+    ],
+)

--- a/pkg/sentry/devices/cudadev/cudadev.go
+++ b/pkg/sentry/devices/cudadev/cudadev.go
@@ -1,0 +1,83 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cudadev implements an unopenable vfs.Device for /dev/cuda.
+package cudadev
+
+import (
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/devtmpfs"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/usermem"
+)
+
+// Static major and minor numbers for the custom /dev/cuda device.
+//
+// This major device number was chosen arbitrarily using a random number
+// generator to avoid conflicts.
+const (
+	cudaDevMajor = 3656
+	cudaDevMinor = 0
+)
+
+// cudaDevice implements vfs.Device for /dev/cuda.
+//
+// +stateify savable
+type cudaDevice struct{}
+
+// Open implements vfs.Device.Open.
+func (cudaDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
+	fd := &cudaFD{}
+	if err := fd.vfsfd.Init(fd, opts.Flags, mnt, vfsd, &vfs.FileDescriptionOptions{
+		UseDentryMetadata: true,
+	}); err != nil {
+		return nil, err
+	}
+	return &fd.vfsfd, nil
+}
+
+// fullFD implements vfs.FileDescriptionImpl for /dev/cuda.
+//
+// +stateify savable
+type cudaFD struct {
+	vfsfd vfs.FileDescription
+	vfs.FileDescriptionDefaultImpl
+	vfs.DentryMetadataFileDescriptionImpl
+	vfs.NoLockFD
+}
+
+// Release implements vfs.FileDescriptionImpl.Release.
+func (fd *cudaFD) Release(context.Context) {
+	// noop
+}
+
+// Ioctl implements vfs.FileDescriptionImpl.Ioctl.
+func (fd *cudaFD) Ioctl(ctx context.Context, uio usermem.IO, args arch.SyscallArguments) (uintptr, error) {
+	return 0, linuxerr.ENOSYS // TODO
+}
+
+// Register registers all devices implemented by this package in vfsObj.
+func Register(vfsObj *vfs.VirtualFilesystem) error {
+	return vfsObj.RegisterDevice(vfs.CharDevice, cudaDevMajor, cudaDevMinor, cudaDevice{}, &vfs.RegisterDeviceOptions{
+		GroupName: "cuda",
+	})
+}
+
+// CreateDevtmpfsFiles creates device special files in dev representing all
+// devices implemented by this package.
+func CreateDevtmpfsFiles(ctx context.Context, dev *devtmpfs.Accessor) error {
+	return dev.CreateDeviceFile(ctx, "cuda", vfs.CharDevice, cudaDevMajor, cudaDevMinor, 0666 /* mode */)
+}

--- a/pkg/sentry/devices/cudadev/cudadev.go
+++ b/pkg/sentry/devices/cudadev/cudadev.go
@@ -65,7 +65,7 @@ func (fd *cudaFD) Release(context.Context) {
 }
 
 // Ioctl implements vfs.FileDescriptionImpl.Ioctl.
-func (fd *cudaFD) Ioctl(ctx context.Context, uio usermem.IO, args arch.SyscallArguments) (uintptr, error) {
+func (fd *cudaFD) Ioctl(ctx context.Context, uio usermem.IO, sysno uintptr, args arch.SyscallArguments) (uintptr, error) {
 	return 0, linuxerr.ENOSYS // TODO
 }
 

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -49,6 +49,7 @@ go_library(
         "//pkg/sentry/arch",
         "//pkg/sentry/arch:registers_go_proto",
         "//pkg/sentry/control",
+        "//pkg/sentry/devices/cudadev",
         "//pkg/sentry/devices/memdev",
         "//pkg/sentry/devices/ttydev",
         "//pkg/sentry/devices/tundev",

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -414,7 +414,7 @@ func New(args Args) (*Loader, error) {
 		return nil, fmt.Errorf("initializing kernel: %w", err)
 	}
 
-	if err := registerFilesystems(k); err != nil {
+	if err := registerFilesystems(k, args.Conf); err != nil {
 		return nil, fmt.Errorf("registering filesystems: %w", err)
 	}
 

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -145,7 +145,7 @@ func registerFilesystems(k *kernel.Kernel, conf *config.Config) error {
 		return fmt.Errorf("registering fusedev: %w", err)
 	}
 
-	if conf.EnableCuda {
+	if conf.Cuda {
 		if err := cudadev.Register(vfsObj); err != nil {
 			return fmt.Errorf("registering cudadev: %v", err)
 		}
@@ -176,7 +176,7 @@ func registerFilesystems(k *kernel.Kernel, conf *config.Config) error {
 		return fmt.Errorf("creating fusedev devtmpfs files: %w", err)
 	}
 
-	if conf.EnableCuda {
+	if conf.Cuda {
 		if err := cudadev.CreateDevtmpfsFiles(ctx, a); err != nil {
 			return fmt.Errorf("creating cudadev devtmpfs files: %v", err)
 		}

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -282,6 +282,12 @@ type Config struct {
 	// exists, but is mostly idle. Not supported in rootless mode.
 	DirectFS bool `flag:"directfs"`
 
+	// EnableCuda enables CUDA support in the sandbox. It creates a custom file
+	// system that provides a single read-only file, libcuda.so, which used by
+	// applications to access the host's CUDA libraries via the /dev/cuda
+	// device enabled by this flag.
+	EnableCuda bool `flag:"enable-cuda"`
+
 	// TestOnlyAllowRunAsCurrentUserWithoutChroot should only be used in
 	// tests. It allows runsc to start the sandbox process as the current
 	// user, and without chrooting the sandbox process. This can be

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -282,11 +282,11 @@ type Config struct {
 	// exists, but is mostly idle. Not supported in rootless mode.
 	DirectFS bool `flag:"directfs"`
 
-	// EnableCuda enables CUDA support in the sandbox. It creates a custom file
+	// Cuda enables CUDA support in the sandbox. It creates a custom file
 	// system that provides a single read-only file, libcuda.so, which used by
 	// applications to access the host's CUDA libraries via the /dev/cuda
 	// device enabled by this flag.
-	EnableCuda bool `flag:"enable-cuda"`
+	Cuda bool `flag:"cuda"`
 
 	// TestOnlyAllowRunAsCurrentUserWithoutChroot should only be used in
 	// tests. It allows runsc to start the sandbox process as the current

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -101,7 +101,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Int("dcache", -1, "Set the global dentry cache size. This acts as a coarse-grained control on the number of host FDs simultaneously open by the sentry. If negative, per-mount caches are used.")
 	flagSet.Bool("iouring", false, "TEST ONLY; Enables io_uring syscalls in the sentry. Support is experimental and very limited.")
 	flagSet.Bool("directfs", false, "directly access the container filesystems from the sentry. Sentry runs with higher privileges.")
-	flagSet.Bool("enable-cuda", false, "TEST ONLY; Enables CUDA support. Not yet implemented.")
+	flagSet.Bool("cuda", false, "TEST ONLY; Enables CUDA support. Not yet implemented.")
 
 	// Flags that control sandbox runtime behavior: network related.
 	flagSet.Var(networkTypePtr(NetworkSandbox), "network", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -101,6 +101,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Int("dcache", -1, "Set the global dentry cache size. This acts as a coarse-grained control on the number of host FDs simultaneously open by the sentry. If negative, per-mount caches are used.")
 	flagSet.Bool("iouring", false, "TEST ONLY; Enables io_uring syscalls in the sentry. Support is experimental and very limited.")
 	flagSet.Bool("directfs", false, "directly access the container filesystems from the sentry. Sentry runs with higher privileges.")
+	flagSet.Bool("enable-cuda", false, "TEST ONLY; Enables CUDA support. Not yet implemented.")
 
 	// Flags that control sandbox runtime behavior: network related.
 	flagSet.Var(networkTypePtr(NetworkSandbox), "network", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")


### PR DESCRIPTION
Hi again @ayushr2, I'm starting on the "gVisor Remote GPU Virtualization" proposal, which we at @modal-labs are keen on using. First I'm adding a `/dev/cuda` driver that connect to a new `cudagofer` process, both triggered via a flag.

My plan is to finish those parts in a first pull request with tests to make sure communication works, then add `cudafs` / a pipeline for building our own `libcuda.so`, and incrementally work on the Nvidia runtime and driver API in follow-ups. Would the gVisor team be open to that?

### Changes in this PR

- [x] Add the `-enable-cuda` flag to `runsc`
- [x] Add a new `/dev/cuda` driver in the `sentry/devices/cudadev` package that handles ioctl requests to `/dev/cuda`
- [ ] Write the `cudagofer` process that communicates with the driver via flipcall (just stubs for now)
- [ ] Write tests