### PR TITLE
runsc: boot: use a more reliable method to check /proc

### DIFF
--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -585,8 +585,10 @@ func umountProc(syncFD int) {
 	if !waitStatus.Exited() || waitStatus.ExitStatus() != 0 {
 		util.Fatalf("the proc umounter process failed: %v", waitStatus)
 	}
-	if err := unix.Access("/proc/self", unix.F_OK); err != unix.ENOENT {
-		util.Fatalf("/proc is still accessible")
+
+	entries, err := os.ReadDir("/proc");
+	if len(entries) != 0 || (err != nil && !os.IsNotExist(err)) {
+		util.Fatalf("/proc is still accessible, error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Currently we check whether /proc is umounted by 'unix.Access'. If we run runsc as setuid binary using unprivileged user(in our use cases) we may get EPERM even the /proc is umounted as Linux uses uid to perform the check. In this case we get the error '/proc is still accessible'.

Notice this error can only occur combined with following two conditions:
1. we uses --network host. This is because in non-host mode, the runsc will create a new userns and do uid identity mapping, the child process will be run as 0:0(uid:gid) so the check will be ok
2. the umask setting should be set to mask the all perm of others such as 0027. This is because if we don't mask the others's read perm, the check will also be ok as the unprivileged uid can also read /proc/ file.

This patch uses a more reliable method to do check /proc check.