### PR TITLE
netstack: remove timed-out endpoints from pendingEndpoints queue.

### DIFF
--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -1193,6 +1193,14 @@ func (e *Endpoint) cleanupLocked() {
 		e.timeWaitTimer.Stop()
 	}
 
+	// Remove current EP from its lEP acceptQueue.pendingEndpoint if exists.
+	if e.h != nil && e.h.listenEP != nil {
+		lEP := e.h.listenEP
+		lEP.acceptMu.Lock()
+		delete(lEP.acceptQueue.pendingEndpoints, e)
+		lEP.acceptMu.Unlock()
+	}
+
 	// Close all endpoints that might have been accepted by TCP but not by
 	// the client.
 	e.closePendingAcceptableConnectionsLocked()


### PR DESCRIPTION
When a handshake times out, the endpoint may remain stuck in the lEP's pendingEndpoints queue.

Related to #11536

It has passed the test-case for `//pkg/tcpip:tcpip_test`
<img width="914" alt="image" src="https://github.com/user-attachments/assets/20247fc6-1e25-4994-ba09-3f917cd761c2" />
