### PR TITLE
Add `ffmpeg` decoding GPU test with h264_cuvid (which uses NVDEC).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ dev: $(RUNTIME_BIN) ## Installs a set of local runtimes. Requires sudo.
 	@$(call configure_noreload,$(RUNTIME)-p,--net-raw --profile)
 	@$(call configure_noreload,$(RUNTIME)-cgroup-d,--net-raw --debug --strace --log-packets --cgroupfs)
 	@$(call configure_noreload,$(RUNTIME)-systemd-d,--net-raw --debug --strace --log-packets --systemd-cgroup)
+	@$(call configure_noreload,$(RUNTIME)-gpu,--nvproxy)
 	@$(call reload_docker)
 .PHONY: dev
 
@@ -298,7 +299,7 @@ cos-gpu-smoke-tests: gpu-smoke-images $(RUNTIME_BIN)
 # This is a superset of those needed for smoke tests.
 # It includes non-GPU images that are used as part of GPU tests,
 # e.g. busybox and python.
-gpu-images: gpu-smoke-images load-gpu_pytorch load-gpu_ollama load-gpu_ollama_client load-basic_busybox load-basic_python load-gpu_stable-diffusion-xl load-gpu_vllm load-gpu_nccl-tests
+gpu-images: gpu-smoke-images load-gpu_pytorch load-gpu_ollama load-gpu_ollama_client load-basic_busybox load-basic_python load-gpu_stable-diffusion-xl load-gpu_vllm load-gpu_nccl-tests load-benchmarks_ffmpeg
 .PHONY: gpu-images
 
 gpu-all-tests: gpu-images gpu-smoke-tests $(RUNTIME_BIN)

--- a/pkg/test/dockerutil/BUILD
+++ b/pkg/test/dockerutil/BUILD
@@ -5,6 +5,17 @@ package(
     licenses = ["notice"],
 )
 
