### PR TITLE
runsc: Fix bug of container creation clean-up process

### DIFF
--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -243,6 +243,9 @@ func New(conf *config.Config, args Args) (*Container, error) {
 	// Lock the container metadata file to prevent concurrent creations of
 	// containers with the same id.
 	if err := c.Saver.LockForNew(); err != nil {
+		// As we have not allocated any resources yet, we revoke the clean-up operation.
+		// Otherwise, we may accidently destroy an existing container.
+		cu.Release()
 		return nil, fmt.Errorf("cannot lock container metadata file: %w", err)
 	}
 	defer c.Saver.UnlockOrDie()


### PR DESCRIPTION
When the container finds that the container already exists, checked by `LockForNew()`, it returns an error and starts the clean-up process. The clean-up process will clean up the metadata file of the container, which was created by others. What's worse, the clean-up process only deletes metadata files rather than all resources of the container, leaking resources including the socket, makes it impossible to create a new container with this ID anymore.

See #10724 for the bug description.