### PR TITLE
netfilter: add raw table and no-op CT target for Istio DNS capture

### DIFF
--- a/pkg/abi/linux/netfilter.go
+++ b/pkg/abi/linux/netfilter.go
@@ -462,6 +462,27 @@ type XTNATTargetV2 struct {
 // SizeOfXTNATTargetV2 is the size of an XTNATTargetV2.
 const SizeOfXTNATTargetV2 = SizeOfXTEntryTarget + SizeOfNFNATRange2
 
+// XTCTTargetInfoV0 corresponds to struct xt_ct_target_info (revision 0) in
+// include/uapi/linux/netfilter/xt_CT.h. The CT target is used in the raw
+// table for conntrack zone assignment. The trailing padding accounts for the
+// kernel-internal nf_conn pointer that is 8-byte aligned.
+//
+// +marshal
+type XTCTTargetInfoV0 struct {
+	_         structs.HostLayout
+	Target    XTEntryTarget
+	Flags     uint16
+	Zone      uint16
+	CTEvents  uint32
+	ExpEvents uint32
+	Helper    [16]byte
+	_         [4]byte // padding for 8-byte alignment of ct pointer
+	_         [8]byte // space for kernel nf_conn pointer (unused in userspace)
+}
+
+// SizeOfXTCTTargetInfoV0 is the size of an XTCTTargetInfoV0.
+const SizeOfXTCTTargetInfoV0 = 72
+
 // IPTGetinfo is the argument for the IPT_SO_GET_INFO sockopt. It corresponds
 // to struct ipt_getinfo in include/uapi/linux/netfilter_ipv4/ip_tables.h.
 //

--- a/pkg/sentry/socket/netfilter/BUILD
+++ b/pkg/sentry/socket/netfilter/BUILD
@@ -8,6 +8,7 @@ package(
 go_library(
     name = "netfilter",
     srcs = [
+        "ct_target.go",
         "dnat.go",
         "extensions.go",
         "ipv4.go",

--- a/pkg/sentry/socket/netfilter/ct_target.go
+++ b/pkg/sentry/socket/netfilter/ct_target.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netfilter
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/marshal"
+	"gvisor.dev/gvisor/pkg/syserr"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// CTTargetName is the name of the CT target used in the raw table for
+// conntrack zone assignment.
+const CTTargetName = "CT"
+
+// ctTarget wraps stack.CTTarget for the extension system.
+//
+// +stateify savable
+type ctTarget struct {
+	stack.CTTarget
+}
+
+func (ct *ctTarget) id() targetID {
+	return targetID{
+		name:            CTTargetName,
+		networkProtocol: ct.NetworkProtocol,
+	}
+}
+
+// ctTargetMaker implements targetMaker for the CT target.
+//
+// +stateify savable
+type ctTargetMaker struct {
+	NetworkProtocol tcpip.NetworkProtocolNumber
+}
+
+func (cm *ctTargetMaker) id() targetID {
+	return targetID{
+		name:            CTTargetName,
+		networkProtocol: cm.NetworkProtocol,
+	}
+}
+
+func (*ctTargetMaker) marshal(target target) []byte {
+	ct := target.(*ctTarget)
+	xt := linux.XTCTTargetInfoV0{
+		Target: linux.XTEntryTarget{
+			TargetSize: linux.SizeOfXTCTTargetInfoV0,
+		},
+		Zone: ct.Zone,
+	}
+	copy(xt.Target.Name[:], CTTargetName)
+	return marshal.Marshal(&xt)
+}
+
+func (cm *ctTargetMaker) unmarshal(buf []byte, filter stack.IPHeaderFilter) (target, *syserr.Error) {
+	if len(buf) < linux.SizeOfXTCTTargetInfoV0 {
+		nflog("ctTargetMaker: buf has insufficient size for CT target %d", len(buf))
+		return nil, syserr.ErrInvalidArgument
+	}
+
+	var ct linux.XTCTTargetInfoV0
+	ct.UnmarshalUnsafe(buf)
+
+	return &ctTarget{CTTarget: stack.CTTarget{
+		NetworkProtocol: filter.NetworkProtocol(),
+		Zone:            ct.Zone,
+	}}, nil
+}

--- a/pkg/sentry/socket/netfilter/netfilter.go
+++ b/pkg/sentry/socket/netfilter/netfilter.go
@@ -49,6 +49,7 @@ const (
 	natTable    = "nat"
 	mangleTable = "mangle"
 	filterTable = "filter"
+	rawTable    = "raw"
 )
 
 // nameToID is immutable.
@@ -56,6 +57,7 @@ var nameToID = map[string]stack.TableID{
 	natTable:    stack.NATID,
 	mangleTable: stack.MangleID,
 	filterTable: stack.FilterID,
+	rawTable:    stack.RawID,
 }
 
 // DefaultLinuxTables returns the rules of stack.DefaultTables() wrapped for
@@ -76,6 +78,8 @@ func DefaultLinuxTables(clock tcpip.Clock, rand *rand.Rand) *stack.IPTables {
 			return &returnTarget{ReturnTarget: *val}
 		case *stack.RedirectTarget:
 			return &redirectTarget{RedirectTarget: *val}
+		case *stack.CTTarget:
+			return &ctTarget{CTTarget: *val}
 		default:
 			panic(fmt.Sprintf("Unknown rule in default iptables of type %T", val))
 		}
@@ -192,6 +196,8 @@ func SetEntries(mapper IDMapper, stk *stack.Stack, optVal []byte, ipv6 bool) *sy
 		table = stack.EmptyFilterTable()
 	case natTable:
 		table = stack.EmptyNATTable()
+	case rawTable:
+		table = stack.EmptyRawTable()
 	default:
 		nflog("unknown iptables table %q", replace.Name.String())
 		return syserr.ErrInvalidArgument

--- a/pkg/sentry/socket/netfilter/targets.go
+++ b/pkg/sentry/socket/netfilter/targets.go
@@ -79,6 +79,14 @@ func init() {
 		NetworkProtocol: header.IPv6ProtocolNumber,
 	})
 
+	// CT targets (used in the raw table for conntrack zone assignment).
+	registerTargetMaker(&ctTargetMaker{
+		NetworkProtocol: header.IPv4ProtocolNumber,
+	})
+	registerTargetMaker(&ctTargetMaker{
+		NetworkProtocol: header.IPv6ProtocolNumber,
+	})
+
 	// DNAT targets.
 	registerTargetMaker(&dnatTargetMakerV4{
 		NetworkProtocol: header.IPv4ProtocolNumber,

--- a/pkg/tcpip/stack/iptables.go
+++ b/pkg/tcpip/stack/iptables.go
@@ -33,6 +33,7 @@ const (
 	NATID TableID = iota
 	MangleID
 	FilterID
+	RawID
 	NumTables
 )
 
@@ -111,6 +112,27 @@ func DefaultTables(clock tcpip.Clock, rand *rand.Rand) *IPTables {
 					Postrouting: HookUnset,
 				},
 			},
+			RawID: {
+				Rules: []Rule{
+					{Filter: EmptyFilter4(), Target: &AcceptTarget{NetworkProtocol: header.IPv4ProtocolNumber}},
+					{Filter: EmptyFilter4(), Target: &AcceptTarget{NetworkProtocol: header.IPv4ProtocolNumber}},
+					{Filter: EmptyFilter4(), Target: &ErrorTarget{NetworkProtocol: header.IPv4ProtocolNumber}},
+				},
+				BuiltinChains: [NumHooks]int{
+					Prerouting:  0,
+					Input:       HookUnset,
+					Forward:     HookUnset,
+					Output:      1,
+					Postrouting: HookUnset,
+				},
+				Underflows: [NumHooks]int{
+					Prerouting:  0,
+					Input:       HookUnset,
+					Forward:     HookUnset,
+					Output:      1,
+					Postrouting: HookUnset,
+				},
+			},
 		},
 		v6Tables: [NumTables]Table{
 			NATID: {
@@ -176,6 +198,27 @@ func DefaultTables(clock tcpip.Clock, rand *rand.Rand) *IPTables {
 					Postrouting: HookUnset,
 				},
 			},
+			RawID: {
+				Rules: []Rule{
+					{Filter: EmptyFilter6(), Target: &AcceptTarget{NetworkProtocol: header.IPv6ProtocolNumber}},
+					{Filter: EmptyFilter6(), Target: &AcceptTarget{NetworkProtocol: header.IPv6ProtocolNumber}},
+					{Filter: EmptyFilter6(), Target: &ErrorTarget{NetworkProtocol: header.IPv6ProtocolNumber}},
+				},
+				BuiltinChains: [NumHooks]int{
+					Prerouting:  0,
+					Input:       HookUnset,
+					Forward:     HookUnset,
+					Output:      1,
+					Postrouting: HookUnset,
+				},
+				Underflows: [NumHooks]int{
+					Prerouting:  0,
+					Input:       HookUnset,
+					Forward:     HookUnset,
+					Output:      1,
+					Postrouting: HookUnset,
+				},
+			},
 		},
 		connections: ConnTrack{
 			seed:  rand.Uint32(),
@@ -211,6 +254,24 @@ func EmptyNATTable() Table {
 		},
 		Underflows: [NumHooks]int{
 			Forward: HookUnset,
+		},
+	}
+}
+
+// EmptyRawTable returns a Table with no rules and only the Prerouting and
+// Output hooks set, matching the Linux raw table's valid hooks.
+func EmptyRawTable() Table {
+	return Table{
+		Rules: []Rule{},
+		BuiltinChains: [NumHooks]int{
+			Input:       HookUnset,
+			Forward:     HookUnset,
+			Postrouting: HookUnset,
+		},
+		Underflows: [NumHooks]int{
+			Input:       HookUnset,
+			Forward:     HookUnset,
+			Postrouting: HookUnset,
 		},
 	}
 }
@@ -340,6 +401,10 @@ func (it *IPTables) CheckPrerouting(pkt *PacketBuffer, addressEP AddressableEndp
 	tables := [...]checkTable{ // escapes: on arm this causes an allocation.
 		{
 			fn:      check,
+			tableID: RawID,
+		},
+		{
+			fn:      check,
 			tableID: MangleID,
 		},
 		{
@@ -448,6 +513,10 @@ func (it *IPTables) CheckForward(pkt *PacketBuffer, inNicName, outNicName string
 // +checkescape
 func (it *IPTables) CheckOutput(pkt *PacketBuffer, r *Route, outNicName string) bool {
 	tables := [...]checkTable{ // escapes: on arm this causes an allocation.
+		{
+			fn:      check,
+			tableID: RawID,
+		},
 		{
 			fn:      check,
 			tableID: MangleID,

--- a/pkg/tcpip/stack/iptables_targets.go
+++ b/pkg/tcpip/stack/iptables_targets.go
@@ -413,6 +413,26 @@ func (mt *MasqueradeTarget) Action(pkt *PacketBuffer, hook Hook, r *Route, addre
 	return snatAction(pkt, hook, r, 0 /* port */, address, true /* changePort */, true /* changeAddress */)
 }
 
+// CTTarget is a no-op implementation of the CT (conntrack) target used in the
+// raw table. In Linux, CT --zone sets conntrack zones for connection tracking
+// isolation. gVisor's conntrack does not support zones, so this target simply
+// accepts the packet, allowing iptables-restore to load rulesets that reference
+// CT targets (e.g. Istio with DNS capture enabled).
+//
+// +stateify savable
+type CTTarget struct {
+	// NetworkProtocol is the network protocol the target is used with.
+	NetworkProtocol tcpip.NetworkProtocolNumber
+
+	// Zone is the conntrack zone ID. Stored but not acted upon.
+	Zone uint16
+}
+
+// Action implements Target.Action. It is a no-op that accepts the packet.
+func (*CTTarget) Action(*PacketBuffer, Hook, *Route, AddressableEndpoint) (RuleVerdict, int) {
+	return RuleAccept, 0
+}
+
 func rewritePacket(n header.Network, t header.Transport, updateSRCFields, fullChecksum, updatePseudoHeader bool, newPortOrIdent uint16, newAddr tcpip.Address) {
 	switch t := t.(type) {
 	case header.ChecksummableTransport:

--- a/test/syscalls/linux/iptables.cc
+++ b/test/syscalls/linux/iptables.cc
@@ -53,6 +53,7 @@ namespace testing {
 namespace {
 
 constexpr char kNatTablename[] = "nat";
+constexpr char kRawTablename[] = "raw";
 constexpr char kErrorTarget[] = "ERROR";
 constexpr size_t kEmptyStandardEntrySize =
     sizeof(struct ipt_entry) + sizeof(struct ipt_standard_target);
@@ -388,6 +389,52 @@ TEST_F(IPTablesTest, LargeReplacePayload) {
   memcpy(restore->entries, orig->entrytable, info.size);
   EXPECT_THAT(setsockopt(s_, SOL_IP, IPT_SO_SET_REPLACE, restore, restore_sz),
               SyscallSucceeds());
+}
+
+// Tests the initial state of the raw table. The raw table has PREROUTING and
+// OUTPUT hooks (no INPUT, FORWARD, or POSTROUTING).
+TEST_F(IPTablesTest, RawTableInitialState) {
+  SKIP_IF(!IsRunningOnGvisor());
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_RAW)));
+
+  struct ipt_getinfo info = {};
+  snprintf(info.name, XT_TABLE_MAXNAMELEN, "%s", kRawTablename);
+  socklen_t info_size = sizeof(info);
+  ASSERT_THAT(getsockopt(s_, SOL_IP, IPT_SO_GET_INFO, &info, &info_size),
+              SyscallSucceeds());
+
+  // The raw table supports PREROUTING and OUTPUT only.
+  unsigned int valid_hooks =
+      (1 << NF_IP_PRE_ROUTING) | (1 << NF_IP_LOCAL_OUT);
+  EXPECT_EQ(info.valid_hooks, valid_hooks);
+
+  // Two chain entries (PREROUTING, OUTPUT) plus one error entry.
+  EXPECT_EQ(info.num_entries, 3);
+  EXPECT_EQ(info.size, 2 * kEmptyStandardEntrySize + kEmptyErrorEntrySize);
+  EXPECT_EQ(strcmp(info.name, kRawTablename), 0);
+}
+
+// Tests that the CT target revision 0 is recognized.
+TEST(IPTablesBasic, CTTargetGetRevision) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_RAW)));
+
+  int sock;
+  ASSERT_THAT(sock = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP),
+              SyscallSucceeds());
+
+  struct xt_get_revision rev = {};
+  socklen_t rev_len = sizeof(rev);
+
+  snprintf(rev.name, sizeof(rev.name), "CT");
+  rev.revision = 0;
+
+  // CT revision 0 should exist.
+  EXPECT_THAT(
+      getsockopt(sock, SOL_IP, IPT_SO_GET_REVISION_TARGET, &rev, &rev_len),
+      SyscallSucceeds());
+  EXPECT_EQ(rev.revision, 0);
+
+  EXPECT_THAT(close(sock), SyscallSucceeds());
 }
 
 struct SockOptArgs {


### PR DESCRIPTION
## Summary

Add the iptables `raw` table and a no-op `CT` (conntrack zone) target to gVisor's netfilter implementation. This enables Istio's `istio-init` container to apply iptables rules when DNS capture is enabled (`ISTIO_META_DNS_CAPTURE=true`).

## Problem

When Istio DNS capture is enabled, `istio-iptables` generates `iptables-restore` input containing both `* nat` and `* raw` table sections. The `raw` table rules use `-j CT --zone N` targets for conntrack zone isolation between Envoy's DNS queries and application DNS queries. gVisor previously only implemented `nat`, `mangle`, and `filter` tables, causing `iptables-restore` to fail with:

```
iptables-restore: unable to initialize table 'raw'
```

This blocks Istio service mesh adoption on gVisor when DNS capture is required.

## Approach

**Raw table**: Added as a new `TableID` (`RawID`) with `PREROUTING` and `OUTPUT` hooks, matching the Linux kernel's raw table. Wired into `CheckPrerouting()` and `CheckOutput()` as the **first** table checked (before mangle), matching Linux's netfilter hook priority ordering:

- Linux hook order: raw → conntrack → mangle → nat → filter
- gVisor hook order (now): raw → mangle → nat (filter is separate)

**CT target**: Implemented as a **no-op** that accepts packets without modifying conntrack behavior. The target parses the `xt_ct_target_info` (revision 0) struct from userspace, stores the zone value, but does not apply zone-based conntrack isolation. This is intentional:

- gVisor's conntrack implementation does not support zones
- The CT target's purpose in Istio is to prevent conntrack table collisions between Envoy (UID 1337) and application DNS traffic
- DNS redirection still works correctly via the `nat` table's `REDIRECT` rules to port 15053
- The lack of zone tracking may cause rare conntrack 5-tuple collisions under heavy concurrent DNS load, but this is acceptable for gVisor's sandboxed environment

**How Linux and other runtimes handle this**:
- **Linux kernel**: Full `raw` table with `CT --zone` support via `nf_conntrack_zones`
- **runc / kata**: Delegate to the host Linux kernel, so they get full support for free
- **gVisor**: Must implement in userspace netstack — this PR adds the table/target scaffolding with a no-op CT action

## Changes

- `pkg/tcpip/stack/iptables.go`: Add `RawID` to `TableID` enum, `EmptyRawTable()`, default table entries for IPv4/IPv6, wire into `CheckPrerouting()` and `CheckOutput()`
- `pkg/tcpip/stack/iptables_targets.go`: Add `CTTarget` struct with no-op `Action()` returning `RuleAccept`
- `pkg/abi/linux/netfilter.go`: Add `XTCTTargetInfoV0` ABI struct (72 bytes) matching Linux's `xt_ct_target_info`
- `pkg/sentry/socket/netfilter/netfilter.go`: Register `raw` table in `nameToID`, `SetEntries`, and `DefaultLinuxTables`
- `pkg/sentry/socket/netfilter/ct_target.go`: New file — `ctTarget` wrapper and `ctTargetMaker` with marshal/unmarshal
- `pkg/sentry/socket/netfilter/targets.go`: Register `ctTargetMaker` for IPv4 and IPv6
- `pkg/sentry/socket/netfilter/BUILD`: Add `ct_target.go` to srcs
- `test/syscalls/linux/iptables.cc`: Add `RawTableInitialState` test (gVisor-only) and `CTTargetGetRevision` test

## Testing

- `RawTableInitialState`: Verifies `IPT_SO_GET_INFO` for the "raw" table returns correct `valid_hooks` (PREROUTING + OUTPUT), `num_entries` (3), and entry sizes
- `CTTargetGetRevision`: Verifies `IPT_SO_GET_REVISION_TARGET` for "CT" target revision 0 succeeds
- **Manual end-to-end test**: Built `runsc` with this change (plus #12686), deployed to an aarch64 node, and verified Istio `istio-init` with `ISTIO_META_DNS_CAPTURE=true` completes successfully — the full `iptables-restore` input including both `* nat` and `* raw` sections is applied without error

## Related

- Fixes #12685
- Depends on #12686 (maxOptLen increase) for large Istio rulesets