### PR TITLE
ring0: set PhysicalAddressBits only when uninitialized

### DIFF
--- a/pkg/ring0/lib_amd64.go
+++ b/pkg/ring0/lib_amd64.go
@@ -106,7 +106,9 @@ func Init(fs cpuid.FeatureSet) {
 	if VirtualAddressBits > 48 {
 		VirtualAddressBits = 48
 	}
-	PhysicalAddressBits = uintptr(fs.PhysicalAddressBits())
+	if PhysicalAddressBits == 0 {
+		PhysicalAddressBits = uintptr(fs.PhysicalAddressBits())
+	}
 	UserspaceSize = uintptr(1) << (VirtualAddressBits - 1)
 	MaximumUserAddress = (UserspaceSize - 1) & ^uintptr(hostarch.PageSize-1)
 	KernelStartAddress = ^uintptr(0) - (UserspaceSize - 1)


### PR DESCRIPTION
Currently ring0.PhysicalAddressBits will be set in ring0.Init() even if it has already been initialized elsewhere. For example, when compiling runsc with cgo enabled, function init() of the package kvm(machine_cgo.go) sets this variable. And this value would be updated by ring0.Init() when creating a new KVM context. If two values are inconsistent, the sandbox would panic during later memory region setting.

This patch fixes it by checking the PhysicalAddressBits in ring0.Init() and setting the value only if it is uninitialized.