### PR TITLE
tcpip/stack/bridge_test: change pkg name to stack

### DIFF
--- a/pkg/tcpip/stack/bridge_test.go
+++ b/pkg/tcpip/stack/bridge_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package bridge_test
+package stack
 
 import (
 	"os"


### PR DESCRIPTION
Declaring a different package than `stack` breaks imports? At least, our project doesn't build on [`release-20240624.0`](https://github.com/google/gvisor/releases/tag/release-20240624.0) ([logs](https://productionresultssa14.blob.core.windows.net/actions-results/c9bad5a5-0316-47fc-9760-f334f5510628/workflow-job-run-ca395085-040a-526b-2ce8-bdc85f692774/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-06-29T19%3A22%3A53Z&sig=ktI3I029L3teGsECd32prA7urOjRKR4kQRIr6M2DojM%3D&ske=2024-06-30T06%3A58%3A57Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2024-06-29T18%3A58%3A57Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2023-11-03&sp=r&spr=https&sr=b&st=2024-06-29T19%3A12%3A48Z&sv=2023-11-03)).