### PR TITLE
[runsc] Print file name when cannot load state file

### DIFF
--- a/runsc/container/state_file.go
+++ b/runsc/container/state_file.go
@@ -383,8 +383,12 @@ func (s *StateFile) load(v any, opts LoadOpts) error {
 	}
 	defer s.UnlockOrDie()
 
-	metaBytes, err := os.ReadFile(s.statePath())
+	path := s.statePath()
+	metaBytes, err := os.ReadFile(path)
 	if err != nil {
+		// Caller of this function relies on error code, we cannot return new error,
+		// but we need to provide a message with file name.
+		log.Warningf("Error loading state file %q: %v", path, err)
 		return err
 	}
 	return json.Unmarshal(metaBytes, &v)


### PR DESCRIPTION
When `runsc` does not work, there are messages like

```
loading container: file does not exist
...
loading sandbox: file does not exist
```

The problem here is, there is no indication of file path, making it harder to debug.

I don't have access to environment where these errors appear, so I cannot repro. Better diagnostics would help.

There's a comment in code suggesting that error code is important, so we cannot modify error IIUC

https://github.com/google/gvisor/blob/9c490f813d37882f0374b7aebdad9961277623b8/runsc/container/state_file.go#L81

so my suggestion is to log the file name.