### PR TITLE
Stop the old watchdog during restore

### DIFF
--- a/runsc/boot/restore.go
+++ b/runsc/boot/restore.go
@@ -242,6 +242,7 @@ func (r *restorer) restore(l *Loader) error {
 	dog := watchdog.New(l.k, dogOpts)
 
 	// Change the loader fields to reflect the changes made when restoring.
+	l.watchdog.Stop()
 	l.watchdog = dog
 	l.root.procArgs = kernel.CreateProcessArgs{}
 	l.restore = true


### PR DESCRIPTION
As we switch to a new watchdog during restore, there is no need to keep the old one running anymore.