### PR TITLE
Add --path flag to runsc tar rootfs-upper for subtree exports

### DIFF
--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -506,13 +506,13 @@ func (fs *filesystem) getLowerDevMinor(layerMajor, layerMinor uint32) (uint32, e
 }
 
 // TarUpperLayer implements vfs.TarSerializer.TarUpperLayer.
-func (fs *filesystem) TarUpperLayer(ctx context.Context, outFD *os.File) error {
+func (fs *filesystem) TarUpperLayer(ctx context.Context, outFD *os.File, path string) error {
 	upperFS := fs.opts.UpperRoot.Mount().Filesystem()
 	ts, ok := upperFS.Impl().(vfs.TarSerializer)
 	if !ok {
 		return fmt.Errorf("upper layer is of type %q, which does not implement vfs.TarSerializer", upperFS.FilesystemType().Name())
 	}
-	return ts.TarUpperLayer(ctx, outFD)
+	return ts.TarUpperLayer(ctx, outFD, path)
 }
 
 // dentry implements vfs.DentryImpl.

--- a/pkg/sentry/vfs/filesystem.go
+++ b/pkg/sentry/vfs/filesystem.go
@@ -529,8 +529,10 @@ type FilesystemImpl interface {
 // It is an extension of FilesystemImpl.
 type TarSerializer interface {
 	// TarUpperLayer serializes the writable upper layer of the filesystem to a
-	// tar archive. It writes the tar archive to outFD.
-	TarUpperLayer(ctx context.Context, outFD *os.File) error
+	// tar archive. It writes the tar archive to outFD. If path is non-empty,
+	// only the subtree rooted at that path (relative to the filesystem root,
+	// e.g. "usr/share") is included, along with ancestor directory headers.
+	TarUpperLayer(ctx context.Context, outFD *os.File, path string) error
 }
 
 // PrependPathAtVFSRootError is returned by implementations of

--- a/pkg/sentry/vfs/memxattr/xattr.go
+++ b/pkg/sentry/vfs/memxattr/xattr.go
@@ -135,3 +135,26 @@ func (x *SimpleExtendedAttributes) RemoveXattr(creds *auth.Credentials, mode lin
 	delete(x.xattrs, name)
 	return nil
 }
+
+// RawXattrs returns a copy of the underlying xattr map for serialization.
+// No permission checks are performed.
+func (x *SimpleExtendedAttributes) RawXattrs() map[string]string {
+	x.mu.RLock()
+	defer x.mu.RUnlock()
+	if x.xattrs == nil {
+		return nil
+	}
+	result := make(map[string]string, len(x.xattrs))
+	for k, v := range x.xattrs {
+		result[k] = v
+	}
+	return result
+}
+
+// SetRawXattrs sets the underlying xattr map from deserialized data.
+// No permission checks are performed.
+func (x *SimpleExtendedAttributes) SetRawXattrs(xattrs map[string]string) {
+	x.mu.Lock()
+	defer x.mu.Unlock()
+	x.xattrs = xattrs
+}

--- a/runsc/cmd/tar.go
+++ b/runsc/cmd/tar.go
@@ -71,6 +71,7 @@ func createCommander(f *flag.FlagSet) *subcommands.Commander {
 // RootfsUpper implements subcommands.Command for the "tar rootfs-upper" command.
 type RootfsUpper struct {
 	file string
+	path string
 }
 
 // Name implements subcommands.Command.
@@ -91,6 +92,7 @@ func (*RootfsUpper) Usage() string {
 // SetFlags implements subcommands.Command.
 func (r *RootfsUpper) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&r.file, "file", "", "output file path, if empty, output to stdout")
+	f.StringVar(&r.path, "path", "", "only include the subtree under this path (e.g., /usr/share)")
 }
 
 // Execute implements subcommands.Command.
@@ -118,7 +120,7 @@ func (r *RootfsUpper) Execute(ctx context.Context, f *flag.FlagSet, args ...any)
 		defer out.Close()
 	}
 
-	if err := c.TarRootfsUpperLayer(out); err != nil {
+	if err := c.TarRootfsUpperLayer(out, r.path); err != nil {
 		util.Fatalf("TarRootfsUpperLayer failed: %v", err)
 	}
 	return subcommands.ExitSuccess

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -708,13 +708,13 @@ func (c *Container) WaitRestore() error {
 
 // TarRootfsUpperLayer serializes the rootfs upper layer of the container to a tar file. When
 // the rootfs is not an overlayfs, it returns an error. It writes the tar file
-// to outFD.
-func (c *Container) TarRootfsUpperLayer(outFD *os.File) error {
-	log.Debugf("TarRootfsUpperLayer, cid: %s", c.ID)
+// to outFD. If path is non-empty, only the subtree under that path is included.
+func (c *Container) TarRootfsUpperLayer(outFD *os.File, path string) error {
+	log.Debugf("TarRootfsUpperLayer, cid: %s, path: %q", c.ID, path)
 	if !c.IsSandboxRunning() {
 		return fmt.Errorf("sandbox is not running")
 	}
-	return c.Sandbox.TarRootfsUpperLayer(c.ID, outFD)
+	return c.Sandbox.TarRootfsUpperLayer(c.ID, outFD, path)
 }
 
 // SignalContainer sends the signal to the container. If all is true and signal

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -154,10 +154,10 @@ func TestMultiContainerTarRootfsUpperLayer(t *testing.T) {
 	}
 	defer os.Remove(subTar.Name())
 
-	if err := containers[0].TarRootfsUpperLayer(rootTar); err != nil {
+	if err := containers[0].TarRootfsUpperLayer(rootTar, ""); err != nil {
 		t.Fatalf("error serializing root container upper layer: %v", err)
 	}
-	if err := containers[1].TarRootfsUpperLayer(subTar); err != nil {
+	if err := containers[1].TarRootfsUpperLayer(subTar, ""); err != nil {
 		t.Fatalf("error serializing sub-container upper layer: %v", err)
 	}
 	rootTar.Close()

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -2092,11 +2092,13 @@ func (s *Sandbox) ContainerRuntimeState(cid string) (boot.ContainerRuntimeState,
 
 // TarRootfsUpperLayer serializes the rootfs upper layer of a given
 // container to a tar file. When the rootfs is not an overlayfs, it
-// returns an error. It writes the tar file to outFD.
-func (s *Sandbox) TarRootfsUpperLayer(containerID string, outFD *os.File) error {
-	log.Debugf("TarRootfsUpperLayer, sandbox: %q, container: %q", s.ID, containerID)
+// returns an error. It writes the tar file to outFD. If path is
+// non-empty, only the subtree under that path is included.
+func (s *Sandbox) TarRootfsUpperLayer(containerID string, outFD *os.File, path string) error {
+	log.Debugf("TarRootfsUpperLayer, sandbox: %q, container: %q, path: %q", s.ID, containerID, path)
 	opts := control.TarRootfsUpperLayerOpts{
 		ContainerID: containerID,
+		Path:        path,
 		FilePayload: urpc.FilePayload{Files: []*os.File{outFD}},
 	}
 	if err := s.call(boot.FsTarRootfsUpperLayer, &opts, nil); err != nil {


### PR DESCRIPTION
## Summary
- Adds a `--path` flag to `runsc tar rootfs-upper` that restricts the tar output to the subtree under the specified path (e.g., `--path=/usr/share`).
- Tar entries remain rooted at the internal upper root so whiteouts and opaque directories along the path are preserved and can be properly processed against the base image by the invoker.
- The path is threaded through the full call chain: CLI flag, Container, Sandbox RPC, control handler, VFS `TarSerializer` interface, overlay delegator, and tmpfs serializer.
- An empty path (the default) exports everything, preserving backward compatibility.

Builds on #12633.

## Test plan
- [x] Added `TestTarRootfsUpperLayerPathFilter` that creates files in two separate directories, tars with a path filter, and verifies only the filtered subtree is included.
- [x] Full container test suite passes (all 8 shards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)