### PR TITLE
feat(shim): implement containerd Task.Update for cgroup resize

### DIFF
--- a/pkg/shim/v1/proc/BUILD
+++ b/pkg/shim/v1/proc/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -39,4 +39,11 @@ go_library(
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_test(
+    name = "proc_test",
+    size = "small",
+    srcs = ["update_test.go"],
+    library = ":proc",
 )

--- a/pkg/shim/v1/proc/init.go
+++ b/pkg/shim/v1/proc/init.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/containerd/fifo"
 	runc "github.com/containerd/go-runc"
+	google_protobuf "github.com/gogo/protobuf/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/shim/v1/extension"
@@ -450,6 +451,21 @@ func (p *Init) Stats(ctx context.Context, id string) (*runc.Stats, error) {
 	defer p.mu.Unlock()
 
 	return p.initState.Stats(ctx, id)
+}
+
+// Update applies resource changes from JSON LinuxResources in the protobuf Any.
+func (p *Init) Update(ctx context.Context, r *google_protobuf.Any) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if r == nil {
+		return fmt.Errorf("resources are required: %w", errdefs.ErrInvalidArgument)
+	}
+	var resources specs.LinuxResources
+	if err := json.Unmarshal(r.Value, &resources); err != nil {
+		return fmt.Errorf("decoding resources: %w", err)
+	}
+	return p.runtime.Update(ctx, p.id, &resources)
 }
 
 func (p *Init) stats(ctx context.Context, id string) (*runc.Stats, error) {

--- a/pkg/shim/v1/proc/update_test.go
+++ b/pkg/shim/v1/proc/update_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/pkg/stdio"
+	"github.com/containerd/errdefs"
+	"github.com/gogo/protobuf/types"
+	"gvisor.dev/gvisor/pkg/shim/v1/runsccmd"
+)
+
+func TestInitUpdateNilAny(t *testing.T) {
+	p := New("id", &runsccmd.Runsc{}, stdio.Stdio{})
+	p.initState = &runningState{p: p}
+	err := p.Update(t.Context(), nil)
+	if !errors.Is(err, errdefs.ErrInvalidArgument) {
+		t.Fatalf("Update(nil): %v, want ErrInvalidArgument", err)
+	}
+}
+
+func TestInitUpdateInvalidJSON(t *testing.T) {
+	p := New("id", &runsccmd.Runsc{}, stdio.Stdio{})
+	p.initState = &runningState{p: p}
+	err := p.Update(t.Context(), &types.Any{Value: []byte(`{`)})
+	if err == nil || !strings.Contains(err.Error(), "decoding resources") {
+		t.Fatalf("Update(bad JSON): %v", err)
+	}
+}
+

--- a/pkg/shim/v1/runsc/container.go
+++ b/pkg/shim/v1/runsc/container.go
@@ -215,6 +215,18 @@ func (c *Container) CloseIO(ctx context.Context, r *task.CloseIORequest) error {
 	return nil
 }
 
+// Update applies cgroup resource limits for the init task.
+func (c *Container) Update(ctx context.Context, r *task.UpdateTaskRequest) error {
+	if r.Resources == nil {
+		return fmt.Errorf("resources are required: %w", errdefs.ErrInvalidArgument)
+	}
+	p, err := c.Process("")
+	if err != nil {
+		return err
+	}
+	return p.(*proc.Init).Update(ctx, r.Resources)
+}
+
 // Restore a process in the container.
 func (c *Container) Restore(ctx context.Context, r *extension.RestoreRequest) (extension.Process, error) {
 	p, err := c.Process(r.Start.ExecID)

--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -765,8 +765,18 @@ func (s *runscService) getV2Stats(stats *runc.Stats, r *taskAPI.StatsRequest) (*
 }
 
 // Update updates a running container.
+// CRI UpdateContainerResources sends the workload container ID, but runsc
+// update only accepts the root (sandbox) container. Route through s.id which
+// is the sandbox container ID assigned at shim startup.
 func (s *runscService) Update(ctx context.Context, r *taskAPI.UpdateTaskRequest) (*types.Empty, error) {
-	return empty, errdefs.ErrNotImplemented
+	c, err := s.getContainer(s.id)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.Update(ctx, r); err != nil {
+		return nil, errdefs.ToGRPC(err)
+	}
+	return empty, nil
 }
 
 // Wait waits for the container to exit.

--- a/pkg/shim/v1/runsc/service_test.go
+++ b/pkg/shim/v1/runsc/service_test.go
@@ -15,11 +15,22 @@
 package runsc
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/containerd/containerd/runtime/v2/task"
+	"github.com/containerd/errdefs"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/shim/v1/utils"
 )
