### PR TITLE
procfs: add cache size x86 cpuinfo field

### DIFF
--- a/pkg/cpuid/cpuid_amd64.go
+++ b/pkg/cpuid/cpuid_amd64.go
@@ -308,7 +308,7 @@ func (fs FeatureSet) HasFeature(feature Feature) bool {
 
 // WriteCPUInfoTo is to generate a section of one cpu in /proc/cpuinfo. This is
 // a minimal /proc/cpuinfo, it is missing some fields like "microcode" that are
-// not always printed in Linux. The bogomips field is simply made up.
+// not always printed in Linux. Several fields are simply made up.
 func (fs FeatureSet) WriteCPUInfoTo(cpu, numCPU uint, w io.Writer) {
 	// Avoid many redundant calls here, since this can occasionally appear
 	// in the hot path. Read all basic information up front, see above.
@@ -322,6 +322,13 @@ func (fs FeatureSet) WriteCPUInfoTo(cpu, numCPU uint, w io.Writer) {
 	fmt.Fprintf(w, "model name\t: %s\n", "unknown") // Unknown for now.
 	fmt.Fprintf(w, "stepping\t: %s\n", "unknown")   // Unknown for now.
 	fmt.Fprintf(w, "cpu MHz\t\t: %.3f\n", cpuFreqMHz)
+        // Pretend the CPU has 8192 KB of cache. Note that real /proc/cpuinfo exposes total L3 cache
+	// size on Intel and per-core L2 cache size on AMD (as of Linux 6.1.0), so the value of this
+        // field is not really important in practice. Any value that is chosen here will be wrong
+        // by an order of magnitude on a significant chunk of x86 machines.
+        // 8192 KB is selected because it is a reasonable size that will be effectively usable on
+        // lightly loaded machines - most machines have 1-4MB of L3 cache per core.
+        fmt.Fprintf(w, "cache size\t: 8192 KB\n")
 	fmt.Fprintf(w, "physical id\t: 0\n") // Pretend all CPUs are in the same socket.
 	fmt.Fprintf(w, "siblings\t: %d\n", numCPU)
 	fmt.Fprintf(w, "core id\t\t: %d\n", cpu)

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -132,6 +132,7 @@ static const char* required_fields[] = {
     "model name",
     "stepping",
     "cpu MHz",
+    "cache size",
     "physical id",
     "siblings",
     "core id",


### PR DESCRIPTION
Linux prints this field when cache information is available. This field is conditional (see arch/x86/kernel/cpu/proc.c:x86_cache_size()). It a different meaning and implementation on each vendor. For example, as of Linux 6.1.0 it returns LLC size on Intel and L2 size on AMD CPUs.

Even though usefullness of this field in its current implementation debatable, some relatively popular software such as PyPy (as of 7.3.11) relies on it and prints a warning if it is not available.