### PR TITLE
fix(tools/checklocks): Add generics support

### DIFF
--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -25,6 +25,7 @@ go_library(
         "return.go",
         "rwmutex.go",
         "test.go",
+        "generics.go",
     ],
     # This ensures that there are no dependencies, since we want to explicitly
     # control expected failures for analysis.

--- a/tools/checklocks/test/generics.go
+++ b/tools/checklocks/test/generics.go
@@ -1,0 +1,34 @@
+package test
+
+import "sync"
+
+// genericGuardStruct demonstrates a generic struct whose field is guarded by a mutex.
+type genericGuardStruct[T any] struct {
+	mu sync.Mutex
+	// +checklocks:mu
+	value T
+}
+
+// genericValidLockedAccess writes while holding the guard lock. This should be OK.
+func genericValidLockedAccess[T any](g *genericGuardStruct[T], v T) {
+	g.mu.Lock()
+	g.value = v
+	g.mu.Unlock()
+}
+
+// genericInvalidUnlockedWrite writes without holding the lock. This should fail.
+func genericInvalidUnlockedWrite[T any](g *genericGuardStruct[T], v T) {
+	g.value = v // +checklocksfail
+}
+
+// genericInvalidUnlockedRead reads without holding the lock. This should fail.
+func genericInvalidUnlockedRead[T any](g *genericGuardStruct[T]) T {
+	return g.value // +checklocksfail
+}
+
+// genericInstantiate exists solely to instantiate genericGuardStruct so that the
+// analyzer observes an instantiation and does not warn about the mutex field
+// itself.
+func genericInstantiate() {
+	var _ genericGuardStruct[int]
+}


### PR DESCRIPTION
## Summary

This PR introduces support for Go generics to the `tools/checklocks` static analysis tool. It resolves issues where `checklocks` would produce false-positive warnings ("may require checklocks annotation") for mutex fields within generic types and ensures that `+checklocksfail` annotations behave correctly with generic code.

The core of the changes involves updating the type resolution and fact-finding logic within `analysis.go` and `facts.go` to correctly interpret lock annotations in the context of generic structs and their instantiations.

## Key Changes

*   **Generic Type Handling:** Modified `analysis.go` to correctly resolve types and associate lock annotations for fields within generic structs. This includes improvements to how guarded-by facts are discovered and applied, particularly using `Origin()` to trace back to generic definitions.
*   **Mutex Identification:** Refined `isMutexType` to accurately identify mutex types, including those used within generic contexts.
*   **SSA Integration:** Ensured proper handling of `*ssa.Alloc` and `*ssa.Store` operations in `state.go` and `analysis.go` respectively, which was crucial for resolving a regression related to lock state propagation in generic helper functions.
*   **New Test Cases:** Added `tools/checklocks/test/generics.go` with specific test cases to validate `checklocks` behavior with generic resources, including scenarios with `+checklocks` and `+checklocksfail` annotations.
*   **Code Refinement:** Refactored parts of `analysis.go` to use a canonical helper function (`importLockGuardFacts`) for importing lock guard facts, reducing code duplication. Removed extensive debug logging now that the core functionality is stable.

## Impact & Testing

*   With these changes, `checklocks` no longer produces false-positive "may require checklocks annotation" warnings for mutex fields in generic types.
*   The `+checklocksfail` annotation now correctly identifies (or not identify) violations in test cases involving generics.
*   All new and existing tests related to generic types in `tools/checklocks/test/generics.go` now pass as expected.
*   Known baseline failures in `test/closures.go` and `test/defer.go` (which predate this work and exist in the main branch) are unaffected and considered out of scope for this PR. 
```text
# gvisor.dev/gvisor/tools/checklocks/test
-: return with unexpected locks held (locks: &({param:tc}.mu) exclusively)
-: return with unexpected locks held (locks: &({param:tc}.mu) exclusively)
-: return with unexpected locks held (locks: &({param:tc}.mu) exclusively)
-: return with unexpected locks held (locks: &({param:tc}.mu) exclusively)
-: return with unexpected locks held (locks: &({param:tc}.mu) exclusively)
-: return with unexpected locks held (locks: &({param:tc}.mu) exclusively)
-: lock a.mu (&({param:a}.mu)) not held exclusively (locks: no locks held)
```
> The missing file and line numbers are handled in #11741.

Fixes #11671

Signed-off-by: Kemal Akkoyun <kemal.akkoyun@datadoghq.com>
