### PR TITLE
provide (read only) /proc/sys/kernel/overflowuid and overflowgid

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -47,6 +47,8 @@ func (fs *filesystem) newSysDir(ctx context.Context, root *auth.Credentials, k *
 		"kernel": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 			"cap_last_cap": fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", linux.CAP_LAST_CAP))),
 			"hostname":     fs.newInode(ctx, root, 0444, &hostnameData{}),
+			"overflowgid": fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowGID))),
+			"overflowuid": fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowUID))),
 			"sem":          fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\t%d\t%d\t%d\n", linux.SEMMSL, linux.SEMMNS, linux.SEMOPM, linux.SEMMNI))),
 			"shmall":       fs.newInode(ctx, root, 0444, ipcData(linux.SHMALL)),
 			"shmmax":       fs.newInode(ctx, root, 0444, ipcData(linux.SHMMAX)),

--- a/pkg/sentry/kernel/auth/id.go
+++ b/pkg/sentry/kernel/auth/id.go
@@ -53,8 +53,8 @@ const (
 
 	// OverflowUID is the default value of /proc/sys/kernel/overflowuid. The
 	// "overflow UID" is usually [1] used when translating a user ID between
-	// namespaces fails because the ID is not mapped. (We don't implement this
-	// file, so the overflow UID is constant.)
+	// namespaces fails because the ID is not mapped. (We implement this
+	// file as read-only, so the overflow UID is constant.)
 	//
 	// [1] "There is one notable case where unmapped user and group IDs are not
 	// converted to the corresponding overflow ID value. When viewing a uid_map

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -2921,6 +2921,20 @@ TEST(ProcFilesystems, ReadCapLastCap) {
   EXPECT_TRUE(lastCap > 32 && lastCap < 64);
 }
 
+TEST(ProcFilesystems, OverflowID) {
+  std::string overflowGidStr =
+      ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/kernel/overflowgid"));
+  std::string overflowUidStr =
+      ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/kernel/overflowuid"));
+  uint64_t overflowGid, overflowUid;
+  ASSERT_TRUE(absl::SimpleAtoi(overflowGidStr, &overflowGid));
+  ASSERT_TRUE(absl::SimpleAtoi(overflowUidStr, &overflowUid));
+
+  const uint64_t defaultOverflowID = 65534;
+  EXPECT_EQ(overflowGid, defaultOverflowID);
+  EXPECT_EQ(overflowUid, defaultOverflowID);
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace gvisor


### PR DESCRIPTION
We have a user application attempting to use [bubblewrap](https://github.com/containers/bubblewrap) inside `gvisor`, and it's hitting errors because of these proc files being missing. 

```
bwrap: Can't read /proc/sys/kernel/overflowuid: No such file or directory
```

This changeset adds the files with their default Linux values, but they're not writeable. https://docs.kernel.org/admin-guide/sysctl/fs.html#overflowgid-overflowuid 