### PR TITLE
Remove SliceHeader and replace.

### DIFF
--- a/nogo.yaml
+++ b/nogo.yaml
@@ -190,6 +190,8 @@ analyzers:
         - pkg/aio/aio_linux_unsafe.go                              # Special case.
         - pkg/eventfd/eventfd_unsafe.go                            # Special case.
         - "pkg/flipcall/.*_unsafe.go"                              # Special case.
+        - pkg/memutil/memutil_unsafe.go                            # Special case.
+        - pkg/tcpip/link/sharedmem/sharedmem_unsafe.go             # Special case.
         - pkg/gohacks/noescape_unsafe.go                           # Special case.
         - pkg/ring0/pagetables/allocator_unsafe.go                 # Special case.
         - pkg/sentry/devices/nvproxy/frontend_mmap_unsafe.go       # Special case.

--- a/pkg/buffer/view_unsafe.go
+++ b/pkg/buffer/view_unsafe.go
@@ -15,12 +15,10 @@
 package buffer
 
 import (
-	"reflect"
 	"unsafe"
 )
 
 // BasePtr returns a pointer to the view's chunk.
 func (v *View) BasePtr() *byte {
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&v.chunk.data))
-	return (*byte)(unsafe.Pointer(hdr.Data))
+	return unsafe.SliceData(v.chunk.data)
 }

