### PR TITLE
Ignore MSG_NOSIGNAL in hostinet recv

### DIFF
--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -548,6 +548,7 @@ func (s *Socket) recvMsgFromHost(iovs []unix.Iovec, flags int, senderRequested b
 const allowedRecvMsgFlags = unix.MSG_CTRUNC |
 	unix.MSG_DONTWAIT |
 	unix.MSG_ERRQUEUE |
+	unix.MSG_NOSIGNAL |
 	unix.MSG_OOB |
 	unix.MSG_PEEK |
 	unix.MSG_TRUNC |


### PR DESCRIPTION
sentry/socket: Ignore MSG_NOSIGNAL in hostinet recv

Linux ignores MSG_NOSIGNAL for receive operations (recv, recvfrom,
recvmsg, recvmmsg). However, gVisor's hostinet implementation was
returning EINVAL when this flag was specified.

This change adds MSG_NOSIGNAL to the set of allowed flags in hostinet
RecvMsg, ensuring consistency with Linux behavior and the base gVisor
socket implementation.

This fixes an issue where programs like Bun would fail when calling
recv with MSG_NOSIGNAL.

Fixes: https://github.com/oven-sh/bun/issues/27389

Tests: Added regression tests to test/syscalls/linux/socket.cc.