### PR TITLE
Fix runsc command in installation instructions

### DIFF
--- a/g3doc/user_guide/install.md
+++ b/g3doc/user_guide/install.md
@@ -27,9 +27,9 @@ To download and install the latest release manually follow these steps:
 To install gVisor as a Docker runtime, run the following commands:
 
 ```shell
-$ /usr/local/bin/runsc install
-$ sudo systemctl reload docker
-$ docker run --rm --runtime=runsc hello-world
+sudo /usr/local/bin/runsc install
+sudo systemctl reload docker
+docker run --rm --runtime=runsc hello-world
 ```
 
 For more details about using gVisor with Docker, see


### PR DESCRIPTION
The [installation instructions](https://gvisor.dev/docs/user_guide/install/) for gVisor contain the line `/usr/local/bin/runsc install`, which fails with "Permission denied" error. The more comprehensive [Docker Quick Start](https://gvisor.dev/docs/user_guide/quick_start/docker/) guide recommends `sudo runsc install` instead.

Also removed unnecessary `$` signs.