### PR TITLE
test/syscalls: fix the duplicate test case

### DIFF
--- a/test/syscalls/linux/mmap.cc
+++ b/test/syscalls/linux/mmap.cc
@@ -1481,7 +1481,7 @@ TEST_P(MMapFileParamTest, NoSigBusOnPagesBeforeEOF) {
               SyscallSucceeds());
 
   // The test passes if this survives.
-  auto* start = reinterpret_cast<volatile char*>(addr + (kPageSize / 2) + 1);
+  auto* start = reinterpret_cast<volatile char*>(addr);
   size_t len = strlen(kFileContents);
   if (prot() & PROT_WRITE) {
     std::copy(kFileContents, kFileContents + len, start);


### PR DESCRIPTION
Currently, the NoSigBusOnPagesBeforeEOF and NoSigBusOnPageContainingEOF test cases are identical. This patch corrects the addr accessed in the former test to match the corresponding comment.