### PR TITLE
arm64: Replace page size panic with warning, add runtime check

### DIFF
--- a/pkg/hostarch/hostarch_arm64_4k.go
+++ b/pkg/hostarch/hostarch_arm64_4k.go
@@ -30,8 +30,7 @@ const (
 )
 
 func init() {
-	// Make sure the page size is 4K on arm64 platform.
 	if size := unix.Getpagesize(); size != PageSize {
-		panic("Only 4K page size is supported on arm64!")
+		println("WARNING: host page size mismatch - running on non-4K host")
 	}
 }

--- a/pkg/hostarch/hostarch_arm64_64k.go
+++ b/pkg/hostarch/hostarch_arm64_64k.go
@@ -30,8 +30,7 @@ const (
 )
 
 func init() {
-	// Make sure the page size is 64K on arm64 platform.
 	if size := unix.Getpagesize(); size != PageSize {
-		panic("Only 64K page size is supported on arm64 with pagesize_64k build tag!")
+		println("WARNING: host page size mismatch - running on non-64K host")
 	}
 }

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -91,6 +91,7 @@ go_library(
         "//pkg/coverage",
         "//pkg/cpuid",
         "//pkg/fd",
+        "//pkg/hostarch",
         "//pkg/log",
         "//pkg/metric",
         "//pkg/prometheus",

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -33,6 +33,7 @@ import (
 	"gvisor.dev/gvisor/pkg/coretag"
 	"gvisor.dev/gvisor/pkg/cpuid"
 	"gvisor.dev/gvisor/pkg/fd"
+	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/metric"
 	"gvisor.dev/gvisor/pkg/prometheus"
@@ -285,6 +286,10 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 	}
 
 	conf := args[0].(*config.Config)
+
+	if hostPageSize := unix.Getpagesize(); hostPageSize != hostarch.PageSize {
+		util.Fatalf("host page size (%d) does not match compiled page size (%d)", hostPageSize, hostarch.PageSize)
+	}
 
 	// Set traceback level
 	debug.SetTraceback(conf.Traceback)


### PR DESCRIPTION
Replace panic with warning in hostarch init() when the host page size
does not match the compiled page size on arm64. This applies to both
4K and 64K variants so build tools that import hostarch don't crash.

Add a page size check at runsc boot startup to fail on mismatch.

Fixes #12717
