### PR TITLE
add --noenable_bzlmod to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,3 +40,5 @@ build:x86_64 --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64
 build:aarch64 --crosstool_top=@crosstool//:toolchains
 build:aarch64 --cpu=aarch64
 build:aarch64 --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64
+
+common --noenable_bzlmod


### PR DESCRIPTION
Without this, bazel keeps creating empty MODULE.bazel and MODULE.bazel.lock files. We should switch over to bzlmod, but for now don't pollute repositories.