### PR TITLE
fsimpl/user: align PATH resolve error handling with glibc execvpe

### DIFF
--- a/pkg/sentry/fsimpl/user/path.go
+++ b/pkg/sentry/fsimpl/user/path.go
@@ -72,9 +72,13 @@ func ResolveExecutablePath(ctx context.Context, args *kernel.CreateProcessArgs) 
 	return f, nil
 }
 
+// resolve searches for an executable in the given PATH directories.
+// Error handling follows glibc execvpe() (posix/execvpe.c).
 func resolve(ctx context.Context, creds *auth.Credentials, mns *vfs.MountNamespace, paths []string, name string) (string, error) {
 	root := mns.Root(ctx)
 	defer root.DecRef(ctx)
+	gotEACCES := false
+	lastErr := error(linuxerr.ENOENT)
 	for _, p := range paths {
 		if !path.IsAbs(p) {
 			// Relative paths aren't safe, no one should be using them.
@@ -94,20 +98,31 @@ func resolve(ctx context.Context, creds *auth.Credentials, mns *vfs.MountNamespa
 			Flags:    linux.O_RDONLY,
 		}
 		dentry, err := root.Mount().Filesystem().VirtualFilesystem().OpenAt(ctx, creds, pop, opts)
-		if linuxerr.Equals(linuxerr.ENOENT, err) || linuxerr.Equals(linuxerr.EACCES, err) {
-			// Didn't find it here.
-			continue
+		if err == nil {
+			dentry.DecRef(ctx)
+			return binPath, nil
 		}
-		if err != nil {
+
+		// Preserve the last error, matching glibc's errno semantics.
+		lastErr = err
+		switch {
+		case linuxerr.Equals(linuxerr.EACCES, err):
+			gotEACCES = true
+		case linuxerr.Equals(linuxerr.ENOENT, err),
+			linuxerr.Equals(linuxerr.ESTALE, err),
+			linuxerr.Equals(linuxerr.ENOTDIR, err),
+			linuxerr.Equals(linuxerr.ENODEV, err),
+			linuxerr.Equals(linuxerr.ETIMEDOUT, err):
+			// Skip to next PATH entry.
+		default:
 			return "", err
 		}
-		dentry.DecRef(ctx)
-
-		return binPath, nil
 	}
 
-	// Couldn't find it.
-	return "", linuxerr.ENOENT
+	if gotEACCES {
+		return "", linuxerr.EACCES
+	}
+	return "", lastErr
 }
 
 // getPath returns the PATH as a slice of strings given the environment

--- a/pkg/sentry/fsimpl/user/user_test.go
+++ b/pkg/sentry/fsimpl/user/user_test.go
@@ -436,3 +436,158 @@ func TestGetExecUIDGIDFromUser(t *testing.T) {
 		})
 	}
 }
