### PR TITLE
runsc: Add EROFS mount support in bundle config.json

### DIFF
--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -342,7 +342,7 @@ func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid i
 
 	mountIdx := 1 // first one is the root
 	for _, m := range spec.Mounts {
-		if !specutils.IsGoferMount(m) {
+		if !specutils.HasMountConfig(m) {
 			continue
 		}
 		mountConf := g.mountConfs[mountIdx]
@@ -528,7 +528,7 @@ func (g *Gofer) setupRootFS(spec *specs.Spec, conf *config.Config, goferToHostRP
 func (g *Gofer) setupMounts(conf *config.Config, mounts []specs.Mount, root, procPath string, goferToHostRPC *urpc.Client) (retErr error) {
 	mountIdx := 1 // First index is for rootfs.
 	for _, m := range mounts {
-		if !specutils.IsGoferMount(m) {
+		if !specutils.HasMountConfig(m) {
 			continue
 		}
 		mountConf := g.mountConfs[mountIdx]
@@ -690,7 +690,7 @@ func (g *Gofer) resolveMounts(conf *config.Config, mounts []specs.Mount, root st
 	mountIdx := 1 // First index is for rootfs.
 	cleanMounts := make([]specs.Mount, 0, len(mounts))
 	for _, m := range mounts {
-		if !specutils.IsGoferMount(m) {
+		if !specutils.HasMountConfig(m) {
 			cleanMounts = append(cleanMounts, m)
 			continue
 		}

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -502,6 +502,16 @@ func IsGoferMount(m specs.Mount) bool {
 	return m.Type == "bind" && m.Source != ""
 }
 
+// IsErofsMount returns true if the given mount can be mounted as EROFS.
+func IsErofsMount(m specs.Mount) bool {
+	return m.Type == "erofs"
+}
+
+// HasMountConfig returns true if the given mount has an associated GoferMountConf.
+func HasMountConfig(m specs.Mount) bool {
+	return IsGoferMount(m) || IsErofsMount(m)
+}
+
 // MaybeConvertToBindMount converts mount type to "bind" in case any of the
 // mount options are either "bind" or "rbind" as required by the OCI spec.
 //


### PR DESCRIPTION
This change enables EROFS filesystems to be specified as regular mounts in the OCI bundle config.json, not just as rootfs or debug mounts.

EROFS mounts are now tracked in goferMountConfs alongside lisafs mounts. The implementation adds:
- IsErofsMount() helper in specutils to identify EROFS mounts
- Updated mount index tracking across container.go, gofer.go, and vfs.go
- Support for opening EROFS image files and passing FDs to the sandbox
- EROFS case in getMountNameAndOptions() for proper mount setup

Key implementation details:
- EROFS mounts are included in goferMountConfs but skip gofer-specific processing (e.g., lisafs serving, filestore creation)
- Mount type determination happens before mount hint logic
- Proper index tracking ensures EROFS mounts increment indices but skip lisafs-only operations

Fixes #12307