### PR TITLE
runsc ps: Add process group ID (PGID) to output

### DIFF
--- a/pkg/sentry/control/proc.go
+++ b/pkg/sentry/control/proc.go
@@ -354,7 +354,9 @@ type Process struct {
 	UID auth.KUID       `json:"uid"`
 	PID kernel.ThreadID `json:"pid"`
 	// Parent PID
-	PPID    kernel.ThreadID   `json:"ppid"`
+	PPID kernel.ThreadID `json:"ppid"`
+	// Process Group ID
+	PGID    kernel.ThreadID   `json:"pgid"`
 	Threads []kernel.ThreadID `json:"threads"`
 	// Processor utilization
 	C int32 `json:"c"`
@@ -370,17 +372,18 @@ type Process struct {
 }
 
 // ProcessListToTable prints a table with the following format:
-// UID       PID       PPID      C         TTY		STIME     TIME       CMD
-// 0         1         0         0         pty/4	14:04     505262ns   tail
+// UID       PID       PPID      PGID      C         TTY		STIME     TIME       CMD
+// 0         1         0         1         0         pty/4	14:04     505262ns   tail
 func ProcessListToTable(pl []*Process) string {
 	var buf bytes.Buffer
 	tw := tabwriter.NewWriter(&buf, 10, 1, 3, ' ', 0)
-	fmt.Fprint(tw, "UID\tPID\tPPID\tC\tTTY\tSTIME\tTIME\tCMD")
+	fmt.Fprint(tw, "UID\tPID\tPPID\tPGID\tC\tTTY\tSTIME\tTIME\tCMD")
 	for _, d := range pl {
-		fmt.Fprintf(tw, "\n%d\t%d\t%d\t%d\t%s\t%s\t%s\t%s",
+		fmt.Fprintf(tw, "\n%d\t%d\t%d\t%d\t%d\t%s\t%s\t%s\t%s",
 			d.UID,
 			d.PID,
 			d.PPID,
+			d.PGID,
 			d.C,
 			d.TTY,
 			d.STime,
@@ -435,11 +438,16 @@ func Processes(k *kernel.Kernel, containerID string, out *[]*Process) error {
 		if p := tg.Leader().Parent(); p != nil {
 			ppid = pidns.IDOfThreadGroup(p.ThreadGroup())
 		}
+		pgid := kernel.ThreadID(0)
+		if pg := tg.ProcessGroup(); pg != nil {
+			pgid = kernel.ThreadID(pidns.IDOfProcessGroup(pg))
+		}
 		threads := tg.MemberIDs(pidns)
 		*out = append(*out, &Process{
 			UID:     tg.Leader().Credentials().EffectiveKUID,
 			PID:     pid,
 			PPID:    ppid,
+			PGID:    pgid,
 			Threads: threads,
 			STime:   formatStartTime(now, tg.Leader().StartTime()),
 			C:       percentCPU(tg.CPUStats(), tg.Leader().StartTime(), now),

--- a/pkg/sentry/control/proc_test.go
+++ b/pkg/sentry/control/proc_test.go
@@ -34,7 +34,7 @@ func TestProcessListTable(t *testing.T) {
 	}{
 		{
 			pl:       []*Process{},
-			expected: "UID       PID       PPID      C         TTY       STIME     TIME      CMD",
+			expected: "UID       PID       PPID      PGID      C         TTY       STIME     TIME      CMD",
 		},
 		{
 			pl: []*Process{
@@ -42,6 +42,7 @@ func TestProcessListTable(t *testing.T) {
 					UID:   0,
 					PID:   0,
 					PPID:  0,
+					PGID:  0,
 					C:     0,
 					TTY:   "?",
 					STime: "0",
@@ -52,6 +53,7 @@ func TestProcessListTable(t *testing.T) {
 					UID:   1,
 					PID:   1,
 					PPID:  1,
+					PGID:  1,
 					C:     1,
 					TTY:   "pts/4",
 					STime: "1",
@@ -59,9 +61,9 @@ func TestProcessListTable(t *testing.T) {
 					Cmd:   "one",
 				},
 			},
-			expected: `UID       PID       PPID      C         TTY       STIME     TIME      CMD
-0         0         0         0         ?         0         0         zero
-1         1         1         1         pts/4     1         1         one`,
+			expected: `UID       PID       PPID      PGID      C         TTY       STIME     TIME      CMD
+0         0         0         0         0         ?         0         0         zero
+1         1         1         1         1         pts/4     1         1         one`,
 		},
 	}
 

--- a/runsc/cmd/ps.go
+++ b/runsc/cmd/ps.go
@@ -84,7 +84,7 @@ func (ps *PS) Execute(ctx context.Context, f *flag.FlagSet, args ...any) subcomm
 	case "table":
 		fmt.Println(control.ProcessListToTable(pList))
 	case "json":
-		o, err := control.PrintPIDsJSON(pList)
+		o, err := control.ProcessListToJSON(pList)
 		if err != nil {
 			util.Fatalf("generating JSON: %v", err)
 		}


### PR DESCRIPTION
Add the process group ID (PGID) field to the Process struct and populate it using the existing kernel ProcessGroup API. The PGID is now displayed in both table and JSON output of `runsc ps`.

The JSON output format is changed from a bare PID array to the full Process struct serialization, making fields like PGID, PPID, UID, and command name available to callers.

This enables container runtimes to discover process group IDs from outside the sandbox without needing to exec into the container, which is useful for sending signals to entire process groups via `runsc kill` when the container may be under memory pressure.