### PR TITLE
Fix nil deref in exec command

### DIFF
--- a/runsc/cmd/exec.go
+++ b/runsc/cmd/exec.go
@@ -449,7 +449,10 @@ func argsFromProcess(specProc *specs.Process, p *specs.Process, enableRaw bool) 
 // auth.TaskCapabilities struct with those capabilities in every capability set.
 // This mimics runc's behavior.
 func capabilities(p *specs.Process, cs []string, enableRaw bool) (*auth.TaskCapabilities, error) {
-	specCaps := *p.Capabilities
+	specCaps := specs.LinuxCapabilities{}
+	if p.Capabilities != nil {
+		specCaps = *p.Capabilities
+	}
 	for _, cap := range cs {
 		specCaps.Bounding = append(specCaps.Bounding, cap)
 		specCaps.Effective = append(specCaps.Effective, cap)


### PR DESCRIPTION
```
$ ./runsc -root runsc-test/var exec k20663363928921 /toybox

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1085ed1]

goroutine 1 [running]:
gvisor.dev/gvisor/runsc/cmd.capabilities(0xc00016b9c8?, {0x0?, 0xc0000b8910?, 0xc00016baf0?}, 0x0)
	runsc/cmd/exec.go:452 +0x31
gvisor.dev/gvisor/runsc/cmd.(*Exec).argsFromCLI(0xc0000d9ba0, 0xc000172870, {0xc0000b61d0, 0x1, 0x1}, 0x0)
	runsc/cmd/exec.go:348 +0x2ce
gvisor.dev/gvisor/runsc/cmd.(*Exec).parseArgs(0x0?, 0x7ffe493e5e6d?, 0xe?, 0xe7?)
	runsc/cmd/exec.go:324 +0x78
gvisor.dev/gvisor/runsc/cmd.(*Exec).Execute(0xc0000d9ba0, {0xc0000b61c0?, 0x114a5c0?}, 0xc00017e620, {0xc0000b4400?, 0x5b6689?, 0x0?})
	runsc/cmd/exec.go:129 +0x1d9
github.com/google/subcommands.(*Commander).Execute(0xc0000fa000, {0x15bcb00, 0x35f2be0}, {0xc0000b4400, 0x2, 0x2})
	external/com_github_google_subcommands/subcommands.go:200 +0x335
github.com/google/subcommands.Execute(...)
	external/com_github_google_subcommands/subcommands.go:481
gvisor.dev/gvisor/runsc/cli.Main()
	runsc/cli/main.go:216 +0x1457
main.main()
	runsc/main.go:31 +0xf
```

```
$ /root/.cache/bazel/_bazel_root/71036fa54589963eb2b971859a78cb62/execroot/__main__/bazel-out/k8-opt/bin/runsc/runsc_/runsc -root runsc-test/var exec k20663363928921 /toybox
[ acpi arch ascii ...
```