### PR TITLE
net: xdp: Support multiple RX queues for LinkEndpoint

### DIFF
--- a/pkg/tcpip/link/xdp/endpoint.go
+++ b/pkg/tcpip/link/xdp/endpoint.go
@@ -109,6 +109,9 @@ type Options struct {
 
 	// GRO enables generic receive offload.
 	GRO bool
+
+	// QueueID is the ID of the RX queue to which the AF_XDP socket is attached.
+	QueueID uint32
 }
 
 // New creates a new endpoint from an AF_XDP socket.
@@ -164,7 +167,7 @@ func New(opts *Options) (stack.LinkEndpoint, error) {
 		NDescriptors: nFrames / 2,
 		Bind:         opts.Bind,
 	}
-	ep.control, err = xdp.NewFromSocket(opts.FD, uint32(opts.InterfaceIndex), 0 /* queueID */, xdpOpts)
+	ep.control, err = xdp.NewFromSocket(opts.FD, uint32(opts.InterfaceIndex), opts.QueueID, xdpOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AF_XDP dispatcher: %v", err)
 	}


### PR DESCRIPTION
This change enhances the XDP LinkEndpoint to support multiple RX queues instead of being limited to queue 0. The implementation includes:

- Add QueueID field to the Options struct to specify which RX queue the AF_XDP socket should be attached to
- Modify the New function to initialize the AF_XDP socket with the specified QueueID instead of hardcoded 0

This allows better distribution of network traffic across multiple queues for improved performance in high-throughput scenarios.

Fixes issue with XDP LinkEndpoint only supporting NIC queue 0.