### PR TITLE
systrap: set PDEATHSIG right after forking a sysmsg thread

### DIFF
--- a/pkg/sentry/platform/systrap/sysmsg_thread_unsafe.go
+++ b/pkg/sentry/platform/systrap/sysmsg_thread_unsafe.go
@@ -39,20 +39,6 @@ func (p *sysmsgThread) setMsg(addr uintptr) {
 
 func (p *sysmsgThread) init(sentryAddr, guestAddr uintptr) {
 	t := p.thread
-
-	// Set the parent death signal to SIGKILL.
-	_, err := t.syscallIgnoreInterrupt(&t.initRegs, unix.SYS_PRCTL,
-		arch.SyscallArgument{Value: linux.PR_SET_PDEATHSIG},
-		arch.SyscallArgument{Value: uintptr(unix.SIGKILL)},
-		arch.SyscallArgument{Value: 0},
-		arch.SyscallArgument{Value: 0},
-		arch.SyscallArgument{Value: 0},
-		arch.SyscallArgument{Value: 0},
-	)
-	if err != nil {
-		panic(fmt.Sprintf("prctl: %v", err))
-	}
-
 	// Set the sysmsg signal stack.
 	//
 	// sentryAddr is from the stub mapping which is mapped once and never
@@ -61,7 +47,7 @@ func (p *sysmsgThread) init(sentryAddr, guestAddr uintptr) {
 	*alt = linux.SignalStack{}
 	alt.Addr = uint64(guestAddr)
 	alt.Size = uint64(sysmsg.MsgOffsetFromSharedStack)
-	_, err = t.syscallIgnoreInterrupt(&t.initRegs, unix.SYS_SIGALTSTACK,
+	_, err := t.syscallIgnoreInterrupt(&t.initRegs, unix.SYS_SIGALTSTACK,
 		arch.SyscallArgument{Value: guestAddr},
 		arch.SyscallArgument{Value: 0},
 		arch.SyscallArgument{Value: 0},


### PR DESCRIPTION
container_test:TestGoferExits fails by timeout, because there are some sysmsg threads survived sandbox process death. When we fork a new sysmsg thread, it is traced with PTRACE_O_EXITKILL, so we need to set PDEATHSIG before detaching from it.