### PR TITLE
fix: copy route MTU when creating interfaces and routes from net namespace

### DIFF
--- a/runsc/boot/network.go
+++ b/runsc/boot/network.go
@@ -43,31 +43,29 @@ import (
 	"gvisor.dev/gvisor/runsc/config"
 )
 
-var (
-	// DefaultLoopbackLink contains IP addresses and routes of "127.0.0.1/8" and
-	// "::1/8" on "lo" interface.
-	DefaultLoopbackLink = LoopbackLink{
-		Name: "lo",
-		Addresses: []IPWithPrefix{
-			{Address: net.IP("\x7f\x00\x00\x01"), PrefixLen: 8},
-			{Address: net.IPv6loopback, PrefixLen: 128},
-		},
-		Routes: []Route{
-			{
-				Destination: net.IPNet{
-					IP:   net.IPv4(0x7f, 0, 0, 0),
-					Mask: net.IPv4Mask(0xff, 0, 0, 0),
-				},
-			},
-			{
-				Destination: net.IPNet{
-					IP:   net.IPv6loopback,
-					Mask: net.IPMask(strings.Repeat("\xff", net.IPv6len)),
-				},
+// DefaultLoopbackLink contains IP addresses and routes of "127.0.0.1/8" and
+// "::1/8" on "lo" interface.
+var DefaultLoopbackLink = LoopbackLink{
+	Name: "lo",
+	Addresses: []IPWithPrefix{
+		{Address: net.IP("\x7f\x00\x00\x01"), PrefixLen: 8},
+		{Address: net.IPv6loopback, PrefixLen: 128},
+	},
+	Routes: []Route{
+		{
+			Destination: net.IPNet{
+				IP:   net.IPv4(0x7f, 0, 0, 0),
+				Mask: net.IPv4Mask(0xff, 0, 0, 0),
 			},
 		},
-	}
-)
+		{
+			Destination: net.IPNet{
+				IP:   net.IPv6loopback,
+				Mask: net.IPMask(strings.Repeat("\xff", net.IPv6len)),
+			},
+		},
+	},
+}
 
 // Network exposes methods that can be used to configure a network stack.
 type Network struct {
@@ -83,6 +81,7 @@ type Network struct {
 type Route struct {
 	Destination net.IPNet
 	Gateway     net.IP
+	MTU         uint32
 }
 
 // DefaultRoute represents a catch all route to the default gateway.
@@ -224,6 +223,7 @@ func (r *Route) toTcpipRoute(id tcpip.NICID) (tcpip.Route, error) {
 		Destination: subnet,
 		Gateway:     ipToAddress(r.Gateway),
 		NIC:         id,
+		MTU:         r.MTU,
 	}, nil
 }
 

--- a/runsc/sandbox/network.go
+++ b/runsc/sandbox/network.go
@@ -509,6 +509,8 @@ func routesForIface(iface net.Interface, disableIPv6 bool) ([]boot.Route, *boot.
 	var defv4, defv6 *boot.Route
 	var routes []boot.Route
 	for _, r := range rs {
+		mtu := uint32(r.MTU)
+
 		// Is it a default route?
 		if r.Dst == nil {
 			if r.Gw == nil {
@@ -526,6 +528,7 @@ func routesForIface(iface net.Interface, disableIPv6 bool) ([]boot.Route, *boot.
 						Mask: net.IPMask(net.IPv4zero),
 					},
 					Gateway: r.Gw,
+					MTU:     mtu,
 				}
 			case header.IPv6AddressSize:
 				if defv6 != nil {
@@ -539,6 +542,7 @@ func routesForIface(iface net.Interface, disableIPv6 bool) ([]boot.Route, *boot.
 							Mask: net.IPMask(net.IPv6zero),
 						},
 						Gateway: r.Gw,
+						MTU:     mtu,
 					}
 				}
 			default:
@@ -555,6 +559,7 @@ func routesForIface(iface net.Interface, disableIPv6 bool) ([]boot.Route, *boot.
 		routes = append(routes, boot.Route{
 			Destination: dst,
 			Gateway:     r.Gw,
+			MTU:         mtu,
 		})
 	}
 	return routes, defv4, defv6, nil


### PR DESCRIPTION
Fixes #11856
