### PR TITLE
usertrap: disable syscall patching when ptraced

### DIFF
--- a/pkg/sentry/platform/systrap/usertrap/usertrap_amd64.go
+++ b/pkg/sentry/platform/systrap/usertrap/usertrap_amd64.go
@@ -198,10 +198,14 @@ func (s *State) PatchSyscall(ctx context.Context, ac *arch.Context64, mm memoryM
 	// the "syshandler" routine used to handle patched syscalls (see
 	// syshandler_amd64.S). This incompatibility can result in inconsistent
 	// process states and failures (e.g. SIGSEGV).
-	// TODO: for a full fix we'd need to roll back existing patched
-	//       syscalls, in case the traced program was patched before being
-	//       traced (e.g. PTRACE_ATTACH on an already running process).
+	// TODO(gvisor.dev/issue/11649): for a full fix we'd need to roll back
+	//     existing patched syscalls, in case the traced program was patched
+	//     before being traced (e.g. PTRACE_ATTACH on an already running
+	//     process).
 	if task.Tracer() != nil {
+		if s.nextTrap > 0 {
+			ctx.Warningf("LIKELY ERROR: Attached tracer to process with patched syscalls (traps %d)! Systrap is not fully compatible with ptrace/debuggers, program may die unexpectedly soon!", s.nextTrap)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Workaround the issue in #12266 .

It's not clear to me yet why the issue appears, but it happens intermittently when ptracing a program. I think also #11649 is related. This patch is similar to `--systrap-disable-syscall-patching` but instead of disabling syscall patching globally, we just disable it for some tasks.

What do you think?