### PR TITLE
nvproxy: add missing UVM peer access ioctls

### DIFF
--- a/pkg/abi/nvgpu/uvm.go
+++ b/pkg/abi/nvgpu/uvm.go
@@ -27,6 +27,8 @@ const (
 	UVM_UNREGISTER_GPU_VASPACE         = 26
 	UVM_REGISTER_CHANNEL               = 27
 	UVM_UNREGISTER_CHANNEL             = 28
+	UVM_ENABLE_PEER_ACCESS             = 29
+	UVM_DISABLE_PEER_ACCESS            = 30
 	UVM_SET_RANGE_GROUP                = 31
 	UVM_MAP_EXTERNAL_ALLOCATION        = 33
 	UVM_FREE                           = 34
@@ -124,6 +126,20 @@ type UVM_UNREGISTER_CHANNEL_PARAMS struct {
 	GPUUUID  NvUUID
 	HClient  Handle
 	HChannel Handle
+	RMStatus uint32
+}
+
+// +marshal
+type UVM_ENABLE_PEER_ACCESS_PARAMS struct {
+	GPUUUIDA  NvUUID
+	GPUUUIDB  NvUUID
+	RMStatus uint32
+}
+
+// +marshal
+type UVM_DISABLE_PEER_ACCESS_PARAMS struct {
+	GPUUUIDA  NvUUID
+	GPUUUIDB  NvUUID
 	RMStatus uint32
 }
 

--- a/pkg/sentry/devices/nvproxy/seccomp_filters.go
+++ b/pkg/sentry/devices/nvproxy/seccomp_filters.go
@@ -136,6 +136,14 @@ func Filters() seccomp.SyscallRules {
 			},
 			seccomp.PerArg{
 				seccomp.NonNegativeFD{},
+				seccomp.EqualTo(nvgpu.UVM_ENABLE_PEER_ACCESS),
+			},
+			seccomp.PerArg{
+				seccomp.NonNegativeFD{},
+				seccomp.EqualTo(nvgpu.UVM_DISABLE_PEER_ACCESS),
+			},
+			seccomp.PerArg{
+				seccomp.NonNegativeFD{},
 				seccomp.EqualTo(nvgpu.UVM_SET_RANGE_GROUP),
 			},
 			seccomp.PerArg{

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -182,6 +182,8 @@ func Init() {
 					nvgpu.UVM_UNREGISTER_GPU_VASPACE:         uvmIoctlSimple[nvgpu.UVM_UNREGISTER_GPU_VASPACE_PARAMS],
 					nvgpu.UVM_REGISTER_CHANNEL:               uvmIoctlHasFrontendFD[nvgpu.UVM_REGISTER_CHANNEL_PARAMS],
 					nvgpu.UVM_UNREGISTER_CHANNEL:             uvmIoctlSimple[nvgpu.UVM_UNREGISTER_CHANNEL_PARAMS],
+					nvgpu.UVM_ENABLE_PEER_ACCESS:             uvmIoctlSimple[nvgpu.UVM_ENABLE_PEER_ACCESS_PARAMS],
+					nvgpu.UVM_DISABLE_PEER_ACCESS:            uvmIoctlSimple[nvgpu.UVM_DISABLE_PEER_ACCESS_PARAMS],
 					nvgpu.UVM_SET_RANGE_GROUP:                uvmIoctlSimple[nvgpu.UVM_SET_RANGE_GROUP_PARAMS],
 					nvgpu.UVM_MAP_EXTERNAL_ALLOCATION:        uvmIoctlHasFrontendFD[nvgpu.UVM_MAP_EXTERNAL_ALLOCATION_PARAMS],
 					nvgpu.UVM_FREE:                           uvmIoctlSimple[nvgpu.UVM_FREE_PARAMS],


### PR DESCRIPTION
Adding ioctls to provide only a partial fix to a simple Huggingface `accelerate` program that does not work on H100s.

---

### Reproduction

**Machine info**

* **NVIDIA driver:** `Driver Version: 550.54.15      CUDA Version: 12.4` 
* **NVIDIA device:**  NVIDIA H100 PCIe
* **uname -a:** `Linux worker-prod-lat-h100-dal-0-d22375e2688d4e5caa12deca256c79ec 5.15.0-113-generic #123-Ubuntu SMP Mon Jun 10 08:16:17 UTC 2024 x86_64 x86_64 x86_64 GNU/Linux` 

**Steps**

**1. Install gvisor**

```bash
ARCH="x86_64"  # all workers are x86
URL="https://storage.googleapis.com/gvisor/releases/master/latest/${ARCH}"
wget -nc "${URL}/runsc" "${URL}/runsc.sha512"
chmod +x runsc
sudo cp runsc /usr/local/bin/runsc
sudo /usr/local/bin/runsc install
sudo systemctl reload docker
```

**2. Add GPU enabling gvisor options**

In `/etc/docker/daemon.json`:

```json
{
    "runtimes": {
        "nvidia": {
            "path": "nvidia-container-runtime",
            "runtimeArgs": []
        },
        "runsc": {
            "path": "/usr/local/bin/runsc",
	    "runtimeArgs": ["--nvproxy", "--nvproxy-docker", "-debug-log=/tmp/runsc/", "-debug", "-strace"]

        }
    }
}
```

then run `sudo systemctl reload docker` 

**3. Run the reproducing `accelerate` application**

```Dockerfile
# Dockerfile
FROM python:3.9.15-slim-bullseye

RUN pip install accelerate
COPY <<EOF repro.py
from accelerate import Accelerator

accelerator = Accelerator()

with accelerator.main_process_first():
    print(f"hello! {accelerator.process_index}")
EOF

ENTRYPOINT ["accelerate", "launch", "repro.py"]
```

`docker build -f Dockerfile.mod3218 .`

```
sudo docker run -it --runtime=runsc --gpus='"device=GPU-f24cdb48-8af0-33a3-bff1-83c72aa5e460,GPU-d5140682-a598-a7f2-23d4-29dcb83bb30f,GPU-556fcf94-b6b7-550d-cfc3-60b9bfbe112e"' 8df8be98ce1ffa22baacf3910e2d22fceeaa003d44bbc384a2df9c971f1829a0
```

**Expected:**

On `runc` this simple program will print: 

```
hello! 0
hello! 1hello! 2
```

Indicating a successful ordering and completion of each process.

**Actual (bug):**

On `runsc` (master) the program hits an error: 

```
torch.distributed.elastic.multiprocessing.errors.ChildFailedError:
============================================================
train_loop FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2024-07-02_18:25:56
  host      : 07de9e138901
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 68)
  error_file: /tmp/torchelastic_d5gyii1n/none_swdujvh0/attempt_0/1/error.json
  traceback : Traceback (most recent call last):
    File "/usr/local/lib/python3.9/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 347, in wrapper
      return f(*args, **kwargs)
    File "//repro_notebook_launch.py", line 6, in train_loop
      with accelerator.main_process_first():
    File "/usr/local/lib/python3.9/contextlib.py", line 119, in __enter__
      return next(self.gen)
    File "/usr/local/lib/python3.9/site-packages/accelerate/accelerator.py", line 882, in main_process_first
      with self.state.main_process_first():
    File "/usr/local/lib/python3.9/contextlib.py", line 119, in __enter__
      return next(self.gen)
    File "/usr/local/lib/python3.9/site-packages/accelerate/state.py", line 1053, in main_process_first
      with PartialState().main_process_first():
    File "/usr/local/lib/python3.9/contextlib.py", line 119, in __enter__
      return next(self.gen)
    File "/usr/local/lib/python3.9/site-packages/accelerate/state.py", line 499, in main_process_first
      yield from self._goes_first(self.is_main_process)
    File "/usr/local/lib/python3.9/site-packages/accelerate/state.py", line 384, in _goes_first
      self.wait_for_everyone()
    File "/usr/local/lib/python3.9/site-packages/accelerate/state.py", line 378, in wait_for_everyone
      torch.distributed.barrier()
    File "/usr/local/lib/python3.9/site-packages/torch/distributed/c10d_logger.py", line 75, in wrapper
      return func(*args, **kwargs)
    File "/usr/local/lib/python3.9/site-packages/torch/distributed/distributed_c10d.py", line 3683, in barrier
      work = default_pg.barrier(opts=opts)
  torch.distributed.DistBackendError: NCCL error in: ../torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:1970, unhandled cuda error (run with NCCL_DEBUG=INFO for details), NCCL version 2.20.5
  ncclUnhandledCudaError: Call to CUDA function failed.
  Last error:
  Cuda failure 1 'invalid argument'
```

---

## Fix (partial)

This change set provides only a _**partial fix**_. By adding the unimplemented UVM ioctls we get at least the main process to print `hello 0` but the program still crashes with no logging and exit code 159.

```
$ sudo docker run -it --runtime=runsc2 --gpus='"device=GPU-f24cdb48-8af0-33a3-bff1-83c72aa5e460,GPU-d5140682-a598-a7f2-23d4-29dcb83bb30f,GPU-556fcf94-b6b7-550d-cfc3-60b9bfbe112e"' 8df8be98ce1ffa22baacf3910e2d22fceeaa003d44bbc384a2df9c971f1829a0
Launching training on 3 GPUs.
Detected kernel version 4.4.0, which is below the recommended minimum of 5.5.0; this can cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher.
hello! 0
$ echo $?
159
```

I suspected that the issue may be due to the `fork` vs `spawn` multiprocessing strategy and saw tried the library's notebook launcher: 

```
COPY <<EOF repro_notebook_launch.py
from accelerate import Accelerator
from accelerate import notebook_launcher

def train_loop():
	accelerator = Accelerator()
	with accelerator.main_process_first():
		print(f"hello! {accelerator.process_index}")

notebook_launcher(train_loop, (), num_processes=3)
EOF

ENV ACCELERATE_LOG_LEVEL=DEBUG
ENTRYPOINT ["python3", "repro_notebook_launch.py"]
```

But this had the same issue. 

---

### Debug logs

These are debug logs from running a `runsc` binary from _this PR_. As noted above, the program still does not succeed.

[mod3218.zip](https://github.com/user-attachments/files/16073043/mod3218.zip)