+
+func TestContainerUpdateNilResources(t *testing.T) {
+	c := &Container{}
+	err := c.Update(t.Context(), &task.UpdateTaskRequest{ID: "x", Resources: nil})
+	if !errors.Is(err, errdefs.ErrInvalidArgument) {
+		t.Fatalf("Update(nil Resources): %v, want ErrInvalidArgument", err)
+	}
+}
 
 func TestCgroupPath(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/shim/v1/runsccmd/BUILD
+++ b/pkg/shim/v1/runsccmd/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -18,4 +18,11 @@ go_library(
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_test(
+    name = "runsccmd_test",
+    size = "small",
+    srcs = ["runsc_test.go"],
+    library = ":runsccmd",
 )

--- a/pkg/shim/v1/runsccmd/runsc.go
+++ b/pkg/shim/v1/runsccmd/runsc.go
@@ -205,6 +205,21 @@ func (r *Runsc) Resume(context context.Context, id string) error {
 	return nil
 }
 
+// Update the current container with the provided resource spec
+// The "-" path reads resources JSON from stdin.
+func (r *Runsc) Update(ctx context.Context, id string, resources *specs.LinuxResources) error {
+	buf := getBuf()
+	defer putBuf(buf)
+
+	if err := json.NewEncoder(buf).Encode(resources); err != nil {
+		return err
+	}
+	args := []string{"update", "--resources=-", id}
+	cmd := r.command(ctx, args...)
+	cmd.Stdin = buf
+	return r.runOrError(cmd)
+}
+
 // Start will start an already created container.
 func (r *Runsc) Start(context context.Context, id string, cio runc.IO) error {
 	return r.start(context, cio, r.command(context, "start", id))

--- a/pkg/shim/v1/runsccmd/runsc_test.go
+++ b/pkg/shim/v1/runsccmd/runsc_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package runsccmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// TestRunscUpdateCLI verifies Update runs the OCI update flow: JSON resources on
+// stdin and "update --resources - <id>" in argv (same contract as go-runc).
+func TestRunscUpdateCLI(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	argsLog := filepath.Join(dir, "args.txt")
+	stdinLog := filepath.Join(dir, "stdin.txt")
+	script := filepath.Join(dir, "fake-runsc")
+	scriptBody := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >%q
+cat >%q
+exit 0
+`, argsLog, stdinLog)
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	limit := int64(4096)
+	wantRes := &specs.LinuxResources{
+		Memory: &specs.LinuxMemory{Limit: &limit},
+	}
+
+	r := &Runsc{
+		Command: script,
+		Root:    filepath.Join(dir, "root"),
+	}
+	if err := r.Update(ctx, "cid-1", wantRes); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	rawArgs, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := strings.Fields(string(rawArgs))
+	var joined strings.Builder
+	for _, a := range args {
+		joined.WriteString(a)
+		joined.WriteByte(' ')
+	}
+	s := joined.String()
+	// go-runc may pass "--resources -"; we use "--resources=-" (same stdin contract).
+	if !strings.Contains(s, "update ") || !strings.Contains(s, "--resources") || !strings.Contains(s, "cid-1") {
+		t.Fatalf("argv missing expected update flags: %q", string(rawArgs))
+	}
+
+	rawStdin, err := os.ReadFile(stdinLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got specs.LinuxResources
+	if err := json.Unmarshal(rawStdin, &got); err != nil {
+		t.Fatalf("stdin JSON: %v", err)
+	}
+	if got.Memory == nil || got.Memory.Limit == nil || *got.Memory.Limit != limit {
+		t.Fatalf("stdin resources: got %+v, want memory limit %d", got.Memory, limit)
+	}
+}

--- a/pkg/test/criutil/criutil.go
+++ b/pkg/test/criutil/criutil.go
@@ -110,7 +110,8 @@ func (cc *Crictl) Create(podID, contSpecFile, sbSpecFile string) (string, error)
 	if err != nil {
 		return "", err
 	}
-	r := regexp.MustCompile(`crictl version ([0-9]+)\.([0-9]+)\.([0-9+])`)
+	// Newer crictl prints "version v1.2.3"; older prints "version 1.2.3".
+	r := regexp.MustCompile(`crictl version v?([0-9]+)\.([0-9]+)\.([0-9]+)`)
 	vs := r.FindStringSubmatch(out)
 	if len(vs) != 4 {
 		return "", fmt.Errorf("crictl -v had unexpected output: %s", out)
@@ -149,6 +150,26 @@ func (cc *Crictl) Start(contID string) (string, error) {
 		return "", fmt.Errorf("start failed: %v", err)
 	}
 	return output, nil
+}
+
+// UpdateContainerResources runs `crictl update` to set the Linux memory limit
+// (CRI UpdateContainerResources). memoryLimitBytes must be positive.
+func (cc *Crictl) UpdateContainerResources(contID string, memoryLimitBytes int64) error {
+	if memoryLimitBytes <= 0 {
+		return fmt.Errorf("memory limit must be positive")
+	}
+	_, err := cc.run("update", "--memory", strconv.FormatInt(memoryLimitBytes, 10), contID)
+	return err
+}
+
+// InspectGoTemplate runs `crictl inspect` with a Go template and returns the
+// trimmed output.
+func (cc *Crictl) InspectGoTemplate(contID, tmpl string) (string, error) {
+	out, err := cc.run("inspect", "-o", "go-template", "--template", tmpl, contID)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
 }
 
 // Stop stops a container. It corresponds to `crictl stop`.

--- a/test/root/crictl_test.go
+++ b/test/root/crictl_test.go
@@ -285,6 +285,73 @@ func TestHomeDir(t *testing.T) {
 	})
 }
 
+// criInspectMemoryLimitBytes reads the Linux memory limit from `crictl inspect`
+// via go-template (same data as RuntimeService.ContainerStatus over gRPC).
+func criInspectMemoryLimitBytes(cc *criutil.Crictl, contID string) (int64, error) {
+	const tmpl = `{{.status.resources.linux.memoryLimitInBytes}}`
+	out, err := cc.InspectGoTemplate(contID, tmpl)
+	if err != nil {
+		return 0, fmt.Errorf("inspect: %w", err)
+	}
+	n, err := strconv.ParseInt(out, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse memory limit %q: %w", out, err)
+	}
+	return n, nil
+}
+
+// TestCrictlUpdateContainerResources covers the kubelet in-place pod resize path:
+// CRI UpdateContainerResources targets the pod workload container (not the pause
+// sandbox). runsc updates host compat cgroups and the sentry cgroupfs for that
+// container id. CRI-reported memory limit must match via inspect JSON.
+func TestCrictlUpdateContainerResources(t *testing.T) {
+	crictl, cleanup, err := setup(t, true /* enableGrouping */)
+	if err != nil {
+		t.Fatalf("failed to setup crictl: %v", err)
+	}
+	defer cleanup()
+
+	const initMem = int64(64 * 1024 * 1024)
+	const updatedMem = int64(96 * 1024 * 1024)
+
+	spec := SimpleSpec("resize", "basic/busybox", []string{"sleep", "1000"}, map[string]any{
+		"linux": map[string]any{
+			"resources": map[string]any{
+				"memory_limit_in_bytes": initMem,
+			},
+		},
+	})
+	podID, contID, err := crictl.StartPodAndContainer(containerdRuntime, "basic/busybox", Sandbox(testutil.RandomID("update-res")), spec)
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+	defer func() {
+		if err := crictl.StopPodAndContainer(podID, contID); err != nil {
+			t.Logf("cleanup stop: %v", err)
+		}
+	}()
+
+	before, err := criInspectMemoryLimitBytes(crictl, contID)
+	if err != nil {
+		t.Fatalf("inspect before update: %v", err)
+	}
+	if before != initMem {
+		t.Fatalf("memory limit before update: got %d want %d", before, initMem)
+	}
+
+	if err := crictl.UpdateContainerResources(contID, updatedMem); err != nil {
+		t.Fatalf("UpdateContainerResources: %v", err)
+	}
+
+	after, err := criInspectMemoryLimitBytes(crictl, contID)
+	if err != nil {
+		t.Fatalf("inspect after update: %v", err)
+	}
+	if after != updatedMem {
+		t.Fatalf("memory limit after update: got %d want %d", after, updatedMem)
+	}
+}
+
 const containerdRuntime = "runsc"
 
 // containerdConfig is the containerd (1.5+) configuration file that


### PR DESCRIPTION
## Summary

Implements **containerd `Task.Update`** on the runsc shim by shelling out to `runsc update` with JSON `specs.LinuxResources` in the protobuf `Any`, same shape as **go-runc** / **containerd-shim-runc-v2**.

Second commit: **CRI `UpdateContainerResources` almost always passes the workload container id**, not the pause/sandbox id. The sandbox id lines up with the “root” OCI container; everything else is a subcontainer in the same gVisor sandbox. The shim-only path could only update when the id matched the sandbox, which is the wrong target for kubelet in-place resize (you care about the app container, not the pause). **`Container.Update` now branches**: sandbox/root id still updates `Sandbox.CgroupJSON`; other ids go through **`updateSubcontainerResources`** (host compat cgroup for that container plus sentry cgroupfs under `/<cid>`). Partial updates are merged with the existing spec inside **`Container.Update`** so the CLI and shim share one path—the extra merge in **`runsc update`** is gone.

**Tests:** root **`TestCrictlUpdateContainerResources`** (`crictl update` + inspect go-template for `memoryLimitInBytes`). **`criutil`** crictl version regex accepts optional `v` and fixes the old `[0-9+]` patch capture.

## Related issue

Closes google/gvisor#12790.

## Testing

- [x] `bazel test //pkg/shim/v1/runsc:runsc_test` (Linux CI)
- [x] `bazel test //runsc/container:linux_resources_update_test`
- [ ] `bazel test //test/root:root_test` (manual / root; `TestCrictlUpdateContainerResources`)
- [ ] Cluster in-place resize + gVisor runtime class (optional)
