### PR TITLE
Add interface templates for external stack support

### DIFF
--- a/pkg/sentry/socket/externalstack/BUILD
+++ b/pkg/sentry/socket/externalstack/BUILD
@@ -1,0 +1,37 @@
+package(licenses = ["notice"])
+
+load("//tools:defs.bzl", "go_library")
+
+go_library(
+    name = "externalstack",
+    srcs = [
+        "notifier.go",
+        "provider.go",
+        "socket.go",
+        "stack.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sentry/inet",
+        "//pkg/abi/linux",
+        "//pkg/abi/linux/errno",
+        "//pkg/context",
+        "//pkg/hostarch",
+        "//pkg/marshal",
+        "//pkg/sentry/arch",
+        "//pkg/sentry/stack",
+        "//pkg/sentry/fsimpl/sockfs",
+        "//pkg/sentry/kernel",
+        "//pkg/sentry/kernel/time",
+        "//pkg/sentry/socket",
+        "//pkg/sentry/socket/externalstack/cgo",
+        "//pkg/sentry/vfs",
+        "//pkg/syserr",
+        "//pkg/tcpip",
+        "//pkg/usermem",
+        "//pkg/waiter",
+        "//pkg/sentry/kernel/auth",
+        "//pkg/tcpip/network/ipv4",
+        "//pkg/tcpip/network/ipv6",
+    ],
+)

--- a/pkg/sentry/socket/externalstack/cgo/BUILD
+++ b/pkg/sentry/socket/externalstack/cgo/BUILD
@@ -1,0 +1,13 @@
+package(licenses = ["notice"])
+
+load("//tools:defs.bzl", "go_library")
+
+go_library(
+    name = "cgo",
+    srcs = [
+        "socket_unsafe.go",
+        "stack_unsafe.go",
+    ],
+    cgo = True,
+    visibility = ["//visibility:public"],
+)

