### PR TITLE
Allow interface filtering on Postrouting

### DIFF
--- a/pkg/tcpip/stack/iptables_types.go
+++ b/pkg/tcpip/stack/iptables_types.go
@@ -279,7 +279,7 @@ func (fl IPHeaderFilter) match(pkt PacketBufferPtr, hook Hook, inNicName, outNic
 		return matchIfName(inNicName, fl.InputInterface, fl.InputInterfaceInvert)
 	case Output:
 		return matchIfName(outNicName, fl.OutputInterface, fl.OutputInterfaceInvert)
-	case Forward:
+	case Postrouting, Forward:
 		if !matchIfName(inNicName, fl.InputInterface, fl.InputInterfaceInvert) {
 			return false
 		}
@@ -288,8 +288,6 @@ func (fl IPHeaderFilter) match(pkt PacketBufferPtr, hook Hook, inNicName, outNic
 			return false
 		}
 
-		return true
-	case Postrouting:
 		return true
 	default:
 		panic(fmt.Sprintf("unknown hook: %d", hook))


### PR DESCRIPTION
Looking at the history of this code, it appears that Forward was updated (https://github.com/google/gvisor/commit/2b457d9ee9ba50da4a9208d957053fac2c77932d#diff-d51613d1afdd9c46e3b45137a989ab337d38cc9e4639c6d840185ed5dfc8f32b) but Postrouting never got the same update.

This is important because it allows the same pattern used in standard iptables, specificly to apply MASQUERADE in Postrouting when packets are exiting a specific interface.