### PR TITLE
all: remove use io/ioutil deprecated package & fix some deprecated thing

### DIFF
--- a/pkg/coretag/coretag.go
+++ b/pkg/coretag/coretag.go
@@ -17,7 +17,7 @@ package coretag
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"golang.org/x/sys/unix"
@@ -77,7 +77,7 @@ func GetAllCoreTags(pid int) ([]uint64, error) {
 // getTids returns set of tids as reported by /proc/<pid>/task.
 func getTids(pid int) (map[int]struct{}, error) {
 	tids := make(map[int]struct{})
-	files, err := ioutil.ReadDir("/proc/" + strconv.Itoa(pid) + "/task")
+	files, err := os.ReadDir("/proc/" + strconv.Itoa(pid) + "/task")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cpuid/cpuid_parse_test.go
+++ b/pkg/cpuid/cpuid_parse_test.go
@@ -15,7 +15,6 @@
 package cpuid
 
 import (
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -38,7 +37,7 @@ func TestHostFeatureFlags(t *testing.T) {
 	}
 
 	// Extract all cpuinfo flags.
-	cpuinfoBytes, _ := ioutil.ReadFile("/proc/cpuinfo")
+	cpuinfoBytes, _ := os.ReadFile("/proc/cpuinfo")
 	cpuinfo := string(cpuinfoBytes)
 	re := regexp.MustCompile(`(?m)^flags\s+: (.*)$`)
 	m := re.FindStringSubmatch(cpuinfo)

--- a/pkg/cpuid/native_amd64.go
+++ b/pkg/cpuid/native_amd64.go
@@ -18,7 +18,7 @@
 package cpuid
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -180,7 +180,7 @@ var (
 // filter installation. This value is used to create the fake /proc/cpuinfo
 // from a FeatureSet.
 func readMaxCPUFreq() {
-	cpuinfob, err := ioutil.ReadFile("/proc/cpuinfo")
+	cpuinfob, err := os.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		// Leave it as 0... the VDSO bails out in the same way.
 		log.Warningf("Could not read /proc/cpuinfo: %v", err)

--- a/pkg/cpuid/native_arm64.go
+++ b/pkg/cpuid/native_arm64.go
@@ -18,7 +18,7 @@
 package cpuid
 
 import (
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -51,7 +51,7 @@ func initCPUInfo() {
 		// warn about them not existing.
 		return
 	}
-	cpuinfob, err := ioutil.ReadFile("/proc/cpuinfo")
+	cpuinfob, err := os.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		// Leave everything at 0, nothing can be done.
 		log.Warningf("Could not read /proc/cpuinfo: %v", err)

--- a/pkg/fdchannel/fdchannel_test.go
+++ b/pkg/fdchannel/fdchannel_test.go
@@ -15,7 +15,6 @@
 package fdchannel
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -26,7 +25,7 @@ import (
 )
 
 func TestSendRecvFD(t *testing.T) {
-	sendFile, err := ioutil.TempFile("", "fdchannel_test_")
+	sendFile, err := os.CreateTemp("", "fdchannel_test_")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
@@ -82,7 +81,7 @@ func TestSendRecvFD(t *testing.T) {
 }
 
 func TestShutdownThenRecvFD(t *testing.T) {
-	sendFile, err := ioutil.TempFile("", "fdchannel_test_")
+	sendFile, err := os.CreateTemp("", "fdchannel_test_")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}
@@ -104,7 +103,7 @@ func TestShutdownThenRecvFD(t *testing.T) {
 }
 
 func TestRecvFDThenShutdown(t *testing.T) {
-	sendFile, err := ioutil.TempFile("", "fdchannel_test_")
+	sendFile, err := os.CreateTemp("", "fdchannel_test_")
 	if err != nil {
 		t.Fatalf("failed to create temporary file: %v", err)
 	}

--- a/pkg/gohacks/gohacks_test.go
+++ b/pkg/gohacks/gohacks_test.go
@@ -15,7 +15,6 @@
 package gohacks
 
 import (
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"runtime"
@@ -75,7 +74,7 @@ func TestSigbusOnMemmove(t *testing.T) {
 	// Test that SIGBUS received by runtime.memmove when *not* doing
 	// CopyIn or CopyOut work gets propagated to the runtime.
 	const bufLen = pageSize
-	f, err := ioutil.TempFile("", "sigbus_test")
+	f, err := os.CreateTemp("", "sigbus_test")
 	if err != nil {
 		t.Fatalf("TempFile failed: %v", err)
 	}

--- a/pkg/lisafs/testsuite/testsuite.go
+++ b/pkg/lisafs/testsuite/testsuite.go
@@ -19,7 +19,6 @@ package testsuite
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"testing"
@@ -54,7 +53,7 @@ type Tester interface {
 // RunAllLocalFSTests runs all local FS tests as subtests.
 func RunAllLocalFSTests(t *testing.T, tester Tester) {
 	for name, testFn := range localFSTests {
-		mountPath, err := ioutil.TempDir(os.Getenv("TEST_TMPDIR"), "")
+		mountPath, err := os.MkdirTemp(os.Getenv("TEST_TMPDIR"), "")
 		if err != nil {
 			t.Fatalf("creation of temporary mountpoint failed: %v", err)
 		}

--- a/pkg/p9/transport.go
+++ b/pkg/p9/transport.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/fd"
@@ -223,7 +222,7 @@ func recv(s *unet.Socket, msize uint32, lookup lookupTagAndType) (Tag, message, 
 	if err != nil {
 		// Throw away the contents of this message.
 		if remaining > 0 {
-			io.Copy(ioutil.Discard, &io.LimitedReader{R: s, N: int64(remaining)})
+			io.Copy(io.Discard, &io.LimitedReader{R: s, N: int64(remaining)})
 		}
 		return tag, nil, err
 	}
@@ -260,7 +259,7 @@ func recv(s *unet.Socket, msize uint32, lookup lookupTagAndType) (Tag, message, 
 		if fixedSize > remaining {
 			// This is not a valid message.
 			if remaining > 0 {
-				io.Copy(ioutil.Discard, &io.LimitedReader{R: s, N: int64(remaining)})
+				io.Copy(io.Discard, &io.LimitedReader{R: s, N: int64(remaining)})
 			}
 			return NoTag, nil, ErrNoValidMessage
 		}

--- a/pkg/p9/transport_test.go
+++ b/pkg/p9/transport_test.go
@@ -15,7 +15,6 @@
 package p9
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -113,7 +112,7 @@ func TestSendRecvWithFile(t *testing.T) {
 	defer client.Close()
 
 	// Create a tempfile.
-	osf, err := ioutil.TempFile("", "p9")
+	osf, err := os.CreateTemp("", "p9")
 	if err != nil {
 		t.Fatalf("tempfile got err %v expected nil", err)
 	}

--- a/pkg/safecopy/safecopy_test.go
+++ b/pkg/safecopy/safecopy_test.go
@@ -17,8 +17,8 @@ package safecopy
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"testing"
 	"unsafe"
 
@@ -239,7 +239,7 @@ func withSegvErrorTestMapping(t *testing.T, fn func(m []byte)) {
 // withBusErrorTestMapping calls fn with a two-page mapping. The first page
 // contains random data, and the second page generates SIGBUS when accessed.
 func withBusErrorTestMapping(t *testing.T, fn func(m []byte)) {
-	f, err := ioutil.TempFile("", "sigbus_test")
+	f, err := os.CreateTemp("", "sigbus_test")
 	if err != nil {
 		t.Fatalf("TempFile failed: %v", err)
 	}

--- a/pkg/seccomp/seccomp_test.go
+++ b/pkg/seccomp/seccomp_test.go
@@ -19,7 +19,6 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"os"
@@ -27,7 +26,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/abi/linux"
@@ -39,7 +37,7 @@ var victimData []byte
 
 // newVictim makes a victim binary.
 func newVictim() (string, error) {
-	f, err := ioutil.TempFile("", "victim")
+	f, err := os.CreateTemp("", "victim")
 	if err != nil {
 		return "", err
 	}
@@ -1078,7 +1076,6 @@ func TestBasic(t *testing.T) {
 
 // TestRandom tests that randomly generated rules are encoded correctly.
 func TestRandom(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	size := rand.Intn(50) + 1
 	syscallRules := NewSyscallRules()
 	for syscallRules.Size() < size {

--- a/pkg/secio/secio_test.go
+++ b/pkg/secio/secio_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"math"
 	"testing"
 )
@@ -63,7 +62,7 @@ func newBufferString(s string) *buffer {
 func TestOffsetReader(t *testing.T) {
 	buf := newBufferString("foobar")
 	r := NewOffsetReader(buf, 3)
-	dst, err := ioutil.ReadAll(r)
+	dst, err := io.ReadAll(r)
 	if want := []byte("bar"); !bytes.Equal(dst, want) || err != nil {
 		t.Errorf("ReadAll: got (%q, %v), wanted (%q, nil)", dst, err, want)
 	}
@@ -72,7 +71,7 @@ func TestOffsetReader(t *testing.T) {
 func TestSectionReader(t *testing.T) {
 	buf := newBufferString("foobarbaz")
 	r := NewSectionReader(buf, 3, 3)
-	dst, err := ioutil.ReadAll(r)
+	dst, err := io.ReadAll(r)
 	if want, wantErr := []byte("bar"), ErrReachedLimit; !bytes.Equal(dst, want) || err != wantErr {
 		t.Errorf("ReadAll: got (%q, %v), wanted (%q, %v)", dst, err, want, wantErr)
 	}
@@ -82,7 +81,7 @@ func TestSectionReaderLimitOverflow(t *testing.T) {
 	// SectionReader behaves like OffsetReader when limit overflows int64.
 	buf := newBufferString("foobar")
 	r := NewSectionReader(buf, 3, math.MaxInt64)
-	dst, err := ioutil.ReadAll(r)
+	dst, err := io.ReadAll(r)
 	if want := []byte("bar"); !bytes.Equal(dst, want) || err != nil {
 		t.Errorf("ReadAll: got (%q, %v), wanted (%q, nil)", dst, err, want)
 	}

--- a/pkg/sentry/hostcpu/hostcpu.go
+++ b/pkg/sentry/hostcpu/hostcpu.go
@@ -18,7 +18,7 @@ package hostcpu
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"unicode"
@@ -33,7 +33,7 @@ func GetCPU() uint32
 // not to change for the lifetime of the host kernel.
 func MaxPossibleCPU() (uint32, error) {
 	const path = "/sys/devices/system/cpu/possible"
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sentry/platform/mmap_min_addr.go
+++ b/pkg/sentry/platform/mmap_min_addr.go
@@ -16,7 +16,7 @@ package platform
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -47,7 +47,7 @@ func (*MMapMinAddr) MinUserAddress() hostarch.Addr {
 
 func init() {
 	// Open the source file.
-	b, err := ioutil.ReadFile(systemMMapMinAddrSource)
+	b, err := os.ReadFile(systemMMapMinAddrSource)
 	if err != nil {
 		panic(fmt.Sprintf("couldn't open %s: %v", systemMMapMinAddrSource, err))
 	}

--- a/pkg/sentry/seccheck/sinks/remote/test/server.go
+++ b/pkg/sentry/seccheck/sinks/remote/test/server.go
@@ -16,7 +16,6 @@
 package test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -53,7 +52,7 @@ type Message struct {
 // NewServer creates a new server that listens to a UDS that it creates under
 // os.TempDir.
 func NewServer() (*Server, error) {
-	dir, err := ioutil.TempDir(os.TempDir(), "remote")
+	dir, err := os.MkdirTemp(os.TempDir(), "remote")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/socket/hostinet/stack.go
+++ b/pkg/sentry/socket/hostinet/stack.go
@@ -17,7 +17,6 @@ package hostinet
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -93,7 +92,7 @@ func (s *Stack) Configure(allowRawSockets bool) error {
 	// SACK is important for performance and even compatibility, assume it's
 	// enabled if we can't find the actual value.
 	s.tcpSACKEnabled = true
-	if sack, err := ioutil.ReadFile("/proc/sys/net/ipv4/tcp_sack"); err == nil {
+	if sack, err := os.ReadFile("/proc/sys/net/ipv4/tcp_sack"); err == nil {
 		s.tcpSACKEnabled = strings.TrimSpace(string(sack)) != "0"
 	} else {
 		log.Warningf("Failed to read if TCP SACK if enabled, setting to true")
@@ -120,7 +119,7 @@ func (s *Stack) Configure(allowRawSockets bool) error {
 }
 
 func readTCPBufferSizeFile(filename string) (inet.TCPBufferSize, error) {
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return inet.TCPBufferSize{}, fmt.Errorf("failed to read %s: %v", filename, err)
 	}

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -29,7 +29,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"reflect"
 	"time"
@@ -2745,7 +2744,7 @@ func (s *sock) nonBlockingRead(ctx context.Context, dst usermem.IOSequence, peek
 
 	if !isPacket && trunc {
 		w = &tcpip.LimitedWriter{
-			W: ioutil.Discard,
+			W: io.Discard,
 			N: dst.NumBytes(),
 		}
 		res, err = s.Endpoint.Read(w, readOptions)

--- a/pkg/shim/runsc/state.go
+++ b/pkg/shim/runsc/state.go
@@ -16,7 +16,7 @@ package runsc
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
@@ -32,7 +32,7 @@ type state struct {
 }
 
 func (s state) load(path string) error {
-	data, err := ioutil.ReadFile(filepath.Join(path, filename))
+	data, err := os.ReadFile(filepath.Join(path, filename))
 	if err != nil {
 		return err
 	}
@@ -44,5 +44,5 @@ func (s state) save(path string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(path, filename), data, 0644)
+	return os.WriteFile(filepath.Join(path, filename), data, 0644)
 }

--- a/pkg/shim/runsccmd/runsc.go
+++ b/pkg/shim/runsccmd/runsc.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -319,7 +318,7 @@ func (o *ExecOpts) args() (out []string, err error) {
 // Exec executes an additional process inside the container based on a full OCI
 // Process specification.
 func (r *Runsc) Exec(context context.Context, id string, spec specs.Process, opts *ExecOpts) error {
-	f, err := ioutil.TempFile(os.Getenv("XDG_RUNTIME_DIR"), "runsc-process")
+	f, err := os.CreateTemp(os.Getenv("XDG_RUNTIME_DIR"), "runsc-process")
 	if err != nil {
 		return err
 	}

--- a/pkg/shim/utils/utils.go
+++ b/pkg/shim/utils/utils.go
@@ -17,7 +17,7 @@ package utils
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -27,7 +27,7 @@ const configFilename = "config.json"
 
 // ReadSpec reads OCI spec from the bundle directory.
 func ReadSpec(bundle string) (*specs.Spec, error) {
-	b, err := ioutil.ReadFile(filepath.Join(bundle, configFilename))
+	b, err := os.ReadFile(filepath.Join(bundle, configFilename))
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func WriteSpec(bundle string, spec *specs.Spec) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(bundle, configFilename), b, 0666)
+	return os.WriteFile(filepath.Join(bundle, configFilename), b, 0666)
 }
 
 // IsSandbox checks whether a container is a sandbox container.

--- a/pkg/shim/utils/volumes_test.go
+++ b/pkg/shim/utils/volumes_test.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -25,7 +24,7 @@ import (
 )
 
 func TestUpdateVolumeAnnotations(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-update-volume-annotations")
+	dir, err := os.MkdirTemp("", "test-update-volume-annotations")
 	if err != nil {
 		t.Fatalf("create tempdir: %v", err)
 	}

--- a/pkg/state/pretty/pretty.go
+++ b/pkg/state/pretty/pretty.go
@@ -18,7 +18,6 @@ package pretty
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"strings"
 
@@ -231,7 +230,7 @@ func (p *printer) printStream(w io.Writer, r io.Reader) (err error) {
 			graph++ // Increment the graph.
 			if length > 0 {
 				fmt.Fprintf(w, "(%d bytes non-object data)\n", length)
-				io.Copy(ioutil.Discard, &io.LimitedReader{
+				io.Copy(io.Discard, &io.LimitedReader{
 					R: r,
 					N: int64(length),
 				})

--- a/pkg/tcpip/link/sharedmem/queuepair.go
+++ b/pkg/tcpip/link/sharedmem/queuepair.go
@@ -19,7 +19,7 @@ package sharedmem
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/eventfd"
@@ -186,7 +186,7 @@ func createFile(sharedMemPath string, size int64, initQueue bool) (fd int, err e
 	if sharedMemPath != "" {
 		tmpDir = sharedMemPath
 	}
-	f, err := ioutil.TempFile(tmpDir, "sharedmem_test")
+	f, err := os.CreateTemp(tmpDir, "sharedmem_test")
 	if err != nil {
 		return -1, fmt.Errorf("TempFile failed: %v", err)
 	}

--- a/pkg/tcpip/network/ipv4/ipv4_test.go
+++ b/pkg/tcpip/network/ipv4/ipv4_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net"
 	"testing"
@@ -3342,7 +3342,7 @@ func TestReceiveFragments(t *testing.T) {
 				}
 			}
 
-			res, err := ep.Read(ioutil.Discard, tcpip.ReadOptions{})
+			res, err := ep.Read(io.Discard, tcpip.ReadOptions{})
 			if _, ok := err.(*tcpip.ErrWouldBlock); !ok {
 				t.Fatalf("(last) got Read = (%#v, %v), want = (_, %s)", res, err, &tcpip.ErrWouldBlock{})
 			}

--- a/pkg/tcpip/network/ipv6/ipv6_test.go
+++ b/pkg/tcpip/network/ipv6/ipv6_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net"
 	"reflect"
@@ -1096,7 +1096,7 @@ func TestReceiveIPv6ExtHdrs(t *testing.T) {
 			}
 
 			// Should not have any more UDP packets.
-			res, err := ep.Read(ioutil.Discard, tcpip.ReadOptions{})
+			res, err := ep.Read(io.Discard, tcpip.ReadOptions{})
 			if _, ok := err.(*tcpip.ErrWouldBlock); !ok {
 				t.Fatalf("got Read = (%v, %v), want = (_, %s)", res, err, &tcpip.ErrWouldBlock{})
 			}
@@ -1931,7 +1931,7 @@ func TestReceiveIPv6Fragments(t *testing.T) {
 				}
 			}
 
-			res, err := ep.Read(ioutil.Discard, tcpip.ReadOptions{})
+			res, err := ep.Read(io.Discard, tcpip.ReadOptions{})
 			if _, ok := err.(*tcpip.ErrWouldBlock); !ok {
 				t.Fatalf("(last) got Read = (%v, %v), want = (_, %s)", res, err, &tcpip.ErrWouldBlock{})
 			}

--- a/pkg/tcpip/stack/transport_demuxer_test.go
+++ b/pkg/tcpip/stack/transport_demuxer_test.go
@@ -15,7 +15,7 @@
 package stack_test
 
 import (
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"strconv"
@@ -424,7 +424,7 @@ func TestBindToDeviceDistribution(t *testing.T) {
 						}
 
 						ep := <-pollChannel
-						if _, err := ep.Read(ioutil.Discard, tcpip.ReadOptions{}); err != nil {
+						if _, err := ep.Read(io.Discard, tcpip.ReadOptions{}); err != nil {
 							t.Fatalf("Read on endpoint %d failed: %s", eps[ep], err)
 						}
 						stats[ep]++

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
@@ -17,7 +17,7 @@ package tcp_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"strings"
@@ -55,7 +55,7 @@ type endpointTester struct {
 // CheckReadError issues a read to the endpoint and checking for an error.
 func (e *endpointTester) CheckReadError(t *testing.T, want tcpip.Error) {
 	t.Helper()
-	res, got := e.ep.Read(ioutil.Discard, tcpip.ReadOptions{})
+	res, got := e.ep.Read(io.Discard, tcpip.ReadOptions{})
 	if got != want {
 		t.Fatalf("ep.Read = %s, want %s", got, want)
 	}
@@ -2606,7 +2606,7 @@ func TestSmallReceiveBufferReadiness(t *testing.T) {
 					total := 0
 					defer t.Logf("read %d bytes in total", total)
 					for {
-						switch res, err := client.Read(ioutil.Discard, tcpip.ReadOptions{}); err.(type) {
+						switch res, err := client.Read(io.Discard, tcpip.ReadOptions{}); err.(type) {
 						case nil:
 							t.Logf("read %d bytes", res.Count)
 							total += res.Count
@@ -3264,7 +3264,7 @@ func TestZeroScaledWindowReceive(t *testing.T) {
 	// read at least 128KB. Since our segments above were 50KB each it means
 	// we need to read at 3 packets.
 	w := tcpip.LimitedWriter{
-		W: ioutil.Discard,
+		W: io.Discard,
 		N: e2e.DefaultMTU * 2,
 	}
 	for w.N != 0 {
@@ -3998,11 +3998,11 @@ func TestReceiveOnResetConnection(t *testing.T) {
 
 loop:
 	for {
-		switch _, err := c.EP.Read(ioutil.Discard, tcpip.ReadOptions{}); err.(type) {
+		switch _, err := c.EP.Read(io.Discard, tcpip.ReadOptions{}); err.(type) {
 		case *tcpip.ErrWouldBlock:
 			<-ch
 			// Expect the state to be StateError and subsequent Reads to fail with HardError.
-			_, err := c.EP.Read(ioutil.Discard, tcpip.ReadOptions{})
+			_, err := c.EP.Read(io.Discard, tcpip.ReadOptions{})
 			if d := cmp.Diff(&tcpip.ErrConnectionReset{}, err); d != "" {
 				t.Fatalf("c.EP.Read() mismatch (-want +got):\n%s", d)
 			}
@@ -7222,7 +7222,7 @@ func TestReceiveBufferAutoTuningApplicationLimited(t *testing.T) {
 	// Now read all the data from the endpoint and verify that advertised
 	// window increases to the full available buffer size.
 	for {
-		_, err := c.EP.Read(ioutil.Discard, tcpip.ReadOptions{})
+		_, err := c.EP.Read(io.Discard, tcpip.ReadOptions{})
 		if cmp.Equal(&tcpip.ErrWouldBlock{}, err) {
 			break
 		}
@@ -7357,7 +7357,7 @@ func TestReceiveBufferAutoTuning(t *testing.T) {
 		// to happen before we measure the new window.
 		totalCopied := 0
 		for {
-			res, err := c.EP.Read(ioutil.Discard, tcpip.ReadOptions{})
+			res, err := c.EP.Read(io.Discard, tcpip.ReadOptions{})
 			if cmp.Equal(&tcpip.ErrWouldBlock{}, err) {
 				break
 			}
@@ -8470,7 +8470,7 @@ func TestIncreaseWindowOnRead(t *testing.T) {
 	// We now have < 1 MSS in the buffer space. Read at least > 2 MSS
 	// worth of data as receive buffer space
 	w := tcpip.LimitedWriter{
-		W: ioutil.Discard,
+		W: io.Discard,
 		// e2e.DefaultMTU is a good enough estimate for the MSS used for this
 		// connection.
 		N: e2e.DefaultMTU * 2,
@@ -9235,7 +9235,7 @@ func TestReadAfterCloseWithBufferedData(t *testing.T) {
 			t.Fatalf("timed out waiting for read to return error %q", &tcpip.ErrClosedForReceive{})
 			return
 		default:
-			if _, err := c.EP.Read(ioutil.Discard, tcpip.ReadOptions{}); cmp.Equal(err, &tcpip.ErrClosedForReceive{}) {
+			if _, err := c.EP.Read(io.Discard, tcpip.ReadOptions{}); cmp.Equal(err, &tcpip.ErrClosedForReceive{}) {
 				return
 			}
 		}

--- a/pkg/tcpip/transport/udp/udp_test.go
+++ b/pkg/tcpip/transport/udp/udp_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"os"
@@ -303,7 +303,7 @@ func TestV4ReadSelfSource(t *testing.T) {
 				t.Errorf("c.Stack.Stats().IP.InvalidSourceAddressesReceived got %d, want %d", got, tt.wantInvalidSource)
 			}
 
-			if _, err := c.EP.Read(ioutil.Discard, tcpip.ReadOptions{}); err != tt.wantErr {
+			if _, err := c.EP.Read(io.Discard, tcpip.ReadOptions{}); err != tt.wantErr {
 				t.Errorf("got c.EP.Read = %s, want = %s", err, tt.wantErr)
 			}
 		})

--- a/pkg/test/dockerutil/container.go
+++ b/pkg/test/dockerutil/container.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -504,9 +503,9 @@ func (c *Container) FindPort(ctx context.Context, sandboxPort int) (int, error) 
 
 // CopyFiles copies in and mounts the given files. They are always ReadOnly.
 func (c *Container) CopyFiles(opts *RunOpts, target string, sources ...string) {
-	dir, err := ioutil.TempDir("", c.Name)
+	dir, err := os.MkdirTemp("", c.Name)
 	if err != nil {
-		c.copyErr = fmt.Errorf("ioutil.TempDir failed: %v", err)
+		c.copyErr = fmt.Errorf("os.MkdirTemp failed: %v", err)
 		return
 	}
 	c.cleanups = append(c.cleanups, func() { os.RemoveAll(dir) })

--- a/pkg/test/dockerutil/dockerutil.go
+++ b/pkg/test/dockerutil/dockerutil.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -68,7 +67,7 @@ var (
 
 // PrintDockerConfig prints the whole Docker configuration file to the log.
 func PrintDockerConfig() {
-	configBytes, err := ioutil.ReadFile(*config)
+	configBytes, err := os.ReadFile(*config)
 	if err != nil {
 		log.Fatalf("Cannot read Docker config at %v: %v", *config, err)
 	}
@@ -168,7 +167,7 @@ func IsGVisorRuntime(ctx context.Context, t *testing.T) (bool, error) {
 // system is using cgroupv2, in which case systemd is the default driver.
 func UsingSystemdCgroup() (bool, error) {
 	// Read the configuration data; the file must exist.
-	configBytes, err := ioutil.ReadFile(*config)
+	configBytes, err := os.ReadFile(*config)
 	if err != nil {
 		return false, err
 	}
@@ -198,7 +197,7 @@ func UsingSystemdCgroup() (bool, error) {
 
 func runtimeMap() (map[string]any, error) {
 	// Read the configuration data; the file must exist.
-	configBytes, err := ioutil.ReadFile(*config)
+	configBytes, err := os.ReadFile(*config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/dockerutil/profile_test.go
+++ b/pkg/test/dockerutil/profile_test.go
@@ -17,7 +17,6 @@ package dockerutil
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,7 +31,7 @@ type testCase struct {
 
 func TestProfile(t *testing.T) {
 	// Basepath and expected file names for each type of profile.
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatalf("unable to create temporary directory: %v", err)
 	}

--- a/pkg/test/testutil/testutil.go
+++ b/pkg/test/testutil/testutil.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"math/rand"
@@ -304,7 +303,7 @@ func NewSpecWithArgs(args ...string) *specs.Spec {
 
 // SetupRootDir creates a root directory for containers.
 func SetupRootDir() (string, func(), error) {
-	rootDir, err := ioutil.TempDir(TmpDir(), "containers")
+	rootDir, err := os.MkdirTemp(TmpDir(), "containers")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating root dir: %v", err)
 	}
@@ -332,7 +331,7 @@ func SetupContainer(spec *specs.Spec, conf *config.Config) (rootDir, bundleDir s
 
 // SetupBundleDir creates a bundle dir and writes the spec to config.json.
 func SetupBundleDir(spec *specs.Spec) (string, func(), error) {
-	bundleDir, err := ioutil.TempDir(TmpDir(), "bundle")
+	bundleDir, err := os.MkdirTemp(TmpDir(), "bundle")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating bundle dir: %v", err)
 	}
@@ -350,7 +349,7 @@ func writeSpec(dir string, spec *specs.Spec) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(dir, "config.json"), b, 0755)
+	return os.WriteFile(filepath.Join(dir, "config.json"), b, 0755)
 }
 
 // idRandomSrc is a pseudo random generator used to in RandomID.
@@ -588,7 +587,7 @@ func KillCommand(cmd *exec.Cmd) error {
 // WriteTmpFile writes text to a temporary file, closes the file, and returns
 // the name of the file. A cleanup function is also returned.
 func WriteTmpFile(pattern, text string) (string, func(), error) {
-	file, err := ioutil.TempFile(TmpDir(), pattern)
+	file, err := os.CreateTemp(TmpDir(), pattern)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/unet/unet_test.go
+++ b/pkg/unet/unet_test.go
@@ -15,7 +15,6 @@
 package unet
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"slices"
@@ -28,7 +27,7 @@ import (
 
 func randomFilename() (string, error) {
 	// Return a randomly generated file in the test dir.
-	f, err := ioutil.TempFile("", "unet-test")
+	f, err := os.CreateTemp("", "unet-test")
 	if err != nil {
 		return "", err
 	}
@@ -427,7 +426,7 @@ func recvFDs(t *testing.T, s *Socket, enableSize int, origFDs []int) {
 	expected := len(origFDs)
 
 	// Count the number of FDs.
-	preEntries, err := ioutil.ReadDir("/proc/self/fd")
+	preEntries, err := os.ReadDir("/proc/self/fd")
 	if err != nil {
 		t.Fatalf("Can't readdir, got err %v expected nil", err)
 	}
@@ -446,7 +445,7 @@ func recvFDs(t *testing.T, s *Socket, enableSize int, origFDs []int) {
 	}
 
 	// Count the new number of FDs.
-	postEntries, err := ioutil.ReadDir("/proc/self/fd")
+	postEntries, err := os.ReadDir("/proc/self/fd")
 	if err != nil {
 		t.Fatalf("Can't readdir, got err %v expected nil", err)
 	}
@@ -479,7 +478,7 @@ func recvFDs(t *testing.T, s *Socket, enableSize int, origFDs []int) {
 	r.CloseFDs()
 
 	// Make sure the count is back to normal.
-	finalEntries, err := ioutil.ReadDir("/proc/self/fd")
+	finalEntries, err := os.ReadDir("/proc/self/fd")
 	if err != nil {
 		t.Fatalf("Can't readdir, got err %v expected nil", err)
 	}

--- a/runsc/cgroup/cgroup.go
+++ b/runsc/cgroup/cgroup.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -117,7 +116,7 @@ func setValue(path, name, data string) error {
 	return writeFile(fullpath, []byte(data), 0700)
 }
 
-// writeFile is similar to ioutil.WriteFile() but doesn't create the file if it
+// writeFile is similar to os.WriteFile() but doesn't create the file if it
 // doesn't exist.
 func writeFile(path string, data []byte, perm os.FileMode) error {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, perm)
@@ -132,7 +131,7 @@ func writeFile(path string, data []byte, perm os.FileMode) error {
 
 func getValue(path, name string) (string, error) {
 	fullpath := filepath.Join(path, name)
-	out, err := ioutil.ReadFile(fullpath)
+	out, err := os.ReadFile(fullpath)
 	if err != nil {
 		return "", err
 	}
@@ -150,7 +149,7 @@ func getInt(path, name string) (int, error) {
 // fillFromAncestor sets the value of a cgroup file from the first ancestor
 // that has content. It does nothing if the file in 'path' has already been set.
 func fillFromAncestor(path string) (string, error) {
-	out, err := ioutil.ReadFile(path)
+	out, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/runsc/cgroup/cgroup_test.go
+++ b/runsc/cgroup/cgroup_test.go
@@ -16,7 +16,6 @@ package cgroup
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -143,7 +142,7 @@ func createDir(dir string, contents map[string]string) error {
 }
 
 func checkDir(t *testing.T, dir string, contents map[string]string) {
-	all, err := ioutil.ReadDir(dir)
+	all, err := os.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("ReadDir(%q): %v", dir, err)
 	}
@@ -160,7 +159,7 @@ func checkDir(t *testing.T, dir string, contents map[string]string) {
 			t.Errorf("file not expected: %q", file.Name())
 			continue
 		}
-		gotBytes, err := ioutil.ReadFile(filepath.Join(dir, file.Name()))
+		gotBytes, err := os.ReadFile(filepath.Join(dir, file.Name()))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -262,7 +261,7 @@ func TestBlockIO(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -315,7 +314,7 @@ func TestCPU(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -357,7 +356,7 @@ func TestCPUSet(t *testing.T) {
 		// See TestCPUSetAncestor().
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -383,17 +382,17 @@ func TestCPUSet(t *testing.T) {
 func TestCPUSetAncestor(t *testing.T) {
 	// Prepare master directory with cgroup files that will be propagated to
 	// children.
-	grandpa, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+	grandpa, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 	if err != nil {
 		t.Fatalf("error creating temporary directory: %v", err)
 	}
 	defer os.RemoveAll(grandpa)
 
-	if err := ioutil.WriteFile(filepath.Join(grandpa, "cpuset.cpus"), []byte("parent-cpus"), 0666); err != nil {
-		t.Fatalf("ioutil.WriteFile(): %v", err)
+	if err := os.WriteFile(filepath.Join(grandpa, "cpuset.cpus"), []byte("parent-cpus"), 0666); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
 	}
-	if err := ioutil.WriteFile(filepath.Join(grandpa, "cpuset.mems"), []byte("parent-mems"), 0666); err != nil {
-		t.Fatalf("ioutil.WriteFile(): %v", err)
+	if err := os.WriteFile(filepath.Join(grandpa, "cpuset.mems"), []byte("parent-mems"), 0666); err != nil {
+		t.Fatalf("os.WriteFile(): %v", err)
 	}
 
 	for _, tc := range []struct {
@@ -411,7 +410,7 @@ func TestCPUSetAncestor(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create empty files in intermediate directory. They should be ignored
 			// when reading, and then populated from parent.
-			parent, err := ioutil.TempDir(grandpa, "parent")
+			parent, err := os.MkdirTemp(grandpa, "parent")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -424,7 +423,7 @@ func TestCPUSetAncestor(t *testing.T) {
 			}
 
 			// cgroup files mmust exist.
-			dir, err := ioutil.TempDir(parent, "child")
+			dir, err := os.MkdirTemp(parent, "child")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -498,7 +497,7 @@ func TestHugeTlb(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -562,7 +561,7 @@ func TestMemory(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -607,7 +606,7 @@ func TestNetworkClass(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -657,7 +656,7 @@ func TestNetworkPriority(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -700,7 +699,7 @@ func TestPids(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}

--- a/runsc/cgroup/cgroup_v2.go
+++ b/runsc/cgroup/cgroup_v2.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"math/big"
 	"os"
@@ -79,7 +78,7 @@ type cgroupV2 struct {
 }
 
 func newCgroupV2(mountpoint, group string, useSystemd bool) (Cgroup, error) {
-	data, err := ioutil.ReadFile(filepath.Join(mountpoint, "cgroup.controllers"))
+	data, err := os.ReadFile(filepath.Join(mountpoint, "cgroup.controllers"))
 	if err != nil {
 		return nil, err
 	}

--- a/runsc/cgroup/cgroup_v2_test.go
+++ b/runsc/cgroup/cgroup_v2_test.go
@@ -15,7 +15,6 @@
 package cgroup
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -97,7 +96,7 @@ func TestIO(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			testutil.TmpDir()
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}
@@ -117,7 +116,7 @@ func TestIO(t *testing.T) {
 				t.Fatalf("ctrlr.set(): %v", err)
 			}
 
-			gotBytes, err := ioutil.ReadFile(filepath.Join(dir, tc.path))
+			gotBytes, err := os.ReadFile(filepath.Join(dir, tc.path))
 			if err != nil {
 				t.Fatal(err.Error())
 			}
@@ -222,7 +221,7 @@ func TestGetLimits(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			testutil.TmpDir()
-			dir, err := ioutil.TempDir(testutil.TmpDir(), "cgroup")
+			dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
 			if err != nil {
 				t.Fatalf("error creating temporary directory: %v", err)
 			}

--- a/runsc/cli/main.go
+++ b/runsc/cli/main.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"runtime"
@@ -153,7 +152,7 @@ func Main() {
 	} else {
 		// Stderr is reserved for the application, just discard the logs if no debug
 		// log is specified.
-		emitters = append(emitters, newEmitter("text", ioutil.Discard))
+		emitters = append(emitters, newEmitter("text", io.Discard))
 	}
 
 	if *panicLogFD > -1 || *debugLogFD > -1 {

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -262,7 +261,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 	// Do these before chroot takes effect, otherwise we can't read /sys.
 	if len(b.productName) == 0 {
-		if product, err := ioutil.ReadFile("/sys/devices/virtual/dmi/id/product_name"); err != nil {
+		if product, err := os.ReadFile("/sys/devices/virtual/dmi/id/product_name"); err != nil {
 			log.Warningf("Not setting product_name: %v", err)
 		} else {
 			b.productName = strings.TrimSpace(string(product))

--- a/runsc/cmd/delete_test.go
+++ b/runsc/cmd/delete_test.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"gvisor.dev/gvisor/runsc/config"
@@ -23,7 +23,7 @@ import (
 
 func TestNotFound(t *testing.T) {
 	ids := []string{"123"}
-	dir, err := ioutil.TempDir("", "metadata")
+	dir, err := os.MkdirTemp("", "metadata")
 	if err != nil {
 		t.Fatalf("error creating dir: %v", err)
 	}

--- a/runsc/cmd/do.go
+++ b/runsc/cmd/do.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"os"
@@ -381,7 +380,7 @@ func deviceMTU(dev string) (int, error) {
 }
 
 func makeFile(dest, content string, spec *specs.Spec) (string, error) {
-	tmpFile, err := ioutil.TempFile("", filepath.Base(dest))
+	tmpFile, err := os.CreateTemp("", filepath.Base(dest))
 	if err != nil {
 		return "", err
 	}
@@ -433,7 +432,7 @@ func startContainerAndWait(spec *specs.Spec, conf *config.Config, cid string, wa
 	if err != nil {
 		return util.Errorf("Error to marshal spec: %v", err)
 	}
-	tmpDir, err := ioutil.TempDir("", "runsc-do")
+	tmpDir, err := os.MkdirTemp("", "runsc-do")
 	if err != nil {
 		return util.Errorf("Error to create tmp dir: %v", err)
 	}
@@ -443,7 +442,7 @@ func startContainerAndWait(spec *specs.Spec, conf *config.Config, cid string, wa
 	conf.RootDir = tmpDir
 
 	cfgPath := filepath.Join(tmpDir, "config.json")
-	if err := ioutil.WriteFile(cfgPath, out, 0755); err != nil {
+	if err := os.WriteFile(cfgPath, out, 0755); err != nil {
 		return util.Errorf("Error write spec: %v", err)
 	}
 

--- a/runsc/cmd/exec.go
+++ b/runsc/cmd/exec.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -212,7 +211,7 @@ func (ex *Exec) exec(conf *config.Config, c *container.Container, e *control.Exe
 	// Write the sandbox-internal pid if required.
 	if ex.internalPidFile != "" {
 		pidStr := []byte(strconv.Itoa(int(pid)))
-		if err := ioutil.WriteFile(ex.internalPidFile, pidStr, 0644); err != nil {
+		if err := os.WriteFile(ex.internalPidFile, pidStr, 0644); err != nil {
 			return util.Errorf("writing internal pid file %q: %v", ex.internalPidFile, err)
 		}
 	}
@@ -221,7 +220,7 @@ func (ex *Exec) exec(conf *config.Config, c *container.Container, e *control.Exe
 	// users can safely assume that the internal pid file is ready after
 	// `runsc exec -d` returns.
 	if ex.pidFile != "" {
-		if err := ioutil.WriteFile(ex.pidFile, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		if err := os.WriteFile(ex.pidFile, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
 			return util.Errorf("writing pid file: %v", err)
 		}
 	}
@@ -248,7 +247,7 @@ func (ex *Exec) execChildAndWait(waitStatus *unix.WaitStatus) subcommands.ExitSt
 	// filename in a temp directory.
 	pidFile := ex.pidFile
 	if pidFile == "" {
-		tmpDir, err := ioutil.TempDir("", "exec-pid-")
+		tmpDir, err := os.MkdirTemp("", "exec-pid-")
 		if err != nil {
 			util.Fatalf("creating TempDir: %v", err)
 		}
@@ -300,7 +299,7 @@ func (ex *Exec) execChildAndWait(waitStatus *unix.WaitStatus) subcommands.ExitSt
 	// '--process' file is deleted as soon as this process returns and the child
 	// may fail to read it.
 	ready := func() (bool, error) {
-		pidb, err := ioutil.ReadFile(pidFile)
+		pidb, err := os.ReadFile(pidFile)
 		if err == nil {
 			// File appeared, check whether pid is fully written.
 			pid, err := strconv.Atoi(string(pidb))

--- a/runsc/cmd/gofer_test.go
+++ b/runsc/cmd/gofer_test.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -55,9 +54,9 @@ func construct(root string, dirs []dir) error {
 }
 
 func TestResolveSymlinks(t *testing.T) {
-	root, err := ioutil.TempDir(tmpDir(), "root")
+	root, err := os.MkdirTemp(tmpDir(), "root")
 	if err != nil {
-		t.Fatal("ioutil.TempDir() failed:", err)
+		t.Fatal("os.MkdirTemp() failed:", err)
 	}
 	dirs := []dir{
 		{"dir1/dir11/dir111/dir1111", ""}, // Just a boring dir
@@ -146,9 +145,9 @@ func TestResolveSymlinks(t *testing.T) {
 }
 
 func TestResolveSymlinksLoop(t *testing.T) {
-	root, err := ioutil.TempDir(tmpDir(), "root")
+	root, err := os.MkdirTemp(tmpDir(), "root")
 	if err != nil {
-		t.Fatal("ioutil.TempDir() failed:", err)
+		t.Fatal("os.MkdirTemp() failed:", err)
 	}
 	dirs := []dir{
 		{"loop1", "loop2"},

--- a/runsc/cmd/install.go
+++ b/runsc/cmd/install.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -273,7 +272,7 @@ type configReaderWriter struct {
 
 func defaultReadConfig(path string) ([]byte, error) {
 	// Read the configuration data.
-	configBytes, err := ioutil.ReadFile(path)
+	configBytes, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
@@ -288,13 +287,13 @@ func defaultWriteConfig(c map[string]any, filename string) error {
 	}
 
 	// Copy the old configuration.
-	old, err := ioutil.ReadFile(filename)
+	old, err := os.ReadFile(filename)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("error reading config file %q: %v", filename, err)
 		}
 	} else {
-		if err := ioutil.WriteFile(filename+"~", old, 0644); err != nil {
+		if err := os.WriteFile(filename+"~", old, 0644); err != nil {
 			return fmt.Errorf("error backing up config file %q: %v", filename, err)
 		}
 	}
@@ -305,7 +304,7 @@ func defaultWriteConfig(c map[string]any, filename string) error {
 	}
 
 	// Write the new configuration.
-	if err := ioutil.WriteFile(filename, b, 0644); err != nil {
+	if err := os.WriteFile(filename, b, 0644); err != nil {
 		return fmt.Errorf("error writing config file %q: %v", filename, err)
 	}
 

--- a/runsc/cmd/mitigate.go
+++ b/runsc/cmd/mitigate.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -157,9 +156,9 @@ func (*machineControlImpl) disable() error {
 
 // Writes data to SMT control. If file not found, logs file not exist error and returns nil
 // error, which is done because machines without the file pointed to by smtPath only have one
-// thread per core in the first place. Otherwise returns error from ioutil.WriteFile.
+// thread per core in the first place. Otherwise returns error from os.WriteFile.
 func checkFileExistsOnWrite(op, data string) error {
-	err := ioutil.WriteFile(smtPath, []byte(data), 0644)
+	err := os.WriteFile(smtPath, []byte(data), 0644)
 	if err != nil && os.IsExist(err) {
 		log.Infof("File %q does not exist for operation %s. This machine probably has no smt control.", smtPath, op)
 		return nil
@@ -168,12 +167,12 @@ func checkFileExistsOnWrite(op, data string) error {
 }
 
 func (*machineControlImpl) isEnabled() (bool, error) {
-	data, err := ioutil.ReadFile(cpuInfo)
+	data, err := os.ReadFile(cpuInfo)
 	return string(data) == "on", err
 }
 
 func (*machineControlImpl) getCPUs() (mitigate.CPUSet, error) {
-	data, err := ioutil.ReadFile(cpuInfo)
+	data, err := os.ReadFile(cpuInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", cpuInfo, err)
 	}

--- a/runsc/cmd/portforward.go
+++ b/runsc/cmd/portforward.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -322,7 +321,7 @@ func portCopy(ctx context.Context, c *container.Container, localConn net.Conn, p
 
 // tmpUDS generates a temporary UDS addr.
 func tmpUDSAddr() (string, error) {
-	tmpFile, err := ioutil.TempFile("", "runsc-port-forward")
+	tmpFile, err := os.CreateTemp("", "runsc-port-forward")
 	if err != nil {
 		return "", err
 	}

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -416,7 +415,7 @@ func New(conf *config.Config, args Args) (*Container, error) {
 	// Write the PID file. Containerd considers the call to create complete after
 	// this file is created, so it must be the last thing we do.
 	if args.PIDFile != "" {
-		if err := ioutil.WriteFile(args.PIDFile, []byte(strconv.Itoa(c.SandboxPid())), 0644); err != nil {
+		if err := os.WriteFile(args.PIDFile, []byte(strconv.Itoa(c.SandboxPid())), 0644); err != nil {
 			return nil, fmt.Errorf("error writing PID file: %v", err)
 		}
 	}

--- a/runsc/container/metric_server_test.go
+++ b/runsc/container/metric_server_test.go
@@ -17,7 +17,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -771,7 +770,7 @@ func TestMetricServerChecksRootDirectoryAccess(t *testing.T) {
 		t.Fatalf("cannot chmod %q as 000: %v", te.sleepConf.RootDir, err)
 	}
 	defer os.Chmod(te.sleepConf.RootDir, prevStat.Mode())
-	if _, err := ioutil.ReadDir(te.sleepConf.RootDir); err == nil {
+	if _, err := os.ReadDir(te.sleepConf.RootDir); err == nil {
 		t.Logf("Can still read directory %v despite chmodding it to 0. Maybe we are running as root? Skipping test.", te.sleepConf.RootDir)
 		return
 	}

--- a/runsc/container/shared_volume_test.go
+++ b/runsc/container/shared_volume_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func TestSharedVolume(t *testing.T) {
 	// the filesystem.
 	spec := testutil.NewSpecWithArgs("sleep", "1000")
 
-	dir, err := ioutil.TempDir(testutil.TmpDir(), "shared-volume-test")
+	dir, err := os.MkdirTemp(testutil.TmpDir(), "shared-volume-test")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
@@ -81,7 +80,7 @@ func TestSharedVolume(t *testing.T) {
 	}
 
 	// Create the file from outside of the sandbox.
-	if err := ioutil.WriteFile(filename, []byte("foobar"), 0777); err != nil {
+	if err := os.WriteFile(filename, []byte("foobar"), 0777); err != nil {
 		t.Fatalf("error writing to file %q: %v", filename, err)
 	}
 
@@ -168,7 +167,7 @@ func checkFile(conf *config.Config, c *Container, filename string, want []byte) 
 	if _, err := execute(conf, c, "/bin/cp", "-f", filename, cpy); err != nil {
 		return fmt.Errorf("unexpected error copying file %q to %q: %v", filename, cpy, err)
 	}
-	got, err := ioutil.ReadFile(cpy)
+	got, err := os.ReadFile(cpy)
 	if err != nil {
 		return fmt.Errorf("error reading file %q: %v", filename, err)
 	}
@@ -189,7 +188,7 @@ func TestSharedVolumeFile(t *testing.T) {
 	// the filesystem.
 	spec := testutil.NewSpecWithArgs("sleep", "1000")
 
-	dir, err := ioutil.TempDir(testutil.TmpDir(), "shared-volume-test")
+	dir, err := os.MkdirTemp(testutil.TmpDir(), "shared-volume-test")
 	if err != nil {
 		t.Fatalf("TempDir failed: %v", err)
 	}
@@ -221,7 +220,7 @@ func TestSharedVolumeFile(t *testing.T) {
 	// Write file from outside the container and check that the same content is
 	// read inside.
 	want := []byte("host-")
-	if err := ioutil.WriteFile(filename, []byte(want), 0666); err != nil {
+	if err := os.WriteFile(filename, []byte(want), 0666); err != nil {
 		t.Fatalf("Error writing to %q: %v", filename, err)
 	}
 	if err := checkFile(conf, c, filename, want); err != nil {

--- a/runsc/container/state_file.go
+++ b/runsc/container/state_file.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -366,7 +365,7 @@ func (s *StateFile) SaveLocked(v any) error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(s.statePath(), meta, 0640); err != nil {
+	if err := os.WriteFile(s.statePath(), meta, 0640); err != nil {
 		return fmt.Errorf("writing json file: %v", err)
 	}
 	return nil
@@ -384,7 +383,7 @@ func (s *StateFile) load(v any, opts LoadOpts) error {
 	}
 	defer s.UnlockOrDie()
 
-	metaBytes, err := ioutil.ReadFile(s.statePath())
+	metaBytes, err := os.ReadFile(s.statePath())
 	if err != nil {
 		return err
 	}

--- a/runsc/container/trace_test.go
+++ b/runsc/container/trace_test.go
@@ -16,7 +16,6 @@ package container
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -56,7 +55,7 @@ func TestTraceStartup(t *testing.T) {
 			}
 			defer server.Close()
 
-			podInitConfig, err := ioutil.TempFile(testutil.TmpDir(), "config")
+			podInitConfig, err := os.CreateTemp(testutil.TmpDir(), "config")
 			if err != nil {
 				t.Fatalf("error creating tmp file: %v", err)
 			}

--- a/runsc/metricserver/metricserver.go
+++ b/runsc/metricserver/metricserver.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -849,7 +848,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 	// container.ListSandboxes uses a glob pattern, which doesn't error out on
 	// permission errors. Double-check by actually listing the directory.
-	if _, err := ioutil.ReadDir(conf.RootDir); err != nil {
+	if _, err := os.ReadDir(conf.RootDir); err != nil {
 		if !m.allowUnknownRoot {
 			return fmt.Errorf("invalid root directory %q: tried to list all entries within it and got: %w", conf.RootDir, err)
 		}
@@ -930,7 +929,7 @@ func (s *Server) Run(ctx context.Context) error {
 		return fmt.Errorf("cannot start background loop: %w", err)
 	}
 	if m.pidFile != "" {
-		if err := ioutil.WriteFile(m.pidFile, []byte(fmt.Sprintf("%d", m.pid)), 0644); err != nil {
+		if err := os.WriteFile(m.pidFile, []byte(fmt.Sprintf("%d", m.pid)), 0644); err != nil {
 			return fmt.Errorf("cannot write PID to file %q: %w", m.pidFile, err)
 		}
 		defer os.Remove(m.pidFile)

--- a/runsc/mitigate/mitigate_test.go
+++ b/runsc/mitigate/mitigate_test.go
@@ -18,7 +18,7 @@
 package mitigate
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -216,7 +216,7 @@ power management:
 
 // TestReadFile is a smoke test for parsing methods.
 func TestReadFile(t *testing.T) {
-	data, err := ioutil.ReadFile("/proc/cpuinfo")
+	data, err := os.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		t.Fatalf("Failed to read cpuinfo: %v", err)
 	}

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -193,7 +192,7 @@ func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) 
 	if _, err := specFile.Seek(0, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("error seeking to beginning of file %q: %v", specFile.Name(), err)
 	}
-	specBytes, err := ioutil.ReadAll(specFile)
+	specBytes, err := io.ReadAll(specFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading spec from file %q: %v", specFile.Name(), err)
 	}
@@ -273,7 +272,7 @@ func fixSpec(spec *specs.Spec, bundleDir string, conf *config.Config) error {
 
 // ReadMounts reads mount list from a file.
 func ReadMounts(f *os.File) ([]specs.Mount, error) {
-	bytes, err := ioutil.ReadAll(f)
+	bytes, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("error reading mounts: %v", err)
 	}
@@ -695,7 +694,7 @@ func RetryEintr(f func() (uintptr, uintptr, error)) (uintptr, uintptr, error) {
 
 // GetOOMScoreAdj reads the given process' oom_score_adj
 func GetOOMScoreAdj(pid int) (int, error) {
-	data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/oom_score_adj", pid))
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/oom_score_adj", pid))
 	if err != nil {
 		return 0, err
 	}

--- a/test/cmd/test_app/fds.go
+++ b/test/cmd/test_app/fds.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -61,12 +60,12 @@ func (fds *fdSender) Execute(ctx context.Context, f *flag.FlagSet, args ...any) 
 		log.Fatalf("socket flag must be set")
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		log.Fatalf("TempDir failed: %v", err)
 	}
 
-	fileToSend, err := ioutil.TempFile(dir, "")
+	fileToSend, err := os.CreateTemp(dir, "")
 	if err != nil {
 		log.Fatalf("TempFile failed: %v", err)
 	}
@@ -173,7 +172,7 @@ func (fdr *fdReceiver) Execute(ctx context.Context, f *flag.FlagSet, args ...any
 		log.Fatalf("Error from seek(0, 0): %v", err)
 	}
 
-	got, err := ioutil.ReadAll(file)
+	got, err := io.ReadAll(file)
 	if err != nil {
 		log.Fatalf("ReadAll failed: %v", err)
 	}

--- a/test/cmd/test_app/main.go
+++ b/test/cmd/test_app/main.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"net"
@@ -433,7 +432,7 @@ func (c *capability) Execute(ctx context.Context, f *flag.FlagSet, args ...any) 
 		return subcommands.ExitUsageError
 	}
 
-	status, err := ioutil.ReadFile("/proc/self/status")
+	status, err := os.ReadFile("/proc/self/status")
 	if err != nil {
 		fmt.Printf("Error reading %q: %v\n", "proc/self/status", err)
 		return subcommands.ExitFailure

--- a/test/e2e/integration_runtime_test.go
+++ b/test/e2e/integration_runtime_test.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ func TestRlimitNoFile(t *testing.T) {
 	const nfiles = 5000
 	tmpDir := testutil.TmpDir()
 	for i := 0; i < nfiles; i++ {
-		if _, err := ioutil.TempFile(tmpDir, "tmp"); err != nil {
+		if _, err := os.CreateTemp(tmpDir, "tmp"); err != nil {
 			t.Fatalf("TempFile(): %v", err)
 		}
 	}
@@ -99,7 +98,7 @@ func TestDentryCacheLimit(t *testing.T) {
 	const nfiles = 5000
 	tmpDir := testutil.TmpDir()
 	for i := 0; i < nfiles; i++ {
-		if _, err := ioutil.TempFile(tmpDir, "tmp"); err != nil {
+		if _, err := os.CreateTemp(tmpDir, "tmp"); err != nil {
 			t.Fatalf("TempFile(): %v", err)
 		}
 	}

--- a/test/e2e/integration_test.go
+++ b/test/e2e/integration_test.go
@@ -26,7 +26,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -438,12 +437,12 @@ func TestTmpFile(t *testing.T) {
 
 // TestTmpMount checks that mounts inside '/tmp' are not overridden.
 func TestTmpMount(t *testing.T) {
-	dir, err := ioutil.TempDir(testutil.TmpDir(), "tmp-mount")
+	dir, err := os.MkdirTemp(testutil.TmpDir(), "tmp-mount")
 	if err != nil {
 		t.Fatalf("TempDir(): %v", err)
 	}
 	const want = "123"
-	if err := ioutil.WriteFile(filepath.Join(dir, "file.txt"), []byte("123"), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("123"), 0666); err != nil {
 		t.Fatalf("WriteFile(): %v", err)
 	}
 	ctx := context.Background()
@@ -472,9 +471,9 @@ func TestTmpMount(t *testing.T) {
 // Test that it is allowed to mount a file on top of /dev files, e.g.
 // /dev/random.
 func TestMountOverDev(t *testing.T) {
-	random, err := ioutil.TempFile(testutil.TmpDir(), "random")
+	random, err := os.CreateTemp(testutil.TmpDir(), "random")
 	if err != nil {
-		t.Fatal("ioutil.TempFile() failed:", err)
+		t.Fatal("os.CreateTemp() failed:", err)
 	}
 	const want = "123"
 	if _, err := random.WriteString(want); err != nil {
@@ -755,7 +754,7 @@ func TestUnmount(t *testing.T) {
 	d := dockerutil.MakeContainer(ctx, t)
 	defer d.CleanUp(ctx)
 
-	dir, err := ioutil.TempDir(testutil.TmpDir(), "sub-mount")
+	dir, err := os.MkdirTemp(testutil.TmpDir(), "sub-mount")
 	if err != nil {
 		t.Fatalf("TempDir(): %v", err)
 	}
@@ -818,7 +817,7 @@ func TestDeleteInterface(t *testing.T) {
 }
 
 func TestProductName(t *testing.T) {
-	want, err := ioutil.ReadFile("/sys/devices/virtual/dmi/id/product_name")
+	want, err := os.ReadFile("/sys/devices/virtual/dmi/id/product_name")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -857,7 +856,7 @@ func TestRevalidateSymlinkChain(t *testing.T) {
 	//  + sym1 -> sym2
 	//  + sym2 -> gen1
 	//
-	dir, err := ioutil.TempDir(testutil.TmpDir(), "sub-mount")
+	dir, err := os.MkdirTemp(testutil.TmpDir(), "sub-mount")
 	if err != nil {
 		t.Fatalf("TempDir(): %v", err)
 	}

--- a/test/fsstress/fsstress_test.go
+++ b/test/fsstress/fsstress_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"strconv"
@@ -91,9 +90,9 @@ func TestFsstressGofer(t *testing.T) {
 }
 
 func TestFsstressGoferShared(t *testing.T) {
-	dir, err := ioutil.TempDir(testutil.TmpDir(), "fsstress")
+	dir, err := os.MkdirTemp(testutil.TmpDir(), "fsstress")
 	if err != nil {
-		t.Fatalf("ioutil.TempDir() failed: %v", err)
+		t.Fatalf("os.MkdirTemp() failed: %v", err)
 	}
 	defer os.RemoveAll(dir)
 

--- a/test/image/image_test.go
+++ b/test/image/image_test.go
@@ -25,7 +25,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -102,7 +102,7 @@ func runHTTPRequest(ip string, port int) error {
 		return fmt.Errorf("Wrong response code, got: %d, want: %d", resp.StatusCode, want)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("Error reading http response: %v", err)
 	}
@@ -309,7 +309,7 @@ func TestRuby(t *testing.T) {
 	if want := http.StatusOK; resp.StatusCode != want {
 		t.Errorf("wrong response code, got: %d, want: %d", resp.StatusCode, want)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatalf("error reading body: %v", err)
 	}

--- a/test/root/cgroup_test.go
+++ b/test/root/cgroup_test.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -114,7 +113,7 @@ func TestMemCgroup(t *testing.T) {
 			}
 		}
 		// Read the cgroup memory limit.
-		outRaw, err := ioutil.ReadFile(path)
+		outRaw, err := os.ReadFile(path)
 		if err != nil {
 			// It's possible that the container does not exist yet.
 			continue
@@ -139,7 +138,7 @@ func TestMemCgroup(t *testing.T) {
 			}
 		}
 		// Read the cgroup memory usage.
-		outRaw, err = ioutil.ReadFile(path)
+		outRaw, err = os.ReadFile(path)
 		if err != nil {
 			t.Fatalf("error reading usage: %v", err)
 		}
@@ -300,7 +299,7 @@ func TestCgroupV1(t *testing.T) {
 	// Check list of attributes defined above.
 	for _, attr := range attrs {
 		path := cgroupPath(attr.ctrl, "docker", gid, attr.file)
-		out, err := ioutil.ReadFile(path)
+		out, err := os.ReadFile(path)
 		if err != nil {
 			if os.IsNotExist(err) && attr.skipIfNotFound {
 				t.Logf("skipped %s/%s", attr.ctrl, attr.file)
@@ -448,7 +447,7 @@ func TestCgroupV2(t *testing.T) {
 			hostconf.Resources.MemorySwappiness = &val
 		case "blkio-weight":
 			// detect existence of io.bfq.weight as this is not always loaded
-			_, err := ioutil.ReadFile(filepath.Join(baseCgroupPath, attr.file))
+			_, err := os.ReadFile(filepath.Join(baseCgroupPath, attr.file))
 			if err == nil || !attr.skipIfNotFound {
 				hostconf.Resources.BlkioWeight = uint16(attr.value)
 			}
@@ -478,7 +477,7 @@ func TestCgroupV2(t *testing.T) {
 		if useSystemd {
 			path = filepath.Join(baseCgroupPath, "docker-"+gid+".scope", attr.file)
 		}
-		out, err := ioutil.ReadFile(path)
+		out, err := os.ReadFile(path)
 		if err != nil {
 			if os.IsNotExist(err) && attr.skipIfNotFound {
 				t.Logf("skipped %s", attr.file)

--- a/test/root/chroot_test.go
+++ b/test/root/chroot_test.go
@@ -18,7 +18,6 @@ package root
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,7 +77,7 @@ func TestChroot(t *testing.T) {
 		t.Errorf("sandbox current dir is wrong, want: %q, got: %q", chroot, path)
 	}
 
-	fi, err := ioutil.ReadDir(procRoot)
+	fi, err := os.ReadDir(procRoot)
 	if err != nil {
 		t.Fatalf("error listing %q: %v", chroot, err)
 	}

--- a/test/root/crictl_test.go
+++ b/test/root/crictl_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -312,7 +311,7 @@ disabled_plugins = ["io.containerd.internal.v1.restart"]
 func setup(t *testing.T) (*criutil.Crictl, func(), error) {
 	// Create temporary containerd root and state directories, and a socket
 	// via which crictl and containerd communicate.
-	containerdRoot, err := ioutil.TempDir(testutil.TmpDir(), "containerd-root")
+	containerdRoot, err := os.MkdirTemp(testutil.TmpDir(), "containerd-root")
 	if err != nil {
 		t.Fatalf("failed to create containerd root: %v", err)
 	}
@@ -320,14 +319,14 @@ func setup(t *testing.T) (*criutil.Crictl, func(), error) {
 	defer cu.Clean()
 	t.Logf("Using containerd root: %s", containerdRoot)
 
-	containerdState, err := ioutil.TempDir(testutil.TmpDir(), "containerd-state")
+	containerdState, err := os.MkdirTemp(testutil.TmpDir(), "containerd-state")
 	if err != nil {
 		t.Fatalf("failed to create containerd state: %v", err)
 	}
 	cu.Add(func() { os.RemoveAll(containerdState) })
 	t.Logf("Using containerd state: %s", containerdState)
 
-	sockDir, err := ioutil.TempDir(testutil.TmpDir(), "containerd-sock")
+	sockDir, err := os.MkdirTemp(testutil.TmpDir(), "containerd-sock")
 	if err != nil {
 		t.Fatalf("failed to create containerd socket directory: %v", err)
 	}
@@ -446,7 +445,7 @@ func setup(t *testing.T) (*criutil.Crictl, func(), error) {
 	}
 
 	// Discard all subsequent data.
-	go io.Copy(ioutil.Discard, startupR)
+	go io.Copy(io.Discard, startupR)
 
 	// Create the crictl interface.
 	cc := criutil.NewCrictl(t, sockAddr)

--- a/test/root/runsc_test.go
+++ b/test/root/runsc_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -118,7 +117,7 @@ func sandboxPid(pid int) (int, error) {
 			return 0, err
 		}
 
-		cmdline, err := ioutil.ReadFile(filepath.Join("/proc", line, "cmdline"))
+		cmdline, err := os.ReadFile(filepath.Join("/proc", line, "cmdline"))
 		if err != nil {
 			if os.IsNotExist(err) {
 				// Raced with process exit.

--- a/test/runner/main.go
+++ b/test/runner/main.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -97,7 +96,7 @@ func getSetupContainerPath() string {
 func runTestCaseNative(testBin string, tc *gtest.TestCase, args []string, t *testing.T) {
 	// These tests might be running in parallel, so make sure they have a
 	// unique test temp dir.
-	tmpDir, err := ioutil.TempDir(testutil.TmpDir(), "")
+	tmpDir, err := os.MkdirTemp(testutil.TmpDir(), "")
 	if err != nil {
 		t.Fatalf("could not create temp dir: %v", err)
 	}
@@ -388,7 +387,7 @@ func runRunsc(tc *gtest.TestCase, spec *specs.Spec) error {
 		if err := os.MkdirAll(testLogDir, 0755); err != nil {
 			return fmt.Errorf("could not create test dir: %v", err)
 		}
-		tmpDir, err := ioutil.TempDir(testLogDir, "runsc")
+		tmpDir, err := os.MkdirTemp(testLogDir, "runsc")
 		if err != nil {
 			return fmt.Errorf("could not create temp dir: %v", err)
 		}
@@ -860,7 +859,7 @@ func runTestCaseRunsc(testBin string, tc *gtest.TestCase, args []string, t *test
 		//
 		// Some tests (e.g., sticky) access this mount from other
 		// users, so make sure it is world-accessible.
-		tmpDir, err := ioutil.TempDir(testutil.TmpDir(), "")
+		tmpDir, err := os.MkdirTemp(testutil.TmpDir(), "")
 		if err != nil {
 			t.Fatalf("could not create temp dir: %v", err)
 		}

--- a/test/runtimes/proctor/lib/lib_test.go
+++ b/test/runtimes/proctor/lib/lib_test.go
@@ -15,7 +15,6 @@
 package lib
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -38,7 +37,7 @@ func touch(t *testing.T, name string) {
 }
 
 func TestSearchEmptyDir(t *testing.T) {
-	td, err := ioutil.TempDir(testutil.TmpDir(), "searchtest")
+	td, err := os.MkdirTemp(testutil.TmpDir(), "searchtest")
 	if err != nil {
 		t.Fatalf("error creating searchtest: %v", err)
 	}
@@ -58,7 +57,7 @@ func TestSearchEmptyDir(t *testing.T) {
 }
 
 func TestSearch(t *testing.T) {
-	td, err := ioutil.TempDir(testutil.TmpDir(), "searchtest")
+	td, err := os.MkdirTemp(testutil.TmpDir(), "searchtest")
 	if err != nil {
 		t.Fatalf("error creating searchtest: %v", err)
 	}

--- a/test/uds/uds.go
+++ b/test/uds/uds.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -292,7 +291,7 @@ type socketCreatorSpec struct {
 // createSocketTree creates a local tree of unix domain sockets for use in
 // testing as per specs.
 func createSocketTree(baseDir string, specs []socketCreatorSpec) (string, func(), error) {
-	dir, err := ioutil.TempDir(baseDir, "sockets")
+	dir, err := os.MkdirTemp(baseDir, "sockets")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating temp dir: %v", err)
 	}
@@ -390,7 +389,7 @@ type pipeCreator func(path string) (cleanup func(), err error)
 //   - /in
 //   - /out
 func CreateFifoTree(baseDir string) (string, func(), error) {
-	dir, err := ioutil.TempDir(baseDir, "pipes")
+	dir, err := os.MkdirTemp(baseDir, "pipes")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating temp dir: %v", err)
 	}

--- a/tools/checkconst/checkconst.go
+++ b/tools/checkconst/checkconst.go
@@ -25,7 +25,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -274,7 +274,7 @@ func checkAssembly(pass *analysis.Pass) error {
 		if !strings.HasSuffix(filename, ".s") {
 			continue
 		}
-		content, err := ioutil.ReadFile(filename)
+		content, err := os.ReadFile(filename)
 		if err != nil {
 			return fmt.Errorf("unable to read assembly file: %w", err)
 		}

--- a/tools/checkescape/checkescape.go
+++ b/tools/checkescape/checkescape.go
@@ -66,7 +66,6 @@ import (
 	"go/token"
 	"go/types"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -374,13 +373,13 @@ func loadObjdump(binary io.Reader) (finalResults map[string][]string, finalErr e
 	if ok {
 		// Ensure that the file is seekable and that the offset is
 		// zero, since we can't control that.
-		if offset, err := input.Seek(0, os.SEEK_CUR); err != nil || offset != 0 {
+		if offset, err := input.Seek(0, io.SeekCurrent); err != nil || offset != 0 {
 			ok = false // Not usable.
 		}
 	}
 	if !ok {
 		// Copy to a temporary path.
-		f, err := ioutil.TempFile("", "")
+		f, err := os.CreateTemp("", "")
 		if err != nil {
 			return nil, fmt.Errorf("unable to create temp file: %w", err)
 		}

--- a/tools/github/main.go
+++ b/tools/github/main.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -115,7 +114,7 @@ func main() {
 	// environment to faciliate use through GitHub's CI system.
 	token := os.Getenv("GITHUB_TOKEN")
 	if len(tokenFile) != 0 {
-		bytes, err := ioutil.ReadFile(tokenFile)
+		bytes, err := os.ReadFile(tokenFile)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(1)

--- a/tools/github/reviver/reviver.go
+++ b/tools/github/reviver/reviver.go
@@ -19,7 +19,6 @@ package reviver
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -105,7 +104,7 @@ func (r *Reviver) Run() []error {
 
 func (r *Reviver) processPath(path string, wg *sync.WaitGroup) {
 	fmt.Printf("Processing dir %q\n", path)
-	fis, err := ioutil.ReadDir(path)
+	fis, err := os.ReadDir(path)
 	if err != nil {
 		r.addErr(fmt.Errorf("error processing dir %q: %v", path, err))
 		return
@@ -114,14 +113,14 @@ func (r *Reviver) processPath(path string, wg *sync.WaitGroup) {
 	for _, fi := range fis {
 		childPath := filepath.Join(path, fi.Name())
 		switch {
-		case fi.Mode().IsDir():
+		case fi.IsDir():
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				r.processPath(childPath, wg)
 			}()
 
-		case fi.Mode().IsRegular():
+		case fi.Type().IsRegular():
 			file, err := os.Open(childPath)
 			if err != nil {
 				r.addErr(err)

--- a/tools/go_generics/main.go
+++ b/tools/go_generics/main.go
@@ -98,7 +98,6 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -296,7 +295,7 @@ func main() {
 		byteBuf = bytes.ReplaceAll(byteBuf, []byte(old), []byte(new))
 	}
 
-	if err := ioutil.WriteFile(*output, byteBuf, 0644); err != nil {
+	if err := os.WriteFile(*output, byteBuf, 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/tools/parsers/parser_main.go
+++ b/tools/parsers/parser_main.go
@@ -20,7 +20,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -67,7 +66,7 @@ func initBenchmarks(ctx context.Context) error {
 // adds some custom data for the commit, and sends the data to BigQuery.
 func parseBenchmarks(ctx context.Context) error {
 	debugLog("Reading file: %s", *file)
-	data, err := ioutil.ReadFile(*file)
+	data, err := os.ReadFile(*file)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %v", *file, err)
 	}

--- a/webhook/pkg/injector/certs.go
+++ b/webhook/pkg/injector/certs.go
@@ -16,7 +16,7 @@ package injector
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 var (
@@ -33,10 +33,10 @@ func init() {
 		serverKeyErr  error
 		serverCertErr error
 	)
-	caKey, caKeyErr = ioutil.ReadFile("caKey.pem")
-	caCert, caCertErr = ioutil.ReadFile("caCert.pem")
-	serverKey, serverKeyErr = ioutil.ReadFile("serverKey.pem")
-	serverCert, serverCertErr = ioutil.ReadFile("serverCert.pem")
+	caKey, caKeyErr = os.ReadFile("caKey.pem")
+	caCert, caCertErr = os.ReadFile("caCert.pem")
+	serverKey, serverKeyErr = os.ReadFile("serverKey.pem")
+	serverCert, serverCertErr = os.ReadFile("serverCert.pem")
 	for _, err := range []error{caKeyErr, caCertErr, serverKeyErr, serverCertErr} {
 		if err != nil {
 			panic(fmt.Errorf("unable to create certificates: %v", err))


### PR DESCRIPTION
SSIA.

- `ioutil.ReadDir` -> `os..ReadDir`
- `ioutil.ReadFile` -> `os.ReadFile`
- `ioutil.TempFile` -> `os.CreateTemp`
- `ioutil.TempDir` -> `os.MkdirTemp`
- `ioutil.Discard` -> `io.Discard`
- `ioutil.ReadAll` -> `io.ReadAll`
- `os.SEEK_CUR` -> `io.SeekCurrent`