### PR TITLE
Extend functionality to serialize rootfs upper layer of an arbitrary container to a tar archive.

### DIFF
--- a/g3doc/user_guide/rootfs_snapshot.md
+++ b/g3doc/user_guide/rootfs_snapshot.md
@@ -85,7 +85,3 @@ hello world
 ```
 
 > Please make sure you kill and delete the sandbox after the experiment.
-
-## Limitation
-
-*   Snapshotting is only supported for single-container sandboxes.

--- a/runsc/cmd/tar.go
+++ b/runsc/cmd/tar.go
@@ -107,10 +107,6 @@ func (r *RootfsUpper) Execute(ctx context.Context, f *flag.FlagSet, args ...any)
 		util.Fatalf("error loading container: %v", err)
 	}
 
-	if c.Sandbox.ID != id {
-		util.Fatalf("`tar rootfs-upper` is only supported for the root container as of now")
-	}
-
 	util.Infof("Serializing rootfs upper layer into a tar archive for container: %s, sandbox: %s", id, c.Sandbox.ID)
 
 	out := os.Stdout
@@ -122,7 +118,7 @@ func (r *RootfsUpper) Execute(ctx context.Context, f *flag.FlagSet, args ...any)
 		defer out.Close()
 	}
 
-	if err := c.Sandbox.TarRootfsUpperLayer(out); err != nil {
+	if err := c.TarRootfsUpperLayer(out); err != nil {
 		util.Fatalf("TarRootfsUpperLayer failed: %v", err)
 	}
 	return subcommands.ExitSuccess

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -673,6 +673,17 @@ func (c *Container) WaitRestore() error {
 	return c.Sandbox.WaitRestore()
 }
 
+// TarRootfsUpperLayer serializes the rootfs upper layer of the container to a tar file. When
+// the rootfs is not an overlayfs, it returns an error. It writes the tar file
+// to outFD.
+func (c *Container) TarRootfsUpperLayer(outFD *os.File) error {
+	log.Debugf("TarRootfsUpperLayer, cid: %s", c.ID)
+	if !c.IsSandboxRunning() {
+		return fmt.Errorf("sandbox is not running")
+	}
+	return c.Sandbox.TarRootfsUpperLayer(c.ID, outFD)
+}
+
 // SignalContainer sends the signal to the container. If all is true and signal
 // is SIGKILL, then waits for all processes to exit before returning.
 // SignalContainer returns an error if the container is already stopped.

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -4053,7 +4053,7 @@ func TestTarRootfsUpperLayer(t *testing.T) {
 	}
 	defer os.Remove(tarFile1.Name())
 
-	if err := cont.Sandbox.TarRootfsUpperLayer(tarFile1); err != nil {
+	if err := cont.TarRootfsUpperLayer(tarFile1); err != nil {
 		t.Fatalf("error serializing rootfs upper layer to tar: %v", err)
 	}
 	tarFile1.Close()
@@ -4103,7 +4103,7 @@ func TestTarRootfsUpperLayer(t *testing.T) {
 	}
 	defer os.Remove(tarFile2.Name())
 
-	if err := newCont.Sandbox.TarRootfsUpperLayer(tarFile2); err != nil {
+	if err := newCont.TarRootfsUpperLayer(tarFile2); err != nil {
 		t.Fatalf("error serializing rootfs upper layer to tar: %v", err)
 	}
 	tarFile2.Close()

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -2065,14 +2065,13 @@ func (s *Sandbox) ContainerRuntimeState(cid string) (boot.ContainerRuntimeState,
 	return state, nil
 }
 
-// TarRootfsUpperLayer serializes the rootfs upper layer to a tar file. When
-// the rootfs is not an overlayfs, it returns an error. It writes the tar file
-// to outFD.
-//
-// This method is not yet supported in for multicontainer mode.
-func (s *Sandbox) TarRootfsUpperLayer(outFD *os.File) error {
-	log.Debugf("TarRootfsUpperLayer, sandbox: %q", s.ID)
+// TarRootfsUpperLayer serializes the rootfs upper layer of a given
+// container to a tar file. When the rootfs is not an overlayfs, it
+// returns an error. It writes the tar file to outFD.
+func (s *Sandbox) TarRootfsUpperLayer(containerID string, outFD *os.File) error {
+	log.Debugf("TarRootfsUpperLayer, sandbox: %q, container: %q", s.ID, containerID)
 	opts := control.TarRootfsUpperLayerOpts{
+		ContainerID: containerID,
 		FilePayload: urpc.FilePayload{Files: []*os.File{outFD}},
 	}
 	if err := s.call(boot.FsTarRootfsUpperLayer, &opts, nil); err != nil {


### PR DESCRIPTION
#11914 implemented [rootfs snapshotting](https://gvisor.dev/docs/user_guide/rootfs_snapshot/) for single-container sandboxes only.
This PR extends this functionality to any container, including containers that are part of a multi-container sandbox.