### PR TITLE
bug: [checklocks] resolve iter on func

### DIFF
--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -647,6 +647,15 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 			pc.checkCall(d, lff, ls)
 		}
 	case *ssa.MakeClosure:
+		clfn := x.Fn.(*ssa.Function)
+		// Range-over-func yield closures are called synchronously
+		// within the current goroutine, so they inherit the lock state
+		// from the enclosing function. We detect these by checking the
+		// Synthetic field which is set by the SSA builder.
+		if clfn.Synthetic == "range-over-func yield" {
+			pc.checkClosure(nil, x, lff, ls)
+			return nil, nil
+		}
 		if refs := x.Referrers(); refs != nil {
 			var (
 				calls    int
@@ -675,7 +684,6 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 		// Analyze the closure without bindings. This means that we
 		// assume no lock facts or have any existing lock state. Only
 		// trivial closures are acceptable in this case.
-		clfn := x.Fn.(*ssa.Function)
 		nlff := lockFunctionFacts{
 			Ignore: lff.Ignore, // Inherit ignore.
 		}
@@ -750,8 +758,18 @@ func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, 
 				}
 			}
 			// Check for other locks, but only if the above didn't trip.
-			if !failed && rls.count() != len(lff.HeldOnExit) && !lff.Ignore {
-				pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
+			if !failed && !lff.Ignore {
+				if fn.Synthetic == "range-over-func yield" {
+					// Range-over-func yield closures inherit lock state from
+					// their parent. We expect the same locks held on exit as
+					// on entry - any locks acquired in the closure should be
+					// released before yielding.
+					if rls.count() != parent.count() {
+						pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
+					}
+				} else if rls.count() != len(lff.HeldOnExit) {
+					pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
+				}
 			}
 		}
 	}

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -22,6 +22,7 @@ go_library(
         "locker.go",
         "methods.go",
         "parameters.go",
+        "rangefunc.go",
         "return.go",
         "rwmutex.go",
         "test.go",

--- a/tools/checklocks/test/rangefunc.go
+++ b/tools/checklocks/test/rangefunc.go
@@ -1,0 +1,84 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+// testRangeFuncValid tests that range-over-func iterators properly inherit
+// lock state from the enclosing function. The lock is held when the iterator
+// body executes, so accessing guarded fields should be valid.
+func testRangeFuncValid(tc *oneGuardStruct) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	for item := range generate {
+		tc.guardedField = item // Should pass: lock is held.
+	}
+}
+
+// testRangeFuncInvalid tests that range-over-func iterators still detect
+// violations when the lock is not held.
+func testRangeFuncInvalid(tc *oneGuardStruct) {
+	for item := range generate {
+		tc.guardedField = item // +checklocksfail
+	}
+}
+
+// testRangeFuncDeferUnlock tests range-over-func with defer unlock pattern.
+func testRangeFuncDeferUnlock(tc *oneGuardStruct) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	for item := range generate {
+		tc.guardedField = item // Should pass: lock is held.
+		tc.unguardedField = item
+	}
+}
+
+// testRangeFuncLockInsideValid tests that acquiring and releasing a lock
+// inside the iterator body works correctly.
+func testRangeFuncLockInsideValid(tc *oneGuardStruct) {
+	for item := range generate {
+		tc.mu.Lock()
+		tc.guardedField = item // Should pass: lock acquired in body.
+		tc.mu.Unlock()
+	}
+}
+
+// testRangeFuncSeq2Valid tests range-over-func with two-value iterators.
+func testRangeFuncSeq2Valid(tc *oneGuardStruct) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	for i, v := range generate2 {
+		tc.guardedField = i + v // Should pass: lock is held.
+	}
+}
+
+// generate is a simple iterator function for testing.
+func generate(yield func(int) bool) {
+	for i := 0; i < 10; i++ {
+		if !yield(i) {
+			return
+		}
+	}
+}
+
+// generate2 is a two-value iterator function for testing.
+func generate2(yield func(int, int) bool) {
+	for i := 0; i < 10; i++ {
+		if !yield(i, i*2) {
+			return
+		}
+	}
+}


### PR DESCRIPTION
use the normal closure logic for the inter on func special closures

fixes #12176 