### PR TITLE
runsc: Write bytes into sandboxSyncFile

### DIFF
--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -874,6 +874,7 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	donations.DonateAndClose("gofer-filestore-fds", args.GoferFilestoreFiles...)
 	donations.DonateAndClose("mounts-fd", args.MountsFile)
 	donations.Donate("start-sync-fd", startSyncFile)
+	startSyncFile.Write([]byte("hello world"))
 	if err := donations.OpenAndDonate("user-log-fd", args.UserLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Read operation for `clientSyncFile` would fail and get an error of `EOF` if nothing is inside "sandboxSyncFile", even the Pipe is successfully created.

Write some bytes into sandboxSyncFile to avoid the issue.

## Testing
Using runsc command line trying to create a container with
```
$ sudo runsc create 8908efda
creating container: cannot create sandbox: cannot read client sync file: waiting for sandbox to start: EOF
```
The error message shows the the result of the `Read()` operation of sync file which is `clientSyncFile`, is `EOF`.
Because nothing is produced inside the pipe. Once we write some data into `sandboxSyncFile`, the container is created without any problem.
```
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$ sudo runsc create 8908efdfs
vax-r@vaxr-ASUSPRO-D840MB-M840MB:~/gvisor$ sudo runsc list
ID          PID         STATUS      BUNDLE               CREATED                               OWNER
8908efdfs   -1          stopped     /home/vax-r/gvisor   2024-12-30T23:00:44.055791375+08:00   root
```