### PR TITLE
Add a new RPC `ConnectWithCreds` to allow gofer to connect to a unix domain socket with application's credentials

### DIFF
--- a/images/basic/integrationtest/Dockerfile
+++ b/images/basic/integrationtest/Dockerfile
@@ -18,8 +18,11 @@ RUN gcc -O2 -o tcp_server tcp_server.c
 
 # Add nonprivileged regular user named "nonroot".
 RUN groupadd --gid 1337 nonroot && \
-    useradd --uid 1337 --gid 1337 \
+    useradd --uid 1338 --gid 1337 \
         --create-home \
         --shell $(which bash) \
         --password '' \
         nonroot
+
+# Copy host_connect to /home/nonroot so that "nonroot" can execute it.
+RUN cp host_connect /home/nonroot/host_connect

--- a/pkg/lisafs/fd.go
+++ b/pkg/lisafs/fd.go
@@ -484,6 +484,13 @@ type ControlFDImpl interface {
 	// On the server, Connect has a read concurrency guarantee.
 	Connect(sockType uint32) (int, error)
 
+	// ConnectWithCreds is a wrapper around Connect but first changes the gofer's
+	// euid and egid to the given uid and gid before calling Connect. It restores
+	// the euid and egid after Connect.
+	//
+	// On the server, ConnectWithCreds has a read concurrency guarantee.
+	ConnectWithCreds(sockType uint32, uid UID, gid GID) (int, error)
+
 	// BindAt creates a host unix domain socket of type sockType, bound to
 	// the given namt of type sockType, bound to the given name. It returns
 	// a ControlFD that can be used for path operations on the socket, a

--- a/pkg/lisafs/message.go
+++ b/pkg/lisafs/message.go
@@ -172,6 +172,10 @@ const (
 
 	// Accept is analogous to accept4(2).
 	Accept MID = 31
+
+	// ConnectWithCreds is analogous to connect(2) but it asks the server
+	// to connect with the provided effective uid/gid.
+	ConnectWithCreds MID = 32
 )
 
 const (
@@ -1316,6 +1320,21 @@ type ConnectResp struct{ EmptyMessage }
 // String implements fmt.Stringer.String.
 func (*ConnectResp) String() string {
 	return "ConnectResp{}"
+}
+
+// ConnectWithCredsReq is used to make a ConnectWithCreds request. The response is also ConnectResp.
+//
+// +marshal boundCheck
+type ConnectWithCredsReq struct {
+	ConnectReq
+	// UID and GID are used to specify the credentials to connect with.
+	UID UID
+	GID GID
+}
+
+// String implements fmt.Stringer.String.
+func (c *ConnectWithCredsReq) String() string {
+	return fmt.Sprintf("ConnectWithCredsReq{FD: %d, SockType: %d, UID: %d, GID: %d}", c.FD, c.SockType, c.UID, c.GID)
 }
 
 // BindAtReq is used to make BindAt requests.

--- a/pkg/sentry/fsimpl/gofer/directfs_dentry.go
+++ b/pkg/sentry/fsimpl/gofer/directfs_dentry.go
@@ -603,13 +603,13 @@ func (d *directfsDentry) getDirentsLocked(recordDirent func(name string, key ino
 }
 
 // Precondition: fs.renameMu is locked.
-func (d *directfsDentry) connect(ctx context.Context, sockType linux.SockType) (int, error) {
+func (d *directfsDentry) connect(ctx context.Context, sockType linux.SockType, euid lisafs.UID, egid lisafs.GID) (int, error) {
 	// There are no filesystems mounted in the sandbox process's mount namespace.
 	// So we can't perform absolute path traversals. So fallback to using lisafs.
 	if err := d.ensureLisafsControlFD(ctx); err != nil {
 		return -1, err
 	}
-	return d.controlFDLisa.Connect(ctx, sockType)
+	return d.controlFDLisa.Connect(ctx, sockType, euid, egid)
 }
 
 func (d *directfsDentry) readlink() (string, error) {

--- a/pkg/sentry/kernel/auth/context.go
+++ b/pkg/sentry/kernel/auth/context.go
@@ -39,6 +39,14 @@ func CredentialsFromContext(ctx context.Context) *Credentials {
 	return NewAnonymousCredentials()
 }
 
+// CredentialsFromContextOrNil returns a copy of the Credentials used by ctx, or nil if ctx does not have Credentials.
+func CredentialsFromContextOrNil(ctx context.Context) *Credentials {
+	if v := ctx.Value(CtxCredentials); v != nil {
+		return v.(*Credentials)
+	}
+	return nil
+}
+
 // ThreadGroupIDFromContext returns the current thread group ID when ctx
 // represents a task context.
 func ThreadGroupIDFromContext(ctx context.Context) (tgid int32, ok bool) {

--- a/runsc/fsgofer/filter/config.go
+++ b/runsc/fsgofer/filter/config.go
@@ -208,7 +208,9 @@ var udsCommonSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule
 })
 
 var udsOpenSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
-	unix.SYS_CONNECT: seccomp.MatchAll{},
+	unix.SYS_CONNECT:  seccomp.MatchAll{},
+	unix.SYS_SETREUID: seccomp.MatchAll{},
+	unix.SYS_SETREGID: seccomp.MatchAll{},
 })
 
 var udsCreateSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{

--- a/test/e2e/integration_runtime_test.go
+++ b/test/e2e/integration_runtime_test.go
@@ -44,7 +44,9 @@ import (
 const (
 	// defaultWait is the default wait time used for tests.
 	defaultWait = time.Minute
-
+	// nonRootUID and nonRootGID correspond to the uid/gid defined in images/basic/integrationtest/Dockerfile.
+	nonRootUID = 1338
+	nonRootGID = 1337
 	memInfoCmd = "cat /proc/meminfo | grep MemTotal: | awk '{print $2}'"
 )
 
@@ -52,6 +54,26 @@ func TestMain(m *testing.M) {
 	dockerutil.EnsureSupportedDockerVersion()
 	flag.Parse()
 	os.Exit(m.Run())
+}
+
+func checkPeerCreds(conn net.Conn) error {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("expected *net.UnixConn, got %T", conn)
+	}
+	file, err := unixConn.File()
+	if err != nil {
+		return fmt.Errorf("file error: %v", err)
+	}
+	defer file.Close()
+	cred, err := unix.GetsockoptUcred(int(file.Fd()), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	if err != nil {
+		return fmt.Errorf("getsockopt error: %v", err)
+	}
+	if cred.Uid != nonRootUID || cred.Gid != nonRootGID {
+		return fmt.Errorf("expected uid/gid %d/%d, got %d/%d", nonRootUID, nonRootGID, cred.Uid, cred.Gid)
+	}
+	return nil
 }
 
 func TestRlimitNoFile(t *testing.T) {
@@ -135,11 +157,16 @@ func TestHostSocketConnect(t *testing.T) {
 	}
 	defer unix.Close(tmpDirFD)
 	// Use /proc/self/fd to generate path to avoid EINVAL on large path.
-	l, err := net.Listen("unix", filepath.Join("/proc/self/fd", strconv.Itoa(tmpDirFD), "test.sock"))
+	socketPath := filepath.Join("/proc/self/fd", strconv.Itoa(tmpDirFD), "test.sock")
+	l, err := net.Listen("unix", socketPath)
 	if err != nil {
 		t.Fatalf("listen error: %v", err)
 	}
 	defer l.Close()
+	// Change the socket's permission so that "nonroot" can connect to it.
+	if err := os.Chmod(socketPath, 0777); err != nil {
+		t.Errorf("chmod error: %v", err)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -150,7 +177,10 @@ func TestHostSocketConnect(t *testing.T) {
 			t.Errorf("accept error: %v", err)
 			return
 		}
-
+		if err := checkPeerCreds(conn); err != nil {
+			t.Errorf("peer creds check failed: %v", err)
+			return
+		}
 		conn.SetReadDeadline(time.Now().Add(30 * time.Second))
 		var buf [5]byte
 		if _, err := conn.Read(buf[:]); err != nil {
@@ -165,16 +195,17 @@ func TestHostSocketConnect(t *testing.T) {
 
 	opts := dockerutil.RunOpts{
 		Image:   "basic/integrationtest",
-		WorkDir: "/root",
+		WorkDir: "/home/nonroot",
+		User:    "nonroot",
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,
 				Source: filepath.Join(tmpDir, "test.sock"),
-				Target: "/test.sock",
+				Target: "/home/nonroot/test.sock",
 			},
 		},
 	}
-	if _, err := d.Run(ctx, opts, "./host_connect", "/test.sock"); err != nil {
+	if _, err := d.Run(ctx, opts, "./host_connect", "./test.sock"); err != nil {
 		t.Fatalf("docker run failed: %v", err)
 	}
 	wg.Wait()


### PR DESCRIPTION
Dear gvisor developers,

Thank you very much for maintaining / developing gvisor!

## Motivation
We had a use case (which I believe is a wide use case) that the sandboxes send requests over a unix domain socket on host, which is mapped to the container's file system and listened to by a server on the local host.

The sandboxed application is started with a prescribed uid. To authenticate the request, the server verifies the request's uid.

However, as the gofer process (which usually runs as root) executes [connect(unix_domain_socket) call](https://github.com/google/gvisor/blob/bd0cbf807169db29837d238209c02c816f3c8dbf/runsc/fsgofer/lisafs.go#L819) on behalf of the sandbox, the server always sees a uid 0. Hence the server cannot authenticate the UDS requests coming from the sandbox.

## Proposal
I propose to Add a new RPC `ConnectWithCreds` to allow gofer to connect to a unix domain socket with application's credentials. On that gofer server thread, the euid/egid are temporarily changed to application's uid/gid and restored after the `connect(2)` call.

## Questions
What do you think of this change? Is there any security/ functionality concern? Thank you so much for your feedback!