### PR TITLE
tty: enable `TCSETSF`

### DIFF
--- a/pkg/sentry/fsimpl/devpts/master.go
+++ b/pkg/sentry/fsimpl/devpts/master.go
@@ -158,6 +158,10 @@ func (mfd *masterFileDescription) Ioctl(ctx context.Context, io usermem.IO, sysn
 	case linux.TCSETSW:
 		// TODO(b/29356795): This should drain the output queue first.
 		return mfd.t.ld.setTermios(t, args)
+	case linux.TCSETSF:
+		// TODO(b/29356795): This should drain the output queue and
+		// clear the input queue first.
+		return mfd.t.ld.setTermios(t, args)
 	case linux.TIOCGPTN:
 		nP := primitive.Uint32(mfd.t.n)
 		_, err := nP.CopyOut(t, args[2].Pointer())

--- a/pkg/sentry/fsimpl/devpts/replica.go
+++ b/pkg/sentry/fsimpl/devpts/replica.go
@@ -170,6 +170,10 @@ func (rfd *replicaFileDescription) Ioctl(ctx context.Context, io usermem.IO, sys
 	case linux.TCSETSW:
 		// TODO(b/29356795): This should drain the output queue first.
 		return rfd.inode.t.ld.setTermios(t, args)
+	case linux.TCSETSF:
+		// TODO(b/29356795): This should drain the output queue and
+		// clear the input queue first.
+		return rfd.inode.t.ld.setTermios(t, args)
 	case linux.TIOCGPTN:
 		nP := primitive.Uint32(rfd.inode.t.n)
 		_, err := nP.CopyOut(t, args[2].Pointer())


### PR DESCRIPTION
While there is a difference between flavors of this ioctl (`TCSETS`, `TCSETSF`, `TCSETSW`), in practice it seems not to matter. We should let users call `TCSETSF` and can implement those differences if necessary.

Fixes #9335.