--- a/pkg/sentry/socket/externalstack/cgo/socket_unsafe.go
+++ b/pkg/sentry/socket/externalstack/cgo/socket_unsafe.go
@@ -1,0 +1,146 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgo
+
+/*
+#include <stdint.h>
+#include <sys/socket.h>
+
+// socket control operations
+int external_socket(int domain, int type, int protocol);
+int external_listen(int sockfd, int backlog);
+int external_bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+int external_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags);
+int external_connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
+int external_getsockopt(int sockfd, int level, int optname,
+			void *optval, socklen_t *optlen);
+int external_setsockopt(int sockfd, int level, int optname,
+			const void *optval, socklen_t optlen);
+int external_getsockname(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+int external_getpeername(int sockfd, struct sockaddr *addr, socklen_t *addrlen);
+int external_ioctl(int d,  unsigned long int request, ...);
+int external_shutdown(int sockfd, int how);
+int external_close(int fd);
+
+// receiving data operations
+ssize_t external_recv(int sockfd, void *buf, size_t len, int flags);
+ssize_t external_recvfrom(int sockfd, void *buf, size_t len, int flags,
+			struct sockaddr *src_addr, socklen_t *addrlen);
+ssize_t external_recvmsg(int sockfd, struct msghdr *msg, int flags);
+ssize_t external_read(int fd, void *buf, size_t count);
+ssize_t external_readv(int fd, const struct iovec *iov, int iovcnt);
+
+// sending data operations
+ssize_t external_send(int sockfd, const void *buf, size_t len, int flags);
+ssize_t external_sendto(int sockfd, const void *buf, size_t len, int flags,
+		const struct sockaddr *dest_addr, socklen_t addrlen);
+ssize_t external_sendmsg(int sockfd, const struct msghdr *msg, int flags);
+ssize_t external_write(int fd, const void *buf, size_t count);
+ssize_t external_writev(int fd, const struct iovec *iov, int iovcnt);
+
+*/
+import "C"
+import (
+	"syscall"
+)
+
+func Socket(domain, skType, protocol int) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Bind(handle uint32, sa []byte) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Listen(handle uint32, backlog int) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Accept(handle uint32, addrPtr *byte, lenPtr *uint32) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Ioctl(handle uint32, cmd uint32, buf []byte) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Connect(handle uint32, addr []byte) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Getsockopt(handle uint32, l int, n int, val []byte, s int) (int, int) {
+	//TODO: implement cgo wrapper
+	return 0, 0
+}
+
+func Setsockopt(handle uint32, l int, n int, val []byte) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Shutdown(handle uint32, how int) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Close(handle uint32) {
+	//TODO: implement cgo wrapper
+}
+
+func Read(handle uint32, buf uintptr, count int) int64 {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Readv(handle uint32, iovs []syscall.Iovec) int64 {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Recvfrom(handle uint32, buf, addr []byte, flags int) (int64, int) {
+	//TODO: implement cgo wrapper
+	return 0, 0
+}
+
+func Recvmsg(handle uint32, iovs []syscall.Iovec, addr, control []byte, flags int) (int64, int, int, int) {
+	//TODO: implement cgo wrapper
+	return 0, 0, 0, 0
+}
+
+func Write(handle uint32, buf uintptr, count int) int64 {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Writev(handle uint32, iovs []syscall.Iovec) int64 {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Sendto(handle uint32, buf uintptr, count int, flags int, addr []byte) int64 {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func Sendmsg(handle uint32, iovs []syscall.Iovec, addr []byte, flags int) int64 {
+	//TODO: implement cgo wrapper
+	return 0
+}

--- a/pkg/sentry/socket/externalstack/cgo/stack_unsafe.go
+++ b/pkg/sentry/socket/externalstack/cgo/stack_unsafe.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgo
+
+/*
+#include <stdlib.h>
+
+int external_initstack(int argc, char **argv);
+int external_preinitstack(int argc, char **argv);
+int external_postinitstack(int argc, char **argv);
+
+*/
+import "C"
+
+func InitExternalStack(argv []string) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func PreInitExternalStack(argv []string) int {
+	//TODO: implement cgo wrapper
+	return 0
+}
+
+func PostInitExternalStack(argv []string) int {
+	//TODO: implement cgo wrapper
+	return 0
+}

--- a/pkg/sentry/socket/externalstack/notifier.go
+++ b/pkg/sentry/socket/externalstack/notifier.go
@@ -1,0 +1,49 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalstack
+
+import (
+	"sync"
+
+	"gvisor.dev/gvisor/pkg/sentry/stack"
+)
+
+// Notifier holds all the state necessary to issue notifications when
+// IO events occur in the observed FDs.
+type ExternalNotifier struct {
+	// the epoll FD used to register for io notifications.
+	epFD int32
+
+	// mu protects fdMap.
+	mu sync.Mutex
+
+	// fdMap maps file descriptors to their notification queues
+	// and waiting status.
+	fdMap map[uint32]*stack.FdInfo
+}
+
+func (n *ExternalNotifier) AddFD(fd uint32, fi *stack.FdInfo) error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (n *ExternalNotifier) RemoveFD(fd uint32) {
+	//TODO: implement glue layer
+}
+
+func (n *ExternalNotifier) UpdateFD(fd uint32) error {
+	//TODO: implement glue layer
+	return nil
+}

--- a/pkg/sentry/socket/externalstack/provider.go
+++ b/pkg/sentry/socket/externalstack/provider.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalstack
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/socket"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/syserr"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
+)
+
+type provider struct {
+	family   int
+	netProto tcpip.NetworkProtocolNumber
+}
+
+// Socket creates a new socket object for the AF_INET or AF_INET6 family.
+func (p *provider) Socket(t *kernel.Task, skType linux.SockType, protocol int) (*vfs.FileDescription, *syserr.Error) {
+	// TODO: implement glue layer
+	return nil, nil
+}
+
+// Pair just returns nil sockets (not supported).
+func (*provider) Pair(*kernel.Task, linux.SockType, int) (*vfs.FileDescription, *vfs.FileDescription, *syserr.Error) {
+	return nil, nil, nil
+}
+
+func init() {
+	// Providers backed by netstack.
+	p := []provider{
+		{
+			family:   linux.AF_INET,
+			netProto: ipv4.ProtocolNumber,
+		},
+
+		{
+			family:   linux.AF_INET6,
+			netProto: ipv6.ProtocolNumber,
+		},
+	}
+
+	for i := range p {
+		socket.RegisterProvider(p[i].family, &p[i])
+	}
+}

--- a/pkg/sentry/socket/externalstack/socket.go
+++ b/pkg/sentry/socket/externalstack/socket.go
@@ -1,0 +1,199 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalstack
+
+import (
+	"sync"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/marshal"
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/inet"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	ktime "gvisor.dev/gvisor/pkg/sentry/kernel/time"
+	"gvisor.dev/gvisor/pkg/sentry/socket"
+	"gvisor.dev/gvisor/pkg/sentry/stack"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/syserr"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/usermem"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+// +stateify savable
+type socketOperations struct {
+	vfsfd vfs.FileDescription
+	vfs.FileDescriptionDefaultImpl
+	vfs.DentryMetadataFileDescriptionImpl
+	vfs.LockFD
+	socket.SendReceiveTimeout
+	*waiter.Queue
+
+	family   int
+	Endpoint tcpip.Endpoint
+	skType   linux.SockType
+	protocol int
+
+	namespace *inet.Namespace
+
+	// readMu protects access to the below fields.
+	readMu sync.Mutex `state:"nosave"`
+
+	// sockOptTimestamp corresponds to SO_TIMESTAMP. When true, timestamps
+	// of returned messages can be returned via control messages. When
+	// false, the same timestamp is instead stored and can be read via the
+	// SIOCGSTAMP ioctl. It is protected by readMu. See socket(7).
+	sockOptTimestamp bool
+
+	// timestampValid indicates whether timestamp for SIOCGSTAMP has been
+	// set. It is protected by readMu.
+	timestampValid bool
+
+	// timestamp holds the timestamp to use with SIOCTSTAMP. It is only
+	// valid when timestampValid is true. It is protected by readMu.
+	timestamp time.Time `state:".(int64)"`
+
+	// sockOptInq corresponds to TCP_INQ.
+	sockOptInq bool
+
+	handle   uint32 `state:"nosave"`
+	udpState uint32
+	fi       stack.FdInfo
+	notifier *ExternalNotifier `state:"nosave"`
+	wq       *waiter.Queue
+}
+
+var _ = socket.Socket(&socketOperations{})
+
+func (s *socketOperations) Bind(t *kernel.Task, sockaddr []byte) *syserr.Error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *socketOperations) Listen(t *kernel.Task, backlog int) *syserr.Error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *socketOperations) Accept(t *kernel.Task, peerRequested bool, flags int, blocking bool) (int32, linux.SockAddr, uint32, *syserr.Error) {
+	//TODO: implement glue layer
+	return 0, nil, 0, nil
+}
+
+func (s *socketOperations) Connect(t *kernel.Task, sockaddr []byte, blocking bool) *syserr.Error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *socketOperations) Shutdown(t *kernel.Task, how int) *syserr.Error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *socketOperations) GetSockOpt(t *kernel.Task, level int, name int, outPtr hostarch.Addr, outLen int) (marshal.Marshallable, *syserr.Error) {
+	//TODO: implement glue layer
+	return nil, nil
+}
+
+func (s *socketOperations) SetSockOpt(t *kernel.Task, level int, name int, optVal []byte) *syserr.Error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *socketOperations) RecvMsg(t *kernel.Task, dst usermem.IOSequence, flags int, haveDeadline bool, deadline ktime.Time, senderRequested bool, controlDataLen uint64) (int, int, linux.SockAddr, uint32, socket.ControlMessages, *syserr.Error) {
+	//TODO: implement glue layer
+	return 0, 0, nil, 0, socket.ControlMessages{}, syserr.ErrInvalidArgument
+}
+
+func (s *socketOperations) SendMsg(t *kernel.Task, src usermem.IOSequence, to []byte, flags int, haveDeadline bool, deadline ktime.Time, controlMessages socket.ControlMessages) (int, *syserr.Error) {
+	//TODO: implement glue layer
+	return 0, nil
+}
+
+func (s *socketOperations) State() uint32 {
+	//TODO: implement glue layer
+	return 0
+}
+
+func (s *socketOperations) Type() (family int, skType linux.SockType, protocol int) {
+	//TODO: implement glue layer
+	return 0, 0, 0
+}
+
+func (s *socketOperations) OnClose(ctx context.Context) error {
+	return nil
+}
+
+func (s *socketOperations) EventRegister(e *waiter.Entry) error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *socketOperations) EventUnregister(e *waiter.Entry) {
+	//TODO: implement glue layer
+}
+
+func (s *socketOperations) Readiness(mask waiter.EventMask) waiter.EventMask {
+	//TODO: implement glue layer
+	return 0
+}
+
+func (s *socketOperations) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
+	//TODO: implement glue layer
+	return 0, nil
+}
+
+func (s *socketOperations) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
+	//TODO: implement glue layer
+	return 0, nil
+}
+
+func (s *socketOperations) Epollable() bool {
+	return true
+}
+
+func (s *socketOperations) Ioctl(ctx context.Context, io usermem.IO, sysno uintptr, args arch.SyscallArguments) (uintptr, error) {
+	//TODO: implement glue layer
+	return 0, nil
+}
+
+func (s *socketOperations) Release(ctx context.Context) {
+	//TODO: implement glue layer
+}
+
+func (s *socketOperations) GetSockName(t *kernel.Task) (linux.SockAddr, uint32, *syserr.Error) {
+	//TODO: implement glue layer
+	return nil, 0, nil
+}
+
+func (s *socketOperations) GetPeerName(t *kernel.Task) (linux.SockAddr, uint32, *syserr.Error) {
+	//TODO: implement glue layer
+	return nil, 0, nil
+}
+
+func (s *socketOperations) saveTimestamp() int64 {
+	s.readMu.Lock()
+	defer s.readMu.Unlock()
+	return s.timestamp.UnixNano()
+}
+
+func (s *socketOperations) loadTimestamp(nsec int64) {
+	s.readMu.Lock()
+	defer s.readMu.Unlock()
+	s.timestamp = time.Unix(0, nsec)
+}

