### PR TITLE
fix(setsockopt): increase maxOptLen from 8KB to 32KB

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_socket.go
+++ b/pkg/sentry/syscalls/linux/sys_socket.go
@@ -42,7 +42,12 @@ import (
 const maxAddrLen = 200
 
 // maxOptLen is the maximum sockopt parameter length we're willing to accept.
-const maxOptLen = 1024 * 8
+// Linux limits this to INT_MAX (net/socket.c: do_sock_setsockopt), but we use
+// a conservative 32KB here to balance compatibility with resource protection.
+// The previous limit of 8KB broke real-world workloads such as iptables-restore
+// with large rulesets (e.g. Istio service mesh) where IPT_SO_SET_REPLACE
+// payloads commonly exceed 8KB.
+const maxOptLen = 32 * 1024
 
 // maxControlLen is the maximum length of the msghdr.msg_control buffer we're
 // willing to accept. Note that this limit is smaller than Linux, which allows

--- a/test/syscalls/linux/iptables.cc
+++ b/test/syscalls/linux/iptables.cc
@@ -283,6 +283,114 @@ TEST_F(IPTablesTest, InitialState) {
   free(entries);
 }
 
+// Regression test for a bug where gVisor's hard-coded maxOptLen of 8KB
+// silently rejected setsockopt(IPT_SO_SET_REPLACE) payloads larger than 8192
+// bytes with EINVAL. Real-world workloads such as Istio service mesh generate
+// nat table rulesets that commonly exceed 8KB (Istio 1.28+ produces ~13KB).
+// The limit has been raised to 32KB; Linux itself uses INT_MAX.
+TEST_F(IPTablesTest, LargeReplacePayload) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_RAW)));
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
+
+  // Get current nat table metadata.
+  struct ipt_getinfo info = {};
+  snprintf(info.name, XT_TABLE_MAXNAMELEN, "%s", kNatTablename);
+  socklen_t info_size = sizeof(info);
+  ASSERT_THAT(getsockopt(s_, SOL_IP, IPT_SO_GET_INFO, &info, &info_size),
+              SyscallSucceeds());
+
+  // Read current entries.
+  socklen_t orig_sz = sizeof(struct ipt_get_entries) + info.size;
+  std::unique_ptr<char[]> orig_buf(new char[orig_sz]());
+  struct ipt_get_entries* orig =
+      reinterpret_cast<struct ipt_get_entries*>(orig_buf.get());
+  snprintf(orig->name, XT_TABLE_MAXNAMELEN, "%s", kNatTablename);
+  orig->size = info.size;
+  ASSERT_THAT(getsockopt(s_, SOL_IP, IPT_SO_GET_ENTRIES, orig, &orig_sz),
+              SyscallSucceeds());
+
+  // Compute extra entries needed to push the total setsockopt payload past 8KB.
+  const size_t kMinPayload = 9 * 1024;
+  size_t extra = 0;
+  if (sizeof(struct ipt_replace) + info.size < kMinPayload) {
+    extra = (kMinPayload - sizeof(struct ipt_replace) - info.size +
+             kEmptyStandardEntrySize - 1) /
+            kEmptyStandardEntrySize;
+  }
+  const size_t shift = extra * kEmptyStandardEntrySize;
+  const size_t new_entries_size = info.size + shift;
+  const unsigned int new_num_entries = info.num_entries + extra;
+  const size_t buf_sz = sizeof(struct ipt_replace) + new_entries_size;
+
+  ASSERT_GT(buf_sz, 8192u);
+
+  // Build ipt_replace buffer.
+  std::unique_ptr<char[]> buf(new char[buf_sz]());
+  struct ipt_replace* repl =
+      reinterpret_cast<struct ipt_replace*>(buf.get());
+
+  snprintf(repl->name, sizeof(repl->name), "%s", kNatTablename);
+  repl->valid_hooks = info.valid_hooks;
+  repl->num_entries = new_num_entries;
+  repl->size = new_entries_size;
+  repl->num_counters = new_num_entries;
+
+  std::unique_ptr<struct xt_counters[]> ctrs(
+      new struct xt_counters[new_num_entries]());
+  repl->counters = ctrs.get();
+
+  // Insert extra entries at the start of the PREROUTING chain. All valid
+  // hook/underflow offsets shift forward by `shift` bytes to account for the
+  // new entries. The PREROUTING hook_entry stays at 0 because the new entries
+  // ARE the beginning of the chain.
+  for (int h = 0; h < NF_IP_NUMHOOKS; h++) {
+    if (info.valid_hooks & (1 << h)) {
+      repl->hook_entry[h] = info.hook_entry[h] + shift;
+      repl->underflow[h] = info.underflow[h] + shift;
+    }
+  }
+  repl->hook_entry[NF_IP_PRE_ROUTING] = 0;
+
+  // Fill extra entries: unconditional ACCEPT rules.
+  char* dst = reinterpret_cast<char*>(repl->entries);
+  for (size_t i = 0; i < extra; i++) {
+    struct ipt_entry* e = reinterpret_cast<struct ipt_entry*>(
+        dst + i * kEmptyStandardEntrySize);
+    memset(e, 0, kEmptyStandardEntrySize);
+    e->target_offset = sizeof(struct ipt_entry);
+    e->next_offset = kEmptyStandardEntrySize;
+    struct ipt_standard_target* t =
+        reinterpret_cast<struct ipt_standard_target*>(e->elems);
+    t->target.u.user.target_size = sizeof(*t);
+    t->verdict = -NF_ACCEPT - 1;
+  }
+
+  // Copy original entries after the extra ones.
+  memcpy(dst + shift, reinterpret_cast<char*>(orig->entrytable), info.size);
+
+  ASSERT_THAT(setsockopt(s_, SOL_IP, IPT_SO_SET_REPLACE, repl, buf_sz),
+              SyscallSucceeds());
+
+  // Restore original table to avoid side effects on other tests.
+  size_t restore_sz = sizeof(struct ipt_replace) + info.size;
+  std::unique_ptr<char[]> restore_buf(new char[restore_sz]());
+  struct ipt_replace* restore =
+      reinterpret_cast<struct ipt_replace*>(restore_buf.get());
+  snprintf(restore->name, sizeof(restore->name), "%s", kNatTablename);
+  restore->valid_hooks = info.valid_hooks;
+  restore->num_entries = info.num_entries;
+  restore->size = info.size;
+  restore->num_counters = info.num_entries;
+  std::unique_ptr<struct xt_counters[]> rctrs(
+      new struct xt_counters[info.num_entries]());
+  restore->counters = rctrs.get();
+  memcpy(restore->hook_entry, info.hook_entry, sizeof(info.hook_entry));
+  memcpy(restore->underflow, info.underflow, sizeof(info.underflow));
+  memcpy(restore->entries, orig->entrytable, info.size);
+  EXPECT_THAT(setsockopt(s_, SOL_IP, IPT_SO_SET_REPLACE, restore, restore_sz),
+              SyscallSucceeds());
+}
+
 struct SockOptArgs {
   int sock;
   int optname;


### PR DESCRIPTION
## Summary

The hard-coded `maxOptLen` of `1024 * 8` (8192 bytes) in `pkg/sentry/syscalls/linux/sys_socket.go` silently returns `EINVAL` for any `setsockopt` call whose `optval` exceeds 8KB. This breaks real-world workloads that rely on `setsockopt(IPT_SO_SET_REPLACE)` with large iptables rulesets.

**Root cause:** `iptables-restore` uses `setsockopt(SOL_IP, IPT_SO_SET_REPLACE, ...)` to atomically replace an entire iptables table. For service meshes like Istio (v1.28+), the nat table payload commonly exceeds 8KB due to the number of rules generated for port exclusions, owner-match rules, and REDIRECT targets. When the payload exceeds `maxOptLen`, gVisor returns `EINVAL` before the buffer even reaches the netfilter layer — with no log message — causing `iptables-restore` to report cryptic errors like `"can't initialize iptables table 'nat': Table does not exist"`.

**Data points:**
- Istio 1.24 full ruleset (~30 rules, TCP-only exclusions): ~5-6KB — under 8KB limit — **passes**
- Existing `istio_blob` test fixture in gVisor: 5,688 bytes — under 8KB limit — **passes**
- Istio 1.28.4 full ruleset (~58+ rules, TCP+UDP exclusions): ~13KB — exceeds 8KB limit — **fails**

## What Linux does

Linux limits `setsockopt` `optval` to `INT_MAX` via the `int optlen` parameter type and a single `if (optlen < 0) return -EINVAL` check in `do_sock_setsockopt()` (`net/socket.c`). There is no upper-bound check — `INT_MAX` is the effective ceiling.

## What other runtimes do

| Runtime | `setsockopt` optlen limit | Mechanism |
|---------|--------------------------|-----------|
| **Linux kernel** | `INT_MAX` (2,147,483,647) | C `int` type + `optlen < 0` check |
| **runc** | `INT_MAX` | Delegates to host kernel |
| **Kata Containers** | `INT_MAX` | Runs real Linux kernel in VM |
| **gVisor (before)** | 8,192 | Arbitrary `maxOptLen` constant |
| **gVisor (this PR)** | 32,768 | Conservative increase |

## Changes

1. **`pkg/sentry/syscalls/linux/sys_socket.go`**: Changed `maxOptLen` from `1024 * 8` (8KB) to `32 * 1024` (32KB). This provides ~2.5x headroom over the largest known real-world payload (Istio 1.28+ at ~13KB).

2. **`test/syscalls/linux/iptables.cc`**: Added `LargeReplacePayload` regression test that constructs a valid nat table replacement payload exceeding 8KB and verifies `setsockopt(IPT_SO_SET_REPLACE)` succeeds. The test restores the original table afterward to avoid side effects.

## Question for maintainers

We chose a conservative 32KB to balance compatibility with resource protection. However, Linux uses `INT_MAX` and the existing `maxControlLen` in the same file is already 10MB. The sandbox's cgroup memory limits are arguably the right place to guard against resource exhaustion, not a per-syscall buffer cap.

**Should this be raised to `math.MaxInt32` to match Linux's `INT_MAX` behavior exactly?** This would eliminate any future risk of hitting this limit with other large `setsockopt` payloads (e.g. `SO_ATTACH_FILTER`, complex kube-proxy rulesets, etc.).

## Reproducer

On a gVisor-enabled Kubernetes node with `--net-raw` enabled:

```bash
# Istio 1.28+ istio-init generates ~13KB nat table payloads
# This fails silently with EINVAL on gVisor (before this fix)
kubectl run istio-test --image=istio/proxyv2:1.28.0 \
  --restart=Never --rm -it \
  --overrides='{"spec":{"runtimeClassName":"gvisor"}}' \
  -- pilot-agent istio-iptables
```

## Risk assessment

- **Low risk**: The `maxOptLen` constant is a gVisor-internal safety cap, not a Linux compatibility requirement. 32KB is still tiny compared to what a sandboxed process can already allocate via `mmap`, and far smaller than the existing `maxControlLen` of 10MB for `msg_control` buffers.
- **Note**: The existing `maxControlLen` comment acknowledges this exact pattern: _"Note that this limit is smaller than Linux, which allows buffers upto INT_MAX."_

Fixes #12685