+# We copy the `run_sniffer` binary here because `go:embed` can only embed
+# from the current directory or subdirectories, not parents of it.
+genrule(
+    name = "run_sniffer_bin",
+    srcs = [
+        "//tools/ioctl_sniffer:run_sniffer",
+    ],
+    outs = ["run_sniffer_copy"],
+    cmd = "cat < $(SRCS) > $@",
+)
+
 go_library(
     name = "dockerutil",
     testonly = 1,
@@ -15,6 +26,9 @@ go_library(
         "gpu.go",
         "network.go",
         "profile.go",
+    ],
+    embedsrcs = [
+        ":run_sniffer_bin",  # keep
     ],
     visibility = ["//:sandbox"],
     deps = [

--- a/test/gpu/BUILD
+++ b/test/gpu/BUILD
@@ -90,6 +90,20 @@ go_test(
 )
 
 go_test(
+    name = "ffmpeg_test",
+    srcs = ["ffmpeg_test.go"],
+    # runsc is needed to invalidate the bazel cache in case of any code changes.
+    data = ["//runsc"],
+    tags = [
+        "manual",
+        "noguitar",
+        "notap",
+    ],
+    visibility = ["//:sandbox"],
+    deps = ["//pkg/test/dockerutil"],
+)
+
+go_test(
     name = "imagegen_test",
     srcs = ["imagegen_test.go"],
     # runsc is needed to invalidate the bazel cache in case of any code changes.
@@ -103,33 +117,16 @@ go_test(
     deps = ["//test/gpu/stablediffusion"],
 )
 
-# We copy the `run_sniffer` binary here because `go:embed` can only embed
-# from the current directory or subdirectories, not parents of it.
-genrule(
-    name = "run_sniffer_copy",
-    srcs = [
-        "//tools/ioctl_sniffer:run_sniffer",
-    ],
-    outs = ["run_sniffer_copy"],
-    cmd = "cat < $(SRCS) > $@",
-)
-
 go_test(
     name = "sniffer_test",
     srcs = ["sniffer_test.go"],
-    embedsrcs = [
-        ":run_sniffer_copy",  # keep
-    ],
     tags = [
         "manual",
         "noguitar",
         "notap",
     ],
     visibility = ["//:sandbox"],
-    deps = [
-        "//pkg/test/dockerutil",
-        "@com_github_docker_docker//api/types/mount:go_default_library",
-    ],
+    deps = ["//pkg/test/dockerutil"],
 )
 
 go_test(

--- a/test/gpu/ffmpeg_test.go
+++ b/test/gpu/ffmpeg_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ffmpeg_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+)
+
+// TestFffmpegGPU runs ffmpeg in a GPU container using NVENC.
+func TestFffmpegGPU(t *testing.T) {
+	ctx := context.Background()
+	container := dockerutil.MakeContainer(ctx, t)
+	defer container.CleanUp(ctx)
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{
+		AllowIncompatibleIoctl: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to get GPU run options: %v", err)
+	}
+	opts.Image = "benchmarks/ffmpeg"
+	cmd := strings.Split("ffmpeg -i video.mp4 -c:v h264_nvenc -preset fast output.mp4", " ")
+	if output, err := container.Run(ctx, opts, cmd...); err != nil {
+		t.Errorf("failed to run container: %v; output:\n%s", err, output)
+	}
+}

--- a/test/gpu/ffmpeg_test.go
+++ b/test/gpu/ffmpeg_test.go
@@ -21,8 +21,8 @@ import (
 	"gvisor.dev/gvisor/pkg/test/dockerutil"
 )
 
-// TestFffmpegGPU runs ffmpeg in a GPU container using NVENC.
-func TestFffmpegGPU(t *testing.T) {
+// TestFffmpegEncodeGPU runs ffmpeg in a GPU container using NVENC.
+func TestFffmpegEncodeGPU(t *testing.T) {
 	ctx := context.Background()
 	container := dockerutil.MakeContainer(ctx, t)
 	defer container.CleanUp(ctx)
@@ -34,6 +34,27 @@ func TestFffmpegGPU(t *testing.T) {
 	}
 	opts.Image = "benchmarks/ffmpeg"
 	cmd := strings.Split("ffmpeg -i video.mp4 -c:v h264_nvenc -preset fast output.mp4", " ")
+	if output, err := container.Run(ctx, opts, cmd...); err != nil {
+		t.Errorf("failed to run container: %v; output:\n%s", err, output)
+	}
+}
+
+// TestFffmpegDecodeGPU runs ffmpeg in a GPU container using NVDEC.
+func TestFffmpegDecodeGPU(t *testing.T) {
+	ctx := context.Background()
+	container := dockerutil.MakeContainer(ctx, t)
+	defer container.CleanUp(ctx)
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{
+		AllowIncompatibleIoctl: true,
+	})
+	if err != nil {
+		t.Fatalf("Failed to get GPU run options: %v", err)
+	}
+	opts.Image = "benchmarks/ffmpeg"
+
+	// h264_cuvid refers to NVDEC. See Section 4.2 in
+	// https://docs.nvidia.com/video-technologies/video-codec-sdk/pdf/Using_FFmpeg_with_NVIDIA_GPU_Hardware_Acceleration.pdf
+	cmd := strings.Split("ffmpeg -y -vsync 0 -c:v h264_cuvid -i video.mp4 output.yuv", " ")
 	if output, err := container.Run(ctx, opts, cmd...); err != nil {
 		t.Errorf("failed to run container: %v; output:\n%s", err, output)
 	}

--- a/test/gpu/nccl_test.go
+++ b/test/gpu/nccl_test.go
@@ -27,7 +27,10 @@ import (
 func runNCCL(ctx context.Context, t *testing.T, testName string) {
 	t.Helper()
 	c := dockerutil.MakeContainer(ctx, t)
-	opts := dockerutil.GPURunOpts()
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{AllowIncompatibleIoctl: true})
+	if err != nil {
+		t.Fatalf("Failed to get GPU run options: %v", err)
+	}
 	opts.Image = "gpu/nccl-tests"
 	cmd := fmt.Sprintf("/nccl-tests/build/%s", testName)
 	out, err := c.Run(ctx, opts, cmd)

--- a/test/gpu/ollama/ollama.go
+++ b/test/gpu/ollama/ollama.go
@@ -149,7 +149,12 @@ type dockerServer struct {
 // NewDocker returns a new Ollama client talking to an Ollama server that runs
 // in a local Docker container.
 func NewDocker(ctx context.Context, cont *dockerutil.Container, logger testutil.Logger) (*Ollama, error) {
-	opts := dockerutil.GPURunOpts()
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{
+		AllowIncompatibleIoctl: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GPU run options: %w", err)
+	}
 	opts.Image = "gpu/ollama"
 	started := time.Now()
 	if err := cont.Spawn(ctx, opts); err != nil {

--- a/test/gpu/pytorch_test.go
+++ b/test/gpu/pytorch_test.go
@@ -26,7 +26,10 @@ import (
 func runPytorch(ctx context.Context, t *testing.T, scriptPath string, args ...string) {
 	t.Helper()
 	c := dockerutil.MakeContainer(ctx, t)
-	opts := dockerutil.GPURunOpts()
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{AllowIncompatibleIoctl: true})
+	if err != nil {
+		t.Fatalf("Failed to get GPU run options: %v", err)
+	}
 	opts.Image = "gpu/pytorch"
 	cmd := append([]string{"python3", scriptPath}, args...)
 	out, err := c.Run(ctx, opts, cmd...)

--- a/test/gpu/smoke_test.go
+++ b/test/gpu/smoke_test.go
@@ -27,13 +27,18 @@ func TestGPUHello(t *testing.T) {
 	c := dockerutil.MakeContainer(ctx, t)
 	defer c.CleanUp(ctx)
 
-	opts := dockerutil.GPURunOpts()
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{
+		DisableSnifferReason: "image has too old version of libc vs sniffer",
+	})
+	if err != nil {
+		t.Fatalf("failed to get GPU run options: %v", err)
+	}
 	opts.Image = "basic/cuda-vector-add"
 	out, err := c.Run(ctx, opts)
+	t.Logf("cuda-vector-add output: %s", string(out))
 	if err != nil {
 		t.Fatalf("could not run cuda-vector-add: %v", err)
 	}
-	t.Logf("cuda-vector-add output: %s", string(out))
 }
 
 func TestCUDASmokeTests(t *testing.T) {
@@ -41,11 +46,14 @@ func TestCUDASmokeTests(t *testing.T) {
 	c := dockerutil.MakeContainer(ctx, t)
 	defer c.CleanUp(ctx)
 
-	opts := dockerutil.GPURunOpts()
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{AllowIncompatibleIoctl: true})
+	if err != nil {
+		t.Fatalf("failed to get GPU run options: %v", err)
+	}
 	opts.Image = "gpu/cuda-tests"
 	out, err := c.Run(ctx, opts, "/run_smoke.sh")
+	t.Logf("cuda-tests smoke tests output: %s", string(out))
 	if err != nil {
 		t.Fatalf("could not run cuda-tests smoke tests: %v", err)
 	}
-	t.Logf("cuda-tests smoke tests output: %s", string(out))
 }

--- a/test/gpu/sniffer_test.go
+++ b/test/gpu/sniffer_test.go
@@ -18,70 +18,32 @@ package sniffer_test
 import (
 	"context"
 	"errors"
-	"os"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/mount"
 	"gvisor.dev/gvisor/pkg/test/dockerutil"
-
-	// Needed for go:embed
-	_ "embed"
 )
 
 const maxDuration = 1 * time.Minute
 
-//go:embed run_sniffer_copy
-var runSnifferBinary []byte
-
-// RunCommand runs the given command via the sniffer, with the -enforce_compatibility flag.
-//
-//	It's run in a docker container, with the cuda-tests image.
+// runCUDATestsCommand runs the given command via the sniffer with compatibility
+// enforcement enabled.
+// It's run in a docker container, with the cuda-tests image.
 func runCUDATestsCommand(t *testing.T, cmd ...string) (string, error) {
-	// Extract the sniffer binary to a temporary location.
-	runSniffer, err := os.CreateTemp("/tmp", "run_sniffer.*")
-	if err != nil {
-		t.Fatalf("Failed to create temporary file: %v", err)
-	}
-	defer func() {
-		if err := runSniffer.Close(); err != nil {
-			t.Fatalf("Failed to close temporary file: %v", err)
-		}
-		if err := os.Remove(runSniffer.Name()); err != nil {
-			t.Fatalf("Failed to unlink temporary file: %v", err)
-		}
-	}()
-	if _, err := runSniffer.Write(runSnifferBinary); err != nil {
-		t.Fatalf("Failed to write to temporary file: %v", err)
-	}
-	if err := runSniffer.Sync(); err != nil {
-		t.Fatalf("Failed to sync temporary file: %v", err)
-	}
-	if err := runSniffer.Chmod(0o555); err != nil {
-		t.Fatalf("Failed to chmod temporary file: %v", err)
-	}
-
-	// Set up our docker container
 	ctx, cancel := context.WithTimeoutCause(context.Background(), maxDuration, errors.New("overall test timed out"))
 	defer cancel()
-
-	listContainer := dockerutil.MakeContainer(ctx, t)
-	defer listContainer.CleanUp(ctx)
-
-	// Mount the sniffer binary into the container
-	opts := dockerutil.GPURunOpts()
-	opts.Image = "gpu/cuda-tests"
-	opts.Mounts = append(opts.Mounts, mount.Mount{
-		Type:     mount.TypeBind,
-		Source:   runSniffer.Name(),
-		Target:   "/run_sniffer",
-		ReadOnly: false,
+	container := dockerutil.MakeContainer(ctx, t)
+	defer container.CleanUp(ctx)
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{
+		AllowIncompatibleIoctl: false,
 	})
-
-	command := append([]string{"/run_sniffer", "-enforce_compatibility", "-verbose"}, cmd...)
-	output, err := listContainer.Run(ctx, opts, command...)
-	return output, err
+	if err != nil {
+		return "", fmt.Errorf("failed to get GPU run options: %w", err)
+	}
+	opts.Image = "gpu/cuda-tests"
+	return container.Run(ctx, opts, cmd...)
 }
 
 func TestSupportedCUDAProgram(t *testing.T) {

--- a/test/gpu/sr_test.go
+++ b/test/gpu/sr_test.go
@@ -34,7 +34,10 @@ func TestGPUCheckpointRestore(t *testing.T) {
 	c := dockerutil.MakeContainer(ctx, t)
 	defer c.CleanUp(ctx)
 
-	opts := dockerutil.GPURunOpts()
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{AllowIncompatibleIoctl: true})
+	if err != nil {
+		t.Fatalf("failed to get GPU run options: %v", err)
+	}
 	opts.Image = "basic/cuda-vector-add"
 	if err := c.Spawn(ctx, opts, "sleep", "infinity"); err != nil {
 		t.Fatalf("could not run cuda-vector-add: %v", err)

--- a/test/gpu/stablediffusion/stablediffusion.go
+++ b/test/gpu/stablediffusion/stablediffusion.go
@@ -47,7 +47,12 @@ type dockerRunner struct {
 func (dr *dockerRunner) Run(ctx context.Context, image string, argv []string) ([]byte, error) {
 	cont := dockerutil.MakeContainer(ctx, dr.logger)
 	defer cont.CleanUp(ctx)
-	opts := dockerutil.GPURunOpts()
+	opts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{
+		AllowIncompatibleIoctl: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get GPU run options: %w", err)
+	}
 	opts.Image = image
 	if err := cont.Spawn(ctx, opts, argv...); err != nil {
 		return nil, fmt.Errorf("could not start Stable Diffusion container: %v", err)

--- a/test/gpu/vllm/vllm_test.go
+++ b/test/gpu/vllm/vllm_test.go
@@ -51,7 +51,10 @@ func doVLLMTest(b *testing.B) {
 	}
 
 	// Run vllm.
-	runOpts := dockerutil.GPURunOpts()
+	runOpts, err := dockerutil.GPURunOpts(dockerutil.SniffGPUOpts{AllowIncompatibleIoctl: true})
+	if err != nil {
+		b.Fatalf("failed to get GPU run options: %v", err)
+	}
 	runOpts.Image = "gpu/vllm"
 	runOpts.Env = []string{"PYTHONPATH=$PYTHONPATH:/vllm"}
 

--- a/test/root/cgroup_test.go
+++ b/test/root/cgroup_test.go
@@ -250,9 +250,12 @@ func TestCgroupV1(t *testing.T) {
 	}
 
 	// Make configs.
-	conf, hostconf, _ := d.ConfigsFrom(dockerutil.RunOpts{
+	conf, hostconf, _, err := d.ConfigsFrom(ctx, dockerutil.RunOpts{
 		Image: "basic/alpine",
 	}, "sleep", "10000")
+	if err != nil {
+		t.Fatalf("Cannot get container config: %v", err)
+	}
 
 	// Add Cgroup arguments to configs.
 	for _, attr := range attrs {
@@ -416,9 +419,12 @@ func TestCgroupV2(t *testing.T) {
 		baseCgroupPath = cgroupPath("system.slice")
 	}
 	// Make configs.
-	conf, hostconf, _ := d.ConfigsFrom(dockerutil.RunOpts{
+	conf, hostconf, _, err := d.ConfigsFrom(ctx, dockerutil.RunOpts{
 		Image: "basic/alpine",
 	}, "sleep", "10000")
+	if err != nil {
+		t.Fatalf("Cannot get container config: %v", err)
+	}
 
 	// Add Cgroup arguments to configs.
 	for _, attr := range attrs {
@@ -515,9 +521,12 @@ func TestCgroupParent(t *testing.T) {
 	if useSystemd {
 		parent = "system-runsc.slice"
 	}
-	conf, hostconf, _ := d.ConfigsFrom(dockerutil.RunOpts{
+	conf, hostconf, _, err := d.ConfigsFrom(ctx, dockerutil.RunOpts{
 		Image: "basic/alpine",
 	}, "sleep", "10000")
+	if err != nil {
+		t.Fatalf("Cannot get container config: %v", err)
+	}
 	hostconf.Resources.CgroupParent = parent
 
 	if err := d.CreateFrom(ctx, "basic/alpine", conf, hostconf, nil); err != nil {
@@ -571,9 +580,12 @@ func TestSystemdCgroupJoinTwice(t *testing.T) {
 
 	// Construct a known cgroup name.
 	parent := "system-runsc.slice"
-	conf, hostconf, _ := d.ConfigsFrom(dockerutil.RunOpts{
+	conf, hostconf, _, err := d.ConfigsFrom(ctx, dockerutil.RunOpts{
 		Image: "basic/alpine",
 	}, "sleep", "10000")
+	if err != nil {
+		t.Fatalf("Cannot get container config: %v", err)
+	}
 	hostconf.Resources.CgroupParent = parent
 
 	if err := d.CreateFrom(ctx, "basic/alpine", conf, hostconf, nil); err != nil {

--- a/tools/ioctl_sniffer/BUILD
+++ b/tools/ioctl_sniffer/BUILD
@@ -48,8 +48,7 @@ go_binary(
     nogo = False,
     static = True,
     visibility = [
-        "//test:__subpackages__",
-        "//tools/ioctl_sniffer:__subpackages__",
+        "//:sandbox",
     ],
     deps = [
         "//pkg/log",


### PR DESCRIPTION
This PR builds off #10884 and adds a ffmpeg decoding test which uses NVDEC (I think).

The command being run:

```
ffmpeg -y -vsync 0 -c:v h264_cuvid -i video.mp4 output.yuv
```

specifies `h264_cuvid`. I believe CUVID is just the [legacy name for NVDEC](https://en.wikipedia.org/wiki/Nvidia_NVDEC). I found the command from Section 4.2 of this PDF: https://docs.nvidia.com/video-technologies/video-codec-sdk/pdf/Using_FFmpeg_with_NVIDIA_GPU_Hardware_Acceleration.pdf

While testing I also had to specify

```go
		Capabilities:           "NVIDIA_DRIVER_CAPABILITIES=all",
```

as part of the `SniffGPUOpts`; otherwise the existing encoding test would fail with

```
        [h264_nvenc @ 0x55809e61a940] Cannot load libnvidia-encode.so.1
        [h264_nvenc @ 0x55809e61a940] The minimum required Nvidia driver for nvenc is (unknown) or newer
```

I left this out of this PR since it wasn't specified for the original test.