### PR TITLE
checklocks: move checklocksalias to type

### DIFF
--- a/pkg/tcpip/transport/tcp/accept.go
+++ b/pkg/tcpip/transport/tcp/accept.go
@@ -258,7 +258,7 @@ func (l *listenContext) startHandshake(s *segment, opts header.TCPSynOptions, qu
 
 		// Propagate any inheritable options from the listening endpoint
 		// to the newly created endpoint.
-		l.listenEP.propagateInheritableOptionsLocked(ep) // +checklocksforce
+		l.listenEP.propagateInheritableOptionsLocked(ep) // +checklocksforce:ep.mu
 
 		if !ep.reserveTupleLocked() {
 			ep.mu.Unlock()

--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -643,11 +643,10 @@ func (h *handshake) retransmitHandlerLocked() tcpip.Error {
 	return nil
 }
 
-// transitionToStateEstablisedLocked transitions the endpoint of the handshake
+// transitionToStateEstablishedLocked transitions the endpoint of the handshake
 // to an established state given the last segment received from peer. It also
 // initializes sender/receiver.
 // +checklocks:h.ep.mu
-// +checklocksalias:h.ep.snd.ep.mu=h.ep.mu
 func (h *handshake) transitionToStateEstablishedLocked(s *segment) {
 	// Stop the SYN retransmissions now that handshake is complete.
 	if h.retransmitTimer != nil {
@@ -657,7 +656,7 @@ func (h *handshake) transitionToStateEstablishedLocked(s *segment) {
 	// Transfer handshake state to TCP connection. We disable
 	// receive window scaling if the peer doesn't support it
 	// (indicated by a negative send window scale).
-	h.ep.snd = newSender(h.ep, h.iss, h.ackNum-1, h.sndWnd, h.mss, h.sndWndScale)
+	initSender(h.ep, h.iss, h.ackNum-1, h.sndWnd, h.mss, h.sndWndScale)
 
 	now := h.ep.stack.Clock().NowMonotonic()
 
@@ -1008,7 +1007,6 @@ func (e *Endpoint) makeOptions(sackBlocks []header.SACKBlock) []byte {
 // sendEmptyRaw sends a TCP segment with no payload to the endpoint's peer.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) sendEmptyRaw(flags header.TCPFlags, seq, ack seqnum.Value, rcvWnd seqnum.Size) tcpip.Error {
 	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{})
 	defer pkt.DecRef()
@@ -1019,7 +1017,6 @@ func (e *Endpoint) sendEmptyRaw(flags header.TCPFlags, seq, ack seqnum.Value, rc
 // ownership of pkt. pkt must not have any headers set.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) sendRaw(pkt *stack.PacketBuffer, flags header.TCPFlags, seq, ack seqnum.Value, rcvWnd seqnum.Size) tcpip.Error {
 	var sackBlocks []header.SACKBlock
 	if e.EndpointState() == StateEstablished && e.rcv.pendingRcvdSegments.Len() > 0 && (flags&header.TCPFlagAck != 0) {
@@ -1048,7 +1045,6 @@ func (e *Endpoint) sendRaw(pkt *stack.PacketBuffer, flags header.TCPFlags, seq, 
 }
 
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) sendData(next *segment) {
 	// Initialize the next segment to write if it's currently nil.
 	if e.snd.writeNext == nil {
@@ -1066,7 +1062,6 @@ func (e *Endpoint) sendData(next *segment) {
 // error code and sends a RST if and only if the error is not ErrConnectionReset
 // indicating that the connection is being reset due to receiving a RST.
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) resetConnectionLocked(err tcpip.Error) {
 	// Only send a reset if the connection is being aborted for a reason
 	// other than receiving a reset.
@@ -1208,7 +1203,6 @@ func (e *Endpoint) handleReset(s *segment) (ok bool, err tcpip.Error) {
 // handleSegments processes all inbound segments.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) handleSegmentsLocked() tcpip.Error {
 	sndUna := e.snd.SndUna
 	for i := 0; i < maxSegmentsPerWake; i++ {
@@ -1263,8 +1257,6 @@ func (e *Endpoint) probeSegmentLocked() {
 // if the connection should be terminated.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.rcv.ep.mu=e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) handleSegmentLocked(s *segment) (cont bool, err tcpip.Error) {
 	// Invoke the tcp probe if installed. The tcp probe function will update
 	// the TCPEndpointState after the segment is processed.
@@ -1338,7 +1330,6 @@ func (e *Endpoint) handleSegmentLocked(s *segment) (cont bool, err tcpip.Error) 
 // keepalive packets periodically when the connection is idle. If we don't hear
 // from the other side after a number of tries, we terminate the connection.
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) keepaliveTimerExpired() tcpip.Error {
 	userTimeout := e.userTimeout
 
@@ -1380,7 +1371,6 @@ func (e *Endpoint) keepaliveTimerExpired() tcpip.Error {
 // whether it is enabled for this endpoint.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) resetKeepaliveTimer(receivedData bool) {
 	e.keepalive.Lock()
 	defer e.keepalive.Unlock()
@@ -1443,7 +1433,6 @@ func (e *Endpoint) handshakeFailed(err tcpip.Error) {
 // handleTimeWaitSegments processes segments received during TIME_WAIT
 // state.
 // +checklocks:e.mu
-// +checklocksalias:e.rcv.ep.mu=e.mu
 func (e *Endpoint) handleTimeWaitSegments() (extendTimeWait bool, reuseTW func()) {
 	for i := 0; i < maxSegmentsPerWake; i++ {
 		s := e.segmentQueue.dequeue()

--- a/pkg/tcpip/transport/tcp/dispatcher.go
+++ b/pkg/tcpip/transport/tcp/dispatcher.go
@@ -152,7 +152,7 @@ func handleConnecting(ep *Endpoint) {
 		ep.mu.Unlock()
 		return
 	}
-	if err := ep.h.processSegments(); err != nil { // +checklocksforce:ep.h.ep.mu
+	if err := ep.h.processSegments(); err != nil {
 		// handshake failed. clean up the tcp endpoint and handshake
 		// state.
 		if lEP := ep.h.listenEP; lEP != nil {

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -341,6 +341,9 @@ func (sq *sndQueueInfo) CloneState(other *TCPSndBufState) {
 // TODO(b/339664055): Checklocks should be used more extensively here. Coverage
 // is currently sparse.
 //
+// +checklocksalias:snd.ep.mu=mu
+// +checklocksalias:rcv.ep.mu=mu
+// +checklocksalias:h.ep.mu=mu
 // +stateify savable
 type Endpoint struct {
 	TCPEndpointStateInner
@@ -641,7 +644,6 @@ func (e *Endpoint) isOwnedByUser() bool {
 // should not be holding the lock for long and spinning reduces latency as we
 // avoid an expensive sleep/wakeup of the syscall goroutine).
 // +checklocksacquire:e.mu
-// +checklocksacquire:e.snd.ep.mu
 func (e *Endpoint) LockUser() {
 	const iterations = 5
 	for i := 0; i < iterations; i++ {
@@ -654,14 +656,14 @@ func (e *Endpoint) LockUser() {
 			if e.ownedByUser.Load() == 1 {
 				e.mu.Lock()
 				e.ownedByUser.Store(1)
-				return // +checklocksforce: this locks e.snd.ep.mu
+				return
 			}
 			// Spin but don't yield the processor since the lower half
 			// should yield the lock soon.
 			continue
 		}
 		e.ownedByUser.Store(1)
-		return // +checklocksforce: this locks e.snd.ep.mu
+		return
 	}
 
 	for i := 0; i < iterations; i++ {
@@ -674,7 +676,7 @@ func (e *Endpoint) LockUser() {
 			if e.ownedByUser.Load() == 1 {
 				e.mu.Lock()
 				e.ownedByUser.Store(1)
-				return // +checklocksforce: this locks e.snd.ep.mu
+				return
 			}
 			// Spin but yield the processor since the lower half
 			// should yield the lock soon.
@@ -682,7 +684,7 @@ func (e *Endpoint) LockUser() {
 			continue
 		}
 		e.ownedByUser.Store(1)
-		return // +checklocksforce: this locks e.snd.ep.mu
+		return
 	}
 
 	// Finally just give up and wait for the Lock.
@@ -1015,7 +1017,6 @@ func (e *Endpoint) purgeReadQueue() {
 }
 
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) purgeWriteQueue() {
 	if e.snd != nil {
 		e.sndQueueInfo.sndQueueMu.Lock()
@@ -1358,7 +1359,7 @@ func (e *Endpoint) ModerateRecvBuf(copied int) {
 	// Send the update after unlocking rcvQueueMu as sending a segment acquires
 	// the lock to calculate the window to be sent.
 	if e.EndpointState().connected() && sendNonZeroWindowUpdate {
-		e.rcv.nonZeroWindow() // +checklocksforce:e.rcv.ep.mu
+		e.rcv.nonZeroWindow()
 	}
 }
 
@@ -1465,7 +1466,7 @@ func (e *Endpoint) Read(dst io.Writer, opts tcpip.ReadOptions) (tcpip.ReadResult
 			e.rcvQueueMu.Unlock()
 
 			if e.EndpointState().connected() && sendNonZeroWindowUpdate {
-				e.rcv.nonZeroWindow() // +checklocksforce:e.rcv.ep.mu
+				e.rcv.nonZeroWindow()
 			}
 		}
 
@@ -1601,7 +1602,6 @@ func (e *Endpoint) readFromPayloader(p tcpip.Payloader, opts tcpip.WriteOptions,
 
 // queueSegment reads data from the payloader and returns a segment to be sent.
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) queueSegment(p tcpip.Payloader, opts tcpip.WriteOptions) (*segment, int, tcpip.Error) {
 	e.sndQueueInfo.sndQueueMu.Lock()
 	defer e.sndQueueInfo.sndQueueMu.Unlock()
@@ -1828,7 +1828,7 @@ func (e *Endpoint) OnSetReceiveBufferSize(rcvBufSz, oldSz int64) (newSz int64, p
 		e.LockUser()
 		defer e.UnlockUser()
 		if e.EndpointState().connected() && sendNonZeroWindowUpdate {
-			e.rcv.nonZeroWindow() // +checklocksforce:e.rcv.ep.mu
+			e.rcv.nonZeroWindow()
 		}
 
 	}
@@ -2383,7 +2383,6 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 
 // connect connects the endpoint to its peer.
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) connect(addr tcpip.FullAddress, handshake bool) tcpip.Error {
 	connectingAddr := addr.Addr
 
@@ -2532,7 +2531,6 @@ func (e *Endpoint) Shutdown(flags tcpip.ShutdownFlags) tcpip.Error {
 }
 
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) shutdownLocked(flags tcpip.ShutdownFlags) tcpip.Error {
 	e.shutdownFlags |= flags
 	switch {
@@ -2949,7 +2947,7 @@ func (e *Endpoint) HandleError(transErr stack.TransportError, pkt *stack.PacketB
 			e.mu.Lock()
 			defer e.mu.Unlock()
 			if e.snd != nil {
-				e.snd.updateMaxPayloadSize(newMTU, 1 /* count */) // +checklocksforce:e.snd.ep.mu
+				e.snd.updateMaxPayloadSize(newMTU, 1 /* count */)
 			}
 		}
 	}
@@ -2986,7 +2984,6 @@ func (e *Endpoint) HandleError(transErr stack.TransportError, pkt *stack.PacketB
 // number of newly available bytes is v.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) updateSndBufferUsage(v int) {
 	sendBufferSize := e.getSendBufferSize()
 	e.sndQueueInfo.sndQueueMu.Lock()
@@ -3168,7 +3165,6 @@ func (e *Endpoint) maxOptionSize() (size int) {
 // used before invoking the probe.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) completeStateLocked(s *TCPEndpointState) {
 	s.TCPEndpointStateInner = e.TCPEndpointStateInner
 	s.ID = TCPEndpointID(e.TransportEndpointInfo.ID)
@@ -3320,7 +3316,6 @@ func GetTCPReceiveBufferLimits(s tcpip.StackHandler) tcpip.ReceiveBufferSizeOpti
 // returns the new send buffer size.
 //
 // +checklocks:e.mu
-// +checklocksalias:e.snd.ep.mu=e.mu
 func (e *Endpoint) computeTCPSendBufferSize() int64 {
 	curSndBufSz := int64(e.getSendBufferSize())
 

--- a/pkg/tcpip/transport/tcp/rcv.go
+++ b/pkg/tcpip/transport/tcp/rcv.go
@@ -96,7 +96,6 @@ func (r *receiver) currentWindow() (curWnd seqnum.Size) {
 // getSendParams returns the parameters needed by the sender when building
 // segments to send.
 // +checklocks:r.ep.mu
-// +checklocksalias:r.ep.snd.ep.mu=r.ep.mu
 func (r *receiver) getSendParams() (RcvNxt seqnum.Value, rcvWnd seqnum.Size) {
 	newWnd := r.ep.selectWindow()
 	curWnd := r.currentWindow()
@@ -187,7 +186,6 @@ func (r *receiver) getSendParams() (RcvNxt seqnum.Value, rcvWnd seqnum.Size) {
 // in such cases we may need to send an ack to indicate to our peer that it can
 // resume sending data.
 // +checklocks:r.ep.mu
-// +checklocksalias:r.ep.snd.ep.mu=r.ep.mu
 func (r *receiver) nonZeroWindow() {
 	// Immediately send an ack.
 	r.ep.snd.sendAck()
@@ -200,7 +198,6 @@ func (r *receiver) nonZeroWindow() {
 // Returns true if the segment was consumed, false if it cannot be consumed
 // yet because of a missing segment.
 // +checklocks:r.ep.mu
-// +checklocksalias:r.ep.snd.ep.mu=r.ep.mu
 func (r *receiver) consumeSegment(s *segment, segSeq seqnum.Value, segLen seqnum.Size) bool {
 	if segLen > 0 {
 		// If the segment doesn't include the seqnum we're expecting to
@@ -354,7 +351,6 @@ func (r *receiver) updateRTT() {
 }
 
 // +checklocks:r.ep.mu
-// +checklocksalias:r.ep.snd.ep.mu=r.ep.mu
 func (r *receiver) handleRcvdSegmentClosing(s *segment, state EndpointState, closed bool) (drop bool, err tcpip.Error) {
 	r.ep.rcvQueueMu.Lock()
 	rcvClosed := r.ep.RcvClosed || r.closed
@@ -452,7 +448,6 @@ func (r *receiver) handleRcvdSegmentClosing(s *segment, state EndpointState, clo
 // handleRcvdSegment handles TCP segments directed at the connection managed by
 // r as they arrive. It is called by the protocol main loop.
 // +checklocks:r.ep.mu
-// +checklocksalias:r.ep.snd.ep.mu=r.ep.mu
 func (r *receiver) handleRcvdSegment(s *segment) (drop bool, err tcpip.Error) {
 	state := r.ep.EndpointState()
 	closed := r.ep.closed
@@ -548,7 +543,6 @@ func (r *receiver) handleRcvdSegment(s *segment) (drop bool, err tcpip.Error) {
 // handleTimeWaitSegment handles inbound segments received when the endpoint
 // has entered the TIME_WAIT state.
 // +checklocks:r.ep.mu
-// +checklocksalias:r.ep.snd.ep.mu=r.ep.mu
 func (r *receiver) handleTimeWaitSegment(s *segment) (resetTimeWait bool, newSyn bool) {
 	segSeq := s.sequenceNumber
 	segLen := seqnum.Size(s.payloadSize())

--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -122,12 +122,25 @@ Additional variants of the `+checklocks` annotation are supported for functions:
     to the caller's lock state.
 *   `+checklocksacquireread`: A read variant of `+checklocksacquire`.
 *   `+checklocksreleaseread`: A read variant of `+checklocksrelease`.
-*   `+checklocksalias:a.b.c=x.y`: For parameters with complex relationships,
-    this annotation can be used to specify that the `a.b.c` lock is equivalent
-    to the `x.y` state. That is, any operation on either of these locks applies
-    to both, and any assertions that can be made about either applies to both.
 
 For examples of these cases see the tests.
+
+### Type Alias Annotations
+
+Types may declare aliases between locks that are structurally equivalent across
+all instances of the type. These annotations must appear on the type
+declaration, and the names are resolved relative to the type itself.
+
+```go
+// +checklocksalias:inner.mu=mu
+type example struct {
+  mu    sync.Mutex
+  inner struct{ mu sync.Mutex }
+}
+```
+
+The alias above means `example.inner.mu` is treated as the same lock as
+`example.mu` anywhere a value of type `example` is used.
 
 #### Anonymous Functions and Closures
 
@@ -248,11 +261,12 @@ applied consistently and without the need for ignoring and forcing.
 
 Tests can be built using the `+checklocksfail` annotation. When applied after a
 statement, these will generate a report if the line does *not* fail an
-assertion. For example:
+assertion. The optional value matches a substring of the failure message and
+multiple expected failures can be separated with `|`. For example:
 
 ```go
 func foo(ts *testStruct) {
-  ts.guardedField = 1 // +checklocksfail: violation.
+  ts.guardedField = 1 // +checklocksfail=violation
 }
 ```
 

--- a/tools/checklocks/importfacts.go
+++ b/tools/checklocks/importfacts.go
@@ -57,3 +57,16 @@ func (pc *passContext) importLockFunctionFacts(fn *types.Func, lff *lockFunction
 		pc.pass.ImportObjectFact(orig, lff)
 	}
 }
+
+func (pc *passContext) importLockTypeFacts(typ types.Type, ltf *lockTypeFacts) {
+	for {
+		if ptr, ok := typ.(*types.Pointer); ok {
+			typ = ptr.Elem()
+			continue
+		}
+		if named, ok := types.Unalias(typ).(*types.Named); ok {
+			pc.pass.ImportObjectFact(named.Obj(), ltf)
+		}
+		return
+	}
+}

--- a/tools/checklocks/test/atomics.go
+++ b/tools/checklocks/test/atomics.go
@@ -86,7 +86,7 @@ func testAtomicMixedValidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan
 
 func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
 	tc.mu.Lock()
-	tc.accessedMixed = 1 // +checklocksfail:2
+	tc.accessedMixed = 1 // +checklocksfail=illegal use of atomic-only field|non-atomic write of field accessedMixed
 	tc.mu.Unlock()
 }
 
@@ -96,8 +96,8 @@ func testAtomicMixedInvalidAtomicWrite(tc *atomicMixedStruct, v chan int32, p ch
 }
 
 func testAtomicMixedInvalidWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
-	tc.accessedMixed = 1 // +checklocksfail:2
-	tc.wrapper.Store(1)  // +checklocksfail:1
+	tc.accessedMixed = 1 // +checklocksfail=illegal use of atomic-only field|non-atomic write of field accessedMixed
+	tc.wrapper.Store(1)  // +checklocksfail
 }
 
 func testAtomicWrapper(tc *atomicStruct, v chan int32) {

--- a/tools/checklocks/test/basics.go
+++ b/tools/checklocks/test/basics.go
@@ -158,7 +158,7 @@ func testTwoLocksDoubleGuardStructOnlyOne(tc *twoLocksDoubleGuardStruct) {
 }
 
 func testTwoLocksDoubleGuardStructInvalid(tc *twoLocksDoubleGuardStruct) {
-	tc.doubleGuardedField = 3 // +checklocksfail:2
+	tc.doubleGuardedField = 3 // +checklocksfail=invalid field access|invalid field access
 }
 
 func testFieldCommentValid(tc *fieldCommentStruct) {

--- a/tools/checklocks/test/branches.go
+++ b/tools/checklocks/test/branches.go
@@ -39,7 +39,7 @@ func testConsistentBranching(tc *oneGuardStruct) {
 	}
 }
 
-func testInconsistentBranching(tc *oneGuardStruct) { // +checklocksfail:2
+func testInconsistentBranching(tc *oneGuardStruct) { // +checklocksfail=incompatible return states|incompatible return states
 	// We traverse the control flow graph in all consistent ways. We cannot
 	// determine however, that the first if block and second if block will
 	// evaluate to the same condition. Therefore, there are two consistent


### PR DESCRIPTION
Repurpose checklocksalias as a type-level annotation so alias
relationships are declared once per type instead of per call. Update
tcp/ipv4 annotations accordingly and drop per-call workarounds.

Enhance checklocksfail to allow substring matching so that robust tests
for checklocksalias are possible.