### PR TITLE
Implement /proc/sys/kernel/pid_max with TasksLimit

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -52,6 +52,7 @@ func (fs *filesystem) newSysDir(ctx context.Context, root *auth.Credentials, k *
 			"hostname":     fs.newInode(ctx, root, 0444, &hostnameData{}),
 			"overflowgid":  fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowGID))),
 			"overflowuid":  fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowUID))),
+			"pid_max":      fs.newInode(ctx, root, 0644, newStaticFile(fmt.Sprintf("%d\n", kernel.TasksLimit))),
 			"random": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 				"boot_id": fs.newInode(ctx, root, 0444, newStaticFile(randUUID())),
 			}),


### PR DESCRIPTION
Previously, /proc/sys/kernel/pid_max did not exist in sandboxes, making some processes which depend on it fail. This commit populates it with kernel.TasksLimit.

Resolves #11120