### PR TITLE
fix: outdated line in debugging.md doc

### DIFF
--- a/g3doc/user_guide/debugging.md
+++ b/g3doc/user_guide/debugging.md
@@ -84,7 +84,7 @@ sudo dlv attach $(docker inspect test | grep Pid | head -n 1 | grep -oe "[0-9]*"
 Set a breakpoint for accept:
 
 ```bash
-break gvisor.dev/gvisor/pkg/sentry/socket/netstack.(*SocketOperations).Accept
+break gvisor.dev/gvisor/pkg/sentry/socket/netstack.(*sock).Accept
 continue
 ```
 


### PR DESCRIPTION
Updated based on current state of `master` and it works 🙂 

<kbd>
<img width="1241" alt="image" src="https://github.com/google/gvisor/assets/12058921/00fed637-20ff-4e7f-826f-b220c7dcdab6">

</kbd>