### PR TITLE
sync: fix go1.26 build constraints

### DIFF
--- a/pkg/sync/runtime_constants_go125.go
+++ b/pkg/sync/runtime_constants_go125.go
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 // https://go.dev/cl/670497 (1.25) adds a new wait reason, adjusting the value of waitReasonSemacquire.
-//go:build go1.25
+// https://go.dev/cl/714800 (1.26) changes size of the schedt.midle field.
+//go:build go1.25 && !go1.26
 
 package sync
 

--- a/pkg/sync/runtime_spinning_amd64.s
+++ b/pkg/sync/runtime_spinning_amd64.s
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 // https://go.dev/cl/669235 (1.25) adds a new schedt field prior to nmspinning.
-// https://go.dev/cl/714800 (1.26) changes size of the schedt.midle field.
-//go:build amd64 && !go1.25 && !go1.26
+//go:build amd64 && !go1.25
 
 #include "textflag.h"
 

--- a/pkg/sync/runtime_spinning_go126_amd64.s
+++ b/pkg/sync/runtime_spinning_go126_amd64.s
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// https://go.dev/cl/669235 (1.25) adds a new schedt field prior to nmspinning.
 // https://go.dev/cl/714800 (1.26) changes size of the schedt.midle field.
-//go:build amd64 && go1.25 && go1.26
+//go:build amd64 && go1.26
 
 #include "textflag.h"
 


### PR DESCRIPTION
Fix compile error on `go1.26rc1`.
There is no error in `pkg/sync/runtime_spinning_go126_amd64.s`, but `pkg/sync/runtime_spinning_go125_amd64.s` is blocking `go1.26`, so fix it as well.

- https://github.com/google/gvisor/blob/9f2192bea5ab6eeec7cf59c2a0f609fffbadbcca/pkg/sync/runtime_spinning_go125_amd64.s#L17

<details>
<summary><code>go env</code> output</summary>

```
AR='/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ar'
CC='/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang'
CGO_CFLAGS='-O2 -g'
CGO_CPPFLAGS=''
CGO_CXXFLAGS='-O2 -g'
CGO_ENABLED='1'
CGO_FFLAGS='-O2 -g'
CGO_LDFLAGS='-O2 -g'
CXX='/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++'
GCCGO='gccgo'
GO111MODULE=''
GOARCH='arm64'
GOARM64='v8.0'
GOAUTH='netrc'
GOBIN=''
GOCACHE='/Users/zchee/.cache/go/go-build'
GOCACHEPROG=''
GODEBUG=''
GOENV='/Users/zchee/.config/go/env/env'
GOEXE=''
GOEXPERIMENT='loopvar,newinliner,jsonv2,greenteagc'
GOFIPS140='latest'
GOFLAGS=''
GOGCCFLAGS='-fPIC -arch arm64 -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -ffile-prefix-map=/var/folders/dp/89wwdp754235m6jmdzj7p5lm0000gn/T/go-build365494810=/tmp/go-build -gno-record-gcc-switches -fno-common'
GOHOSTARCH='arm64'
GOHOSTOS='darwin'
GOINSECURE=''
GOMOD='/Users/zchee/go/src/gvisor.dev/gvisor/go.mod'
GOMODCACHE='/Users/zchee/go/pkg/mod'
GONOPROXY=''
GONOSUMDB=''
GOOS='darwin'
GOPATH='/Users/zchee/go'
GOPRIVATE=''
GOPROXY='https://proxy.golang.org,direct'
GOROOT='/Users/zchee/sdk/go1.26rc1'
GOSUMDB='sum.golang.org'
GOTELEMETRY='on'
GOTELEMETRYDIR='/Users/zchee/Library/Application Support/go/telemetry'
GOTMPDIR=''
GOTOOLCHAIN='go1.26rc1+auto'
GOTOOLDIR='/Users/zchee/sdk/go1.26rc1/pkg/tool/darwin_arm64'
GOVCS=''
GOVERSION='go1.26rc1'
GOWORK=''
PKG_CONFIG='pkgconf'
```
</details>

```console
$ git rev-parse --abbrev-ref HEAD
go
$ git rev-parse HEAD
9f2192bea5ab6eeec7cf59c2a0f609fffbadbcca

# my local machine is darwin/arm64

$ GOOS=linux GOARCH=amd64 go1.26rc1 build -o /dev/null -v ./sync
gvisor.dev/gvisor/pkg/sync
# gvisor.dev/gvisor/pkg/sync
sync/runtime_constants_go126.go:22:2: WaitReasonSelect redeclared in this block
	sync/runtime_constants_go125.go:22:2: other declaration of WaitReasonSelect
sync/runtime_constants_go126.go:23:2: WaitReasonChanReceive redeclared in this block
	sync/runtime_constants_go125.go:23:2: other declaration of WaitReasonChanReceive
sync/runtime_constants_go126.go:24:2: WaitReasonSemacquire redeclared in this block
	sync/runtime_constants_go125.go:24:2: other declaration of WaitReasonSemacquire
```