### PR TITLE
Extend functionality to deserialize rootfs upper layer of an arbitrary container to a tar archive.

### DIFF
--- a/g3doc/user_guide/rootfs_snapshot.md
+++ b/g3doc/user_guide/rootfs_snapshot.md
@@ -51,8 +51,11 @@ hello world
 ## How to start a container with the tar file
 
 To start a new gVisor sandbox with the tar file we just get, you will need
-provide the annotation to OCI runtime spec, the key is
-`dev.gvisor.tar.rootfs.upper`, the value is the path to the tar file.
+provide the annotation to OCI runtime spec. For single-container sandboxes the
+key is `dev.gvisor.tar.rootfs.upper`, whose value is the path to the tar
+file. For pods with multiple containers, append the container name to the key,
+for example `dev.gvisor.tar.rootfs.upper.my-container`, allowing different containers'
+rootfs snapshots to be restored from different tar files.
 
 ### Start with Docker
 
@@ -76,7 +79,14 @@ You can add annotation to the bundle's `config.json` as:
 ```
 
 Then you can start a new sandbox and observe the file changes from the previous
-sandbox:
+sandbox. For a multi-container pod, add one entry per container name:
+
+```json
+    "annotations": {
+      "dev.gvisor.tar.rootfs.upper.app": "/tmp/app-rootfs.tar",
+      "dev.gvisor.tar.rootfs.upper.sidecar": "/tmp/sidecar-rootfs.tar"
+    },
+```
 
 ```
 $ sudo runsc run -detach=true alpine

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -473,7 +473,9 @@ func (s *Sandbox) StartSubcontainer(spec *specs.Spec, conf *config.Config, cid s
 			return fmt.Errorf("opening rootfs upper tar file: %v", err)
 		}
 	}
-	defer rootfsUpperTarFile.Close()
+	if rootfsUpperTarFile != nil {
+		defer rootfsUpperTarFile.Close()
+	}
 
 	// The payload contains (in this specific order):
 	// * stdin/stdout/stderr (optional: only present when not using TTY)

