### PR TITLE
Do not return ErrWouldBlock when writing nothing to PTY output queue

### DIFF
--- a/pkg/sentry/fsimpl/devpts/line_discipline.go
+++ b/pkg/sentry/fsimpl/devpts/line_discipline.go
@@ -271,11 +271,8 @@ func (l *lineDiscipline) outputQueueWrite(ctx context.Context, src usermem.IOSeq
 	if err != nil {
 		return 0, err
 	}
-	if n > 0 {
-		l.masterWaiter.Notify(waiter.ReadableEvents)
-		return n, nil
-	}
-	return 0, linuxerr.ErrWouldBlock
+	l.masterWaiter.Notify(waiter.ReadableEvents)
+	return n, nil
 }
 
 // replicaOpen is called when a replica file descriptor is opened.

--- a/test/syscalls/linux/pty.cc
+++ b/test/syscalls/linux/pty.cc
@@ -1384,6 +1384,25 @@ TEST_F(PtyTest, PartialBadBuffer) {
   EXPECT_THAT(munmap(addr, 2 * kPageSize), SyscallSucceeds()) << addr;
 }
 
+// Test that writing nothing to the PTY replica's output queue does not return an error.
+TEST_F(PtyTest, ReplicaWriteNothingCanonical) {
+  constexpr char kInput[] = "";
+  EXPECT_THAT(WriteFd(replica_.get(), kInput, strlen(kInput)),
+              SyscallSucceedsWithValue(strlen(kInput)));
+
+  ExpectFinished(master_);
+}
+
+TEST_F(PtyTest, ReplicaWriteNothingNonCanonical) {
+  DisableCanonical();
+
+  constexpr char kInput[] = "";
+  EXPECT_THAT(WriteFd(replica_.get(), kInput, strlen(kInput)),
+              SyscallSucceedsWithValue(strlen(kInput)));
+
+  ExpectFinished(master_);
+}
+
 TEST_F(PtyTest, SimpleEcho) {
   constexpr char kInput[] = "Mr. Eko";
   EXPECT_THAT(WriteFd(master_.get(), kInput, strlen(kInput)),


### PR DESCRIPTION
Fixes #9955

Unfortunately I'm not familiar with the codebase or Linux terminals so I don't know if this fix is correct, but it does fix the problems I'm seeing in #9955.

The `queue.write` function already returns `linux.ErrWouldBlock` if the wait buffer is out of room, I think.