### PR TITLE
docs(k8s): updated apiVersion for RuntimeClass

### DIFF
--- a/g3doc/user_guide/containerd/quick_start.md
+++ b/g3doc/user_guide/containerd/quick_start.md
@@ -154,7 +154,7 @@ Install the RuntimeClass for gVisor:
 
 ```shell
 cat <<EOF | kubectl apply -f -
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: gvisor


### PR DESCRIPTION
### Changes
- Updated apiVersion of RuntimeClass.
https://kubernetes.io/docs/concepts/containers/runtime-class/#2-create-the-corresponding-runtimeclass-resources