### PR TITLE
systrap: use seccomp notifications to communicate with syscall threads

### DIFF
--- a/pkg/abi/linux/seccomp.go
+++ b/pkg/abi/linux/seccomp.go
@@ -25,9 +25,20 @@ const (
 	SECCOMP_RET_ACTION      = 0x7fff0000
 	SECCOMP_RET_DATA        = 0x0000ffff
 
-	SECCOMP_SET_MODE_FILTER   = 1
-	SECCOMP_FILTER_FLAG_TSYNC = 1
-	SECCOMP_GET_ACTION_AVAIL  = 2
+	SECCOMP_SET_MODE_FILTER  = 1
+	SECCOMP_GET_ACTION_AVAIL = 2
+	SECCOMP_GET_NOTIF_SIZES  = 3
+
+	SECCOMP_FILTER_FLAG_TSYNC        = 1
+	SECCOMP_FILTER_FLAG_NEW_LISTENER = 1 << 3
+
+	SECCOMP_USER_NOTIF_FLAG_CONTINUE = 1
+
+	SECCOMP_IOCTL_NOTIF_RECV      = 0xc0502100
+	SECCOMP_IOCTL_NOTIF_SEND      = 0xc0182101
+	SECCOMP_IOCTL_NOTIF_SET_FLAGS = 0x40082104
+
+	SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP = 1
 )
 
 // BPFAction is an action for a BPF filter.
@@ -40,6 +51,7 @@ const (
 	SECCOMP_RET_TRAP         BPFAction = 0x00030000
 	SECCOMP_RET_ERRNO        BPFAction = 0x00050000
 	SECCOMP_RET_TRACE        BPFAction = 0x7ff00000
+	SECCOMP_RET_USER_NOTIF   BPFAction = 0x7fc00000
 	SECCOMP_RET_ALLOW        BPFAction = 0x7fff0000
 )
 
@@ -65,6 +77,8 @@ func (a BPFAction) String() string {
 		return fmt.Sprintf("trace (data=%#x)", data)
 	case SECCOMP_RET_ALLOW:
 		return "allow"
+	case SECCOMP_RET_USER_NOTIF:
+		return "unotify"
 	}
 	return fmt.Sprintf("invalid action: %#x", a)
 }
@@ -111,6 +125,35 @@ type SeccompData struct {
 
 	// Args contains the first 6 system call arguments.
 	Args [6]uint64
+}
+
+// SeccompNotifResp is equivalent to struct seccomp_notif_resp.
+//
+// +marshal
+type SeccompNotifResp struct {
+	ID    uint64
+	Val   int64
+	Error int32
+	Flags uint32
+}
+
+// SeccompNotifSizes is equivalent to struct seccomp_notif_sizes.
+//
+// +marshal
+type SeccompNotifSizes struct {
+	Notif      uint16
+	Notif_resp uint16
+	Data       uint16
+}
+
+// SeccompNotif is equivalent to struct seccomp_notif.
+//
+// +marshal
+type SeccompNotif struct {
+	ID    uint64
+	Pid   int32
+	Flags uint32
+	Data  SeccompData
 }
 
 // String returns a human-friendly representation of this `SeccompData`.

--- a/pkg/sentry/platform/systrap/filters.go
+++ b/pkg/sentry/platform/systrap/filters.go
@@ -94,6 +94,21 @@ func (systrapSeccomp) SyscallFilters(vars precompiledseccomp.Values) seccomp.Sys
 		},
 		unix.SYS_TGKILL: seccomp.MatchAll{},
 		unix.SYS_WAIT4:  seccomp.MatchAll{},
