### PR TITLE
Add support for execution via host file descriptor

### DIFF
--- a/pkg/sentry/control/proc.go
+++ b/pkg/sentry/control/proc.go
@@ -45,27 +45,33 @@ type Proc struct {
 	Kernel *kernel.Kernel
 }
 
-// FilePayload aids to ensure that len(urpc.FilePayload.Files) == len(GuestFDs)
-// when instantiated through the NewFDMap helper method.
+// FilePayload aids to ensure that payload files and guest file descriptors are
+// consistent when instantiated through the NewFilePayload helper method.
 type FilePayload struct {
 	// FilePayload is the file payload that is transferred via RPC.
 	urpc.FilePayload
 
 	// GuestFDs are the file descriptors in the file descriptor map of the
 	// executed application. They correspond 1:1 to the files in the
-	// urpc.FilePayload.
+	// urpc.FilePayload. If a program is executed from a host file descriptor,
+	// the file payload may contain one additional file. In that case, the file
+	// used for program execution is the last file in the Files array.
 	GuestFDs []int
 }
 
-// NewFDMap returns a FilePayload that maps file descriptors to files inside
-// the executed process.
-func NewFDMap(fdMap map[int]*os.File) FilePayload {
-	files := make([]*os.File, 0, len(fdMap))
+// NewFilePayload returns a FilePayload that maps file descriptors to files inside
+// the executed process and provides a file for execution.
+func NewFilePayload(fdMap map[int]*os.File, execFile *os.File) FilePayload {
+	fileCount := len(fdMap)
+	if execFile != nil {
+		fileCount += 1
+	}
+	files := make([]*os.File, 0, fileCount)
+	guestFDs := make([]int, 0, len(fdMap))
 
 	// Make the map iteration order deterministic for the sake of testing.
 	// Otherwise, the order is randomized and tests relying on the comparison
 	// of equality will fail.
-	guestFDs := make([]int, 0, len(fdMap))
 	for key := range fdMap {
 		guestFDs = append(guestFDs, key)
 	}
@@ -74,6 +80,11 @@ func NewFDMap(fdMap map[int]*os.File) FilePayload {
 	for _, guestFD := range guestFDs {
 		files = append(files, fdMap[guestFD])
 	}
+
+	if execFile != nil {
+		files = append(files, execFile)
+	}
+
 	return FilePayload{
 		FilePayload: urpc.FilePayload{Files: files},
 		GuestFDs:    guestFDs,
@@ -219,13 +230,8 @@ func (proc *Proc) execAsync(args *ExecArgs) (*kernel.ThreadGroup, kernel.ThreadI
 		initArgs.MountNamespace = proc.Kernel.GlobalInit().Leader().MountNamespace()
 		initArgs.MountNamespace.IncRef()
 	}
-	resolved, err := user.ResolveExecutablePath(ctx, &initArgs)
-	if err != nil {
-		return nil, 0, nil, err
-	}
-	initArgs.Filename = resolved
 
-	fdMap, err := args.createFDMap()
+	fdMap, execFD, err := args.unpackFiles()
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("creating fd map: %w", err)
 	}
@@ -234,6 +240,32 @@ func (proc *Proc) execAsync(args *ExecArgs) (*kernel.ThreadGroup, kernel.ThreadI
 			_ = hostFD.Close()
 		}
 	}()
+
+	if execFD != nil {
+		if initArgs.Filename != "" {
+			return nil, 0, nil, fmt.Errorf("process must either be started from a file or a filename, not both")
+		}
+		file, err := host.NewFD(ctx, proc.Kernel.HostMount(), execFD.FD(), &host.NewFDOptions{
+			Readonly:     true,
+			Savable:      true,
+			VirtualOwner: true,
+			UID:          args.KUID,
+			GID:          args.KGID,
+		})
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		defer file.DecRef(ctx)
+		execFD.Release()
+		initArgs.File = file
+	} else {
+		resolved, err := user.ResolveExecutablePath(ctx, &initArgs)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		initArgs.Filename = resolved
+	}
+
 	ttyFile, err := fdimport.Import(ctx, fdTable, args.StdioIsPty, args.KUID, args.KGID, fdMap)
 	if err != nil {
 		return nil, 0, nil, err
@@ -437,21 +469,35 @@ func ContainerUsage(kr *kernel.Kernel) map[string]uint64 {
 	return cusage
 }
 
-// createFDMap creates the file descriptor map from the unmarshalled ExecArgs.
-func (args *ExecArgs) createFDMap() (map[int]*fd.FD, error) {
-	if len(args.Files) != len(args.GuestFDs) {
-		return nil, fmt.Errorf("length of payload files does not match length of file descriptor array")
+// unpackFiles unpacks the file descriptor map and, if applicable, the file
+// descriptor to be used for execution from the unmarshalled ExecArgs.
+func (args *ExecArgs) unpackFiles() (map[int]*fd.FD, *fd.FD, error) {
+	var execFD *fd.FD
+	var err error
+
+	// If there is one additional file, the last file is used for program
+	// execution.
+	if len(args.Files) == len(args.GuestFDs)+1 {
+		execFD, err = fd.NewFromFile(args.Files[len(args.Files)-1])
+		if err != nil {
+			return nil, nil, fmt.Errorf("duplicating exec file: %w", err)
+		}
+	} else if len(args.Files) != len(args.GuestFDs) {
+		return nil, nil, fmt.Errorf("length of payload files does not match length of file descriptor array")
 	}
-	fdMap := make(map[int]*fd.FD, len(args.Files))
-	for i, file := range args.Files {
-		var appFD int
-		// GuestFDs are the indexes of our FD map.
-		appFD = args.GuestFDs[i]
+
+	// GuestFDs are the indexes of our FD map.
+	fdMap := make(map[int]*fd.FD, len(args.GuestFDs))
+	for i, appFD := range args.GuestFDs {
+		file := args.Files[i]
+		if appFD < 0 {
+			return nil, nil, fmt.Errorf("guest file descriptors must be 0 or greater")
+		}
 		hostFD, err := fd.NewFromFile(file)
 		if err != nil {
-			return nil, fmt.Errorf("duplicating payload files: %w", err)
+			return nil, nil, fmt.Errorf("duplicating payload files: %w", err)
 		}
 		fdMap[appFD] = hostFD
 	}
-	return fdMap, nil
+	return fdMap, execFD, nil
 }

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -179,6 +179,10 @@ func setupContainerVFS(ctx context.Context, conf *config.Config, mntr *container
 	}
 	procArgs.MountNamespace = mns
 
+	// We are executing a file directly. Do not resolve the executable path.
+	if procArgs.File != nil {
+		return nil
+	}
 	// Resolve the executable path from working dir and environment.
 	resolved, err := user.ResolveExecutablePath(ctx, procArgs)
 	if err != nil {

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -89,6 +89,9 @@ type Boot struct {
 	// passFDs are mappings of user-supplied host to guest file descriptors.
 	passFDs fdMappings
 
+	// execFD is the host file descriptor used for program execution.
+	execFD int
+
 	// applyCaps determines if capabilities defined in the spec should be applied
 	// to the process.
 	applyCaps bool
@@ -172,6 +175,7 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.Var(&b.ioFDs, "io-fds", "list of FDs to connect gofer clients. They must follow this order: root first, then mounts as defined in the spec")
 	f.Var(&b.stdioFDs, "stdio-fds", "list of FDs containing sandbox stdin, stdout, and stderr in that order")
 	f.Var(&b.passFDs, "pass-fd", "mapping of host to guest FDs. They must be in M:N format. M is the host and N the guest descriptor.")
+	f.IntVar(&b.execFD, "exec-fd", -1, "host file descriptor used for program execution.")
 	f.Var(&b.overlayFilestoreFDs, "overlay-filestore-fds", "FDs to the regular files that will back the tmpfs upper mount in the overlay mounts.")
 	f.IntVar(&b.userLogFD, "user-log-fd", 0, "file descriptor to write user logs to. 0 means no logging.")
 	f.IntVar(&b.startSyncFD, "start-sync-fd", -1, "required FD to used to synchronize sandbox startup")
@@ -390,6 +394,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		GoferFDs:            b.ioFDs.GetArray(),
 		StdioFDs:            b.stdioFDs.GetArray(),
 		PassFDs:             b.passFDs.GetArray(),
+		ExecFD:              b.execFD,
 		OverlayFilestoreFDs: b.overlayFilestoreFDs.GetArray(),
 		NumCPU:              b.cpuNum,
 		TotalMem:            b.totalMem,

--- a/runsc/cmd/exec_test.go
+++ b/runsc/cmd/exec_test.go
@@ -75,11 +75,11 @@ func TestCLIArgs(t *testing.T) {
 			expected: control.ExecArgs{
 				Argv:             []string{"ls", "/"},
 				WorkingDirectory: "/foo/bar",
-				FilePayload: control.NewFDMap(map[int]*os.File{
+				FilePayload: control.NewFilePayload(map[int]*os.File{
 					0: os.Stdin,
 					1: os.Stdout,
 					2: os.Stderr,
-				}),
+				}, nil),
 				KUID:       0,
 				KGID:       0,
 				ExtraKGIDs: []auth.KGID{1, 2, 3},
@@ -132,11 +132,11 @@ func TestJSONArgs(t *testing.T) {
 			expected: control.ExecArgs{
 				Argv:             []string{"ls", "/"},
 				WorkingDirectory: "/foo/bar",
-				FilePayload: control.NewFDMap(map[int]*os.File{
+				FilePayload: control.NewFilePayload(map[int]*os.File{
 					0: os.Stdin,
 					1: os.Stdout,
 					2: os.Stderr,
-				}),
+				}, nil),
 				KUID:       0,
 				KGID:       0,
 				ExtraKGIDs: []auth.KGID{1, 2, 3},

--- a/runsc/container/console_test.go
+++ b/runsc/container/console_test.go
@@ -281,9 +281,9 @@ func TestJobControlSignalExec(t *testing.T) {
 		// our PID counts get messed up.
 		Argv: []string{"/bin/bash", "--noprofile", "--norc"},
 		// Pass the pty replica as FD 0, 1, and 2.
-		FilePayload: control.NewFDMap(map[int]*os.File{
+		FilePayload: control.NewFilePayload(map[int]*os.File{
 			0: ptyReplica, 1: ptyReplica, 2: ptyReplica,
-		}),
+		}, nil),
 		StdioIsPty: true,
 	}
 

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -180,6 +180,9 @@ type Args struct {
 	// PassFiles are user-supplied files from the host to be exposed to the
 	// sandboxed app.
 	PassFiles map[int]*os.File
+
+	// ExecFile is the host file used for program execution.
+	ExecFile *os.File
 }
 
 // New creates the container in a new Sandbox process, unless the metadata
@@ -301,6 +304,7 @@ func New(conf *config.Config, args Args) (*Container, error) {
 				Attached:              args.Attached,
 				OverlayFilestoreFiles: overlayFilestoreFiles,
 				PassFiles:             args.PassFiles,
+				ExecFile:              args.ExecFile,
 			}
 			sand, err := sandbox.New(conf, sandArgs)
 			if err != nil {

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -69,19 +69,26 @@ func execute(conf *config.Config, cont *Container, name string, arg ...string) (
 	return cont.executeSync(conf, args)
 }
 
-func executeCombinedOutput(conf *config.Config, cont *Container, name string, arg ...string) ([]byte, error) {
+// executeCombinedOutput executes a process in the container and captures
+// stdout and stderr. If execFile is supplied, a host file will be executed.
+// Otherwise, the name argument is used to resolve the executable in the guest.
+func executeCombinedOutput(conf *config.Config, cont *Container, execFile *os.File, name string, arg ...string) ([]byte, error) {
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, err
 	}
 	defer r.Close()
 
+	// Unset the filename when we execute via FD.
+	if execFile != nil {
+		name = ""
+	}
 	args := &control.ExecArgs{
 		Filename: name,
 		Argv:     append([]string{name}, arg...),
-		FilePayload: control.NewFDMap(map[int]*os.File{
+		FilePayload: control.NewFilePayload(map[int]*os.File{
 			0: os.Stdin, 1: w, 2: w,
-		}),
+		}, execFile),
 	}
 	ws, err := cont.executeSync(conf, args)
 	w.Close()
@@ -176,7 +183,7 @@ func blockUntilWaitable(pid int) error {
 
 // execPS executes `ps` inside the container and return the processes.
 func execPS(conf *config.Config, c *Container) ([]*control.Process, error) {
-	out, err := executeCombinedOutput(conf, c, "/bin/ps", "-e")
+	out, err := executeCombinedOutput(conf, c, nil, "/bin/ps", "-e")
 	if err != nil {
 		return nil, err
 	}
@@ -854,9 +861,9 @@ func TestExec(t *testing.T) {
 
 				_, err = cont.executeSync(conf, &control.ExecArgs{
 					Argv: []string{"/nonexist"},
-					FilePayload: control.NewFDMap(map[int]*os.File{
+					FilePayload: control.NewFilePayload(map[int]*os.File{
 						0: os.NewFile(uintptr(fds[1]), "sock"),
-					}),
+					}, nil),
 				})
 				want := "failed to load /nonexist"
 				if err == nil || !strings.Contains(err.Error(), want) {
@@ -1625,7 +1632,7 @@ func TestReadonlyRoot(t *testing.T) {
 			}
 
 			// Read mounts to check that root is readonly.
-			out, err := executeCombinedOutput(conf, c, "/bin/sh", "-c", "mount | grep ' / ' | grep -o -e '(.*)'")
+			out, err := executeCombinedOutput(conf, c, nil, "/bin/sh", "-c", "mount | grep ' / ' | grep -o -e '(.*)'")
 			if err != nil {
 				t.Fatalf("exec failed: %v", err)
 			}
@@ -1684,7 +1691,7 @@ func TestReadonlyMount(t *testing.T) {
 
 			// Read mounts to check that volume is readonly.
 			cmd := fmt.Sprintf("mount | grep ' %s ' | grep -o -e '(.*)'", dir)
-			out, err := executeCombinedOutput(conf, c, "/bin/sh", "-c", cmd)
+			out, err := executeCombinedOutput(conf, c, nil, "/bin/sh", "-c", cmd)
 			if err != nil {
 				t.Fatalf("exec failed, err: %v", err)
 			}
@@ -2505,7 +2512,7 @@ func TestRlimitsExec(t *testing.T) {
 		t.Fatalf("error starting container: %v", err)
 	}
 
-	got, err := executeCombinedOutput(conf, cont, "/bin/sh", "-c", "ulimit -n")
+	got, err := executeCombinedOutput(conf, cont, nil, "/bin/sh", "-c", "ulimit -n")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2869,10 +2876,10 @@ func TestFDPassingExec(t *testing.T) {
 	cmd := fmt.Sprintf("cat /proc/self/fd/%d > /proc/self/fd/%d", int(guestRead.Fd()), int(guestWrite.Fd()))
 	execArgs := &control.ExecArgs{
 		Argv: []string{"/bin/bash", "-c", cmd},
-		FilePayload: control.NewFDMap(map[int]*os.File{
+		FilePayload: control.NewFilePayload(map[int]*os.File{
 			int(guestRead.Fd()):  guestRead,
 			int(guestWrite.Fd()): guestWrite,
-		}),
+		}, nil),
 	}
 
 	if _, err = cont.Execute(conf, execArgs); err != nil {
@@ -2890,5 +2897,138 @@ func TestFDPassingExec(t *testing.T) {
 	}
 	if got != msg {
 		t.Errorf("got message %q, want %q", got, msg)
+	}
+}
+
+// findInPath finds a filename in the PATH environment variable.
+func findInPath(filename string) string {
+	for _, dir := range strings.Split(os.Getenv("PATH"), ":") {
+		fullPath := filepath.Join(dir, filename)
+		if _, err := os.Stat(fullPath); err == nil {
+			return fullPath
+		}
+	}
+	return ""
+}
+
+// TestExecFDRun checks that an executable from the host can be started inside
+// a container.
+func TestExecFDRun(t *testing.T) {
+	// In the guest, read from the host and write the result back to the host.
+	conf := testutil.TestConfig(t)
+	// Note that we do not supply the name or path of the echo binary here.
+	// Thus, the guest does not know the binary path or name either.
+	// argv[0] inside echo is "can be anything".
+	spec := testutil.NewSpecWithArgs("can be anything", "hello world")
+
+	_, bundleDir, cleanup, err := testutil.SetupContainer(spec, conf)
+	if err != nil {
+		t.Fatalf("error setting up container: %v", err)
+	}
+	defer cleanup()
+
+	// Find the echo binary on the host.
+	echoPath := findInPath("echo")
+	if echoPath == "" {
+		t.Fatalf("failed to find echo executable in PATH")
+	}
+
+	// Open the echo binary as a file.
+	echoFile, err := os.Open(echoPath)
+	if err != nil {
+		t.Fatalf("opening echo binary: %v", err)
+	}
+	defer echoFile.Close()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating pipe: %v", err)
+	}
+	defer r.Close()
+
+	args := Args{
+		ID:        testutil.RandomContainerID(),
+		Spec:      spec,
+		BundleDir: bundleDir,
+		PassFiles: map[int]*os.File{
+			0: os.Stdin, 1: w, 2: w,
+		},
+		ExecFile: echoFile,
+	}
+
+	cont, err := New(conf, args)
+	if err != nil {
+		t.Fatalf("Creating container: %v", err)
+	}
+	defer cont.Destroy()
+
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("starting container: %v", err)
+	}
+
+	w.Close()
+
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Errorf("reading container output: %v", err)
+	}
+	if want := "hello world\n"; string(got) != want {
+		t.Errorf("got message %q, want %q", got, want)
+	}
+}
+
+// TestExecFDExec checks that an executable from the host can be started from a
+// file descriptor inside an already running container.
+func TestExecFDExec(t *testing.T) {
+	conf := testutil.TestConfig(t)
+
+	// We just sleep here because we want to test execution in an already
+	// running container.
+	spec := testutil.NewSpecWithArgs("bash", "-c", "sleep infinity")
+
+	_, bundleDir, cleanup, err := testutil.SetupContainer(spec, conf)
+	if err != nil {
+		t.Fatalf("error setting up container: %v", err)
+	}
+	defer cleanup()
+
+	args := Args{
+		ID:        testutil.RandomContainerID(),
+		Spec:      spec,
+		BundleDir: bundleDir,
+	}
+
+	cont, err := New(conf, args)
+	if err != nil {
+		t.Fatalf("Creating container: %v", err)
+	}
+	defer cont.Destroy()
+
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("starting container: %v", err)
+	}
+
+	// Find the echo binary on the host.
+	echoPath := findInPath("echo")
+	if echoPath == "" {
+		t.Fatalf("failed to find echo executable in PATH")
+	}
+
+	// Open the echo binary as a file.
+	echoFile, err := os.Open(echoPath)
+	if err != nil {
+		t.Fatalf("opening echo binary: %v", err)
+	}
+	defer echoFile.Close()
+
+	// Note that we do not supply the name or path of the echo binary here.
+	// Thus, the guest does not know the binary path or name either.
+	// argv[0] inside echo is "can be anything".
+	got, err := executeCombinedOutput(conf, cont, echoFile, "can be anything", "hello world")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "hello world\n"; string(got) != want {
+		t.Errorf("echo result, got: %q, want: %q", got, want)
 	}
 }

--- a/runsc/container/metric_server_test.go
+++ b/runsc/container/metric_server_test.go
@@ -184,7 +184,7 @@ func TestContainerMetrics(t *testing.T) {
 	}
 	t.Logf("After container start, fs_opens=%d (snapshotted at %v)", postStartOpens, postStartTimestamp)
 	// The touch operation may fail from permission errors, but the metric should still be incremented.
-	shOutput, err := executeCombinedOutput(te.sleepConf, cont, "/bin/bash", "-c", fmt.Sprintf("for i in $(seq 1 %d); do touch /tmp/$i || true; done", targetOpens))
+	shOutput, err := executeCombinedOutput(te.sleepConf, cont, nil, "/bin/bash", "-c", fmt.Sprintf("for i in $(seq 1 %d); do touch /tmp/$i || true; done", targetOpens))
 	if err != nil {
 		t.Fatalf("Exec failed: %v; output: %v", err, shOutput)
 	}
@@ -290,7 +290,7 @@ func TestContainerMetricsRobustAgainstRestarts(t *testing.T) {
 	if err := cont.Start(te.sleepConf); err != nil {
 		t.Fatalf("Cannot start container: %v", err)
 	}
-	shOutput, err := executeCombinedOutput(te.sleepConf, cont, "/bin/bash", "-c", fmt.Sprintf("for i in $(seq 1 %d); do touch /tmp/$i || true; done", targetOpens))
+	shOutput, err := executeCombinedOutput(te.sleepConf, cont, nil, "/bin/bash", "-c", fmt.Sprintf("for i in $(seq 1 %d); do touch /tmp/$i || true; done", targetOpens))
 	if err != nil {
 		t.Fatalf("Exec failed: %v; output: %v", err, shOutput)
 	}
@@ -327,7 +327,7 @@ func TestContainerMetricsRobustAgainstRestarts(t *testing.T) {
 
 	// Do a bunch of touches again. The metric server is down during this time.
 	// This verifies that metric value modifications does not depend on the metric server being up.
-	shOutput, err = executeCombinedOutput(te.sleepConf, cont, "/bin/bash", "-c", fmt.Sprintf("for i in $(seq 1 %d); do touch /tmp/$i || true; done", targetOpens))
+	shOutput, err = executeCombinedOutput(te.sleepConf, cont, nil, "/bin/bash", "-c", fmt.Sprintf("for i in $(seq 1 %d); do touch /tmp/$i || true; done", targetOpens))
 	if err != nil {
 		t.Fatalf("Exec failed: %v; output: %v", err, shOutput)
 	}

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -2205,7 +2205,7 @@ func TestMultiContainerShm(t *testing.T) {
 	}
 
 	// Check that file can be found in the other container.
-	out, err := executeCombinedOutput(conf, containers[1], "/bin/cat", output)
+	out, err := executeCombinedOutput(conf, containers[1], nil, "/bin/cat", output)
 	if err != nil {
 		t.Fatalf("exec failed: %v", err)
 	}

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -245,6 +245,9 @@ type Args struct {
 	// PassFiles are user-supplied files from the host to be exposed to the
 	// sandboxed app.
 	PassFiles map[int]*os.File
+
+	// ExecFile is the file from the host used for program execution.
+	ExecFile *os.File
 }
 
 // New creates the sandbox process. The caller must call Destroy() on the
@@ -957,6 +960,10 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 		cmd.SysProcAttr.Pdeathsig = unix.SIGKILL
 		// Tells boot that any process it creates must have pdeathsig set.
 		cmd.Args = append(cmd.Args, "--attached")
+	}
+
+	if args.ExecFile != nil {
+		donations.Donate("exec-fd", args.ExecFile)
 	}
 
 	nextFD = donations.Transfer(cmd, nextFD)


### PR DESCRIPTION
Hi,

this commit adds support for program execution via a host file descriptor. To make use of this feature, the host file descriptor must be mapped to -1 in the guest. For example,

    exec 3</usr/bin/echo
    runsc exec --pass-fd=3:-1 mycontainer hello world

will run the host's echo binary inside gVisor. In this case, "hello" is supplied to echo as argv[0]. As a result, the output of the above command is "world".

This feature is useful for bootstrapping unknown guest environments and allows static executables to perform setup actions inside the container while they need not be part of the guest file system.

Again, I am not sure whether this is a feature you would agree on merging. If not, please feel free to close this PR. Otherwise, I am happy about feedback on the implementation details (for example in case you prefer an extra command line argument instead of mapping to the special FD value of -1 through the CLI).