### PR TITLE
[bugfix/close_endpoints_on_stack_close] On net stack close, wake up all the waiters

### DIFF
--- a/pkg/tcpip/adapters/gonet/gonet_test.go
+++ b/pkg/tcpip/adapters/gonet/gonet_test.go
@@ -370,6 +370,65 @@ func TestCloseWrite(t *testing.T) {
 	}
 }
 
+
+// TestCloseStack tests that stack.Close wakes TCPConn.Read when
+// using tcp.Forwarder.
+func TestCloseStack(t *testing.T) {
+	s, err := newLoopbackStack()
+	if err != nil {
+		t.Fatalf("newLoopbackStack() = %v", err)
+	}
+
+	addr := tcpip.FullAddress{NICID, tcpip.Address(net.IPv4(169, 254, 10, 1).To4()), 11211}
+	protocolAddr := tcpip.ProtocolAddress{
+		Protocol:          ipv4.ProtocolNumber,
+		AddressWithPrefix: addr.Addr.WithPrefix(),
+	}
+	if err := s.AddProtocolAddress(NICID, protocolAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("AddProtocolAddress(%d, %+v, {}): %s", NICID, protocolAddr, err)
+	}
+
+	done := make(chan struct{})
+
+	fwd := tcp.NewForwarder(s, 30000, 10, func(r *tcp.ForwarderRequest) {
+		defer close(done)
+
+		var wq waiter.Queue
+		ep, err := r.CreateEndpoint(&wq)
+		if err != nil {
+			t.Fatalf("r.CreateEndpoint() = %v", err)
+		}
+		r.Complete(false)
+
+		c := NewTCPConn(&wq, ep)
+
+		// Give c.Read() a chance to block before closing the stack.
+		time.AfterFunc(time.Second*1, func() {
+			s.Close()
+			s.Wait()
+		})
+
+		buf := make([]byte, 256)
+		n, e := c.Read(buf)
+		if n != 0 || !strings.Contains(e.Error(), "operation aborted") {
+			t.Errorf("c.Read() = (%d, %v), want (0, operation aborted)", n, e)
+		}
+	})
+	s.SetTransportProtocolHandler(tcp.ProtocolNumber, fwd.HandlePacket)
+
+	sender, err := connect(s, addr)
+	if err != nil {
+		t.Fatalf("connect() = %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Errorf("c.Read() didn't unblock")
+	}
+	sender.close()
+}
+
 func TestUDPForwarder(t *testing.T) {
 	s, terr := newLoopbackStack()
 	if terr != nil {

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -1012,6 +1012,7 @@ func (e *endpoint) Abort() {
 	switch state := e.EndpointState(); {
 	case state.connected():
 		e.resetConnectionLocked(&tcpip.ErrAborted{})
+                e.waiterQueue.Notify(waiter.EventHUp | waiter.EventErr | waiter.ReadableEvents | waiter.WritableEvents)
 		return
 	}
 	e.closeLocked()


### PR DESCRIPTION
### Summary
This PR includes the changes to unblock all the waiters as part of net stack close.

### Root Cause Analysis
https://github.com/google/gvisor/issues/8748

### Testing
1. Testing the fix by porting the fix to "go" branch and confirmed that all the readers get unblocked when net stack is closed.
2. Added the unit test and confirmed unit test is running as expected.

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/119408922/229873819-b4d4d1eb-2574-4103-85f7-38e8cc20648a.png">
<img width="742" alt="image" src="https://user-images.githubusercontent.com/119408922/229873922-cf837abe-c2c5-42b3-a5a8-a933f5690095.png">
<img width="1360" alt="image" src="https://user-images.githubusercontent.com/119408922/229874433-2fb6ab66-dd93-4afb-a6b3-dda3a31cdce7.png">
 
