### PR TITLE
add strace dbg processing for 'faccessat2'

### DIFF
--- a/pkg/sentry/strace/linux64_amd64.go
+++ b/pkg/sentry/strace/linux64_amd64.go
@@ -373,6 +373,7 @@ var linuxAMD64 = SyscallMap{
 	434: makeSyscallInfo("pidfd_open", Hex, Hex),
 	435: makeSyscallInfo("clone3", Hex, Hex),
 	436: makeSyscallInfo("close_range", FD, FD, CloseRangeFlags),
+	439: makeSyscallInfo("faccessat2", FD, Path, Oct, Hex),
 	441: makeSyscallInfo("epoll_pwait2", FD, EpollEvents, Hex, Timespec, SigSet),
 }
 

--- a/pkg/sentry/strace/linux64_arm64.go
+++ b/pkg/sentry/strace/linux64_arm64.go
@@ -314,6 +314,7 @@ var linuxARM64 = SyscallMap{
 	434: makeSyscallInfo("pidfd_open", Hex, Hex),
 	435: makeSyscallInfo("clone3", Hex, Hex),
 	436: makeSyscallInfo("close_range", FD, FD, CloseRangeFlags),
+	439: makeSyscallInfo("faccessat2", FD, Path, Oct, Hex),
 	441: makeSyscallInfo("epoll_pwait2", FD, EpollEvents, Hex, Timespec, SigSet),
 }
 


### PR DESCRIPTION
Trivial change that would have made debugging `nvidia-smi topo -m` problems easier. 

**Status quo**

```
0x7ec93d642705 "0-4\n", 0xa) = 4 (0x4) (1.52µs)
I0507 19:46:54.276168  1868651 strace.go:561] [   7:   7] nvidia-smi E close(0xb /sys/devices/system/cpu/online)
I0507 19:46:54.276174  1868651 strace.go:599] [   7:   7] nvidia-smi X close(0xb /sys/devices/system/cpu/online) = 0 (0x0) (1.61µs)
I0507 19:46:54.276188  1868651 strace.go:576] [   7:   7] nvidia-smi E sys_439(0xffffffff, 0x7ebada99f057, 0x5, 0x0, 0x1999999999999999, 0x0)
I0507 19:46:54.276200  1868651 strace.go:614] [   7:   7] nvidia-smi X sys_439(0xffffffff, 0x7ebada99f057, 0x5, 0x0, 0x1999999999999999, 0x0) = 0 (0x0) (6.99µs)
I0507 19:46:54.276210  1868651 strace.go:576] [   7:   7] nvidia-smi E sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75)
I0507 19:46:54.276221  1868651 strace.go:614] [   7:   7] nvidia-smi X sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75) = 0 (0x0) errno=2 (no such file or directory) (5.141µs)
I0507 19:46:54.276230  1868651 strace.go:576] [   7:   7] nvidia-smi E sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75)
I0507 19:46:54.276240  1868651 strace.go:614] [   7:   7] nvidia-smi X sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75) = 0 (0x0) errno=2 (no such file or directory) (5.15µs)
I0507 19:46:54.276248  1868651 strace.go:576] [   7:   7] nvidia-smi E sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75)
I0507 19:46:54.276260  1868651 strace.go:614] [   7:   7] nvidia-smi X sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75) = 0 (0x0) errno=2 (no such file or directory) (6.27µs)
I0507 19:46:54.276268  1868651 strace.go:576] [   7:   7] nvidia-smi E sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75)
I0507 19:46:54.276278  1868651 strace.go:614] [   7:   7] nvidia-smi X sys_439(0xffffffff, 0x7ec93d642730, 0x4, 0x0, 0x0, 0x75) = 0 (0x0) errno=2 (no such file or directory) (5.08µs)
I0507 19:46:54.276289  1868651 strace.go:567] [   7:   7] nvidia-smi E write(0x2 host:[3], 0x7ebada99fea8 "hwloc/linux: failed to find sysfs cpu topology directory, aborting linux discovery.\n", 0x54)
```