### PR TITLE
Update bazel to 7.1.2

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,7 +16,9 @@
 startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 
 # Build with C++17.
-build --cxxopt=-std=c++17
+# com_google_protobuf is compiled with a few warnings.
+build --cxxopt=-std=c++17 --cxxopt=-Wno-error=maybe-uninitialized
+build --host_cxxopt=-std=c++17 --host_cxxopt=-Wno-error=maybe-uninitialized
 
 # Display the current git revision in the info block.
 build --stamp --workspace_status_command tools/workspace_status.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,5 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 # Root certificates.
 #
@@ -84,8 +84,8 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_rules_dependencies")
 
 go_rules_dependencies()
 
@@ -178,6 +178,8 @@ http_archive(
 # Load C++ cross-compilation toolchains.
 http_archive(
     name = "coral_crosstool",
+    patch_args = ["-p1"],
+    patches = ["//tools:crosstool-arm-dirs.patch"],
     sha256 = "f86d488ca353c5ee99187579fe408adb73e9f2bb1d69c6e3a42ffb904ce3ba01",
     strip_prefix = "crosstool-8e885509123395299bed6a5f9529fdc1b9751599",
     urls = [
@@ -193,6 +195,17 @@ cc_crosstool(
 )
 
 register_toolchains("//:cc_toolchain_k8", "//:cc_toolchain_aarch64")
+
+http_archive(
+    name = "com_google_protobuf",
+    sha256 = "c968404387c9cccd18676c6e1d83a1dcc39d162a7f468dace4b243c274de1f02",
+    strip_prefix = "protobuf-5.26.1",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v5.26.1.zip"],
+)
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
 
 # Load protobuf dependencies.
 http_archive(
@@ -1467,10 +1480,10 @@ http_archive(
     name = "com_github_grpc_grpc",
     patch_args = ["-p1"],
     patches = ["//tools:grpc_extra_deps.patch"],
-    sha256 = "ec125d7fdb77ecc25b01050a0d5d32616594834d3fe163b016768e2ae42a2df6",
-    strip_prefix = "grpc-1.52.1",
+    sha256 = "493d9905aa09124c2f44268b66205dd013f3925a7e82995f36745974e97af609",
+    strip_prefix = "grpc-1.63.0",
     urls = [
-        "https://github.com/grpc/grpc/archive/v1.52.1.tar.gz",
+        "https://github.com/grpc/grpc/archive/v1.63.0.tar.gz",
     ],
 )
 
@@ -1501,17 +1514,6 @@ http_archive(
         "https://github.com/google/benchmark/archive/v1.7.1.tar.gz",
     ],
 )
-
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "528927e398f4e290001886894dac17c5c6a2e5548f3fb68004cfb01af901b53a",
-    strip_prefix = "protobuf-3.17.3",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.17.3.zip"],
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
 
 # Schemas for testing.
 http_file(

--- a/images/default/Dockerfile
+++ b/images/default/Dockerfile
@@ -29,6 +29,6 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     ln -s /google-cloud-sdk/bin/gcloud /usr/bin/gcloud
 
 # Download the official bazel binary. The APT repository isn't used because there is not packages for arm64.
-RUN sh -c 'curl -o /usr/local/bin/bazel https://releases.bazel.build/6.3.1/release/bazel-6.3.1-linux-$(uname -m | sed s/aarch64/arm64/) && chmod ugo+x /usr/local/bin/bazel'
+RUN sh -c 'curl -o /usr/local/bin/bazel https://releases.bazel.build/7.1.2/release/bazel-7.1.2-linux-$(uname -m | sed s/aarch64/arm64/) && chmod ugo+x /usr/local/bin/bazel'
 WORKDIR /workspace
 ENTRYPOINT ["/usr/local/bin/bazel"]

--- a/tools/bazel.mk
+++ b/tools/bazel.mk
@@ -83,6 +83,7 @@ BAZEL              := bazel $(STARTUP_OPTIONS)
 BASE_OPTIONS       := --color=no --curses=no $(BAZEL_REMOTE_CACHE)
 BAZEL_TEST_OUTPUT  ?= errors
 TEST_OPTIONS       += $(BASE_OPTIONS) \
+  --incompatible_sandbox_hermetic_tmp=false \
   --test_output=$(BAZEL_TEST_OUTPUT) \
   --keep_going \
   --verbose_failures=true \

--- a/tools/crosstool-arm-dirs.patch
+++ b/tools/crosstool-arm-dirs.patch
@@ -1,0 +1,20 @@
+diff --git a/cc_toolchain_config.bzl.tpl b/cc_toolchain_config.bzl.tpl
+index e864fa2..3de0405 100644
+--- a/cc_toolchain_config.bzl.tpl
++++ b/cc_toolchain_config.bzl.tpl
+@@ -76,6 +76,7 @@ CXX_BUILTIN_INCLUDE_DIRECTORIES = {
+         "/usr/lib/gcc/x86_64-linux-gnu/%d/include-fixed" % GCC_VERSION,
+         "/usr/include/x86_64-linux-gnu",
+         "/usr/include",
++        "/usr/x86_64-linux-gnu/include/",
+     ],
+     "armv7a": [
+         "/usr/arm-linux-gnueabihf/include/c++/%d" % GCC_VERSION,
+@@ -100,6 +101,7 @@ CXX_BUILTIN_INCLUDE_DIRECTORIES = {
+         "/usr/aarch64-linux-gnu/include/c++/%d" % GCC_VERSION,
+         "/usr/aarch64-linux-gnu/include/c++/%d/aarch64-linux-gnu" % GCC_VERSION,
+         "/usr/aarch64-linux-gnu/include/c++/%d/backward" % GCC_VERSION,
++        "/usr/lib/gcc/aarch64-linux-gnu/%d/include" % GCC_VERSION,
+         "/usr/lib/gcc-cross/aarch64-linux-gnu/%d/include" % GCC_VERSION,
+         "/usr/lib/gcc-cross/aarch64-linux-gnu/%d/include-fixed" % GCC_VERSION,
+         "/usr/aarch64-linux-gnu/include",


### PR DESCRIPTION
The key highlight from the release notes:

Build without the Bytes for builds using remote caching and/or remote execution is now enabled by default (i.e. --remote_download_outputs defaults to toplevel). This means that Bazel will no longer try to download any intermediate outputs from the remote server, but only the outputs of requested top-level targets instead. This significantly improves build performance. Bazel now also handles the case of an artifact falling out of the remote cache gracefully, by rewinding the build.