### PR TITLE
Fix TestBundleValidate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,7 +232,7 @@ nogo-tests:
 #
 # FIXME(gvisor.dev/issue/10045): Need to fix broken tests.
 unit-tests: ## Local package unit tests in pkg/..., tools/.., etc.
-	@$(call test,--test_tag_filters=-nogo$(COMMA)-requires-kvm --build_tag_filters=-network_plugins -- //:all pkg/... tools/... runsc/... vdso/... test/trace/... -//pkg/metric:metric_test -//pkg/coretag:coretag_test -//runsc/config:config_test -//tools/tracereplay:tracereplay_test -//test/trace:trace_test)
+	@$(call test,--test_tag_filters=-nogo$(COMMA)-requires-kvm --build_tag_filters=-network_plugins -- //:all pkg/... tools/... runsc/... vdso/... test/trace/... -//pkg/metric:metric_test -//pkg/coretag:coretag_test -//tools/tracereplay:tracereplay_test -//test/trace:trace_test)
 .PHONY: unit-tests
 
 # See unit-tests: this includes runsc/container.

--- a/runsc/config/config_test.go
+++ b/runsc/config/config_test.go
@@ -695,9 +695,12 @@ func TestBundleValidate(t *testing.T) {
 			name:   "invalid value",
 			bundle: Bundle(map[string]string{"debug": "invalid"}),
 			verify: func(err error) error {
-				want := `parsing "invalid": invalid syntax`
-				if !strings.Contains(err.Error(), want) {
-					return fmt.Errorf("mismatch error: got: %q want: %q", err.Error(), want)
+				// Error differs in open-source version, and internally at Google
+				// https://github.com/google/gvisor/pull/11722#issuecomment-2877847616
+				wantOss := "parse error"
+				wantInternal := `parsing "invalid": invalid syntax`
+				if !strings.Contains(err.Error(), wantOss) && !strings.Contains(err.Error(), wantInternal) {
+					return fmt.Errorf("mismatch error: got: %q want: %q or %s", err.Error(), wantOss, wantInternal)
 				}
 				return nil
 			},


### PR DESCRIPTION
Updates https://github.com/google/gvisor/issues/10045

Before:

```
--- FAIL: TestBundleValidate (0.00s)
    --- FAIL: TestBundleValidate/invalid_value (0.00s)
        config_test.go:713: Validate failed: mismatch error: got: "parse error" want: "parsing \"invalid\": invalid syntax"
FAIL
```

Different flags is used in OSS and internal versions, check comment below.