### PR TITLE
Fix a lock problem in pkg/tcpip/sample/tun_tcp_echo

### DIFF
--- a/pkg/tcpip/sample/tun_tcp_echo/main.go
+++ b/pkg/tcpip/sample/tun_tcp_echo/main.go
@@ -87,13 +87,17 @@ func echo(wq *waiter.Queue, ep tcpip.Endpoint) {
 	}
 
 	for {
-		_, err := ep.Read(&w, tcpip.ReadOptions{})
-		if err != nil {
+		var buf bytes.Buffer
+		if _, err := ep.Read(&buf, tcpip.ReadOptions{}); err != nil {
 			if _, ok := err.(*tcpip.ErrWouldBlock); ok {
 				<-notifyCh
 				continue
 			}
 
+			return
+		}
+		
+		if _, err := w.Write(buf.Bytes()); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
should not call `tcpip.endpoint.Write` in `tcpip.endpoint.Read`.

## setup(as root)
```shell
ip tuntap add abc mode tun
ip link set abc up
ip addr add 192.168.140.2/24 dev abc
```

In one shell:
```shell
./tun_tcp_echo abc 192.168.140.1 8000
```

In another shell:
```shell
nc 192.168.140.2 8000
# and input some text
```

## Before:
**The program blocks forever.**
![image](https://github.com/google/gvisor/assets/89972596/4f0e7d09-fe3a-458a-b570-e638292618ae)

pkg/tcpip/sample/tun_tcp_echo.go:91: ep.Read calls
pkg/tcpip/transport/tcp/endpoint.go:1402: Read, and locks e.mu.

pkg/tcpip/sample/tun_tcp_echo.go:64 e.ep.Write needs to aquire e.mu

## After repair:
![image](https://github.com/google/gvisor/assets/89972596/3245b119-29a4-4a99-acbe-8f69a8f5d24b)
