### PR TITLE
Add flag to disable container spec validation when restoring checkpoints

### DIFF
--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -384,6 +384,10 @@ type Config struct {
 
 	// TestOnlySaveRestoreNetstack indicates netstack should be saved and restored.
 	TestOnlySaveRestoreNetstack bool `flag:"TESTONLY-save-restore-netstack"`
+
+	// UnsafeSkipRestoreSpecValidation optionally skips validation of the container spec for restored
+	// containers.
+	UnsafeSkipRestoreSpecValidation bool `flag:"unsafe-skip-restore-spec-validation"`
 }
 
 func (c *Config) validate() error {

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -105,6 +105,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("enable-core-tags", false, "enables core tagging. Requires host linux kernel >= 5.14.")
 	flagSet.String("pod-init-config", "", "path to configuration file with additional steps to take during pod creation.")
 	flagSet.Var(HostSettingsCheck.Ptr(), "host-settings", "how to handle non-optimal host kernel settings: check (default, advisory-only), ignore (do not check), adjust (best-effort auto-adjustment), or enforce (auto-adjustment must succeed).")
+	flagSet.Bool("unsafe-skip-restore-spec-validation", false, "Enables skipping validation of the restore-time container spec when restoring checkpoints.")
 
 	// Flags that control sandbox runtime behavior: MM related.
 	flagSet.Bool("app-huge-pages", true, "enable use of huge pages for application memory; requires /sys/kernel/mm/transparent_hugepage/shmem_enabled = advise")


### PR DESCRIPTION
This PR adds a new flag entitled `skip-restore-spec-validation-unsafe`, defaulting to false. If the flag is set, the container spec given when restoring a checkpoint will no longer be validated against the original container spec given when the checkpoint was taken. In practice, many spec differences are benign, and it can be useful to allow the container specs to vary somewhat between checkpoint and restore. See https://github.com/google/gvisor/issues/11307 .