### PR TITLE
Remove references to math/rand package's Read function.

### DIFF
--- a/pkg/aio/BUILD
+++ b/pkg/aio/BUILD
@@ -25,6 +25,7 @@ go_test(
     library = ":aio",
     deps = [
         "//pkg/bitmap",
+        "//pkg/rand",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/aio/aio_test.go
+++ b/pkg/aio/aio_test.go
@@ -17,12 +17,12 @@ package aio
 import (
 	"bytes"
 	"io"
-	"math/rand"
 	"os"
 	"testing"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/bitmap"
+	"gvisor.dev/gvisor/pkg/rand"
 )
 
 func TestRead(t *testing.T) {

--- a/pkg/buffer/BUILD
+++ b/pkg/buffer/BUILD
@@ -62,6 +62,7 @@ go_test(
     ],
     library = ":buffer",
     deps = [
+        "//pkg/rand",
         "//pkg/state",
         "//pkg/tcpip/checksum",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/pkg/buffer/buffer_test.go
+++ b/pkg/buffer/buffer_test.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"slices"
 	"strings"
 	"testing"
 
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/state"
 	"gvisor.dev/gvisor/pkg/tcpip/checksum"
 )

--- a/pkg/buffer/view_test.go
+++ b/pkg/buffer/view_test.go
@@ -16,10 +16,10 @@ package buffer
 
 import (
 	"bytes"
-	"math/rand"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"gvisor.dev/gvisor/pkg/rand"
 )
 
 func TestNewView(t *testing.T) {

--- a/pkg/lisafs/BUILD
+++ b/pkg/lisafs/BUILD
@@ -125,6 +125,7 @@ go_test(
     library = ":lisafs",
     deps = [
         "//pkg/marshal",
+        "//pkg/rand",
         "//pkg/sync",
         "//pkg/unet",
         "@org_golang_x_sys//unix:go_default_library",

--- a/pkg/lisafs/sock_test.go
+++ b/pkg/lisafs/sock_test.go
@@ -16,12 +16,12 @@ package lisafs
 
 import (
 	"bytes"
-	"math/rand"
 	"reflect"
 	"testing"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/marshal"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/unet"
 )

--- a/pkg/lisafs/testsuite/BUILD
+++ b/pkg/lisafs/testsuite/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/lisafs",
+        "//pkg/rand",
         "//pkg/refs",
         "//pkg/unet",
         "@com_github_syndtr_gocapability//capability:go_default_library",

--- a/pkg/lisafs/testsuite/testsuite.go
+++ b/pkg/lisafs/testsuite/testsuite.go
@@ -19,7 +19,6 @@ package testsuite
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/lisafs"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/unet"
 )

--- a/pkg/p9/p9test/BUILD
+++ b/pkg/p9/p9test/BUILD
@@ -87,6 +87,7 @@ go_test(
     deps = [
         "//pkg/fd",
         "//pkg/p9",
+        "//pkg/rand",
         "//pkg/sync",
         "@com_github_golang_mock//gomock:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",

--- a/pkg/p9/p9test/client_test.go
+++ b/pkg/p9/p9test/client_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/fd"
 	"gvisor.dev/gvisor/pkg/p9"
+	gvisorrand "gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/sync"
 )
 
@@ -2192,7 +2193,7 @@ func TestReadWriteConcurrent(t *testing.T) {
 
 	// Initialize random data for each instance.
 	for i := 0; i < instances; i++ {
-		if _, err := rand.Read(dataSets[i][:]); err != nil {
+		if _, err := gvisorrand.Read(dataSets[i][:]); err != nil {
 			t.Fatalf("error initializing dataSet#%d, got %v", i, err)
 		}
 	}

--- a/pkg/tcpip/BUILD
+++ b/pkg/tcpip/BUILD
@@ -49,6 +49,7 @@ go_library(
     deps = [
         "//pkg/atomicbitops",
         "//pkg/buffer",
+        "//pkg/rand",
         "//pkg/sync",
         "//pkg/waiter",
         "@org_golang_x_sys//unix:go_default_library",

--- a/pkg/tcpip/link/fdbased/BUILD
+++ b/pkg/tcpip/link/fdbased/BUILD
@@ -42,6 +42,7 @@ go_test(
     library = ":fdbased",
     deps = [
         "//pkg/buffer",
+        "//pkg/rand",
         "//pkg/refs",
         "//pkg/tcpip",
         "//pkg/tcpip/header",

--- a/pkg/tcpip/link/fdbased/endpoint_test.go
+++ b/pkg/tcpip/link/fdbased/endpoint_test.go
@@ -20,7 +20,6 @@ package fdbased
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
 	"os"
 	"slices"
 	"testing"
@@ -30,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"

--- a/pkg/tcpip/network/internal/testutil/BUILD
+++ b/pkg/tcpip/network/internal/testutil/BUILD
@@ -19,6 +19,7 @@ go_library(
     ],
     deps = [
         "//pkg/buffer",
+        "//pkg/rand",
         "//pkg/tcpip",
         "//pkg/tcpip/checker",
         "//pkg/tcpip/header",

--- a/pkg/tcpip/network/internal/testutil/testutil.go
+++ b/pkg/tcpip/network/internal/testutil/testutil.go
@@ -18,11 +18,11 @@ package testutil
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/checker"
 	"gvisor.dev/gvisor/pkg/tcpip/header"

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -35,7 +35,6 @@ import (
 	"io"
 	"math"
 	"math/bits"
-	"math/rand"
 	"net"
 	"reflect"
 	"strconv"
@@ -43,6 +42,7 @@ import (
 	"time"
 
 	"gvisor.dev/gvisor/pkg/atomicbitops"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/waiter"
 )

--- a/pkg/test/testutil/BUILD
+++ b/pkg/test/testutil/BUILD
@@ -17,6 +17,7 @@ go_library(
     visibility = ["//:sandbox"],
     deps = [
         "//pkg/sentry/watchdog",
+        "//pkg/rand",
         "//pkg/sync",
         "//runsc/config",
         "//runsc/flag",

--- a/test/benchmarks/tcp/BUILD
+++ b/test/benchmarks/tcp/BUILD
@@ -13,6 +13,7 @@ go_binary(
     ],
     visibility = ["//:sandbox"],
     deps = [
+        "//pkg/rand",
         "//pkg/tcpip",
         "//pkg/tcpip/adapters/gonet",
         "//pkg/tcpip/link/fdbased",

--- a/test/benchmarks/tcp/tcp_proxy.go
+++ b/test/benchmarks/tcp/tcp_proxy.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"net"
 	"os"
 	"os/signal"
@@ -33,6 +32,7 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/link/fdbased"

--- a/test/cmd/test_app/BUILD
+++ b/test/cmd/test_app/BUILD
@@ -19,6 +19,7 @@ go_binary(
         "//test/syscalls/linux:__pkg__",
     ],
     deps = [
+        "//pkg/rand",
         "//pkg/test/testutil",
         "//pkg/unet",
         "//runsc/flag",

--- a/test/cmd/test_app/main.go
+++ b/test/cmd/test_app/main.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/google/subcommands"
 	"github.com/kr/pty"
+	gvisorrand "gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/test/testutil"
 	"gvisor.dev/gvisor/runsc/flag"
 )
@@ -104,7 +105,7 @@ func (c *fsTreeCreator) Execute(ctx context.Context, f *flag.FlagSet, args ...an
 	}
 
 	data := make([]byte, fileSize)
-	rand.Read(data)
+	gvisorrand.Read(data)
 	for i := uint(0); i < depth; i++ {
 		for j := uint(0); j < numFilesPerLevel; j++ {
 			filePath := filepath.Join(curDir, fmt.Sprintf("file%d", j))

--- a/test/packetimpact/testbench/BUILD
+++ b/test/packetimpact/testbench/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/binary",
         "//pkg/buffer",
         "//pkg/hostarch",
+        "//pkg/rand",
         "//pkg/tcpip",
         "//pkg/tcpip/checksum",
         "//pkg/tcpip/header",

--- a/test/packetimpact/testbench/testbench.go
+++ b/test/packetimpact/testbench/testbench.go
@@ -20,10 +20,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"math/rand"
 	"net"
 	"testing"
 	"time"
+
+	"gvisor.dev/gvisor/pkg/rand"
 )
 
 var (

--- a/test/packetimpact/tests/BUILD
+++ b/test/packetimpact/tests/BUILD
@@ -281,6 +281,7 @@ packetimpact_testbench(
     name = "ipv4_fragment_reassembly",
     srcs = ["ipv4_fragment_reassembly_test.go"],
     deps = [
+        "//pkg/rand",
         "//pkg/tcpip/checksum",
         "//pkg/tcpip/header",
         "//test/packetimpact/testbench",
@@ -293,6 +294,7 @@ packetimpact_testbench(
     name = "ipv6_fragment_reassembly",
     srcs = ["ipv6_fragment_reassembly_test.go"],
     deps = [
+        "//pkg/rand",
         "//pkg/tcpip",
         "//pkg/tcpip/checksum",
         "//pkg/tcpip/header",

--- a/test/packetimpact/tests/ipv4_fragment_reassembly_test.go
+++ b/test/packetimpact/tests/ipv4_fragment_reassembly_test.go
@@ -16,11 +16,11 @@ package ipv4_fragment_reassembly_test
 
 import (
 	"flag"
-	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/tcpip/checksum"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/test/packetimpact/testbench"

--- a/test/packetimpact/tests/ipv6_fragment_reassembly_test.go
+++ b/test/packetimpact/tests/ipv6_fragment_reassembly_test.go
@@ -16,11 +16,11 @@ package ipv6_fragment_reassembly_test
 
 import (
 	"flag"
-	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"gvisor.dev/gvisor/pkg/rand"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/checksum"
 	"gvisor.dev/gvisor/pkg/tcpip/header"

--- a/tools/go_marshal/analysis/BUILD
+++ b/tools/go_marshal/analysis/BUILD
@@ -8,6 +8,9 @@ go_library(
     name = "analysis",
     testonly = 1,
     srcs = ["analysis_unsafe.go"],
+    deps = [
+        "//pkg/rand",
+    ],
     visibility = [
         "//:sandbox",
     ],

--- a/tools/go_marshal/analysis/analysis_unsafe.go
+++ b/tools/go_marshal/analysis/analysis_unsafe.go
@@ -26,10 +26,11 @@ package analysis
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"testing"
 	"unsafe"
+
+	"gvisor.dev/gvisor/pkg/rand"
 )
 
 // RandomizeValue assigns random value(s) to an abitrary type. This is intended


### PR DESCRIPTION
The helper function is deprecated. The package gvisor.dev/gvisor/pkg/rand depends on crypto/rand which performs worse thatn math/rand, the changes are fine since they are not at any gVisor's hot path.

The ultimate goal is to migrate math/rand to math/rand/v2.