--- a/pkg/sentry/socket/externalstack/stack.go
+++ b/pkg/sentry/socket/externalstack/stack.go
@@ -1,0 +1,48 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalstack
+
+import (
+	"gvisor.dev/gvisor/pkg/sentry/inet"
+	"gvisor.dev/gvisor/pkg/sentry/stack"
+)
+
+type ExternalStack struct {
+	inet.Stack
+	interfaces     map[int32]inet.Interface
+	interfaceAddrs map[int32][]inet.InterfaceAddr
+	routes         []inet.Route
+	notifier       *ExternalNotifier `state:"nosave"`
+	tcpRecovery    inet.TCPLossRecovery
+}
+
+func (s *ExternalStack) InitExternalStack(args *stack.InitExternalStackArgs) error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *ExternalStack) PreInitExternalStack(args *stack.PreInitExternalStackArgs) error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func (s *ExternalStack) PostInitExternalStack(args *stack.PostInitExternalStackArgs) error {
+	//TODO: implement glue layer
+	return nil
+}
+
+func init() {
+	stack.RegisterExternalStack(&ExternalStack{})
+}

--- a/pkg/sentry/stack/BUILD
+++ b/pkg/sentry/stack/BUILD
@@ -1,0 +1,17 @@
+package(licenses = ["notice"])
+
+load("//tools:defs.bzl", "go_library")
+
+go_library(
+    name = "stack",
+    srcs = [
+        "externalstack.go",
+        "notifier.go",
+        "util.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sentry/inet",
+        "//pkg/waiter",
+    ],
+)