+		unix.SYS_IOCTL: seccomp.Or{
+			seccomp.PerArg{
+				seccomp.AnyValue{},
+				seccomp.EqualTo(linux.SECCOMP_IOCTL_NOTIF_RECV),
+			},
+			seccomp.PerArg{
+				seccomp.AnyValue{},
+				seccomp.EqualTo(linux.SECCOMP_IOCTL_NOTIF_SEND),
+			},
+			seccomp.PerArg{
+				seccomp.AnyValue{},
+				seccomp.EqualTo(linux.SECCOMP_IOCTL_NOTIF_SET_FLAGS),
+				seccomp.EqualTo(linux.SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP),
+			},
+		},
 		unix.SYS_WAITID: seccomp.PerArg{
 			seccomp.EqualTo(unix.P_PID),
 			seccomp.AnyValue{},

--- a/pkg/sentry/platform/systrap/stub_amd64.s
+++ b/pkg/sentry/platform/systrap/stub_amd64.s
@@ -22,6 +22,7 @@
 #define SIGKILL		 9   // +checkconst unix SIGKILL
 #define SIGSTOP		 19  // +checkconst unix SIGSTOP
 #define SYS_PRCTL	 157 // +checkconst unix SYS_PRCTL
+#define SYS_EXIT_GROUP   231 // +checkconst unix SYS_SELECT
 #define PR_SET_PDEATHSIG 1   // +checkconst unix PR_SET_PDEATHSIG
 
 #define SYS_FUTEX	 202 // +checkconst unix SYS_FUTEX
@@ -30,6 +31,7 @@
 
 #define NEW_STUB	 1 // +checkconst . _NEW_STUB
 #define RUN_SYSCALL_LOOP 5 // +checkconst . _RUN_SYSCALL_LOOP
+#define RUN_SECCOMP_LOOP 6 // +checkconst . _RUN_SECCOMP_LOOP
 
 // syscallSentryMessage offsets.
 #define SENTRY_MESSAGE_STATE 0  // +checkoffset . syscallSentryMessage.state
@@ -103,6 +105,9 @@ begin:
         // thread.
 	CMPQ BX, $RUN_SYSCALL_LOOP
 	JE syscall_loop
+
+	CMPQ BX, $RUN_SECCOMP_LOOP
+	JE seccomp_loop
 
 	// Notify the Sentry that syscall exited.
 done:
@@ -195,6 +200,35 @@ wake_up_sentry:
 
 	INCL R13
 	JMP syscall_loop
+seccomp_loop:
+	MOVQ $SYS_EXIT_GROUP, AX
+	SYSCALL
+
+	// ret = syscall(sysno, args...)
+	MOVQ SENTRY_MESSAGE_SYSNO(R12), AX
+	MOVQ SENTRY_MESSAGE_ARG0(R12), DI
+	MOVQ SENTRY_MESSAGE_ARG1(R12), SI
+	MOVQ SENTRY_MESSAGE_ARG2(R12), DX
+	MOVQ SENTRY_MESSAGE_ARG3(R12), R10
+	MOVQ SENTRY_MESSAGE_ARG4(R12), R8
+	MOVQ SENTRY_MESSAGE_ARG5(R12), R9
+	SYSCALL
+
+	// stubMessage->ret = ret
+	MOVQ AX, (STUB_MESSAGE_OFFSET + STUB_MESSAGE_RET)(R12)
+
+	// for {
+	//   if futex(sentryMessage->state, FUTEX_WAKE, 1) == 1 {
+	//     break;
+	//   }
+	// }
+	MOVQ R12, DI
+	MOVQ $FUTEX_WAKE, SI
+	MOVQ $1, DX
+	MOVQ $0, R10
+	MOVQ $0, R8
+	MOVQ $0, R9
+	JMP seccomp_loop
 
 // func addrOfInitStubProcess() uintptr
 TEXT ·addrOfInitStubProcess(SB), $0-8

--- a/pkg/sentry/platform/systrap/stub_arm64.s
+++ b/pkg/sentry/platform/systrap/stub_arm64.s
@@ -22,6 +22,7 @@
 #define SIGKILL		 9   // +checkconst unix SIGKILL
 #define SIGSTOP		 19  // +checkconst unix SIGSTOP
 #define SYS_PRCTL	 167 // +checkconst unix SYS_PRCTL
+#define SYS_EXIT_GROUP   94  // +checkconst unix SYS_EXIT_GROUP
 #define PR_SET_PDEATHSIG 1   // +checkconst unix PR_SET_PDEATHSIG
 
 #define SYS_FUTEX	 98 // +checkconst unix SYS_FUTEX
@@ -189,6 +190,22 @@ wake_up_sentry:
 
 	ADDW $1, R13, R13
 	JMP syscall_loop
+seccomp_loop:
+	MOVD $SYS_EXIT_GROUP, R8
+	SVC
+
+	MOVD SENTRY_MESSAGE_SYSNO(R12), R8
+	MOVD SENTRY_MESSAGE_ARG0(R12), R0
+	MOVD SENTRY_MESSAGE_ARG1(R12), R1
+	MOVD SENTRY_MESSAGE_ARG2(R12), R2
+	MOVD SENTRY_MESSAGE_ARG3(R12), R3
+	MOVD SENTRY_MESSAGE_ARG4(R12), R4
+	MOVD SENTRY_MESSAGE_ARG5(R12), R5
+	SVC
+
+	// stubMessage->ret = ret
+	MOVD R0, (STUB_MESSAGE_OFFSET + STUB_MESSAGE_RET)(R12)
+	JMP seccomp_loop
 
 // func addrOfInitStubProcess() uintptr
 TEXT ·addrOfInitStubProcess(SB), $0-8

--- a/pkg/sentry/platform/systrap/stub_defs.go
+++ b/pkg/sentry/platform/systrap/stub_defs.go
@@ -25,3 +25,4 @@ const _NEW_STUB = 1
 
 // _NEW_STUB is the value of the BX register when the syscall loop is executed.
 const _RUN_SYSCALL_LOOP = 5
+const _RUN_SECCOMP_LOOP = 6

--- a/pkg/sentry/platform/systrap/subprocess_linux.go
+++ b/pkg/sentry/platform/systrap/subprocess_linux.go
@@ -120,11 +120,19 @@ func attachedThread(flags uintptr, defaultAction linux.BPFAction) (*thread, erro
 					seccomp.AnyValue{},
 					seccomp.EqualTo(unix.SIGSTOP),
 				},
-				unix.SYS_GETTID: seccomp.MatchAll{},
-				seccomp.SYS_SECCOMP: seccomp.PerArg{
-					seccomp.EqualTo(linux.SECCOMP_SET_MODE_FILTER),
-					seccomp.EqualTo(0),
-					seccomp.AnyValue{},
+				unix.SYS_GETTID:     seccomp.MatchAll{},
+				unix.SYS_EXIT_GROUP: seccomp.MatchAll{},
+				seccomp.SYS_SECCOMP: seccomp.Or{
+					seccomp.PerArg{
+						seccomp.EqualTo(linux.SECCOMP_SET_MODE_FILTER),
+						seccomp.EqualTo(0),
+						seccomp.AnyValue{},
+					},
+					seccomp.PerArg{
+						seccomp.EqualTo(linux.SECCOMP_SET_MODE_FILTER),
+						seccomp.EqualTo(linux.SECCOMP_FILTER_FLAG_NEW_LISTENER),
+						seccomp.AnyValue{},
+					},
 				},
 			}),
 			Action: linux.SECCOMP_RET_ALLOW,

