### PR TITLE
fix: use LittleEndian for VirtioNetHeader field encoding

### DIFF
--- a/pkg/tcpip/header/virtionet.go
+++ b/pkg/tcpip/header/virtionet.go
@@ -87,8 +87,8 @@ func (v VirtioNetHeader) CSumOffset() uint16 {
 func (v VirtioNetHeader) Encode(f *VirtioNetHeaderFields) {
 	v[flags] = uint8(f.Flags)
 	v[gsoType] = uint8(f.GSOType)
-	binary.BigEndian.PutUint16(v[hdrLen:], f.HdrLen)
-	binary.BigEndian.PutUint16(v[gsoSize:], f.GSOSize)
-	binary.BigEndian.PutUint16(v[csumStart:], f.CSumStart)
-	binary.BigEndian.PutUint16(v[csumOffset:], f.CSumOffset)
+	binary.LittleEndian.PutUint16(v[hdrLen:], f.HdrLen)
+	binary.LittleEndian.PutUint16(v[gsoSize:], f.GSOSize)
+	binary.LittleEndian.PutUint16(v[csumStart:], f.CSumStart)
+	binary.LittleEndian.PutUint16(v[csumOffset:], f.CSumOffset)
 }


### PR DESCRIPTION
This change updates the encoding of several fields in `VirtioNetHeader.Encode` from big endian to little endian.

Although this code path is not currently exercised in production (the current usage always passes an all-zero structure, where big endian and little endian encoding yield the same result), I encountered this issue while using this method in my own project, where the values are non-zero. According to the [Virtual I/O Device Specification](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html), these fields (`HdrLen`, `GSOSize`, `CSumStart`, `CSumOffset`)should be encoded in little endian format. Using big endian encoding here is incorrect and leads to failures when interoperating with compliant Virtio implementations(for example tun devices).

This PR corrects the encoding to use `binary.LittleEndian` as required by the specification.

---

**References:**
- [Virtual I/O Device Specification v1.1 — Section 5.1.6 Device Operation](https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-2050006:~:text=%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0le16%C2%A0hdr_len%3B%C2%A0%0A%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0le16%C2%A0gso_size%3B%C2%A0%0A%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0le16%C2%A0csum_start%3B%C2%A0%0A%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0%C2%A0le16%C2%A0csum_offset%3B%C2%A0)
