### PR TITLE
devpts: Support TCGETS2, TCSETS2, TCSETSW2, TCSETSF2

### DIFF
--- a/pkg/abi/linux/ioctl.go
+++ b/pkg/abi/linux/ioctl.go
@@ -19,9 +19,13 @@ package linux
 // These are ordered by request number (low byte).
 const (
 	TCGETS      = 0x00005401
+	TCGETS2     = 0x802c542a
 	TCSETS      = 0x00005402
+	TCSETS2     = 0x402c542b
 	TCSETSW     = 0x00005403
+	TCSETSW2    = 0x402c542c
 	TCSETSF     = 0x00005404
+	TCSETSF2    = 0x402c542d
 	TCSBRK      = 0x00005409
 	TIOCEXCL    = 0x0000540c
 	TIOCNXCL    = 0x0000540d

--- a/pkg/abi/linux/tty.go
+++ b/pkg/abi/linux/tty.go
@@ -54,6 +54,7 @@ type Termios struct {
 // uapi/asm-generic/termbits.h.
 //
 // +stateify savable
+// +marshal
 type KernelTermios struct {
 	_                 structs.HostLayout
 	InputFlags        uint32

--- a/pkg/sentry/fsimpl/devpts/replica.go
+++ b/pkg/sentry/fsimpl/devpts/replica.go
@@ -147,6 +147,8 @@ func (rfd *replicaFileDescription) Ioctl(ctx context.Context, io usermem.IO, sys
 		return 0, rfd.inode.t.ld.inputQueueReadSize(t, io, args)
 	case linux.TCGETS:
 		return rfd.inode.t.ld.getTermios(t, args)
+	case linux.TCGETS2:
+		return rfd.inode.t.ld.getTermios2(t, args)
 	case linux.TCSETS:
 		return rfd.inode.t.ld.setTermios(t, args)
 	case linux.TCSETSW:
@@ -157,6 +159,16 @@ func (rfd *replicaFileDescription) Ioctl(ctx context.Context, io usermem.IO, sys
 		// This should drain the output queue and clear the input queue
 		// first, but we don't implement that yet.
 		return rfd.inode.t.ld.setTermios(t, args)
+	case linux.TCSETS2:
+		return rfd.inode.t.ld.setTermios2(t, args)
+	case linux.TCSETSW2:
+		// Note that this should drain the output queue first, but we
+		// don't implement that yet.
+		return rfd.inode.t.ld.setTermios2(t, args)
+	case linux.TCSETSF2:
+		// This should drain the output queue and clear the input queue
+		// first, but we don't implement that yet.
+		return rfd.inode.t.ld.setTermios2(t, args)
 	case linux.TIOCGPTN:
 		nP := primitive.Uint32(rfd.inode.t.n)
 		_, err := nP.CopyOut(t, args[2].Pointer())

--- a/pkg/sentry/fsimpl/host/ioctl_unsafe.go
+++ b/pkg/sentry/fsimpl/host/ioctl_unsafe.go
@@ -38,6 +38,23 @@ func ioctlSetTermios(fd int, req uint64, t *linux.Termios) error {
 	return nil
 }
 
+func ioctlGetTermios2(fd int) (*linux.KernelTermios, error) {
+	var t linux.KernelTermios
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), linux.TCGETS2, uintptr(unsafe.Pointer(&t)))
+	if errno != 0 {
+		return nil, errno
+	}
+	return &t, nil
+}
+
+func ioctlSetTermios2(fd int, req uint64, t *linux.KernelTermios) error {
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(unsafe.Pointer(t)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
 func ioctlGetWinsize(fd int) (*linux.Winsize, error) {
 	var w linux.Winsize
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), linux.TIOCGWINSZ, uintptr(unsafe.Pointer(&w)))

--- a/runsc/boot/filter/config/config_main.go
+++ b/runsc/boot/filter/config/config_main.go
@@ -144,6 +144,26 @@ var allowedSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
 		},
 		seccomp.PerArg{
 			seccomp.NonNegativeFD{}, /* fd */
+			seccomp.EqualTo(linux.TCGETS2),
+			seccomp.AnyValue{}, /* termios2 struct */
+		},
+		seccomp.PerArg{
+			seccomp.NonNegativeFD{}, /* fd */
+			seccomp.EqualTo(linux.TCSETS2),
+			seccomp.AnyValue{}, /* termios2 struct */
+		},
+		seccomp.PerArg{
+			seccomp.NonNegativeFD{}, /* fd */
+			seccomp.EqualTo(linux.TCSETSF2),
+			seccomp.AnyValue{}, /* termios2 struct */
+		},
+		seccomp.PerArg{
+			seccomp.NonNegativeFD{}, /* fd */
+			seccomp.EqualTo(linux.TCSETSW2),
+			seccomp.AnyValue{}, /* termios2 struct */
+		},
+		seccomp.PerArg{
+			seccomp.NonNegativeFD{}, /* fd */
 			seccomp.EqualTo(linux.TIOCSWINSZ),
 			seccomp.AnyValue{}, /* winsize struct */
 		},

--- a/test/runner/BUILD
+++ b/test/runner/BUILD
@@ -26,6 +26,7 @@ go_binary(
         "//test/runner/gtest",
         "//test/trace/config",
         "//test/uds",
+        "@com_github_kr_pty//:go_default_library",
         "@com_github_moby_sys_capability//:go_default_library",
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",

--- a/test/runner/defs.bzl
+++ b/test/runner/defs.bzl
@@ -71,6 +71,7 @@ def _syscall_test(
         add_host_uds = False,
         add_host_connector = False,
         add_host_fifo = False,
+        add_host_tty = False,
         iouring = False,
         container = None,
         one_sandbox = True,
@@ -167,6 +168,7 @@ def _syscall_test(
         "--add-host-uds=" + str(add_host_uds),
         "--add-host-connector=" + str(add_host_connector),
         "--add-host-fifo=" + str(add_host_fifo),
+        "--add-host-tty=" + str(add_host_tty),
         "--strace=" + str(debug),
         "--debug=" + str(debug),
         "--container=" + str(container),
@@ -208,6 +210,7 @@ def syscall_test_variants(
         add_host_uds = False,
         add_host_connector = False,
         add_host_fifo = False,
+        add_host_tty = False,
         add_hostinet = False,
         add_directfs = True,
         one_sandbox = True,
@@ -236,6 +239,7 @@ def syscall_test_variants(
       add_host_uds: setup bound UDS on the host.
       add_host_connector: setup host threads to connect to bound UDS created by sandbox.
       add_host_fifo: setup FIFO files on the host.
+      add_host_tty: setup host TTY at /dev/tty.
       add_hostinet: add a hostinet test.
       add_directfs: add a directfs test.
       one_sandbox: runs each unit test in a new sandbox instance.
@@ -265,6 +269,7 @@ def syscall_test_variants(
             add_host_uds = add_host_uds,
             add_host_connector = add_host_connector,
             add_host_fifo = add_host_fifo,
+            add_host_tty = add_host_tty,
             tags = platform_tags + tags,
             iouring = iouring,
             directfs = directfs,
@@ -291,6 +296,7 @@ def syscall_test_variants(
             add_host_uds = add_host_uds,
             add_host_connector = add_host_connector,
             add_host_fifo = add_host_fifo,
+            add_host_tty = add_host_tty,
             tags = platforms.get(default_platform, []) + tags,
             debug = debug,
             iouring = iouring,
@@ -318,6 +324,7 @@ def syscall_test_variants(
             add_host_uds = add_host_uds,
             add_host_connector = add_host_connector,
             add_host_fifo = add_host_fifo,
+            add_host_tty = add_host_tty,
             tags = platforms.get(default_platform, []) + tags,
             debug = debug,
             iouring = iouring,
@@ -342,6 +349,7 @@ def syscall_test_variants(
             add_host_uds = add_host_uds,
             add_host_connector = add_host_connector,
             add_host_fifo = add_host_fifo,
+            add_host_tty = add_host_tty,
             tags = platforms.get(default_platform, []) + tags,
             iouring = iouring,
             debug = debug,
@@ -367,6 +375,7 @@ def syscall_test_variants(
             add_host_uds = add_host_uds,
             add_host_connector = add_host_connector,
             add_host_fifo = add_host_fifo,
+            add_host_tty = add_host_tty,
             tags = platforms.get(default_platform, []) + tags,
             debug = debug,
             container = container,
@@ -390,6 +399,7 @@ def syscall_test(
         add_host_uds = False,
         add_host_connector = False,
         add_host_fifo = False,
+        add_host_tty = False,
         add_hostinet = False,
         add_directfs = True,
         one_sandbox = True,
@@ -417,6 +427,7 @@ def syscall_test(
       add_host_uds: setup bound UDS on the host.
       add_host_connector: setup host threads to connect to bound UDS created by sandbox.
       add_host_fifo: setup FIFO files on the host.
+      add_host_tty: setup host TTY at /dev/tty.
       add_hostinet: add a hostinet test.
       add_directfs: add a directfs test.
       one_sandbox: runs each unit test in a new sandbox instance.
@@ -443,7 +454,8 @@ def syscall_test(
     if debug == None:
         debug = not perf
     if save == None:
-        save = not perf
+        # add_host_tty is not compatible with save/resume
+        save = not perf and not add_host_tty
     if perf:
         tags.append("perf")
 
@@ -455,6 +467,7 @@ def syscall_test(
             add_host_uds = add_host_uds,
             add_host_connector = add_host_connector,
             add_host_fifo = add_host_fifo,
+            add_host_tty = add_host_tty,
             tags = tags,
             iouring = iouring,
             debug = debug,
@@ -472,6 +485,7 @@ def syscall_test(
         add_host_uds,
         add_host_connector,
         add_host_fifo,
+        add_host_tty,
         add_hostinet,
         add_directfs,
         one_sandbox,
@@ -503,6 +517,7 @@ def syscall_test(
             add_host_uds,
             add_host_connector,
             add_host_fifo,
+            add_host_tty,
             add_hostinet,
             add_directfs,
             one_sandbox,
@@ -531,6 +546,7 @@ def syscall_test(
                 add_host_uds,
                 add_host_connector,
                 add_host_fifo,
+                add_host_tty,
                 add_hostinet,
                 add_directfs,
                 one_sandbox,
@@ -559,6 +575,7 @@ def syscall_test(
             add_host_uds,
             add_host_connector,
             add_host_fifo,
+            add_host_tty,
             add_hostinet,
             add_directfs,
             one_sandbox,

--- a/test/syscalls/BUILD
+++ b/test/syscalls/BUILD
@@ -297,6 +297,11 @@ syscall_test(
 )
 
 syscall_test(
+    add_host_tty = True,
+    test = "//test/syscalls/linux:host_pty_test",
+)
+
+syscall_test(
     size = "medium",
     add_overlay = True,
     test = "//test/syscalls/linux:inotify_test",

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4900,3 +4900,18 @@ cc_binary(
         "@com_google_absl//absl/strings",
     ],
 )
+
+cc_binary(
+    name = "host_pty_test",
+    testonly = 1,
+    srcs = ["host_pty.cc"],
+    linkstatic = 1,
+    malloc = "//test/util:errno_safe_allocator",
+    deps = select_gtest() + [
+        "//test/util:pty_util",
+        "//test/util:test_main",
+        "//test/util:test_util",
+        "@com_google_absl//absl/strings",
+    ],
+)
+

--- a/test/syscalls/linux/host_pty.cc
+++ b/test/syscalls/linux/host_pty.cc
@@ -1,0 +1,68 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+
+#include "absl/strings/numbers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "test/util/pty_util.h"
+#include "test/util/test_util.h"
+
+namespace gvisor {
+namespace testing {
+
+namespace {
+
+TEST(HostPtyTest, Termios2) {
+  // We expect a host PTY FD to be passed.
+  char* fd_str = getenv("TEST_HOST_PTY_FD");
+  ASSERT_NE(fd_str, nullptr) << "TEST_HOST_PTY_FD environment variable not set";
+  int fd;
+  ASSERT_TRUE(absl::SimpleAtoi(fd_str, &fd)) << "Invalid TEST_HOST_PTY_FD: " << fd_str;
+
+  struct termios t;
+  ASSERT_THAT(ioctl(fd, TCGETS, &t), SyscallSucceeds());
+
+  struct kernel_termios2 t2 = {};
+  ASSERT_THAT(ioctl(fd, TCGETS2, &t2), SyscallSucceeds());
+
+  EXPECT_EQ(t.c_iflag, t2.c_iflag);
+  EXPECT_EQ(t.c_oflag, t2.c_oflag);
+  EXPECT_EQ(t.c_cflag, t2.c_cflag);
+  EXPECT_EQ(t.c_lflag, t2.c_lflag);
+  for (int i = 0; i < NCCS && i < KERNEL_NCCS; ++i) {
+    EXPECT_EQ(t.c_cc[i], t2.c_cc[i]);
+  }
+
+  // Test TCSETS2.
+  auto original_lflag = t2.c_lflag;
+  t2.c_lflag ^= ECHO;
+  ASSERT_THAT(ioctl(fd, TCSETS2, &t2), SyscallSucceeds());
+
+  struct kernel_termios2 t3 = {};
+  ASSERT_THAT(ioctl(fd, TCGETS2, &t3), SyscallSucceeds());
+  EXPECT_EQ(t2.c_lflag, t3.c_lflag);
+
+  // Restore original flags.
+  t2.c_lflag = original_lflag;
+  ASSERT_THAT(ioctl(fd, TCSETS2, &t2), SyscallSucceeds());
+}
+
+}  // namespace
+
+}  // namespace testing
+}  // namespace gvisor

--- a/test/syscalls/linux/pty.cc
+++ b/test/syscalls/linux/pty.cc
@@ -91,23 +91,6 @@ constexpr int kMaxLineSize = 4096;
 
 constexpr char kMasterPath[] = "/dev/ptmx";
 
-// glibc defines its own, different, version of struct termios. We care about
-// what the kernel does, not glibc.
-#define KERNEL_NCCS 19
-struct kernel_termios {
-  tcflag_t c_iflag;
-  tcflag_t c_oflag;
-  tcflag_t c_cflag;
-  tcflag_t c_lflag;
-  cc_t c_line;
-  cc_t c_cc[KERNEL_NCCS];
-};
-
-bool operator==(struct kernel_termios const &a,
-                struct kernel_termios const &b) {
-  return memcmp(&a, &b, sizeof(a)) == 0;
-}
-
 // Returns the termios-style control character for the passed character.
 //
 // e.g., for Ctrl-C, i.e., ^C, call ControlCharacter('C').
@@ -118,216 +101,7 @@ constexpr char ControlCharacter(char c) {
   return c - 'A' + 1;
 }
 
-// Returns the printable character the given control character represents.
-constexpr char FromControlCharacter(char c) { return c + 'A' - 1; }
-
-// Returns true if c is a control character.
-//
-// Standard control characters are ASCII bytes 0 through 31.
-constexpr bool IsControlCharacter(char c) { return c <= 31; }
-
-struct Field {
-  const char *name;
-  uint64_t mask;
-  uint64_t value;
-};
-
-// ParseFields returns a string representation of value, using the names in
 // fields.
-std::string ParseFields(const Field *fields, size_t len, uint64_t value) {
-  bool first = true;
-  std::string s;
-  for (size_t i = 0; i < len; i++) {
-    const Field f = fields[i];
-    if ((value & f.mask) == f.value) {
-      if (!first) {
-        s += "|";
-      }
-      s += f.name;
-      first = false;
-      value &= ~f.mask;
-    }
-  }
-
-  if (value) {
-    if (!first) {
-      s += "|";
-    }
-    absl::StrAppend(&s, value);
-  }
-
-  return s;
-}
-
-const Field kIflagFields[] = {
-    {"IGNBRK", IGNBRK, IGNBRK}, {"BRKINT", BRKINT, BRKINT},
-    {"IGNPAR", IGNPAR, IGNPAR}, {"PARMRK", PARMRK, PARMRK},
-    {"INPCK", INPCK, INPCK},    {"ISTRIP", ISTRIP, ISTRIP},
-    {"INLCR", INLCR, INLCR},    {"IGNCR", IGNCR, IGNCR},
-    {"ICRNL", ICRNL, ICRNL},    {"IUCLC", IUCLC, IUCLC},
-    {"IXON", IXON, IXON},       {"IXANY", IXANY, IXANY},
-    {"IXOFF", IXOFF, IXOFF},    {"IMAXBEL", IMAXBEL, IMAXBEL},
-    {"IUTF8", IUTF8, IUTF8},
-};
-
-const Field kOflagFields[] = {
-    {"OPOST", OPOST, OPOST}, {"OLCUC", OLCUC, OLCUC},
-    {"ONLCR", ONLCR, ONLCR}, {"OCRNL", OCRNL, OCRNL},
-    {"ONOCR", ONOCR, ONOCR}, {"ONLRET", ONLRET, ONLRET},
-    {"OFILL", OFILL, OFILL}, {"OFDEL", OFDEL, OFDEL},
-    {"NL0", NLDLY, NL0},     {"NL1", NLDLY, NL1},
-    {"CR0", CRDLY, CR0},     {"CR1", CRDLY, CR1},
-    {"CR2", CRDLY, CR2},     {"CR3", CRDLY, CR3},
-    {"TAB0", TABDLY, TAB0},  {"TAB1", TABDLY, TAB1},
-    {"TAB2", TABDLY, TAB2},  {"TAB3", TABDLY, TAB3},
-    {"BS0", BSDLY, BS0},     {"BS1", BSDLY, BS1},
-    {"FF0", FFDLY, FF0},     {"FF1", FFDLY, FF1},
-    {"VT0", VTDLY, VT0},     {"VT1", VTDLY, VT1},
-    {"XTABS", XTABS, XTABS},
-};
-
-#ifndef IBSHIFT
-// Shift from CBAUD to CIBAUD.
-#define IBSHIFT 16
-#endif
-
-const Field kCflagFields[] = {
-    {"B0", CBAUD, B0},
-    {"B50", CBAUD, B50},
-    {"B75", CBAUD, B75},
-    {"B110", CBAUD, B110},
-    {"B134", CBAUD, B134},
-    {"B150", CBAUD, B150},
-    {"B200", CBAUD, B200},
-    {"B300", CBAUD, B300},
-    {"B600", CBAUD, B600},
-    {"B1200", CBAUD, B1200},
-    {"B1800", CBAUD, B1800},
-    {"B2400", CBAUD, B2400},
-    {"B4800", CBAUD, B4800},
-    {"B9600", CBAUD, B9600},
-    {"B19200", CBAUD, B19200},
-    {"B38400", CBAUD, B38400},
-    {"CS5", CSIZE, CS5},
-    {"CS6", CSIZE, CS6},
-    {"CS7", CSIZE, CS7},
-    {"CS8", CSIZE, CS8},
-    {"CSTOPB", CSTOPB, CSTOPB},
-    {"CREAD", CREAD, CREAD},
-    {"PARENB", PARENB, PARENB},
-    {"PARODD", PARODD, PARODD},
-    {"HUPCL", HUPCL, HUPCL},
-    {"CLOCAL", CLOCAL, CLOCAL},
-    {"B57600", CBAUD, B57600},
-    {"B115200", CBAUD, B115200},
-    {"B230400", CBAUD, B230400},
-    {"B460800", CBAUD, B460800},
-    {"B500000", CBAUD, B500000},
-    {"B576000", CBAUD, B576000},
-    {"B921600", CBAUD, B921600},
-    {"B1000000", CBAUD, B1000000},
-    {"B1152000", CBAUD, B1152000},
-    {"B1500000", CBAUD, B1500000},
-    {"B2000000", CBAUD, B2000000},
-    {"B2500000", CBAUD, B2500000},
-    {"B3000000", CBAUD, B3000000},
-    {"B3500000", CBAUD, B3500000},
-    {"B4000000", CBAUD, B4000000},
-    {"CMSPAR", CMSPAR, CMSPAR},
-    {"CRTSCTS", CRTSCTS, CRTSCTS},
-    {"IB0", CIBAUD, B0 << IBSHIFT},
-    {"IB50", CIBAUD, B50 << IBSHIFT},
-    {"IB75", CIBAUD, B75 << IBSHIFT},
-    {"IB110", CIBAUD, B110 << IBSHIFT},
-    {"IB134", CIBAUD, B134 << IBSHIFT},
-    {"IB150", CIBAUD, B150 << IBSHIFT},
-    {"IB200", CIBAUD, B200 << IBSHIFT},
-    {"IB300", CIBAUD, B300 << IBSHIFT},
-    {"IB600", CIBAUD, B600 << IBSHIFT},
-    {"IB1200", CIBAUD, B1200 << IBSHIFT},
-    {"IB1800", CIBAUD, B1800 << IBSHIFT},
-    {"IB2400", CIBAUD, B2400 << IBSHIFT},
-    {"IB4800", CIBAUD, B4800 << IBSHIFT},
-    {"IB9600", CIBAUD, B9600 << IBSHIFT},
-    {"IB19200", CIBAUD, B19200 << IBSHIFT},
-    {"IB38400", CIBAUD, B38400 << IBSHIFT},
-    {"IB57600", CIBAUD, B57600 << IBSHIFT},
-    {"IB115200", CIBAUD, B115200 << IBSHIFT},
-    {"IB230400", CIBAUD, B230400 << IBSHIFT},
-    {"IB460800", CIBAUD, B460800 << IBSHIFT},
-    {"IB500000", CIBAUD, B500000 << IBSHIFT},
-    {"IB576000", CIBAUD, B576000 << IBSHIFT},
-    {"IB921600", CIBAUD, B921600 << IBSHIFT},
-    {"IB1000000", CIBAUD, B1000000 << IBSHIFT},
-    {"IB1152000", CIBAUD, B1152000 << IBSHIFT},
-    {"IB1500000", CIBAUD, B1500000 << IBSHIFT},
-    {"IB2000000", CIBAUD, B2000000 << IBSHIFT},
-    {"IB2500000", CIBAUD, B2500000 << IBSHIFT},
-    {"IB3000000", CIBAUD, B3000000 << IBSHIFT},
-    {"IB3500000", CIBAUD, B3500000 << IBSHIFT},
-    {"IB4000000", CIBAUD, B4000000 << IBSHIFT},
-};
-
-const Field kLflagFields[] = {
-    {"ISIG", ISIG, ISIG},          {"ICANON", ICANON, ICANON},
-    {"XCASE", XCASE, XCASE},       {"ECHO", ECHO, ECHO},
-    {"ECHOE", ECHOE, ECHOE},       {"ECHOK", ECHOK, ECHOK},
-    {"ECHONL", ECHONL, ECHONL},    {"NOFLSH", NOFLSH, NOFLSH},
-    {"TOSTOP", TOSTOP, TOSTOP},    {"ECHOCTL", ECHOCTL, ECHOCTL},
-    {"ECHOPRT", ECHOPRT, ECHOPRT}, {"ECHOKE", ECHOKE, ECHOKE},
-    {"FLUSHO", FLUSHO, FLUSHO},    {"PENDIN", PENDIN, PENDIN},
-    {"IEXTEN", IEXTEN, IEXTEN},    {"EXTPROC", EXTPROC, EXTPROC},
-};
-
-std::string FormatCC(char c) {
-  if (isgraph(c)) {
-    return std::string(1, c);
-  } else if (c == ' ') {
-    return " ";
-  } else if (c == '\t') {
-    return "\\t";
-  } else if (c == '\r') {
-    return "\\r";
-  } else if (c == '\n') {
-    return "\\n";
-  } else if (c == '\0') {
-    return "\\0";
-  } else if (IsControlCharacter(c)) {
-    return absl::StrCat("^", std::string(1, FromControlCharacter(c)));
-  }
-  return absl::StrCat("\\x", absl::Hex(c));
-}
-
-std::ostream &operator<<(std::ostream &os, struct kernel_termios const &a) {
-  os << "{ c_iflag = "
-     << ParseFields(kIflagFields, ABSL_ARRAYSIZE(kIflagFields), a.c_iflag);
-  os << ", c_oflag = "
-     << ParseFields(kOflagFields, ABSL_ARRAYSIZE(kOflagFields), a.c_oflag);
-  os << ", c_cflag = "
-     << ParseFields(kCflagFields, ABSL_ARRAYSIZE(kCflagFields), a.c_cflag);
-  os << ", c_lflag = "
-     << ParseFields(kLflagFields, ABSL_ARRAYSIZE(kLflagFields), a.c_lflag);
-  os << ", c_line = " << a.c_line;
-  os << ", c_cc = { [VINTR] = '" << FormatCC(a.c_cc[VINTR]);
-  os << "', [VQUIT] = '" << FormatCC(a.c_cc[VQUIT]);
-  os << "', [VERASE] = '" << FormatCC(a.c_cc[VERASE]);
-  os << "', [VKILL] = '" << FormatCC(a.c_cc[VKILL]);
-  os << "', [VEOF] = '" << FormatCC(a.c_cc[VEOF]);
-  os << "', [VTIME] = '" << static_cast<int>(a.c_cc[VTIME]);
-  os << "', [VMIN] = " << static_cast<int>(a.c_cc[VMIN]);
-  os << ", [VSWTC] = '" << FormatCC(a.c_cc[VSWTC]);
-  os << "', [VSTART] = '" << FormatCC(a.c_cc[VSTART]);
-  os << "', [VSTOP] = '" << FormatCC(a.c_cc[VSTOP]);
-  os << "', [VSUSP] = '" << FormatCC(a.c_cc[VSUSP]);
-  os << "', [VEOL] = '" << FormatCC(a.c_cc[VEOL]);
-  os << "', [VREPRINT] = '" << FormatCC(a.c_cc[VREPRINT]);
-  os << "', [VDISCARD] = '" << FormatCC(a.c_cc[VDISCARD]);
-  os << "', [VWERASE] = '" << FormatCC(a.c_cc[VWERASE]);
-  os << "', [VLNEXT] = '" << FormatCC(a.c_cc[VLNEXT]);
-  os << "', [VEOL2] = '" << FormatCC(a.c_cc[VEOL2]);
-  os << "'}";
-  return os;
-}
 
 // Return the default termios settings for a new terminal.
 struct kernel_termios DefaultTermios() {
@@ -918,6 +692,78 @@ TEST_F(PtyTest, DefaultTermios) {
 
   EXPECT_THAT(ioctl(master_.get(), TCGETS, &t), SyscallSucceeds());
   EXPECT_EQ(t, DefaultTermios());
+}
+
+TEST_F(PtyTest, Termios2) {
+  struct kernel_termios t = {};
+  EXPECT_THAT(ioctl(replica_.get(), TCGETS, &t), SyscallSucceeds());
+
+  struct kernel_termios2 t2 = {};
+  EXPECT_THAT(ioctl(replica_.get(), TCGETS2, &t2), SyscallSucceeds());
+
+  EXPECT_EQ(t.c_iflag, t2.c_iflag);
+  EXPECT_EQ(t.c_oflag, t2.c_oflag);
+  EXPECT_EQ(t.c_cflag, t2.c_cflag);
+  EXPECT_EQ(t.c_lflag, t2.c_lflag);
+  EXPECT_EQ(t.c_line, t2.c_line);
+  for (int i = 0; i < KERNEL_NCCS; ++i) {
+    EXPECT_EQ(t.c_cc[i], t2.c_cc[i]);
+  }
+
+  // Default speed is 38400.
+  EXPECT_EQ(t2.c_ispeed, 38400);
+  EXPECT_EQ(t2.c_ospeed, 38400);
+
+  // Test TCSETS2.
+  t2.c_lflag ^= ICANON;
+  EXPECT_THAT(ioctl(replica_.get(), TCSETS2, &t2), SyscallSucceeds());
+  struct kernel_termios2 t3 = {};
+  EXPECT_THAT(ioctl(replica_.get(), TCGETS2, &t3), SyscallSucceeds());
+  EXPECT_EQ(t2.c_lflag, t3.c_lflag);
+
+  // Test TCSETSW2.
+  t2.c_lflag ^= ICANON;
+  EXPECT_THAT(ioctl(replica_.get(), TCSETSW2, &t2), SyscallSucceeds());
+  EXPECT_THAT(ioctl(replica_.get(), TCGETS2, &t3), SyscallSucceeds());
+  EXPECT_EQ(t2.c_lflag, t3.c_lflag);
+
+  // Test TCSETSF2.
+  t2.c_lflag ^= ICANON;
+  EXPECT_THAT(ioctl(replica_.get(), TCSETSF2, &t2), SyscallSucceeds());
+  EXPECT_THAT(ioctl(replica_.get(), TCGETS2, &t3), SyscallSucceeds());
+  EXPECT_EQ(t2.c_lflag, t3.c_lflag);
+}
+
+TEST_F(PtyTest, TermiosFault) {
+  struct kernel_termios t_orig = {};
+  ASSERT_THAT(ioctl(replica_.get(), TCGETS, &t_orig), SyscallSucceeds());
+
+  struct kernel_termios t = t_orig;
+  t.c_lflag ^= ICANON;
+  ASSERT_THAT(ioctl(replica_.get(), TCSETS, &t), SyscallSucceeds());
+
+  struct kernel_termios t_new = {};
+  ASSERT_THAT(ioctl(replica_.get(), TCGETS, &t_new), SyscallSucceeds());
+  EXPECT_EQ(t.c_lflag, t_new.c_lflag);
+
+  // Call TCSETS with an invalid pointer.
+  EXPECT_THAT(ioctl(replica_.get(), TCSETS, nullptr),
+              SyscallFailsWithErrno(EFAULT));
+
+  // Verify that the termios state is unchanged.
+  struct kernel_termios t_after = {};
+  ASSERT_THAT(ioctl(replica_.get(), TCGETS, &t_after), SyscallSucceeds());
+  EXPECT_EQ(t_after, t);
+
+  // Also test TCSETS2.
+  struct kernel_termios2 t2 = {};
+  ASSERT_THAT(ioctl(replica_.get(), TCGETS2, &t2), SyscallSucceeds());
+  EXPECT_THAT(ioctl(replica_.get(), TCSETS2, nullptr),
+              SyscallFailsWithErrno(EFAULT));
+
+  struct kernel_termios2 t2_after = {};
+  ASSERT_THAT(ioctl(replica_.get(), TCGETS2, &t2_after), SyscallSucceeds());
+  EXPECT_EQ(memcmp(&t2, &t2_after, sizeof(t2)), 0);
 }
 
 // Changing termios from the master actually affects the replica.

--- a/test/util/BUILD
+++ b/test/util/BUILD
@@ -255,6 +255,8 @@ cc_library(
     deps = [
         ":file_descriptor",
         ":posix_error",
+        "@com_google_absl//absl/base:core_headers",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/test/util/pty_util.cc
+++ b/test/util/pty_util.cc
@@ -14,14 +14,242 @@
 
 #include "test/util/pty_util.h"
 
+#include <stddef.h>
+#include <stdint.h>
 #include <sys/ioctl.h>
 #include <termios.h>
 
+#include <cctype>
+#include <cstring>
+#include <ostream>
+#include <string>
+
+#include "absl/base/macros.h"
+#include "absl/strings/str_cat.h"
 #include "test/util/file_descriptor.h"
 #include "test/util/posix_error.h"
 
 namespace gvisor {
 namespace testing {
+
+namespace {
+
+// Returns the printable character the given control character represents.
+constexpr char FromControlCharacter(char c) { return c + 'A' - 1; }
+
+// Returns true if c is a control character.
+//
+// Standard control characters are ASCII bytes 0 through 31.
+constexpr bool IsControlCharacter(char c) { return c <= 31; }
+
+struct Field {
+  const char* name;
+  uint64_t mask;
+  uint64_t value;
+};
+
+// ParseFields returns a string representation of value, using the names in
+// fields.
+std::string ParseFields(const Field* fields, size_t len, uint64_t value) {
+  bool first = true;
+  std::string s;
+  for (size_t i = 0; i < len; i++) {
+    const Field f = fields[i];
+    if ((value & f.mask) == f.value) {
+      if (!first) {
+        s += "|";
+      }
+      s += f.name;
+      first = false;
+      value &= ~f.mask;
+    }
+  }
+
+  if (value) {
+    if (!first) {
+      s += "|";
+    }
+    absl::StrAppend(&s, value);
+  }
+
+  return s;
+}
+
+const Field kIflagFields[] = {
+    {"IGNBRK", IGNBRK, IGNBRK}, {"BRKINT", BRKINT, BRKINT},
+    {"IGNPAR", IGNPAR, IGNPAR}, {"PARMRK", PARMRK, PARMRK},
+    {"INPCK", INPCK, INPCK},    {"ISTRIP", ISTRIP, ISTRIP},
+    {"INLCR", INLCR, INLCR},    {"IGNCR", IGNCR, IGNCR},
+    {"ICRNL", ICRNL, ICRNL},    {"IUCLC", IUCLC, IUCLC},
+    {"IXON", IXON, IXON},       {"IXANY", IXANY, IXANY},
+    {"IXOFF", IXOFF, IXOFF},    {"IMAXBEL", IMAXBEL, IMAXBEL},
+    {"IUTF8", IUTF8, IUTF8},
+};
+
+const Field kOflagFields[] = {
+    {"OPOST", OPOST, OPOST}, {"OLCUC", OLCUC, OLCUC},
+    {"ONLCR", ONLCR, ONLCR}, {"OCRNL", OCRNL, OCRNL},
+    {"ONOCR", ONOCR, ONOCR}, {"ONLRET", ONLRET, ONLRET},
+    {"OFILL", OFILL, OFILL}, {"OFDEL", OFDEL, OFDEL},
+    {"NL0", NLDLY, NL0},     {"NL1", NLDLY, NL1},
+    {"CR0", CRDLY, CR0},     {"CR1", CRDLY, CR1},
+    {"CR2", CRDLY, CR2},     {"CR3", CRDLY, CR3},
+    {"TAB0", TABDLY, TAB0},  {"TAB1", TABDLY, TAB1},
+    {"TAB2", TABDLY, TAB2},  {"TAB3", TABDLY, TAB3},
+    {"BS0", BSDLY, BS0},     {"BS1", BSDLY, BS1},
+    {"FF0", FFDLY, FF0},     {"FF1", FFDLY, FF1},
+    {"VT0", VTDLY, VT0},     {"VT1", VTDLY, VT1},
+    {"XTABS", XTABS, XTABS},
+};
+
+#ifndef IBSHIFT
+// Shift from CBAUD to CIBAUD.
+#define IBSHIFT 16
+#endif
+
+const Field kCflagFields[] = {
+    {"B0", CBAUD, B0},
+    {"B50", CBAUD, B50},
+    {"B75", CBAUD, B75},
+    {"B110", CBAUD, B110},
+    {"B134", CBAUD, B134},
+    {"B150", CBAUD, B150},
+    {"B200", CBAUD, B200},
+    {"B300", CBAUD, B300},
+    {"B600", CBAUD, B600},
+    {"B1200", CBAUD, B1200},
+    {"B1800", CBAUD, B1800},
+    {"B2400", CBAUD, B2400},
+    {"B4800", CBAUD, B4800},
+    {"B9600", CBAUD, B9600},
+    {"B19200", CBAUD, B19200},
+    {"B38400", CBAUD, B38400},
+    {"CS5", CSIZE, CS5},
+    {"CS6", CSIZE, CS6},
+    {"CS7", CSIZE, CS7},
+    {"CS8", CSIZE, CS8},
+    {"CSTOPB", CSTOPB, CSTOPB},
+    {"CREAD", CREAD, CREAD},
+    {"PARENB", PARENB, PARENB},
+    {"PARODD", PARODD, PARODD},
+    {"HUPCL", HUPCL, HUPCL},
+    {"CLOCAL", CLOCAL, CLOCAL},
+    {"B57600", CBAUD, B57600},
+    {"B115200", CBAUD, B115200},
+    {"B230400", CBAUD, B230400},
+    {"B460800", CBAUD, B460800},
+    {"B500000", CBAUD, B500000},
+    {"B576000", CBAUD, B576000},
+    {"B921600", CBAUD, B921600},
+    {"B1000000", CBAUD, B1000000},
+    {"B1152000", CBAUD, B1152000},
+    {"B1500000", CBAUD, B1500000},
+    {"B2000000", CBAUD, B2000000},
+    {"B2500000", CBAUD, B2500000},
+    {"B3000000", CBAUD, B3000000},
+    {"B3500000", CBAUD, B3500000},
+    {"B4000000", CBAUD, B4000000},
+    {"CMSPAR", CMSPAR, CMSPAR},
+    {"CRTSCTS", CRTSCTS, CRTSCTS},
+    {"IB0", CIBAUD, B0 << IBSHIFT},
+    {"IB50", CIBAUD, B50 << IBSHIFT},
+    {"IB75", CIBAUD, B75 << IBSHIFT},
+    {"IB110", CIBAUD, B110 << IBSHIFT},
+    {"IB134", CIBAUD, B134 << IBSHIFT},
+    {"IB150", CIBAUD, B150 << IBSHIFT},
+    {"IB200", CIBAUD, B200 << IBSHIFT},
+    {"IB300", CIBAUD, B300 << IBSHIFT},
+    {"IB600", CIBAUD, B600 << IBSHIFT},
+    {"IB1200", CIBAUD, B1200 << IBSHIFT},
+    {"IB1800", CIBAUD, B1800 << IBSHIFT},
+    {"IB2400", CIBAUD, B2400 << IBSHIFT},
+    {"IB4800", CIBAUD, B4800 << IBSHIFT},
+    {"IB9600", CIBAUD, B9600 << IBSHIFT},
+    {"IB19200", CIBAUD, B19200 << IBSHIFT},
+    {"IB38400", CIBAUD, B38400 << IBSHIFT},
+    {"IB57600", CIBAUD, B57600 << IBSHIFT},
+    {"IB115200", CIBAUD, B115200 << IBSHIFT},
+    {"IB230400", CIBAUD, B230400 << IBSHIFT},
+    {"IB460800", CIBAUD, B460800 << IBSHIFT},
+    {"IB500000", CIBAUD, B500000 << IBSHIFT},
+    {"IB576000", CIBAUD, B576000 << IBSHIFT},
+    {"IB921600", CIBAUD, B921600 << IBSHIFT},
+    {"IB1000000", CIBAUD, B1000000 << IBSHIFT},
+    {"IB1152000", CIBAUD, B1152000 << IBSHIFT},
+    {"IB1500000", CIBAUD, B1500000 << IBSHIFT},
+    {"IB2000000", CIBAUD, B2000000 << IBSHIFT},
+    {"IB2500000", CIBAUD, B2500000 << IBSHIFT},
+    {"IB3000000", CIBAUD, B3000000 << IBSHIFT},
+    {"IB3500000", CIBAUD, B3500000 << IBSHIFT},
+    {"IB4000000", CIBAUD, B4000000 << IBSHIFT},
+};
+
+const Field kLflagFields[] = {
+    {"ISIG", ISIG, ISIG},          {"ICANON", ICANON, ICANON},
+    {"XCASE", XCASE, XCASE},       {"ECHO", ECHO, ECHO},
+    {"ECHOE", ECHOE, ECHOE},       {"ECHOK", ECHOK, ECHOK},
+    {"ECHONL", ECHONL, ECHONL},    {"NOFLSH", NOFLSH, NOFLSH},
+    {"TOSTOP", TOSTOP, TOSTOP},    {"ECHOCTL", ECHOCTL, ECHOCTL},
+    {"ECHOPRT", ECHOPRT, ECHOPRT}, {"ECHOKE", ECHOKE, ECHOKE},
+    {"FLUSHO", FLUSHO, FLUSHO},    {"PENDIN", PENDIN, PENDIN},
+    {"IEXTEN", IEXTEN, IEXTEN},    {"EXTPROC", EXTPROC, EXTPROC},
+};
+
+std::string FormatCC(char c) {
+  if (isgraph(c)) {
+    return std::string(1, c);
+  } else if (c == ' ') {
+    return " ";
+  } else if (c == '\t') {
+    return "\\t";
+  } else if (c == '\r') {
+    return "\\r";
+  } else if (c == '\n') {
+    return "\\n";
+  } else if (c == '\0') {
+    return "\\0";
+  } else if (IsControlCharacter(c)) {
+    return absl::StrCat("^", std::string(1, FromControlCharacter(c)));
+  }
+  return absl::StrCat("\\x", absl::Hex(c));
+}
+
+}  // namespace
+
+bool operator==(struct kernel_termios const& a, struct kernel_termios const& b) {
+  return memcmp(&a, &b, sizeof(a)) == 0;
+}
+
+std::ostream& operator<<(std::ostream& os, struct kernel_termios const& a) {
+  os << "{ c_iflag = "
+     << ParseFields(kIflagFields, ABSL_ARRAYSIZE(kIflagFields), a.c_iflag);
+  os << ", c_oflag = "
+     << ParseFields(kOflagFields, ABSL_ARRAYSIZE(kOflagFields), a.c_oflag);
+  os << ", c_cflag = "
+     << ParseFields(kCflagFields, ABSL_ARRAYSIZE(kCflagFields), a.c_cflag);
+  os << ", c_lflag = "
+     << ParseFields(kLflagFields, ABSL_ARRAYSIZE(kLflagFields), a.c_lflag);
+  os << ", c_line = " << (int)a.c_line;
+  os << ", c_cc = { [VINTR] = '" << FormatCC(a.c_cc[VINTR]);
+  os << "', [VQUIT] = '" << FormatCC(a.c_cc[VQUIT]);
+  os << "', [VERASE] = '" << FormatCC(a.c_cc[VERASE]);
+  os << "', [VKILL] = '" << FormatCC(a.c_cc[VKILL]);
+  os << "', [VEOF] = '" << FormatCC(a.c_cc[VEOF]);
+  os << "', [VTIME] = '" << static_cast<int>(a.c_cc[VTIME]);
+  os << "', [VMIN] = " << static_cast<int>(a.c_cc[VMIN]);
+  os << ", [VSWTC] = '" << FormatCC(a.c_cc[VSWTC]);
+  os << "', [VSTART] = '" << FormatCC(a.c_cc[VSTART]);
+  os << "', [VSTOP] = '" << FormatCC(a.c_cc[VSTOP]);
+  os << "', [VSUSP] = '" << FormatCC(a.c_cc[VSUSP]);
+  os << "', [VEOL] = '" << FormatCC(a.c_cc[VEOL]);
+  os << "', [VREPRINT] = '" << FormatCC(a.c_cc[VREPRINT]);
+  os << "', [VDISCARD] = '" << FormatCC(a.c_cc[VDISCARD]);
+  os << "', [VWERASE] = '" << FormatCC(a.c_cc[VWERASE]);
+  os << "', [VLNEXT] = '" << FormatCC(a.c_cc[VLNEXT]);
+  os << "', [VEOL2] = '" << FormatCC(a.c_cc[VEOL2]);
+  os << "'}";
+  return os;
+}
 
 PosixErrorOr<FileDescriptor> OpenReplica(const FileDescriptor& master) {
   return OpenReplica(master, O_NONBLOCK | O_RDWR | O_NOCTTY);


### PR DESCRIPTION
glibc 2.42 uses TCGETS2 in isatty, and fails to properly detect ttys
without TCGETS2 supported.