+
+// newResolveTestVFS creates a tmpfs-backed VFS for resolve() tests.
+func newResolveTestVFS(t *testing.T) (context.Context, *auth.Credentials, *vfs.VirtualFilesystem, *vfs.MountNamespace, vfs.VirtualDentry) {
+	t.Helper()
+	ctx := contexttest.Context(t)
+	creds := auth.CredentialsFromContext(ctx)
+
+	vfsObj := &vfs.VirtualFilesystem{}
+	if err := vfsObj.Init(ctx); err != nil {
+		t.Fatalf("VFS init: %v", err)
+	}
+	vfsObj.MustRegisterFilesystemType("tmpfs", tmpfs.FilesystemType{}, &vfs.RegisterFilesystemTypeOptions{
+		AllowUserMount: true,
+	})
+	mns, err := vfsObj.NewMountNamespace(ctx, creds, "", "tmpfs", &vfs.MountOptions{}, nil)
+	if err != nil {
+		t.Fatalf("failed to create tmpfs root mount: %v", err)
+	}
+	root := mns.Root(ctx)
+	return ctx, creds, vfsObj, mns, root
+}
+
+// createFile creates a regular file at the given path in the test VFS.
+func createFile(t *testing.T, ctx context.Context, creds *auth.Credentials, vfsObj *vfs.VirtualFilesystem, root vfs.VirtualDentry, filePath string, mode uint16) {
+	t.Helper()
+	pop := vfs.PathOperation{
+		Root:  root,
+		Start: root,
+		Path:  fspath.Parse(filePath),
+	}
+	fd, err := vfsObj.OpenAt(ctx, creds, &pop, &vfs.OpenOptions{
+		Flags: linux.O_CREAT | linux.O_WRONLY,
+		Mode:  linux.S_IFREG | linux.FileMode(mode),
+	})
+	if err != nil {
+		t.Fatalf("failed to create %s: %v", filePath, err)
+	}
+	fd.DecRef(ctx)
+}
+
+// createDir creates a directory at the given path in the test VFS.
+func createDir(t *testing.T, ctx context.Context, creds *auth.Credentials, vfsObj *vfs.VirtualFilesystem, root vfs.VirtualDentry, dirPath string) {
+	t.Helper()
+	pop := vfs.PathOperation{
+		Root:  root,
+		Start: root,
+		Path:  fspath.Parse(dirPath),
+	}
+	if err := vfsObj.MkdirAt(ctx, creds, &pop, &vfs.MkdirOptions{Mode: 0755}); err != nil {
+		t.Fatalf("failed to create directory %s: %v", dirPath, err)
+	}
+}
+
+// TestResolveExecutablePath tests that resolve() follows glibc execvpe()
+// semantics for handling errors during PATH search:
+//   - ENOENT, ENOTDIR, ESTALE, ENODEV, ETIMEDOUT: skip to next PATH entry.
+//   - EACCES: record and continue; if no executable is found, return EACCES
+//     instead of ENOENT.
+//   - Any other error: stop and return immediately.
+//
+// Reference: glibc posix/execvpe.c __execvpe_common().
+func TestResolveExecutablePath(t *testing.T) {
+	ctx, creds, vfsObj, mns, root := newResolveTestVFS(t)
+	defer mns.DecRef(ctx)
+	defer root.DecRef(ctx)
+
+	// Layout:
+	//   /not_a_dir       — regular file (triggers ENOTDIR)
+	//   /bin/myexec      — executable
+	createFile(t, ctx, creds, vfsObj, root, "not_a_dir", 0755)
+	createDir(t, ctx, creds, vfsObj, root, "bin")
+	createFile(t, ctx, creds, vfsObj, root, "bin/myexec", 0755)
+
+	t.Run("SkipENOTDIR", func(t *testing.T) {
+		// /not_a_dir/myexec → ENOTDIR, should skip and find /bin/myexec.
+		got, err := resolve(ctx, creds, mns, []string{"/not_a_dir", "/bin"}, "myexec")
+		if err != nil {
+			t.Fatalf("resolve failed: %v", err)
+		}
+		if got != "/bin/myexec" {
+			t.Fatalf("expected /bin/myexec, got %v", got)
+		}
+	})
+
+	t.Run("SkipENOENT", func(t *testing.T) {
+		// /nonexistent doesn't exist → ENOENT, should skip and find /bin/myexec.
+		got, err := resolve(ctx, creds, mns, []string{"/nonexistent", "/bin"}, "myexec")
+		if err != nil {
+			t.Fatalf("resolve failed: %v", err)
+		}
+		if got != "/bin/myexec" {
+			t.Fatalf("expected /bin/myexec, got %v", got)
+		}
+	})
+
+	t.Run("AllMissReturnENOENT", func(t *testing.T) {
+		// PATH has ENOTDIR then ENOENT. glibc preserves the last errno
+		// from execve(), which is ENOENT from /nonexistent.
+		_, err := resolve(ctx, creds, mns, []string{"/not_a_dir", "/nonexistent"}, "myexec")
+		if !linuxerr.Equals(linuxerr.ENOENT, err) {
+			t.Fatalf("expected ENOENT, got: %v", err)
+		}
+	})
+
+	t.Run("OnlyENOTDIR", func(t *testing.T) {
+		// All PATH entries are files (not directories) → ENOTDIR.
+		// glibc preserves the last errno, which is ENOTDIR.
+		_, err := resolve(ctx, creds, mns, []string{"/not_a_dir"}, "myexec")
+		if !linuxerr.Equals(linuxerr.ENOTDIR, err) {
+			t.Fatalf("expected ENOTDIR, got: %v", err)
+		}
+	})
+
+	t.Run("EACCESReturnedOverENOENT", func(t *testing.T) {
+		// Create a file that exists but is not executable (mode 0644).
+		// The first PATH entry will fail with EACCES, and the second
+		// with ENOENT. Per glibc, EACCES should be returned.
+		createDir(t, ctx, creds, vfsObj, root, "noperm")
+		createFile(t, ctx, creds, vfsObj, root, "noperm/myexec", 0644)
+
+		_, err := resolve(ctx, creds, mns, []string{"/noperm", "/nonexistent"}, "myexec")
+		if !linuxerr.Equals(linuxerr.EACCES, err) {
+			t.Fatalf("expected EACCES, got: %v", err)
+		}
+	})
+
+	t.Run("EACCESThenFound", func(t *testing.T) {
+		// EACCES in first entry, but found in second → success.
+		got, err := resolve(ctx, creds, mns, []string{"/noperm", "/bin"}, "myexec")
+		if err != nil {
+			t.Fatalf("resolve failed: %v", err)
+		}
+		if got != "/bin/myexec" {
+			t.Fatalf("expected /bin/myexec, got %v", got)
+		}
+	})
+
+	t.Run("EmptyPATH", func(t *testing.T) {
+		_, err := resolve(ctx, creds, mns, nil, "myexec")
+		if !linuxerr.Equals(linuxerr.ENOENT, err) {
+			t.Fatalf("expected ENOENT, got: %v", err)
+		}
+	})
+
+	t.Run("SkipRelativePath", func(t *testing.T) {
+		// Relative paths should be skipped.
+		got, err := resolve(ctx, creds, mns, []string{"relative", "/bin"}, "myexec")
+		if err != nil {
+			t.Fatalf("resolve failed: %v", err)
+		}
+		if got != "/bin/myexec" {
+			t.Fatalf("expected /bin/myexec, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
Align resolve() error handling with glibc execvpe() (posix/execvpe.c):

- Skip ENOENT, ENOTDIR, ESTALE, ENODEV, ETIMEDOUT and continue to the next PATH entry, matching glibc's switch(errno) behavior.
- Track EACCES separately: if all PATH entries fail and at least one returned EACCES, report EACCES instead of ENOENT, matching glibc's got_eacces logic.
- Preserve the last error from execve() when no entry works, matching glibc's behavior of not resetting errno after the loop. For example, if all PATH entries are regular files (ENOTDIR), return ENOTDIR instead of ENOENT.
- Any other error is returned immediately.

Previously only ENOENT and EACCES were skipped, and ENOENT was always returned as the fallback error regardless of the actual last failure.

Test: TestResolveExecutablePath