### PR TITLE
proc: expose dirty/writeback accounting

### DIFF
--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -744,7 +744,7 @@ func (fs *filesystem) Release(ctx context.Context) {
 		}
 		// Discard cached pages.
 		d.inode.cache.DropAll(mf)
-		d.inode.dirty.RemoveAll()
+		d.inode.dirty.RemoveAllAndAccount()
 		d.inode.dataMu.Unlock()
 		// Close host FDs if they exist.
 		d.inode.closeHostFDs()
@@ -1015,7 +1015,7 @@ func (i *inode) destroy(ctx context.Context, d *dentry) {
 	if !i.cache.IsEmpty() {
 		mf.MarkAllUnevictable(i)
 		i.cache.DropAll(mf)
-		i.dirty.RemoveAll()
+		i.dirty.RemoveAllAndAccount()
 	}
 
 	i.dataMu.Unlock()

--- a/pkg/sentry/fsimpl/gofer/regular_file.go
+++ b/pkg/sentry/fsimpl/gofer/regular_file.go
@@ -865,7 +865,7 @@ func (d *dentry) InvalidateUnsavable(ctx context.Context) error {
 	// because per InvalidateUnsavable invariants, no new translations can have
 	// been returned after we invalidated all existing translations above.
 	d.inode.cache.DropAll(mf)
-	d.inode.dirty.RemoveAll()
+	d.inode.dirty.RemoveAllAndAccount()
 
 	return nil
 }

--- a/pkg/sentry/fsimpl/proc/tasks_files.go
+++ b/pkg/sentry/fsimpl/proc/tasks_files.go
@@ -285,6 +285,7 @@ func (*meminfoData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 		// Underflow.
 		memFree = 0
 	}
+	dirty, writeback := usage.DirtyMemoryAccounting.Copy()
 	// We use MemFree as MemAvailable because we don't swap.
 	// TODO(rahat): When reclaim is implemented the value of MemAvailable
 	// should change.
@@ -304,8 +305,8 @@ func (*meminfoData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	fmt.Fprintf(buf, "Mlocked:               0 kB\n") // TODO(b/31823263)
 	fmt.Fprintf(buf, "SwapTotal:             0 kB\n")
 	fmt.Fprintf(buf, "SwapFree:              0 kB\n")
-	fmt.Fprintf(buf, "Dirty:                 0 kB\n")
-	fmt.Fprintf(buf, "Writeback:             0 kB\n")
+	fmt.Fprintf(buf, "Dirty:          %8d kB\n", dirty/1024)
+	fmt.Fprintf(buf, "Writeback:      %8d kB\n", writeback/1024)
 	fmt.Fprintf(buf, "AnonPages:      %8d kB\n", anon/1024)
 	fmt.Fprintf(buf, "Mapped:         %8d kB\n", file/1024) // doesn't count mapped tmpfs, which we don't know
 	fmt.Fprintf(buf, "Shmem:          %8d kB\n", snapshot.Tmpfs/1024)

--- a/pkg/sentry/fsutil/BUILD
+++ b/pkg/sentry/fsutil/BUILD
@@ -160,5 +160,6 @@ go_test(
     deps = [
         "//pkg/hostarch",
         "//pkg/sentry/memmap",
+        "//pkg/sentry/usage",
     ],
 )

--- a/pkg/sentry/fsutil/dirty_set_test.go
+++ b/pkg/sentry/fsutil/dirty_set_test.go
@@ -20,6 +20,7 @@ import (
 
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
 )
 
 func TestDirtySet(t *testing.T) {
@@ -32,5 +33,53 @@ func TestDirtySet(t *testing.T) {
 	}
 	if got := set.ExportSlice(); !slices.Equal(got, want) {
 		t.Errorf("set:\n\tgot %v,\n\twant %v", got, want)
+	}
+}
+
+func TestDirtySetAccounting(t *testing.T) {
+	// Reset accounting for this test
+	initialDirty, _ := usage.DirtyMemoryAccounting.Copy()
+
+	var set DirtySet
+
+	// Mark 2 pages dirty - should increment dirty counter
+	set.MarkDirty(memmap.MappableRange{0, 2 * hostarch.PageSize})
+	dirty, _ := usage.DirtyMemoryAccounting.Copy()
+	expectedDirty := initialDirty + 2*hostarch.PageSize
+	if dirty != expectedDirty {
+		t.Errorf("after MarkDirty: dirty = %d, want %d", dirty, expectedDirty)
+	}
+
+	// Mark overlapping range dirty - should not double-count
+	set.MarkDirty(memmap.MappableRange{0, hostarch.PageSize})
+	dirty, _ = usage.DirtyMemoryAccounting.Copy()
+	if dirty != expectedDirty {
+		t.Errorf("after overlapping MarkDirty: dirty = %d, want %d", dirty, expectedDirty)
+	}
+
+	// Mark 1 more page dirty
+	set.MarkDirty(memmap.MappableRange{2 * hostarch.PageSize, 3 * hostarch.PageSize})
+	dirty, _ = usage.DirtyMemoryAccounting.Copy()
+	expectedDirty += hostarch.PageSize
+	if dirty != expectedDirty {
+		t.Errorf("after extending MarkDirty: dirty = %d, want %d", dirty, expectedDirty)
+	}
+
+	// MarkClean should decrement (but not for Keep segments)
+	set.KeepDirty(memmap.MappableRange{hostarch.PageSize, 2 * hostarch.PageSize})
+	set.MarkClean(memmap.MappableRange{0, 3 * hostarch.PageSize})
+	dirty, _ = usage.DirtyMemoryAccounting.Copy()
+	// Only the Keep segment remains, so we lost 2 pages (0-1 and 2-3)
+	expectedDirty -= 2 * hostarch.PageSize
+	if dirty != expectedDirty {
+		t.Errorf("after MarkClean: dirty = %d, want %d", dirty, expectedDirty)
+	}
+
+	// RemoveAllAndAccount should remove remaining
+	set.RemoveAllAndAccount()
+	dirty, _ = usage.DirtyMemoryAccounting.Copy()
+	expectedDirty -= hostarch.PageSize
+	if dirty != expectedDirty {
+		t.Errorf("after RemoveAllAndAccount: dirty = %d, want %d", dirty, expectedDirty)
 	}
 }


### PR DESCRIPTION
Resolves #203 

- Wire meminfo `Dirty`/`Writeback` fields to the dirty/writeback accounting.
- Add global `Dirty`/`Writeback` counters in usage and hook `DirtySet` ops (mark/clean/sync/remove) to update them.
- Adjust gofer cleanup paths to use accounted removal
- Add a unit test for dirty accounting.

## Note
with directfs/InteropModeShared defaults, writes bypass the sandbox cache, so values often remain 0