### PR TITLE
Newtype OverlayMedium

### DIFF
--- a/runsc/boot/mount_hints_test.go
+++ b/runsc/boot/mount_hints_test.go
@@ -257,7 +257,7 @@ func TestRootfsHintHappy(t *testing.T) {
 		Annotations: map[string]string{
 			RootfsPrefix + "source":  imagePath,
 			RootfsPrefix + "type":    erofs.Name,
-			RootfsPrefix + "overlay": config.MemoryOverlay.String(),
+			RootfsPrefix + "overlay": config.OverlayMediumMemory().String(),
 		},
 	}
 	hint, err := NewRootfsHint(spec)
@@ -272,7 +272,7 @@ func TestRootfsHintHappy(t *testing.T) {
 	if hint.Mount.Type != erofs.Name {
 		t.Errorf("rootfs type, want: %q, got: %q", erofs.Name, hint.Mount.Type)
 	}
-	if hint.Overlay != config.MemoryOverlay {
+	if hint.Overlay.MediumType() != config.MemoryOverlay {
 		t.Errorf("rootfs overlay, want: %q, got: %q", config.MemoryOverlay, hint.Overlay)
 	}
 }
@@ -317,7 +317,7 @@ func TestRootfsHintErrors(t *testing.T) {
 				RootfsPrefix + "invalid": "invalid",
 				RootfsPrefix + "source":  imagePath,
 				RootfsPrefix + "type":    erofs.Name,
-				RootfsPrefix + "overlay": config.MemoryOverlay.String(),
+				RootfsPrefix + "overlay": config.OverlayMediumMemory().String(),
 			},
 			error: "invalid rootfs annotation",
 		},
@@ -325,7 +325,7 @@ func TestRootfsHintErrors(t *testing.T) {
 			name: "missing source",
 			annotations: map[string]string{
 				RootfsPrefix + "type":    erofs.Name,
-				RootfsPrefix + "overlay": config.MemoryOverlay.String(),
+				RootfsPrefix + "overlay": config.OverlayMediumMemory().String(),
 			},
 			error: "rootfs annotations missing required field",
 		},
@@ -333,7 +333,7 @@ func TestRootfsHintErrors(t *testing.T) {
 			name: "missing type",
 			annotations: map[string]string{
 				RootfsPrefix + "source":  imagePath,
-				RootfsPrefix + "overlay": config.MemoryOverlay.String(),
+				RootfsPrefix + "overlay": config.OverlayMediumMemory().String(),
 			},
 			error: "rootfs annotations missing required field",
 		},

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -193,7 +193,7 @@ func checkOverlay2(name string, value string) error {
 	if err := o.Set(value); err != nil {
 		return fmt.Errorf("invalid overlay2 annotation: %w", err)
 	}
-	switch o.medium {
+	switch o.medium.MediumType() {
 	case NoOverlay, MemoryOverlay, SelfOverlay:
 		return nil
 	default:

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -911,7 +911,7 @@ func createGoferConf(overlayMedium config.OverlayMedium, mountType string, mount
 	default:
 		return boot.GoferMountConf{}, fmt.Errorf("unsupported mount type %q in mount hint", mountType)
 	}
-	switch overlayMedium {
+	switch overlayMedium.MediumType() {
 	case config.NoOverlay:
 		return boot.GoferMountConf{Lower: lower, Upper: boot.NoOverlay}, nil
 	case config.MemoryOverlay:
@@ -947,7 +947,7 @@ func (c *Container) initGoferConfs(ovlConf config.Overlay2, mountHints *boot.Pod
 		}
 	}
 	if c.Spec.Root.Readonly {
-		overlayMedium = config.NoOverlay
+		overlayMedium = config.OverlayMediumNoOverlay()
 	}
 	goferConf, err := createGoferConf(overlayMedium, mountType, c.Spec.Root.Path)
 	if err != nil {
@@ -963,12 +963,12 @@ func (c *Container) initGoferConfs(ovlConf config.Overlay2, mountHints *boot.Pod
 		overlayMedium = ovlConf.SubMountOverlayMedium()
 		mountType = boot.Bind
 		if specutils.IsReadonlyMount(c.Spec.Mounts[i].Options) {
-			overlayMedium = config.NoOverlay
+			overlayMedium = config.OverlayMediumNoOverlay()
 		}
 		if hint := mountHints.FindMount(c.Spec.Mounts[i].Source); hint != nil {
 			// Note that we want overlayMedium=self even if this is a read-only mount so that
 			// the shared mount is created correctly. Future containers may mount this writably.
-			overlayMedium = config.SelfOverlay
+			overlayMedium = config.OverlayMediumNoOverlay()
 			if !specutils.IsGoferMount(hint.Mount) {
 				mountType = hint.Mount.Type
 			}

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -3486,7 +3486,7 @@ func TestRootfsEROFS(t *testing.T) {
 	spec.Annotations[boot.RootfsPrefix+"source"] = rootfsImage
 	// Disable the overlay, as we want to be sure that rootfs will always be
 	// shown as EROFS in mountinfo.
-	spec.Annotations[boot.RootfsPrefix+"overlay"] = config.NoOverlay.String()
+	spec.Annotations[boot.RootfsPrefix+"overlay"] = config.OverlayMediumNoOverlay().String()
 
 	conf := testutil.TestConfig(t)
 
@@ -3563,7 +3563,7 @@ func TestCheckpointRestoreEROFS(t *testing.T) {
 				// a writeable and savable overlay for rootfs, which allows the sentry to
 				// create the mount point for the bind mount of the temporary directory shared
 				// between host and test container.
-				spec.Annotations[boot.RootfsPrefix+"overlay"] = config.MemoryOverlay.String()
+				spec.Annotations[boot.RootfsPrefix+"overlay"] = config.OverlayMediumMemory().String()
 				return spec
 			})
 		})


### PR DESCRIPTION
For https://github.com/google/gvisor/pull/11723 `OverlayMedium` may need a `size` field. Encoding it in the string will make code too complex, so this PR proposes converting `OverlayMedium` to a struct.

Even if `size` should not be added to `OverlayMedium`, I believe this extra type safety helps, so I'm submitting this PR.

I do not usually write code in Go, so code style feedback is also welcome.