### PR TITLE
Add video and graphics capability for `gpu-all-tests` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ gpu-images: gpu-smoke-images load-gpu_pytorch load-gpu_ollama load-gpu_ollama_cl
 .PHONY: gpu-images
 
 gpu-all-tests: gpu-images gpu-smoke-tests $(RUNTIME_BIN)
-	@$(call install_runtime,$(RUNTIME),--nvproxy=true --nvproxy-docker=true)
+	@$(call install_runtime,$(RUNTIME),--nvproxy=true --nvproxy-docker=true --nvproxy-allowed-driver-capabilities=all)
 	@$(call sudo,test/gpu:pytorch_test,--runtime=$(RUNTIME) -test.v $(ARGS))
 	@$(call sudo,test/gpu:textgen_test,--runtime=$(RUNTIME) -test.v $(ARGS))
 	@$(call sudo,test/gpu:imagegen_test,--runtime=$(RUNTIME) -test.v $(ARGS))


### PR DESCRIPTION
This should fix the test failure for `ffmpeg_test` in `gpu-all-tests`. 

There is an additional failure in `cos-gpu-all-tests`. Briefly looking at the code, it seems like there is special logic mounting NVIDIA libraries https://github.com/google/gvisor/blob/c5c74f4c90ac8f9556a251117765cb951da369e7/pkg/test/dockerutil/gpu.go#L131
and probably `libcuvid.so` is not getting mounted properly (or isn't even installed). I don't know about how the COS instances are configured so I'd have to look deeper into this, potentially we could remove the test for now.

@EtiennePerot @ayushr2 