### PR TITLE
Add dummy /proc/<pid>/setgroups

### DIFF
--- a/pkg/sentry/fsimpl/proc/task.go
+++ b/pkg/sentry/fsimpl/proc/task.go
@@ -86,6 +86,7 @@ func (fs *filesystem) newTaskInode(ctx context.Context, task *kernel.Task, pidns
 		"oom_score":     fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, newStaticFile("0\n")),
 		"oom_score_adj": fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0644, &oomScoreAdj{task: task}),
 		"root":          fs.newRootSymlink(ctx, task, fs.NextIno()),
+		"setgroups":     fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, newStaticFile("allow\n")),
 		"smaps":         fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, &smapsData{task: task}),
 		"stat":          fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, &taskStatData{task: task, pidns: pidns, tgstats: isThreadGroup}),
 		"statm":         fs.newTaskOwnedInode(ctx, task, fs.NextIno(), 0444, &statmData{task: task}),

--- a/pkg/sentry/fsimpl/proc/tasks_test.go
+++ b/pkg/sentry/fsimpl/proc/tasks_test.go
@@ -92,6 +92,7 @@ var (
 		"oom_score":     linux.DT_REG,
 		"oom_score_adj": linux.DT_REG,
 		"root":          linux.DT_LNK,
+		"setgroups":     linux.DT_REG,
 		"smaps":         linux.DT_REG,
 		"stat":          linux.DT_REG,
 		"statm":         linux.DT_REG,


### PR DESCRIPTION
[Buildah does not work in gVisor](https://github.com/containers/buildah/issues/2099), it tries to write to `/proc/<pid>/setgroups`.

This PR does not fix it, but one step at a time.

The idea I'm pursuing is to allow writing `allow` to `/proc/<pid>/setgroups` without supporting `deny`.