### PR TITLE
netstack: fall back to slower checksum when buffer isn't aligned

### DIFF
--- a/pkg/tcpip/checksum/BUILD
+++ b/pkg/tcpip/checksum/BUILD
@@ -17,6 +17,8 @@ go_library(
         "checksum.go",
         "checksum_amd64.go",
         "checksum_amd64.s",
+        "checksum_mips64.go",
+        "checksum_noasm.go",
         "checksum_noasm_unsafe.go",
     ],
     visibility = ["//visibility:public"],

--- a/pkg/tcpip/checksum/checksum_mips64.go
+++ b/pkg/tcpip/checksum/checksum_mips64.go
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build amd64
-// +build amd64
+//go:build mips64
+// +build mips64
 
 package checksum
-
-// calculateChecksumAMD64 is defined in assembly.
-func calculateChecksumAMD64(buf []byte, odd bool, initial uint16) (uint16, bool)
 
 // Note: odd indicates whether initial is a partial checksum over an odd number
 // of bytes.
 func calculateChecksum(buf []byte, odd bool, initial uint16) (uint16, bool) {
-	return calculateChecksumAMD64(buf, odd, initial)
+	return unrolledCalculateChecksum(buf, odd, initial)
 }

--- a/pkg/tcpip/checksum/checksum_noasm.go
+++ b/pkg/tcpip/checksum/checksum_noasm.go
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build amd64
-// +build amd64
+//go:build !amd64 && !mips64
+// +build !amd64,!mips64
 
 package checksum
-
-// calculateChecksumAMD64 is defined in assembly.
-func calculateChecksumAMD64(buf []byte, odd bool, initial uint16) (uint16, bool)
 
 // Note: odd indicates whether initial is a partial checksum over an odd number
 // of bytes.
 func calculateChecksum(buf []byte, odd bool, initial uint16) (uint16, bool) {
-	return calculateChecksumAMD64(buf, odd, initial)
+	return calculateChecksumNoASM(buf, odd, initial)
 }

--- a/pkg/tcpip/checksum/checksum_noasm_unsafe.go
+++ b/pkg/tcpip/checksum/checksum_noasm_unsafe.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !amd64
-// +build !amd64
-
 package checksum
 
 import (
@@ -25,10 +22,16 @@ import (
 
 // Note: odd indicates whether initial is a partial checksum over an odd number
 // of bytes.
-func calculateChecksum(buf []byte, odd bool, initial uint16) (uint16, bool) {
-	// Note: we can probably remove unrolledCalculateChecksum altogether,
-	// but I don't have any 32 bit machines to benchmark on.
-	if bits.UintSize != 64 {
+func calculateChecksumNoASM(buf []byte, odd bool, initial uint16) (uint16, bool) {
+	// Fall back to slower checksum if we're not on a 64 bit machine or if
+	// this optimization will result in misaligned accesses. Calculating
+	// the checksum starting at an odd address messes up the endianness
+	// expected by the below.
+	var oddOffset uintptr
+	if odd {
+		oddOffset = 1
+	}
+	if bits.UintSize != 64 || (sliceAddr(buf)+oddOffset)%2 != 0 {
 		return unrolledCalculateChecksum(buf, odd, initial)
 	}
 
@@ -37,12 +40,12 @@ func calculateChecksum(buf []byte, odd bool, initial uint16) (uint16, bool) {
 
 	// It doesn't matter what endianness we use, only that it's
 	// consistent throughout the calculation. See RFC 1071 1.2.B.
-	acc := uint(((initial & 0xff00) >> 8) | ((initial & 0x00ff) << 8))
+	acc := uint64(((initial & 0xff00) >> 8) | ((initial & 0x00ff) << 8))
 
 	// Account for initial having been calculated over an odd number of
 	// bytes.
 	if odd {
-		acc += uint(buf[0]) << 8
+		acc += uint64(buf[0]) << 8
 		buf = buf[1:]
 	}
 
@@ -50,21 +53,28 @@ func calculateChecksum(buf []byte, odd bool, initial uint16) (uint16, bool) {
 	// so, the final byte is a big endian most significant byte.
 	odd = len(buf)%2 != 0
 	if odd {
-		acc += uint(buf[len(buf)-1])
+		acc += uint64(buf[len(buf)-1])
 		buf = buf[:len(buf)-1]
 	}
 
+	// Deal with unaligned bytes. We're guaranteed at this point that buf
+	// points to an even address.
+	var carry uint64
+	for sliceAddr(buf)%8 != 0 && len(buf) >= 2 {
+		acc, carry = bits.Add64(acc, uint64(*(*uint16)(unsafe.Pointer(&buf[0]))), carry)
+		buf = buf[2:]
+	}
+
 	// Compute the checksum 8 bytes at a time.
-	var carry uint
 	for len(buf) >= 8 {
-		acc, carry = bits.Add(acc, *(*uint)(unsafe.Pointer(&buf[0])), carry)
+		acc, carry = bits.Add64(acc, *(*uint64)(unsafe.Pointer(&buf[0])), carry)
 		buf = buf[8:]
 	}
 
 	// Compute the remainder 2 bytes at a time. We are guaranteed that
 	// len(buf) is even due to the above handling of odd-length buffers.
 	for len(buf) > 0 {
-		acc, carry = bits.Add(acc, uint(*(*uint16)(unsafe.Pointer(&buf[0]))), carry)
+		acc, carry = bits.Add64(acc, uint64(*(*uint16)(unsafe.Pointer(&buf[0]))), carry)
 		buf = buf[2:]
 	}
 	acc += carry
@@ -77,4 +87,8 @@ func calculateChecksum(buf []byte, odd bool, initial uint16) (uint16, bool) {
 	// Swap the byte order before returning.
 	acc = ((acc & 0xff00) >> 8) | ((acc & 0x00ff) << 8)
 	return uint16(acc), odd
+}
+
+func sliceAddr(buf []byte) uintptr {
+	return uintptr(unsafe.Pointer(unsafe.SliceData(buf)))
 }


### PR DESCRIPTION
- When buffers aren't 64 bit aligned, use the slower unrolled checksum that's safe across different architectures.
- Remove the copied checksum implementation in checksum_test so we don't have to update both.
- Play with build tags such that checksum_test tests all checksum implementations, not just the preferred one on that architecture.

Fixes #9499.