### PR TITLE
erofs: avoid unnecessary escapes and memory copies

### DIFF
--- a/pkg/erofs/BUILD
+++ b/pkg/erofs/BUILD
@@ -7,7 +7,10 @@ package(
 
 go_library(
     name = "erofs",
-    srcs = ["erofs.go"],
+    srcs = [
+        "erofs.go",
+        "erofs_unsafe.go",
+    ],
     marshal = True,
     visibility = ["//visibility:public"],
     deps = [
@@ -17,7 +20,6 @@ go_library(
         "//pkg/hostarch",
         "//pkg/log",
         "//pkg/marshal",
-        "//pkg/marshal/primitive",
         "//pkg/safemem",
         "@org_golang_x_sys//unix:go_default_library",
     ],

--- a/pkg/erofs/erofs_test.go
+++ b/pkg/erofs/erofs_test.go
@@ -19,19 +19,19 @@ import (
 )
 
 func TestOnDiskStructureSizes(t *testing.T) {
-	if sb := new(SuperBlock); sb.SizeBytes() != 128 {
-		t.Errorf("wrong super block size: want 128, got %d", sb.SizeBytes())
+	if sb := new(SuperBlock); sb.SizeBytes() != SuperBlockSize {
+		t.Errorf("wrong super block size: want %d, got %d", SuperBlockSize, sb.SizeBytes())
 	}
 
-	if i := new(InodeCompact); i.SizeBytes() != 32 {
-		t.Errorf("wrong compact inode size: want 32, got %d", i.SizeBytes())
+	if i := new(InodeCompact); i.SizeBytes() != InodeCompactSize {
+		t.Errorf("wrong compact inode size: want %d, got %d", InodeCompactSize, i.SizeBytes())
 	}
 
-	if i := new(InodeExtended); i.SizeBytes() != 64 {
-		t.Errorf("wrong extended inode size: want 64, got %d", i.SizeBytes())
+	if i := new(InodeExtended); i.SizeBytes() != InodeExtendedSize {
+		t.Errorf("wrong extended inode size: want %d, got %d", InodeExtendedSize, i.SizeBytes())
 	}
 
-	if d := new(Dirent); d.SizeBytes() != 12 {
-		t.Errorf("wrong dirent size: want 12, got %d", d.SizeBytes())
+	if d := new(Dirent); d.SizeBytes() != DirentSize {
+		t.Errorf("wrong dirent size: want %d, got %d", DirentSize, d.SizeBytes())
 	}
 }

--- a/pkg/erofs/erofs_unsafe.go
+++ b/pkg/erofs/erofs_unsafe.go
@@ -1,0 +1,21 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package erofs
+
+import "unsafe"
+
+func (i *Image) pointerAt(off uint64) unsafe.Pointer {
+	return unsafe.Pointer(&i.bytes[off])
+}


### PR DESCRIPTION
Currently, when we access the on-disk filesystem objects, the objects will be copied to temporary buffers and will escape to heap. This patch gets rid of these unnecessary copies and escapes by casting and using the memory backed the image file directly.