### PR TITLE
Cleanup: remove unnecessary `runtime.fastrand` imports and use `math/rand` for seeding

### DIFF
--- a/pkg/sentry/vfs/mount_unsafe.go
+++ b/pkg/sentry/vfs/mount_unsafe.go
@@ -17,6 +17,7 @@ package vfs
 import (
 	"fmt"
 	"math/bits"
+	"math/rand"
 	"sync/atomic"
 	"unsafe"
 
@@ -38,7 +39,7 @@ type mountKey struct {
 
 var (
 	mountKeyHasher = sync.MapKeyHasher(map[mountKey]struct{}(nil))
-	mountKeySeed   = sync.RandUintptr()
+	mountKeySeed   = uintptr(rand.Uint64())
 )
 
 func (k *mountKey) hash() uintptr {

--- a/pkg/sync/atomicptrmap/generic_atomicptrmap_unsafe.go
+++ b/pkg/sync/atomicptrmap/generic_atomicptrmap_unsafe.go
@@ -17,6 +17,7 @@
 package atomicptrmap
 
 import (
+	"math/rand"
 	"sync/atomic"
 	"unsafe"
 
@@ -56,7 +57,7 @@ type defaultHasher struct {
 // Init initializes the Hasher.
 func (h *defaultHasher) Init() {
 	h.fn = sync.MapKeyHasher(map[Key]*Value(nil))
-	h.seed = sync.RandUintptr()
+	h.seed = uintptr(rand.Uint64())
 }
 
 // Hash returns the hash value for the given Key.

--- a/pkg/sync/runtime_unsafe.go
+++ b/pkg/sync/runtime_unsafe.go
@@ -73,27 +73,6 @@ func Goready(gp uintptr, traceskip int, wakep bool) {
 	}
 }
 
-// Rand32 returns a non-cryptographically-secure random uint32.
-func Rand32() uint32 {
-	return fastrand()
-}
-
-// Rand64 returns a non-cryptographically-secure random uint64.
-func Rand64() uint64 {
-	return uint64(fastrand())<<32 | uint64(fastrand())
-}
-
-//go:linkname fastrand runtime.fastrand
-func fastrand() uint32
-
-// RandUintptr returns a non-cryptographically-secure random uintptr.
-func RandUintptr() uintptr {
-	if unsafe.Sizeof(uintptr(0)) == 4 {
-		return uintptr(Rand32())
-	}
-	return uintptr(Rand64())
-}
-
 // MapKeyHasher returns a hash function for pointers of m's key type.
 //
 // Preconditions: m must be a map.


### PR DESCRIPTION
Remove unnecessary `runtime.fastrand` imports and use `math/rand` for seeding.