### PR TITLE
runsc: add cpuinfo to the sandbox proc

### DIFF
--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -143,6 +143,9 @@ func setupMinimalProcfs(chroot string) error {
 	if err := os.Symlink(procSubmountDir+"/self", filepath.Join(procRoot, "self")); err != nil {
 		return fmt.Errorf("error creating symlink %q -> %q: %w", filepath.Join(procRoot, "self"), procSubmountDir+"/self", err)
 	}
+	if err := os.Symlink(procSubmountDir+"/cpuinfo", filepath.Join(procRoot, "cpuinfo")); err != nil {
+		return fmt.Errorf("error creating symlink %q -> %q: %w", filepath.Join(procRoot, "cpuinfo"), procSubmountDir+"/cpuinfo", err)
+	}
 	if err := os.Chmod(procRoot, 0o111); err != nil {
 		return fmt.Errorf("error chmodding %q: %v", procRoot, err)
 	}


### PR DESCRIPTION
It is required to initialize cpuid.hostFeatureSet.