### PR TITLE
Avoid sending a signal to the container during checkpointing

### DIFF
--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//pkg/metric",
         "//pkg/rand",
         "//pkg/refs",
+        "//pkg/atomicbitops",
         "//pkg/sentry/arch",
         "//pkg/sentry/arch:registers_go_proto",
         "//pkg/sentry/control",


### PR DESCRIPTION
When checkpointing, the container.SignalContainer will be blocked until the end of the checkpointing process, during which it cannot acquire the kernel.extMu mutex. As a result, some runsc commands, such as the runsc list, will have to wait. The waiting time may vary with the duration of the checkpoint. This patch adds a flag to prevent sending signals to the container during checkpointing.