### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/tools/go_generics/globals/globals_visitor.go
+++ b/tools/go_generics/globals/globals_visitor.go
@@ -517,7 +517,7 @@ func (v *globalsVisitor) visitFuncDecl(d *ast.FuncDecl) {
 	v.popScope()
 }
 
-// globalsFromDecl is called in the first, and adds symbols to global scope.
+// globalsFromGenDecl is called in the first, and adds symbols to global scope.
 func (v *globalsVisitor) globalsFromGenDecl(d *ast.GenDecl) {
 	switch d.Tok {
 	case token.IMPORT:

--- a/tools/go_marshal/gomarshal/generator_interfaces.go
+++ b/tools/go_marshal/gomarshal/generator_interfaces.go
@@ -53,7 +53,7 @@ func (g *interfaceGenerator) typeName() string {
 	return g.t.Name.Name
 }
 
-// newinterfaceGenerator creates a new interface generator.
+// newInterfaceGenerator creates a new interface generator.
 func newInterfaceGenerator(t *ast.TypeSpec, r string, fset *token.FileSet) *interfaceGenerator {
 	g := &interfaceGenerator{
 		t:  t,
@@ -188,7 +188,7 @@ func (g *interfaceGenerator) emitCastToByteSlice(srcPtr, dstVar, lenExpr string)
 	g.emit("hdr.Cap = %s\n\n", lenExpr)
 }
 
-// emitCastToByteSlice unsafely casts a slice with elements of an arbitrary type
+// emitCastSliceToByteSlice unsafely casts a slice with elements of an arbitrary type
 // to a byte slice. As part of the cast, the byte slice is made to look
 // independent of the src slice by bypassing escape analysis. This means the
 // byte slice can be used without causing the source to escape. The caller is

--- a/tools/go_marshal/test/marshal_test.go
+++ b/tools/go_marshal/test/marshal_test.go
@@ -333,7 +333,7 @@ func TestLimitedMarshalling(t *testing.T) {
 	}
 }
 
-// TestLimitedMarshalling verifies marshalling/unmarshalling of slices of
+// TestLimitedSliceMarshalling verifies marshalling/unmarshalling of slices of
 // marshallable types succeed when the underlying copy in/out operations
 // partially succeed.
 func TestLimitedSliceMarshalling(t *testing.T) {


### PR DESCRIPTION
fix inconsistent function name in comment