### PR TITLE
WIP: Add runsc update command

### DIFF
--- a/runsc/cgroup/cgroup.go
+++ b/runsc/cgroup/cgroup.go
@@ -319,6 +319,7 @@ type Cgroup interface {
 	Install(res *specs.LinuxResources) error
 	Uninstall() error
 	Join() (func(), error)
+	Set(res *specs.LinuxResources) error
 	CPUQuota() (float64, error)
 	CPUUsage() (uint64, error)
 	NumCPU() (int, error)
@@ -624,6 +625,10 @@ func (c *cgroupV1) Join() (func(), error) {
 		}
 	}
 	return cu.Release(), nil
+}
+
+func (c *cgroupV1) Set(res *specs.LinuxResources) error {
+	return errors.New("not implemented")
 }
 
 // CPUQuota returns the CFS CPU quota.

--- a/runsc/cgroup/cgroup_v2.go
+++ b/runsc/cgroup/cgroup_v2.go
@@ -141,29 +141,8 @@ func (c *cgroupV2) Install(res *specs.LinuxResources) error {
 	}
 	if created {
 		// If we created our final cgroup path then we can set the resources.
-		for controllerName, ctrlr := range controllers2 {
-			// First check if our controller is found in the system.
-			found := false
-			for _, knownController := range c.Controllers {
-				if controllerName == knownController {
-					found = true
-				}
-			}
-
-			// In case we don't have the controller.
-			if found {
-				if err := ctrlr.set(res, c.MakePath("")); err != nil {
-					return err
-				}
-				continue
-			}
-			if ctrlr.optional() {
-				if err := ctrlr.skip(res); err != nil {
-					return err
-				}
-			} else {
-				return fmt.Errorf("mandatory cgroup controller %q is missing for %q", controllerName, c.MakePath(""))
-			}
+		if err := c.Set(res); err != nil {
+			return err
 		}
 	}
 
@@ -231,6 +210,35 @@ func (c *cgroupV2) Join() (func(), error) {
 	}
 
 	return cu.Release(), nil
+}
+
+// Set sets the cgroup resources.
+func (c *cgroupV2) Set(res *specs.LinuxResources) error {
+	for controllerName, ctrlr := range controllers2 {
+		// First check if our controller is found in the system.
+		found := false
+		for _, knownController := range c.Controllers {
+			if controllerName == knownController {
+				found = true
+			}
+		}
+
+		// In case we don't have the controller.
+		if found {
+			if err := ctrlr.set(res, c.MakePath("")); err != nil {
+				return err
+			}
+			continue
+		}
+		if ctrlr.optional() {
+			if err := ctrlr.skip(res); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("mandatory cgroup controller %q is missing for %q", controllerName, c.MakePath(""))
+		}
+	}
+	return nil
 }
 
 func getCPUQuota(path string) (float64, error) {

--- a/runsc/cli/main.go
+++ b/runsc/cli/main.go
@@ -261,6 +261,7 @@ func forEachCmd(cb func(cmd subcommands.Command, group string)) {
 	cb(new(cmd.Spec), "")
 	cb(new(cmd.Start), "")
 	cb(new(cmd.State), "")
+	cb(new(cmd.Update), "")
 	cb(new(cmd.Wait), "")
 
 	// Helpers.

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -71,6 +71,7 @@ go_library(
         "symbolize.go",
         "syscalls.go",
         "umount_unsafe.go",
+        "update.go",
         "usage.go",
         "wait.go",
         "write_control.go",

--- a/runsc/cmd/update.go
+++ b/runsc/cmd/update.go
@@ -1,0 +1,215 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/google/subcommands"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/container"
+	"gvisor.dev/gvisor/runsc/flag"
+)
+
+func i64Ptr(i int64) *int64   { return &i }
+func u64Ptr(i uint64) *uint64 { return &i }
+func u16Ptr(i uint16) *uint16 { return &i }
+func boolPtr(b bool) *bool    { return &b }
+
+// Update implements subcommands.Command for the "update" command.
+type Update struct {
+	resources string
+
+	cpuPeriod    uint64
+	cpuQuota     int64
+	cpuBurst     uint64
+	cpuShares    uint64
+	cpuRtPeriod  uint64
+	cpuRtRuntime int64
+	cpusetCpus   string // can this be string or this has to be list of smth?
+	cpusetMems   string
+	cpuIdle      int64
+
+	memory            int64
+	memoryReservation int64
+	memorySwap        int64
+
+	blkioWeight int
+
+	pidsLimit int64
+
+	l3CacheSchema string
+	memBwSchema   string
+}
+
+// Name implements subcommands.Command.Name.
+func (*Update) Name() string {
+	return "update"
+}
+
+// Synopsis implements subcommands.Command.Synopsis.
+func (*Update) Synopsis() string {
+	return "update container resource constraints"
+}
+
+// Usage implements subcommands.Command.Usage.
+func (*Update) Usage() string {
+	return `update [flags] <container id> - update container resource constraints
+`
+}
+
+// SetFlags implements subcommands.Command.SetFlags.
+func (u *Update) SetFlags(f *flag.FlagSet) {
+	f.StringVar(&u.resources, "resources", "", `path to the file containing the resources to update or '-' to read from the standard input
+
+The accepted format is as follow (unchanged values can be omitted):
+
+{
+  "memory": {
+    "limit": 0,
+    "reservation": 0,
+    "swap": 0,
+    "checkBeforeUpdate": true
+  },
+  "cpu": {
+    "shares": 0,
+    "quota": 0,
+    "burst": 0,
+    "period": 0,
+    "realtimeRuntime": 0,
+    "realtimePeriod": 0,
+    "cpus": "",
+    "mems": "",
+    "idle": 0
+  },
+  "blockIO": {
+    "weight": 0
+  }
+}
+
+Note: if data is to be read from a file or the standard input, all
+other options are ignored.
+`)
+
+	f.Uint64Var(&u.cpuPeriod, "cpu-period", 0, "CPU CFS period to be used for hardcapping (in usecs). 0 to use system default")
+	f.Int64Var(&u.cpuQuota, "cpu-quota", 0, "CPU CFS hardcap limit (in usecs). Allowed cpu time in a given period")
+	f.Uint64Var(&u.cpuBurst, "cpu-burst", 0, "CPU CFS hardcap burst limit (in usecs). Allowed accumulated cpu time additionally for burst a given period")
+	f.Uint64Var(&u.cpuShares, "cpu-share", 0, "CPU shares (relative weight vs. other containers)")
+	f.Uint64Var(&u.cpuRtPeriod, "cpu-rt-period", 0, "CPU realtime period to be used for hardcapping (in usecs). 0 to use system default")
+	f.Int64Var(&u.cpuRtRuntime, "cpu-rt-runtime", 0, "CPU realtime hardcap limit (in usecs). Allowed cpu time in a given period")
+	f.StringVar(&u.cpusetCpus, "cpuset-cpus", "", "CPU(s) to use")
+	f.StringVar(&u.cpusetMems, "cpuset-mems", "", "Memory node(s) to use")
+	f.Int64Var(&u.cpuIdle, "cpu-idle", 0, "set cgroup SCHED_IDLE or not, 0: default behavior, 1: SCHED_IDLE")
+
+	f.Int64Var(&u.memory, "memory", 0, "Memory limit (in bytes)")
+	f.Int64Var(&u.memoryReservation, "memory-reservation", 0, "Memory reservation or soft_limit (in bytes)")
+	f.Int64Var(&u.memorySwap, "memory-swap", 0, "Total memory usage (memory + swap); set '-1' to enable unlimited swap")
+
+	f.IntVar(&u.blkioWeight, "blkio-weight", 0, "Specifies per cgroup weight, range is from 10 to 1000")
+
+	f.Int64Var(&u.pidsLimit, "pids-limit", 0, "Maximum number of pids allowed in the container")
+
+	f.StringVar(&u.l3CacheSchema, "l3-cache-schema", "", "The string of Intel RDT/CAT L3 cache schema")
+	f.StringVar(&u.memBwSchema, "mem-bw-schema", "", "The string of Intel RDT/MBA memory bandwidth schema")
+}
+
+// Execute implements subcommands.Command.Execute.
+func (u *Update) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcommands.ExitStatus {
+	if f.NArg() != 1 {
+		f.Usage()
+		return subcommands.ExitUsageError
+	}
+
+	id := f.Arg(0)
+	conf := args[0].(*config.Config)
+
+	c, err := container.Load(conf.RootDir, container.FullID{ContainerID: id}, container.LoadOpts{})
+	if err != nil {
+		util.Fatalf("loading container %v", err)
+	}
+
+	r := specs.LinuxResources{
+		Memory: &specs.LinuxMemory{
+			Limit:             i64Ptr(0),
+			Reservation:       i64Ptr(0),
+			Swap:              i64Ptr(0),
+			CheckBeforeUpdate: boolPtr(false),
+		},
+		CPU: &specs.LinuxCPU{
+			Shares:          u64Ptr(0),
+			Quota:           i64Ptr(0),
+			Burst:           u64Ptr(0),
+			Period:          u64Ptr(0),
+			RealtimeRuntime: i64Ptr(0),
+			RealtimePeriod:  u64Ptr(0),
+			Cpus:            "",
+			Mems:            "",
+		},
+		BlockIO: &specs.LinuxBlockIO{
+			Weight: u16Ptr(0),
+		},
+		Pids: &specs.LinuxPids{
+			Limit: 0,
+		},
+	}
+
+	if in := u.resources; in != "" {
+		var (
+			f   *os.File
+			err error
+		)
+		switch in {
+		case "-":
+			f = os.Stdin
+		default:
+			f, err = os.Open(in)
+			if err != nil {
+				return util.Errorf("opening %q: %v", in, err)
+			}
+			defer f.Close()
+		}
+		err = json.NewDecoder(f).Decode(&r)
+		if err != nil {
+			return util.Errorf("decoding %q: %v", in, err)
+		}
+	} else {
+		r.Memory.Limit = i64Ptr(u.memory)
+		r.Memory.Reservation = i64Ptr(u.memoryReservation)
+		r.Memory.Swap = i64Ptr(u.memorySwap)
+
+		r.CPU.Shares = u64Ptr(u.cpuShares)
+		r.CPU.Quota = i64Ptr(u.cpuQuota)
+		r.CPU.Burst = u64Ptr(u.cpuBurst)
+		r.CPU.Period = u64Ptr(u.cpuPeriod)
+		r.CPU.RealtimeRuntime = i64Ptr(u.cpuRtRuntime)
+		r.CPU.RealtimePeriod = u64Ptr(u.cpuRtPeriod)
+		r.CPU.Cpus = u.cpusetCpus
+		r.CPU.Mems = u.cpusetMems
+
+		r.BlockIO.Weight = u16Ptr(uint16(u.blkioWeight))
+
+		r.Pids.Limit = u.pidsLimit
+	}
+
+	if err = c.Set(&r); err != nil {
+		return util.Errorf("setting resources: %v", err)
+	}
+
+	return subcommands.ExitSuccess
+}

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -586,6 +586,40 @@ func Run(conf *config.Config, args Args) (unix.WaitStatus, error) {
 	return 0, nil
 }
 
+// Set sets the resources of a running container as configured.
+func (c *Container) Set(res *specs.LinuxResources) error {
+	log.Debugf("Set resources for container, cid: %s", c.ID)
+	if err := c.requireStatus("set resources for", Created, Running); err != nil {
+		return err
+	}
+
+	if c.Sandbox == nil {
+		return fmt.Errorf("sandbox is not set")
+	}
+
+	var cg cgroup.Cgroup
+	if c.Sandbox.IsRootContainer(c.ID) {
+		cg = c.Sandbox.CgroupJSON.Cgroup
+	} else {
+		cg = c.CompatCgroup.Cgroup
+	}
+
+	if err := cg.Set(res); err != nil {
+		// set back to original
+		if err2 := cg.Set(c.Spec.Linux.Resources); err2 != nil {
+			return fmt.Errorf("setting back cgroup configs failed due to error: %v, your state file and actual configs might be inconsistent.", err2)
+		}
+		return err
+	}
+
+	c.Spec.Linux.Resources = res
+	c.CompatCgroup = cgroup.CgroupJSON{Cgroup: cg}
+
+	c.Saver.lock(BlockAcquire)
+	defer c.Saver.unlock()
+	return c.saveLocked()
+}
+
 // Execute runs the specified command in the container. It returns the PID of
 // the newly created process.
 func (c *Container) Execute(conf *config.Config, args *control.ExecArgs) (int32, error) {


### PR DESCRIPTION
This PR adds the `runsc update` command, which enables updating resource constraints of running containers. It is the runsc equivalent of `runc update`.

Closes #9554.