### PR TITLE
fix(tty): handle SendSignal error to prevent infinite loop

### DIFF
--- a/pkg/sentry/kernel/tty.go
+++ b/pkg/sentry/kernel/tty.go
@@ -159,6 +159,7 @@ func (tty *TTY) CheckChange(ctx context.Context, sig linux.Signal) error {
 	// the signal is not pending. Returning ERESTARTSYS without a pending signal
 	// causes an infinite tight loop. We must abort if signaling fails.
 	if err := pg.SendSignal(SignalInfoPriv(sig)); err != nil {
+		// Signal failed to queue. We cannot return ERESTARTSYS or we loop.
 		return linuxerr.EIO
 	}
 

--- a/pkg/sentry/kernel/tty.go
+++ b/pkg/sentry/kernel/tty.go
@@ -154,7 +154,13 @@ func (tty *TTY) CheckChange(ctx context.Context, sig linux.Signal) error {
 	// handle -ERESTARTSYS in kernel.runApp.execute() even if the
 	// kernel.Task isn't interrupted.
 	//
-	// Linux ignores the result of kill_pgrp().
-	_ = pg.SendSignal(SignalInfoPriv(sig))
+	// Linux ignores the result of kill_pgrp(), but relies on setting TIF_SIGPENDING
+	// to ensure the process handles the signal. In gVisor, if SendSignal fails,
+	// the signal is not pending. Returning ERESTARTSYS without a pending signal
+	// causes an infinite tight loop. We must abort if signaling fails.
+	if err := pg.SendSignal(SignalInfoPriv(sig)); err != nil {
+		return linuxerr.EIO
+	}
+
 	return linuxerr.ERESTARTSYS
 }


### PR DESCRIPTION
**The Issue**
In `CheckChange`, the code ignores the error from `SendSignal` and returns `ERESTARTSYS`.
In Linux, `TIF_SIGPENDING` is set unconditionally, ensuring the loop breaks.
In gVisor, if `SendSignal` fails, no signal is pending. Returning `ERESTARTSYS` causes the syscall to restart immediately, leading to an infinite loop (DoS).

**The Fix**
I added an error check. If `SendSignal` fails, we return `EIO` to abort the syscall safely.