### PR TITLE
erofs: accept 0padding feature flag set by mkfs.erofs 1.9 on plain images

### DIFF
--- a/pkg/erofs/erofs.go
+++ b/pkg/erofs/erofs.go
@@ -89,7 +89,11 @@ const (
 //
 // This is not exhaustive, unused features are not listed.
 const (
-	FeatureIncompatSupported = 0x0
+	// FeatureIncompatZeroPadding is used for compressed data layouts only
+	// and is safe to accept for uncompressed (flat) images.
+	FeatureIncompatZeroPadding = 0x00000001
+
+	FeatureIncompatSupported = FeatureIncompatZeroPadding
 )
 
 // Sizes of on-disk structures in bytes.


### PR DESCRIPTION
### Problem

Mounting EROFS images fails with:

```
unsupported incompatible features detected: 0x1
```

The `0x1` bit is `LZ4_0PADDING`, a feature used for in-place decompression in compressed EROFS images. Since gvisor only supports uncompressed (flat) data layouts, this flag is irrelevant and safe to ignore.

### Root cause

A [regression in erofs-utils](https://github.com/erofs/erofs-utils/commit/16a77fed8511c1a12509341e704fefdfb8e87333) (Sep 2025) causes `mkfs.erofs` to set `LZ4_0PADDING` on plain/uncompressed images where it has no meaning. The bug has been present for ~5 months and was [fixed upstream](https://github.com/erofs/erofs-utils/commit/7c24c409d75ab89b0410951586ac0a56b67b31fb) on Feb 25, 2026, but the fix has not yet been included in Homebrew.

### Fix

Added `FeatureIncompatZeroPadding` (`0x1`) to `FeatureIncompatSupported` in `pkg/erofs/erofs.go`. This is safe because gvisor only supports `FlatPlain` and `FlatInline` data layouts.