### PR TITLE
Add the checkpoint/restore support to EROFS

### DIFF
--- a/pkg/erofs/erofs.go
+++ b/pkg/erofs/erofs.go
@@ -223,6 +223,25 @@ func OpenImage(src *os.File) (*Image, error) {
 	return i, nil
 }
 
+// UpdateImage updates the underlying image file. This is typically used in checkpoint/restore.
+//
+// On success, the ownership of src is transferred to Image.
+//
+// Preconditions:
+//   - i.src == nil.
+//   - i.bytes == nil.
+func (i *Image) UpdateImage(src *os.File) error {
+	newImage, err := OpenImage(src)
+	if err != nil {
+		return err
+	}
+	if newImage.sb != i.sb {
+		return fmt.Errorf("superblock mismatch detected, got %+v, expected %+v", newImage.sb, i.sb)
+	}
+	*i = *newImage
+	return nil
+}
+
 // Close closes the image.
 func (i *Image) Close() {
 	unix.Munmap(i.bytes)

--- a/pkg/sentry/fsimpl/erofs/regular_file.go
+++ b/pkg/sentry/fsimpl/erofs/regular_file.go
@@ -131,15 +131,22 @@ func (fd *regularFileFD) ConfigureMMap(ctx context.Context, opts *memmap.MMapOpt
 
 // AddMapping implements memmap.Mappable.AddMapping.
 func (i *inode) AddMapping(ctx context.Context, ms memmap.MappingSpace, ar hostarch.AddrRange, offset uint64, writable bool) error {
+	i.mapsMu.Lock()
+	i.mappings.AddMapping(ms, ar, offset, writable)
+	i.mapsMu.Unlock()
 	return nil
 }
 
 // RemoveMapping implements memmap.Mappable.RemoveMapping.
 func (i *inode) RemoveMapping(ctx context.Context, ms memmap.MappingSpace, ar hostarch.AddrRange, offset uint64, writable bool) {
+	i.mapsMu.Lock()
+	i.mappings.RemoveMapping(ms, ar, offset, writable)
+	i.mapsMu.Unlock()
 }
 
 // CopyMapping implements memmap.Mappable.CopyMapping.
 func (i *inode) CopyMapping(ctx context.Context, ms memmap.MappingSpace, srcAR, dstAR hostarch.AddrRange, offset uint64, writable bool) error {
+	i.AddMapping(ctx, ms, dstAR, offset, writable)
 	return nil
 }
 
@@ -175,6 +182,9 @@ func (i *inode) Translate(ctx context.Context, required, optional memmap.Mappabl
 
 // InvalidateUnsavable implements memmap.Mappable.InvalidateUnsavable.
 func (i *inode) InvalidateUnsavable(ctx context.Context) error {
+	i.mapsMu.Lock()
+	i.mappings.InvalidateAll(memmap.InvalidateOpts{})
+	i.mapsMu.Unlock()
 	return nil
 }
 

--- a/pkg/sentry/fsimpl/gofer/save_restore.go
+++ b/pkg/sentry/fsimpl/gofer/save_restore.go
@@ -29,15 +29,6 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 )
 
-type saveRestoreContextID int
-
-const (
-	// CtxRestoreServerFDMap is a Context.Value key for a map[string]int
-	// mapping filesystem unique IDs (cf. InternalFilesystemOptions.UniqueID)
-	// to host FDs.
-	CtxRestoreServerFDMap saveRestoreContextID = iota
-)
-
 // +stateify savable
 type savedDentryRW struct {
 	read  bool
@@ -181,7 +172,7 @@ func (d *dentry) loadParent(parent *dentry) {
 // CompleteRestore implements
 // vfs.FilesystemImplSaveRestoreExtension.CompleteRestore.
 func (fs *filesystem) CompleteRestore(ctx context.Context, opts vfs.CompleteRestoreOptions) error {
-	fdmapv := ctx.Value(CtxRestoreServerFDMap)
+	fdmapv := ctx.Value(vfs.CtxRestoreFilesystemFDMap)
 	if fdmapv == nil {
 		return fmt.Errorf("no server FD map available")
 	}

--- a/pkg/sentry/vfs/context.go
+++ b/pkg/sentry/vfs/context.go
@@ -27,6 +27,11 @@ const (
 
 	// CtxRoot is a Context.Value key for a VFS root.
 	CtxRoot
+
+	// CtxRestoreFilesystemFDMap is a Context.Value key for a map[string]int
+	// mapping filesystem unique IDs (cf. gofer.InternalFilesystemOptions.UniqueID)
+	// to host FDs.
+	CtxRestoreFilesystemFDMap
 )
 
 // MountNamespaceFromContext returns the MountNamespace used by ctx. If ctx is

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -1087,7 +1087,7 @@ func (c *containerMounter) configureRestore(ctx context.Context) (context.Contex
 			fdmap[submount.mount.Destination] = submount.goferFD.Release()
 		}
 	}
-	return context.WithValue(ctx, gofer.CtxRestoreServerFDMap, fdmap), nil
+	return context.WithValue(ctx, vfs.CtxRestoreFilesystemFDMap, fdmap), nil
 }
 
 func createDeviceFiles(ctx context.Context, creds *auth.Credentials, info *containerInfo, vfsObj *vfs.VirtualFilesystem, root vfs.VirtualDentry) error {


### PR DESCRIPTION
This PR adds the checkpoint/restore support to EROFS. A test for checkpoint/restore will be included in the rootfs support PR (https://github.com/google/gvisor/pull/9486).

cc @ayushr2 