### PR TITLE
runsc: Allow map host user to non-root user in rootless mode

### DIFF
--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -187,6 +187,10 @@ type Boot struct {
 
 	// nvidiaDriverVersion is the Nvidia driver version on the host.
 	nvidiaDriverVersion string
+
+	// uid and gud are the user and group IDs to switch to after setting up the user namespace.
+	uid int
+	gid int
 }
 
 // Name implements subcommands.Command.Name.
@@ -219,6 +223,8 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&b.nvidiaDriverVersion, "nvidia-driver-version", "", "Nvidia driver version on the host")
 	f.StringVar(&b.hostTHP.ShmemEnabled, "host-thp-shmem-enabled", "", "value of /sys/kernel/mm/transparent_hugepage/shmem_enabled on the host")
 	f.StringVar(&b.hostTHP.Defrag, "host-thp-defrag", "", "value of /sys/kernel/mm/transparent_hugepage/defrag on the host")
+	f.IntVar(&b.uid, "uid", 0, "user ID")
+	f.IntVar(&b.gid, "gid", 0, "user ID")
 
 	// Open FDs that are donated to the sandbox.
 	f.IntVar(&b.specFD, "spec-fd", -1, "required fd with the container spec")
@@ -309,7 +315,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 	}
 
 	if b.syncUsernsFD >= 0 {
-		syncUsernsForRootless(b.syncUsernsFD)
+		syncUsernsForRootless(b.syncUsernsFD, uint32(b.uid), uint32(b.gid))
 		argOverride["sync-userns-fd"] = "-1"
 	}
 

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1441,6 +1441,13 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 			return nil, nil, nil, nil, err
 		}
 		defer syncFile.Close()
+		uid, gid := sandbox.SandboxUserGroupIDs(c.Spec)
+		if uid != 0 {
+			cmd.Args = append(cmd.Args, fmt.Sprintf("--uid=%d", uid))
+		}
+		if gid != 0 {
+			cmd.Args = append(cmd.Args, fmt.Sprintf("--gid=%d", gid))
+		}
 	}
 
 	// Create synchronization FD for chroot.


### PR DESCRIPTION
Fix #9918.

Currently, the rootless mode(runsc is called by no-root user) is not working well with the filesystem if we uses a non-root user in runsc container. This is because the runsc is mapping the host non-root user to root-user in container.

In some cases we need to map the host non-root user to runsc container non-root user (with the same uid).

After this patch, the following filesystem operations works well.

test@test-virtual-machine:~/test$ ./runsc   -ignore-cgroups --network host run abc
id
uid=1000(test) gid=1000(test) groups=1000(test)
touch /tmp/runsctest
echo aaa > /tmp/runsctest
ls -lh /tmp/runsctest
-rw-r--r-- 1 test test 4 Jun 29 18:46 /tmp/runsctest
exit
test@test-virtual-machine:~/test$ ls -lh /tmp/runsctest
-rw-r--r-- 1 test test 4  6月 29 18:46 /tmp/runsctest
test@test-virtual-machine:~/test$ cat /tmp/runsctest