### PR TITLE
Allows `driverABI` to be saveable

### DIFF
--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -119,11 +119,13 @@ type abiConAndChecksum struct {
 //     set are not versioned.
 //  4. allocation classes within NV_ESC_RM_ALLOC in frontend device (based on
 //     NVOS64_PARAMETERS.HClass).
+//
+// +stateify savable
 type driverABI struct {
-	frontendIoctl   map[uint32]frontendIoctlHandler
-	uvmIoctl        map[uint32]uvmIoctlHandler
-	controlCmd      map[uint32]controlCmdHandler
-	allocationClass map[uint32]allocationClassHandler
+	frontendIoctl   map[uint32]frontendIoctlHandler   `state:"nosave"`
+	uvmIoctl        map[uint32]uvmIoctlHandler        `state:"nosave"`
+	controlCmd      map[uint32]controlCmdHandler      `state:"nosave"`
+	allocationClass map[uint32]allocationClassHandler `state:"nosave"`
 
 	useRmAllocParamsV535 bool
 }


### PR DESCRIPTION
Patches the `driverABI` struct, allowing containers started with `-nvproxy` to be checkpointed.  The downside of this patch is

> "[...] this would imply that the container must be restored on a host with the same nvidia driver version." ([comment](https://github.com/google/gvisor/issues/9649#issuecomment-1797811786))

Closes: https://github.com/google/gvisor/issues/9649

cc @ayushr2