### PR TITLE
checklocks: enforce mixed atomic rules for wrappers

### DIFF
--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -204,6 +204,11 @@ type foo struct {
 
 This enforces that the preconditions above are upheld.
 
+This also applies to atomic wrapper types (for example, atomic.Int32). In the
+mixed case, lock-free access is limited to read-only atomic operations such as
+Load. Any atomic write operation (for example, Store, Swap, or Add) requires the
+lock to be held.
+
 ## Ignoring and Forcing
 
 From time to time, it may be necessary to ignore results produced by the

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -140,11 +140,12 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 			}
 			return
 		}
-		if fn.Signature.Recv() != nil {
-			// always allow calls to methods of atomic wrappers such as atomic.Int32 introduced in Go 1.19
-			return
-		}
 		if ar == nonAtomic {
+			if fn.Signature.Recv() != nil {
+				// Always allow calls to methods of atomic wrappers such as
+				// atomic.Int32 introduced in Go 1.19 when no annotation exists.
+				return
+			}
 			// We are *not* expecting an atomic dispatch.
 			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic function")


### PR DESCRIPTION
Atomic wrapper methods now respect mixed atomic+lock rules so lock-free
access is read-only and writes require the lock. The README documents
the wrapper behavior and tests cover the new cases.

Closes #11481.
