### PR TITLE
nvproxy: add support for NVIDIA driver 570.211.01

### DIFF
--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -917,7 +917,8 @@ func Init() {
 		// The following versions exist on the "570" branch, which was branched
 		// from the main branch at 570.133.20.
 		v570_172_08 := addDriverABI(570, 172, 8, "0256867e082caf93d7b25fa7c8e69b316062a9c6c72c6e228fad7b238c6fa17d", "15547216f2b514ace7724a5ab4c3327669904a41cafb8d4d9048d3c9b60963d8", v570_133_20)
-		_ = addDriverABI(570, 195, 03, "d47de81d9a513496a60adc9cfa72fe9e162c65f2722fb960c4f531bd7ac5dc1e", "a38ae007abe8f82bfdd25272c28bc8c950114464b7475e73610523f9fd67cd64", v570_172_08)
+		v570_195_03 := addDriverABI(570, 195, 03, "d47de81d9a513496a60adc9cfa72fe9e162c65f2722fb960c4f531bd7ac5dc1e", "a38ae007abe8f82bfdd25272c28bc8c950114464b7475e73610523f9fd67cd64", v570_172_08)
+		_ = addDriverABI(570, 211, 01, "6d038c4fb83448ea4a3d25bdab1556514d5ac1da43377859e0586219a25ff72b", "ab144a828be2fb9956125b973f94d91b733b4911e3a0262cb827134b1d6e2b81", v570_195_03)
 
 		// 575.51.02 is an intermediate unqualified version from the main branch.
 		v575_51_02 := func() *driverABI {


### PR DESCRIPTION
### Description

Add NVIDIA driver version 570.211.01 to the supported driver list in nvproxy.

570.211.01 is placed on the "570" branch as a child of 570.195.03. There are no ABI changes between these two versions — verified by diffing the ioctl/ctrl header directories (`kernel-open/common/inc/ctrl`, `src/common/sdk`) between the two tags in [NVIDIA/open-gpu-kernel-modules](https://github.com/NVIDIA/open-gpu-kernel-modules). The NVIDIA commit history confirms the ancestry:

```
570.195.03 → 570.207 (intermediate) → 570.211.01
```

**Checksums** (SHA256 of official `.run` installers):
- x86_64: `6d038c4fb83448ea4a3d25bdab1556514d5ac1da43377859e0586219a25ff72b`
- aarch64: `ab144a828be2fb9956125b973f94d91b733b4911e3a0262cb827134b1d6e2b81`

### Motivation

NVIDIA driver 570.211.01 is being rolled out to cloud GPU fleets (e.g., AWS EC2 GPU instances). Without this change, any node running 570.211.01 with `nvproxy` enabled causes gVisor sandboxes to crash on boot with:

```
OCI runtime create failed: creating container: cannot create sandbox:
  cannot read client sync file: waiting for sandbox to start: EOF
```

The underlying fatal error (only visible with `--debug --debug-log`) is:

```
FATAL ERROR: creating loader: registering filesystems: registering nvproxy driver:
  unsupported Nvidia driver version: 570.211.01
```

This affects all pods on the node when nvproxy is enabled globally, including non-GPU pods.

Fixes #12773

### Changes

- `pkg/sentry/devices/nvproxy/version.go`: Rename `570.195.03` from `_` to `v570_195_03` and add `570.211.01` as its child with no ABI delta.