### PR TITLE
fix: Check that handshake is non-nil at Endpoint.onICMPError

### DIFF
--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -2925,7 +2925,8 @@ func (e *Endpoint) onICMPError(err tcpip.Error, transErr stack.TransportError, p
 
 	if e.EndpointState().connecting() {
 		e.mu.Lock()
-		if lEP := e.h.listenEP; lEP != nil {
+		if e.h != nil && e.h.listenEP != nil {
+			lEP := e.h.listenEP
 			// Remove from listening endpoints pending list.
 			lEP.acceptMu.Lock()
 			delete(lEP.acceptQueue.pendingEndpoints, e)


### PR DESCRIPTION
Similar to the approach in `handshake.synRcvdState` (https://github.com/google/gvisor/commit/4733e050ebeca36a2805587f12a5d67dfd08e1e2) and `Endpoint.cleanupLocked` (https://github.com/google/gvisor/commit/e22e7c46e02443f758ec37fa9238e0207d4502b0),

An additional check should be made here to ensure that `e.h` is `nil` to avoid panics at edge cases. 
We found this issue in our downstream fork: https://github.com/MetaCubeX/mihomo/issues/2467