### PR TITLE
Sentry: Add support for sysfs osrelease

### DIFF
--- a/pkg/sentry/fsimpl/proc/BUILD
+++ b/pkg/sentry/fsimpl/proc/BUILD
@@ -107,6 +107,7 @@ go_library(
         "//pkg/sentry/inet",
         "//pkg/sentry/kernel",
         "//pkg/sentry/kernel/auth",
+        "//pkg/sentry/kernel/version",
         "//pkg/sentry/ktime",
         "//pkg/sentry/limits",
         "//pkg/sentry/mm",

--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -30,6 +30,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/inet"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/version"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
@@ -69,6 +70,9 @@ func (fs *filesystem) newSysDir(ctx context.Context, root *auth.Credentials, k *
 			"keys": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 				"maxkeys": fs.newMaxKeySizeFile(ctx, k, root),
 			}),
+			"osrelease": fs.newInode(ctx, root, 0444, newStaticFile(version.LinuxRelease)),
+			"ostype":    fs.newInode(ctx, root, 0444, newStaticFile(version.LinuxSysname)),
+			"version":   fs.newInode(ctx, root, 0444, newStaticFile(version.LinuxVersion)),
 		}),
 		"fs": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 			"nr_open": fs.newInode(ctx, root, 0644, &atomicInt32File{val: &k.MaxFDLimit, min: 8, max: kernel.MaxFdLimit}),

--- a/pkg/sentry/kernel/version/BUILD
+++ b/pkg/sentry/kernel/version/BUILD
@@ -1,0 +1,14 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "version",
+    srcs = [
+        "version.go",
+    ],
+    visibility = ["//pkg/sentry:internal"],
+)

--- a/pkg/sentry/kernel/version/version.go
+++ b/pkg/sentry/kernel/version/version.go
@@ -1,0 +1,27 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package version holds the kernel versioning information.
+package version
+
+const (
+	// LinuxSysname is the OS name advertised by gVisor.
+	LinuxSysname = "Linux"
+
+	// LinuxRelease is the Linux release version number advertised by gVisor.
+	LinuxRelease = "4.4.0"
+
+	// LinuxVersion is the version info advertised by gVisor.
+	LinuxVersion = "#1 SMP Sun Jan 10 15:06:54 PST 2016"
+)

--- a/pkg/sentry/syscalls/linux/BUILD
+++ b/pkg/sentry/syscalls/linux/BUILD
@@ -102,6 +102,7 @@ go_library(
         "//pkg/sentry/kernel/pipe",
         "//pkg/sentry/kernel/sched",
         "//pkg/sentry/kernel/shm",
+        "//pkg/sentry/kernel/version",
         "//pkg/sentry/ktime",
         "//pkg/sentry/limits",
         "//pkg/sentry/memmap",

--- a/pkg/sentry/syscalls/linux/linux64.go
+++ b/pkg/sentry/syscalls/linux/linux64.go
@@ -22,18 +22,8 @@ import (
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/version"
 	"gvisor.dev/gvisor/pkg/sentry/syscalls"
-)
-
-const (
-	// LinuxSysname is the OS name advertised by gVisor.
-	LinuxSysname = "Linux"
-
-	// LinuxRelease is the Linux release version number advertised by gVisor.
-	LinuxRelease = "4.4.0"
-
-	// LinuxVersion is the version info advertised by gVisor.
-	LinuxVersion = "#1 SMP Sun Jan 10 15:06:54 PST 2016"
 )
 
 // AMD64 is a table of Linux amd64 syscall API with the corresponding syscall
@@ -46,9 +36,9 @@ var AMD64 = &kernel.SyscallTable{
 		// guides the interface provided by this syscall table. The build
 		// version is that for a clean build with default kernel config, at 5
 		// minutes after v4.4 was tagged.
-		Sysname: LinuxSysname,
-		Release: LinuxRelease,
-		Version: LinuxVersion,
+		Sysname: version.LinuxSysname,
+		Release: version.LinuxRelease,
+		Version: version.LinuxVersion,
 	},
 	AuditNumber: linux.AUDIT_ARCH_X86_64,
 	Table: map[uintptr]kernel.Syscall{
@@ -425,9 +415,9 @@ var ARM64 = &kernel.SyscallTable{
 	OS:   abi.Linux,
 	Arch: arch.ARM64,
 	Version: kernel.Version{
-		Sysname: LinuxSysname,
-		Release: LinuxRelease,
-		Version: LinuxVersion,
+		Sysname: version.LinuxSysname,
+		Release: version.LinuxRelease,
+		Version: version.LinuxVersion,
 	},
 	AuditNumber: linux.AUDIT_ARCH_AARCH64,
 	Table: map[uintptr]kernel.Syscall{


### PR DESCRIPTION
The linux kernel outputs the current release version to `/proc/sys/kernel/osrelease`. Some libraries read this file to determine which features to enable. Implement the `osrelease`, `ostype`, `version` files to match what is returned for uname.

Fixes: #12487