### PR TITLE
Fix host socket ioctl when len == 0 and ifc_buf != 0

### DIFF
--- a/pkg/sentry/socket/hostinet/socket_unsafe.go
+++ b/pkg/sentry/socket/hostinet/socket_unsafe.go
@@ -107,7 +107,7 @@ func ioctl(ctx context.Context, fd int, io usermem.IO, sysno uintptr, args arch.
 		// The user's ifconf can have a nullable pointer to a buffer. Use a Sentry array if non-null.
 		ifcNested := linux.IFConf{Len: ifc.Len}
 		var ifcBuf []byte
-		if ifc.Ptr != 0 {
+		if ifc.Ptr != 0 && ifc.Len > 0 {
 			ifcBuf = make([]byte, ifc.Len)
 			ifcNested.Ptr = uint64(uintptr(unsafe.Pointer(&ifcBuf[0])))
 		}


### PR DESCRIPTION
## Description

We are currently using gVisor with `--network=host` in our infrastructure environment. In addition, the environment is not configured with any network interfaces (There is even no loopback interface). This has triggered an edge case when running Java workloads which calls `ioctl` to list current available network interfaces on a socket.

## Reproduce workload

```
import org.apache.logging.log4j.Logger;
import org.apache.logging.log4j.LogManager;

public class Reproduce {
  private static final Logger LOGGER = LogManager.getLogger();

  public static String handle(final Session session) {
    return "Success";
  }
}
``` 

The `LogManager.getLogger()` here will trigger a network interface lookup from Java's native code, stacktrace:

```
org.apache.logging.log4j.LogManager.getLogger
 - org.apache.logging.log4j.LogManager.getContext
  - org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext
   - org.apache.logging.log4j.core.LoggerContext.start
    - org.apache.logging.log4j.core.LoggerContext.reconfigure()
     - org.apache.logging.log4j.core.LoggerContext.reconfigure(final URI configURI)
      - org.apache.logging.log4j.core.LoggerContext.setConfiguration(final Configuration config)
       - org.apache.logging.log4j.core.util.NetUtils.getLocalHostname()
        - java.net.NwtworkInterface.getNetworkInterfaces()
         - native java.net.NetworkInterface.getAll() -- This is causing issue
```

Corresponding Java code is https://github.com/openjdk/jdk11/blob/master/src/java.base/unix/native/libnet/NetworkInterface.c#L1113:

```
// do a dummy SIOCGIFCONF to determine the buffer size
    // SIOCGIFCOUNT doesn't work
    ifc.ifc_buf = NULL;
    if (ioctl(sock, SIOCGIFCONF, (char *)&ifc) < 0) {
        JNU_ThrowByNameWithMessageAndLastError
            (env, JNU_JAVANETPKG "SocketException", "ioctl(SIOCGIFCONF) failed");
        return ifs;
    }

    // call SIOCGIFCONF to enumerate the interfaces
    CHECKED_MALLOC3(buf, char *, ifc.ifc_len);
    ifc.ifc_buf = buf;
    if (ioctl(sock, SIOCGIFCONF, (char *)&ifc) < 0) {
        JNU_ThrowByNameWithMessageAndLastError
            (env, JNU_JAVANETPKG "SocketException", "ioctl(SIOCGIFCONF) failed");
        free(buf);
        return ifs;
    }
```

This has hit a bug inside gVisor that when the sandbox environment is not configured with any network interfaces, the first `ioctl` call would get `len` as 0. However, `CHECKED_MALLOC3` would still give a valid address even when allocation size is 0. Causing second `ioctl` system call to have len as 0 while buffer as non-NULL, and gVisor is not handling this correctly:

```
ifcNested := linux.IFConf{Len: ifc.Len}
    var ifcBuf []byte
    if ifc.Ptr != 0 {
        ifcBuf = make([]byte, ifc.Len)
	ifcNested.Ptr = uint64(uintptr(unsafe.Pointer(&ifcBuf[0])))
    }
```

In this case `ifcBuf` is initialized with length 0, but later we are trying to access `unsafe.Pointer(&ifcBuf[0])`, which triggers crash with following error:

```
I0228 18:37:21.489117       1 strace.go:567] [   1:  21] grpcpp_sync_ser E ioctl(0x12 socket:[8], 0x8912, 0xf557457ca520)
I0228 18:37:21.489145       1 strace.go:605] [   1:  21] grpcpp_sync_ser X ioctl(0x12 socket:[8], 0x8912, 0xf557457ca520) = 0 (0x0) (20.143µs)

I0228 18:37:21.489168       1 strace.go:567] [   1:  21] grpcpp_sync_ser E ioctl(0x12 socket:[8], 0x8912, 0xf557457ca520)
panic: runtime error: index out of range [0] with length 0
goroutine 96 gp=0x40005fe1c0 m=31 mp=0x40003e6308 [running]:
panic({0xdc7a40?, 0x4000a824c8?})
        bazel-out/aarch64-fastbuild/bin/external/io_bazel_rules_go/stdlib_/src/runtime/panic.go:804 +0x154 fp=0x400091d680 sp=0x400091d5d0 pc=0x84234
runtime.goPanicIndex(0x0, 0x0)
        bazel-out/aarch64-fastbuild/bin/external/io_bazel_rules_go/stdlib_/src/runtime/panic.go:115 +0x74 fp=0x400091d6c0 sp=0x400091d680 pc=0x47664

```

Thus this change is to fix this edge case