### PR TITLE
runsc: Fix newline for cmd usage display

### DIFF
--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -201,7 +201,7 @@ func (*Boot) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Boot) Usage() string {
-	return `boot [flags] <container id>`
+	return "boot [flags] <container id>\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/checkpoint.go
+++ b/runsc/cmd/checkpoint.go
@@ -55,8 +55,7 @@ func (*Checkpoint) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Checkpoint) Usage() string {
-	return `checkpoint [flags] <container id> - save current state of container.
-`
+	return "checkpoint [flags] <container id> - save current state of container.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/create.go
+++ b/runsc/cmd/create.go
@@ -62,8 +62,7 @@ func (*Create) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Create) Usage() string {
-	return `create [flags] <container id> - create a secure container
-`
+	return "create [flags] <container id> - create a secure container\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/debug.go
+++ b/runsc/cmd/debug.go
@@ -64,7 +64,7 @@ func (*Debug) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*Debug) Usage() string {
-	return `debug [flags] <container id>`
+	return "debug [flags] <container id>\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/delete.go
+++ b/runsc/cmd/delete.go
@@ -45,7 +45,7 @@ func (*Delete) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Delete) Usage() string {
-	return `delete [flags] <container ids>`
+	return "delete [flags] <container ids>\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -112,7 +112,7 @@ func (g *Gofer) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*Gofer) Usage() string {
-	return `gofer [flags]`
+	return "gofer [flags]\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/install.go
+++ b/runsc/cmd/install.go
@@ -52,8 +52,7 @@ func (*Install) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Install) Usage() string {
-	return `install [--runtime=<name>] [flags] [-- [args...]] -- if provided, args are passed to the runtime
-`
+	return "install [--runtime=<name>] [flags] [-- [args...]] -- if provided, args are passed to the runtime\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.
@@ -212,8 +211,7 @@ func (*Uninstall) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Uninstall) Usage() string {
-	return `uninstall [flags] <name>
-`
+	return "uninstall [flags] <name>\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/kill.go
+++ b/runsc/cmd/kill.go
@@ -46,7 +46,7 @@ func (*Kill) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Kill) Usage() string {
-	return `kill <container id> [signal]`
+	return "kill <container id> [signal]\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/list.go
+++ b/runsc/cmd/list.go
@@ -51,7 +51,7 @@ func (*List) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*List) Usage() string {
-	return `list [flags]`
+	return "list [flags]\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/metric_export.go
+++ b/runsc/cmd/metric_export.go
@@ -47,8 +47,7 @@ func (*MetricExport) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*MetricExport) Usage() string {
-	return `export-metrics [-exporter-prefix=<runsc_>] <container id> - prints sandbox metric data in Prometheus metric format
-`
+	return "export-metrics [-exporter-prefix=<runsc_>] <container id> - prints sandbox metric data in Prometheus metric format\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/metricserver/metricservercmd/metricservercmd.go
+++ b/runsc/cmd/metricserver/metricservercmd/metricservercmd.go
@@ -39,8 +39,7 @@ func (*Cmd) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Cmd) Usage() string {
-	return `-root=<root dir> -metric-server=<addr> metric-server [-exporter-prefix=<runsc_>]
-`
+	return "-root=<root dir> -metric-server=<addr> metric-server [-exporter-prefix=<runsc_>]\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/nvproxy/list_supported_drivers.go
+++ b/runsc/cmd/nvproxy/list_supported_drivers.go
@@ -39,8 +39,7 @@ func (*listSupportedDrivers) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*listSupportedDrivers) Usage() string {
-	return `list-supported-drivers - list all nvidia driver versions supported by nvproxy
-`
+	return "list-supported-drivers - list all nvidia driver versions supported by nvproxy\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/pause.go
+++ b/runsc/cmd/pause.go
@@ -39,7 +39,7 @@ func (*Pause) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Pause) Usage() string {
-	return `pause <container id> - pause process in instance of container.`
+	return "pause <container id> - pause process in instance of container.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/platforms.go
+++ b/runsc/cmd/platforms.go
@@ -39,8 +39,7 @@ func (*Platforms) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Platforms) Usage() string {
-	return `platforms [options] - Print available platforms.
-`
+	return "platforms [options] - Print available platforms.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/restore.go
+++ b/runsc/cmd/restore.go
@@ -67,8 +67,7 @@ func (*Restore) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Restore) Usage() string {
-	return `restore [flags] <container id> - restore saved state of container.
-`
+	return "restore [flags] <container id> - restore saved state of container.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/resume.go
+++ b/runsc/cmd/resume.go
@@ -39,8 +39,7 @@ func (*Resume) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Resume) Usage() string {
-	return `resume <container id> - resume a paused container.
-`
+	return "resume <container id> - resume a paused container.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/run.go
+++ b/runsc/cmd/run.go
@@ -56,8 +56,7 @@ func (*Run) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Run) Usage() string {
-	return `run [flags] <container id> - create and run a secure container.
-`
+	return "run [flags] <container id> - create and run a secure container.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/start.go
+++ b/runsc/cmd/start.go
@@ -40,7 +40,7 @@ func (*Start) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Start) Usage() string {
-	return `start <container id> - start a secure container.`
+	return "start <container id> - start a secure container.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/state.go
+++ b/runsc/cmd/state.go
@@ -42,7 +42,7 @@ func (*State) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*State) Usage() string {
-	return `state [flags] <container id> - get the state of a container`
+	return "state [flags] <container id> - get the state of a container\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/statefile.go
+++ b/runsc/cmd/statefile.go
@@ -47,7 +47,7 @@ func (*Statefile) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*Statefile) Usage() string {
-	return `statefile [flags] <statefile>`
+	return "statefile [flags] <statefile>\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/syscalls.go
+++ b/runsc/cmd/syscalls.go
@@ -91,8 +91,7 @@ func (*Syscalls) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Syscalls) Usage() string {
-	return `syscalls [options] - Print compatibility information for syscalls.
-`
+	return "syscalls [options] - Print compatibility information for syscalls.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/trace/create.go
+++ b/runsc/cmd/trace/create.go
@@ -48,8 +48,7 @@ func (*create) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*create) Usage() string {
-	return `create [flags] <sandbox id> - create a trace session
-`
+	return "create [flags] <sandbox id> - create a trace session\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/trace/delete.go
+++ b/runsc/cmd/trace/delete.go
@@ -42,8 +42,7 @@ func (*delete) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*delete) Usage() string {
-	return `delete [flags] <sandbox id> - delete a trace session
-`
+	return "delete [flags] <sandbox id> - delete a trace session\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/trace/list.go
+++ b/runsc/cmd/trace/list.go
@@ -40,8 +40,7 @@ func (*list) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*list) Usage() string {
-	return `list - list all trace sessions
-`
+	return "list - list all trace sessions\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/trace/metadata.go
+++ b/runsc/cmd/trace/metadata.go
@@ -40,8 +40,7 @@ func (*metadata) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*metadata) Usage() string {
-	return `metadata - list all trace points configuration information
-`
+	return "metadata - list all trace points configuration information\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/trace/procfs.go
+++ b/runsc/cmd/trace/procfs.go
@@ -43,8 +43,7 @@ func (*procfs) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*procfs) Usage() string {
-	return `procfs <sandbox id> - get procfs dump for a trace session
-`
+	return "procfs <sandbox id> - get procfs dump for a trace session\n"
 }
 
 // SetFlags implements subcommands.Command.

