### PR TITLE
runsc: support multiple image layers as rootfs

### DIFF
--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -344,6 +344,10 @@ type StartArgs struct {
 	// for bind mounts in Spec.Mounts (in the same order).
 	GoferMountConfs []GoferMountConf
 
+	// NumRootfsGoferFDs is the number of gofer FDs for rootfs. This is typically 1,
+	// but can be more when rootfs uses multiple lower directories for overlayfs.
+	NumRootfsGoferFDs int
+
 	// IsRootfsUpperTarFilePresent indicates whether the rootfs upper tar file is present.
 	IsRootfsUpperTarFilePresent bool
 

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -492,6 +492,12 @@ func (s *Sandbox) StartSubcontainer(spec *specs.Spec, conf *config.Config, cid s
 	}
 	payload.Files = append(payload.Files, goferFiles...)
 
+	// Calculate number of rootfs gofer FDs
+	numRootfsGoferFDs := 1 // Default to 1
+	if rootfsHint, err := boot.NewRootfsHint(spec); err == nil && rootfsHint != nil && len(rootfsHint.LowerDirs) > 0 {
+		numRootfsGoferFDs = len(rootfsHint.LowerDirs)
+	}
+
 	// Start running the container.
 	args := boot.StartArgs{
 		Spec:                        spec,
@@ -500,6 +506,7 @@ func (s *Sandbox) StartSubcontainer(spec *specs.Spec, conf *config.Config, cid s
 		NumGoferFilestoreFDs:        len(goferFilestores),
 		IsDevIoFilePresent:          devIOFile != nil,
 		GoferMountConfs:             goferConfs,
+		NumRootfsGoferFDs:           numRootfsGoferFDs,
 		IsRootfsUpperTarFilePresent: rootfsUpperTarFile != nil,
 		FilePayload:                 payload,
 	}
@@ -617,6 +624,12 @@ func (s *Sandbox) RestoreSubcontainer(spec *specs.Spec, conf *config.Config, cid
 	}
 	payload.Files = append(payload.Files, goferFiles...)
 
+	// Calculate number of rootfs gofer FDs
+	numRootfsGoferFDs := 1 // Default to 1
+	if rootfsHint, err := boot.NewRootfsHint(spec); err == nil && rootfsHint != nil && len(rootfsHint.LowerDirs) > 0 {
+		numRootfsGoferFDs = len(rootfsHint.LowerDirs)
+	}
+
 	// Start running the container.
 	args := boot.StartArgs{
 		Spec:                 spec,
@@ -625,6 +638,7 @@ func (s *Sandbox) RestoreSubcontainer(spec *specs.Spec, conf *config.Config, cid
 		NumGoferFilestoreFDs: len(goferFilestoreFiles),
 		IsDevIoFilePresent:   devIOFile != nil,
 		GoferMountConfs:      goferMountConf,
+		NumRootfsGoferFDs:    numRootfsGoferFDs,
 		FilePayload:          payload,
 	}
 	if err := s.call(boot.ContMgrRestoreSubcontainer, &args, nil); err != nil {


### PR DESCRIPTION
Prototype for supporting multiple image layers as rootfs
Creates gofer FD for each image layer and create overlayfs inside sandbox using these layers as lower layer