### PR TITLE
docs: images/Makefile does not exist.

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -7,7 +7,7 @@ Note that all these images must be pushed to the testing project hosted on
 continuous integration. This will speed up loading as images will not need to be
 built from scratch for each test run.
 
-Image tooling is accessible via `make`, specifically via `images/Makefile`.
+Image tooling is accessible via `make`, specifically via `tools/images.mk`.
 
 ## Why make?
 


### PR DESCRIPTION
This reverts commit 12c2c6ae3, as commit a855a814d ("Refactor the Makefile to avoid recursive Make.") recreated tools/images.mk and removed images/Makefile.