### PR TITLE
Add option to enable/disable unknown fields in OCI config

### DIFF
--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"bytes"
 
 	"github.com/cenkalti/backoff"
 	"github.com/mohae/deepcopy"
@@ -215,8 +216,14 @@ func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) 
 		return nil, fmt.Errorf("error reading spec from file %q: %v", specFile.Name(), err)
 	}
 	var spec specs.Spec
-	if err := json.Unmarshal(specBytes, &spec); err != nil {
-		return nil, fmt.Errorf("error unmarshaling spec from file %q: %v\n %s", specFile.Name(), err, string(specBytes))
+	decoder := json.NewDecoder(bytes.NewReader(specBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&spec); err != nil {
+		if err2 := json.Unmarshal(specBytes, &spec); err2 != nil {
+			return nil, fmt.Errorf("error unmarshaling spec from file %q: %v\n %s", specFile.Name(), err2, string(specBytes))
+		} else {
+			log.Warningf("Problem with spec file %q: %v. Consider removing unnecessary fields.", specFile.Name(), err)
+		}
 	}
 	if err := ValidateSpec(&spec); err != nil {
 		return nil, err

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -218,11 +218,11 @@ func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) 
 	var spec specs.Spec
 	decoder := json.NewDecoder(bytes.NewReader(specBytes))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&spec); err != nil {
-		if err2 := json.Unmarshal(specBytes, &spec); err2 != nil {
-			return nil, fmt.Errorf("error unmarshaling spec from file %q: %v\n %s", specFile.Name(), err2, string(specBytes))
+	if errLooseDecode := decoder.Decode(&spec); errLooseDecode != nil {
+		if errStrictDecode := json.Unmarshal(specBytes, &spec); errStrictDecode != nil {
+			return nil, fmt.Errorf("error unmarshaling spec from file %q: %v\n %s", specFile.Name(), errStrictDecode, string(specBytes))
 		} else {
-			log.Warningf("Problem with spec file %q: %v. Consider removing unnecessary fields.", specFile.Name(), err)
+			log.Warningf("OCI spec file %q contains fields unknown to `runsc`: %v. Ignoring these fields and continuing anyway.", specFile.Name(), errLooseDecode)
 		}
 	}
 	if err := ValidateSpec(&spec); err != nil {


### PR DESCRIPTION
Currently in OCI config it is possible to add any extra json data, which will be ignored by runsc.
I found it is a bit confusing when was learning OCI implementation of gvisor (adding wrong/non existent  fields does not produce any error or warning), therefore decided to add flag `allow-unknown-fields`, which is `true` by default (does not modify current behavior).
In case of being `false`, gvisor produces error like this:
```
reading spec: error unmarshaling spec from file "config.json": json: unknown field "oooooo"
```