### PR TITLE
refs: replace go_generics with Go generics

### DIFF
--- a/pkg/buffer/BUILD
+++ b/pkg/buffer/BUILD
@@ -7,17 +7,6 @@ package(
 )
 
 go_template_instance(
-    name = "chunk_refs",
-    out = "chunk_refs.go",
-    package = "buffer",
-    prefix = "chunk",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "chunk",
-    },
-)
-
-go_template_instance(
     name = "view_list",
     out = "view_list.go",
     package = "buffer",
@@ -35,7 +24,6 @@ go_library(
         "buffer.go",
         "buffer_state.go",
         "chunk.go",
-        "chunk_refs.go",
         "view.go",
         "view_list.go",
         "view_unsafe.go",

--- a/pkg/buffer/chunk.go
+++ b/pkg/buffer/chunk.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"gvisor.dev/gvisor/pkg/bits"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sync"
 )
 
@@ -77,6 +78,9 @@ type chunk struct {
 	chunkRefs
 	data []byte
 }
+
+// +stateify transparent
+type chunkRefs struct{ refs.Refs[chunk] }
 
 func newChunk(size int) *chunk {
 	var c *chunk

--- a/pkg/buffer/view.go
+++ b/pkg/buffer/view.go
@@ -119,7 +119,7 @@ func (v *View) Reset() {
 }
 
 func (v *View) sharesChunk() bool {
-	return v.chunk.refCount.Load() > 1
+	return v.chunk.ReadRefs() > 1
 }
 
 // Full indicates the chunk is full.

--- a/pkg/buffer/view_test.go
+++ b/pkg/buffer/view_test.go
@@ -67,12 +67,12 @@ func TestClone(t *testing.T) {
 	if orig.chunk != clone.chunk {
 		t.Errorf("orig.Clone().chunk = %p, want %p", clone.chunk, orig.chunk)
 	}
-	if orig.chunk.refCount.Load() != 2 {
-		t.Errorf("got orig.chunk.chunkRefs.Load() = %d, want 2", orig.chunk.refCount.Load())
+	if want, got := int64(2), orig.chunk.ReadRefs(); got != want {
+		t.Errorf("got orig.chunk.ReadRefs() = %d, want %d", got, want)
 	}
 	orig.Release()
-	if clone.chunk.refCount.Load() != 1 {
-		t.Errorf("got clone.chunk.chunkRefs.Load() = %d, want 1", clone.chunk.refCount.Load())
+	if want, got := int64(1), clone.chunk.ReadRefs(); got != want {
+		t.Errorf("got clone.chunk.ReadRefs() = %d, want %d", got, want)
 	}
 	clone.Release()
 }

--- a/pkg/lisafs/BUILD
+++ b/pkg/lisafs/BUILD
@@ -8,50 +8,6 @@ package(
 )
 
 go_template_instance(
-    name = "control_fd_refs",
-    out = "control_fd_refs.go",
-    package = "lisafs",
-    prefix = "controlFD",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "ControlFD",
-    },
-)
-
-go_template_instance(
-    name = "open_fd_refs",
-    out = "open_fd_refs.go",
-    package = "lisafs",
-    prefix = "openFD",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "OpenFD",
-    },
-)
-
-go_template_instance(
-    name = "bound_socket_fd_refs",
-    out = "bound_socket_fd_refs.go",
-    package = "lisafs",
-    prefix = "boundSocketFD",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "BoundSocketFD",
-    },
-)
-
-go_template_instance(
-    name = "node_fd_refs",
-    out = "node_fd_refs.go",
-    package = "lisafs",
-    prefix = "node",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "Node",
-    },
-)
-
-go_template_instance(
     name = "control_fd_list",
     out = "control_fd_list.go",
     package = "lisafs",
@@ -78,22 +34,18 @@ go_template_instance(
 go_library(
     name = "lisafs",
     srcs = [
-        "bound_socket_fd_refs.go",
         "channel.go",
         "client.go",
         "client_file.go",
         "communicator.go",
         "connection.go",
         "control_fd_list.go",
-        "control_fd_refs.go",
         "fd.go",
         "handlers.go",
         "lisafs.go",
         "message.go",
         "node.go",
-        "node_fd_refs.go",
         "open_fd_list.go",
-        "open_fd_refs.go",
         "sample_message.go",
         "server.go",
         "sock.go",

--- a/pkg/lisafs/fd.go
+++ b/pkg/lisafs/fd.go
@@ -41,6 +41,15 @@ type genericFD interface {
 	refs.RefCounter
 }
 
+// +stateify transparent
+type controlFDRefs struct{ refs.Refs[ControlFD] }
+
+// +stateify transparent
+type openFDRefs struct{ refs.Refs[OpenFD] }
+
+// +stateify transparent
+type boundSocketFDRefs struct{ refs.Refs[BoundSocketFD] }
+
 // A ControlFD is the gateway to the backing filesystem tree node. It is an
 // unusual concept. This exists to provide a safe way to do path-based
 // operations on the file. It performs operations that can modify the

--- a/pkg/lisafs/node.go
+++ b/pkg/lisafs/node.go
@@ -18,6 +18,7 @@ import (
 	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/fspath"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sync"
 )
 
@@ -100,6 +101,9 @@ type Node struct {
 	}
 	dynamicChildren map[string]*Node
 }
+
+// +stateify transparent
+type nodeRefs struct{ refs.Refs[Node] }
 
 // DecRef implements refs.RefCounter.DecRef. Note that the context
 // parameter should never be used. It exists solely to comply with the

--- a/pkg/refs/BUILD
+++ b/pkg/refs/BUILD
@@ -1,27 +1,8 @@
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template")
 
 package(
     default_applicable_licenses = ["//:license"],
     licenses = ["notice"],
-)
-
-go_template(
-    name = "refs_template",
-    srcs = [
-        "refs_template.go",
-    ],
-    opt_consts = [
-        "enableLogging",
-    ],
-    types = [
-        "T",
-    ],
-    visibility = ["//:sandbox"],
-    deps = [
-        "//pkg/log",
-        "//pkg/refs",
-    ],
 )
 
 go_library(
@@ -29,6 +10,7 @@ go_library(
     srcs = [
         "refcounter.go",
         "refs_map.go",
+        "refs_template.go",
     ],
     visibility = ["//:sandbox"],
     deps = [

--- a/pkg/refs/README.md
+++ b/pkg/refs/README.md
@@ -8,12 +8,12 @@ appropriately. For example, the filesystem has many reference-counted objects
 object persists while anything holds a reference on it and is destroyed once all
 references are dropped.
 
-We provide a template in `refs_template.go` that can be applied to most objects
-in need of reference counting. It contains a simple `Refs` struct that can be
-incremented and decremented, and once the reference count reaches zero, a
-destructor can be called. Note that there are some objects (e.g. `gofer.dentry`,
-`overlay.dentry`) that should not immediately be destroyed upon reaching zero
-references; in these cases, this template cannot be applied.
+We provide a generic `Refs` type in `refs_template.go` that can be applied to
+most objects in need of reference counting. It contains a simple `Refs` struct
+that can be incremented and decremented, and once the reference count reaches
+zero, a destructor can be called. Note that there are some objects (e.g.
+`gofer.dentry`, `overlay.dentry`) that should not immediately be destroyed upon
+reaching zero references; in these cases, this helper cannot be applied.
 
 # Reference Checking
 
@@ -44,9 +44,9 @@ report everything left in the map as having leaked. Leak-checking objects
 implement the `CheckedObject` interface, which allows us to print informative
 warnings for each of the leaked objects.
 
-Leak checking is provided by `refs_template`, but objects that do not use the
-template will also need to implement `CheckedObject` and be manually
-registered/unregistered from the map in order to be checked.
+Leak checking is provided by `Refs`, but objects that do not use it will also
+need to implement `CheckedObject` and be manually registered/unregistered from
+the map in order to be checked.
 
 Note that leak checking affects performance and memory usage, so it should only
 be enabled in testing environments.
@@ -56,11 +56,10 @@ be enabled in testing environments.
 Even with the checks described above, it can be difficult to track down the
 exact source of a reference counting error. The error may occur far before it is
 discovered (for instance, a missing `IncRef` may not be discovered until a
-future `DecRef` makes the count negative). To aid in debugging, `refs_template`
-provides the `enableLogging` option to log every `IncRef`, `DecRef`, and leak
+future `DecRef` makes the count negative). To aid in debugging, `Refs` can be
+instantiated with `refs.LoggingEnabled` to log every `IncRef`, `DecRef`, and leak
 check registration/unregistration, along with the object address and a call
 stack. This allows us to search a log for all of the changes to a particular
 object's reference count, which makes it much easier to identify the absent or
-extraneous operation(s). The reference-counted objects that do not use
-`refs_template` also provide logging, and others defined in the future should do
-so as well.
+extraneous operation(s). The reference-counted objects that do not use `Refs`
+also provide logging, and others defined in the future should do so as well.

--- a/pkg/refs/refcounter.go
+++ b/pkg/refs/refcounter.go
@@ -31,8 +31,8 @@ type RefCounter interface {
 	// IncRef increments the reference counter on the object.
 	IncRef()
 
-	// DecRef decrements the object's reference count. Users of refs_template.Refs
-	// may specify a destructor to be called once the reference count reaches zero.
+	// DecRef decrements the object's reference count. Users of Refs may specify
+	// a destructor to be called once the reference count reaches zero.
 	DecRef(ctx context.Context)
 }
 

--- a/pkg/sentry/fsimpl/cgroupfs/BUILD
+++ b/pkg/sentry/fsimpl/cgroupfs/BUILD
@@ -1,6 +1,5 @@
 load("//pkg/sync/locking:locking.bzl", "declare_mutex", "declare_rwmutex")
 load("//tools:defs.bzl", "go_library", "go_test")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(default_applicable_licenses = ["//:license"])
 
@@ -20,17 +19,6 @@ declare_rwmutex(
     prefix = "task",
 )
 
-go_template_instance(
-    name = "dir_refs",
-    out = "dir_refs.go",
-    package = "cgroupfs",
-    prefix = "dir",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "dir",
-    },
-)
-
 go_library(
     name = "cgroupfs",
     srcs = [
@@ -41,7 +29,6 @@ go_library(
         "cpuacct.go",
         "cpuset.go",
         "devices.go",
-        "dir_refs.go",
         "job.go",
         "memory.go",
         "pids.go",

--- a/pkg/sentry/fsimpl/devpts/BUILD
+++ b/pkg/sentry/fsimpl/devpts/BUILD
@@ -1,20 +1,8 @@
 load("//tools:defs.bzl", "go_library", "go_test")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
-
-go_template_instance(
-    name = "root_inode_refs",
-    out = "root_inode_refs.go",
-    package = "devpts",
-    prefix = "rootInode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "rootInode",
-    },
-)
 
 go_library(
     name = "devpts",
@@ -24,7 +12,6 @@ go_library(
         "master.go",
         "queue.go",
         "replica.go",
-        "root_inode_refs.go",
         "terminal.go",
     ],
     visibility = ["//pkg/sentry:internal"],

--- a/pkg/sentry/fsimpl/devpts/devpts.go
+++ b/pkg/sentry/fsimpl/devpts/devpts.go
@@ -26,6 +26,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -246,6 +247,9 @@ type rootInode struct {
 	// nextIdx is the next pty index to use. Must be accessed atomically.
 	nextIdx uint32
 }
+
+// +stateify transparent
+type rootInodeRefs struct{ refs.Refs[rootInode] }
 
 var _ kernfs.Inode = (*rootInode)(nil)
 

--- a/pkg/sentry/fsimpl/erofs/BUILD
+++ b/pkg/sentry/fsimpl/erofs/BUILD
@@ -18,37 +18,13 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "dentry_refs",
-    out = "dentry_refs.go",
-    package = "erofs",
-    prefix = "dentry",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "dentry",
-    },
-)
-
-go_template_instance(
-    name = "inode_refs",
-    out = "inode_refs.go",
-    package = "erofs",
-    prefix = "inode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "inode",
-    },
-)
-
 go_library(
     name = "erofs",
     srcs = [
-        "dentry_refs.go",
         "directory.go",
         "erofs.go",
         "filesystem.go",
         "fstree.go",
-        "inode_refs.go",
         "regular_file.go",
         "save_restore.go",
     ],

--- a/pkg/sentry/fsimpl/erofs/erofs.go
+++ b/pkg/sentry/fsimpl/erofs/erofs.go
@@ -26,6 +26,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/erofs"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
@@ -282,6 +283,9 @@ type inode struct {
 	watches vfs.Watches
 }
 
+// +stateify transparent
+type inodeRefs struct{ refs.Refs[inode] }
+
 // getInode returns the inode identified by nid. A reference on inode is also
 // returned to caller.
 func (fs *filesystem) getInode(nid uint64) (*inode, error) {
@@ -394,6 +398,9 @@ type dentry struct {
 	// +checklocks:dirMu
 	childMap map[string]*dentry
 }
+
+// +stateify transparent
+type dentryRefs struct{ refs.Refs[dentry] }
 
 // The caller is expected to handle dentry insertion into dentry tree.
 func (fs *filesystem) newDentry(nid uint64) (*dentry, error) {

--- a/pkg/sentry/fsimpl/fuse/BUILD
+++ b/pkg/sentry/fsimpl/fuse/BUILD
@@ -18,28 +18,6 @@ go_template_instance(
 )
 
 go_template_instance(
-    name = "inode_refs",
-    out = "inode_refs.go",
-    package = "fuse",
-    prefix = "inode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "inode",
-    },
-)
-
-go_template_instance(
-    name = "connection_refs",
-    out = "connection_refs.go",
-    package = "fuse",
-    prefix = "connection",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "connection",
-    },
-)
-
-go_template_instance(
     name = "seqatomic_time",
     out = "seqatomic_time_unsafe.go",
     imports = {
@@ -58,13 +36,11 @@ go_library(
     srcs = [
         "connection.go",
         "connection_control.go",
-        "connection_refs.go",
         "dev.go",
         "directory.go",
         "file.go",
         "fusefs.go",
         "inode.go",
-        "inode_refs.go",
         "read_write.go",
         "register.go",
         "regular_file.go",

--- a/pkg/sentry/fsimpl/fuse/connection.go
+++ b/pkg/sentry/fsimpl/fuse/connection.go
@@ -24,6 +24,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/syserr"
@@ -230,6 +231,9 @@ type connection struct {
 	// This flag only influences performance, not correctness of the program.
 	noOpen bool
 }
+
+// +stateify transparent
+type connectionRefs struct{ refs.Refs[connection] }
 
 func connError(err error) error {
 	// The error may contain arbitrary errno values that can't be converted.

--- a/pkg/sentry/fsimpl/fuse/inode.go
+++ b/pkg/sentry/fsimpl/fuse/inode.go
@@ -25,6 +25,7 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/marshal"
 	"gvisor.dev/gvisor/pkg/marshal/primitive"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -114,6 +115,9 @@ type inode struct {
 	// +checklocks:attrMu
 	blockSize atomicbitops.Uint32 // 0 if unknown.
 }
+
+// +stateify transparent
+type inodeRefs struct{ refs.Refs[inode] }
 
 func pidFromContext(ctx context.Context) uint32 {
 	kernelTask := kernel.TaskFromContext(ctx)

--- a/pkg/sentry/fsimpl/gofer/BUILD
+++ b/pkg/sentry/fsimpl/gofer/BUILD
@@ -6,17 +6,6 @@ package(default_applicable_licenses = ["//:license"])
 licenses(["notice"])
 
 go_template_instance(
-    name = "inode_refs",
-    out = "inode_refs.go",
-    package = "gofer",
-    prefix = "inode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "inode",
-    },
-)
-
-go_template_instance(
     name = "string_list",
     out = "string_list.go",
     package = "gofer",
@@ -76,7 +65,6 @@ go_library(
         "handle.go",
         "host_named_pipe.go",
         "inode_impl.go",
-        "inode_refs.go",
         "lisafs_inode.go",
         "regular_file.go",
         "revalidate.go",

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -976,6 +976,9 @@ type inode struct {
 	impl any // immutable
 }
 
+// +stateify transparent
+type inodeRefs struct{ refs.Refs[inode] }
+
 func (i *inode) init(impl any) {
 	i.refs.InitRefs()
 	i.pf.inode = i

--- a/pkg/sentry/fsimpl/host/BUILD
+++ b/pkg/sentry/fsimpl/host/BUILD
@@ -1,27 +1,14 @@
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
-
-go_template_instance(
-    name = "inode_refs",
-    out = "inode_refs.go",
-    package = "host",
-    prefix = "inode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "inode",
-    },
-)
 
 go_library(
     name = "host",
     srcs = [
         "host.go",
         "host_unsafe.go",
-        "inode_refs.go",
         "ioctl_unsafe.go",
         "save_restore.go",
         "tty.go",

--- a/pkg/sentry/fsimpl/host/host.go
+++ b/pkg/sentry/fsimpl/host/host.go
@@ -29,6 +29,7 @@ import (
 	"gvisor.dev/gvisor/pkg/fspath"
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/eventfd"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
@@ -185,6 +186,9 @@ type inode struct {
 	termiosMu sync.Mutex `state:"nosave"`
 	termios   linux.KernelTermios
 }
+
+// +stateify transparent
+type inodeRefs struct{ refs.Refs[inode] }
 
 func newInode(ctx context.Context, fs *filesystem, hostFD int, savable bool, restoreKey vfs.RestoreID, fileType linux.FileMode, isTTY bool, readonly bool) (*inode, error) {
 	// Determine if hostFD is seekable.

--- a/pkg/sentry/fsimpl/kernfs/BUILD
+++ b/pkg/sentry/fsimpl/kernfs/BUILD
@@ -42,50 +42,6 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "static_directory_refs",
-    out = "static_directory_refs.go",
-    package = "kernfs",
-    prefix = "StaticDirectory",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "StaticDirectory",
-    },
-)
-
-go_template_instance(
-    name = "dir_refs",
-    out = "dir_refs.go",
-    package = "kernfs_test",
-    prefix = "dir",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "dir",
-    },
-)
-
-go_template_instance(
-    name = "readonly_dir_refs",
-    out = "readonly_dir_refs.go",
-    package = "kernfs_test",
-    prefix = "readonlyDir",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "readonlyDir",
-    },
-)
-
-go_template_instance(
-    name = "synthetic_directory_refs",
-    out = "synthetic_directory_refs.go",
-    package = "kernfs",
-    prefix = "syntheticDirectory",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "syntheticDirectory",
-    },
-)
-
 declare_rwmutex(
     name = "ancestry_mutex",
     out = "ancestry_mutex.go",
@@ -123,10 +79,8 @@ go_library(
         "mmap_util.go",
         "save_restore.go",
         "slot_list.go",
-        "static_directory_refs.go",
         "symlink.go",
         "synthetic_directory.go",
-        "synthetic_directory_refs.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [
@@ -156,9 +110,7 @@ go_test(
     name = "kernfs_test",
     size = "small",
     srcs = [
-        "dir_refs.go",
         "kernfs_test.go",
-        "readonly_dir_refs.go",
     ],
     deps = [
         ":kernfs",

--- a/pkg/sentry/fsimpl/kernfs/inode_impl_util.go
+++ b/pkg/sentry/fsimpl/kernfs/inode_impl_util.go
@@ -22,6 +22,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/ktime"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
@@ -740,6 +741,11 @@ type StaticDirectory struct {
 	locks  vfs.FileLocks
 	fdOpts GenericDirectoryFDOptions
 }
+
+// StaticDirectoryRefs is the reference count for StaticDirectory.
+//
+// +stateify transparent
+type StaticDirectoryRefs struct{ refs.Refs[StaticDirectory] }
 
 var _ Inode = (*StaticDirectory)(nil)
 

--- a/pkg/sentry/fsimpl/kernfs/kernfs_test.go
+++ b/pkg/sentry/fsimpl/kernfs/kernfs_test.go
@@ -24,6 +24,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/fspath"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/testutil"
@@ -114,6 +115,9 @@ type readonlyDir struct {
 	locks vfs.FileLocks
 }
 
+// +stateify transparent
+type readonlyDirRefs struct{ refs.Refs[readonlyDir] }
+
 func (fs *filesystem) newReadonlyDir(ctx context.Context, creds *auth.Credentials, mode linux.FileMode, contents map[string]kernfs.Inode) kernfs.Inode {
 	dir := &readonlyDir{}
 	dir.attrs.Init(ctx, creds, 0 /* devMajor */, 0 /* devMinor */, fs.NextIno(), linux.ModeDirectory|mode)
@@ -153,6 +157,9 @@ type dir struct {
 
 	fs *filesystem
 }
+
+// +stateify transparent
+type dirRefs struct{ refs.Refs[dir] }
 
 func (fs *filesystem) newDir(ctx context.Context, creds *auth.Credentials, mode linux.FileMode, contents map[string]kernfs.Inode) kernfs.Inode {
 	dir := &dir{}

--- a/pkg/sentry/fsimpl/kernfs/synthetic_directory.go
+++ b/pkg/sentry/fsimpl/kernfs/synthetic_directory.go
@@ -20,6 +20,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 )
@@ -41,6 +42,9 @@ type syntheticDirectory struct {
 
 	locks vfs.FileLocks
 }
+
+// +stateify transparent
+type syntheticDirectoryRefs struct{ refs.Refs[syntheticDirectory] }
 
 var _ Inode = (*syntheticDirectory)(nil)
 

--- a/pkg/sentry/fsimpl/mqfs/BUILD
+++ b/pkg/sentry/fsimpl/mqfs/BUILD
@@ -1,20 +1,8 @@
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
     default_applicable_licenses = ["//:license"],
     licenses = ["notice"],
-)
-
-go_template_instance(
-    name = "root_inode_refs",
-    out = "root_inode_refs.go",
-    package = "mqfs",
-    prefix = "rootInode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "rootInode",
-    },
 )
 
 go_library(
@@ -24,7 +12,6 @@ go_library(
         "queue.go",
         "registry.go",
         "root.go",
-        "root_inode_refs.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [

--- a/pkg/sentry/fsimpl/mqfs/root.go
+++ b/pkg/sentry/fsimpl/mqfs/root.go
@@ -18,6 +18,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
@@ -40,6 +41,9 @@ type rootInode struct {
 
 	locks vfs.FileLocks
 }
+
+// +stateify transparent
+type rootInodeRefs struct{ refs.Refs[rootInode] }
 
 var _ kernfs.Inode = (*rootInode)(nil)
 

--- a/pkg/sentry/fsimpl/nsfs/BUILD
+++ b/pkg/sentry/fsimpl/nsfs/BUILD
@@ -1,25 +1,12 @@
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
 
-go_template_instance(
-    name = "inode_refs",
-    out = "inode_refs.go",
-    package = "nsfs",
-    prefix = "inode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "Inode",
-    },
-)
-
 go_library(
     name = "nsfs",
     srcs = [
-        "inode_refs.go",
         "nsfs.go",
     ],
     visibility = ["//pkg/sentry:internal"],

--- a/pkg/sentry/fsimpl/nsfs/nsfs.go
+++ b/pkg/sentry/fsimpl/nsfs/nsfs.go
@@ -22,6 +22,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
@@ -91,6 +92,9 @@ type Inode struct {
 
 	mnt *vfs.Mount
 }
+
+// +stateify transparent
+type inodeRefs struct{ refs.Refs[Inode] }
 
 // DecRef implements kernfs.Inode.DecRef.
 func (i *Inode) DecRef(ctx context.Context) {

--- a/pkg/sentry/fsimpl/proc/BUILD
+++ b/pkg/sentry/fsimpl/proc/BUILD
@@ -1,65 +1,9 @@
 load("//pkg/sync/locking:locking.bzl", "declare_rwmutex")
 load("//tools:defs.bzl", "go_library", "go_test")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
-
-go_template_instance(
-    name = "fd_dir_inode_refs",
-    out = "fd_dir_inode_refs.go",
-    package = "proc",
-    prefix = "fdDirInode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "fdDirInode",
-    },
-)
-
-go_template_instance(
-    name = "fd_info_dir_inode_refs",
-    out = "fd_info_dir_inode_refs.go",
-    package = "proc",
-    prefix = "fdInfoDirInode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "fdInfoDirInode",
-    },
-)
-
-go_template_instance(
-    name = "subtasks_inode_refs",
-    out = "subtasks_inode_refs.go",
-    package = "proc",
-    prefix = "subtasksInode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "subtasksInode",
-    },
-)
-
-go_template_instance(
-    name = "task_inode_refs",
-    out = "task_inode_refs.go",
-    package = "proc",
-    prefix = "taskInode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "taskInode",
-    },
-)
-
-go_template_instance(
-    name = "tasks_inode_refs",
-    out = "tasks_inode_refs.go",
-    package = "proc",
-    prefix = "tasksInode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "tasksInode",
-    },
-)
 
 declare_rwmutex(
     name = "dentries_mutex",
@@ -72,21 +16,16 @@ go_library(
     name = "proc",
     srcs = [
         "dentries_mutex.go",
-        "fd_dir_inode_refs.go",
-        "fd_info_dir_inode_refs.go",
         "filesystem.go",
         "keys.go",
         "proc_impl.go",
         "subtasks.go",
-        "subtasks_inode_refs.go",
         "task.go",
         "task_fds.go",
         "task_files.go",
-        "task_inode_refs.go",
         "task_net.go",
         "tasks.go",
         "tasks_files.go",
-        "tasks_inode_refs.go",
         "tasks_sys.go",
         "yama.go",
     ],

--- a/pkg/sentry/fsimpl/proc/subtasks.go
+++ b/pkg/sentry/fsimpl/proc/subtasks.go
@@ -21,6 +21,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -50,6 +51,9 @@ type subtasksInode struct {
 	pidns             *kernel.PIDNamespace
 	cgroupControllers map[string]string
 }
+
+// +stateify transparent
+type subtasksInodeRefs struct{ refs.Refs[subtasksInode] }
 
 var _ kernfs.Inode = (*subtasksInode)(nil)
 

--- a/pkg/sentry/fsimpl/proc/task.go
+++ b/pkg/sentry/fsimpl/proc/task.go
@@ -21,6 +21,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -50,6 +51,9 @@ type taskInode struct {
 	// dentries is a list of dentries to be invalidated when the task is destroyed.
 	dentries map[*kernfs.Dentry]struct{}
 }
+
+// +stateify transparent
+type taskInodeRefs struct{ refs.Refs[taskInode] }
 
 var _ kernfs.Inode = (*taskInode)(nil)
 

--- a/pkg/sentry/fsimpl/proc/task_fds.go
+++ b/pkg/sentry/fsimpl/proc/task_fds.go
@@ -23,6 +23,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -120,6 +121,12 @@ type fdDirInode struct {
 	kernfs.OrderedChildren
 	kernfs.InodeFSOwned
 }
+
+// +stateify transparent
+type fdDirInodeRefs struct{ refs.Refs[fdDirInode] }
+
+// +stateify transparent
+type fdInfoDirInodeRefs struct{ refs.Refs[fdInfoDirInode] }
 
 var _ kernfs.Inode = (*fdDirInode)(nil)
 

--- a/pkg/sentry/fsimpl/proc/tasks.go
+++ b/pkg/sentry/fsimpl/proc/tasks.go
@@ -23,6 +23,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -63,6 +64,9 @@ type tasksInode struct {
 	// in /proc/pid/cgroup if not nil.
 	fakeCgroupControllers map[string]string
 }
+
+// +stateify transparent
+type tasksInodeRefs struct{ refs.Refs[tasksInode] }
 
 var _ kernfs.Inode = (*tasksInode)(nil)
 

--- a/pkg/sentry/fsimpl/sys/BUILD
+++ b/pkg/sentry/fsimpl/sys/BUILD
@@ -1,25 +1,12 @@
 load("//tools:defs.bzl", "go_library", "go_test")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
 
-go_template_instance(
-    name = "dir_refs",
-    out = "dir_refs.go",
-    package = "sys",
-    prefix = "dir",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "dir",
-    },
-)
-
 go_library(
     name = "sys",
     srcs = [
-        "dir_refs.go",
         "kcov.go",
         "pci.go",
         "save_restore.go",

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -29,6 +29,7 @@ import (
 	"gvisor.dev/gvisor/pkg/coverage"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -365,6 +366,9 @@ type dir struct {
 
 	locks vfs.FileLocks
 }
+
+// +stateify transparent
+type dirRefs struct{ refs.Refs[dir] }
 
 func (fs *filesystem) newDir(ctx context.Context, creds *auth.Credentials, mode linux.FileMode, contents map[string]kernfs.Inode) kernfs.Inode {
 	d := &dir{}

--- a/pkg/sentry/fsimpl/tmpfs/BUILD
+++ b/pkg/sentry/fsimpl/tmpfs/BUILD
@@ -30,17 +30,6 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "inode_refs",
-    out = "inode_refs.go",
-    package = "tmpfs",
-    prefix = "inode",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "inode",
-    },
-)
-
 declare_rwmutex(
     name = "ancestry_mutex",
     out = "ancestry_mutex.go",
@@ -87,7 +76,6 @@ go_library(
         "filesystem_mutex.go",
         "fstree.go",
         "inode_mutex.go",
-        "inode_refs.go",
         "iter_mutex.go",
         "named_pipe.go",
         "pages_used_mutex.go",

--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -42,6 +42,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/ktime"
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
@@ -519,6 +520,9 @@ type inode struct {
 
 	impl any // immutable
 }
+
+// +stateify transparent
+type inodeRefs struct{ refs.Refs[inode] }
 
 const maxLinks = math.MaxUint32
 

--- a/pkg/sentry/inet/BUILD
+++ b/pkg/sentry/inet/BUILD
@@ -1,22 +1,10 @@
 load("//pkg/sync/locking:locking.bzl", "declare_mutex")
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//:sandbox"],
     licenses = ["notice"],
-)
-
-go_template_instance(
-    name = "namespace_refs",
-    out = "namespace_refs.go",
-    package = "inet",
-    prefix = "namespace",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "Namespace",
-    },
 )
 
 declare_mutex(
@@ -41,7 +29,6 @@ go_library(
         "context.go",
         "inet.go",
         "namespace.go",
-        "namespace_refs.go",
         "nlmcast.go",
         "nlmcast_table_mutex.go",
         "test_stack.go",

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -185,50 +185,6 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "fd_table_refs",
-    out = "fd_table_refs.go",
-    package = "kernel",
-    prefix = "FDTable",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "FDTable",
-    },
-)
-
-go_template_instance(
-    name = "fs_context_refs",
-    out = "fs_context_refs.go",
-    package = "kernel",
-    prefix = "FSContext",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "FSContext",
-    },
-)
-
-go_template_instance(
-    name = "process_group_refs",
-    out = "process_group_refs.go",
-    package = "kernel",
-    prefix = "ProcessGroup",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "ProcessGroup",
-    },
-)
-
-go_template_instance(
-    name = "session_refs",
-    out = "session_refs.go",
-    package = "kernel",
-    prefix = "Session",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "Session",
-    },
-)
-
 proto_library(
     name = "uncaught_signal",
     srcs = ["uncaught_signal.proto"],
@@ -249,11 +205,9 @@ go_library(
         "context.go",
         "fd_table.go",
         "fd_table_mutex.go",
-        "fd_table_refs.go",
         "fd_table_unsafe.go",
         "fs_context.go",
         "fs_context_mutex.go",
-        "fs_context_refs.go",
         "ipc_namespace.go",
         "kcov.go",
         "kcov_unsafe.go",
@@ -266,7 +220,6 @@ go_library(
         "pending_signals_state.go",
         "posixtimer.go",
         "process_group_list.go",
-        "process_group_refs.go",
         "ptrace.go",
         "ptrace_amd64.go",
         "ptrace_arm64.go",
@@ -275,7 +228,6 @@ go_library(
         "seccheck.go",
         "seccomp.go",
         "session_list.go",
-        "session_refs.go",
         "sessions.go",
         "signal.go",
         "signal_handlers.go",

--- a/pkg/sentry/kernel/shm/BUILD
+++ b/pkg/sentry/kernel/shm/BUILD
@@ -1,23 +1,8 @@
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
     default_applicable_licenses = ["//:license"],
     licenses = ["notice"],
-)
-
-go_template_instance(
-    name = "shm_refs",
-    out = "shm_refs.go",
-    consts = {
-        "enableLogging": "true",
-    },
-    package = "shm",
-    prefix = "Shm",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "Shm",
-    },
 )
 
 go_library(
@@ -25,7 +10,6 @@ go_library(
     srcs = [
         "context.go",
         "shm.go",
-        "shm_refs.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [

--- a/pkg/sentry/mm/BUILD
+++ b/pkg/sentry/mm/BUILD
@@ -96,28 +96,6 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "aio_mappable_refs",
-    out = "aio_mappable_refs.go",
-    package = "mm",
-    prefix = "aioMappable",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "aioMappable",
-    },
-)
-
-go_template_instance(
-    name = "special_mappable_refs",
-    out = "special_mappable_refs.go",
-    package = "mm",
-    prefix = "SpecialMappable",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "SpecialMappable",
-    },
-)
-
 go_library(
     name = "mm",
     srcs = [
@@ -127,7 +105,6 @@ go_library(
         "aio_context_mutex.go",
         "aio_context_state.go",
         "aio_manager_mutex.go",
-        "aio_mappable_refs.go",
         "debug.go",
         "io.go",
         "io_list.go",
@@ -142,7 +119,6 @@ go_library(
         "save_restore.go",
         "shm.go",
         "special_mappable.go",
-        "special_mappable_refs.go",
         "syscalls.go",
         "vma.go",
         "vma_set.go",

--- a/pkg/sentry/mm/aio_context.go
+++ b/pkg/sentry/mm/aio_context.go
@@ -19,6 +19,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
 	"gvisor.dev/gvisor/pkg/sentry/usage"
@@ -249,6 +250,9 @@ type aioMappable struct {
 	mf *pgalloc.MemoryFile `state:"nosave"`
 	fr memmap.FileRange
 }
+
+// +stateify transparent
+type aioMappableRefs struct{ refs.Refs[aioMappable] }
 
 var aioRingBufferSize = uint64(hostarch.Addr(linux.AIORingSize).MustRoundUp())
 

--- a/pkg/sentry/mm/special_mappable.go
+++ b/pkg/sentry/mm/special_mappable.go
@@ -18,6 +18,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
 )
@@ -29,12 +30,15 @@ import (
 //
 // +stateify savable
 type SpecialMappable struct {
-	SpecialMappableRefs
+	specialMappableRefs
 
 	mf   *pgalloc.MemoryFile `state:"nosave"`
 	fr   memmap.FileRange
 	name string
 }
+
+// +stateify transparent
+type specialMappableRefs struct{ refs.Refs[SpecialMappable] }
 
 // NewSpecialMappable returns a SpecialMappable that owns fr, which represents
 // offsets in mfp.MemoryFile() that contain the SpecialMappable's data. The
@@ -49,7 +53,7 @@ func NewSpecialMappable(name string, mf *pgalloc.MemoryFile, fr memmap.FileRange
 
 // DecRef implements refs.RefCounter.DecRef.
 func (m *SpecialMappable) DecRef(ctx context.Context) {
-	m.SpecialMappableRefs.DecRef(func() {
+	m.specialMappableRefs.DecRef(func() {
 		m.mf.DecRef(m.fr)
 	})
 }

--- a/pkg/sentry/platform/systrap/BUILD
+++ b/pkg/sentry/platform/systrap/BUILD
@@ -18,17 +18,6 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "subprocess_refs",
-    out = "subprocess_refs.go",
-    package = "systrap",
-    prefix = "subprocess",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "subprocess",
-    },
-)
-
 go_library(
     name = "systrap",
     srcs = [
@@ -54,7 +43,6 @@ go_library(
         "subprocess_linux.go",
         "subprocess_linux_unsafe.go",
         "subprocess_pool.go",
-        "subprocess_refs.go",
         "subprocess_unsafe.go",
         "syscall_thread.go",
         "syscall_thread_amd64.go",

--- a/pkg/sentry/platform/systrap/subprocess.go
+++ b/pkg/sentry/platform/systrap/subprocess.go
@@ -28,6 +28,7 @@ import (
 	"gvisor.dev/gvisor/pkg/hostsyscall"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/pool"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/seccomp"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
@@ -179,6 +180,9 @@ type subprocess struct {
 	// dead indicates whether the subprocess is alive or not.
 	dead atomicbitops.Bool
 }
+
+// +stateify transparent
+type subprocessRefs struct{ refs.Refs[subprocess] }
 
 var seccompNotifyIsSupported = false
 

--- a/pkg/sentry/socket/unix/BUILD
+++ b/pkg/sentry/socket/unix/BUILD
@@ -1,27 +1,14 @@
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
     default_applicable_licenses = ["//:license"],
     licenses = ["notice"],
 )
 
-go_template_instance(
-    name = "socket_refs",
-    out = "socket_refs.go",
-    package = "unix",
-    prefix = "socket",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "Socket",
-    },
-)
-
 go_library(
     name = "unix",
     srcs = [
         "io.go",
-        "socket_refs.go",
         "unix.go",
     ],
     visibility = ["//pkg/sentry:internal"],

--- a/pkg/sentry/socket/unix/transport/BUILD
+++ b/pkg/sentry/socket/unix/transport/BUILD
@@ -43,28 +43,6 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "queue_refs",
-    out = "queue_refs.go",
-    package = "transport",
-    prefix = "queue",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "queue",
-    },
-)
-
-go_template_instance(
-    name = "host_connected_endpoint_refs",
-    out = "host_connected_endpoint_refs.go",
-    package = "transport",
-    prefix = "HostConnectedEndpoint",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "HostConnectedEndpoint",
-    },
-)
-
 go_library(
     name = "transport",
     srcs = [
@@ -74,12 +52,10 @@ go_library(
         "connectionless_state.go",
         "endpoint_mutex.go",
         "host.go",
-        "host_connected_endpoint_refs.go",
         "host_iovec.go",
         "host_unsafe.go",
         "queue.go",
         "queue_mutex.go",
-        "queue_refs.go",
         "save_restore.go",
         "stream_queue_receiver_mutex.go",
         "transport_message_list.go",

--- a/pkg/sentry/socket/unix/transport/host.go
+++ b/pkg/sentry/socket/unix/transport/host.go
@@ -24,6 +24,7 @@ import (
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/fdnotifier"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/syserr"
 	"gvisor.dev/gvisor/pkg/tcpip"
@@ -61,7 +62,7 @@ func (c *SCMRights) Release(ctx context.Context) {
 //
 // +stateify savable
 type HostConnectedEndpoint struct {
-	HostConnectedEndpointRefs
+	hostConnectedEndpointRefs
 
 	// mu protects fd below.
 	mu sync.RWMutex `state:"nosave"`
@@ -88,6 +89,11 @@ type HostConnectedEndpoint struct {
 
 	// wrShutdown is true if transmissions have been shutdown with SHUT_WR.
 	wrShutdown atomicbitops.Bool
+}
+
+// +stateify transparent
+type hostConnectedEndpointRefs struct {
+	refs.Refs[HostConnectedEndpoint]
 }
 
 // init performs initialization required for creating new
@@ -149,7 +155,7 @@ func NewHostConnectedEndpoint(hostFD int, addr string) (*HostConnectedEndpoint, 
 		return nil, err
 	}
 
-	// HostConnectedEndpointRefs start off with a single reference. We need two.
+	// hostConnectedEndpointRefs start off with a single reference. We need two.
 	e.IncRef()
 	return &e, nil
 }

--- a/pkg/sentry/socket/unix/transport/queue.go
+++ b/pkg/sentry/socket/unix/transport/queue.go
@@ -17,6 +17,7 @@ package transport
 import (
 	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/syserr"
 	"gvisor.dev/gvisor/pkg/waiter"
 )
@@ -37,6 +38,9 @@ type queue struct {
 	limit    int64
 	dataList messageList
 }
+
+// +stateify transparent
+type queueRefs struct{ refs.Refs[queue] }
 
 // Close closes q for reading and writing. It is immediately not writable and
 // will become unreadable when no more data is pending.

--- a/pkg/sentry/socket/unix/unix.go
+++ b/pkg/sentry/socket/unix/unix.go
@@ -28,6 +28,7 @@ import (
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/marshal"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sockfs"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
@@ -66,6 +67,9 @@ type Socket struct {
 	abstractName  string
 	abstractBound bool
 }
+
+// +stateify transparent
+type socketRefs struct{ refs.Refs[Socket] }
 
 var _ = socket.Socket(&Socket{})
 

--- a/pkg/sentry/vfs/BUILD
+++ b/pkg/sentry/vfs/BUILD
@@ -88,39 +88,6 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "file_description_refs",
-    out = "file_description_refs.go",
-    package = "vfs",
-    prefix = "FileDescription",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "FileDescription",
-    },
-)
-
-go_template_instance(
-    name = "mount_namespace_refs",
-    out = "mount_namespace_refs.go",
-    package = "vfs",
-    prefix = "namespace",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "MountNamespace",
-    },
-)
-
-go_template_instance(
-    name = "filesystem_refs",
-    out = "filesystem_refs.go",
-    package = "vfs",
-    prefix = "Filesystem",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "Filesystem",
-    },
-)
-
 proto_library(
     name = "events",
     srcs = ["events.proto"],
@@ -143,10 +110,8 @@ go_library(
         "event_list.go",
         "file_description.go",
         "file_description_impl_util.go",
-        "file_description_refs.go",
         "filesystem.go",
         "filesystem_impl_util.go",
-        "filesystem_refs.go",
         "filesystem_type.go",
         "inotify.go",
         "inotify_event_mutex.go",
@@ -154,7 +119,6 @@ go_library(
         "lock.go",
         "mount.go",
         "mount_list.go",
-        "mount_namespace_refs.go",
         "mount_ring.go",
         "mount_unsafe.go",
         "namespace.go",

--- a/pkg/sentry/vfs/namespace.go
+++ b/pkg/sentry/vfs/namespace.go
@@ -94,6 +94,9 @@ type namespaceDefaultRefs struct {
 	destroy func(ctx context.Context)
 }
 
+// +stateify transparent
+type namespaceRefs struct{ refs.Refs[MountNamespace] }
+
 func (r *namespaceDefaultRefs) DecRef(ctx context.Context) {
 	r.namespaceRefs.DecRef(
 		func() {

--- a/pkg/tcpip/link/tun/BUILD
+++ b/pkg/tcpip/link/tun/BUILD
@@ -1,21 +1,9 @@
 load("//pkg/sync/locking:locking.bzl", "declare_mutex", "declare_rwmutex")
 load("//tools:defs.bzl", "go_library")
-load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
     default_applicable_licenses = ["//:license"],
     licenses = ["notice"],
-)
-
-go_template_instance(
-    name = "tun_endpoint_refs",
-    out = "tun_endpoint_refs.go",
-    package = "tun",
-    prefix = "tunEndpoint",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "tunEndpoint",
-    },
 )
 
 declare_rwmutex(
@@ -39,7 +27,6 @@ go_library(
         "device_mutex.go",
         "endpoint_mutex.go",
         "protocol.go",
-        "tun_endpoint_refs.go",
         "tun_unsafe.go",
     ],
     visibility = ["//visibility:public"],

--- a/pkg/tcpip/link/tun/device.go
+++ b/pkg/tcpip/link/tun/device.go
@@ -20,6 +20,7 @@ import (
 	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
@@ -371,6 +372,9 @@ type tunEndpoint struct {
 	persistent    bool
 	closed        bool
 }
+
+// +stateify transparent
+type tunEndpointRefs struct{ refs.Refs[tunEndpoint] }
 
 func (e *tunEndpoint) setPersistent(v bool) {
 	e.mu.Lock()

--- a/pkg/tcpip/stack/BUILD
+++ b/pkg/tcpip/stack/BUILD
@@ -179,33 +179,10 @@ go_template_instance(
     },
 )
 
-go_template_instance(
-    name = "packet_buffer_refs",
-    out = "packet_buffer_refs.go",
-    package = "stack",
-    prefix = "packetBuffer",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "PacketBuffer",
-    },
-)
-
-go_template_instance(
-    name = "address_state_refs",
-    out = "address_state_refs.go",
-    package = "stack",
-    prefix = "addressState",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "addressState",
-    },
-)
-
 go_library(
     name = "stack",
     srcs = [
         "address_state_mutex.go",
-        "address_state_refs.go",
         "addressable_endpoint_state.go",
         "addressable_endpoint_state_mutex.go",
         "bridge.go",
@@ -237,7 +214,6 @@ go_library(
         "nud.go",
         "packet_buffer.go",
         "packet_buffer_list.go",
-        "packet_buffer_refs.go",
         "packet_buffer_unsafe.go",
         "packet_endpoint_list_mutex.go",
         "packet_eps_mutex.go",

--- a/pkg/tcpip/stack/addressable_endpoint_state.go
+++ b/pkg/tcpip/stack/addressable_endpoint_state.go
@@ -17,6 +17,7 @@ package stack
 import (
 	"fmt"
 
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 )
@@ -768,6 +769,9 @@ type addressState struct {
 	// checklocks:mu
 	disp AddressDispatcher
 }
+
+// +stateify transparent
+type addressStateRefs struct{ refs.Refs[addressState] }
 
 // AddressWithPrefix implements AddressEndpoint.
 func (a *addressState) AddressWithPrefix() tcpip.AddressWithPrefix {

--- a/pkg/tcpip/stack/packet_buffer.go
+++ b/pkg/tcpip/stack/packet_buffer.go
@@ -18,6 +18,7 @@ import (
 	"io"
 
 	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
@@ -167,6 +168,9 @@ type PacketBuffer struct {
 	// referenced (released back to the pool).
 	onRelease func() `state:"nosave"`
 }
+
+// +stateify transparent
+type packetBufferRefs struct{ refs.Refs[PacketBuffer] }
 
 // NewPacketBuffer creates a new PacketBuffer with opts.
 func NewPacketBuffer(opts PacketBufferOptions) *PacketBuffer {

--- a/pkg/tcpip/transport/tcp/BUILD
+++ b/pkg/tcpip/transport/tcp/BUILD
@@ -118,17 +118,6 @@ go_template_instance(
 )
 
 go_template_instance(
-    name = "tcp_segment_refs",
-    out = "tcp_segment_refs.go",
-    package = "tcp",
-    prefix = "segment",
-    template = "//pkg/refs:refs_template",
-    types = {
-        "T": "segment",
-    },
-)
-
-go_template_instance(
     name = "tcp_endpoint_list",
     out = "tcp_endpoint_list.go",
     package = "tcp",
@@ -182,7 +171,6 @@ go_library(
         "state.go",
         "tcp_endpoint_list.go",
         "tcp_segment_list.go",
-        "tcp_segment_refs.go",
         "timer.go",
     ],
     visibility = ["//visibility:public"],

--- a/pkg/tcpip/transport/tcp/segment.go
+++ b/pkg/tcpip/transport/tcp/segment.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
@@ -91,6 +92,9 @@ type segment struct {
 	// lost indicates if the segment is marked as lost by RACK.
 	lost bool
 }
+
+// +stateify transparent
+type segmentRefs struct{ refs.Refs[segment] }
 
 func newIncomingSegment(id stack.TransportEndpointID, clock tcpip.Clock, pkt *stack.PacketBuffer) (*segment, error) {
 	hdr := header.TCP(pkt.TransportHeader().Slice())

--- a/tools/go_stateify/test/BUILD
+++ b/tools/go_stateify/test/BUILD
@@ -1,0 +1,27 @@
+load("//tools:defs.bzl", "go_library", "go_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "test",
+    testonly = True,
+    srcs = ["transparent.go"],
+    deps = [
+        "//pkg/state",
+        "//tools/go_stateify/test/external",
+    ],
+)
+
+go_test(
+    name = "transparent_test",
+    size = "small",
+    srcs = ["transparent_test.go"],
+    library = ":test",
+    deps = [
+        "//pkg/state",
+        "//tools/go_stateify/test/external",
+    ],
+)

--- a/tools/go_stateify/test/external/BUILD
+++ b/tools/go_stateify/test/external/BUILD
@@ -1,0 +1,15 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "external",
+    srcs = ["external.go"],
+    visibility = ["//tools/go_stateify/test:__pkg__"],
+    deps = [
+        "//pkg/state",
+    ],
+)

--- a/tools/go_stateify/test/external/external.go
+++ b/tools/go_stateify/test/external/external.go
@@ -1,0 +1,23 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package external contains types for cross-package stateify tests.
+package external
+
+// Box is a generic type for testing.
+//
+// +stateify savable
+type Box[T any] struct {
+	Value T
+}

--- a/tools/go_stateify/test/transparent.go
+++ b/tools/go_stateify/test/transparent.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test contains data structures for testing the go_stateify tool.
+package test
+
+import (
+	"context"
+
+	"gvisor.dev/gvisor/tools/go_stateify/test/external"
+)
+
+// +stateify savable
+type box[T any] struct {
+	Value T
+}
+
+// +stateify transparent
+type intBox struct {
+	box[int]
+}
+
+// +stateify transparent
+type externalIntBox struct {
+	external.Box[int]
+}
+
+// +stateify savable
+type plainBox struct {
+	Value int
+}
+
+// +stateify transparent
+type plainBoxWrapper struct {
+	plainBox
+}
+
+// +stateify savable
+type embeddedExternal struct {
+	external.Box[int]
+}
+
+// afterLoad exists to exercise receiver parsing for parenthesized generics.
+func (s *(singleParamBox[T])) afterLoad(context.Context) {}
+
+// +stateify savable
+type singleParamBox[T any] struct {
+	Value T
+}

--- a/tools/go_stateify/test/transparent_test.go
+++ b/tools/go_stateify/test/transparent_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"slices"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/state"
+	"gvisor.dev/gvisor/tools/go_stateify/test/external"
+)
+
+func TestTransparentWrapperRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	original := intBox{box[int]{Value: 42}}
+	if got, want := original.StateTypeName(), "tools/go_stateify/test.intBox"; got != want {
+		t.Fatalf("StateTypeName()=%q, want %q", got, want)
+	}
+	if got, want := original.StateFields(), []string{"Value"}; !slices.Equal(got, want) {
+		t.Fatalf("StateFields()=%q, want %q", got, want)
+	}
+
+	var buf bytes.Buffer
+	if _, err := state.Save(ctx, &buf, &original); err != nil {
+		t.Fatalf("Save failed: %s", err)
+	}
+
+	var restored intBox
+	if _, err := state.Load(ctx, &buf, &restored); err != nil {
+		t.Fatalf("Load failed: %s", err)
+	}
+	if restored.Value != original.Value {
+		t.Fatalf("restored.Value=%d, want %d", restored.Value, original.Value)
+	}
+}
+
+func TestTransparentWrapperCrossPackage(t *testing.T) {
+	ctx := context.Background()
+	original := externalIntBox{external.Box[int]{Value: 7}}
+	if got, want := original.StateTypeName(), "tools/go_stateify/test.externalIntBox"; got != want {
+		t.Fatalf("StateTypeName()=%q, want %q", got, want)
+	}
+	if got, want := original.StateFields(), []string{"Value"}; !slices.Equal(got, want) {
+		t.Fatalf("StateFields()=%q, want %q", got, want)
+	}
+
+	var buf bytes.Buffer
+	if _, err := state.Save(ctx, &buf, &original); err != nil {
+		t.Fatalf("Save failed: %s", err)
+	}
+
+	var restored externalIntBox
+	if _, err := state.Load(ctx, &buf, &restored); err != nil {
+		t.Fatalf("Load failed: %s", err)
+	}
+	if restored.Value != original.Value {
+		t.Fatalf("restored.Value=%d, want %d", restored.Value, original.Value)
+	}
+}
+
+func TestTransparentWrapperPlain(t *testing.T) {
+	ctx := context.Background()
+	original := plainBoxWrapper{plainBox{Value: 5}}
+	if got, want := original.StateTypeName(), "tools/go_stateify/test.plainBoxWrapper"; got != want {
+		t.Fatalf("StateTypeName()=%q, want %q", got, want)
+	}
+	if got, want := original.StateFields(), []string{"Value"}; !slices.Equal(got, want) {
+		t.Fatalf("StateFields()=%q, want %q", got, want)
+	}
+
+	var buf bytes.Buffer
+	if _, err := state.Save(ctx, &buf, &original); err != nil {
+		t.Fatalf("Save failed: %s", err)
+	}
+
+	var restored plainBoxWrapper
+	if _, err := state.Load(ctx, &buf, &restored); err != nil {
+		t.Fatalf("Load failed: %s", err)
+	}
+	if restored.Value != original.Value {
+		t.Fatalf("restored.Value=%d, want %d", restored.Value, original.Value)
+	}
+}


### PR DESCRIPTION
Replace generated reference counters with refs.Refs[T] and refs.LoggedRefs[T], making their definitions available to ordinary Go tooling. Add generic-type support to go_stateify and transparent wrappers that give each instantiated counter a registered state type.

The effect of the generic logging policy on generated code remains an open review concern.

Assisted-by: Codex (description)