--- a/pkg/sentry/stack/externalstack.go
+++ b/pkg/sentry/stack/externalstack.go
@@ -1,0 +1,42 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import "gvisor.dev/gvisor/pkg/sentry/inet"
+
+type ExternalStack interface {
+	inet.Stack
+
+	// InitExternalStack initializes external stack.
+	InitExternalStack(args *InitExternalStackArgs) error
+
+	// PreInitExternalStack handles prepare steps before initializing
+	// external stack.
+	PreInitExternalStack(args *PreInitExternalStackArgs) error
+
+	// PostInitExternalStack handles post steps after external stack
+	// initialized.
+	PostInitExternalStack(args *PostInitExternalStackArgs) error
+}
+
+var externalStack ExternalStack
+
+func RegisterExternalStack(stack ExternalStack) {
+	externalStack = stack
+}
+
+func GetExternalStack() ExternalStack {
+	return externalStack
+}

--- a/pkg/sentry/stack/notifier.go
+++ b/pkg/sentry/stack/notifier.go
@@ -1,0 +1,32 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import "gvisor.dev/gvisor/pkg/waiter"
+
+type FdInfo struct {
+	Queue   *waiter.Queue
+	Mask    waiter.EventMask
+	Ready   waiter.EventMask
+	Waiting bool `state:"nosave"`
+}
+
+type Notifier interface {
+	AddFD(fd uint32, fi *FdInfo) error
+
+	RemoveFD(fd uint32)
+
+	UpdateFD(fd uint32) error
+}

