### PR TITLE
[WIP] Fix runsc exec --detach failure when pid-file is not provided.

### DIFF
--- a/runsc/cmd/exec.go
+++ b/runsc/cmd/exec.go
@@ -239,7 +239,10 @@ func (ex *Exec) execChildAndWait(waitStatus *unix.WaitStatus) subcommands.ExitSt
 		}
 		defer os.RemoveAll(tmpDir)
 		pidFile = filepath.Join(tmpDir, "pid")
-		args = append(args, "--pid-file="+pidFile)
+		// Current args: [<runsc flags>..., "exec", <exec flags>..., <cid>]
+		// We need:      [<runsc flags>..., "exec", <exec flags>..., --pid-file=<path>, <cid>]
+		n := len(args)
+		args = append(args[:n-1], append([]string{"--pid-file=" + pidFile}, args[n-1:]...)...)
 	}
 
 	cmd := exec.Command(specutils.ExePath, args...)


### PR DESCRIPTION
When running 'runsc exec --detach' without a pid-file argument, the code would append --pid-file to the end of args. However, this is incorrect because the container ID must be the last argument for the child process.

This change inserts --pid-file before the container ID (last element) instead of appending it at the end.