### PR TITLE
runsc/container_test: fix executeCombinedOutput's output

### DIFF
--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -98,11 +98,13 @@ func executeCombinedOutput(conf *config.Config, cont *Container, execFile *os.Fi
 	if err != nil {
 		return nil, err
 	}
-	if ws != 0 {
-		return nil, fmt.Errorf("exec failed, status: %v", ws)
-	}
-
 	out, err := ioutil.ReadAll(r)
+	switch {
+	case ws != 0 && err != nil:
+		err = fmt.Errorf("exec failed, status: %v, ioutil.ReadAll failed: %v", ws, err)
+	case ws != 0:
+		err = fmt.Errorf("exec failed, status: %v", ws)
+	}
 	return out, err
 }
 


### PR DESCRIPTION
When ws is not zero (i.e. the app in container exited with a non-zero status), executeCombinedOutput should still read and return app's output, because it may contain the contents that app sent to stdout/stderr which can be helpful for diagnosing the failures.