### PR TITLE
Update tests to run on ARM

### DIFF
--- a/images/gpu/cuda-tests/Dockerfile.aarch64
+++ b/images/gpu/cuda-tests/Dockerfile.aarch64
@@ -1,0 +1,46 @@
+FROM nvidia/cuda:12.2.2-devel-ubuntu22.04
+
+# From: https://github.com/NVIDIA/cuda-samples/releases
+# Ideally, pick a release that matches the CUDA version of the image above.
+ARG CUDA_SAMPLES_VERSION=v12.2
+
+WORKDIR /
+COPY *.cu *.h *.sh *.go *.cc /
+ENV PATH=$PATH:/usr/local/nvidia/bin
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    apt-get update && \
+    apt-get install -y \
+      build-essential \
+      cmake \
+      freeglut3 freeglut3-dev \
+      git \
+      golang \
+      imagemagick \
+      libegl-dev \
+      libfreeimage3 libfreeimage-dev \
+      libfreeimageplus3 libfreeimageplus-dev \
+      libgles2-mesa-dev \
+      libglfw3 libglfw3-dev \
+      libglu1-mesa libglu1-mesa-dev \
+      libxi-dev \
+      libxmu-dev \
+      llvm \
+      mpich \
+      pkg-config \
+      x11-xserver-utils \
+      xdotool \
+      xvfb \
+      zlib1g zlib1g-dev \
+    && \
+    chmod 555 /*.sh && \
+    git clone --depth=1 --branch="$CUDA_SAMPLES_VERSION" --single-branch \
+      https://github.com/NVIDIA/cuda-samples.git /cuda-samples && \
+    go install \
+      github.com/TheZoraiz/ascii-image-converter@d05a757c5e02ab23e97b6f6fca4e1fbeb10ab559 && \
+    mv "$HOME/go/bin/ascii-image-converter" /usr/bin/ && \
+    gcc -o /unsupported_ioctl /unsupported_ioctl.cc && \
+    go build -o /run_sample /run_sample.go
+
+# Override entrypoint to nothing, otherwise all invocations will have
+# a copyright notice printed, which breaks parsing the stdout logs.
+ENTRYPOINT []

--- a/pkg/sentry/devices/memdev/null.go
+++ b/pkg/sentry/devices/memdev/null.go
@@ -31,6 +31,11 @@ type nullDevice struct{}
 
 // Open implements vfs.Device.Open.
 func (nullDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
+	return NewNullFD(ctx, mnt, vfsd, opts)
+}
+
+// NewNullFD returns a vfs.FileDescription for /dev/null.
+func NewNullFD(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
 	fd := &nullFD{}
 	if err := fd.vfsfd.Init(fd, opts.Flags, mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,

--- a/pkg/sentry/devices/nvproxy/BUILD
+++ b/pkg/sentry/devices/nvproxy/BUILD
@@ -115,6 +115,7 @@ go_test(
     deps = [
         ":nvproxy",
         "//pkg/abi/nvgpu",
+        "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/test/testutil",
         "//tools/nvidia_driver_differ/parser",
     ],

--- a/pkg/sentry/devices/nvproxy/nvconf/BUILD
+++ b/pkg/sentry/devices/nvproxy/nvconf/BUILD
@@ -9,8 +9,10 @@ go_library(
     srcs = [
         "caps.go",
         "nvconf.go",
+        "version.go",
     ],
     visibility = [
         "//pkg/sentry:internal",
+        "//tools:__subpackages__",
     ],
 )

--- a/pkg/sentry/devices/nvproxy/nvconf/version.go
+++ b/pkg/sentry/devices/nvproxy/nvconf/version.go
@@ -1,0 +1,96 @@
+// Copyright 2025 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvconf
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// DriverVersion represents a NVIDIA driver version patch release.
+//
+// +stateify savable
+type DriverVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+// NewDriverVersion returns a new driver version.
+func NewDriverVersion(major, minor, patch int) DriverVersion {
+	return DriverVersion{major, minor, patch}
+}
+
+// DriverVersionFrom returns a DriverVersion from a string.
+func DriverVersionFrom(version string) (DriverVersion, error) {
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return DriverVersion{}, fmt.Errorf("invalid format of version string %q", version)
+	}
+	var (
+		res DriverVersion
+		err error
+	)
+	res.major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return DriverVersion{}, fmt.Errorf("invalid format for major version %q: %v", version, err)
+	}
+	res.minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return DriverVersion{}, fmt.Errorf("invalid format for minor version %q: %v", version, err)
+	}
+	res.patch, err = strconv.Atoi(parts[2])
+	if err != nil {
+		return DriverVersion{}, fmt.Errorf("invalid format for patch version %q: %v", version, err)
+	}
+	return res, nil
+}
+
+func (v DriverVersion) String() string {
+	return fmt.Sprintf("%02d.%02d.%02d", v.major, v.minor, v.patch)
+}
+
+// Equals returns true if the two driver versions are equal.
+func (v DriverVersion) Equals(other DriverVersion) bool {
+	return v.major == other.major && v.minor == other.minor && v.patch == other.patch
+}
+
+// IsGreaterThan returns true if v is greater than other.
+// isGreaterThan returns true if v is more recent than other, assuming v and other are on the same
+// dev branch.
+func (v DriverVersion) IsGreaterThan(other DriverVersion) bool {
+	switch {
+	case v.major > other.major:
+		return true
+	case other.major > v.major:
+		return false
+	case v.minor > other.minor:
+		return true
+	case other.minor > v.minor:
+		return false
+	case v.patch > other.patch:
+		return true
+	case other.patch > v.patch:
+		return false
+	default:
+		return true
+	}
+}
+
+// Major returns the major version number.
+func (v DriverVersion) Major() int {
+	return v.major
+}

--- a/pkg/sentry/devices/nvproxy/nvproxy.go
+++ b/pkg/sentry/devices/nvproxy/nvproxy.go
@@ -30,17 +30,13 @@ import (
 )
 
 // Register registers all devices implemented by this package in vfsObj.
-func Register(vfsObj *vfs.VirtualFilesystem, versionStr string, driverCaps nvconf.DriverCaps, uvmDevMajor uint32) error {
+func Register(vfsObj *vfs.VirtualFilesystem, version nvconf.DriverVersion, driverCaps nvconf.DriverCaps, uvmDevMajor uint32) error {
 	// The kernel driver's interface is unstable, so only allow versions of the
 	// driver that are known to be supported.
-	log.Infof("NVIDIA driver version: %s", versionStr)
-	version, err := DriverVersionFrom(versionStr)
-	if err != nil {
-		return fmt.Errorf("failed to parse Nvidia driver version %s: %w", versionStr, err)
-	}
+	log.Infof("NVIDIA driver version: %s", version)
 	abiCons, ok := abis[version]
 	if !ok {
-		return fmt.Errorf("unsupported Nvidia driver version: %s", versionStr)
+		return fmt.Errorf("unsupported Nvidia driver version: %s", version)
 	}
 	if driverCaps == 0 {
 		log.Warningf("nvproxy: NVIDIA driver capability set is empty; all GPU operations will fail")
@@ -76,7 +72,7 @@ func Register(vfsObj *vfs.VirtualFilesystem, versionStr string, driverCaps nvcon
 // +stateify savable
 type nvproxy struct {
 	abi         *driverABI `state:"nosave"`
-	version     DriverVersion
+	version     nvconf.DriverVersion
 	capsEnabled nvconf.DriverCaps
 
 	fdsMu       fdsMutex `state:"nosave"`

--- a/pkg/sentry/devices/nvproxy/nvproxy_driver_parity_test.go
+++ b/pkg/sentry/devices/nvproxy/nvproxy_driver_parity_test.go
@@ -32,6 +32,7 @@ import (
 	"gvisor.dev/gvisor/pkg/test/testutil"
 
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 	"gvisor.dev/gvisor/tools/nvidia_driver_differ/parser"
 )
 
@@ -56,7 +57,7 @@ func createParserRunner(t *testing.T) (*os.File, *parser.Runner) {
 	return parserFile, runner
 }
 
-func getDriverDefs(t *testing.T, runner *parser.Runner, version nvproxy.DriverVersion) ([]nvproxy.DriverStructName, *parser.OutputJSON) {
+func getDriverDefs(t *testing.T, runner *parser.Runner, version nvconf.DriverVersion) ([]nvproxy.DriverStructName, *parser.OutputJSON) {
 	t.Helper()
 
 	structNames, ok := nvproxy.SupportedStructNames(version)
@@ -84,7 +85,7 @@ func TestSupportedStructNames(t *testing.T) {
 	nvproxy.Init()
 
 	// Run the parser on all supported driver versions
-	nvproxy.ForEachSupportDriver(func(version nvproxy.DriverVersion, checksum string) {
+	nvproxy.ForEachSupportDriver(func(version nvconf.DriverVersion, checksum string) {
 		t.Run(version.String(), func(t *testing.T) {
 			t.Parallel()
 			f, runner := createParserRunner(t)
@@ -109,7 +110,7 @@ func TestSupportedStructNames(t *testing.T) {
 func TestStructDefinitionParity(t *testing.T) {
 	nvproxy.Init()
 
-	nvproxy.ForEachSupportDriver(func(version nvproxy.DriverVersion, checksum string) {
+	nvproxy.ForEachSupportDriver(func(version nvconf.DriverVersion, checksum string) {
 		t.Run(version.String(), func(t *testing.T) {
 			t.Parallel()
 			f, runner := createParserRunner(t)

--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -478,6 +478,17 @@ func (tg *ThreadGroup) MemberIDs(pidns *PIDNamespace) []ThreadID {
 	return tasks
 }
 
+// ForEachTask invokes f() on each task in tg.
+func (tg *ThreadGroup) ForEachTask(f func(t *Task) bool) {
+	tg.pidns.owner.mu.RLock()
+	defer tg.pidns.owner.mu.RUnlock()
+	for t := tg.tasks.Front(); t != nil; t = t.Next() {
+		if !f(t) {
+			break
+		}
+	}
+}
+
 // ID returns tg's leader's thread ID in its own PID namespace.
 // If tg's leader is dead, ID returns 0.
 func (tg *ThreadGroup) ID() ThreadID {

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -153,7 +153,7 @@ type containerInfo struct {
 
 	// nvidiaDriverVersion is the NVIDIA driver ABI version to use for
 	// communicating with NVIDIA devices on the host.
-	nvidiaDriverVersion string
+	nvidiaDriverVersion nvconf.DriverVersion
 }
 
 type loaderState int
@@ -351,7 +351,7 @@ type Args struct {
 	ProfileOpts profile.Opts
 	// NvidiaDriverVersion is the NVIDIA driver ABI version to use for
 	// communicating with NVIDIA devices on the host.
-	NvidiaDriverVersion string
+	NvidiaDriverVersion nvconf.DriverVersion
 	// HostTHP contains host transparent hugepage settings.
 	HostTHP HostTHP
 

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -90,6 +90,7 @@ go_library(
         "//pkg/prometheus",
         "//pkg/ring0",
         "//pkg/sentry/control",
+        "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/devices/tpuproxy",
         "//pkg/sentry/devices/tpuproxy/vfio",
         "//pkg/sentry/hostmm",

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -37,6 +37,7 @@ import (
 	"gvisor.dev/gvisor/pkg/metric"
 	"gvisor.dev/gvisor/pkg/prometheus"
 	"gvisor.dev/gvisor/pkg/ring0"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 	"gvisor.dev/gvisor/pkg/sentry/hostmm"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
 	"gvisor.dev/gvisor/runsc/boot"
@@ -493,6 +494,14 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		log.Infof("Core tag enabled (core tag=%d)", coreTags[0])
 	}
 
+	var nvidiaDriverVersion nvconf.DriverVersion
+	if b.nvidiaDriverVersion != "" {
+		nvidiaDriverVersion, err = nvconf.DriverVersionFrom(b.nvidiaDriverVersion)
+		if err != nil {
+			util.Fatalf("Failed to parse nvidia driver version: %v", err)
+		}
+	}
+
 	// Create the loader.
 	bootArgs := boot.Args{
 		ID:                  f.Arg(0),
@@ -515,7 +524,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		PodInitConfigFD:     b.podInitConfigFD,
 		SinkFDs:             b.sinkFDs.GetArray(),
 		ProfileOpts:         b.profileFDs.ToOpts(),
-		NvidiaDriverVersion: b.nvidiaDriverVersion,
+		NvidiaDriverVersion: nvidiaDriverVersion,
 		HostTHP:             b.hostTHP,
 		SaveFDs:             b.saveFDs.GetFDs(),
 	}

--- a/runsc/sandbox/BUILD
+++ b/runsc/sandbox/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/prometheus",
         "//pkg/sentry/control",
         "//pkg/sentry/devices/nvproxy",
+        "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/fsimpl/erofs",
         "//pkg/sentry/pgalloc",
         "//pkg/sentry/platform",

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -47,6 +47,7 @@ import (
 	"gvisor.dev/gvisor/pkg/prometheus"
 	"gvisor.dev/gvisor/pkg/sentry/control"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/erofs"
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
@@ -1747,7 +1748,7 @@ func getNvproxyDriverVersion(conf *config.Config) (string, error) {
 		nvproxy.Init()
 		return nvproxy.LatestDriver().String(), nil
 	default:
-		version, err := nvproxy.DriverVersionFrom(conf.NVProxyDriverVersion)
+		version, err := nvconf.DriverVersionFrom(conf.NVProxyDriverVersion)
 		return version.String(), err
 	}
 }

--- a/tools/bazeldefs/BUILD
+++ b/tools/bazeldefs/BUILD
@@ -26,17 +26,23 @@ bzl_library(
 
 config_setting(
     name = "amd64",
-    values = {"cpu": "k8"},
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+    ],
 )
 
 config_setting(
     name = "arm64",
-    values = {"cpu": "aarch64"},
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+    ],
 )
 
 config_setting(
     name = "riscv64",
-    values = {"cpu": "riscv64"},
+    constraint_values = [
+        "@platforms//cpu:riscv64",
+    ],
 )
 
 genrule(

--- a/tools/gpu/BUILD
+++ b/tools/gpu/BUILD
@@ -11,6 +11,7 @@ go_binary(
     deps = [
         "//pkg/log",
         "//pkg/sentry/devices/nvproxy",
+        "//pkg/sentry/devices/nvproxy/nvconf",
         "//runsc/flag",
         "//tools/gpu/drivers",
     ],

--- a/tools/gpu/drivers/BUILD
+++ b/tools/gpu/drivers/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/log",
         "//pkg/sentry/devices/nvproxy",
+        "//pkg/sentry/devices/nvproxy/nvconf",
     ],
 )
 
@@ -19,5 +20,5 @@ go_test(
     name = "drivers_test",
     srcs = ["install_driver_test.go"],
     library = ":drivers",
-    deps = ["//pkg/sentry/devices/nvproxy"],
+    deps = ["//pkg/sentry/devices/nvproxy/nvconf"],
 )

--- a/tools/gpu/drivers/install_driver_test.go
+++ b/tools/gpu/drivers/install_driver_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 )
 
 // TestVersionInstalled tests when the version is already installed.
@@ -30,12 +30,12 @@ func TestVersionInstalled(t *testing.T) {
 	ctx := context.Background()
 	versionContent := []byte("some cool content")
 	checksum := fmt.Sprintf("%x", sha256.Sum256(versionContent))
-	version := nvproxy.NewDriverVersion(1, 2, 3)
-	getFunction := func() (nvproxy.DriverVersion, error) { return version, nil }
+	version := nvconf.NewDriverVersion(1, 2, 3)
+	getFunction := func() (nvconf.DriverVersion, error) { return version, nil }
 	downloadFunction := func(context.Context, string) (io.ReadCloser, error) { return nil, fmt.Errorf("should not get here") }
 	installer := &Installer{
 		requestedVersion: version,
-		expectedChecksumFunc: func(v nvproxy.DriverVersion) (string, bool) {
+		expectedChecksumFunc: func(v nvconf.DriverVersion) (string, bool) {
 			if v == version {
 				return checksum, true
 			}
@@ -52,10 +52,10 @@ func TestVersionInstalled(t *testing.T) {
 // TestVersionNotSupported tests when the version is not supported.
 func TestVersionNotSupported(t *testing.T) {
 	ctx := context.Background()
-	unsupportedVersion := nvproxy.NewDriverVersion(1, 2, 3)
+	unsupportedVersion := nvconf.NewDriverVersion(1, 2, 3)
 	installer := &Installer{
 		requestedVersion: unsupportedVersion,
-		expectedChecksumFunc: func(v nvproxy.DriverVersion) (string, bool) {
+		expectedChecksumFunc: func(v nvconf.DriverVersion) (string, bool) {
 			return "", false
 		},
 	}
@@ -71,13 +71,13 @@ func TestVersionNotSupported(t *testing.T) {
 // TestShaMismatch tests when a checksum of a driver doesn't match what's in the map.
 func TestShaMismatch(t *testing.T) {
 	ctx := context.Background()
-	version := nvproxy.NewDriverVersion(1, 2, 3)
+	version := nvconf.NewDriverVersion(1, 2, 3)
 	installer := &Installer{
 		requestedVersion: version,
-		getCurrentDriverFunc: func() (nvproxy.DriverVersion, error) {
-			return nvproxy.DriverVersion{}, nil
+		getCurrentDriverFunc: func() (nvconf.DriverVersion, error) {
+			return nvconf.DriverVersion{}, nil
 		},
-		expectedChecksumFunc: func(v nvproxy.DriverVersion) (string, bool) {
+		expectedChecksumFunc: func(v nvconf.DriverVersion) (string, bool) {
 			if v == version {
 				return "mismatch", true
 			}
@@ -102,13 +102,13 @@ func TestDriverInstalls(t *testing.T) {
 	ctx := context.Background()
 	content := []byte("some content")
 	checksum := fmt.Sprintf("%x", sha256.Sum256(content))
-	version := nvproxy.NewDriverVersion(1, 2, 3)
+	version := nvconf.NewDriverVersion(1, 2, 3)
 	installer := &Installer{
 		requestedVersion: version,
-		getCurrentDriverFunc: func() (nvproxy.DriverVersion, error) {
-			return nvproxy.DriverVersion{}, nil
+		getCurrentDriverFunc: func() (nvconf.DriverVersion, error) {
+			return nvconf.DriverVersion{}, nil
 		},
-		expectedChecksumFunc: func(v nvproxy.DriverVersion) (string, bool) {
+		expectedChecksumFunc: func(v nvconf.DriverVersion) (string, bool) {
 			if v == version {
 				return checksum, true
 			}

--- a/tools/gpu/main.go
+++ b/tools/gpu/main.go
@@ -22,6 +22,7 @@ import (
 
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 	"gvisor.dev/gvisor/runsc/flag"
 	"gvisor.dev/gvisor/tools/gpu/drivers"
 )
@@ -114,7 +115,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		nvproxy.ForEachSupportDriver(func(version nvproxy.DriverVersion, checksum string) {
+		nvproxy.ForEachSupportDriver(func(version nvconf.DriverVersion, checksum string) {
 			wantChecksum, err := drivers.ChecksumDriver(ctx, version.String())
 			if err != nil {
 				log.Warningf("error on version %q: %v", version.String(), err)

--- a/tools/ioctl_sniffer/sniffer/BUILD
+++ b/tools/ioctl_sniffer/sniffer/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/abi/nvgpu",
         "//pkg/log",
         "//pkg/sentry/devices/nvproxy",
+        "//pkg/sentry/devices/nvproxy/nvconf",
         "//tools/ioctl_sniffer:ioctl_go_proto",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],

--- a/tools/ioctl_sniffer/sniffer/sniffer.go
+++ b/tools/ioctl_sniffer/sniffer/sniffer.go
@@ -28,6 +28,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/nvgpu"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 	pb "gvisor.dev/gvisor/tools/ioctl_sniffer/ioctl_go_proto"
 )
 
@@ -183,7 +184,7 @@ func Init() error {
 	if err != nil {
 		return fmt.Errorf("failed to get host driver version: %w", err)
 	}
-	driverVer, err := nvproxy.DriverVersionFrom(driverVerStr)
+	driverVer, err := nvconf.DriverVersionFrom(driverVerStr)
 	if err != nil {
 		return fmt.Errorf("failed to parse host driver version: %w", err)
 	}

--- a/tools/nvidia_driver_differ/BUILD
+++ b/tools/nvidia_driver_differ/BUILD
@@ -52,6 +52,7 @@ go_binary(
     deps = [
         "//pkg/log",
         "//pkg/sentry/devices/nvproxy",
+        "//pkg/sentry/devices/nvproxy/nvconf",
         "//tools/nvidia_driver_differ/parser",
     ],
 )

--- a/tools/nvidia_driver_differ/parser/BUILD
+++ b/tools/nvidia_driver_differ/parser/BUILD
@@ -20,6 +20,7 @@ go_library(
     ],
     deps = [
         "//pkg/sentry/devices/nvproxy",
+        "//pkg/sentry/devices/nvproxy/nvconf",
         "@com_github_google_go_cmp//cmp:go_default_library",
     ],
 )

--- a/tools/nvidia_driver_differ/parser/auxiliary_files.go
+++ b/tools/nvidia_driver_differ/parser/auxiliary_files.go
@@ -20,14 +20,14 @@ import (
 	"os/exec"
 	"path"
 
-	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 )
 
 // GitRepoURL is the URL for the NVIDIA open-gpu-kernel-modules repo.
 const GitRepoURL = "https://github.com/NVIDIA/open-gpu-kernel-modules.git"
 
 // CloneDriverSource clones the given driver version into the given directory.
-func CloneDriverSource(dir string, version nvproxy.DriverVersion) (*DriverSourceDir, error) {
+func CloneDriverSource(dir string, version nvconf.DriverVersion) (*DriverSourceDir, error) {
 	// git clone -b $VERSION --depth 1 https://github.com/NVIDIA/open-gpu-kernel-modules.git $PATH
 	args := []string{
 		"clone",

--- a/tools/nvidia_driver_differ/parser/runner.go
+++ b/tools/nvidia_driver_differ/parser/runner.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 )
 
 // ParserFile is a wrapper around the driver_ast_parser binary.
@@ -120,7 +121,7 @@ func (r *Runner) runParserConfig(config []ClangASTConfig) (*OutputJSON, error) {
 
 // ParseDriver checks out the git repo for the given version, and runs the driver_ast_parser on the
 // source code.
-func (r *Runner) ParseDriver(version nvproxy.DriverVersion) (*OutputJSON, error) {
+func (r *Runner) ParseDriver(version nvconf.DriverVersion) (*OutputJSON, error) {
 	// Create a temp directory to run the parser in.
 	// This is needed to set up compile_commands.json, since it needs to be named that exactly.
 	dir, err := os.MkdirTemp(r.dir, "run_differ_*")

--- a/tools/nvidia_driver_differ/parser/sources.go
+++ b/tools/nvidia_driver_differ/parser/sources.go
@@ -20,13 +20,13 @@ import (
 	"io"
 	"path/filepath"
 
-	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 )
 
 // DriverSourceDir represents a directory containing the source code for a given driver version.
 type DriverSourceDir struct {
 	ParentDirectory string
-	Version         nvproxy.DriverVersion
+	Version         nvconf.DriverVersion
 }
 
 // Name returns the name of the driver source directory.

--- a/tools/nvidia_driver_differ/run_differ.go
+++ b/tools/nvidia_driver_differ/run_differ.go
@@ -24,6 +24,7 @@ import (
 
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 
 	_ "embed" // Necessary to use go:embed.
 )
@@ -63,11 +64,11 @@ func createParserBinary() (*os.File, error) {
 // Main is the main function for the NVIDIA driver differ.
 func Main() error {
 	// Read driver version from command line
-	baseVersion, err := nvproxy.DriverVersionFrom(*baseVersionString)
+	baseVersion, err := nvconf.DriverVersionFrom(*baseVersionString)
 	if err != nil {
 		return fmt.Errorf("failed to parse driver version %s: %w", *baseVersionString, err)
 	}
-	nextVersion, err := nvproxy.DriverVersionFrom(*nextVersionString)
+	nextVersion, err := nvconf.DriverVersionFrom(*nextVersionString)
 	if err != nil {
 		return fmt.Errorf("failed to parse driver version %s: %w", *nextVersionString, err)
 	}


### PR DESCRIPTION
Update gpu-all-tests target to run on ARM. Several tests do not work for a few reasons:

Several tests using the cuda-tests image don't work due to cross compiling errors. This includes save-restore tests.

pytorch does not yet work due to some non-trivial issues with python packages.

StableDiffusion doesn't work (and probably never will) due to facebook support on ARM not existing and not on their roadmap.