### PR TITLE
Add subcommand to list nvproxy supported driver versions

### DIFF
--- a/runsc/cli/BUILD
+++ b/runsc/cli/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sentry/platform",
         "//pkg/sentry/syscalls/linux",
         "//runsc/cmd",
+        "//runsc/cmd/nvproxy",
         "//runsc/cmd/trace",
         "//runsc/cmd/util",
         "//runsc/config",

--- a/runsc/cli/main.go
+++ b/runsc/cli/main.go
@@ -34,6 +34,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/platform"
 	"gvisor.dev/gvisor/pkg/sentry/syscalls/linux"
 	"gvisor.dev/gvisor/runsc/cmd"
+	"gvisor.dev/gvisor/runsc/cmd/nvproxy"
 	"gvisor.dev/gvisor/runsc/cmd/trace"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
@@ -267,6 +268,7 @@ func forEachCmd(cb func(cmd subcommands.Command, group string)) {
 	cb(new(cmd.Install), helperGroup)
 	cb(new(cmd.Mitigate), helperGroup)
 	cb(new(cmd.Uninstall), helperGroup)
+	cb(new(nvproxy.Nvproxy), helperGroup)
 	cb(new(trace.Trace), helperGroup)
 
 	const debugGroup = "debug"

--- a/runsc/cmd/nvproxy/BUILD
+++ b/runsc/cmd/nvproxy/BUILD
@@ -1,0 +1,22 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "nvproxy",
+    srcs = [
+        "list_supported_drivers.go",
+        "nvproxy.go",
+    ],
+    visibility = [
+        "//runsc:__subpackages__",
+    ],
+    deps = [
+        "//pkg/sentry/devices/nvproxy",
+        "//runsc/flag",
+        "@com_github_google_subcommands//:go_default_library",
+    ],
+)

--- a/runsc/cmd/nvproxy/list_supported_drivers.go
+++ b/runsc/cmd/nvproxy/list_supported_drivers.go
@@ -1,0 +1,61 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nvproxy provides subcommands for the nvproxy command.
+package nvproxy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/subcommands"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/runsc/flag"
+)
+
+// listSupportedDrivers implements subcommands.Command for the "nvproxy list-supported-drivers" command.
+type listSupportedDrivers struct{}
+
+// Name implements subcommands.Command.
+func (*listSupportedDrivers) Name() string {
+	return "list-supported-drivers"
+}
+
+// Synopsis implements subcommands.Command.
+func (*listSupportedDrivers) Synopsis() string {
+	return "list all nvidia driver versions supported by nvproxy"
+}
+
+// Usage implements subcommands.Command.
+func (*listSupportedDrivers) Usage() string {
+	return `list-supported-drivers - list all nvidia driver versions supported by nvproxy
+`
+}
+
+// SetFlags implements subcommands.Command.
+func (*listSupportedDrivers) SetFlags(*flag.FlagSet) {}
+
+// Execute implements subcommands.Command.
+func (*listSupportedDrivers) Execute(ctx context.Context, f *flag.FlagSet, args ...any) subcommands.ExitStatus {
+	if f.NArg() != 0 {
+		f.Usage()
+		return subcommands.ExitUsageError
+	}
+
+	for version, _ := range nvproxy.GetSupportedDriversAndChecksums() {
+		fmt.Println(version)
+	}
+
+	return subcommands.ExitSuccess
+}

--- a/runsc/cmd/nvproxy/nvproxy.go
+++ b/runsc/cmd/nvproxy/nvproxy.go
@@ -1,0 +1,62 @@
+// Copyright 2023 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package nvproxy provides subcommands for the nvproxy command.
+package nvproxy
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/google/subcommands"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/runsc/flag"
+)
+
+type Nvproxy struct{}
+
+func (*Nvproxy) Name() string {
+	return "nvproxy"
+}
+
+func (*Nvproxy) Synopsis() string {
+	return "shows information about nvproxy support"
+}
+
+func (*Nvproxy) Usage() string {
+	buf := bytes.Buffer{}
+	buf.WriteString("Usage: nvproxy <flags> <subcommand> <subcommand args>\n\n")
+
+	cdr := createCommander(&flag.FlagSet{})
+	cdr.VisitGroups(func(grp *subcommands.CommandGroup) {
+		cdr.ExplainGroup(&buf, grp)
+	})
+
+	return buf.String()
+}
+
+func (*Nvproxy) SetFlags(*flag.FlagSet) {}
+
+func (*Nvproxy) Execute(ctx context.Context, f *flag.FlagSet, args ...any) subcommands.ExitStatus {
+	nvproxy.Init()
+	return createCommander(f).Execute(ctx, args...)
+}
+
+func createCommander(f *flag.FlagSet) *subcommands.Commander {
+	cdr := subcommands.NewCommander(f, "nvproxy")
+	cdr.Register(cdr.HelpCommand(), "")
+	cdr.Register(cdr.FlagsCommand(), "")
+	cdr.Register(new(listSupportedDrivers), "")
+	return cdr
+}


### PR DESCRIPTION
Since the driver versions are hard-coded, determining the supported version list requires code inspection, which is difficult to automate. Add a sub-command (and category) to print the list of nvidia driver versions supported by nvproxy for a given build of runsc.