### PR TITLE
Fix /proc/[pid]/io rchar field name typo

### DIFF
--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -1022,7 +1022,7 @@ func (i *ioData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	io := usage.IO{}
 	io.Accumulate(i.IOUsage())
 
-	fmt.Fprintf(buf, "char: %d\n", io.CharsRead.RacyLoad())
+	fmt.Fprintf(buf, "rchar: %d\n", io.CharsRead.RacyLoad())
 	fmt.Fprintf(buf, "wchar: %d\n", io.CharsWritten.RacyLoad())
 	fmt.Fprintf(buf, "syscr: %d\n", io.ReadSyscalls.RacyLoad())
 	fmt.Fprintf(buf, "syscw: %d\n", io.WriteSyscalls.RacyLoad())


### PR DESCRIPTION
## Problem

The `/proc/[pid]/io` output uses `char:` instead of the correct `rchar:` prefix for the read characters field. This does not match the Linux kernel's `proc_pid_io` format (`fs/proc/base.c`), where the fields are: `rchar`, `wchar`, `syscr`, `syscw`, `read_bytes`, `write_bytes`, `cancelled_write_bytes`.

Fixes #12755

## Fix

Changed the string literal in `pkg/sentry/fsimpl/proc/task_files.go:1025` from `"char: %d\n"` to `"rchar: %d\n"`.

## Test

No existing unit test covers the `/proc/[pid]/io` output format. The fix is a single-character string literal correction matching the Linux kernel's documented format.