### PR TITLE
nvproxy: Add support for PyTorch CUDA profiler

### DIFF
--- a/pkg/abi/nvgpu/classes.go
+++ b/pkg/abi/nvgpu/classes.go
@@ -50,6 +50,7 @@ const (
 	NV50_THIRD_PARTY_P2P             = 0x0000503c
 	NV50_MEMORY_VIRTUAL              = 0x000050a0
 	GT200_DEBUGGER                   = 0x000083de
+	GF100_PROFILER                   = 0x000090cc
 	GF100_SUBDEVICE_MASTER           = 0x000090e6
 	FERMI_CONTEXT_SHARE_A            = 0x00009067
 	FERMI_VASPACE_A                  = 0x000090f1

--- a/pkg/abi/nvgpu/ctrl.go
+++ b/pkg/abi/nvgpu/ctrl.go
@@ -485,7 +485,8 @@ const (
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080perf.h:
 const (
-	NV2080_CTRL_CMD_PERF_BOOST = 0x2080200a
+	NV2080_CTRL_CMD_PERF_BOOST              = 0x2080200a
+	NV2080_CTRL_CMD_PERF_GET_CURRENT_PSTATE = 0x20802068
 )
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080rc.h:
@@ -498,7 +499,7 @@ const (
 // From src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080tmr.h:
 const (
 	NV2080_CTRL_CMD_TIMER_GET_GPU_CPU_TIME_CORRELATION_INFO = 0x20800406
-	NV2080_CTRL_CMD_PERF_GET_CURRENT_PSTATE                 = 0x20802068
+	NV2080_CTRL_CMD_TIMER_SET_GR_TICK_FREQ                  = 0x20800407
 )
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl503c.h:

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -304,6 +304,7 @@ func Init() {
 					nvgpu.NV2080_CTRL_CMD_RC_RELEASE_WATCHDOG_REQUESTS:                     rmControlSimple,
 					nvgpu.NV2080_CTRL_CMD_RC_SOFT_DISABLE_WATCHDOG:                         rmControlSimple,
 					nvgpu.NV2080_CTRL_CMD_TIMER_GET_GPU_CPU_TIME_CORRELATION_INFO:          rmControlSimple,
+					nvgpu.NV2080_CTRL_CMD_TIMER_SET_GR_TICK_FREQ:                           rmControlSimple,
 					nvgpu.NV503C_CTRL_CMD_REGISTER_VIDMEM:                                  rmControlSimple,
 					nvgpu.NV503C_CTRL_CMD_UNREGISTER_VIDMEM:                                rmControlSimple,
 					nvgpu.NV83DE_CTRL_CMD_DEBUG_SET_EXCEPTION_MASK:                         rmControlSimple,
@@ -353,6 +354,7 @@ func Init() {
 					nvgpu.NV50_MEMORY_VIRTUAL:        rmAllocSimple[nvgpu.NV_MEMORY_ALLOCATION_PARAMS],
 					nvgpu.NV50_P2P:                   rmAllocSimple[nvgpu.NV503B_ALLOC_PARAMETERS],
 					nvgpu.NV50_THIRD_PARTY_P2P:       rmAllocSimple[nvgpu.NV503C_ALLOC_PARAMETERS],
+					nvgpu.GF100_PROFILER:             rmAllocNoParams,
 					nvgpu.GT200_DEBUGGER:             rmAllocSMDebuggerSession,
 					nvgpu.FERMI_CONTEXT_SHARE_A:      rmAllocContextShare,
 					nvgpu.FERMI_VASPACE_A:            rmAllocSimple[nvgpu.NV_VASPACE_ALLOCATION_PARAMETERS],
@@ -502,6 +504,7 @@ func Init() {
 							nvgpu.NV2080_CTRL_CMD_RC_RELEASE_WATCHDOG_REQUESTS:                     nil, // No params.
 							nvgpu.NV2080_CTRL_CMD_RC_SOFT_DISABLE_WATCHDOG:                         nil, // No params.
 							nvgpu.NV2080_CTRL_CMD_TIMER_GET_GPU_CPU_TIME_CORRELATION_INFO:          simpleIoctl("NV2080_CTRL_TIMER_GET_GPU_CPU_TIME_CORRELATION_INFO_PARAMS"),
+							nvgpu.NV2080_CTRL_CMD_TIMER_SET_GR_TICK_FREQ:                           simpleIoctl("NV2080_CTRL_CMD_TIMER_SET_GR_TICK_FREQ_PARAMS"),
 							nvgpu.NV503C_CTRL_CMD_REGISTER_VIDMEM:                                  simpleIoctl("NV503C_CTRL_REGISTER_VIDMEM_PARAMS"),
 							nvgpu.NV503C_CTRL_CMD_UNREGISTER_VIDMEM:                                simpleIoctl("NV503C_CTRL_UNREGISTER_VIDMEM_PARAMS"),
 							nvgpu.NV83DE_CTRL_CMD_DEBUG_SET_EXCEPTION_MASK:                         simpleIoctl("NV83DE_CTRL_DEBUG_SET_EXCEPTION_MASK_PARAMS"),
@@ -552,6 +555,7 @@ func Init() {
 							nvgpu.NV50_P2P:                   getStructName(nvgpu.NV503B_ALLOC_PARAMETERS{}),
 							nvgpu.NV50_THIRD_PARTY_P2P:       getStructName(nvgpu.NV503C_ALLOC_PARAMETERS{}),
 							nvgpu.GT200_DEBUGGER:             getStructName(nvgpu.NV83DE_ALLOC_PARAMETERS{}),
+							nvgpu.GF100_PROFILER:             nil, // No params
 							nvgpu.FERMI_CONTEXT_SHARE_A:      getStructName(nvgpu.NV_CTXSHARE_ALLOCATION_PARAMETERS{}),
 							nvgpu.FERMI_VASPACE_A:            getStructName(nvgpu.NV_VASPACE_ALLOCATION_PARAMETERS{}),
 							nvgpu.KEPLER_CHANNEL_GROUP_A:     getStructName(nvgpu.NV_CHANNEL_GROUP_ALLOCATION_PARAMETERS{}),


### PR DESCRIPTION
This PR adds support for the GF100_PROFILER allocation class and the NV2080_CTRL_CMD_TIMER_SET_GR_TICK_FREQ control command, both of which are needed for gVisor to work with the PyTorch profiler.

```py
# main.py
import torch
from torch.profiler import profile, record_function, ProfilerActivity

ff1 = torch.nn.Linear(8192, 8192).to("cuda")
ff2 = torch.nn.Linear(8192, 8192).to("cuda")
ff3 = torch.nn.Linear(8192, 8192).to("cuda")

def do_work(x: torch.Tensor):
    return ff3(ff2(ff1(x)))

x = torch.randn((8192, 8192)).to("cuda")
with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA], record_shapes=True, profile_memory=True, with_stack=True) as prof:
    for i in range(10):
        do_work(x)

print(prof.key_averages(group_by_input_shape=True).table(sort_by="cpu_time_total", row_limit=10))
prof.export_chrome_trace("trace.json")
```

```
# Dockerfile
FROM pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime
WORKDIR /app
COPY . .
CMD ["python", "main.py"]
```

```
docker run --gpus=all --rm --runtime=torch-profiler-gpu -v $(pwd):/app torch-profile
```

Without this change, the above code would fail and not report correct CUDA timings.

```
# PyTorch message
function cbapi->getCuptiStatus() failed with error CUPTI_ERROR_NOT_INITIALIZED (15)

# runsc logs
W0926 19:50:09.135629       1 frontend.go:835] [   2:   2] nvproxy: unknown allocation class 0x000090cc
W0926 19:50:09.136672       1 frontend.go:563] [   2:   2] nvproxy: unknown control command 0x20800407 (paramsSize=1)
```

I tested this change on AWS with a T4 and an A10G, verifying that the output `trace.json` file is reasonable and nonzero CUDA times are reported.