### PR TITLE
ring0: set PhysicalAddressBits only when uninitialized

### DIFF
--- a/pkg/ring0/lib_amd64.go
+++ b/pkg/ring0/lib_amd64.go
@@ -99,7 +99,9 @@ var (
 // another time with a  different FeatureSet.
 func Init(fs cpuid.FeatureSet) {
 	// Initialize all sizes.
-	VirtualAddressBits = uintptr(fs.VirtualAddressBits())
+	if VirtualAddressBits == 0 {
+		VirtualAddressBits = uintptr(fs.VirtualAddressBits())
+	}
 	// TODO(gvisor.dev/issue/7349): introduce support for 5-level paging.
 	// Four-level page tables allows to address up to 48-bit virtual
 	// addresses.


### PR DESCRIPTION
Currently ring0.PhysicalAddressBits will be set in ring0.Init() even if it has already been initialized elsewhere. For example, when compiling runsc with cgo enabled, function init() of the package kvm(machine_cgo.go) sets this variable. And this value would be updated by ring0.Init() when creating a new KVM context. If two values are inconsistent, the sandbox would panic during later memory region setting.

This patch fixes it by checking the PhysicalAddressBits in ring0.Init() and setting the value only if it is uninitialized.