### PR TITLE
atomicptr: use atomic.Pointer

### DIFF
--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -9,7 +9,7 @@ package(
 
 go_template_instance(
     name = "atomicptr_bucket_slice",
-    out = "atomicptr_bucket_slice_unsafe.go",
+    out = "atomicptr_bucket_slice.go",
     package = "kernel",
     prefix = "descriptorBucketSlice",
     template = "//pkg/sync/atomicptr:generic_atomicptr",
@@ -20,7 +20,7 @@ go_template_instance(
 
 go_template_instance(
     name = "atomicptr_bucket",
-    out = "atomicptr_bucket_unsafe.go",
+    out = "atomicptr_bucket.go",
     package = "kernel",
     prefix = "descriptorBucket",
     template = "//pkg/sync/atomicptr:generic_atomicptr",
@@ -31,7 +31,7 @@ go_template_instance(
 
 go_template_instance(
     name = "atomicptr_descriptor",
-    out = "atomicptr_descriptor_unsafe.go",
+    out = "atomicptr_descriptor.go",
     package = "kernel",
     prefix = "descriptor",
     template = "//pkg/sync/atomicptr:generic_atomicptr",
@@ -42,7 +42,7 @@ go_template_instance(
 
 go_template_instance(
     name = "atomicptr_fscontext",
-    out = "atomicptr_fscontext_unsafe.go",
+    out = "atomicptr_fscontext.go",
     package = "kernel",
     prefix = "fsContext",
     template = "//pkg/sync/atomicptr:generic_atomicptr",
@@ -240,9 +240,9 @@ go_library(
     name = "kernel",
     srcs = [
         "aio.go",
-        "atomicptr_bucket_slice_unsafe.go",
-        "atomicptr_bucket_unsafe.go",
-        "atomicptr_descriptor_unsafe.go",
+        "atomicptr_bucket.go",
+        "atomicptr_bucket_slice.go",
+        "atomicptr_descriptor.go",
         "cgroup.go",
         "cgroup_mounts_mutex.go",
         "cgroup_mutex.go",

--- a/pkg/sentry/kernel/auth/BUILD
+++ b/pkg/sentry/kernel/auth/BUILD
@@ -9,7 +9,7 @@ package(
 
 go_template_instance(
     name = "atomicptr_credentials",
-    out = "atomicptr_credentials_unsafe.go",
+    out = "atomicptr_credentials.go",
     package = "auth",
     suffix = "Credentials",
     template = "//pkg/sync/atomicptr:generic_atomicptr",
@@ -71,7 +71,7 @@ declare_mutex(
 go_library(
     name = "auth",
     srcs = [
-        "atomicptr_credentials_unsafe.go",
+        "atomicptr_credentials.go",
         "auth.go",
         "capability_set.go",
         "context.go",

--- a/pkg/sentry/kernel/futex/BUILD
+++ b/pkg/sentry/kernel/futex/BUILD
@@ -19,7 +19,7 @@ declare_mutex(
 
 go_template_instance(
     name = "atomicptr_bucket",
-    out = "atomicptr_bucket_unsafe.go",
+    out = "atomicptr_bucket.go",
     package = "futex",
     suffix = "Bucket",
     template = "//pkg/sync/atomicptr:generic_atomicptr",
@@ -43,7 +43,7 @@ go_template_instance(
 go_library(
     name = "futex",
     srcs = [
-        "atomicptr_bucket_unsafe.go",
+        "atomicptr_bucket.go",
         "futex.go",
         "futex_mutex.go",
         "waiter_list.go",

--- a/pkg/sentry/platform/kvm/BUILD
+++ b/pkg/sentry/platform/kvm/BUILD
@@ -8,7 +8,7 @@ package(
 
 go_template_instance(
     name = "atomicptr_machine",
-    out = "atomicptr_machine_unsafe.go",
+    out = "atomicptr_machine.go",
     package = "kvm",
     prefix = "machine",
     template = "//pkg/sync/atomicptr:generic_atomicptr",
@@ -30,7 +30,7 @@ go_library(
         "address_space.go",
         "address_space_amd64.go",
         "address_space_arm64.go",
-        "atomicptr_machine_unsafe.go",
+        "atomicptr_machine.go",
         "bluepill.go",
         "bluepill_allocator.go",
         "bluepill_amd64.go",

--- a/pkg/sync/atomicptr/BUILD
+++ b/pkg/sync/atomicptr/BUILD
@@ -8,7 +8,7 @@ package(
 
 go_template(
     name = "generic_atomicptr",
-    srcs = ["generic_atomicptr_unsafe.go"],
+    srcs = ["generic_atomicptr.go"],
     types = [
         "Value",
     ],
@@ -17,7 +17,7 @@ go_template(
 
 go_template_instance(
     name = "atomicptr_int",
-    out = "atomicptr_int_unsafe.go",
+    out = "atomicptr_int.go",
     package = "atomicptr",
     suffix = "Int",
     template = ":generic_atomicptr",
@@ -28,7 +28,7 @@ go_template_instance(
 
 go_library(
     name = "atomicptr",
-    srcs = ["atomicptr_int_unsafe.go"],
+    srcs = ["atomicptr_int.go"],
 )
 
 go_test(

--- a/tools/go_generics/tests/typeparams/BUILD
+++ b/tools/go_generics/tests/typeparams/BUILD
@@ -1,0 +1,19 @@
+load("//tools/go_generics/tests:defs.bzl", "go_generics_test")
+
+package(default_applicable_licenses = ["//:license"])
+
+go_generics_test(
+    name = "typeparams",
+    inputs = ["input.go"],
+    output = "output.go",
+    package = "tests",
+    types = {
+        "T": "MyT",
+    },
+)
+
+# @unused
+glaze_ignore = [
+    "input.go",
+    "output.go",
+]

--- a/tools/go_generics/tests/typeparams/input.go
+++ b/tools/go_generics/tests/typeparams/input.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+type Number interface {
+	~int | ~int64
+}
+
+type T struct{}
+
+type Box[T any] struct {
+	v T
+}
+
+func (b Box[T]) Get() T {
+	return b.v
+}
+
+func Use[T Number](v T) Box[T] {
+	return Box[T]{v: v}
+}
+
+func UseGlobal(x T) T {
+	return x
+}
+
+type Pair[A, B any] struct {
+	first  A
+	second B
+}
+
+var _ = Pair[int, string]{}
+var _ = Box[int]{}
+var _ = Use[int](1)

--- a/tools/go_generics/tests/typeparams/output.go
+++ b/tools/go_generics/tests/typeparams/output.go
@@ -1,0 +1,30 @@
+package tests
+
+type Number interface {
+	~int | ~int64
+}
+
+type Box[T any] struct {
+	v T
+}
+
+func (b Box[T]) Get() T {
+	return b.v
+}
+
+func Use[T Number](v T) Box[T] {
+	return Box[T]{v: v}
+}
+
+func UseGlobal(x MyT) MyT {
+	return x
+}
+
+type Pair[A, B any] struct {
+	first  A
+	second B
+}
+
+var _ = Pair[int, string]{}
+var _ = Box[int]{}
+var _ = Use[int](1)


### PR DESCRIPTION
Replace unsafe.Pointer and its casts in the atomicptr template with atomic.Pointer. Teach go_generics to handle type parameters and instantiated types so it can generate these wrappers.

The wrappers remain because go_stateify does not yet support generic types directly.

Assisted-by: Codex (description)