### PR TITLE
crosstool: add /usr/lib/gcc-cross/ to the toolchain

### DIFF
--- a/tools/crosstool-arm-dirs.patch
+++ b/tools/crosstool-arm-dirs.patch
@@ -2,11 +2,12 @@ diff --git a/cc_toolchain_config.bzl.tpl b/cc_toolchain_config.bzl.tpl
 index e864fa2..3de0405 100644
 --- a/cc_toolchain_config.bzl.tpl
 +++ b/cc_toolchain_config.bzl.tpl
-@@ -76,6 +76,7 @@ CXX_BUILTIN_INCLUDE_DIRECTORIES = {
+@@ -76,6 +76,8 @@ CXX_BUILTIN_INCLUDE_DIRECTORIES = {
          "/usr/lib/gcc/x86_64-linux-gnu/%d/include-fixed" % GCC_VERSION,
          "/usr/include/x86_64-linux-gnu",
          "/usr/include",
 +        "/usr/x86_64-linux-gnu/include/",
++        "/usr/lib/gcc-cross/x86_64-linux-gnu/%d/include/" % GCC_VERSION,
      ],
      "armv7a": [
          "/usr/arm-linux-gnueabihf/include/c++/%d" % GCC_VERSION,


### PR DESCRIPTION
This should fix the compile time error:
ERROR: Compiling absl/base/log_severity.cc failed: absolute path inclusion(s) found in rule '@@com_google_absl//absl/base:log_severity': the source file 'absl/base/log_severity.cc' includes the following non-builtin files with absolute paths (if these are builtin files, make sure these paths are in your toolchain):
  '/usr/lib/gcc-cross/x86_64-linux-gnu/11/include/stddef.h'
  '/usr/lib/gcc-cross/x86_64-linux-gnu/11/include/stdarg.h'
  '/usr/lib/gcc-cross/x86_64-linux-gnu/11/include/stdint.h'
  '/usr/lib/gcc-cross/x86_64-linux-gnu/11/include/limits.h'
  '/usr/lib/gcc-cross/x86_64-linux-gnu/11/include/syslimits.h'