### PR TITLE
use new clear builtin to clear bufferv2 data

### DIFF
--- a/pkg/buffer/chunk.go
+++ b/pkg/buffer/chunk.go
@@ -87,9 +87,7 @@ func newChunk(size int) *chunk {
 	} else {
 		pool := getChunkPool(size)
 		c = pool.Get().(*chunk)
-		for i := range c.data {
-			c.data[i] = 0
-		}
+		clear(c.data)
 	}
 	c.InitRefs()
 	return c

--- a/pkg/safemem/block_unsafe.go
+++ b/pkg/safemem/block_unsafe.go
@@ -221,12 +221,7 @@ func Zero(dst Block) (int, error) {
 	if !dst.needSafecopy {
 		bs := dst.ToSlice()
 		if !sync.RaceEnabled {
-			// If the race detector isn't enabled, the golang
-			// compiler replaces the next loop with memclr
-			// (https://github.com/golang/go/issues/5373).
-			for i := range bs {
-				bs[i] = 0
-			}
+			clear(bs)
 		} else {
 			bsLen := len(bs)
 			if bsLen == 0 {

--- a/pkg/sentry/arch/fpu/fpu_amd64.go
+++ b/pkg/sentry/arch/fpu/fpu_amd64.go
@@ -111,9 +111,7 @@ func (s *State) Fork() State {
 // Reset resets s to its initial state.
 func (s *State) Reset() {
 	f := *s
-	for i := range f {
-		f[i] = 0
-	}
+	clear(f)
 	initX86FPState(&f[0], cpuid.HostFeatureSet().UseXsave())
 }
 
@@ -269,9 +267,7 @@ func (s *State) SanitizeUser(featureSet cpuid.FeatureSet) {
 		hostarch.ByteOrder.PutUint64(f[xstateBVOffset:], xstateBV)
 		// Force XCOMP_BV and reserved bytes in the XSAVE header to 0.
 		reserved := f[xsaveHeaderZeroedOffset : xsaveHeaderZeroedOffset+xsaveHeaderZeroedBytes]
-		for i := range reserved {
-			reserved[i] = 0
-		}
+		clear(reserved)
 	}
 }
 

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -815,9 +815,7 @@ func (f *MemoryFile) Decommit(fr memmap.FileRange) error {
 
 func (f *MemoryFile) manuallyZero(fr memmap.FileRange) error {
 	return f.forEachMappingSlice(fr, func(bs []byte) {
-		for i := range bs {
-			bs[i] = 0
-		}
+		clear(bs)
 	})
 }
 

--- a/pkg/sentry/syscalls/linux/sys_getdents.go
+++ b/pkg/sentry/syscalls/linux/sys_getdents.go
@@ -150,9 +150,7 @@ func (cb *getdentsCallback) Handle(dirent vfs.Dirent) error {
 		// Zero out all remaining bytes in buf, including the NUL terminator
 		// after dirent.Name.
 		bufTail := buf[19+len(dirent.Name):]
-		for i := range bufTail {
-			bufTail[i] = 0
-		}
+		clear(bufTail)
 		cb.copied += size
 	} else {
 		// struct linux_dirent {
@@ -188,9 +186,7 @@ func (cb *getdentsCallback) Handle(dirent vfs.Dirent) error {
 		// after dirent.Name and the zero padding byte between the name and
 		// dirent type.
 		bufTail := buf[18+len(dirent.Name) : size-1]
-		for i := range bufTail {
-			bufTail[i] = 0
-		}
+		clear(bufTail)
 		buf[size-1] = dirent.Type
 		cb.copied += size
 	}

--- a/pkg/tcpip/header/ipv4.go
+++ b/pkg/tcpip/header/ipv4.go
@@ -1137,9 +1137,7 @@ func (s IPv4OptionsSerializer) Serialize(b []byte) uint8 {
 	//  header ends on a 32 bit boundary. The padding is zero.
 	padded := padIPv4OptionsLength(total)
 	b = b[:padded-total]
-	for i := range b {
-		b[i] = 0
-	}
+	clear(b)
 	return padded
 }
 

--- a/pkg/tcpip/header/ipv6_extension_headers.go
+++ b/pkg/tcpip/header/ipv6_extension_headers.go
@@ -130,9 +130,7 @@ func padIPv6Option(b []byte) {
 		b[ipv6ExtHdrOptionTypeOffset] = uint8(ipv6Pad1ExtHdrOptionIdentifier)
 	default: // Pad with PadN.
 		s := b[ipv6ExtHdrOptionPayloadOffset:]
-		for i := range s {
-			s[i] = 0
-		}
+		clear(s)
 		b[ipv6ExtHdrOptionTypeOffset] = uint8(ipv6PadNExtHdrOptionIdentifier)
 		b[ipv6ExtHdrOptionLengthOffset] = uint8(len(s))
 	}

--- a/pkg/usermem/bytes_io.go
+++ b/pkg/usermem/bytes_io.go
@@ -58,9 +58,7 @@ func (b *BytesIO) ZeroOut(ctx context.Context, addr hostarch.Addr, toZero int64,
 		return 0, rngErr
 	}
 	zeroSlice := b.Bytes[int(addr) : int(addr)+rngN]
-	for i := range zeroSlice {
-		zeroSlice[i] = 0
-	}
+	clear(zeroSlice)
 	return int64(rngN), rngErr
 }
 

--- a/tools/go_marshal/analysis/analysis_unsafe.go
+++ b/tools/go_marshal/analysis/analysis_unsafe.go
@@ -81,9 +81,7 @@ func RandomizeValue(x any) {
 // This is used for zeroing padding fields after calling RandomizeValue.
 func reflectZeroPaddingFields(r reflect.Type, data []byte, zero bool) {
 	if zero {
-		for i := range data {
-			data[i] = 0
-		}
+		clear(data)
 	}
 	switch r.Kind() {
 	case reflect.Int8, reflect.Uint8, reflect.Int16, reflect.Uint16, reflect.Int32, reflect.Uint32, reflect.Int64, reflect.Uint64:


### PR DESCRIPTION
This PR is really simple,
Go 1.21 added the `clear` builtin which clears slices,
using it here can give up to 15% performance increase in use cases pertaining to high volume of small buffers