--- a/pkg/flipcall/flipcall_unsafe.go
+++ b/pkg/flipcall/flipcall_unsafe.go
@@ -15,7 +15,6 @@
 package flipcall
 
 import (
-	"reflect"
 	"unsafe"
 
 	"gvisor.dev/gvisor/pkg/atomicbitops"
@@ -62,12 +61,9 @@ func (ep *Endpoint) dataLen() *atomicbitops.Uint32 {
 //   - Writers must not assume that they will read back the same data that they
 //     have written. In other words, writers should avoid reading from Data() at
 //     all.
-func (ep *Endpoint) Data() (bs []byte) {
-	bshdr := (*reflect.SliceHeader)(unsafe.Pointer(&bs))
-	bshdr.Data = ep.packet + PacketHeaderBytes
-	bshdr.Len = int(ep.dataCap)
-	bshdr.Cap = int(ep.dataCap)
-	return
+func (ep *Endpoint) Data() []byte {
+	ptr := unsafe.Pointer(ep.packet + PacketHeaderBytes)
+	return unsafe.Slice((*byte)(ptr), int(ep.dataCap))
 }
 
 // ioSync is a dummy variable used to indicate synchronization to the Go race

--- a/pkg/rawfile/rawfile_unsafe.go
+++ b/pkg/rawfile/rawfile_unsafe.go
@@ -19,7 +19,6 @@
 package rawfile
 
 import (
-	"reflect"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -43,12 +42,9 @@ func IovecFromBytes(bs []byte) unix.Iovec {
 	return iov
 }
 
-func bytesFromIovec(iov unix.Iovec) (bs []byte) {
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&bs))
-	sh.Data = uintptr(unsafe.Pointer(iov.Base))
-	sh.Len = int(iov.Len)
-	sh.Cap = int(iov.Len)
-	return
+func bytesFromIovec(iov unix.Iovec) []byte {
+	ptr := unsafe.Pointer(iov.Base)
+	return unsafe.Slice((*byte)(ptr), int(iov.Len))
 }
 
 // AppendIovecFromBytes returns append(iovs, IovecFromBytes(bs)). If len(bs) ==

--- a/pkg/sentry/platform/systrap/stub_unsafe.go
+++ b/pkg/sentry/platform/systrap/stub_unsafe.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"reflect"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -69,11 +68,7 @@ func copySeccompRulesToStub(instrs []bpf.Instruction, stubAddr, size uintptr) {
 		panic("not enough space for sysmsg seccomp rules")
 	}
 
-	var targetSlice []bpf.Instruction
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&targetSlice))
-	sh.Data = progPtr
-	sh.Cap = len(instrs)
-	sh.Len = sh.Cap
+	targetSlice := unsafe.Slice((*bpf.Instruction)(unsafe.Pointer(progPtr)), len(instrs))
 
 	copy(targetSlice, instrs)
 

--- a/pkg/tcpip/link/sharedmem/sharedmem_unsafe.go
+++ b/pkg/tcpip/link/sharedmem/sharedmem_unsafe.go
@@ -16,7 +16,6 @@ package sharedmem
 
 import (
 	"fmt"
-	"reflect"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -48,12 +47,7 @@ func getBuffer(fd int) ([]byte, error) {
 		return nil, fmt.Errorf("failed to map memory for buffer fd: %d, error: %s", fd, err)
 	}
 
-	// Use unsafe to convert addr into a []byte.
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Data = addr
-	hdr.Len = int(s.Size)
-	hdr.Cap = int(s.Size)
+	b := unsafe.Slice((*byte)(unsafe.Pointer(addr)), int(s.Size))
 
 	return b, nil
 }

--- a/pkg/tcpip/transport/tcp/connect_unsafe.go
+++ b/pkg/tcpip/transport/tcp/connect_unsafe.go
@@ -15,7 +15,6 @@
 package tcp
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -26,5 +25,5 @@ import (
 func optionsToArray(options []byte) *[maxOptionSize]byte {
 	// Reslice to full capacity.
 	options = options[0:maxOptionSize]
-	return (*[maxOptionSize]byte)(unsafe.Pointer((*reflect.SliceHeader)(unsafe.Pointer(&options)).Data))
+	return (*[maxOptionSize]byte)(unsafe.Pointer(&options[0]))
 }

--- a/pkg/xdp/xdp_unsafe.go
+++ b/pkg/xdp/xdp_unsafe.go
@@ -16,7 +16,6 @@ package xdp
 
 import (
 	"fmt"
-	"reflect"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -62,20 +61,16 @@ func sizeOfTXQueueDesc() uint64 {
 }
 
 func (fq *FillQueue) init(off unix.XDPMmapOffsets, opts Opts) {
-	fillQueueRingHdr := (*reflect.SliceHeader)(unsafe.Pointer(&fq.ring))
-	fillQueueRingHdr.Data = uintptr(unsafe.Pointer(&fq.mem[off.Fr.Desc]))
-	fillQueueRingHdr.Len = int(opts.NDescriptors)
-	fillQueueRingHdr.Cap = fillQueueRingHdr.Len
+	base := unsafe.Pointer(&fq.mem[off.Fr.Desc])
+	fq.ring = unsafe.Slice((*uint64)(base), int(opts.NDescriptors))
 	fq.producer = (*atomicbitops.Uint32)(unsafe.Pointer(&fq.mem[off.Fr.Producer]))
 	fq.consumer = (*atomicbitops.Uint32)(unsafe.Pointer(&fq.mem[off.Fr.Consumer]))
 	fq.flags = (*atomicbitops.Uint32)(unsafe.Pointer(&fq.mem[off.Fr.Flags]))
 }
 
 func (rq *RXQueue) init(off unix.XDPMmapOffsets, opts Opts) {
-	rxQueueRingHdr := (*reflect.SliceHeader)(unsafe.Pointer(&rq.ring))
-	rxQueueRingHdr.Data = uintptr(unsafe.Pointer(&rq.mem[off.Rx.Desc]))
-	rxQueueRingHdr.Len = int(opts.NDescriptors)
-	rxQueueRingHdr.Cap = rxQueueRingHdr.Len
+	base := unsafe.Pointer(&rq.mem[off.Rx.Desc])
+	rq.ring = unsafe.Slice((*unix.XDPDesc)(base), int(opts.NDescriptors))
 	rq.producer = (*atomicbitops.Uint32)(unsafe.Pointer(&rq.mem[off.Rx.Producer]))
 	rq.consumer = (*atomicbitops.Uint32)(unsafe.Pointer(&rq.mem[off.Rx.Consumer]))
 	rq.flags = (*atomicbitops.Uint32)(unsafe.Pointer(&rq.mem[off.Rx.Flags]))
@@ -86,10 +81,8 @@ func (rq *RXQueue) init(off unix.XDPMmapOffsets, opts Opts) {
 }
 
 func (cq *CompletionQueue) init(off unix.XDPMmapOffsets, opts Opts) {
-	completionQueueRingHdr := (*reflect.SliceHeader)(unsafe.Pointer(&cq.ring))
-	completionQueueRingHdr.Data = uintptr(unsafe.Pointer(&cq.mem[off.Cr.Desc]))
-	completionQueueRingHdr.Len = int(opts.NDescriptors)
-	completionQueueRingHdr.Cap = completionQueueRingHdr.Len
+	base := unsafe.Pointer(&cq.mem[off.Cr.Desc])
+	cq.ring = unsafe.Slice((*uint64)(base), int(opts.NDescriptors))
 	cq.producer = (*atomicbitops.Uint32)(unsafe.Pointer(&cq.mem[off.Cr.Producer]))
 	cq.consumer = (*atomicbitops.Uint32)(unsafe.Pointer(&cq.mem[off.Cr.Consumer]))
 	cq.flags = (*atomicbitops.Uint32)(unsafe.Pointer(&cq.mem[off.Cr.Flags]))
@@ -100,10 +93,8 @@ func (cq *CompletionQueue) init(off unix.XDPMmapOffsets, opts Opts) {
 }
 
 func (tq *TXQueue) init(off unix.XDPMmapOffsets, opts Opts) {
-	txQueueRingHdr := (*reflect.SliceHeader)(unsafe.Pointer(&tq.ring))
-	txQueueRingHdr.Data = uintptr(unsafe.Pointer(&tq.mem[off.Tx.Desc]))
-	txQueueRingHdr.Len = int(opts.NDescriptors)
-	txQueueRingHdr.Cap = txQueueRingHdr.Len
+	base := unsafe.Pointer(&tq.mem[off.Tx.Desc])
+	tq.ring = unsafe.Slice((*unix.XDPDesc)(base), int(opts.NDescriptors))
 	tq.producer = (*atomicbitops.Uint32)(unsafe.Pointer(&tq.mem[off.Tx.Producer]))
 	tq.consumer = (*atomicbitops.Uint32)(unsafe.Pointer(&tq.mem[off.Tx.Consumer]))
 	tq.flags = (*atomicbitops.Uint32)(unsafe.Pointer(&tq.mem[off.Tx.Flags]))

--- a/tools/go_marshal/analysis/analysis_unsafe.go
+++ b/tools/go_marshal/analysis/analysis_unsafe.go
@@ -54,13 +54,9 @@ func RandomizeValue(x any) {
 		panic("RandomizeType() called with an unaddressable value. You probably need to pass a pointer to the argument")
 	}
 
-	// Cast the underlying memory for the type into a byte slice.
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	size := int(v.Type().Size())
 	// Note: v.UnsafeAddr panics if x is passed by value. x should be a pointer.
-	hdr.Data = v.UnsafeAddr()
-	hdr.Len = int(v.Type().Size())
-	hdr.Cap = hdr.Len
+	b := unsafe.Slice((*byte)(unsafe.Pointer(v.UnsafeAddr())), size)
 
 	// Fill the byte slice with random data, which in effect fills the type with
 	// random values.


### PR DESCRIPTION
Removes most uses of SliceHeader as referenced by https://github.com/google/gvisor/issues/8422

SliceHeader is deprecated - so we prefer to use unsafe.Slice() and unsafe.Pointer().