### PR TITLE
use new clear builtin to clear bufferv2 storage

### DIFF
--- a/pkg/buffer/chunk.go
+++ b/pkg/buffer/chunk.go
@@ -87,9 +87,7 @@ func newChunk(size int) *chunk {
 	} else {
 		pool := getChunkPool(size)
 		c = pool.Get().(*chunk)
-		for i := range c.data {
-			c.data[i] = 0
-		}
+		clear(c.data)
 	}
 	c.InitRefs()
 	return c


### PR DESCRIPTION
This PR is really simple,
Go 1.21 added the `clear` builtin which clears slices,
using it here can give up to 15% performance increase in use cases pertaining to high volume of small buffers