### PR TITLE
Don't error out when deleting parent cgroup dirs

### DIFF
--- a/runsc/cgroup/cgroup_v2.go
+++ b/runsc/cgroup/cgroup_v2.go
@@ -191,6 +191,15 @@ func (c *cgroupV2) Uninstall() error {
 			if os.IsNotExist(err) {
 				return nil
 			}
+
+			// When deleting cgroups beyond the top one (the one that we run in)
+			// be soft in the deletion because while we might have created the
+			// directory, there might be other processes that have joined it
+			// and we don't want to fail the deletion.
+			if i < len(c.Own)-1 {
+				return nil
+			}
+
 			return err
 		}
 		if err := backoff.Retry(fn, b); err != nil {


### PR DESCRIPTION
The current logic says "if we created a cgroup directory, we remove it". But the flaw in that logic is that if you run in
/sys/fs/cgroup/ns1/container1 you'll end up creating ns1 and container1. But if another container launches as /sys/fs/cgroup/ns1/container2, now while the first run created ns1, it can't delete it because container2 is in there.

The best fix I can think of, other than changing the logic full scale, is to just allow for a removal error on all but the top Own'd directory.