### PR TITLE
Strip the extra path in go_types_memoize.patch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -96,7 +96,7 @@ go_download_sdk(
     # analysis. Without this fix, the nogo rules will often fail to run in
     # time on our continuous integration.
     patch = "//tools:go_types_memoize.patch",
-    patch_strip = 2,
+    patch_strip = 1,
     version = "1.23.2",
 )
 

--- a/tools/go_types_memoize.patch
+++ b/tools/go_types_memoize.patch
@@ -1,7 +1,7 @@
-diff --git a/go/src/go/types/scope.go b/src/go/types/scope.go
+diff --git a/src/go/types/scope.go b/src/go/types/scope.go
 index 010727eb72..0f134b872e 100644
---- a/go/src/go/types/scope.go
-+++ b/go/src/go/types/scope.go
+--- a/src/go/types/scope.go
++++ b/src/go/types/scope.go
 @@ -25,6 +25,7 @@ type Scope struct {
  	children []*Scope
  	number   int               // parent.children[number-1] is this scope; 0 if there is no parent


### PR DESCRIPTION
The go_types_memoize.patch was generated using the git diff command, with the 'go' field manually added to the path. It would be more appropriate to set the patch_strip value to 1 when applying such patches.