### PR TITLE
nvproxy: add missing size validation for control commands

### DIFF
--- a/pkg/sentry/devices/nvproxy/frontend.go
+++ b/pkg/sentry/devices/nvproxy/frontend.go
@@ -825,6 +825,9 @@ func rmControlSimple(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETER
 	if ioctlParams.Params == 0 {
 		return 0, linuxerr.EINVAL
 	}
+	if ioctlParams.ParamsSize > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE {
+		return 0, linuxerr.EINVAL
+	}
 
 	ctrlParams := make([]byte, ioctlParams.ParamsSize)
 	if _, err := fi.t.CopyInBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {

--- a/pkg/sentry/devices/nvproxy/frontend_unsafe.go
+++ b/pkg/sentry/devices/nvproxy/frontend_unsafe.go
@@ -168,7 +168,7 @@ func ctrlDevFIFOGetChannelList(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54
 	if _, err := ctrlParams.CopyIn(fi.t, addrFromP64(ioctlParams.Params)); err != nil {
 		return 0, err
 	}
-	if ctrlParams.NumChannels == 0 {
+	if !rmapiParamsSizeCheck(ctrlParams.NumChannels, 4 /* sizeof(NvU32) */) {
 		// Compare
 		// src/nvidia/src/kernel/gpu/fifo/kernel_fifo_ctrl.c:deviceCtrlCmdFifoGetChannelList_IMPL().
 		return 0, linuxerr.EINVAL
@@ -215,8 +215,11 @@ func ctrlClientSystemGetP2PCapsInitializeArray(origArr nvgpu.P64, gpuCount uint3
 	}
 
 	// Params size is gpuCount * gpuCount * sizeof(NvU32).
-	numEntries := gpuCount * gpuCount
-	if numEntries*4 > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE {
+	// Use uint64 to handle overflow. In the driver, this is handled by
+	// portSafeMulU32(). See
+	// src/nvidia/src/kernel/rmapi/embedded_param_copy.c::embeddedParamCopyIn().
+	numEntries := uint64(gpuCount) * uint64(gpuCount)
+	if numEntries == 0 || numEntries*4 > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE {
 		return 0, nil, false
 	}
 


### PR DESCRIPTION
Three control command handlers lack proper size validation before allocating buffers from user-controlled parameters, inconsistent with the NVIDIA driver's centralized validation in `rmapiParamsAcquire()`:

**1. `rmControlSimple` — unbounded `ParamsSize` allocation**
`ParamsSize` (uint32) is used directly in `make([]byte, ParamsSize)` without checking against `RMAPI_PARAM_COPY_MAX_PARAMS_SIZE` (1MB). The real driver validates all control params in `src/nvidia/src/kernel/rmapi/param_copy.c:rmapiParamsAcquire()`.

**2. `ctrlDevFIFOGetChannelList` — missing `rmapiParamsSizeCheck`**
`NumChannels` is only checked for zero but not against `rmapiParamsSizeCheck()`, unlike similar handlers (`ctrlGetNvU32List`, `ctrlDevGRGetCaps`, `rmIdleChannels`) which all call it.

**3. `ctrlClientSystemGetP2PCapsInitializeArray` — uint32 overflow**
`gpuCount * gpuCount` uses uint32 arithmetic that overflows to 0 when `gpuCount` is 0 or 65536. This passes the size check, creates an empty slice, and `&arr[0]` panics with index-out-of-range. The real driver uses `portSafeMulU32()` for overflow detection.

**Fixes:**
- Add `ParamsSize > RMAPI_PARAM_COPY_MAX_PARAMS_SIZE` check to `rmControlSimple`
- Replace `NumChannels == 0` with `rmapiParamsSizeCheck(NumChannels, 4)` in `ctrlDevFIFOGetChannelList`
- Use `uint64` multiplication and add `numEntries == 0` check in P2P caps

Related: c50105dc (similar size check added for `NV0000_CTRL_CMD_SYSTEM_GET_BUILD_VERSION`)