### PR TITLE
Fix EOFs when reading from an empty canon->noncanon PTY

### DIFF
--- a/pkg/sentry/fsimpl/devpts/line_discipline.go
+++ b/pkg/sentry/fsimpl/devpts/line_discipline.go
@@ -154,7 +154,7 @@ func (l *lineDiscipline) setTermios(task *kernel.Task, args arch.SyscallArgument
 	if oldCanonEnabled && !l.termios.LEnabled(linux.ICANON) {
 		l.inQueue.mu.Lock()
 		l.inQueue.pushWaitBufLocked(l)
-		l.inQueue.readable = true
+		l.inQueue.readable = len(l.inQueue.readBuf) > 0
 		l.inQueue.mu.Unlock()
 		l.termiosMu.Unlock()
 		l.replicaWaiter.Notify(waiter.ReadableEvents)


### PR DESCRIPTION
When switching from canonical to non-canonical mode, only mark inQueue as readable if there is input to be read. This fixes a bug where a program running in a PTY in canonical mode switches to non-canonical mode with nothing in the canonical read buffer, and then proceeds to read from the standard input, which erroneously results in an EOF error.

Closes #9953 