### PR TITLE
netstack: add support for connection marking

### DIFF
--- a/pkg/tcpip/stack/packet_buffer.go
+++ b/pkg/tcpip/stack/packet_buffer.go
@@ -161,6 +161,10 @@ type PacketBuffer struct {
 	// NetworkPacketInfo holds an incoming packet's network-layer information.
 	NetworkPacketInfo NetworkPacketInfo
 
+	// ConnMark is an optional packet mark that can be used to associate a
+	// packet with a connection.
+	ConnMark uint32
+
 	tuple *tuple
 
 	// onRelease is a function to be run when the packet buffer is no longer
@@ -389,6 +393,7 @@ func (pk *PacketBuffer) Clone() *PacketBuffer {
 	newPk.NICID = pk.NICID
 	newPk.RXChecksumValidated = pk.RXChecksumValidated
 	newPk.NetworkPacketInfo = pk.NetworkPacketInfo
+	newPk.ConnMark = pk.ConnMark
 	newPk.tuple = pk.tuple
 	newPk.InitRefs()
 	return newPk

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -1412,6 +1412,14 @@ const (
 	TCPTimeWaitReuseLoopbackOnly
 )
 
+// ConnMarkOption is used by SetSockOpt/GetSockOpt to set/get the
+// connection mark for each packet sent through this socket.
+type ConnMarkOption uint32
+
+func (*ConnMarkOption) isGettableSocketOption() {}
+
+func (*ConnMarkOption) isSettableSocketOption() {}
+
 // LingerOption is used by SetSockOpt/GetSockOpt to set/get the
 // duration for which a socket lingers before returning from Close.
 //

--- a/pkg/tcpip/transport/tcp/accept.go
+++ b/pkg/tcpip/transport/tcp/accept.go
@@ -202,6 +202,7 @@ func (l *listenContext) createConnectingEndpoint(s *segment, rcvdSynOpts header.
 	n.boundNICID = s.pkt.NICID
 	n.route = route
 	n.effectiveNetProtos = []tcpip.NetworkProtocolNumber{s.pkt.NetworkProtocolNumber}
+	n.connMark = s.pkt.ConnMark
 	n.ops.SetReceiveBufferSize(int64(l.rcvWnd), false /* notify */)
 	n.amss = calculateAdvertisedMSS(n.userMSS, n.route)
 	n.setEndpointState(StateConnecting)

--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -967,6 +967,10 @@ func (e *Endpoint) makeOptions(sackBlocks []header.SACKBlock) []byte {
 func (e *Endpoint) sendEmptyRaw(flags header.TCPFlags, seq, ack seqnum.Value, rcvWnd seqnum.Size) tcpip.Error {
 	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{})
 	defer pkt.DecRef()
+
+	// Pass throught the connection mark (if set).
+	pkt.ConnMark = e.connMark
+
 	return e.sendRaw(pkt, flags, seq, ack, rcvWnd)
 }
 

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -1716,6 +1716,9 @@ func (s *sender) sendSegmentFromPacketBuffer(pkt *stack.PacketBuffer, flags head
 	pkt = pkt.Clone()
 	defer pkt.DecRef()
 
+	// Pass throught the connection mark (if set).
+	pkt.ConnMark = s.ep.connMark
+
 	return s.ep.sendRaw(pkt, flags, seq, rcvNxt, rcvWnd)
 }
 


### PR DESCRIPTION
Add support for netfilter style connmarks so that packets can be associated with connections, and vice versa.