### PR TITLE
checklocks: always allow calls to methods of atomic wrappers

### DIFF
--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -140,6 +140,10 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 			}
 			return
 		}
+		if fn.Signature.Recv() != nil {
+			// always allow calls to methods of atomic wrappers such as atomic.Int32 introduced in Go 1.19
+			return
+		}
 		if ar == nonAtomic {
 			// We are *not* expecting an atomic dispatch.
 			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {

--- a/tools/checklocks/test/atomics.go
+++ b/tools/checklocks/test/atomics.go
@@ -27,6 +27,8 @@ type atomicStruct struct {
 
 	// +checklocksignore
 	ignored int32
+
+	wrapper atomic.Int32 // safe without any annotations
 }
 
 func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -88,4 +90,10 @@ func testAtomicMixedInvalidAtomicWrite(tc *atomicMixedStruct, v chan int32, p ch
 
 func testAtomicMixedInvalidWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
 	tc.accessedMixed = 1 // +checklocksfail:2
+}
+
+func testAtomicWrapper(tc *atomicStruct, v chan int32) {
+	v <- tc.wrapper.Load()
+	v <- tc.wrapper.Add(33)
+	tc.wrapper.Store(44)
 }


### PR DESCRIPTION
This allows the use of wrappers such as atomic.Int32 introduced in Go 1.19 without triggering the `unexpected call to atomic function`.

I tried running recent checklocks on `github.com/kopia/kopia` and got a ton of such errors, which I don't think should be reported since the wrappers are there to ensure safety of atomic operations. This PR fixes the issue.