### PR TITLE
perf: Remove call to nvidia-container-cli info

### DIFF
--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1700,22 +1700,28 @@ func nvProxyPreGoferHostSetup(spec *specs.Spec, conf *config.Config) error {
 	// nvidia-container-cli --load-kmods seems to be a noop; load kernel modules ourselves.
 	nvproxyLoadKernelModules()
 
-	// Run `nvidia-container-cli info`.
-	// This has the side-effect of automatically creating GPU device files.
-	argv := []string{cliPath, "--load-kmods", "info"}
-	log.Debugf("Executing %q", argv)
-	var infoOut, infoErr strings.Builder
-	cmd := exec.Cmd{
-		Path:   argv[0],
-		Args:   argv,
-		Env:    os.Environ(),
-		Stdout: &infoOut,
-		Stderr: &infoErr,
+	if _, err := os.Stat("/dev/nvidiactl"); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("stat(2) for /dev/nvidiactl failed: %w", err)
+		}
+
+		// Run `nvidia-container-cli info`.
+		// This has the side-effect of automatically creating GPU device files.
+		argv := []string{cliPath, "--load-kmods", "info"}
+		log.Debugf("Executing %q", argv)
+		var infoOut, infoErr strings.Builder
+		cmd := exec.Cmd{
+			Path:   argv[0],
+			Args:   argv,
+			Env:    os.Environ(),
+			Stdout: &infoOut,
+			Stderr: &infoErr,
+		}
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("nvidia-container-cli info failed, err: %v\nstdout: %s\nstderr: %s", err, infoOut.String(), infoErr.String())
+		}
+		log.Debugf("nvidia-container-cli info: %v", infoOut.String())
 	}
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("nvidia-container-cli info failed, err: %v\nstdout: %s\nstderr: %s", err, infoOut.String(), infoErr.String())
-	}
-	log.Debugf("nvidia-container-cli info: %v", infoOut.String())
 
 	return nil
 }


### PR DESCRIPTION
This call is repeated on every container startup sequence, but it is expensive, consistently taking between 2-3 seconds to run each time. This adds a significant amount of startup latency to every container. From `strace` output, the main issue appears to be a call to `openat(AT_FDCWD, "/dev/nvidia0", O_RDWR|O_CLOEXEC)`. The first time this is called, it creates a new open device file descriptor and blocks for 2 seconds while doing so. This was measured on a `g4dn.2xlarge` instance on AWS, running a Tesla T4 GPU.

For comparison, the `nvidia-container-prestart-hook` for runc also runs `nvidia-container-cli` during container boot, but it only calls it once for the `configure` command. gVisor appears to call it twice, once for `info` and then for `configure`.

By removing the `info` call, or at least only running it when the GPU device files are not already present on the host, GPU container startups can be 2-3 seconds faster.

One way to work around this is by pre-opening the `/dev/nvidia*` device files in a separate process. If there is at least open file descriptor, operations on the device files take less than a millisecond again. This is what `nvidia-persistenced` does, see below.

> A Linux daemon utility, **nvidia-persistenced**, addresses an undesirable side effect of the NVIDIA kernel driver behavior in certain computing environments. Whenever the NVIDIA device resources are no longer in use, the NVIDIA kernel driver will tear down the device state. Normally, this is the intended behavior of the device driver, but for some applications, the latencies incurred by repetitive device initialization can significantly impact performance.
>
> Source: https://download.nvidia.com/XFree86/Linux-x86_64/396.51/README/nvidia-persistenced.html

But even when that is done, calling `nvidia-container-cli info` still takes at least 50 milliseconds, so removing this subprocess call here when not necessary still speeds up gVisor container startups.

---

Does this sound reasonable? I tested the change, and gVisor nvproxy still works.