### PR TITLE
Implement the `beforeSave` hook for `processorManager`

### DIFF
--- a/pkg/tcpip/link/fdbased/processors.go
+++ b/pkg/tcpip/link/fdbased/processors.go
@@ -276,3 +276,8 @@ func (m *processorManager) wakeReady() {
 		m.ready[i] = false
 	}
 }
+
+func (m *processorManager) beforeSave() {
+	m.close()
+	m.wg.Wait()
+}


### PR DESCRIPTION
This hook is supposed to "quiesce" data structures before the stateify system serializes them to a memory checkpoint. `processorManager` has a packet-processing goroutine which needs to be stopped before we can serialize the object.

A more detailed investigation is in https://github.com/google/gvisor/issues/12072.