### PR TITLE
Fix a few typos

### DIFF
--- a/pkg/abi/linux/capability.go
+++ b/pkg/abi/linux/capability.go
@@ -68,7 +68,7 @@ const (
 	CAP_CHECKPOINT_RESTORE = Capability(40)
 
 	// CAP_LAST_CAP is the highest-numbered capability.
-	// Seach for "CAP_LAST_CAP" to find other places that need to change.
+	// Search for "CAP_LAST_CAP" to find other places that need to change.
 	CAP_LAST_CAP = CAP_CHECKPOINT_RESTORE
 )
 

--- a/pkg/abi/linux/fuse.go
+++ b/pkg/abi/linux/fuse.go
@@ -139,7 +139,7 @@ type FUSEHeaderOut struct {
 var SizeOfFUSEHeaderOut = uint32((*FUSEHeaderOut)(nil).SizeBytes())
 
 // FUSE_INIT flags, consistent with the ones in include/uapi/linux/fuse.h.
-// Our taget version is 7.23 but we have few implemented in advance.
+// Our target version is 7.23 but we have few implemented in advance.
 const (
 	FUSE_ASYNC_READ       = 1 << 0
 	FUSE_POSIX_LOCKS      = 1 << 1
@@ -299,7 +299,7 @@ type FUSEGetAttrIn struct {
 	Fh uint64
 }
 
-// FUSEAttr is the struct used in the reponse FUSEGetAttrOut.
+// FUSEAttr is the struct used in the response FUSEGetAttrOut.
 //
 // +marshal
 type FUSEAttr struct {

--- a/pkg/abi/linux/mqueue.go
+++ b/pkg/abi/linux/mqueue.go
@@ -43,7 +43,7 @@ const (
 	NOTIFY_COOKIE_LEN = 32
 )
 
-// MqAttr is equivelant to struct mq_attr. Source: include/uapi/linux/mqueue.h
+// MqAttr is equivalent to struct mq_attr. Source: include/uapi/linux/mqueue.h
 //
 // +marshal
 type MqAttr struct {

--- a/pkg/abi/linux/msgqueue.go
+++ b/pkg/abi/linux/msgqueue.go
@@ -50,7 +50,7 @@ const (
 	MSGSEG = 0xffff
 )
 
-// MsqidDS is equivelant to struct msqid64_ds. Source:
+// MsqidDS is equivalent to struct msqid64_ds. Source:
 // include/uapi/asm-generic/shmbuf.h
 //
 // +marshal
@@ -68,7 +68,7 @@ type MsqidDS struct {
 	unused5   uint64
 }
 
-// MsgBuf is equivelant to struct msgbuf. Source: include/uapi/linux/msg.h
+// MsgBuf is equivalent to struct msgbuf. Source: include/uapi/linux/msg.h
 //
 // +marshal dynamic
 type MsgBuf struct {
@@ -93,7 +93,7 @@ func (b *MsgBuf) UnmarshalBytes(src []byte) []byte {
 	return b.Text.UnmarshalBytes(src)
 }
 
-// MsgInfo is equivelant to struct msginfo. Source: include/uapi/linux/msg.h
+// MsgInfo is equivalent to struct msginfo. Source: include/uapi/linux/msg.h
 //
 // +marshal
 type MsgInfo struct {

--- a/pkg/abi/linux/netfilter_ipv6.go
+++ b/pkg/abi/linux/netfilter_ipv6.go
@@ -236,7 +236,7 @@ const (
 	IP6T_F_PROTO = 0x01
 	// Whether to match the TOS field.
 	IP6T_F_TOS = 0x02
-	// Indicates that the jump target is an aboslute GOTO, not an offset.
+	// Indicates that the jump target is an absolute GOTO, not an offset.
 	IP6T_F_GOTO = 0x04
 	// Enables all flags.
 	IP6T_F_MASK = 0x07

--- a/pkg/abi/linux/sem.go
+++ b/pkg/abi/linux/sem.go
@@ -32,7 +32,7 @@ const (
 	SEM_STAT_ANY = 20
 )
 
-// Information about system-wide sempahore limits and parameters.
+// Information about system-wide semaphore limits and parameters.
 //
 // Source: include/uapi/linux/sem.h
 const (

--- a/pkg/abi/linux/socket.go
+++ b/pkg/abi/linux/socket.go
@@ -349,7 +349,7 @@ const SizeOfLinger = 8
 // TCPInfo is a collection of TCP statistics.
 //
 // From uapi/linux/tcp.h. Newer versions of Linux continue to add new fields to
-// the end of this struct or within existing unusued space, so its size grows
+// the end of this struct or within existing unused space, so its size grows
 // over time. The current iteration is based on linux v4.17. New versions are
 // always backwards compatible.
 //

--- a/pkg/buffer/buffer.go
+++ b/pkg/buffer/buffer.go
@@ -572,7 +572,7 @@ func (b *Buffer) readByte() (byte, error) {
 	return bt, nil
 }
 
-// AsBufferReader returns the Buffer as a BufferReader capabable of io methods.
+// AsBufferReader returns the Buffer as a BufferReader capable of io methods.
 // The new BufferReader takes ownership of b.
 func (b *Buffer) AsBufferReader() BufferReader {
 	return BufferReader{b}

--- a/pkg/buffer/chunk.go
+++ b/pkg/buffer/chunk.go
@@ -27,7 +27,7 @@ const (
 	// number and passing the result to MostSignificantOne64.
 	baseChunkSizeLog2 = 6
 
-	// This is the size of the buffers in the first pool. Each subsquent pool
+	// This is the size of the buffers in the first pool. Each subsequent pool
 	// creates payloads 2^(pool index) times larger than the first pool's
 	// payloads.
 	baseChunkSize = 1 << baseChunkSizeLog2 // 64

--- a/pkg/compressio/compressio_test.go
+++ b/pkg/compressio/compressio_test.go
@@ -125,7 +125,7 @@ func doTest(t harness, opts testOpts) {
 			return
 		}
 		if _, err := io.Copy(&decompressed, r); (err != nil) != opts.CorruptData {
-			t.Errorf("%s: decompress got err %v unexpectly", opts.Name, err)
+			t.Errorf("%s: decompress got err %v unexpectedly", opts.Name, err)
 			return
 		}
 	}

--- a/pkg/compressio/nocompressio.go
+++ b/pkg/compressio/nocompressio.go
@@ -124,7 +124,7 @@ func (r *SimpleReader) Read(p []byte) (int, error) {
 	}
 
 	toRead := uint32(len(p))
-	// can't read more than whats left
+	// can't read more than what's left
 	if toRead > r.chunkSize-r.done {
 		toRead = r.chunkSize - r.done
 	}

--- a/pkg/cpuid/cpuid_amd64.go
+++ b/pkg/cpuid/cpuid_amd64.go
@@ -309,7 +309,7 @@ func (fs FeatureSet) HasFeature(feature Feature) bool {
 // a minimal /proc/cpuinfo, it is missing some fields like "microcode" that are
 // not always printed in Linux. The bogomips field is simply made up.
 func (fs FeatureSet) WriteCPUInfoTo(cpu uint, w io.Writer) {
-	// Avoid many redunant calls here, since this can occasionally appear
+	// Avoid many redundant calls here, since this can occasionally appear
 	// in the hot path. Read all basic information up front, see above.
 	ax, _, _, _ := fs.query(featureInfo)
 	ef, em, _, f, m, _ := signatureSplit(ax)

--- a/pkg/errors/linuxerr/linuxerr.go
+++ b/pkg/errors/linuxerr/linuxerr.go
@@ -252,7 +252,7 @@ var errorSlice = []*errors.Error{
 	errno.ENODATA:         ENODATA,
 	errno.ETIME:           ETIME,
 	errno.ENOSR:           ENOSR,
-	errno.ENOSR + 1:       errNotValidError, // No valid errno betweeen ENOSR and ENOPKG.
+	errno.ENOSR + 1:       errNotValidError, // No valid errno between ENOSR and ENOPKG.
 	errno.ENOPKG:          ENOPKG,
 	errno.EREMOTE:         EREMOTE,
 	errno.ENOLINK:         ENOLINK,

--- a/pkg/fd/fd.go
+++ b/pkg/fd/fd.go
@@ -138,7 +138,7 @@ func (r *ReadWriter) String() string {
 //
 // It is similar to os.File, with a few important distinctions:
 //
-// FD provies a Release() method which relinquishes ownership. Like os.File,
+// FD provides a Release() method which relinquishes ownership. Like os.File,
 // FD adds a finalizer to close the backing FD. However, the finalizer cannot
 // be removed from os.File, forever pinning the lifetime of an FD to its
 // os.File.

--- a/pkg/lisafs/client.go
+++ b/pkg/lisafs/client.go
@@ -120,9 +120,9 @@ func (c *Client) StartChannels() error {
 	c.availableChannels = make([]*channel, 0, maxChans)
 	c.channelsMu.Unlock()
 
-	// Create channels parallely so that channels can be used to create more
+	// Create channels parallelly so that channels can be used to create more
 	// channels and costly initialization like flipcall.Endpoint.Connect can
-	// proceed parallely.
+	// proceed parallelly.
 	var channelsWg sync.WaitGroup
 	for i := 0; i < maxChans; i++ {
 		channelsWg.Add(1)

--- a/pkg/lisafs/fd.go
+++ b/pkg/lisafs/fd.go
@@ -574,7 +574,7 @@ type OpenFDImpl interface {
 	// On the server, Stat has a read concurrency guarantee.
 	Stat() (linux.Statx, error)
 
-	// Sync is simialr to fsync(2).
+	// Sync is similar to fsync(2).
 	//
 	// On the server, Sync has a read concurrency guarantee.
 	Sync() error

--- a/pkg/lisafs/message.go
+++ b/pkg/lisafs/message.go
@@ -48,7 +48,7 @@ import (
 // because a malicious encoder could have manipulated payload bytes to make the
 // unchecked unmarshal variants panic due to the lack of bound checking.
 // Marshalling code does not need additional bound checking because the caller
-// itself intializes the struct being marshalled, so it is trusted.
+// itself initializes the struct being marshalled, so it is trusted.
 //
 // String() implementations must ensure that the message struct doesn't escape.
 // For instance, directly passing the struct to fmt.Sprintf() escapes it

--- a/pkg/lisafs/node.go
+++ b/pkg/lisafs/node.go
@@ -92,7 +92,7 @@ type Node struct {
 	// upto numStaticChildren children using hardcoded pointers. If more children
 	// are inserted then move to a map. Use dynamicChildren iff it is non-nil.
 
-	// The folowing fields are protected by childrenMu.
+	// The following fields are protected by childrenMu.
 	childrenMu     sync.Mutex
 	staticChildren [numStaticChildren]struct {
 		name string

--- a/pkg/lisafs/node_test.go
+++ b/pkg/lisafs/node_test.go
@@ -78,7 +78,7 @@ func TestDelete(t *testing.T) {
 			for i := 0; i < numChildren; i++ {
 				name := fmt.Sprintf("%d", i)
 				if got, want := root.removeChildLocked(name), truth[name]; got != want {
-					t.Errorf("root deleted incorrect ndoe: want %p, got %p", want, got)
+					t.Errorf("root deleted incorrect node: want %p, got %p", want, got)
 				}
 			}
 		})

--- a/pkg/lisafs/testsuite/testsuite.go
+++ b/pkg/lisafs/testsuite/testsuite.go
@@ -540,7 +540,7 @@ func testWalk(ctx context.Context, t *testing.T, tester Tester, root lisafs.Clie
 		closeFD(ctx, t, root.Client().NewFD(inode.ControlFD))
 	}
 
-	// Test WalkStat which additonally returns Statx for root because the first
+	// Test WalkStat which additionally returns Statx for root because the first
 	// path component is "".
 	dirNames = append([]string{""}, dirNames...)
 	gotStats := walkStat(ctx, t, root, dirNames)

--- a/pkg/p9/client.go
+++ b/pkg/p9/client.go
@@ -406,7 +406,7 @@ func (c *Client) handleOne() {
 	}
 }
 
-// waitAndRecv co-ordinates with other receivers to handle responses.
+// waitAndRecv coordinates with other receivers to handle responses.
 func (c *Client) waitAndRecv(done chan error) error {
 	for {
 		select {
@@ -474,7 +474,7 @@ func (c *Client) sendRecvLegacy(t message, r message) (bool, error) {
 		return false, err
 	}
 
-	// Co-ordinate with other receivers.
+	// Coordinate with other receivers.
 	if err := c.waitAndRecv(resp.done); err != nil {
 		return false, err
 	}

--- a/pkg/p9/p9test/client_test.go
+++ b/pkg/p9/p9test/client_test.go
@@ -408,7 +408,7 @@ type deleter func(parent p9.File, name string) error
 // unlinkAt is a deleter.
 func unlinkAt(parent p9.File, name string) error {
 	// Call unlink. Note that a filesystem may normally impose additional
-	// constaints on unlinkat success, such as ensuring that a directory is
+	// constraints on unlinkat success, such as ensuring that a directory is
 	// empty, requiring AT_REMOVEDIR in flags to remove a directory, etc.
 	// None of that is required internally (entire trees can be marked
 	// deleted when this operation succeeds), so the mock will succeed.

--- a/pkg/p9/path_tree.go
+++ b/pkg/p9/path_tree.go
@@ -33,7 +33,7 @@ import (
 // Two different pathNodes may only be locked if Server.renameMu is held for
 // write, in which case they can be acquired in any order.
 type pathNode struct {
-	// opMu synchronizes high-level, sematic operations, such as the
+	// opMu synchronizes high-level, semantic operations, such as the
 	// simultaneous creation and deletion of a file.
 	opMu sync.RWMutex
 

--- a/pkg/p9/server.go
+++ b/pkg/p9/server.go
@@ -136,7 +136,7 @@ type fidRef struct {
 	// file is the associated File.
 	file File
 
-	// refs is an active refence count.
+	// refs is an active reference count.
 	//
 	// The node above will be closed only when refs reaches zero.
 	refs atomicbitops.Int64

--- a/pkg/prometheus/prometheus.go
+++ b/pkg/prometheus/prometheus.go
@@ -125,7 +125,7 @@ func (m *Metric) writeHeaderTo(w io.Writer, options SnapshotExportOptions) error
 // In Prometheus, all numbers are float64s.
 // However, for the purpose of usage of this library, we support expressing numbers as integers,
 // which makes things like counters much easier and more precise.
-// At data export time (i.e. when written out in Prometheus data format), it is coallesced into
+// At data export time (i.e. when written out in Prometheus data format), it is coalesced into
 // a float.
 type Number struct {
 	// Float is the float value of this number.

--- a/pkg/ring0/defs_arm64.go
+++ b/pkg/ring0/defs_arm64.go
@@ -62,7 +62,7 @@ type CPUArchState struct {
 	// ttbr0Kvm is the value of ttbr0_el1 for sentry.
 	ttbr0Kvm uintptr
 
-	// ttbr0App is the value of ttbr0_el1 for applicaton.
+	// ttbr0App is the value of ttbr0_el1 for application.
 	ttbr0App uintptr
 
 	// exception vector.

--- a/pkg/ring0/entry_arm64.s
+++ b/pkg/ring0/entry_arm64.s
@@ -533,7 +533,7 @@ TEXT ·kernelExitToEl0(SB),NOSPLIT,$0
 	MOVD PTRACE_PSTATE(RSV_REG_APP), R1
 	WORD $0xd5184001  //MSR R1, SPSR_EL1
 
-	// need use kernel space address to excute below code, since
+	// need use kernel space address to execute below code, since
 	// after SWITCH_TO_APP_PAGETABLE the ASID is changed to app's
 	// ASID.
 	WORD $0x10000061		// ADR R1, do_exit_to_el0

--- a/pkg/ring0/pagetables/walker_amd64.go
+++ b/pkg/ring0/pagetables/walker_amd64.go
@@ -123,7 +123,7 @@ func (w *Walker) iterateRangeCanonical(start, end uintptr) bool {
 					}
 
 					// This level has 2-MB huge pages. If this
-					// region is contined in a single PMD entry?
+					// region is continued in a single PMD entry?
 					// As above, we can skip allocating a new page.
 					if start&(pmdSize-1) == 0 && end-start >= pmdSize {
 						pmdEntry.SetSuper()

--- a/pkg/ring0/pagetables/walker_arm64.go
+++ b/pkg/ring0/pagetables/walker_arm64.go
@@ -129,7 +129,7 @@ func (w *Walker) iterateRangeCanonical(start, end uintptr) bool {
 					}
 
 					// This level has 2-MB huge pages. If this
-					// region is contined in a single PMD entry?
+					// region is continued in a single PMD entry?
 					// As above, we can skip allocating a new page.
 					if start&(pmdSize-1) == 0 && end-start >= pmdSize {
 						pmdEntry.SetSect()

--- a/pkg/ring0/x86.go
+++ b/pkg/ring0/x86.go
@@ -76,7 +76,7 @@ const (
 	//
 	// Here, _RFLAGS_IOPL0 is used only to determine whether the task is
 	// running in the kernel or userspace mode. In the user mode, the CPL is
-	// always 3 and it doesn't matter what IOPL is set if it is bellow CPL.
+	// always 3 and it doesn't matter what IOPL is set if it is below CPL.
 	//
 	// We need to have one bit which will be always different in user and
 	// kernel modes. And we have to remember that even though we have
@@ -100,7 +100,7 @@ const (
 	UserFlagsClear = _RFLAGS_NT | _RFLAGS_IOPL1
 )
 
-// IsKernelFlags returns true if rflags coresponds to the kernel mode.
+// IsKernelFlags returns true if rflags corresponds to the kernel mode.
 //
 //go:nosplit
 func IsKernelFlags(rflags uint64) bool {

--- a/pkg/sentry/arch/arch.go
+++ b/pkg/sentry/arch/arch.go
@@ -91,7 +91,7 @@ type contextInterface interface {
 	// SyscallNo returns the syscall number.
 	SyscallNo() uintptr
 
-	// SyscallSaveOrig save orignal register value.
+	// SyscallSaveOrig save original register value.
 	SyscallSaveOrig()
 
 	// SyscallArgs returns the syscall arguments in an array.

--- a/pkg/sentry/fdimport/fdimport.go
+++ b/pkg/sentry/fdimport/fdimport.go
@@ -72,7 +72,7 @@ func Import(ctx context.Context, fdTable *kernel.FDTable, console bool, uid auth
 					return nil, err
 				}
 				defer appFile.DecRef(ctx)
-				hostFD.Release() // FD is transfered to host FD.
+				hostFD.Release() // FD is transferred to host FD.
 
 				// Remember this in the TTY file, as we will use it for the other stdio
 				// FDs.
@@ -90,7 +90,7 @@ func Import(ctx context.Context, fdTable *kernel.FDTable, console bool, uid auth
 				return nil, err
 			}
 			defer appFile.DecRef(ctx)
-			hostFD.Release() // FD is transfered to host FD.
+			hostFD.Release() // FD is transferred to host FD.
 		}
 
 		if err := fdTable.NewFDAt(ctx, int32(appFD), appFile, fdFlags[hostFD]); err != nil {

--- a/pkg/sentry/fsimpl/cgroupfs/bitmap.go
+++ b/pkg/sentry/fsimpl/cgroupfs/bitmap.go
@@ -22,8 +22,8 @@ import (
 	"gvisor.dev/gvisor/pkg/bitmap"
 )
 
-// formatBitmap produces a string representation of b, which lists the indicies
-// of set bits in the bitmap. Indicies are separated by commas and ranges of
+// formatBitmap produces a string representation of b, which lists the indices
+// of set bits in the bitmap. Indices are separated by commas and ranges of
 // set bits are abbreviated. Example outputs: "0,2,4", "0,3-7,10", "0-10".
 //
 // Inverse of parseBitmap.

--- a/pkg/sentry/fsimpl/cgroupfs/memory.go
+++ b/pkg/sentry/fsimpl/cgroupfs/memory.go
@@ -47,7 +47,7 @@ var _ controller = (*memoryController)(nil)
 func newMemoryController(fs *filesystem, defaults map[string]int64) *memoryController {
 	c := &memoryController{
 		// Linux sets these limits to (PAGE_COUNTER_MAX * PAGE_SIZE) by default,
-		// which is ~ 2**63 on a 64-bit system. So essentially, inifinity. The
+		// which is ~ 2**63 on a 64-bit system. So essentially, infinity. The
 		// exact value isn't very important.
 
 		limitBytes:     atomicbitops.FromInt64(math.MaxInt64),

--- a/pkg/sentry/fsimpl/cgroupfs/pids.go
+++ b/pkg/sentry/fsimpl/cgroupfs/pids.go
@@ -55,7 +55,7 @@ const pidLimitUnlimited = pidMaxLimit + 1
 type pidsController struct {
 	controllerCommon
 
-	// isRoot indiciates if this is the root cgroup in its hierarchy. Immutable
+	// isRoot indicates if this is the root cgroup in its hierarchy. Immutable
 	// since cgroupfs doesn't allow cross directory renames.
 	isRoot bool
 
@@ -123,7 +123,7 @@ func (c *pidsController) AddControlFiles(ctx context.Context, creds *auth.Creden
 // Enter implements controller.Enter.
 //
 // Enter attempts to commit a charge from the pending pool. If at least one
-// charge is pending for t, one pending charge is converted to a commited
+// charge is pending for t, one pending charge is converted to a committed
 // charge, and the net change in total charges is zero. If no charge is pending,
 // a new charge is added directly to the committed pool.
 func (c *pidsController) Enter(t *kernel.Task) {

--- a/pkg/sentry/fsimpl/fuse/inode.go
+++ b/pkg/sentry/fsimpl/fuse/inode.go
@@ -162,7 +162,7 @@ func (i *inode) touchCMtime() {
 	i.ctime.Store(now)
 }
 
-// touchAtime updates the atime attribut to be the current time.
+// touchAtime updates the atime attribute to be the current time.
 //
 // +checklocks:i.attrMu
 func (i *inode) touchAtime() {
@@ -197,7 +197,7 @@ func (i *inode) CheckPermissions(ctx context.Context, creds *auth.Credentials, a
 	// default FUSE only allows the mount owner to interact with the
 	// filesystem. This explicitly excludes setuid/setgid processes.
 	//
-	// This behaviour can be overriden with the 'allow_other' mount option.
+	// This behaviour can be overridden with the 'allow_other' mount option.
 	//
 	// See fs/fuse/dir.c:fuse_allow_current_process() in Linux.
 	if !i.fs.opts.allowOther {

--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -272,7 +272,7 @@ func (fs *filesystem) getRemoteChildLocked(ctx context.Context, parent *dentry, 
 	defer parent.childrenMu.Unlock()
 
 	if checkForRace {
-		// See if we raced with anoter getRemoteChild call that added
+		// See if we raced with another getRemoteChild call that added
 		// to the cache.
 		if cachedChild, ok := parent.children[name]; ok && cachedChild != nil {
 			// We raced. Destroy our child and return the cached
@@ -1139,7 +1139,7 @@ func (d *dentry) open(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.Open
 	}
 
 	if trunc {
-		// If no errors occured so far then update file size in memory. This
+		// If no errors occurred so far then update file size in memory. This
 		// step is required even if !d.cachedMetadataAuthoritative() because
 		// d.mappings has to be updated.
 		// d.metadataMu has already been acquired if trunc == true.

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package gofer provides a filesystem implementation that is backed by a 9p
-// server, interchangably referred to as "gofers" throughout this package.
+// server, interchangeably referred to as "gofers" throughout this package.
 //
 // Lock order:
 //
@@ -147,7 +147,7 @@ type dentryCache struct {
 	dentries dentryList
 	// dentriesLen is the number of dentries in dentries.
 	dentriesLen uint64
-	// maxCachedDentries is the maximum number of cachable dentries.
+	// maxCachedDentries is the maximum number of cacheable dentries.
 	maxCachedDentries uint64
 }
 

--- a/pkg/sentry/fsimpl/iouringfs/buffer.go
+++ b/pkg/sentry/fsimpl/iouringfs/buffer.go
@@ -124,7 +124,7 @@ func (b *sharedBuffer) view(n int) ([]byte, error) {
 // call. On return, writeback indicates if the previous view may be reused, or
 // needs to be refetched with a new call to view.
 //
-// Precondition: Must follow a call to view. n must match the value pased to
+// Precondition: Must follow a call to view. n must match the value passed to
 // view.
 //
 // Postcondition: Previous view is invalidated whether writeback is successful

--- a/pkg/sentry/fsimpl/iouringfs/iouringfs.go
+++ b/pkg/sentry/fsimpl/iouringfs/iouringfs.go
@@ -59,7 +59,7 @@ type FileDescription struct {
 	// processed. This is either 0 for not running, or 1 for running.
 	running atomicbitops.Uint32
 	// runC is used to wake up serialized task goroutines waiting for any
-	// concurrent processors of the submisison queue.
+	// concurrent processors of the submission queue.
 	runC chan struct{} `state:"nosave"`
 
 	ioRings linux.IORings
@@ -299,7 +299,7 @@ func (fd *FileDescription) ProcessSubmissions(t *kernel.Task, toSubmit uint32, m
 	// Task B (entering, sleeping)                        | Task A (active, releasing)
 	// ---------------------------------------------------+-------------------------
 	//                                                    | fd.running.Store(0)
-	// for !fd.running.CompareAndSwap(0, 1) { // Succeess |
+	// for !fd.running.CompareAndSwap(0, 1) { // Success |
 	//                                                    | nonblockingSend(runC) // Missed!
 	//     t.Block(fd.runC) // Will block forever         |
 	// }
@@ -382,7 +382,7 @@ func (fd *FileDescription) ProcessSubmissions(t *kernel.Task, toSubmit uint32, m
 		overflowPtr := atomicUint32AtOffset(view, int(cqOff.Overflow))
 
 		// Load the pointers once, so we work with a stable value. Particularly,
-		// usersapce can update the SQ tail at any time.
+		// userspace can update the SQ tail at any time.
 		sqHead := sqHeadPtr.Load()
 		sqTail := sqTailPtr.Load()
 

--- a/pkg/sentry/fsimpl/kernfs/fd_impl_util.go
+++ b/pkg/sentry/fsimpl/kernfs/fd_impl_util.go
@@ -117,12 +117,12 @@ func (fd *GenericDirectoryFD) ConfigureMMap(ctx context.Context, opts *memmap.MM
 	return fd.FileDescriptionDefaultImpl.ConfigureMMap(ctx, opts)
 }
 
-// Read implmenets vfs.FileDescriptionImpl.Read.
+// Read implements vfs.FileDescriptionImpl.Read.
 func (fd *GenericDirectoryFD) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	return fd.DirectoryFileDescriptionDefaultImpl.Read(ctx, dst, opts)
 }
 
-// PRead implmenets vfs.FileDescriptionImpl.PRead.
+// PRead implements vfs.FileDescriptionImpl.PRead.
 func (fd *GenericDirectoryFD) PRead(ctx context.Context, dst usermem.IOSequence, offset int64, opts vfs.ReadOptions) (int64, error) {
 	return fd.DirectoryFileDescriptionDefaultImpl.PRead(ctx, dst, offset, opts)
 }

--- a/pkg/sentry/fsimpl/kernfs/inode_impl_util.go
+++ b/pkg/sentry/fsimpl/kernfs/inode_impl_util.go
@@ -516,7 +516,7 @@ func (o *OrderedChildren) Lookup(ctx context.Context, name string) (Inode, error
 	return s.inode, nil
 }
 
-// ForEachChild calls fn on all childrens tracked by this ordered children.
+// ForEachChild calls fn on all children tracked by this ordered children.
 func (o *OrderedChildren) ForEachChild(fn func(string, Inode)) {
 	o.mu.RLock()
 	defer o.mu.RUnlock()

--- a/pkg/sentry/fsimpl/kernfs/kernfs.go
+++ b/pkg/sentry/fsimpl/kernfs/kernfs.go
@@ -30,7 +30,7 @@
 // Reference Model:
 //
 // Kernfs dentries represents named pointers to inodes. Kernfs is solely
-// reponsible for maintaining and modifying its dentry tree; inode
+// responsible for maintaining and modifying its dentry tree; inode
 // implementations can not access the tree. Dentries and inodes have
 // independent lifetimes and reference counts. A child dentry unconditionally
 // holds a reference on its parent directory's dentry. A dentry also holds a

--- a/pkg/sentry/fsimpl/mqfs/mqfs.go
+++ b/pkg/sentry/fsimpl/mqfs/mqfs.go
@@ -51,7 +51,7 @@ func (ft FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.VirtualF
 	// a POSIX message registry with a root dentry, filesystem, and a
 	// disconnected mount. We want the fs to be consistent for all processes in
 	// the same ipc namespace, so instead of creating a new fs and root dentry,
-	// we retreive them using IPCNamespace.PosixQueues and use them.
+	// we retrieve them using IPCNamespace.PosixQueues and use them.
 
 	i := ipcNamespaceFromContext(ctx)
 	if i == nil {

--- a/pkg/sentry/fsimpl/mqfs/registry.go
+++ b/pkg/sentry/fsimpl/mqfs/registry.go
@@ -38,7 +38,7 @@ const (
 // +stateify savable
 type RegistryImpl struct {
 	// root is the root dentry of the mq filesystem. Its main usage is to
-	// retreive the root inode, which we use to add, remove, and lookup message
+	// retrieve the root inode, which we use to add, remove, and lookup message
 	// queues.
 	//
 	// We hold a reference on root and release when the registry is destroyed.

--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -573,7 +573,7 @@ type dentry struct {
 
 	locks vfs.FileLocks
 
-	// watches is the set of inotify watches on the file repesented by this dentry.
+	// watches is the set of inotify watches on the file represented by this dentry.
 	//
 	// Note that hard links to the same file will not share the same set of
 	// watches, due to the fact that we do not have inode structures in this

--- a/pkg/sentry/fsimpl/proc/task_net.go
+++ b/pkg/sentry/fsimpl/proc/task_net.go
@@ -435,7 +435,7 @@ func commonGenerateTCP(ctx context.Context, buf *bytes.Buffer, k *kernel.Kernel,
 			fmt.Fprintf(buf, "%8d ", stat.Ino)
 		}
 
-		// Field: refcount. Don't count the ref we obtain while deferencing
+		// Field: refcount. Don't count the ref we obtain while dereferencing
 		// the weakref to this socket.
 		fmt.Fprintf(buf, "%d ", s.ReadRefs()-1)
 
@@ -595,7 +595,7 @@ func (d *netUDPData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 		}
 
 		// Field: ref; reference count on the socket inode. Don't count the ref
-		// we obtain while deferencing the weakref to this socket.
+		// we obtain while dereferencing the weakref to this socket.
 		fmt.Fprintf(buf, "%d ", s.ReadRefs()-1)
 
 		// Field: Socket struct address. Redacted due to the same reason as

--- a/pkg/sentry/fsimpl/testutil/kernel.go
+++ b/pkg/sentry/fsimpl/testutil/kernel.go
@@ -38,7 +38,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/time"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 
-	// Platforms are plugable.
+	// Platforms are pluggable.
 	_ "gvisor.dev/gvisor/pkg/sentry/platform/kvm"
 	_ "gvisor.dev/gvisor/pkg/sentry/platform/ptrace"
 )

--- a/pkg/sentry/fsimpl/tmpfs/filesystem.go
+++ b/pkg/sentry/fsimpl/tmpfs/filesystem.go
@@ -980,7 +980,7 @@ func (fs *filesystem) IsDescendant(vfsroot, vd vfs.VirtualDentry) bool {
 }
 
 // adjustPageAcct adjusts the accounting done against filesystem size limit in
-// case there is any discrepency between the number of pages reserved vs the
+// case there is any discrepancy between the number of pages reserved vs the
 // number of pages actually allocated.
 func (fs *filesystem) adjustPageAcct(reserved, alloced uint64) {
 	if reserved < alloced {

--- a/pkg/sentry/fsimpl/tmpfs/regular_file.go
+++ b/pkg/sentry/fsimpl/tmpfs/regular_file.go
@@ -707,7 +707,7 @@ func (rw *regularFileReadWriter) WriteFromBlocks(srcs safemem.BlockSeq) (uint64,
 		// containing EOF fails, resulting in a partial write up to the start of
 		// that page.
 		//
-		// To emulate this behaviour, artifically truncate the write to the
+		// To emulate this behaviour, artificially truncate the write to the
 		// start of the page containing the current EOF.
 		//
 		// See Linux, mm/filemap.c:generic_perform_write() and

--- a/pkg/sentry/fsimpl/tmpfs/regular_file_test.go
+++ b/pkg/sentry/fsimpl/tmpfs/regular_file_test.go
@@ -182,7 +182,7 @@ func TestPRead(t *testing.T) {
 	defer cleanup()
 
 	// Write 100 sequences of 'gVisor is awesome'.
-	data := bytes.Repeat([]byte("gVisor is awsome"), 100)
+	data := bytes.Repeat([]byte("gVisor is awesome"), 100)
 	n, err := fd.Write(ctx, usermem.BytesIOSequence(data), vfs.WriteOptions{})
 	if err != nil {
 		t.Fatalf("fd.Write failed: %v", err)
@@ -236,7 +236,7 @@ func TestTruncate(t *testing.T) {
 	defer cleanup()
 
 	// Fill the file with some data.
-	data := bytes.Repeat([]byte("gVisor is awsome"), 100)
+	data := bytes.Repeat([]byte("gVisor is awesome"), 100)
 	written, err := fd.Write(ctx, usermem.BytesIOSequence(data), vfs.WriteOptions{})
 	if err != nil {
 		t.Fatalf("fd.Write failed: %v", err)

--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -503,7 +503,7 @@ type inode struct {
 	xattrs memxattr.SimpleExtendedAttributes
 
 	// Inode metadata. Writing multiple fields atomically requires holding
-	// mu, othewise atomic operations can be used.
+	// mu, otherwise atomic operations can be used.
 	mu    inodeMutex          `state:"nosave"`
 	mode  atomicbitops.Uint32 // file type and mode
 	nlink atomicbitops.Uint32 // protected by filesystem.mu instead of inode.mu

--- a/pkg/sentry/kernel/cgroup.go
+++ b/pkg/sentry/kernel/cgroup.go
@@ -205,7 +205,7 @@ type CgroupImpl interface {
 	// The implementer should silently succeed if no matching controllers are
 	// found.
 	//
-	// The underlying implementaion will panic if passed an incompatible
+	// The underlying implementation will panic if passed an incompatible
 	// resource type for a given controller.
 	//
 	// See cgroupfs.controller.Charge.
@@ -232,7 +232,7 @@ type hierarchy struct {
 	id   uint32
 	name string
 	// These are a subset of the controllers in CgroupRegistry.controllers,
-	// grouped here by hierarchy for conveninent lookup.
+	// grouped here by hierarchy for convenient lookup.
 	controllers map[CgroupControllerType]CgroupController
 	// fs is not owned by hierarchy. The FS is responsible for unregistering the
 	// hierarchy on destruction, which removes this association.

--- a/pkg/sentry/kernel/fasync/fasync.go
+++ b/pkg/sentry/kernel/fasync/fasync.go
@@ -60,7 +60,7 @@ type FileAsync struct {
 	// The fd value is passed to the signal recipient in siginfo.si_fd.
 	fd int
 
-	// regMu protects registeration and unregistration actions on e.
+	// regMu protects registration and unregistration actions on e.
 	//
 	// regMu must be held while registration decisions are being made
 	// through the registration action itself.

--- a/pkg/sentry/kernel/ipc/ns.go
+++ b/pkg/sentry/kernel/ipc/ns.go
@@ -16,7 +16,7 @@ package ipc
 
 type contextID int
 
-// CtxIPCNamespace is the context.Value key used to retreive an IPC namespace.
+// CtxIPCNamespace is the context.Value key used to retrieve an IPC namespace.
 // We define it here because it's needed in several packages, and is not
 // possible to use otherwise without causing a circular depenedency.
 const CtxIPCNamespace contextID = iota

--- a/pkg/sentry/kernel/ipc_namespace.go
+++ b/pkg/sentry/kernel/ipc_namespace.go
@@ -44,7 +44,7 @@ type IPCNamespace struct {
 
 	// posixQueues is a POSIX message queue registry.
 	//
-	// posixQueues is somewhat equivelant to Linux's ipc_namespace.mq_mnt.
+	// posixQueues is somewhat equivalent to Linux's ipc_namespace.mq_mnt.
 	// Unlike SysV utilities, mq.Registry is not map-based, but is backed by
 	// a virtual filesystem.
 	posixQueues *mq.Registry

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1014,7 +1014,7 @@ func (k *Kernel) Start() error {
 func (k *Kernel) pauseTimeLocked(ctx context.Context) {
 	// Since all task goroutines have been stopped by precondition, the CPU clock
 	// ticker should stop on its own; wait for it to do so, waking it up from
-	// sleeping betwen ticks if necessary.
+	// sleeping between ticks if necessary.
 	k.runningTasksMu.Lock()
 	for k.cpuClockTickerRunning {
 		select {

--- a/pkg/sentry/kernel/mq/mq.go
+++ b/pkg/sentry/kernel/mq/mq.go
@@ -81,7 +81,7 @@ type Registry struct {
 // Registry to avoid dealing directly with the filesystem. RegistryImpl should
 // be implemented by mqfs and provided to Registry at initialization.
 type RegistryImpl interface {
-	// Get searchs for a queue with the given name, if it exists, the queue is
+	// Get searches for a queue with the given name, if it exists, the queue is
 	// used to create a new FD, return it and return true. If the queue  doesn't
 	// exist, return false and no error. An error is returned if creation fails.
 	Get(ctx context.Context, name string, access AccessType, block bool, flags uint32) (*vfs.FileDescription, bool, error)
@@ -292,7 +292,7 @@ type Queue struct {
 }
 
 // View is a view into a message queue. Views should only be used in file
-// descriptions, but not inodes, because we use inodes to retreive the actual
+// descriptions, but not inodes, because we use inodes to retrieve the actual
 // queue, and only FDs are responsible for providing user functionality.
 type View interface {
 	// TODO: Add Send and Receive when mq_timedsend(2) and mq_timedreceive(2)

--- a/pkg/sentry/kernel/msgqueue/msgqueue.go
+++ b/pkg/sentry/kernel/msgqueue/msgqueue.go
@@ -86,7 +86,7 @@ type Queue struct {
 	// messages is a list of sent messages.
 	messages msgList
 
-	// sendTime is the last time a msgsnd was perfomed.
+	// sendTime is the last time a msgsnd was performed.
 	sendTime ktime.Time
 
 	// receiveTime is the last time a msgrcv was performed.
@@ -424,7 +424,7 @@ func (q *Queue) pop(ctx context.Context, creds *auth.Credentials, mType int64, m
 		msg = q.msgOfTypeLessThan(-1 * mType)
 	}
 
-	// If no message exists, return a blocking singal.
+	// If no message exists, return a blocking signal.
 	if msg == nil {
 		return nil, linuxerr.EWOULDBLOCK
 	}

--- a/pkg/sentry/kernel/pipe/pipe.go
+++ b/pkg/sentry/kernel/pipe/pipe.go
@@ -233,7 +233,7 @@ func (p *Pipe) consumeLocked(n int64) {
 // writeLocked passes a safemem.BlockSeq representing the first count bytes of
 // unused space in the pipe to f and returns the result. If fewer than count
 // bytes are free, the safemem.BlockSeq passed to f will be less than count
-// bytes in length. If the pipe is full or otherwise cannot accomodate a write
+// bytes in length. If the pipe is full or otherwise cannot accommodate a write
 // of any number of bytes up to count, writeLocked returns ErrWouldBlock
 // without calling f.
 //

--- a/pkg/sentry/kernel/sessions.go
+++ b/pkg/sentry/kernel/sessions.go
@@ -113,7 +113,7 @@ type ProcessGroup struct {
 	processGroupEntry
 }
 
-// Originator retuns the originator of the process group.
+// Originator returns the originator of the process group.
 func (pg *ProcessGroup) Originator() *ThreadGroup {
 	return pg.originator
 }

--- a/pkg/sentry/kernel/shm/shm.go
+++ b/pkg/sentry/kernel/shm/shm.go
@@ -65,7 +65,7 @@ type Registry struct {
 
 	// reg defines basic fields and operations needed for all SysV registries.
 	//
-	// Withing reg, there are two maps, Objects and KeysToIDs.
+	// Within reg, there are two maps, Objects and KeysToIDs.
 	//
 	// reg.objects holds all referenced segments, which are removed on the last
 	// DecRef. Thus, it cannot itself hold a reference on the Shm.

--- a/pkg/sentry/kernel/syscalls.go
+++ b/pkg/sentry/kernel/syscalls.go
@@ -48,7 +48,7 @@ var outOfRangeSyscallNumber = []*metric.FieldValue{&metric.FieldValue{"-1"}}
 // SyscallSupportLevel is a syscall support levels.
 type SyscallSupportLevel int
 
-// String returns a human readable represetation of the support level.
+// String returns a human readable representation of the support level.
 func (l SyscallSupportLevel) String() string {
 	switch l {
 	case SupportUnimplemented:

--- a/pkg/sentry/kernel/task_block.go
+++ b/pkg/sentry/kernel/task_block.go
@@ -145,7 +145,7 @@ func (t *Task) block(C <-chan struct{}, timerChan <-chan struct{}) error {
 	default:
 	}
 
-	// Deactive our address space, we don't need it.
+	// Deactivate our address space, we don't need it.
 	t.prepareSleep()
 	defer t.completeSleep()
 

--- a/pkg/sentry/kernel/task_cgroup.go
+++ b/pkg/sentry/kernel/task_cgroup.go
@@ -236,7 +236,7 @@ func (t *Task) GetCgroupEntries() []TaskCgroupEntry {
 		// We're guaranteed to have a valid name, a non-empty controller list,
 		// or both.
 
-		// Explicit hierachy name, if any.
+		// Explicit hierarchy name, if any.
 		if name := c.Name(); name != "" {
 			ctlNames = append(ctlNames, fmt.Sprintf("name=%s", name))
 		}

--- a/pkg/sentry/kernel/task_start.go
+++ b/pkg/sentry/kernel/task_start.go
@@ -185,7 +185,7 @@ func (ts *TaskSet) newTask(ctx context.Context, cfg *TaskConfig) (*Task, error) 
 		charged, committed bool
 	)
 
-	// Reserve cgroup PIDs controller charge. This is either commited when the
+	// Reserve cgroup PIDs controller charge. This is either committed when the
 	// new task enters the cgroup below, or rolled back on failure.
 	//
 	// We may also get here from a non-task context (for example, when

--- a/pkg/sentry/loader/interpreter.go
+++ b/pkg/sentry/loader/interpreter.go
@@ -63,7 +63,7 @@ func parseInterpreterScript(ctx context.Context, filename string, fd *vfs.FileDe
 		line = line[:i]
 	}
 
-	// Skip any whitespace before the interpeter.
+	// Skip any whitespace before the interpreter.
 	line = bytes.TrimLeft(line, " \t")
 
 	// Linux only looks for spaces or tabs delimiting the interpreter and

--- a/pkg/sentry/loader/loader.go
+++ b/pkg/sentry/loader/loader.go
@@ -260,7 +260,7 @@ func Load(ctx context.Context, args LoadArgs, extraAuxv []arch.AuxEntry, vdso *V
 	}
 
 	// Setup the heap. brk starts at the next page after the end of the
-	// executable. Userspace can assume that the remainer of the page after
+	// executable. Userspace can assume that the remainder of the page after
 	// loaded.end is available for its use.
 	e, ok := loaded.end.RoundUp()
 	if !ok {

--- a/pkg/sentry/mm/procfs.go
+++ b/pkg/sentry/mm/procfs.go
@@ -96,7 +96,7 @@ func (mm *MemoryManager) ReadMapsDataInto(ctx context.Context, fn MapsCallbackFu
 	// get the sorting on the maps file wrong at worst; but that's not possible
 	// on any current platform).
 	//
-	// Artifically adjust the seqfile handle so we only output vsyscall entry once.
+	// Artificially adjust the seqfile handle so we only output vsyscall entry once.
 	if start != vsyscallEnd {
 		fn(hostarch.Addr(0xffffffffff600000), hostarch.Addr(0xffffffffff601000), hostarch.ReadExecute, "p", 0, 0, 0, 0, "[vsyscall]")
 	}

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -121,7 +121,7 @@ type MemoryFile struct {
 	// file blocks expected. This is used to elide the scan when this
 	// matches the underlying file blocks.
 	//
-	// To track swapped pages, usageSwapped tracks the discrepency between
+	// To track swapped pages, usageSwapped tracks the discrepancy between
 	// what is observed in core and what is reported by the file. When
 	// usageSwapped is non-zero, a sweep will be performed at least every
 	// second. The start of the last sweep is recorded in usageLast.

--- a/pkg/sentry/platform/kvm/bluepill.go
+++ b/pkg/sentry/platform/kvm/bluepill.go
@@ -61,7 +61,7 @@ var (
 	// This is called by bluepillHandler.
 	savedHandler uintptr
 
-	// savedSigsysHandler is a pointer to the previos handler of the SIGSYS signals.
+	// savedSigsysHandler is a pointer to the previous handler of the SIGSYS signals.
 	savedSigsysHandler uintptr
 
 	// dieTrampolineAddr is the address of dieTrampoline.

--- a/pkg/sentry/platform/kvm/bluepill_amd64_unsafe.go
+++ b/pkg/sentry/platform/kvm/bluepill_amd64_unsafe.go
@@ -63,7 +63,7 @@ func getHypercallID(addr uintptr) int {
 	return _KVM_HYPERCALL_MAX
 }
 
-// bluepillStopGuest is reponsible for injecting interrupt.
+// bluepillStopGuest is responsible for injecting interrupt.
 //
 //go:nosplit
 func bluepillStopGuest(c *vCPU) {
@@ -80,7 +80,7 @@ func bluepillStopGuest(c *vCPU) {
 	c.runData.requestInterruptWindow = 0
 }
 
-// bluepillSigBus is reponsible for injecting NMI to trigger sigbus.
+// bluepillSigBus is responsible for injecting NMI to trigger sigbus.
 //
 //go:nosplit
 func bluepillSigBus(c *vCPU) {
@@ -92,7 +92,7 @@ func bluepillSigBus(c *vCPU) {
 	}
 }
 
-// bluepillHandleEnosys is reponsible for handling enosys error.
+// bluepillHandleEnosys is responsible for handling enosys error.
 //
 //go:nosplit
 func bluepillHandleEnosys(c *vCPU) {

--- a/pkg/sentry/platform/kvm/bluepill_arm64_unsafe.go
+++ b/pkg/sentry/platform/kvm/bluepill_arm64_unsafe.go
@@ -77,7 +77,7 @@ func getHypercallID(addr uintptr) int {
 	}
 }
 
-// bluepillStopGuest is reponsible for injecting sError.
+// bluepillStopGuest is responsible for injecting sError.
 //
 //go:nosplit
 func bluepillStopGuest(c *vCPU) {
@@ -97,7 +97,7 @@ func bluepillStopGuest(c *vCPU) {
 	}
 }
 
-// bluepillSigBus is reponsible for injecting sError to trigger sigbus.
+// bluepillSigBus is responsible for injecting sError to trigger sigbus.
 //
 //go:nosplit
 func bluepillSigBus(c *vCPU) {
@@ -123,7 +123,7 @@ func bluepillSigBus(c *vCPU) {
 	}
 }
 
-// bluepillExtDabt is reponsible for injecting external data abort.
+// bluepillExtDabt is responsible for injecting external data abort.
 //
 //go:nosplit
 func bluepillExtDabt(c *vCPU) {
@@ -143,7 +143,7 @@ func bluepillExtDabt(c *vCPU) {
 	}
 }
 
-// bluepillHandleEnosys is reponsible for handling enosys error.
+// bluepillHandleEnosys is responsible for handling enosys error.
 //
 //go:nosplit
 func bluepillHandleEnosys(c *vCPU) {

--- a/pkg/sentry/platform/kvm/bluepill_unsafe.go
+++ b/pkg/sentry/platform/kvm/bluepill_unsafe.go
@@ -59,7 +59,7 @@ func bluepillArchContext(context unsafe.Pointer) *arch.SignalContext64 {
 	return &((*arch.UContext64)(context).MContext)
 }
 
-// bluepillHandleHlt is reponsible for handling VM-Exit.
+// bluepillHandleHlt is responsible for handling VM-Exit.
 //
 //go:nosplit
 func bluepillGuestExit(c *vCPU, context unsafe.Pointer) {

--- a/pkg/sentry/platform/kvm/machine.go
+++ b/pkg/sentry/platform/kvm/machine.go
@@ -450,7 +450,7 @@ func (m *machine) Destroy() {
 //
 // It is guaranteed that if any OS thread TID is in guest, m.vCPUs[TID] points
 // to the vCPU in which the OS thread TID is running. So if Get() returns with
-// the corrent context in guest, the vCPU of it must be the same as what
+// the current context in guest, the vCPU of it must be the same as what
 // Get() returns.
 func (m *machine) Get() *vCPU {
 	m.mu.RLock()

--- a/pkg/sentry/platform/ptrace/subprocess.go
+++ b/pkg/sentry/platform/ptrace/subprocess.go
@@ -255,7 +255,7 @@ func (s *subprocess) unmap() {
 
 // Release kills the subprocess.
 //
-// Just kidding! We can't safely co-ordinate the detaching of all the
+// Just kidding! We can't safely coordinate the detaching of all the
 // tracees (since the tracers are random runtime threads, and the process
 // won't exit until tracers have been notifier).
 //

--- a/pkg/sentry/platform/ptrace/subprocess_amd64.go
+++ b/pkg/sentry/platform/ptrace/subprocess_amd64.go
@@ -131,7 +131,7 @@ func dumpRegs(regs *arch.Registers) string {
 }
 
 // adjustInitregsRip adjust the current register RIP value to
-// be just before the system call instruction excution
+// be just before the system call instruction execution
 func (t *thread) adjustInitRegsRip() {
 	t.initRegs.Rip -= initRegsRipAdjustment
 }

--- a/pkg/sentry/platform/ptrace/subprocess_linux.go
+++ b/pkg/sentry/platform/ptrace/subprocess_linux.go
@@ -83,7 +83,7 @@ func attachedThread(flags uintptr, defaultAction linux.BPFAction) (*thread, erro
 				unix.SYS_CLONE: seccomp.Or{
 					// Allow creation of new subprocesses (used by the master).
 					seccomp.PerArg{seccomp.EqualTo(unix.CLONE_FILES | unix.SIGKILL)},
-					// Allow creation of new threads within a single address space (used by addresss spaces).
+					// Allow creation of new threads within a single address space (used by address spaces).
 					seccomp.PerArg{
 						seccomp.EqualTo(
 							unix.CLONE_FILES |

--- a/pkg/sentry/platform/systrap/context_queue.go
+++ b/pkg/sentry/platform/systrap/context_queue.go
@@ -103,7 +103,7 @@ func (q *contextQueue) add(ctx *sharedContext, stubFastPathEnabled bool) uint32 
 	next := atomic.AddUint32(&q.end, 1)
 	if (next % maxContextQueueEntries) ==
 		(atomic.LoadUint32(&q.start) % maxContextQueueEntries) {
-		// should be unreacheable
+		// should be unreachable
 		panic("contextQueue is full")
 	}
 	idx := next - 1

--- a/pkg/sentry/platform/systrap/subprocess.go
+++ b/pkg/sentry/platform/systrap/subprocess.go
@@ -428,7 +428,7 @@ func (s *subprocess) unmap() {
 
 // Release kills the subprocess.
 //
-// Just kidding! We can't safely co-ordinate the detaching of all the
+// Just kidding! We can't safely coordinate the detaching of all the
 // tracees (since the tracers are random runtime threads, and the process
 // won't exit until tracers have been notifier).
 //

--- a/pkg/sentry/platform/systrap/subprocess_amd64.go
+++ b/pkg/sentry/platform/systrap/subprocess_amd64.go
@@ -127,7 +127,7 @@ func dumpRegs(regs *arch.Registers) string {
 }
 
 // adjustInitregsRip adjust the current register RIP value to
-// be just before the system call instruction excution
+// be just before the system call instruction execution
 func (t *thread) adjustInitRegsRip() {
 	t.initRegs.Rip -= initRegsRipAdjustment
 }

--- a/pkg/sentry/platform/systrap/subprocess_linux.go
+++ b/pkg/sentry/platform/systrap/subprocess_linux.go
@@ -64,7 +64,7 @@ func attachedThread(flags uintptr, defaultAction linux.BPFAction) (*thread, erro
 							unix.CLONE_FS |
 							unix.CLONE_VM |
 							unix.CLONE_PTRACE)},
-					// Allow creation of new threads within a single address space (used by addresss spaces).
+					// Allow creation of new threads within a single address space (used by address spaces).
 					seccomp.PerArg{seccomp.EqualTo(
 						unix.CLONE_FILES |
 							unix.CLONE_FS |

--- a/pkg/sentry/platform/systrap/sysmsg/sighandler_amd64.c
+++ b/pkg/sentry/platform/systrap/sysmsg/sighandler_amd64.c
@@ -286,7 +286,7 @@ void __export_sighandler(int signo, siginfo_t *siginfo, void *_ucontext) {
         uint8_t syscall_opcode = *(syscall_code + 6);
 
         // A binary patch is built so that the first byte of the syscall
-        // instruction is changed on the invalid instuction. If we meet this
+        // instruction is changed on the invalid instruction. If we meet this
         // case, this means that another thread has been patched this syscall
         // and we need to restart it.
         if (syscall_opcode == FAULT_OPCODE) {

--- a/pkg/sentry/seccheck/points/common.proto
+++ b/pkg/sentry/seccheck/points/common.proto
@@ -58,7 +58,7 @@ package gvisor.common;
 // Note that addition of new message types do not require version changes.
 // Server implementations should gracefully handle messages that it doesn't
 // understand. Similarly, payload for message can change following protobuf
-// rules for compatibilty. For example, adding new fields to a protobuf type
+// rules for compatibility. For example, adding new fields to a protobuf type
 // doesn't require version bump.
 message Handshake {
   uint32 version = 1;

--- a/pkg/sentry/seccheck/sinks/remote/test/server.go
+++ b/pkg/sentry/seccheck/sinks/remote/test/server.go
@@ -136,7 +136,7 @@ func (m *msgHandler) Message(_ []byte, hdr wire.Header, payload []byte) error {
 	return nil
 }
 
-// Version returns the wire version supported or overriden by SetVersion.
+// Version returns the wire version supported or overridden by SetVersion.
 func (m *msgHandler) Version() uint32 {
 	m.owner.mu.Lock()
 	defer m.owner.mu.Unlock()

--- a/pkg/sentry/seccheck/sinks/remote/wire/wire.go
+++ b/pkg/sentry/seccheck/sinks/remote/wire/wire.go
@@ -30,7 +30,7 @@ const HeaderStructSize = 8
 // +marshal
 type Header struct {
 	// HeaderSize is the size of the header in bytes. The payload comes
-	// immediatelly after the header. The length is needed to allow the header to
+	// immediately after the header. The length is needed to allow the header to
 	// expand in the future without breaking remotes that do not yet understand
 	// the new fields.
 	HeaderSize uint16

--- a/pkg/sentry/socket/netlink/message.go
+++ b/pkg/sentry/socket/netlink/message.go
@@ -50,7 +50,7 @@ func NewMessage(hdr linux.NetlinkMessageHeader) *Message {
 
 // ParseMessage parses the first message seen at buf, returning the rest of the
 // buffer. If message is malformed, ok of false is returned. For last message,
-// padding check is loose, if there isn't enought padding, whole buf is consumed
+// padding check is loose, if there isn't enough padding, whole buf is consumed
 // and ok is set to true.
 func ParseMessage(buf []byte) (msg *Message, rest []byte, ok bool) {
 	b := BytesView(buf)

--- a/pkg/sentry/socket/unix/transport/connectionless.go
+++ b/pkg/sentry/socket/unix/transport/connectionless.go
@@ -22,7 +22,7 @@ import (
 )
 
 // connectionlessEndpoint is a unix endpoint for unix sockets that support operating in
-// a connectionless fashon.
+// a connectionless fashion.
 //
 // Specifically, this means datagram unix sockets not created with
 // socketpair(2).

--- a/pkg/sentry/socket/unix/transport/host.go
+++ b/pkg/sentry/socket/unix/transport/host.go
@@ -388,7 +388,7 @@ func (e *SCMConnectedEndpoint) Release(ctx context.Context) {
 // NewSCMEndpoint creates a new SCMConnectedEndpoint backed by a host fd that
 // was passed through a Unix socket.
 //
-// The caller is responsible for calling Init(). Additionaly, Release needs to
+// The caller is responsible for calling Init(). Additionally, Release needs to
 // be called twice because ConnectedEndpoint is both a Receiver and
 // ConnectedEndpoint.
 func NewSCMEndpoint(hostFD int, queue *waiter.Queue, addr string) (*SCMConnectedEndpoint, *syserr.Error) {

--- a/pkg/sentry/syscalls/linux/sys_shm.go
+++ b/pkg/sentry/syscalls/linux/sys_shm.go
@@ -44,7 +44,7 @@ func Shmget(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr,
 	return uintptr(segment.ID()), nil, nil
 }
 
-// findSegment retrives a shm segment by the given id.
+// findSegment retrieves a shm segment by the given id.
 //
 // findSegment returns a reference on Shm.
 func findSegment(t *kernel.Task, id ipc.ID) (*shm.Shm, error) {

--- a/pkg/sentry/syscalls/linux/sys_syslog.go
+++ b/pkg/sentry/syscalls/linux/sys_syslog.go
@@ -30,7 +30,7 @@ const logBufLen = 1 << 17
 
 // Syslog implements part of Linux syscall syslog.
 //
-// Only the unpriviledged commands are implemented, allowing applications to
+// Only the unprivileged commands are implemented, allowing applications to
 // read a fun dmesg.
 func Syslog(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
 	command := args[0].Int()

--- a/pkg/sentry/syscalls/syscalls.go
+++ b/pkg/sentry/syscalls/syscalls.go
@@ -43,7 +43,7 @@ func Supported(name string, fn kernel.SyscallFn) kernel.Syscall {
 	}
 }
 
-// SupportedPoint returns a syscall that is fully supported with a correspoding
+// SupportedPoint returns a syscall that is fully supported with a corresponding
 // seccheck.Point.
 func SupportedPoint(name string, fn kernel.SyscallFn, cb kernel.SyscallToProto) kernel.Syscall {
 	sys := Supported(name, fn)
@@ -63,7 +63,7 @@ func PartiallySupported(name string, fn kernel.SyscallFn, note string, urls []st
 }
 
 // PartiallySupportedPoint returns a syscall that has a partial implementation
-// with a correspoding seccheck.Point.
+// with a corresponding seccheck.Point.
 func PartiallySupportedPoint(name string, fn kernel.SyscallFn, cb kernel.SyscallToProto, note string, urls []string) kernel.Syscall {
 	sys := PartiallySupported(name, fn, note, urls)
 	sys.PointCallback = cb

--- a/pkg/sentry/time/sampler_arm64.go
+++ b/pkg/sentry/time/sampler_arm64.go
@@ -26,9 +26,9 @@ func getCNTFRQ() TSCValue
 // calibrate defaultOverheadCycles for ARM.
 func getDefaultArchOverheadCycles() TSCValue {
 	// estimated the clock frequency on x86 is 1Ghz.
-	// 1Ghz devided by counter-timer frequency of ARM to get
+	// 1Ghz divided by counter-timer frequency of ARM to get
 	// frqRatio. defaultOverheadCycles of ARM equals to that on
-	// x86 devided by frqRatio
+	// x86 divided by frqRatio
 	cntfrq := getCNTFRQ()
 	frqRatio := 1000000000 / float64(cntfrq)
 	overheadCycles := (1 * 1000) / frqRatio

--- a/pkg/sentry/usage/memory.go
+++ b/pkg/sentry/usage/memory.go
@@ -68,7 +68,7 @@ const (
 	// exact amount of memory used by mapping on the host, because we don't have
 	// any visibility into the host kernel memory management. In particular,
 	// once we map some part of a host file, the host kernel is free to
-	// abitrarily populate/decommit the pages, which it may do for various
+	// arbitrarily populate/decommit the pages, which it may do for various
 	// reasons (ex. host memory reclaim, NUMA balancing).
 	//
 	// This memory kind is backed by the host pagecache, via host mmaps.

--- a/pkg/sentry/vfs/inotify.go
+++ b/pkg/sentry/vfs/inotify.go
@@ -743,7 +743,7 @@ func InotifyEventFromStatMask(mask uint32) uint32 {
 	return ev
 }
 
-// InotifyRemoveChild sends the appriopriate notifications to the watch sets of
+// InotifyRemoveChild sends the appropriate notifications to the watch sets of
 // the child being removed and its parent. Note that unlike most pairs of
 // parent/child notifications, the child is notified first in this case.
 func InotifyRemoveChild(ctx context.Context, self, parent *Watches, name string) {
@@ -755,7 +755,7 @@ func InotifyRemoveChild(ctx context.Context, self, parent *Watches, name string)
 	}
 }
 
-// InotifyRename sends the appriopriate notifications to the watch sets of the
+// InotifyRename sends the appropriate notifications to the watch sets of the
 // file being renamed and its old/new parents.
 func InotifyRename(ctx context.Context, renamed, oldParent, newParent *Watches, oldName, newName string, isDir bool) {
 	var dirEv uint32

--- a/pkg/sentry/vfs/mount.go
+++ b/pkg/sentry/vfs/mount.go
@@ -150,7 +150,7 @@ func (mnt *Mount) Options() MountOptions {
 	}
 }
 
-// setMountOptions sets mnt's opions to the given opts.
+// setMountOptions sets mnt's options to the given opts.
 //
 // Preconditions:
 //   - vfs.mountMu must be locked.

--- a/pkg/sentry/watchdog/watchdog.go
+++ b/pkg/sentry/watchdog/watchdog.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package watchdog is responsible for monitoring the sentry for tasks that may
-// potentially be stuck or looping inderterminally causing hard to debug hungs in
+// potentially be stuck or looping inderterminally causing hard to debug hangs in
 // the untrusted app.
 //
 // It works by periodically querying all tasks to check whether they are in user
@@ -180,7 +180,7 @@ func New(k *kernel.Kernel, opts Opts) *Watchdog {
 	// Handle StartupTimeout if it exists.
 	if w.StartupTimeout > 0 {
 		log.Infof("Watchdog waiting %v for startup", w.StartupTimeout)
-		go w.waitForStart() // S/R-SAFE: watchdog is stopped buring save and restarted after restore.
+		go w.waitForStart() // S/R-SAFE: watchdog is stopped during save and restarted after restore.
 	}
 
 	return w

--- a/pkg/state/decode.go
+++ b/pkg/state/decode.go
@@ -244,7 +244,7 @@ func (ds *decodeState) waitObject(ods *objectDecodeState, encoded wire.Object, c
 		// See decodeObject; we need to wait for the array (if non-nil).
 		ds.wait(ods, objectID(sv.Ref.Root), callback)
 	} else if iv, ok := encoded.(*wire.Interface); ok {
-		// It's an interface (wait recurisvely).
+		// It's an interface (wait recursively).
 		ds.waitObject(ods, iv.Value, callback)
 	} else if callback != nil {
 		// Nothing to wait for: execute the callback immediately.
@@ -567,7 +567,7 @@ func (ds *decodeState) decodeObject(ods *objectDecodeState, obj reflect.Value, e
 	case *wire.Interface:
 		ds.decodeInterface(ods, obj, x)
 	default:
-		// Shoud not happen, not propagated as an error.
+		// Should not happen, not propagated as an error.
 		Failf("unknown object %#v for %q", encoded, obj.Type().Name())
 	}
 }

--- a/pkg/state/encode.go
+++ b/pkg/state/encode.go
@@ -31,7 +31,7 @@ type objectEncodeState struct {
 
 	// obj is the object value. Note that this may be replaced if we
 	// encounter an object that contains this object. When this happens (in
-	// resolve), we will update existing references approprately, below,
+	// resolve), we will update existing references appropriately, below,
 	// and defer a re-encoding of the object.
 	obj reflect.Value
 
@@ -417,7 +417,7 @@ func traverse(rootType, targetType reflect.Type, rootAddr, targetAddr uintptr) [
 		Failf("no field in root type %v contains target type %v", rootType, targetType)
 
 	case reflect.Array:
-		// Since arrays have homogenous types, all elements have the
+		// Since arrays have homogeneous types, all elements have the
 		// same size and we can compute where the target lives. This
 		// does not matter for the purpose of typing, but matters for
 		// the purpose of computing the address of the given index.
@@ -432,7 +432,7 @@ func traverse(rootType, targetType reflect.Type, rootAddr, targetAddr uintptr) [
 
 	default:
 		// For any other type, there's no possibility of aliasing so if
-		// the types didn't match earlier then we have an addresss
+		// the types didn't match earlier then we have an address
 		// collision which shouldn't be possible at this point.
 		Failf("traverse failed for root type %v and target type %v", rootType, targetType)
 	}

--- a/pkg/state/statefile/statefile_test.go
+++ b/pkg/state/statefile/statefile_test.go
@@ -139,7 +139,7 @@ func TestStatefile(t *testing.T) {
 									t.Fatalf("missing metadata: %s", k)
 								}
 								if v != nv {
-									t.Fatalf("mismatched metdata for %s: got %s, expected %s", k, nv, v)
+									t.Fatalf("mismatched metadata for %s: got %s, expected %s", k, nv, v)
 								}
 							}
 

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -198,7 +198,7 @@ var singleFieldOrder = []int{0}
 // Lookup looks up or registers the given object.
 //
 // First, the typeID is searched to see if this has already been appropriately
-// reconciled. If no, then a reconcilation will take place that may result in a
+// reconciled. If no, then a reconciliation will take place that may result in a
 // field ordering. If a nil reconciledTypeEntry is returned from this method,
 // then the object does not support the Type interface.
 //

--- a/pkg/sync/locking/generic_mutex.go
+++ b/pkg/sync/locking/generic_mutex.go
@@ -33,7 +33,7 @@ var genericMarkIndex *locking.MutexClass
 var lockNames []string
 
 // lockNameIndex is used as an index passed to NestedLock and NestedUnlock,
-// refering to an index within lockNames.
+// referring to an index within lockNames.
 // Values are specified using the "consts" field of go_template_instance.
 type lockNameIndex int
 

--- a/pkg/sync/locking/generic_rwmutex.go
+++ b/pkg/sync/locking/generic_rwmutex.go
@@ -31,7 +31,7 @@ type RWMutex struct {
 var lockNames []string
 
 // lockNameIndex is used as an index passed to NestedLock and NestedUnlock,
-// refering to an index within lockNames.
+// referring to an index within lockNames.
 // Values are specified using the "consts" field of go_template_instance.
 type lockNameIndex int
 

--- a/pkg/sync/runtime_spinning_other.s
+++ b/pkg/sync/runtime_spinning_other.s
@@ -15,4 +15,4 @@
 //go:build !amd64
 
 // This file is intentionally left blank. Other arches don't use
-// addrOfSpinning, but we still need an input to the nogo temlate rule.
+// addrOfSpinning, but we still need an input to the nogo template rule.

--- a/pkg/sync/rwmutex_test.go
+++ b/pkg/sync/rwmutex_test.go
@@ -152,10 +152,10 @@ func TestDowngradableRWMutex(t *testing.T) {
 func TestRWDoubleTryLock(t *testing.T) {
 	var rwm RWMutex
 	if !rwm.TryLock() {
-		t.Fatal("failed to aquire lock")
+		t.Fatal("failed to acquire lock")
 	}
 	if rwm.TryLock() {
-		t.Fatal("unexpectedly succeeded in aquiring locked mutex")
+		t.Fatal("unexpectedly succeeded in acquiring locked mutex")
 	}
 }
 
@@ -163,18 +163,18 @@ func TestRWTryLockAfterLock(t *testing.T) {
 	var rwm RWMutex
 	rwm.Lock()
 	if rwm.TryLock() {
-		t.Fatal("unexpectedly succeeded in aquiring locked mutex")
+		t.Fatal("unexpectedly succeeded in acquiring locked mutex")
 	}
 }
 
 func TestRWTryLockUnlock(t *testing.T) {
 	var rwm RWMutex
 	if !rwm.TryLock() {
-		t.Fatal("failed to aquire lock")
+		t.Fatal("failed to acquire lock")
 	}
 	rwm.Unlock() // +checklocksforce
 	if !rwm.TryLock() {
-		t.Fatal("failed to aquire lock after unlock")
+		t.Fatal("failed to acquire lock after unlock")
 	}
 }
 
@@ -182,7 +182,7 @@ func TestTryRLockAfterLock(t *testing.T) {
 	var rwm RWMutex
 	rwm.Lock()
 	if rwm.TryRLock() {
-		t.Fatal("unexpectedly succeeded in aquiring locked mutex")
+		t.Fatal("unexpectedly succeeded in acquiring locked mutex")
 	}
 }
 
@@ -190,16 +190,16 @@ func TestTryLockAfterRLock(t *testing.T) {
 	var rwm RWMutex
 	rwm.RLock()
 	if rwm.TryLock() {
-		t.Fatal("unexpectedly succeeded in aquiring locked mutex")
+		t.Fatal("unexpectedly succeeded in acquiring locked mutex")
 	}
 }
 
 func TestDoubleTryRLock(t *testing.T) {
 	var rwm RWMutex
 	if !rwm.TryRLock() {
-		t.Fatal("failed to aquire lock")
+		t.Fatal("failed to acquire lock")
 	}
 	if !rwm.TryRLock() {
-		t.Fatal("failed to read aquire read locked lock")
+		t.Fatal("failed to read acquire read locked lock")
 	}
 }

--- a/pkg/tcpip/errors.go
+++ b/pkg/tcpip/errors.go
@@ -589,7 +589,7 @@ func (*ErrMissingRequiredFields) isError() {}
 func (*ErrMissingRequiredFields) IgnoreStats() bool {
 	return true
 }
-func (*ErrMissingRequiredFields) String() string { return "mising required fields" }
+func (*ErrMissingRequiredFields) String() string { return "missing required fields" }
 
 // ErrMulticastInputCannotBeOutput indicates that an input interface matches an
 // output interface in the same multicast route.

--- a/pkg/tcpip/header/eth.go
+++ b/pkg/tcpip/header/eth.go
@@ -82,7 +82,7 @@ const (
 	// capture all traffic.
 	EthernetProtocolAll tcpip.NetworkProtocolNumber = 0x0003
 
-	// EthernetProtocolPUP is the PARC Universial Packet protocol ethertype.
+	// EthernetProtocolPUP is the PARC Universal Packet protocol ethertype.
 	EthernetProtocolPUP tcpip.NetworkProtocolNumber = 0x0200
 )
 

--- a/pkg/tcpip/header/icmpv6.go
+++ b/pkg/tcpip/header/icmpv6.go
@@ -53,7 +53,7 @@ const (
 	ICMPv6EchoMinimumSize = 8
 
 	// ICMPv6ErrorHeaderSize is the size of an ICMP error packet header,
-	// as per RFC 4443, Apendix A, item 4 and the errata.
+	// as per RFC 4443, Appendix A, item 4 and the errata.
 	//   ... all ICMP error messages shall have exactly
 	//   32 bits of type-specific data, so that receivers can reliably find
 	//   the embedded invoking packet even when they don't recognize the

--- a/pkg/tcpip/header/igmpv3.go
+++ b/pkg/tcpip/header/igmpv3.go
@@ -378,7 +378,7 @@ func (r IGMPv3ReportGroupAddressRecord) RecordType() IGMPv3ReportRecordType {
 	return IGMPv3ReportRecordType(r[igmpv3ReportGroupAddressRecordTypeOffset])
 }
 
-// AuxDataLen returns the length of the auxillary data in this record.
+// AuxDataLen returns the length of the auxiliary data in this record.
 func (r IGMPv3ReportGroupAddressRecord) AuxDataLen() int {
 	return int(r[igmpv3ReportGroupAddressRecordAuxDataLenOffset]) * igmpv3ReportGroupAddressRecordAuxDataLenUnits
 }

--- a/pkg/tcpip/header/ipv6_extension_headers.go
+++ b/pkg/tcpip/header/ipv6_extension_headers.go
@@ -110,7 +110,7 @@ const (
 
 	// IPv6FragmentExtHdrFragmentOffsetBytesPerUnit is the unit size of a Fragment
 	// extension header's Fragment Offset field. That is, given a Fragment Offset
-	// of 2, the extension header is indiciating that the fragment's payload
+	// of 2, the extension header is indicating that the fragment's payload
 	// starts at the 16th byte in the reassembled packet.
 	IPv6FragmentExtHdrFragmentOffsetBytesPerUnit = 8
 )
@@ -317,7 +317,7 @@ func (*IPv6UnknownExtHdrOption) isIPv6ExtHdrOption() {}
 //
 // The return is of the format (option, done, error). done will be true when
 // Next is unable to return anything because the iterator has reached the end of
-// the options data, or an error occured.
+// the options data, or an error occurred.
 func (i *IPv6OptionsExtHdrOptionsIterator) Next() (IPv6ExtHdrOption, bool, error) {
 	for {
 		i.optionOffset = i.nextOptionOffset
@@ -462,7 +462,7 @@ func (b IPv6FragmentExtHdr) More() bool {
 // ID returns the Identification field.
 //
 // This value is used to uniquely identify the packet, between a
-// souce and destination.
+// source and destination.
 func (b IPv6FragmentExtHdr) ID() uint32 {
 	return binary.BigEndian.Uint32(b[ipv6FragmentExtHdrIdentificationOffset:])
 }
@@ -568,7 +568,7 @@ func (i *IPv6PayloadIterator) AsRawHeader(consume bool) IPv6RawPayloadHeader {
 //
 // The return is of the format (header, done, error). done will be true when
 // Next is unable to return anything because the iterator has reached the end of
-// the payload, or an error occured.
+// the payload, or an error occurred.
 func (i *IPv6PayloadIterator) Next() (IPv6PayloadHeader, bool, error) {
 	i.headerOffset = i.nextOffset
 	i.parseOffset = 0

--- a/pkg/tcpip/header/ipv6_extension_headers_test.go
+++ b/pkg/tcpip/header/ipv6_extension_headers_test.go
@@ -722,7 +722,7 @@ func TestIPv6ExtHdrIter(t *testing.T) {
 				// Routing extension header.
 				//
 				// Even though we have a routing ext header here, it should be
-				// be interpretted as raw bytes as only the first fragment is expected
+				// be interpreted as raw bytes as only the first fragment is expected
 				// to hold headers.
 				255, 0, 1, 2, 3, 4, 5, 6,
 
@@ -968,7 +968,7 @@ func TestIPv6ExtHdrIter(t *testing.T) {
 			}},
 		},
 		{
-			name:         "Unknwon next header raw payload",
+			name:         "Unknown next header raw payload",
 			firstNextHdr: 255,
 			payload:      buffer.MakeWithData(upperLayerData),
 			expected: []IPv6PayloadHeader{IPv6RawPayloadHeader{
@@ -977,7 +977,7 @@ func TestIPv6ExtHdrIter(t *testing.T) {
 			}},
 		},
 		{
-			name:         "Unknwon next header raw payload (across views)",
+			name:         "Unknown next header raw payload (across views)",
 			firstNextHdr: 255,
 			payload:      makeBufferFromByteBuffers(upperLayerData[:2], upperLayerData[2:]),
 			expected: []IPv6PayloadHeader{IPv6RawPayloadHeader{

--- a/pkg/tcpip/header/mldv2.go
+++ b/pkg/tcpip/header/mldv2.go
@@ -422,7 +422,7 @@ func (r MLDv2ReportMulticastAddressRecord) RecordType() MLDv2ReportRecordType {
 	return MLDv2ReportRecordType(r[mldv2ReportMulticastAddressRecordTypeOffset])
 }
 
-// AuxDataLen returns the length of the auxillary data in this record.
+// AuxDataLen returns the length of the auxiliary data in this record.
 func (r MLDv2ReportMulticastAddressRecord) AuxDataLen() int {
 	return int(r[mldv2ReportMulticastAddressRecordAuxDataLenOffset]) * mldv2ReportMulticastAddressRecordAuxDataLenUnits
 }

--- a/pkg/tcpip/header/ndp_options.go
+++ b/pkg/tcpip/header/ndp_options.go
@@ -63,7 +63,7 @@ const (
 	// ndpPrefixInformationLength is the expected length, in bytes, of the
 	// body of an NDP Prefix Information option, as per RFC 4861 section
 	// 4.6.2 which specifies that the Length field is 4. Given this, the
-	// expected length, in bytes, is 30 becuase 4 * lengthByteUnits (8) - 2
+	// expected length, in bytes, is 30 because 4 * lengthByteUnits (8) - 2
 	// (Type & Length) = 30.
 	ndpPrefixInformationLength = 30
 
@@ -173,7 +173,7 @@ var (
 )
 
 // Next returns the next element in the backing NDPOptions, or true if we are
-// done, or false if an error occured.
+// done, or false if an error occurred.
 //
 // The return can be read as option, done, error. Note, option should only be
 // used if done is false and error is nil.

--- a/pkg/tcpip/header/tcp.go
+++ b/pkg/tcpip/header/tcp.go
@@ -689,7 +689,7 @@ func Acceptable(segSeq seqnum.Value, segLen seqnum.Size, rcvNxt, rcvAcc seqnum.V
 		return segSeq.InRange(rcvNxt, rcvAcc.Add(1))
 	}
 	// Page 70 of RFC 793 allows packets that can be made "acceptable" by trimming
-	// the payload, so we'll accept any payload that overlaps the receieve window.
+	// the payload, so we'll accept any payload that overlaps the receive window.
 	// segSeq < rcvAcc is more correct according to RFC, however, Linux does it
 	// differently, it uses segSeq <= rcvAcc, we'd want to keep the same behavior
 	// as Linux.

--- a/pkg/tcpip/link/channel/channel.go
+++ b/pkg/tcpip/link/channel/channel.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package channel provides the implemention of channel-based data-link layer
+// Package channel provides the implementation of channel-based data-link layer
 // endpoints. Such endpoints allow injection of inbound packets and store
 // outbound packets in a channel.
 package channel

--- a/pkg/tcpip/link/fdbased/endpoint.go
+++ b/pkg/tcpip/link/fdbased/endpoint.go
@@ -15,7 +15,7 @@
 //go:build linux
 // +build linux
 
-// Package fdbased provides the implemention of data-link layer endpoints
+// Package fdbased provides the implementation of data-link layer endpoints
 // backed by boundary-preserving file descriptors (e.g., TUN devices,
 // seqpacket/datagram sockets).
 //

--- a/pkg/tcpip/link/fdbased/endpoint_test.go
+++ b/pkg/tcpip/link/fdbased/endpoint_test.go
@@ -436,7 +436,7 @@ func TestBufConfigMaxLength(t *testing.T) {
 }
 
 func TestBufConfigFirst(t *testing.T) {
-	// The stack assumes that the TCP/IP header is enterily contained in the first view.
+	// The stack assumes that the TCP/IP header is entirely contained in the first view.
 	// Therefore, the first view needs to be large enough to contain the maximum TCP/IP
 	// header, which is 120 bytes (60 bytes for IP + 60 bytes for TCP).
 	want := 120
@@ -551,7 +551,7 @@ func TestIovecBufferSkipVnetHdr(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			b := newIovecBuffer([]int{128, 256, 512, 1024}, true)
 			defer b.release()
-			// Pretend a read happend.
+			// Pretend a read happened.
 			b.nextIovecs()
 			buf := b.pullBuffer(test.readN)
 			defer buf.Release()

--- a/pkg/tcpip/link/loopback/loopback.go
+++ b/pkg/tcpip/link/loopback/loopback.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package loopback provides the implemention of loopback data-link layer
+// Package loopback provides the implementation of loopback data-link layer
 // endpoints. Such endpoints just turn outbound packets into inbound ones.
 //
 // Loopback endpoints can be used in the networking stack by calling New() to

--- a/pkg/tcpip/link/qdisc/fifo/fifo.go
+++ b/pkg/tcpip/link/qdisc/fifo/fifo.go
@@ -38,7 +38,7 @@ const (
 
 // discipline represents a QueueingDiscipline which implements a FIFO queue for
 // all outgoing packets. discipline can have 1 or more underlying
-// queueDispatchers. All outgoing packets are consistenly hashed to a single
+// queueDispatchers. All outgoing packets are consistently hashed to a single
 // underlying queue using the PacketBuffer.Hash if set, otherwise all packets
 // are queued to the first queue to avoid reordering in case of missing hash.
 type discipline struct {

--- a/pkg/tcpip/link/sharedmem/sharedmem.go
+++ b/pkg/tcpip/link/sharedmem/sharedmem.go
@@ -15,7 +15,7 @@
 //go:build linux
 // +build linux
 
-// Package sharedmem provides the implemention of data-link layer endpoints
+// Package sharedmem provides the implementation of data-link layer endpoints
 // backed by shared memory.
 //
 // Shared memory endpoints can be used in the networking stack by calling New()

--- a/pkg/tcpip/link/sharedmem/sharedmem_server_test.go
+++ b/pkg/tcpip/link/sharedmem/sharedmem_server_test.go
@@ -340,7 +340,7 @@ func TestServerBulkTransfer(t *testing.T) {
 			}
 			response.Body.Close()
 			if got, want := int(n), payloadSize; got != want {
-				t.Fatalf("unexpected resposne size got: %d, want: %d", got, want)
+				t.Fatalf("unexpected response size got: %d, want: %d", got, want)
 			}
 			log.Infof("read %d bytes", n)
 		})
@@ -396,7 +396,7 @@ func TestClientBulkTransfer(t *testing.T) {
 			}
 			response.Body.Close()
 			if got, want := int(n), payloadSize; got != want {
-				t.Fatalf("unexpected resposne size got: %d, want: %d", got, want)
+				t.Fatalf("unexpected response size got: %d, want: %d", got, want)
 			}
 			log.Infof("read %d bytes", n)
 		})

--- a/pkg/tcpip/link/sharedmem/sharedmem_unsafe.go
+++ b/pkg/tcpip/link/sharedmem/sharedmem_unsafe.go
@@ -48,7 +48,7 @@ func getBuffer(fd int) ([]byte, error) {
 		return nil, fmt.Errorf("failed to map memory for buffer fd: %d, error: %s", fd, err)
 	}
 
-	// Use unsafe to conver addr into a []byte.
+	// Use unsafe to convert addr into a []byte.
 	var b []byte
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	hdr.Data = addr

--- a/pkg/tcpip/link/tun/device.go
+++ b/pkg/tcpip/link/tun/device.go
@@ -166,7 +166,7 @@ func attachOrCreateNIC(s *stack.Stack, name, prefix string, linkCaps stack.LinkE
 	}
 }
 
-// MTU returns the tun enpoint MTU (maximum transmission unit).
+// MTU returns the tun endpoint MTU (maximum transmission unit).
 func (d *Device) MTU() (uint32, error) {
 	d.mu.RLock()
 	endpoint := d.endpoint

--- a/pkg/tcpip/network/internal/ip/errors.go
+++ b/pkg/tcpip/network/internal/ip/errors.go
@@ -20,7 +20,7 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip"
 )
 
-// ForwardingError represents an error that occured while trying to forward
+// ForwardingError represents an error that occurred while trying to forward
 // a packet.
 type ForwardingError interface {
 	isForwardingError()
@@ -75,7 +75,7 @@ func (*ErrLinkLocalDestinationAddress) isForwardingError() {}
 
 func (*ErrLinkLocalDestinationAddress) String() string { return "link local destination address" }
 
-// ErrHostUnreachable indicates that the destinatino host could not be reached.
+// ErrHostUnreachable indicates that the destination host could not be reached.
 type ErrHostUnreachable struct{}
 
 func (*ErrHostUnreachable) isForwardingError() {}

--- a/pkg/tcpip/network/internal/ip/generic_multicast_protocol_test.go
+++ b/pkg/tcpip/network/internal/ip/generic_multicast_protocol_test.go
@@ -875,7 +875,7 @@ func TestHandleQueryV2Response(t *testing.T) {
 					// Receiving a query should make us reschedule our delayed report
 					// timer to some time within the new max response delay.
 					//
-					// Note that if we are in V1 compatbility mode, the V2 query will be
+					// Note that if we are in V1 compatibility mode, the V2 query will be
 					// handled as a V1 query.
 					mgp.handleQueryV2(test.queryAddr, test.maxDelay, header.MakeAddressIterator(addr1.Len(), bytes.NewBuffer(nil)), 0, 0)
 					if subTest.v1Compatibility {
@@ -1217,7 +1217,7 @@ func TestMakeAllNonMemberAndInitialize(t *testing.T) {
 			}, test.v1)
 
 			if test.v1Compatibility {
-				// V1 query targetting an unjoined group should drop us into V1
+				// V1 query targeting an unjoined group should drop us into V1
 				// compatibility mode without sending any packets, affecting tests.
 				mgp.handleQuery(addr3, 0)
 			}

--- a/pkg/tcpip/network/internal/ip/stats.go
+++ b/pkg/tcpip/network/internal/ip/stats.go
@@ -66,7 +66,7 @@ type MultiCounterIPForwardingStats struct {
 	UnknownOutputEndpoint tcpip.MultiCounterStat
 
 	// NoMulticastPendingQueueBufferSpace is the number of multicast packets that
-	// were dropped due to insufficent buffer space in the pending packet queue.
+	// were dropped due to insufficient buffer space in the pending packet queue.
 	NoMulticastPendingQueueBufferSpace tcpip.MultiCounterStat
 
 	// OutgoingDeviceNoBufferSpace is the number of packets that were dropped due

--- a/pkg/tcpip/network/ipv4/igmp.go
+++ b/pkg/tcpip/network/ipv4/igmp.go
@@ -586,7 +586,7 @@ func (igmp *igmpState) softLeaveAll() {
 	igmp.genericMulticastProtocol.MakeAllNonMemberLocked()
 }
 
-// initializeAll attemps to initialize the IGMP state for each group that has
+// initializeAll attempts to initialize the IGMP state for each group that has
 // been joined locally.
 //
 // +checklocks:igmp.ep.mu

--- a/pkg/tcpip/network/ipv6/icmp.go
+++ b/pkg/tcpip/network/ipv6/icmp.go
@@ -596,7 +596,7 @@ func (e *endpoint) handleICMP(pkt stack.PacketBufferPtr, hasFragmentHeader bool,
 
 			// We just got an NA from a node that owns an address we are performing
 			// DAD on, implying the address is not unique. In this case we let the
-			// stack know so it can handle such a scenario and do nothing furthur with
+			// stack know so it can handle such a scenario and do nothing further with
 			// the NDP NA.
 			//
 			// We would get an error if the address no longer exists or the address
@@ -961,7 +961,7 @@ type icmpReason interface {
 type icmpReasonParameterProblem struct {
 	code header.ICMPv6Code
 
-	// pointer is defined in the RFC 4443 setion 3.4 which reads:
+	// pointer is defined in the RFC 4443 section 3.4 which reads:
 	//
 	//  Pointer         Identifies the octet offset within the invoking packet
 	//                  where the error was detected.

--- a/pkg/tcpip/network/ipv6/mld.go
+++ b/pkg/tcpip/network/ipv6/mld.go
@@ -308,7 +308,7 @@ func (mld *mldState) softLeaveAll() {
 	mld.genericMulticastProtocol.MakeAllNonMemberLocked()
 }
 
-// initializeAll attemps to initialize the MLD state for each group that has
+// initializeAll attempts to initialize the MLD state for each group that has
 // been joined locally.
 //
 // Precondition: mld.ep.mu must be locked.

--- a/pkg/tcpip/network/ipv6/ndp.go
+++ b/pkg/tcpip/network/ipv6/ndp.go
@@ -1169,7 +1169,7 @@ func (ndp *ndpState) addAndAcquireSLAACAddr(addr tcpip.AddressWithPrefix, tempor
 // The IPv6 endpoint that ndp belongs to MUST be locked.
 func (ndp *ndpState) generateSLAACAddr(prefix tcpip.Subnet, state *slaacPrefixState) bool {
 	if addressEndpoint := state.stableAddr.addressEndpoint; addressEndpoint != nil {
-		panic(fmt.Sprintf("ndp: SLAAC prefix %s already has a permenant address %s", prefix, addressEndpoint.AddressWithPrefix()))
+		panic(fmt.Sprintf("ndp: SLAAC prefix %s already has a permanent address %s", prefix, addressEndpoint.AddressWithPrefix()))
 	}
 
 	// If we have already reached the maximum address generation attempts for the
@@ -1620,7 +1620,7 @@ func (ndp *ndpState) refreshSLAACPrefixLifetimes(prefix tcpip.Subnet, prefixStat
 	// have been regenerated, or we need to immediately regenerate an address
 	// due to an update in preferred lifetime.
 	//
-	// If each temporay address has already been regenerated, no new temporary
+	// If each temporary address has already been regenerated, no new temporary
 	// address is generated. To ensure continuation of temporary SLAAC addresses,
 	// we manually try to regenerate an address here.
 	if regenForAddr.BitLen() != 0 || allAddressesRegenerated {

--- a/pkg/tcpip/ports/flags.go
+++ b/pkg/tcpip/ports/flags.go
@@ -23,7 +23,7 @@ type Flags struct {
 
 	// LoadBalanced indicates SO_REUSEPORT.
 	//
-	// LoadBalanced takes precidence over MostRecent.
+	// LoadBalanced takes precedence over MostRecent.
 	LoadBalanced bool
 
 	// TupleOnly represents TCP SO_REUSEADDR.

--- a/pkg/tcpip/sample/tun_tcp_echo/main.go
+++ b/pkg/tcpip/sample/tun_tcp_echo/main.go
@@ -44,7 +44,7 @@ import (
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-var tap = flag.Bool("tap", false, "use tap istead of tun")
+var tap = flag.Bool("tap", false, "use tap instead of tun")
 var mac = flag.String("mac", "aa:00:01:01:01:01", "mac address to use in tap device")
 
 type endpointWriter struct {

--- a/pkg/tcpip/stack/iptables_test.go
+++ b/pkg/tcpip/stack/iptables_test.go
@@ -30,7 +30,7 @@ const (
 	dstPort    = 3
 
 	// The network protocol used for these tests doesn't matter as the tests are
-	// not targetting anything protocol specific.
+	// not targeting anything protocol specific.
 	ipv6     = true
 	netProto = header.IPv6ProtocolNumber
 )

--- a/pkg/tcpip/stack/ndp_test.go
+++ b/pkg/tcpip/stack/ndp_test.go
@@ -2137,12 +2137,12 @@ func TestMaxSlaacPrefixes(t *testing.T) {
 			PrefixLen: 64,
 		}
 		prefixes[i] = prefix.Subnet()
-		// Serialize a perfix information option.
+		// Serialize a prefix information option.
 		buf := [30]byte{}
 		buf[0] = uint8(prefix.PrefixLen)
 		// Set the autonomous configuration flag.
 		buf[1] = 64
-		// Set the preferred and valid lifetimes to the maxiumum possible value.
+		// Set the preferred and valid lifetimes to the maximum possible value.
 		binary.BigEndian.PutUint32(buf[2:], math.MaxUint32)
 		binary.BigEndian.PutUint32(buf[6:], math.MaxUint32)
 		if n := copy(buf[14:], prefix.Address.AsSlice()); n != prefix.Address.Len() {
@@ -2674,7 +2674,7 @@ func TestNoAutoGenTempAddrForLinkLocal(t *testing.T) {
 			// No new addresses should be generated.
 			select {
 			case e := <-ndpDisp.autoGenAddrC:
-				t.Errorf("got unxpected auto gen addr event = %+v", e)
+				t.Errorf("got unexpected auto gen addr event = %+v", e)
 			default:
 			}
 		})
@@ -3197,7 +3197,7 @@ func TestMixedSLAACAddrConflictRegen(t *testing.T) {
 		lifetimeSeconds = 9999
 		// From stack.maxSLAACAddrLocalRegenAttempts
 		maxSLAACAddrLocalRegenAttempts = 10
-		// We use 2 more addreses than the maximum local regeneration attempts
+		// We use 2 more addresses than the maximum local regeneration attempts
 		// because we want to also trigger regeneration in response to a DAD
 		// conflicts for this test.
 		maxAddrs         = maxSLAACAddrLocalRegenAttempts + 2

--- a/pkg/tcpip/stack/nud_test.go
+++ b/pkg/tcpip/stack/nud_test.go
@@ -167,7 +167,7 @@ func TestNUDFunctions(t *testing.T) {
 			{
 				neighbors, err := s.Neighbors(test.nicID, ipv6.ProtocolNumber)
 				if diff := cmp.Diff(test.expectedErr, err); diff != "" {
-					t.Errorf("s.Neigbors(%d, %d) error mismatch (-want +got):\n%s", test.nicID, ipv6.ProtocolNumber, diff)
+					t.Errorf("s.Neighbors(%d, %d) error mismatch (-want +got):\n%s", test.nicID, ipv6.ProtocolNumber, diff)
 				} else if test.expectedErr == nil {
 					if diff := cmp.Diff(
 						[]stack.NeighborEntry{{Addr: llAddr2, LinkAddr: linkAddr1, State: stack.Static, UpdatedAt: clock.NowMonotonic()}},

--- a/pkg/tcpip/stack/packet_buffer.go
+++ b/pkg/tcpip/stack/packet_buffer.go
@@ -94,7 +94,7 @@ type PacketBufferPtr = *PacketBuffer
 //
 // Outgoing Packet: When a header is pushed, `pushed` gets incremented by the
 // pushed length, and the current value is stored for each header. PacketBuffer
-// substracts this value from `reserved` to compute the starting offset of each
+// subtracts this value from `reserved` to compute the starting offset of each
 // header in `buf`.
 //
 // Incoming Packet: When a header is consumed (a.k.a. parsed), the current

--- a/pkg/tcpip/stack/registration.go
+++ b/pkg/tcpip/stack/registration.go
@@ -929,7 +929,7 @@ type MulticastRouteOutgoingInterface struct {
 	// ID corresponds to the outgoing NIC.
 	ID tcpip.NICID
 
-	// MinTTL represents the minumum TTL/HopLimit a multicast packet must have to
+	// MinTTL represents the minimum TTL/HopLimit a multicast packet must have to
 	// be sent through the outgoing interface.
 	//
 	// Note: a value of 0 allows all packets to be forwarded.

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -1321,7 +1321,7 @@ func (s *Stack) findRouteWithLocalAddrFromAnyInterfaceRLocked(outgoingNIC *nic, 
 // leave through any interface unless the route is link-local.
 //
 // If no local address is provided, the stack will select a local address. If no
-// remote address is provided, the stack wil use a remote address equal to the
+// remote address is provided, the stack will use a remote address equal to the
 // local address.
 func (s *Stack) FindRoute(id tcpip.NICID, localAddr, remoteAddr tcpip.Address, netProto tcpip.NetworkProtocolNumber, multicastLoop bool) (*Route, tcpip.Error) {
 	s.mu.RLock()
@@ -1625,7 +1625,7 @@ func (s *Stack) AddStaticNeighbor(nicID tcpip.NICID, protocol tcpip.NetworkProto
 }
 
 // RemoveNeighbor removes an IP to MAC address association previously created
-// either automically or by AddStaticNeighbor. Returns ErrBadAddress if there
+// either automatically or by AddStaticNeighbor. Returns ErrBadAddress if there
 // is no association with the provided address.
 func (s *Stack) RemoveNeighbor(nicID tcpip.NICID, protocol tcpip.NetworkProtocolNumber, addr tcpip.Address) tcpip.Error {
 	s.mu.RLock()

--- a/pkg/tcpip/stack/stack_test.go
+++ b/pkg/tcpip/stack/stack_test.go
@@ -4366,7 +4366,7 @@ func TestGetMainNICAddressWhenNICDisabled(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Should still get the address when the NIC is diabled.
+	// Should still get the address when the NIC is disabled.
 	if err := s.DisableNIC(nicID); err != nil {
 		t.Fatalf("DisableNIC(%d): %s", nicID, err)
 	}

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -890,7 +890,7 @@ type WriteOptions struct {
 
 	// Atomic means that all data fetched from Payloader must be written to the
 	// endpoint. If Atomic is false, then data fetched from the Payloader may be
-	// discarded if available endpoint buffer space is unsufficient.
+	// discarded if available endpoint buffer space is insufficient.
 	Atomic bool
 
 	// ControlMessages contains optional overrides used when writing a packet.
@@ -1128,7 +1128,7 @@ type SettableSocketOption interface {
 	isSettableSocketOption()
 }
 
-// ICMPv6Filter specifes a filter for ICMPv6 types.
+// ICMPv6Filter specifies a filter for ICMPv6 types.
 //
 // +stateify savable
 type ICMPv6Filter struct {
@@ -1386,16 +1386,16 @@ func (*TCPTimeWaitReuseOption) isGettableTransportProtocolOption() {}
 func (*TCPTimeWaitReuseOption) isSettableTransportProtocolOption() {}
 
 const (
-	// TCPTimeWaitReuseDisabled indicates reuse of port bound by endponts in TIME-WAIT cannot
+	// TCPTimeWaitReuseDisabled indicates reuse of port bound by endpoints in TIME-WAIT cannot
 	// be reused for new connections.
 	TCPTimeWaitReuseDisabled TCPTimeWaitReuseOption = iota
 
-	// TCPTimeWaitReuseGlobal indicates reuse of port bound by endponts in TIME-WAIT can
+	// TCPTimeWaitReuseGlobal indicates reuse of port bound by endpoints in TIME-WAIT can
 	// be reused for new connections irrespective of the src/dest addresses.
 	TCPTimeWaitReuseGlobal
 
 	// TCPTimeWaitReuseLoopbackOnly indicates reuse of port bound by endpoint in TIME-WAIT can
-	// only be reused if the connection was a connection over loopback. i.e src/dest adddresses
+	// only be reused if the connection was a connection over loopback. i.e src/dest addresses
 	// are loopback addresses.
 	TCPTimeWaitReuseLoopbackOnly
 )
@@ -1891,7 +1891,7 @@ type IPForwardingStats struct {
 	UnknownOutputEndpoint *StatCounter
 
 	// NoMulticastPendingQueueBufferSpace is the number of multicast packets that
-	// were dropped due to insufficent buffer space in the pending packet queue.
+	// were dropped due to insufficient buffer space in the pending packet queue.
 	NoMulticastPendingQueueBufferSpace *StatCounter
 
 	// OutgoingDeviceNoBufferSpace is the number of packets that were dropped due
@@ -2302,11 +2302,11 @@ func (m *MultiIntegralStatCounterMap) Increment(key uint64) {
 type NICStats struct {
 	// LINT.IfChange(NICStats)
 
-	// UnknownL3ProtocolRcvdPacketCounts records the number of packets recieved
-	// for each unknown or unsupported netowrk protocol number.
+	// UnknownL3ProtocolRcvdPacketCounts records the number of packets received
+	// for each unknown or unsupported network protocol number.
 	UnknownL3ProtocolRcvdPacketCounts *IntegralStatCounterMap
 
-	// UnknownL4ProtocolRcvdPacketCounts records the number of packets recieved
+	// UnknownL4ProtocolRcvdPacketCounts records the number of packets received
 	// for each unknown or unsupported transport protocol number.
 	UnknownL4ProtocolRcvdPacketCounts *IntegralStatCounterMap
 

--- a/pkg/tcpip/tests/integration/link_resolution_test.go
+++ b/pkg/tcpip/tests/integration/link_resolution_test.go
@@ -102,7 +102,7 @@ func setupStackWithSeparateOpts(t *testing.T, stack1Opts stack.Options, stack2Op
 	return host1Stack, host2Stack
 }
 
-// TestPing tests that two hosts can ping eachother when link resolution is
+// TestPing tests that two hosts can ping each other when link resolution is
 // enabled.
 func TestPing(t *testing.T) {
 	const (

--- a/pkg/tcpip/transport/internal/network/endpoint.go
+++ b/pkg/tcpip/transport/internal/network/endpoint.go
@@ -411,7 +411,7 @@ func (e *Endpoint) AcquireContextForWrite(opts tcpip.WriteOptions) (WriteContext
 		// interface/address used to send the packet so we need to construct
 		// a new route instead of using the connected route.
 		//
-		// Contruct a destination matching the remote the endpoint is connected
+		// Construct a destination matching the remote the endpoint is connected
 		// to.
 		to = &tcpip.FullAddress{
 			// RegisterNICID is set when the endpoint is connected. It is usually

--- a/pkg/tcpip/transport/packet/endpoint.go
+++ b/pkg/tcpip/transport/packet/endpoint.go
@@ -263,7 +263,7 @@ func (*endpoint) Disconnect() tcpip.Error {
 }
 
 // Connect implements tcpip.Endpoint.Connect. Packet sockets cannot be
-// connected, and this function always returnes *tcpip.ErrNotSupported.
+// connected, and this function always returns *tcpip.ErrNotSupported.
 func (*endpoint) Connect(tcpip.FullAddress) tcpip.Error {
 	return &tcpip.ErrNotSupported{}
 }

--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -1087,7 +1087,7 @@ func (e *endpoint) tryDeliverSegmentFromClosedEndpoint(s *segment) {
 	}
 
 	if e == ep {
-		panic(fmt.Sprintf("current endpoint not removed from demuxer, enqueing segments to itself, endpoint in state %v", e.EndpointState()))
+		panic(fmt.Sprintf("current endpoint not removed from demuxer, enqueuing segments to itself, endpoint in state %v", e.EndpointState()))
 	}
 
 	if ep := ep.(*endpoint); ep.enqueueSegment(s) {

--- a/pkg/tcpip/transport/tcp/cubic.go
+++ b/pkg/tcpip/transport/tcp/cubic.go
@@ -192,7 +192,7 @@ func (c *cubicState) fastConvergence() {
 	c.K = math.Cbrt(c.WMax * (1 - c.Beta) / c.C)
 }
 
-// PostRecovery implemements congestionControl.PostRecovery.
+// PostRecovery implements congestionControl.PostRecovery.
 func (c *cubicState) PostRecovery() {
 	c.T = c.s.ep.stack.Clock().NowMonotonic()
 }

--- a/pkg/tcpip/transport/tcp/rcv.go
+++ b/pkg/tcpip/transport/tcp/rcv.go
@@ -554,7 +554,7 @@ func (r *receiver) handleTimeWaitSegment(s *segment) (resetTimeWait bool, newSyn
 	segLen := seqnum.Size(s.payloadSize())
 
 	// Just silently drop any RST packets in TIME_WAIT. We do not support
-	// TIME_WAIT assasination as a result we confirm w/ fix 1 as described
+	// TIME_WAIT assassination as a result we confirm w/ fix 1 as described
 	// in https://tools.ietf.org/html/rfc1337#section-3.
 	//
 	// This behavior overrides RFC793 page 70 where we transition to CLOSED

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -646,12 +646,12 @@ func (s *sender) NextSeg(nextSegHint *segment) (nextSeg, hint *segment, rescueRt
 		//     1. If there exists a smallest unSACKED sequence number
 		//     'S2' that meets the following 3 criteria for determinig
 		//     loss, the sequence range of one segment of up to SMSS
-		//     octects starting with S2 MUST be returned.
+		//     octets starting with S2 MUST be returned.
 		if !s.ep.scoreboard.IsSACKED(header.SACKBlock{Start: segSeq, End: segSeq.Add(1)}) {
 			// NextSeg():
 			//
 			//    (1.a) S2 is greater than HighRxt
-			//    (1.b) S2 is less than highest octect covered by
+			//    (1.b) S2 is less than highest octet covered by
 			//    any received SACK.
 			if s.FastRecovery.HighRxt.LessThan(segSeq) && segSeq.LessThan(s.ep.scoreboard.maxSACKED) {
 				// NextSeg():
@@ -682,7 +682,7 @@ func (s *sender) NextSeg(nextSegHint *segment) (nextSeg, hint *segment, rescueRt
 			//     retransmission per entry into loss recovery. If
 			//     HighACK is greater than RescueRxt (or RescueRxt
 			//     is undefined), then one segment of upto SMSS
-			//     octects that MUST include the highest outstanding
+			//     octets that MUST include the highest outstanding
 			//     unSACKed sequence number SHOULD be returned, and
 			//     RescueRxt set to RecoveryPoint. HighRxt MUST NOT
 			//     be updated.
@@ -822,7 +822,7 @@ func (s *sender) maybeSendSegment(seg *segment, limit int, end seqnum.Value) (se
 		}
 
 		// If the whole segment or at least 1MSS sized segment cannot
-		// be accomodated in the receiver advertized window, skip
+		// be accommodated in the receiver advertised window, skip
 		// splitting and sending of the segment. ref:
 		// net/ipv4/tcp_output.c::tcp_snd_wnd_test()
 		//
@@ -921,7 +921,7 @@ func (s *sender) postXmit(dataSent bool, shouldScheduleProbe bool) {
 		s.ep.disableKeepaliveTimer()
 	}
 
-	// If the sender has advertized zero receive window and we have
+	// If the sender has advertised zero receive window and we have
 	// data to be sent out, start zero window probing to query the
 	// the remote for it's receive window size.
 	if s.writeNext != nil && s.SndWnd == 0 {
@@ -1091,7 +1091,7 @@ func (s *sender) SetPipe() {
 			//
 			// NOTE: here we mark the whole segment as lost. We do not try
 			// and test every byte in our write buffer as we maintain our
-			// pipe in terms of oustanding packets and not bytes.
+			// pipe in terms of outstanding packets and not bytes.
 			if !s.ep.scoreboard.IsRangeLost(sb) {
 				pipe++
 			}
@@ -1453,7 +1453,7 @@ func (s *sender) handleRcvdSegment(rcvdSeg *segment) {
 	// Stash away the current window size.
 	s.SndWnd = rcvdSeg.window
 
-	// Disable zero window probing if remote advertizes a non-zero receive
+	// Disable zero window probing if remote advertises a non-zero receive
 	// window. This can be with an ACK to the zero window probe (where the
 	// acknumber refers to the already acknowledged byte) OR to any previously
 	// unacknowledged segment.

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_rack_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_rack_test.go
@@ -652,7 +652,7 @@ func TestRACKDetectDSACKSingleDup(t *testing.T) {
 	bytesRead += maxPayload
 	c.SendAckWithSACK(seq, bytesRead, []header.SACKBlock{{start, end}})
 
-	// Simulate receving delayed subsegment of #2 packet and delayed #3 packet by
+	// Simulate receiving delayed subsegment of #2 packet and delayed #3 packet by
 	// sending DSACK block for the subsegment.
 	dsackStart := c.IRS.Add(1 + seqnum.Size(bytesRead))
 	dsackEnd := dsackStart.Add(seqnum.Size(maxPayload / 2))

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
@@ -135,7 +135,7 @@ func TestGiveUpConnect(t *testing.T) {
 	// Wait for ep to become writable.
 	<-notifyCh
 
-	// Call Connect again to retreive the handshake failure status
+	// Call Connect again to retrieve the handshake failure status
 	// and stats updates.
 	{
 		err := ep.Connect(tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort})
@@ -1380,7 +1380,7 @@ func TestNoSynCookieOnFailedHandshakes(t *testing.T) {
 }
 
 // TestTCPAckBeforeAcceptV4 tests that once the 3-way handshake is complete,
-// peers can send data and expect a response within a reasonable ammount of time
+// peers can send data and expect a response within a reasonable amount of time
 // without calling Accept on the listening endpoint first.
 //
 // This test uses IPv4.
@@ -1428,7 +1428,7 @@ func TestTCPAckBeforeAcceptV4(t *testing.T) {
 }
 
 // TestTCPAckBeforeAcceptV6 tests that once the 3-way handshake is complete,
-// peers can send data and expect a response within a reasonable ammount of time
+// peers can send data and expect a response within a reasonable amount of time
 // without calling Accept on the listening endpoint first.
 //
 // This test uses IPv6.
@@ -6073,7 +6073,7 @@ func TestKeepalive(t *testing.T) {
 		)
 	}
 
-	// Sleep for a litte over the KeepAlive interval to make sure
+	// Sleep for a little over the KeepAlive interval to make sure
 	// the timer has time to fire after the last ACK and close the
 	// close the socket.
 	time.Sleep(keepAliveInterval + keepAliveInterval/2)
@@ -7241,7 +7241,7 @@ func TestReceiveBufferAutoTuningApplicationLimited(t *testing.T) {
 				return
 			}
 			// We use 10% here as the error margin upwards as the initial window we
-			// got was afer 1 segment was already in the receive buffer queue.
+			// got was after 1 segment was already in the receive buffer queue.
 			tolerance := 1.1
 			if w := tcp.WindowSize(); w == 0 || w > uint16(float64(rcvWnd)*tolerance) {
 				t.Errorf("expected a non-zero window: got %d, want <= %d", w, uint16(float64(rcvWnd)*tolerance))
@@ -8388,7 +8388,7 @@ func TestKeepaliveWithUserTimeout(t *testing.T) {
 		),
 	)
 
-	// Sleep for a litte over the KeepAlive interval to make sure
+	// Sleep for a little over the KeepAlive interval to make sure
 	// the timer has time to fire after the last ACK and close the
 	// close the socket.
 	time.Sleep(keepAliveInterval + keepAliveInterval/2)
@@ -8723,7 +8723,7 @@ func TestResetDuringClose(t *testing.T) {
 
 	// Close in a separate goroutine so that we can trigger
 	// a race with the RST we send below. This should not
-	// panic due to the route being released depeding on
+	// panic due to the route being released depending on
 	// whether Close() sends an active RST or the RST sent
 	// below is processed by the worker first.
 	var wg sync.WaitGroup

--- a/pkg/test/testutil/testutil.go
+++ b/pkg/test/testutil/testutil.go
@@ -61,7 +61,7 @@ var (
 	isRunningWithHostNet = flag.Bool("test-hostnet", BoolFromEnv("TEST_HOSTNET", false), "whether test is running with hostnet")
 
 	// TestEnvSupportsNetAdmin indicates whether a test sandbox can perform
-	// all net admin tasks. Note that some test environments cannot peform
+	// all net admin tasks. Note that some test environments cannot perform
 	// some tasks despite the presence of CAP_NET_ADMIN.
 	TestEnvSupportsNetAdmin = true
 )
@@ -357,7 +357,7 @@ func writeSpec(dir string, spec *specs.Spec) error {
 var idRandomSrc = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // idRandomSrcMtx is the mutex protecting idRandomSrc.Read from being used
-// concurrently in differnt goroutines.
+// concurrently in different goroutines.
 var idRandomSrcMtx sync.Mutex
 
 // RandomID returns 20 random bytes following the given prefix.

--- a/pkg/test/testutil/testutil_runfiles.go
+++ b/pkg/test/testutil/testutil_runfiles.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 )
 
-// FindFile searchs for a file inside the test run environment. It returns the
+// FindFile searches for a file inside the test run environment. It returns the
 // full path to the file. It fails if none or more than one file is found.
 func FindFile(path string) (string, error) {
 	wd, err := os.Getwd()

--- a/pkg/urpc/urpc.go
+++ b/pkg/urpc/urpc.go
@@ -597,7 +597,7 @@ func unmarshal(s *unet.Socket, v any) ([]*os.File, error) {
 	// instead of the default float type for those intermediate values, such
 	// that when they get re-encoded, their values are not printed out in
 	// floating-point formats such as 1e9, which could not be decoded to
-	// explicitly typed intergers later.
+	// explicitly typed integers later.
 	d.UseNumber()
 	if err := d.Decode(v); err != nil {
 		log.Warningf("urpc: error decoding: %s", err.Error())

--- a/pkg/xdp/fillqueue.go
+++ b/pkg/xdp/fillqueue.go
@@ -111,7 +111,7 @@ func (fq *FillQueue) FillAll(umem *UMEM) {
 		available = umem.nFreeFrames
 	}
 
-	// Fill the queue as much as possible and notify ther kernel.
+	// Fill the queue as much as possible and notify the kernel.
 	index := fq.cachedProducer
 	fq.cachedProducer += available
 	for i := uint32(0); i < available; i++ {

--- a/pkg/xdp/umem.go
+++ b/pkg/xdp/umem.go
@@ -25,7 +25,7 @@ import (
 )
 
 // TODO(b/240191988): There's some kind of memory corruption bug that occurs
-// occasionally. This occured even before TX was supported.
+// occasionally. This occurred even before TX was supported.
 
 // TODO(b/240191988): We can hold locks for less time if we accept a more
 // obtuse API. For example, CompletionQueue.FreeAll doesn't need to hold a

--- a/pkg/xdp/xdp.go
+++ b/pkg/xdp/xdp.go
@@ -28,7 +28,7 @@
 //     that userspace may read the packet.
 //   - Trasmit: Userspace adds a descriptor to TX queue. The kernel
 //     sends the packet (stored in UMEM) pointed to by the descriptor.
-//     Upon completion, the kernel places a desciptor in the completion
+//     Upon completion, the kernel places a descriptor in the completion
 //     queue to notify userspace that the packet is sent and the UMEM
 //     area can be reused.
 //


### PR DESCRIPTION
It is an idea of running codespell as part of our presubmit checks. Before enabling it for new changes, let's fix what it has found.