### PR TITLE
Add build instructions to WORKSPACE and BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,8 @@
+# NOTICE: BUILD IN DOCKER
+#
+# Building runsc requires complex external dependencies.
+# Consider building in docker. Refer to `README.md` for instructions.
+
 load("@rules_license//rules:license.bzl", "license")
 load("//tools:defs.bzl", "build_test", "gazelle", "go_path")
 load("//tools/nogo:defs.bzl", "nogo_config")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,8 @@
+# NOTICE: BUILD IN DOCKER
+#
+# Building runsc requires complex external dependencies.
+# Consider building in docker. Refer to `README.md` for instructions.
+
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 


### PR DESCRIPTION
I made a mistake (again) of building runsc using bazel directly.

Instruction at the top of `BUILD` and `WORKSPACE` file may help.