### PR TITLE
test/runtimes: Add runsc to runfiles

### DIFF
--- a/test/runtimes/defs.bzl
+++ b/test/runtimes/defs.bzl
@@ -30,7 +30,7 @@ def _runtime_test_impl(ctx):
     return [DefaultInfo(
         executable = runner,
         runfiles = ctx.runfiles(
-            files = ctx.files._runner + ctx.files.exclude_file + ctx.files._proctor,
+            files = ctx.files._runner + ctx.files.exclude_file + ctx.files._proctor + ctx.files._runsc,
             collect_default = True,
             collect_data = True,
         ),


### PR DESCRIPTION
The runtime_test rule depends on runsc, but runsc was not included in the runfiles. This meant that changes to runsc did not invalidate the Bazel cache for runtime tests.

By adding runsc to runfiles, Bazel correctly identifies it as an input and will re-execute the tests when the runsc binary changes.