### PR TITLE
Clarify -cgroupfs

### DIFF
--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -123,7 +123,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("vfs2", true, "DEPRECATED: this flag has no effect.")
 	flagSet.Bool("fuse", true, "DEPRECATED: this flag has no effect.")
 	flagSet.Bool("lisafs", true, "DEPRECATED: this flag has no effect.")
-	flagSet.Bool("cgroupfs", false, "Automatically mount cgroupfs.")
+	flagSet.Bool("cgroupfs", false, "DEPRECATED: this flag has no effect.")
 	flagSet.Bool("ignore-cgroups", false, "don't configure cgroups.")
 	flagSet.Int("fdlimit", -1, "Specifies a limit on the number of host file descriptors that can be open. Applies separately to the sentry and gofer. Note: each file in the sandbox holds more than one host FD open.")
 	flagSet.Int("dcache", -1, "Set the global dentry cache size. This acts as a coarse-grained control on the number of host FDs simultaneously open by the sentry. If negative, per-mount caches are used.")


### PR DESCRIPTION
This flag's behavior was removed back in 29234bc44b51, so clarify for the user not to bother with it anymore.