### PR TITLE
tcpip: fix IP_MTU_DISCOVER flag for tcp and udp

### DIFF
--- a/pkg/tcpip/network/ipv4/ipv4.go
+++ b/pkg/tcpip/network/ipv4/ipv4.go
@@ -609,9 +609,7 @@ func (e *endpoint) writePacketPostRouting(r *stack.Route, pkt *stack.PacketBuffe
 
 	if packetMustBeFragmented(pkt, networkMTU) {
 		h := header.IPv4(pkt.NetworkHeader().Slice())
-		if h.Flags()&header.IPv4FlagDontFragment != 0 && pkt.NetworkPacketInfo.IsForwardedPacket {
-			// TODO(gvisor.dev/issue/5919): Handle error condition in which DontFragment
-			// is set but the packet must be fragmented for the non-forwarding case.
+		if h.Flags()&header.IPv4FlagDontFragment != 0 {
 			return &tcpip.ErrMessageTooLong{}
 		}
 		sent, remain, err := e.handleFragments(r, networkMTU, pkt, func(fragPkt *stack.PacketBuffer) tcpip.Error {

--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -1042,7 +1042,7 @@ func (e *Endpoint) sendRaw(pkt *stack.PacketBuffer, flags header.TCPFlags, seq, 
 		ack:       ack,
 		rcvWnd:    rcvWnd,
 		opts:      options,
-		df:        e.pmtud == tcpip.PMTUDiscoveryWant || e.pmtud == tcpip.PMTUDiscoveryDo,
+		df:        e.pmtud == tcpip.PMTUDiscoveryWant || e.pmtud == tcpip.PMTUDiscoveryDo || e.pmtud == tcpip.PMTUDiscoveryProbe,
 		expOptVal: expOptVal,
 	}, pkt, e.gso)
 }

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -1895,18 +1895,9 @@ func (e *Endpoint) SetSockOptInt(opt tcpip.SockOptInt, v int) tcpip.Error {
 		e.UnlockUser()
 
 	case tcpip.MTUDiscoverOption:
-		switch v := tcpip.PMTUDStrategy(v); v {
-		case tcpip.PMTUDiscoveryWant, tcpip.PMTUDiscoveryDont, tcpip.PMTUDiscoveryDo:
-			e.LockUser()
-			e.pmtud = v
-			e.UnlockUser()
-		case tcpip.PMTUDiscoveryProbe:
-			// We don't support a way to ignore MTU updates; it's
-			// either on or it's off.
-			return &tcpip.ErrNotSupported{}
-		default:
-			return &tcpip.ErrNotSupported{}
-		}
+		e.LockUser()
+		e.pmtud = tcpip.PMTUDStrategy(v)
+		e.UnlockUser()
 
 	case tcpip.IPv4TTLOption:
 		e.LockUser()
@@ -2965,7 +2956,14 @@ func (e *Endpoint) HandleError(transErr stack.TransportError, pkt *stack.PacketB
 	// TODO(gvisor.dev/issues/5270): Handle all transport errors.
 	switch transErr.Kind() {
 	case stack.PacketTooBigTransportError:
-		handlePacketTooBig(transErr.Info())
+		e.mu.Lock()
+		pmtud := e.pmtud
+		e.mu.Unlock()
+		if pmtud == tcpip.PMTUDiscoveryProbe {
+			e.onICMPError(&tcpip.ErrMessageTooLong{}, transErr, pkt)
+		} else {
+			handlePacketTooBig(transErr.Info())
+		}
 	case stack.DestinationHostUnreachableTransportError:
 		e.onICMPError(&tcpip.ErrHostUnreachable{}, transErr, pkt)
 	case stack.DestinationNetworkUnreachableTransportError:

--- a/test/packetimpact/tests/ipv4_id_uniqueness_test.go
+++ b/test/packetimpact/tests/ipv4_id_uniqueness_test.go
@@ -79,14 +79,9 @@ func TestIPv4RetransmitIdentificationUniqueness(t *testing.T) {
 
 			dut.SetSockOptInt(t, remoteFD, unix.IPPROTO_TCP, unix.TCP_NODELAY, 1)
 
-			// TODO(b/129291778) The following socket option clears the DF bit on
-			// IP packets sent over the socket, and is currently not supported by
-			// gVisor. gVisor by default sends packets with DF=0 anyway, so the
-			// socket option being not supported does not affect the operation of
-			// this test. Once the socket option is supported, the following call
-			// can be changed to simply assert success.
+			// Set IP_PMTUDISC_DONT to clear the DF bit on IP packets.
+			// Fuchsia will return ENOPROTOOPT errno.
 			ret, errno := dut.SetSockOptIntWithErrno(context.Background(), t, remoteFD, unix.IPPROTO_IP, linux.IP_MTU_DISCOVER, linux.IP_PMTUDISC_DONT)
-			// Fuchsia will return ENOPROTOPT errno.
 			if ret == -1 && errno != unix.ENOPROTOOPT {
 				t.Fatalf("failed to set IP_MTU_DISCOVER socket option to IP_PMTUDISC_DONT: %s", errno)
 			}

--- a/test/syscalls/linux/tcp_socket.cc
+++ b/test/syscalls/linux/tcp_socket.cc
@@ -2357,21 +2357,14 @@ TEST_P(TcpSocketTest, SetPMTUD) {
       SyscallSucceeds());
   EXPECT_EQ(got, IP_PMTUDISC_DONT);
 
-  // IP_PMTUDISC_PROBE is not supported by gVisor.
   set = IP_PMTUDISC_PROBE;
-  if (IsRunningOnGvisor() && !IsRunningWithHostinet()) {
-    ASSERT_THAT(
-        setsockopt(accepted_.get(), SOL_IP, IP_MTU_DISCOVER, &set, length),
-        SyscallFailsWithErrno(ENOTSUP));
-  } else {
-    ASSERT_THAT(
-        setsockopt(accepted_.get(), SOL_IP, IP_MTU_DISCOVER, &set, length),
-        SyscallSucceeds());
-    ASSERT_THAT(
-        getsockopt(accepted_.get(), SOL_IP, IP_MTU_DISCOVER, &got, &length),
-        SyscallSucceeds());
-    EXPECT_EQ(got, IP_PMTUDISC_PROBE);
-  }
+  ASSERT_THAT(
+      setsockopt(accepted_.get(), SOL_IP, IP_MTU_DISCOVER, &set, length),
+      SyscallSucceeds());
+  ASSERT_THAT(
+      getsockopt(accepted_.get(), SOL_IP, IP_MTU_DISCOVER, &got, &length),
+      SyscallSucceeds());
+  EXPECT_EQ(got, IP_PMTUDISC_PROBE);
 }
 
 TEST_P(SimpleTcpSocketTest, GetSocketAcceptConnWithShutdown) {


### PR DESCRIPTION
Fixes #12319

This patch only supports various IP_MTU_DISCOVER flags.
To fully support `tracepath` actually tracing the path the correct propagation of TTL exceeded is needed.
