### PR TITLE
Fix //debian:debian build target.

### DIFF
--- a/tools/show_paths.bzl
+++ b/tools/show_paths.bzl
@@ -13,7 +13,7 @@ def format(target):
     if files_to_run and files_to_run.executable:
         outputs[files_to_run.executable.path] = True
     elif default_info:
-        for x in default_info.files:
+        for x in default_info.files.to_list():
             outputs[x.path] = True
     elif output_group_info:
         for entry in dir(output_group_info):


### PR DESCRIPTION
This is needed for releases. For some reason, prior to this CL `make debian` would succeed, despite the obvious failure in the logs, and the script using show_paths.bzl doing `set -euo`.