### PR TITLE
nvproxy: Implement missing CTRL_CMD_PERF_GET_CURRENT_PSTATE control cmd

### DIFF
--- a/pkg/abi/nvgpu/ctrl.go
+++ b/pkg/abi/nvgpu/ctrl.go
@@ -371,6 +371,7 @@ const (
 // From src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080tmr.h:
 const (
 	NV2080_CTRL_CMD_TIMER_GET_GPU_CPU_TIME_CORRELATION_INFO = 0x20800406
+	NV2080_CTRL_CMD_PERF_GET_CURRENT_PSTATE                 = 0x20802068
 )
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl503c.h:

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -370,6 +370,7 @@ func Init() {
 			abi.controlCmd[nvgpu.NV0000_CTRL_CMD_GPU_ASYNC_ATTACH_ID] = rmControlSimple
 			abi.controlCmd[nvgpu.NV0000_CTRL_CMD_GPU_WAIT_ATTACH_ID] = rmControlSimple
 			abi.controlCmd[nvgpu.NV0080_CTRL_CMD_PERF_CUDA_LIMIT_SET_CONTROL] = rmControlSimple // NV0080_CTRL_PERF_CUDA_LIMIT_CONTROL_PARAMS
+			abi.controlCmd[nvgpu.NV2080_CTRL_CMD_PERF_GET_CURRENT_PSTATE] = rmControlSimple
 			// NV2081_BINAPI forwards all control commands to the GSP in
 			// src/nvidia/src/kernel/rmapi/binary_api.c:binapiControl_IMPL().
 			abi.controlCmd[(nvgpu.NV2081_BINAPI<<16)|0x0108] = rmControlSimple


### PR DESCRIPTION
This PR adds support for the `NV2080_CTRL_CMD_PERF_GET_CURRENT_PSTATE` ioctl in nvproxy.

### Bug Description
Currently, when `nvidia-smi` is executed in a container, `nvproxy: unknown control command 0x20802068 (paramsSize=4)` appears in the debug logs. Additionally, the output of `nvidia-smi` shows `ERR!` under the `Perf` column for each GPU. This error effects T4s and L4s, although it likely effects other GPUs. This PR fixes both of these issues.

This is one of the five unimplemented ioctls mentioned in #10627. I also plan on completing #10627.

### Reproduction
To reproduce this, simply run `nvidia-smi` in any gVisor container with the NVIDIA drivers installed. This can be done in many ways; here is one.

1. Dockerfile
```dockerfile
FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu20.04
CMD ["nvidia-smi"]
```
2. Build the container image
```bash
#!/bin/bash
image="nvidia-smi-container"
docker build -t $image .
mkdir --mode=0755 rootfs
docker export $(docker create $image) | sudo tar -xf - -C rootfs --same-owner --same-permissions
runsc spec -- /usr/bin/nvidia-smi
```
3. Add the nvidia container toolkit
Details: https://gvisor.dev/docs/user_guide/gpu/
Entire `config.json` provided for convenience:
```json
{
    "ociVersion": "1.0.0",
    "process": {
        "user": {
            "uid": 0,
            "gid": 0
        },
        "args": [
            "nvidia-smi"
        ],
        "env": [
            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
            "TERM=xterm",
            "NVIDIA_VISIBLE_DEVICES=all",
            "NVIDIA_DRIVER_CAPABILITIES=all"
        ],
        "cwd": "/",
        "capabilities": {
            "bounding": [
                "CAP_AUDIT_WRITE",
                "CAP_KILL",
                "CAP_NET_BIND_SERVICE"
            ],
            "effective": [
                "CAP_AUDIT_WRITE",
                "CAP_KILL",
                "CAP_NET_BIND_SERVICE"
            ],
            "inheritable": [
                "CAP_AUDIT_WRITE",
                "CAP_KILL",
                "CAP_NET_BIND_SERVICE"
            ],
            "permitted": [
                "CAP_AUDIT_WRITE",
                "CAP_KILL",
                "CAP_NET_BIND_SERVICE"
            ]
        },
        "rlimits": [
            {
                "type": "RLIMIT_NOFILE",
                "hard": 1024,
                "soft": 1024
            }
        ]
    },
    "root": {
        "path": "rootfs",
        "readonly": true
    },
    "hostname": "runsc",
    "mounts": [
        {
            "destination": "/proc",
            "type": "proc",
            "source": "proc"
        },
        {
            "destination": "/dev",
            "type": "tmpfs",
            "source": "tmpfs"
        },
        {
            "destination": "/sys",
            "type": "sysfs",
            "source": "sysfs",
            "options": [
                "nosuid",
                "noexec",
                "nodev",
                "ro"
            ]
        }
    ],
    "linux": {
        "namespaces": [
            {
                "type": "pid"
            },
            {
                "type": "network"
            },
            {
                "type": "ipc"
            },
            {
                "type": "uts"
            },
            {
                "type": "mount"
            }
        ]
    },
    "hooks": {
        "path": "/bin/bash",
        "args": ["bash", "-c", "nvidia-container-runtime-hook prestart"]
    }
}
```
4. Run the container
```
sudo runsc \
    -nvproxy \
    -nvproxy-driver-version 'latest' \
    -nvproxy-docker \
    -debug \
    -debug-log "logs/" \
    run cont_id
```