--- a/runsc/specutils/cri.go
+++ b/runsc/specutils/cri.go
@@ -35,6 +35,10 @@ const (
 	// is not the first container in the sandbox.
 	ContainerdSandboxIDAnnotation = "io.kubernetes.cri.sandbox-id"
 
+	// ContainerdContainerNameAnnotation is the OCI annotation set by
+	// containerd to indicate the name of the container.
+	ContainerdContainerNameAnnotation = "io.kubernetes.cri.container-name"
+
 	// CRIOContainerTypeAnnotation is the OCI annotation set by
 	// CRI-O to indicate whether the container to create should have
 	// its own sandbox or a container within an existing sandbox.

--- a/runsc/specutils/specutils_test.go
+++ b/runsc/specutils/specutils_test.go
@@ -284,7 +284,7 @@ func TestSeccomp(t *testing.T) {
 			seccompPresent: true,
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName: containerName,
+					ContainerdContainerNameAnnotation: containerName,
 				},
 				Linux: &specs.Linux{
 					Seccomp: &specs.LinuxSeccomp{},
@@ -296,7 +296,7 @@ func TestSeccomp(t *testing.T) {
 			seccompPresent: true,
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:     containerName,
+					ContainerdContainerNameAnnotation:     containerName,
 					annotationSeccomp + "cont2": annotationSeccompRuntimeDefault,
 				},
 				Linux: &specs.Linux{
@@ -309,7 +309,7 @@ func TestSeccomp(t *testing.T) {
 			seccompPresent: true,
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:           containerName,
+					ContainerdContainerNameAnnotation:           containerName,
 					annotationSeccomp + containerName: "foobar",
 				},
 				Linux: &specs.Linux{
@@ -322,7 +322,7 @@ func TestSeccomp(t *testing.T) {
 			seccompPresent: true,
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:           containerName,
+					ContainerdContainerNameAnnotation:           containerName,
 					annotationSeccomp + containerName: "foobar",
 					annotationSeccomp + "cont2":       annotationSeccompRuntimeDefault,
 				},
@@ -335,7 +335,7 @@ func TestSeccomp(t *testing.T) {
 			name: "remove",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:           containerName,
+					ContainerdContainerNameAnnotation:           containerName,
 					annotationSeccomp + containerName: annotationSeccompRuntimeDefault,
 				},
 				Linux: &specs.Linux{
@@ -347,7 +347,7 @@ func TestSeccomp(t *testing.T) {
 			name: "remove many names",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:           containerName,
+					ContainerdContainerNameAnnotation:           containerName,
 					annotationSeccomp + containerName: annotationSeccompRuntimeDefault,
 					annotationSeccomp + "cont2":       "foobar",
 				},
@@ -360,7 +360,7 @@ func TestSeccomp(t *testing.T) {
 			name: "remap does not affect seccomp",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:            containerName,
+					ContainerdContainerNameAnnotation:            containerName,
 					annotationSeccomp + containerName:  annotationSeccompRuntimeDefault,
 					annotationContainerNameRemap + "1": containerName + "=another",
 				},
@@ -526,10 +526,93 @@ func TestRootfsUpperTarPath(t *testing.T) {
 			name: "get gvisor tar rootfs upper annotation",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					"dev.gvisor.tar.rootfs.upper": "123",
+					AnnotationRootfsUpperTar: "123",
 				},
 			},
 			want: "123",
+		},
+		{
+			name: "container specific rootfs upper annotation",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerNameAnnotation:      "cont",
+					AnnotationRootfsUpperTar + "." + "cont": "456",
+				},
+			},
+			want: "456",
+		},
+		{
+			name: "container specific rootfs upper annotation with remap",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerNameAnnotation:       "cont-123",
+					annotationContainerNameRemap + "1":      "cont-123=cont",
+					AnnotationRootfsUpperTar + "." + "cont": "789",
+				},
+			},
+			want: "789",
+		},
+		{
+			name: "no fallback when other container-specific annotation exists",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerNameAnnotation:        "cont",
+					AnnotationRootfsUpperTar + "." + "other": "should-not-be-used",
+					AnnotationRootfsUpperTar:                 "base",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "container specific takes priority over base",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerNameAnnotation:       "cont",
+					AnnotationRootfsUpperTar:                "base-path",
+					AnnotationRootfsUpperTar + "." + "cont": "specific-path",
+				},
+			},
+			want: "specific-path",
+		},
+		{
+			name: "empty container name falls back to base",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerNameAnnotation: "",
+					AnnotationRootfsUpperTar:          "base-path",
+				},
+			},
+			want: "base-path",
+		},
+		{
+			name: "container name set but no matching annotation",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerNameAnnotation: "cont",
+					AnnotationRootfsUpperTar:          "base-path",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "CRI sandbox without container name returns empty",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerTypeAnnotation: ContainerdContainerTypeSandbox,
+					AnnotationRootfsUpperTar:          "base-path",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "CRI container without container name returns empty",
+			spec: specs.Spec{
+				Annotations: map[string]string{
+					ContainerdContainerTypeAnnotation: ContainerdContainerTypeContainer,
+					AnnotationRootfsUpperTar:          "base-path",
+				},
+			},
+			want: "",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -556,7 +639,7 @@ func TestContainerName(t *testing.T) {
 			name: "container-name",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName: "cont",
+					ContainerdContainerNameAnnotation: "cont",
 				},
 			},
 			want: "cont",
@@ -565,7 +648,7 @@ func TestContainerName(t *testing.T) {
 			name: "remap",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:            "cont-123",
+					ContainerdContainerNameAnnotation:            "cont-123",
 					annotationContainerNameRemap + "1": "cont-123=cont",
 				},
 			},
@@ -575,7 +658,7 @@ func TestContainerName(t *testing.T) {
 			name: "remap-not-found",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:            "cont",
+					ContainerdContainerNameAnnotation:            "cont",
 					annotationContainerNameRemap + "1": "another-123=another",
 				},
 			},
@@ -585,7 +668,7 @@ func TestContainerName(t *testing.T) {
 			name: "remap-invalid",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:            "cont",
+					ContainerdContainerNameAnnotation:            "cont",
 					annotationContainerNameRemap + "1": "another-123",
 				},
 			},
@@ -595,7 +678,7 @@ func TestContainerName(t *testing.T) {
 			name: "remap-invalid-empty",
 			spec: specs.Spec{
 				Annotations: map[string]string{
-					annotationContainerName:            "cont",
+					ContainerdContainerNameAnnotation:            "cont",
 					annotationContainerNameRemap + "1": "",
 				},
 			},


### PR DESCRIPTION
#12119 implemented [rootfs snapshotting](https://gvisor.dev/docs/user_guide/rootfs_snapshot/) deserialization (restore) for single-container sandboxes only.
This PR extends this functionality to any container, including containers that are part of a multi-container sandbox.
builds on top of: https://github.com/google/gvisor/pull/12411