--- a/pkg/sentry/stack/util.go
+++ b/pkg/sentry/stack/util.go
@@ -1,0 +1,21 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+type InitExternalStackArgs struct{}
+
+type PreInitExternalStackArgs struct{}
+
+type PostInitExternalStackArgs struct{}

--- a/runsc/BUILD
+++ b/runsc/BUILD
@@ -20,6 +20,23 @@ go_binary(
     ],
 )
 
+go_binary(
+    name = "runsc-external-stack",
+    srcs = ["main-external-stack.go"],
+    pure = False,
+    static = True,
+    tags = ["staging"],
+    visibility = [
+        "//visibility:public",
+    ],
+    x_defs = {"gvisor.dev/gvisor/runsc/version.version": "{STABLE_VERSION}"},
+    deps = [
+        "//runsc/cli",
+        "//runsc/version",
+        "//pkg/sentry/socket/externalstack",
+    ],
+)
+
 # The runsc-race target is a race-compatible BUILD target. This must be built
 # via: bazel build --features=race :runsc-race
 #

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -88,6 +88,7 @@ go_library(
         "//pkg/sentry/socket/netlink/uevent",
         "//pkg/sentry/socket/netstack",
         "//pkg/sentry/socket/unix",
+        "//pkg/sentry/stack",
         "//pkg/sentry/state",
         "//pkg/sentry/strace",
         "//pkg/sentry/time",

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -34,6 +34,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/seccheck"
 	"gvisor.dev/gvisor/pkg/sentry/socket/netstack"
+	externalstack "gvisor.dev/gvisor/pkg/sentry/stack"
 	"gvisor.dev/gvisor/pkg/sentry/state"
 	"gvisor.dev/gvisor/pkg/sentry/time"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
@@ -108,6 +109,9 @@ const (
 const (
 	// NetworkCreateLinksAndRoutes creates links and routes in a network stack.
 	NetworkCreateLinksAndRoutes = "Network.CreateLinksAndRoutes"
+
+	// NetworkInitExternalStack initializes third-party network stack.
+	NetworkInitExternalStack = "Network.InitExternalStack"
 
 	// DebugStacks collects sandbox stacks for debugging.
 	DebugStacks = "debug.Stacks"
@@ -190,6 +194,14 @@ func newController(fd int, l *Loader) (*controller, error) {
 	if eps, ok := l.k.RootNetworkNamespace().Stack().(*netstack.Stack); ok {
 		ctrl.srv.Register(&Network{Stack: eps.Stack})
 	}
+
+	if externalStack := externalstack.GetExternalStack(); externalStack != nil {
+		net := &Network{
+			ExternalStack: externalStack,
+		}
+		ctrl.srv.Register(net)
+	}
+
 	if l.root.conf.ProfileEnable {
 		ctrl.srv.Register(control.NewProfile(l.k))
 	}

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -52,6 +52,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/seccheck"
 	pb "gvisor.dev/gvisor/pkg/sentry/seccheck/points/points_go_proto"
 	"gvisor.dev/gvisor/pkg/sentry/socket/netfilter"
+	externalstack "gvisor.dev/gvisor/pkg/sentry/stack"
 	"gvisor.dev/gvisor/pkg/sentry/time"
 	"gvisor.dev/gvisor/pkg/sentry/usage"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
@@ -1249,6 +1250,8 @@ func newRootNetworkNamespace(conf *config.Config, clock tcpip.Clock, uniqueID st
 			allowPacketEndpointWrite: conf.AllowPacketEndpointWrite,
 		}
 		return inet.NewRootNamespace(s, creator, userns), nil
+	case config.NetworkExternalStack:
+		return inet.NewRootNamespace(externalstack.GetExternalStack(), nil, userns), nil
 
 	default:
 		panic(fmt.Sprintf("invalid network configuration: %v", conf.Network))

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -521,6 +521,9 @@ const (
 
 	// NetworkNone sets up just loopback using netstack.
 	NetworkNone
+
+	// NetworkExternalStack uses third-party network stack.
+	NetworkExternalStack
 )
 
 func networkTypePtr(v NetworkType) *NetworkType {

--- a/runsc/main-external-stack.go
+++ b/runsc/main-external-stack.go
@@ -1,0 +1,33 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.1
+// +build go1.1
+
+// Binary runsc implements the OCI runtime interface.
+package main
+
+import (
+	_ "gvisor.dev/gvisor/pkg/sentry/socket/externalstack"
+	"gvisor.dev/gvisor/runsc/cli"
+	"gvisor.dev/gvisor/runsc/version"
+)
+
+// version.Version is set dynamically, but needs to be
+// linked in the binary, so reference it here.
+var _ = version.Version()
+
+func main() {
+	cli.Main()
+}

--- a/runsc/sandbox/BUILD
+++ b/runsc/sandbox/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//pkg/sentry/fsimpl/erofs",
         "//pkg/sentry/platform",
         "//pkg/sentry/seccheck",
+        "//pkg/sentry/stack",
         "//pkg/state/statefile",
         "//pkg/sync",
         "//pkg/tcpip/header",


### PR DESCRIPTION
This commit adds network stack and socket interfaces for supporting external network stack.

- pkg/sentry/stack: Interfaces for initializing external network stack. It will be used in network setting up during sandbox creating.

- pkg/sentry/socket/externalstack: Glue layer for external stack's socket and stack ops with sentry. It will also register external stack operations if imported.

- pkg/sentry/socket/externalstack/cgo: Interfaces defined in C for external network stack to support.

To build target runsc-external-stack, which imports pkg/sentry/socket/externalstack package and enables CGO:

`bazel build runsc:runsc-external-stack`

By using runsc-external-stack binary and setting network type as external stack, user can use third-party network stack instead of netstack embedded in gVisor.

This commit only sets up the interfaces template, the specific implementation for external stack operations will be provided in follow up commits.

Updates #9266