### PR TITLE
checklocks: fix generics Origin fact lookup

### DIFF
--- a/tools/checklocks/BUILD
+++ b/tools/checklocks/BUILD
@@ -12,6 +12,7 @@ go_library(
         "annotations.go",
         "checklocks.go",
         "facts.go",
+        "importfacts.go",
         "state.go",
     ],
     nogo = False,

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -79,6 +79,7 @@ type passContext struct {
 
 // observationsFor retrieves observations for the given object.
 func (pc *passContext) observationsFor(obj types.Object) *objectObservations {
+	obj = originObject(obj)
 	if pc.observations == nil {
 		pc.observations = make(map[types.Object]*objectObservations)
 	}
@@ -187,11 +188,12 @@ func run(pass *analysis.Pass) (any, error) {
 		// by named functions in the package, and they are analyzing
 		// inline on every call. Thus we skip the analysis here. They
 		// will be hit on calls, or picked up in the pass below.
-		if obj := fn.Object(); obj == nil {
+		obj := fn.Object()
+		if obj == nil {
 			continue
 		}
 		var lff lockFunctionFacts
-		pc.pass.ImportObjectFact(fn.Object(), &lff)
+		pc.importLockFunctionFacts(obj.(*types.Func), &lff)
 
 		// Check the basic blocks in the function.
 		pc.checkFunction(nil, fn, &lff, nil, false /* force */)

--- a/tools/checklocks/importfacts.go
+++ b/tools/checklocks/importfacts.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checklocks
+
+import "go/types"
+
+// originObject returns obj's origin (for instantiated generic objects) when
+// available, otherwise it returns obj unchanged.
+func originObject(obj types.Object) types.Object {
+	switch obj := obj.(type) {
+	case *types.Var:
+		return obj.Origin()
+	case *types.Func:
+		return obj.Origin()
+	default:
+		return obj
+	}
+}
+
+// importLockGuardFacts imports lock guard facts for obj.
+//
+// For generic code, the `types.Object` identity observed during SSA analysis can
+// differ from the declaration object where facts were exported. When that
+// happens, we fall back to importing facts from the origin object.
+func (pc *passContext) importLockGuardFacts(obj types.Object, lgf *lockGuardFacts) {
+	pc.pass.ImportObjectFact(obj, lgf)
+	if len(lgf.GuardedBy) != 0 || lgf.AtomicDisposition != atomicDisallow {
+		return
+	}
+
+	// Fallback: import from the object's origin.
+	if orig := originObject(obj); orig != nil && orig != obj {
+		pc.pass.ImportObjectFact(orig, lgf)
+	}
+}
+
+// importLockFunctionFacts imports lock function facts for fn, falling back to
+// the origin object when fn is an instantiated generic function/method.
+func (pc *passContext) importLockFunctionFacts(fn *types.Func, lff *lockFunctionFacts) {
+	pc.pass.ImportObjectFact(fn, lff)
+	if lff.Ignore || len(lff.HeldOnEntry) != 0 || len(lff.HeldOnExit) != 0 || len(lff.ExcludedOnEntry) != 0 {
+		return
+	}
+	if orig := fn.Origin(); orig != nil && orig != fn {
+		pc.pass.ImportObjectFact(orig, lff)
+	}
+}

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -19,6 +19,7 @@ go_library(
         "globals.go",
         "incompat.go",
         "inferred.go",
+        "generics.go",
         "locker.go",
         "methods.go",
         "parameters.go",

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -24,3 +24,12 @@ var (
 	Foo   int
 	FooMu sync.Mutex
 )
+
+// GenericGuard is a generic type with a guarded field. This is used to verify
+// that facts exported by this package are correctly imported when another
+// package instantiates GenericGuard[T].
+type GenericGuard[T any] struct {
+	Mu sync.Mutex
+	// +checklocks:Mu
+	Value T
+}

--- a/tools/checklocks/test/generics.go
+++ b/tools/checklocks/test/generics.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"sync"
+
+	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
+)
+
+var genericGlobalMu sync.Mutex
+
+type genericValueStruct[T any] struct {
+	mu sync.Mutex
+	// +checklocks:mu
+	value T
+}
+
+func (g *genericValueStruct[T]) set(v T) {
+	g.mu.Lock()
+	g.value = v
+	g.mu.Unlock()
+}
+
+func (g *genericValueStruct[T]) setUnlocked(v T) {
+	g.value = v // +checklocksfail
+}
+
+// +checklocks:g.mu
+func (g *genericValueStruct[T]) setLocked(v T) {
+	g.value = v
+}
+
+// genericMapStruct is a minimal reproduction of generic guarded fields.
+// See https://github.com/google/gvisor/issues/10372 and #11671.
+type genericMapStruct[K comparable] struct {
+	mu sync.Mutex
+	// +checklocks:mu
+	m map[K]struct{}
+}
+
+func (g *genericMapStruct[K]) add(k K) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.m[k] = struct{}{}
+}
+
+// genericUnlockedWrite should fail: writing without holding the guard.
+func genericUnlockedWrite[K comparable](g *genericMapStruct[K], k K) {
+	g.m[k] = struct{}{} // +checklocksfail
+}
+
+// +checklocks:genericGlobalMu
+func genericNeedsGlobalLock[T any](v T) {
+	_ = v
+}
+
+func genericCallsWithoutLock[T any](v T) {
+	genericNeedsGlobalLock(v) // +checklocksfail
+}
+
+func genericCallsWithLock[T any](v T) {
+	genericGlobalMu.Lock()
+	genericNeedsGlobalLock(v)
+	genericGlobalMu.Unlock()
+}
+
+// crossPkgGenericValid ensures that lock guard facts on generic types imported
+// from another package are still found when analyzing a generic use site.
+func crossPkgGenericValid[T any](g *crosspkg.GenericGuard[T], v T) {
+	g.Mu.Lock()
+	g.Value = v
+	g.Mu.Unlock()
+}
+
+// crossPkgGenericInvalidWrite should fail: writing without holding the guard.
+func crossPkgGenericInvalidWrite[T any](g *crosspkg.GenericGuard[T], v T) {
+	g.Value = v // +checklocksfail
+}


### PR DESCRIPTION
checklocks attaches lock facts to the declaration objects produced by
go/types, but SSA analysis of generic code can observe instantiated
`*types.Var/*types.Func` objects instead. Importing facts from those
instantiated objects fails, which causes spurious inference warnings
("may require checklocks annotation...") and can miss expected
checklocksfail reports.

Fix this by falling back to Origin() when importing lock guard and
function facts, and by normalizing inference observation keys to the
origin object so inference uses the same fact identity as export.

Add regression coverage for generic methods and functions, including a
cross-package generics.

Fixes #10372.
Fixes #11671.
Closes #11740.
