### PR TITLE
Keep spec-file FD alive past point of exec as nobody

### DIFF
--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -293,6 +293,11 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 				// because the ReadSpecFromFile function seeks to the beginning
 				// of the file before reading.
 				util.Fatalf("callSelfAsNobody(%v): %v", args, callSelfAsNobody(args))
+
+				// This prevents the specFile finalizer from running and closed
+				// the specFD, which we have passed to ourselves when
+				// re-execing.
+				runtime.KeepAlive(specFile)
 				panic("unreachable")
 			}
 		}


### PR DESCRIPTION
The Go runtime can run GC at any point once it falls into the branch of `setupRoot && !rootless && !applyCaps`, so `specFile` becomes eligible for closing. This results in the occasional crash on re-exec where the FD was recycled for the proc-mount-sync-fd pipe created in that branch and causes the seek back to 0 to re-read the spec to fail with an ESPIPE error.