### PR TITLE
Fix error when applying upperdir tar snapshot containing empty files

### DIFF
--- a/pkg/sentry/fsimpl/tmpfs/tar.go
+++ b/pkg/sentry/fsimpl/tmpfs/tar.go
@@ -77,8 +77,10 @@ func (fs *filesystem) readFromTar(ctx context.Context, tr *tar.Reader) error {
 			if n != header.Size {
 				return fmt.Errorf("failed to read all file content, got %d bytes, want %d", n, header.Size)
 			}
+			if header.Size > 0 {
+				fileToContent[header.Name] = &buffer
+			}
 			fileToHeader[header.Name] = header
-			fileToContent[header.Name] = &buffer
 		case tar.TypeFifo, tar.TypeBlock, tar.TypeChar:
 			fileToHeader[header.Name] = header
 		case tar.TypeSymlink:

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -4035,11 +4035,10 @@ func TestTarRootfsUpperLayer(t *testing.T) {
 	if err := cont.Start(conf); err != nil {
 		t.Fatalf("error starting container: %v", err)
 	}
-
 	// Exec the command in the container.
 	execArgs := &control.ExecArgs{
 		Filename: app,
-		Argv:     []string{app, "fsTreeCreate", "--depth=3", "--file-per-level=2", "--file-size=1470", "--create-symlink"},
+		Argv:     []string{app, "fsTreeCreate", "--depth=3", "--file-per-level=2", "--file-size=1470", "--create-symlink", "--add-empty-files"},
 	}
 	if ws, err := cont.executeSync(conf, execArgs); err != nil {
 		t.Fatalf("error exec'ing: %v", err)

--- a/test/cmd/test_app/main.go
+++ b/test/cmd/test_app/main.go
@@ -67,6 +67,7 @@ type fsTreeCreator struct {
 	fileSize         uint
 	targetDir        string
 	createSymlink    bool
+	addEmptyFiles    bool
 }
 
 // Name implements subcommands.Command.Name.
@@ -91,6 +92,7 @@ func (c *fsTreeCreator) SetFlags(f *flag.FlagSet) {
 	f.UintVar(&c.fileSize, "file-size", 4096, "size of each file")
 	f.StringVar(&c.targetDir, "target-dir", "/", "directory under which to create the filesystem tree")
 	f.BoolVar(&c.createSymlink, "create-symlink", false, "create symlinks other than the first file per level")
+	f.BoolVar(&c.addEmptyFiles, "add-empty-files", false, "add empty file to each level")
 }
 
 // Execute implements subcommands.Command.Execute.
@@ -115,6 +117,12 @@ func (c *fsTreeCreator) Execute(ctx context.Context, f *flag.FlagSet, args ...an
 				if err := os.WriteFile(filePath, data, 0666); err != nil {
 					log.Fatalf("error writing file %q: %v", filePath, err)
 				}
+			}
+		}
+		if c.addEmptyFiles {
+			emptyPath := filepath.Join(curDir, fmt.Sprintf("empty%d", i))
+			if err := os.WriteFile(emptyPath, nil, 0666); err != nil {
+				log.Fatalf("error writing empty file %q: %v", emptyPath, err)
 			}
 		}
 		nextDir := filepath.Join(curDir, "dir")


### PR DESCRIPTION
Added size check to prevent sentry tmpfs mknodFromTar from trying to write empty files, this caused running containers from a snapshot from upper tar to fail when empty files were in the archive. 

Fixes #12228 