--- a/pkg/sentry/platform/systrap/syscall_thread.go
+++ b/pkg/sentry/platform/systrap/syscall_thread.go
@@ -16,10 +16,13 @@ package systrap
 
 import (
 	"fmt"
+	"os"
 	"sync/atomic"
 
 	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/seccomp"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
@@ -70,9 +73,12 @@ type syscallThread struct {
 	// stubMessage is the second page of the shared message that can be
 	// modified by the stub thread.
 	stubMessage *syscallStubMessage
+
+	seccompNotify     *os.File
+	seccompNotifyResp linux.SeccompNotifResp
 }
 
-func (t *syscallThread) init() error {
+func (t *syscallThread) init(seccompNotify bool) error {
 	// Allocate a new shared memory message.
 	opts := pgalloc.AllocOpts{
 		Kind: usage.System,
@@ -89,6 +95,10 @@ func (t *syscallThread) init() error {
 	if err != nil {
 		t.destroy()
 		return err
+	}
+
+	if seccompNotify {
+		t.seccompNotify = t.installSeccompNotify()
 	}
 
 	// Map the stack into the sentry.
@@ -130,6 +140,21 @@ func (t *syscallThread) destroy() {
 	}
 	t.subproc.memoryFile.DecRef(t.stackRange)
 	t.subproc.sysmsgStackPool.Put(t.thread.sysmsgStackID)
+}
+
+func (t *syscallThread) installSeccompNotify() *os.File {
+	fd, err := t.thread.syscallIgnoreInterrupt(&t.thread.initRegs, seccomp.SYS_SECCOMP,
+		arch.SyscallArgument{Value: uintptr(linux.SECCOMP_SET_MODE_FILTER)},
+		arch.SyscallArgument{Value: uintptr(linux.SECCOMP_FILTER_FLAG_NEW_LISTENER)},
+		arch.SyscallArgument{Value: stubSyscallRules})
+	if err != nil {
+		panic(fmt.Sprintf("seccomp failed: %v", err))
+	}
+	_, _, errno := unix.RawSyscall(unix.SYS_IOCTL, fd, linux.SECCOMP_IOCTL_NOTIF_SET_FLAGS, linux.SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP)
+	if errno != 0 {
+		t.thread.Debugf("failed to set SECCOMP_USER_NOTIF_FD_SYNC_WAKE_UP")
+	}
+	return os.NewFile(fd, "seccomp_notify")
 }
 
 // mapMessageIntoStub maps the syscall message into the stub process address space.
@@ -182,15 +207,37 @@ func (t *syscallThread) syscall(sysno uintptr, args ...arch.SyscallArgument) (ui
 		}
 	}
 
-	// Notify the syscall thread about a new syscall request.
-	atomic.AddUint32(&sentryMsg.state, 1)
-	futexWakeUint32(&sentryMsg.state)
+	if t.seccompNotify != nil {
+		for {
+			errno := t.sendReq()
+			if errno == 0 {
+				break
+			}
+			if errno == unix.EINTR && t.subproc.alive() {
+				continue
+			}
+			t.thread.kill()
+			t.thread.Warningf("failed sending request to syscall thread: %s", errno)
+			return 0, errDeadSubprocess
+		}
+		errno := t.waitResp()
+		if errno != 0 {
+			t.thread.kill()
+			t.thread.Warningf("failed getting response from syscall thread : %s", errno)
+			return 0, errDeadSubprocess
+		}
+	} else {
 
-	// Wait for reply.
-	//
-	// futex waits for sentryMsg.state that isn't changed, so it will
-	// returns only only when the other side will call FUTEX_WAKE.
-	futexWaitWake(&sentryMsg.state, atomic.LoadUint32(&sentryMsg.state))
+		// Notify the syscall thread about a new syscall request.
+		atomic.AddUint32(&sentryMsg.state, 1)
+		futexWakeUint32(&sentryMsg.state)
+
+		// Wait for reply.
+		//
+		// futex waits for sentryMsg.state that isn't changed, so it will
+		// returns only only when the other side will call FUTEX_WAKE.
+		futexWaitWake(&sentryMsg.state, atomic.LoadUint32(&sentryMsg.state))
+	}
 
 	return uintptr(stubMsg.ret), nil
 }

--- a/pkg/sentry/platform/systrap/syscall_thread_amd64.go
+++ b/pkg/sentry/platform/systrap/syscall_thread_amd64.go
@@ -36,7 +36,11 @@ func (t *syscallThread) detach() {
 	regs.Rsp = 0
 	regs.R12 = uint64(t.stubAddr)
 	regs.R13 = uint64(t.sentryMessage.state + 1)
-	regs.Rbx = _RUN_SYSCALL_LOOP
+	if t.seccompNotify != nil {
+		regs.Rbx = _RUN_SECCOMP_LOOP
+	} else {
+		regs.Rbx = _RUN_SYSCALL_LOOP
+	}
 	// Skip the syscall instruction.
 	regs.Rip += arch.SyscallWidth
 	if err := p.setRegs(&regs); err != nil {
@@ -47,4 +51,8 @@ func (t *syscallThread) detach() {
 		panic(fmt.Sprintf("tkill failed: %v", e))
 	}
 	runtime.UnlockOSThread()
+
+	if t.seccompNotify != nil {
+		t.waitResp()
+	}
 }

--- a/pkg/sentry/platform/systrap/syscall_thread_arm64.go
+++ b/pkg/sentry/platform/systrap/syscall_thread_arm64.go
@@ -36,7 +36,11 @@ func (t *syscallThread) detach() {
 	regs.Sp = 0
 	regs.Regs[12] = uint64(t.stubAddr)
 	regs.Regs[13] = uint64(t.sentryMessage.state + 1)
-	regs.Regs[9] = _RUN_SYSCALL_LOOP
+	if t.seccompNotify != nil {
+		regs.Regs[9] = _RUN_SECCOMP_LOOP
+	} else {
+		regs.Regs[9] = _RUN_SYSCALL_LOOP
+	}
 	// Skip the syscall instruction.
 	regs.Pc += arch.SyscallWidth
 	if err := p.setRegs(&regs); err != nil {
@@ -47,4 +51,8 @@ func (t *syscallThread) detach() {
 		panic(fmt.Sprintf("tkill failed: %v", e))
 	}
 	runtime.UnlockOSThread()
+
+	if t.seccompNotify != nil {
+		t.waitResp()
+	}
 }

--- a/pkg/sentry/platform/systrap/systrap.go
+++ b/pkg/sentry/platform/systrap/systrap.go
@@ -86,8 +86,10 @@ var (
 	stubContextRegion    uintptr
 	stubContextRegionLen uintptr
 	// The memory blob with precompiled seccomp rules.
-	stubSysmsgRules    uintptr
-	stubSysmsgRulesLen uintptr
+	stubSysmsgRules     uintptr
+	stubSysmsgRulesLen  uintptr
+	stubSyscallRules    uintptr
+	stubSyscallRulesLen uintptr
 
 	stubSpinningThreadQueueAddr uintptr
 	stubSpinningThreadQueueSize uintptr
@@ -329,7 +331,7 @@ func New() (*Systrap, error) {
 
 		// Create the source process for the global pool. This must be
 		// done before initializing any other processes.
-		source, err := newSubprocess(createStub, mf)
+		source, err := newSubprocess(createStub, mf, false)
 		if err != nil {
 			// Should never happen.
 			panic("unable to initialize systrap source: " + err.Error())
@@ -374,7 +376,7 @@ func (*Systrap) MaxUserAddress() hostarch.Addr {
 
 // NewAddressSpace returns a new subprocess.
 func (p *Systrap) NewAddressSpace(any) (platform.AddressSpace, <-chan struct{}, error) {
-	as, err := newSubprocess(globalPool.source.createStub, p.memoryFile)
+	as, err := newSubprocess(globalPool.source.createStub, p.memoryFile, true)
 	return as, nil, err
 }
 


### PR DESCRIPTION
The new synchronous mode of seccomp-unotify (v6.6-rc1~205^2~6) reduces overhead of context switches.