### PR TITLE
netstack: add support for user cookie socket option

### DIFF
--- a/pkg/tcpip/stack/packet_buffer.go
+++ b/pkg/tcpip/stack/packet_buffer.go
@@ -161,6 +161,10 @@ type PacketBuffer struct {
 	// NetworkPacketInfo holds an incoming packet's network-layer information.
 	NetworkPacketInfo NetworkPacketInfo
 
+	// userCookie is used to store a user supplied cookie value associated with
+	// the packet.
+	UserCookie uint32
+
 	tuple *tuple
 
 	// onRelease is a function to be run when the packet buffer is no longer
@@ -389,6 +393,7 @@ func (pk *PacketBuffer) Clone() *PacketBuffer {
 	newPk.NICID = pk.NICID
 	newPk.RXChecksumValidated = pk.RXChecksumValidated
 	newPk.NetworkPacketInfo = pk.NetworkPacketInfo
+	newPk.UserCookie = pk.UserCookie
 	newPk.tuple = pk.tuple
 	newPk.InitRefs()
 	return newPk

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -1412,6 +1412,14 @@ const (
 	TCPTimeWaitReuseLoopbackOnly
 )
 
+// TCPUserCookieOption is used by SetSockOpt/GetSockOpt to set/get a user
+// specified cookie value on a TCP endpoint.
+type TCPUserCookieOption uint32
+
+func (*TCPUserCookieOption) isGettableSocketOption() {}
+
+func (*TCPUserCookieOption) isSettableSocketOption() {}
+
 // LingerOption is used by SetSockOpt/GetSockOpt to set/get the
 // duration for which a socket lingers before returning from Close.
 //

--- a/pkg/tcpip/transport/tcp/accept.go
+++ b/pkg/tcpip/transport/tcp/accept.go
@@ -202,6 +202,7 @@ func (l *listenContext) createConnectingEndpoint(s *segment, rcvdSynOpts header.
 	n.boundNICID = s.pkt.NICID
 	n.route = route
 	n.effectiveNetProtos = []tcpip.NetworkProtocolNumber{s.pkt.NetworkProtocolNumber}
+	n.userCookie = s.pkt.UserCookie
 	n.ops.SetReceiveBufferSize(int64(l.rcvWnd), false /* notify */)
 	n.amss = calculateAdvertisedMSS(n.userMSS, n.route)
 	n.setEndpointState(StateConnecting)


### PR DESCRIPTION
Basically mirror the behavior of `SO_USER_COOKIE` from the BSDs. This is added so that endpoints can be marked with user supplied metadata.