### PR TITLE
runsc:gofer: don't mount a new proc instance

### DIFF
--- a/runsc/boot/loader_test.go
+++ b/runsc/boot/loader_test.go
@@ -42,7 +42,7 @@ import (
 func init() {
 	log.SetLevel(log.Debug)
 	rand.Seed(time.Now().UnixNano())
-	if err := fsgofer.OpenProcSelfFD(); err != nil {
+	if err := fsgofer.OpenProcSelfFD("/proc/self/fd"); err != nil {
 		panic(err)
 	}
 }

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -383,24 +383,29 @@ func (g *Gofer) setupRootFS(spec *specs.Spec, conf *config.Config) error {
 		// We need a directory to construct a new root and we know that
 		// runsc can't start without /proc, so we can use it for this.
 		flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
-		if err := specutils.SafeMount("runsc-root", "/proc", "tmpfs", flags, "", procPath); err != nil {
+		if err := specutils.SafeMount("runsc-root", "/proc/fs", "tmpfs", flags, "", procPath); err != nil {
 			util.Fatalf("error mounting tmpfs: %v", err)
 		}
-
+		if err := unix.Mount("", "/proc/fs", "", unix.MS_UNBINDABLE, ""); err != nil {
+			util.Fatalf("error setting MS_UNBINDABLE")
+		}
 		// Prepare tree structure for pivot_root(2).
-		if err := os.Mkdir("/proc/proc", 0755); err != nil {
-			util.Fatalf("error creating /proc/proc: %v", err)
+		if err := os.Mkdir("/proc/fs/proc", 0755); err != nil {
+			util.Fatalf("error creating /proc/fs/proc: %v", err)
 		}
-		if err := os.Mkdir("/proc/root", 0755); err != nil {
-			util.Fatalf("error creating /proc/root: %v", err)
+		if err := os.Mkdir("/proc/fs/root", 0755); err != nil {
+			util.Fatalf("error creating /proc/fs/root: %v", err)
 		}
-		if err := os.Mkdir("/proc/etc", 0755); err != nil {
-			util.Fatalf("error creating /proc/etc: %v", err)
+		if err := os.Mkdir("/proc/fs/etc", 0755); err != nil {
+			util.Fatalf("error creating /proc/fs/etc: %v", err)
 		}
 		// This cannot use SafeMount because there's no available procfs. But we
-		// know that /proc is an empty tmpfs mount, so this is safe.
-		if err := unix.Mount("runsc-proc", "/proc/proc", "proc", flags|unix.MS_RDONLY, ""); err != nil {
-			util.Fatalf("error mounting proc: %v", err)
+		// know that /proc/fs is an empty tmpfs mount, so this is safe.
+		if err := unix.Mount("/proc", "/proc/fs/proc", "", flags|unix.MS_RDONLY|unix.MS_BIND|unix.MS_REC, ""); err != nil {
+			util.Fatalf("error mounting /proc/fs/proc: %v", err)
+		}
+		if err := unix.Mount("/proc/fs", "/proc", "", unix.MS_MOVE, ""); err != nil {
+			util.Fatalf("error mounting /proc: %v", err)
 		}
 		// self/fd is bind-mounted, so that the FD return by
 		// OpenProcSelfFD() does not allow escapes with walking ".." .

--- a/runsc/fsgofer/lisafs.go
+++ b/runsc/fsgofer/lisafs.go
@@ -69,8 +69,8 @@ var procSelfFD *rwfd.FD
 
 // OpenProcSelfFD opens the /proc/self/fd directory, which will be used to
 // reopen file descriptors.
-func OpenProcSelfFD() error {
-	d, err := unix.Open("/proc/self/fd", unix.O_RDONLY|unix.O_DIRECTORY, 0)
+func OpenProcSelfFD(path string) error {
+	d, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY, 0)
 	if err != nil {
 		return fmt.Errorf("error opening /proc/self/fd: %v", err)
 	}

--- a/runsc/fsgofer/lisafs_test.go
+++ b/runsc/fsgofer/lisafs_test.go
@@ -29,7 +29,7 @@ import (
 
 func init() {
 	log.SetLevel(log.Debug)
-	if err := fsgofer.OpenProcSelfFD(); err != nil {
+	if err := fsgofer.OpenProcSelfFD("/proc/self/fd"); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
If the existing proc instance has over-mounted areas, it can be
impossible to mount a new /proc instance (look at SB_I_USERNS_VISIBLE
for more details).
    
Actually, runsc-gofer needs /proc just to open /proc/self/fd and to read
a few generic files, so it doesn't need a proc instance of the target
pid namespace.
    
Fixes #8205

