### PR TITLE
doc: correct the supported architecture in the Installation guide

### DIFF
--- a/g3doc/user_guide/install.md
+++ b/g3doc/user_guide/install.md
@@ -2,7 +2,7 @@
 
 [TOC]
 
-> Note: gVisor supports only x86\_64 and requires Linux 4.14.77+
+> Note: gVisor supports x86\_64 and ARM64, and requires Linux 4.14.77+
 > ([older Linux](./networking.md#gso)).
 
 ## Install latest release {#install-latest}


### PR DESCRIPTION
gVisor supports x86\_64 and ARM64 for now, but [Installation document in User Guide](https://gvisor.dev/docs/user_guide/install/) still says the x86\_64 is supported only. This PR is posted to correct it.