--- a/runsc/cmd/umount_unsafe.go
+++ b/runsc/cmd/umount_unsafe.go
@@ -44,7 +44,7 @@ func (*Umount) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Umount) Usage() string {
-	return `umount --sync-fd=FD <directory path>`
+	return "umount --sync-fd=FD <directory path>\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/usage.go
+++ b/runsc/cmd/usage.go
@@ -43,8 +43,7 @@ func (*Usage) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Usage) Usage() string {
-	return `usage [flags] <container id> - print memory usages to standard output.
-`
+	return "usage [flags] <container id> - print memory usages to standard output.\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.

--- a/runsc/cmd/wait.go
+++ b/runsc/cmd/wait.go
@@ -51,7 +51,7 @@ func (*Wait) Synopsis() string {
 
 // Usage implements subcommands.Command.Usage.
 func (*Wait) Usage() string {
-	return `wait [flags] <container id>`
+	return "wait [flags] <container id>\n"
 }
 
 // SetFlags implements subcommands.Command.SetFlags.


### PR DESCRIPTION
## Summary
Originally, some of the commands' usage display didn't achieved to show newline, while some of them does, which are more user-friendly, and won't confuse the message if there're more which should be in the nextline.

Fix this issue by returning usage string with a newline.

## Tests
Before the change some commands display their usage like the following, for example `runsc start`
```
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$ runsc start
start <container id> - start a secure container.vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$
```
Or `runsc wait`
```
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$ runsc wait
wait [flags] <container id>  -checkpoint
    	wait for the next checkpoint to complete
  -pid int
    	select a PID in the container's PID namespace to wait on instead of the container's root process (default -1)
  -rootpid int
    	select a PID in the sandbox root PID namespace to wait on instead of the container's root process (default -1)
```
We can see in the case of `runsc wait`, the flag `-checkpoint` is expected to be shown in a way which is aligned with other flags, like
```
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$ runsc wait
wait [flags] <container id>  
  -checkpoint
    	wait for the next checkpoint to complete
  -pid int
    	select a PID in the container's PID namespace to wait on instead of the container's root process (default -1)
  -rootpid int
    	select a PID in the sandbox root PID namespace to wait on instead of the container's root process (default -1)
```

After the change , we can see those commands with this issue are being fixed.
```
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$ runsc start
start <container id> - start a secure container.
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$
```
```
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$ runsc wait
wait [flags] <container id>
  -checkpoint
    	wait for the next checkpoint to complete
  -pid int
    	select a PID in the container's PID namespace to wait on instead of the container's root process (default -1)
  -rootpid int
    	select a PID in the sandbox root PID namespace to wait on instead of the container's root process (default -1)
```