### PR TITLE
[POC] platform/kvm: rewriting bluepill() without signal handler trampolining

### DIFF
--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -62,6 +62,7 @@ go_library(
     visibility = ["//pkg/sentry:internal"],
     deps = [
         "//pkg/abi/linux",
+        "//pkg/sigframe",
         "//pkg/atomicbitops",
         "//pkg/context",
         "//pkg/cpuid",

--- a/pkg/sentry/platform/kvm/bluepill.go
+++ b/pkg/sentry/platform/kvm/bluepill.go
@@ -15,16 +15,10 @@
 package kvm
 
 import (
-	"fmt"
-
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/ring0"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
-	"gvisor.dev/gvisor/pkg/sighandling"
 )
-
-// bluepill enters guest mode.
-func bluepill(*vCPU)
 
 // sighandler is the signal entry point.
 func sighandler()
@@ -100,11 +94,6 @@ func (c *vCPU) die(context *arch.SignalContext64, msg string) {
 }
 
 func init() {
-	// Install the handler.
-	if err := sighandling.ReplaceSignalHandler(bluepillSignal, addrOfSighandler(), &savedHandler); err != nil {
-		panic(fmt.Sprintf("Unable to set handler for signal %d: %v", bluepillSignal, err))
-	}
-
 	// Extract the address for the trampoline.
 	dieTrampolineAddr = addrOfDieTrampoline()
 }

--- a/pkg/sentry/platform/kvm/bluepill_amd64.s
+++ b/pkg/sentry/platform/kvm/bluepill_amd64.s
@@ -40,30 +40,6 @@
 // System call definitions.
 #define SYS_MMAP 9
 
-// See bluepill.go.
-TEXT ·bluepill(SB),NOSPLIT|NOFRAME,$0
-begin:
-	MOVQ arg+0(FP), AX
-	LEAQ VCPU_CPU(AX), BX
-
-	// The gorountine stack will be changed in guest which renders
-	// the frame pointer outdated and misleads perf tools.
-	// Disconnect the frame-chain with the zeroed frame pointer
-	// when it is saved in the frame in bluepillHandler().
-	MOVQ BP, CX
-	MOVQ $0, BP
-	BYTE CLI;
-	MOVQ CX, BP
-check_vcpu:
-	MOVQ ENTRY_CPU_SELF(GS), CX
-	CMPQ BX, CX
-	JE right_vCPU
-wrong_vcpu:
-	CALL ·redpill(SB)
-	JMP begin
-right_vCPU:
-	RET
-
 // sighandler: see bluepill.go for documentation.
 //
 // The arguments are the following:
@@ -122,6 +98,17 @@ fallback:
 	MOVQ ·savedSigsysHandler(SB), AX
 	JMP AX
 
+TEXT ·rflags(SB), $8-8
+	PUSHFQ
+	POPQ AX
+	MOVQ AX, ret+0(FP)
+	RET
+
+TEXT ·addrOfBluepillUserHandler(SB), $0-8
+	MOVQ $·bluepillUserHandler(SB), AX
+	MOVQ AX, ret+0(FP)
+	RET
+
 // func addrOfSighandler() uintptr
 TEXT ·addrOfSigsysHandler(SB), $0-8
 	MOVQ $·sigsysHandler(SB), AX
@@ -137,5 +124,10 @@ TEXT ·dieTrampoline(SB),NOSPLIT|NOFRAME,$0
 // func addrOfDieTrampoline() uintptr
 TEXT ·addrOfDieTrampoline(SB), $0-8
 	MOVQ $·dieTrampoline(SB), AX
+	MOVQ AX, ret+0(FP)
+	RET
+
+TEXT ·currentCPU(SB), $0-8
+	MOVQ ENTRY_CPU_SELF(GS), AX
 	MOVQ AX, ret+0(FP)
 	RET

--- a/pkg/sentry/platform/kvm/kvm_test.go
+++ b/pkg/sentry/platform/kvm/kvm_test.go
@@ -510,6 +510,7 @@ func BenchmarkKernelSyscall(b *testing.B) {
 	applicationTest(b, true, testutil.AddrOfGetpid(), func(c *vCPU, regs *arch.Registers, pt *pagetables.PageTables) bool {
 		// iteration does not include machine.Get() / machine.Put().
 		for i := 0; i < b.N; i++ {
+			bluepill(c)
 			testutil.Getpid()
 		}
 		return false

--- a/pkg/sigframe/BUILD
+++ b/pkg/sigframe/BUILD
@@ -1,0 +1,33 @@
+load("//tools:defs.bzl", "go_library", "go_test")
+
+package(default_applicable_licenses = ["//:license"])
+
+licenses(["notice"])
+
+go_library(
+    name = "sigframe",
+    srcs = [
+        "sigframe_amd64.go",
+        "sigframe_amd64.s",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/sentry/arch",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
+go_test(
+    name = "sigframe_test",
+    srcs = [
+        "sigframe_amd64_test.go",
+        "sigframe_amd64_test.s",
+    ],
+    library = ":sigframe",
+    deps = [
+        "//pkg/hostarch",
+        "//pkg/sentry/arch",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)

--- a/pkg/sigframe/sigframe_amd64.go
+++ b/pkg/sigframe/sigframe_amd64.go
@@ -1,0 +1,45 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build amd64
+// +build amd64
+
+package sigframe
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+)
+
+func callUserSignalHandler(stack uintptr, handler uintptr, sigframeRAX uintptr, sigframe *arch.UContext64, fpstate uintptr)
+
+//go:nosplit
+func CallUserSignalHandler(stack uintptr, handler uintptr, sigframeRAX uintptr, sigframe *arch.UContext64, fpstate uintptr, sigmask *linux.SignalSet) {
+	_, _, errno := unix.RawSyscall6(
+		unix.SYS_RT_SIGPROCMASK, linux.SIG_BLOCK,
+		uintptr(unsafe.Pointer(sigmask)),
+		uintptr(unsafe.Pointer(&sigframe.Sigset)),
+		linux.SignalSetSize,
+		0, 0)
+	if errno != 0 {
+		panic(fmt.Sprintf("sigprocmask failed: %d", errno))
+	}
+	callUserSignalHandler(stack, handler, sigframeRAX, sigframe, fpstate)
+}
+
+func UserSigreturn(addr *arch.UContext64)

--- a/pkg/sigframe/sigframe_amd64.s
+++ b/pkg/sigframe/sigframe_amd64.s
@@ -1,0 +1,89 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "funcdata.h"
+#include "textflag.h"
+
+#define SIGMCTX 40
+#define SIGCTX_R8  0 + SIGMCTX
+#define SIGCTX_R9  8 + SIGMCTX
+#define SIGCTX_R10 16 + SIGMCTX
+#define SIGCTX_R11 24 + SIGMCTX
+#define SIGCTX_R12 32 + SIGMCTX
+#define SIGCTX_R13 40 + SIGMCTX
+#define SIGCTX_R14 48 + SIGMCTX
+#define SIGCTX_R15 56 + SIGMCTX
+#define SIGCTX_RDI 64 + SIGMCTX
+#define SIGCTX_RSI 72 + SIGMCTX
+#define SIGCTX_RBP 80 + SIGMCTX
+#define SIGCTX_RBX 88 + SIGMCTX
+#define SIGCTX_RDX 96 + SIGMCTX
+#define SIGCTX_RAX 104 + SIGMCTX
+#define SIGCTX_RCX 112 + SIGMCTX
+#define SIGCTX_RSP 120 + SIGMCTX
+#define SIGCTX_RIP 128 + SIGMCTX
+#define SIGCTX_FL  136 + SIGMCTX
+#define SIGCTX_CS  144 + SIGMCTX
+#define SIGCTX_GS  146 + SIGMCTX
+#define SIGCTX_FS  148 + SIGMCTX
+#define SIGCTX_SS  150 + SIGMCTX
+#define SIGCTX_ERR     152 + SIGMCTX
+#define SIGCTX_TRAPNO  160 + SIGMCTX
+#define SIGCTX_MASK    168 + SIGMCTX
+#define SIGCTX_CR2     176 + SIGMCTX
+#define SIGCTX_FPSTATE 184 + SIGMCTX
+
+// Callee-Save: RBX, RBP, and R12-R15 are preserved across function calls.
+// Caller-Save: RAX, RCX, RDX, RSI, RDI, and R8-R11 are free to be used by
+// the called function and may be overwritten.
+TEXT ·callUserSignalHandler(SB),NOSPLIT,$8-40
+	MOVQ stack+0(FP), DI
+	MOVQ handler+8(FP), AX
+	MOVQ sigframeRAX+16(FP), SI
+	MOVQ sigframe+24(FP), R8
+
+	MOVQ fpstate+32(FP), R9
+	MOVQ R9, SIGCTX_FPSTATE(R8)
+
+	MOVQ BX, SIGCTX_RBX(R8)
+	MOVQ BP, SIGCTX_RBP(R8)
+	MOVQ R12, SIGCTX_R12(R8)
+	MOVQ R13, SIGCTX_R13(R8)
+	MOVQ R14, SIGCTX_R14(R8)
+	MOVQ R15, SIGCTX_R15(R8)
+	PUSHFQ
+	POPQ R9
+	MOVQ R9, SIGCTX_FL(R8)
+	MOVQ SP, SIGCTX_RSP(R8)
+	MOVQ $·return(SB),R9
+	MOVQ R9, SIGCTX_RIP(R8)
+	MOVQ $0x33, SIGCTX_CS(R8)
+	MOVQ $0x2b, SIGCTX_SS(R8)
+	MOVQ SI, SIGCTX_RAX(R8)
+	MOVQ DI, SP
+	PUSHQ $0x0
+	MOVQ SP, BP
+	PUSHQ R8    // Save CPU.
+	CALL AX
+
+TEXT ·UserSigreturn(SB),NOSPLIT,$0-8
+	MOVQ ADDR+0(FP), SP
+	MOVQ $15, AX
+	SYSCALL
+
+TEXT ·return(SB),NOSPLIT,$0-0
+	ADDQ    $0x8,SP
+	MOVQ (SP), BP
+	ADDQ    $0x8,SP
+	RET

--- a/pkg/sigframe/sigframe_amd64_test.go
+++ b/pkg/sigframe/sigframe_amd64_test.go
@@ -1,0 +1,54 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build amd64
+// +build amd64
+
+package sigframe
+
+import (
+	"testing"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+)
+
+func TestUserSignalHandler(t *testing.T) {
+	addr, _, _ := unix.Syscall6(unix.SYS_MMAP, 0, hostarch.PageSize*4, uintptr(unix.PROT_READ|unix.PROT_WRITE),
+		uintptr(unix.MAP_PRIVATE|unix.MAP_ANONYMOUS),
+		0, 0)
+	set := linux.MakeSignalSet(linux.SIGURG)
+	sigframe := (*arch.UContext64)(unsafe.Pointer(addr + hostarch.PageSize))
+	CallUserSignalHandler(addr+hostarch.PageSize, addrOfUserHandler(), addr+hostarch.PageSize*2, sigframe, 0, &set)
+}
+
+func BenchmarkUserSigHandler(b *testing.B) {
+	addr, _, _ := unix.Syscall6(unix.SYS_MMAP, 0, hostarch.PageSize*4, uintptr(unix.PROT_READ|unix.PROT_WRITE),
+		uintptr(unix.MAP_PRIVATE|unix.MAP_ANONYMOUS),
+		0, 0)
+	set := linux.MakeSignalSet(linux.SIGURG)
+	sigframe := (*arch.UContext64)(unsafe.Pointer(addr + hostarch.PageSize))
+	for i := 0; i < b.N; i++ {
+		CallUserSignalHandler(addr+hostarch.PageSize, addrOfUserHandler(), addr+hostarch.PageSize*2, sigframe, 0, &set)
+	}
+}
+
+func addrOfUserHandler() uintptr
+
+func userHandler(sigframe *arch.UContext64) {
+	UserSigreturn(sigframe)
+}

--- a/pkg/sigframe/sigframe_amd64_test.s
+++ b/pkg/sigframe/sigframe_amd64_test.s
@@ -1,0 +1,26 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "funcdata.h"
+#include "textflag.h"
+
+// ADDR_OF_FUNC defines a function named 'name' that returns the address of
+// 'symbol'.
+#define ADDR_OF_FUNC(name, symbol) \
+TEXT name,$0-8; \
+        MOVQ $symbol, AX; \
+        MOVQ AX, ret+0(FP); \
+        RET
+
+ADDR_OF_FUNC(·addrOfUserHandler(SB), ·userHandler(SB));


### PR DESCRIPTION
Here are benchmark results before and after this change: Before:
BenchmarkWorldSwitchToUserRoundtrip-8   	  255940	      4407 ns/op
After:
BenchmarkWorldSwitchToUserRoundtrip-8   	  307773	      3765 ns/op