### PR TITLE
fix typo in mount setup for initial userns fallback

### DIFF
--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -532,7 +532,7 @@ func (g *Gofer) setupMounts(conf *config.Config, mounts []specs.Mount, root, pro
 			// to open the mount, so let's try to open it in the
 			// parent user namespace.
 			var res container.OpenMountResult
-			if err := goferToHostRPC.Call("goferRPC.OpenMount", &m, &res); err != nil {
+			if err := goferToHostRPC.Call("goferToHostRPC.OpenMount", &m, &res); err != nil {
 				return fmt.Errorf("opening %s: %w", m.Source, err)
 			}
 			srcFile = res.Files[0]


### PR DESCRIPTION
- this fixes an invalid reference to the `goferToHostRPC.OpenMount` method in the urpc client, which leads to consistent errors like `FATAL ERROR: error setting up FS: opening <dir name>: unknown method`. The struct is called `goferToHostRPC`, not `goferRPC`
- this bug is always hit when the current process does *not* have permissions to access the mount
- this bug was introduced in this recently merged PR: https://github.com/google/gvisor/pull/11128, which added this fallback mechanism