### PR TITLE
feat(nvproxy): support nvidia-container-runtime csv mode

### DIFF
--- a/g3doc/user_guide/gpu.md
+++ b/g3doc/user_guide/gpu.md
@@ -42,17 +42,25 @@ executable can be used:
 exec /path/to/runsc --nvproxy <other runsc flags> "$@"
 ```
 
-NOTE: gVisor currently only supports
-[legacy mode](https://github.com/NVIDIA/nvidia-container-toolkit/tree/main/cmd/nvidia-container-runtime#legacy-mode).
-The alternative,
-[csv mode](https://github.com/NVIDIA/nvidia-container-toolkit/tree/main/cmd/nvidia-container-runtime#csv-mode),
-is not yet supported.
+gVisor supports both
+[legacy mode](https://github.com/NVIDIA/nvidia-container-toolkit/tree/main/cmd/nvidia-container-runtime#legacy-mode)
+and
+[csv mode](https://github.com/NVIDIA/nvidia-container-toolkit/tree/main/cmd/nvidia-container-runtime#csv-mode)
+when `runsc` is configured as the low-level runtime with `--nvproxy`. In csv
+mode, `nvidia-container-runtime` injects GPU devices and mounts into the OCI
+spec (CDI-style) instead of using the legacy prestart hook; gVisor handles that
+path by running host preparation when a GPU workload is detected and skipping
+`nvidia-container-cli configure` when `/dev/nvidiactl` is already listed in
+`spec.Linux.Devices`.
 
 ### Docker
 
 The "legacy" mode of `nvidia-container-runtime` is directly compatible with the
-`--gpus` flag implemented by the docker CLI. So with Docker, `runsc` can be used
-directly (without having to go through `nvidia-container-runtime`).
+`--gpus` flag implemented by the docker CLI when `runsc` is the runtime. For csv
+mode or other non-legacy NVIDIA runtime modes, NVIDIA documents using
+`--runtime=nvidia` (or setting `nvidia-container-runtime` as default) so the
+high-level NVIDIA runtime can apply the correct OCI edits before invoking the
+low-level runtime.
 
 ```
 $ docker run --runtime=runsc --gpus=all --rm -it nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubi8

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -1471,9 +1471,9 @@ func createDeviceFiles(ctx context.Context, creds *auth.Credentials, info *conta
 			}
 		}
 	}
-	if specutils.GPUFunctionalityRequestedViaHook(info.spec, info.conf) {
-		// When using nvidia-container-runtime-hook, devices are not injected into
-		// spec.Linux.Devices. So manually create appropriate device files.
+	if specutils.GPUFunctionalityNeedsSyntheticNvidiaDevices(info.spec, info.conf) {
+		// Legacy nvidia-container-runtime-hook does not inject spec.Linux.Devices.
+		// CSV/CDI and GKE list /dev/nvidiactl there instead; skip synthesis then.
 		nvidiaDevs := []specs.LinuxDevice{
 			{Path: "/dev/nvidiactl", Type: "c", Major: nvgpu.NV_MAJOR_DEVICE_NUMBER, Minor: nvgpu.NV_MINOR_DEVICE_NUMBER_CONTROL_DEVICE},
 			{Path: "/dev/nvidia-uvm", Type: "c", Major: int64(info.nvproxyDevInfo.UVMDevMajor), Minor: nvgpu.NVIDIA_UVM_PRIMARY_MINOR_NUMBER},

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1351,7 +1351,7 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 	if err := c.initGoferConfs(conf.GetOverlay2(), mountHints, rootfsHint); err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("error initializing gofer confs: %w", err)
 	}
-	if !c.GoferMountConfs[0].ShouldUseLisafs() && specutils.GPUFunctionalityRequestedViaHook(c.Spec, conf) {
+	if !c.GoferMountConfs[0].ShouldUseLisafs() && specutils.GPUFunctionalityNeedsNvidiaContainerCLIConfigure(c.Spec, conf) {
 		// nvidia-container-runtime-hook attempts to populate the container
 		// rootfs with NVIDIA libraries and devices. With EROFS, spec.Root.Path
 		// points to an empty directory and populating that has no effect.
@@ -2031,14 +2031,15 @@ func logIDMappings(mappings []specs.LinuxIDMapping, idType string) {
 	}
 }
 
-// nvProxyPreGoferHostSetup does host setup work so that `nvidia-container-cli
-// configure` can be run in the future. It runs before any Gofers start.
+// nvProxyPreGoferHostSetup does host setup work for GPU containers (modules,
+// host device nodes) before any Gofers start. It runs whenever
+// GPUFunctionalityRequested, including CSV/CDI specs that skip configure.
 // It verifies that all the required dependencies are in place, loads kernel
 // modules, and ensures the correct device files exist and are accessible.
 // This should only be necessary once on the host. It should be run during the
 // root container setup sequence to make sure it has run at least once.
 func nvProxyPreGoferHostSetup(spec *specs.Spec, conf *config.Config) error {
-	if !specutils.GPUFunctionalityRequestedViaHook(spec, conf) {
+	if !specutils.GPUFunctionalityRequested(spec, conf) {
 		return nil
 	}
 
@@ -2114,20 +2115,18 @@ func nvproxyLoadKernelModules() {
 //
 // This should be called after the Gofer has started but before it has
 // pivot-root'd, as the bind mounts are created in the Gofer's mount namespace.
-// This function has no effect if nvproxy functionality is not requested.
+// This function has no effect unless GPUFunctionalityNeedsNvidiaContainerCLIConfigure
+// (legacy Docker / nvidia-container-runtime-hook path). CSV/CDI and GKE inject
+// devices and mounts into the OCI spec instead; configure is skipped for those.
 //
 // This function essentially replicates
 // nvidia-container-toolkit:cmd/nvidia-container-runtime-hook, i.e. the
-// binary that executeHook() is hard-coded to skip, with differences noted
-// inline. We do this rather than move the prestart hook because the
-// "runtime environment" in which prestart hooks execute is vaguely
-// defined, such that nvidia-container-runtime-hook and existing runsc
-// hooks differ in their expected environment.
+// binary that executeHook() skips, with differences noted inline.
 //
 // Note that nvidia-container-cli will set up files in /proc which are useless,
 // since they will be hidden by sentry procfs.
 func nvproxySetup(spec *specs.Spec, conf *config.Config, goferPid int) error {
-	if !specutils.GPUFunctionalityRequestedViaHook(spec, conf) {
+	if !specutils.GPUFunctionalityNeedsNvidiaContainerCLIConfigure(spec, conf) {
 		return nil
 	}
 

--- a/runsc/container/hook.go
+++ b/runsc/container/hook.go
@@ -69,12 +69,14 @@ func executeHook(h specs.Hook, s specs.State) error {
 		return fmt.Errorf("path for hook is not absolute: %q", h.Path)
 	}
 
-	// Don't invoke nvidia-container-runtime-hook at prestart, which may be
-	// configured by e.g. Docker's --gpus flag, since
-	// nvidia-container-runtime-hook doesn't understand gVisor's bifurcation
-	// between sentry and application filesystems.
-	if strings.HasSuffix(h.Path, "/nvidia-container-runtime-hook") {
-		log.Infof("Skipping nvidia-container-runtime-hook")
+	// Don't invoke NVIDIA toolkit prestart hooks: they assume a runc-style
+	// container filesystem, not gVisor's sentry/gofer split. Legacy mode uses
+	// nvidia-container-runtime-hook; CSV/CDI may inject nvidia-cdi-hook or
+	// nvidia-ctk (see nvidia-container-toolkit internal/modifier/hook_remover.go).
+	switch filepath.Base(h.Path) {
+	case "nvidia-container-runtime-hook", "nvidia-container-toolkit",
+		"nvidia-cdi-hook", "nvidia-ctk":
+		log.Infof("Skipping NVIDIA hook %q", filepath.Base(h.Path))
 		return nil
 	}
 

--- a/runsc/specutils/BUILD
+++ b/runsc/specutils/BUILD
@@ -35,7 +35,10 @@ go_library(
 go_test(
     name = "specutils_test",
     size = "small",
-    srcs = ["specutils_test.go"],
+    srcs = [
+        "nvidia_test.go",
+        "specutils_test.go",
+    ],
     library = ":specutils",
     deps = [
         "//pkg/sentry/devices/nvproxy/nvconf",

--- a/runsc/specutils/nvidia.go
+++ b/runsc/specutils/nvidia.go
@@ -59,14 +59,40 @@ func GPUFunctionalityRequested(spec *specs.Spec, conf *config.Config) bool {
 	}
 	// In GKE, the nvidia_gpu device plugin injects NVIDIA devices into
 	// spec.Linux.Devices when GPUs are allocated to a container.
-	if spec.Linux != nil {
-		for _, dev := range spec.Linux.Devices {
-			if dev.Path == "/dev/nvidiactl" {
-				return true
-			}
-		}
+	// nvidia-container-runtime CSV mode (and CDI) inject the same via OCI edits.
+	if LinuxSpecHasNvidiaControlDevice(spec) {
+		return true
 	}
 	return gpuFunctionalityRequestedViaHook(spec, conf)
+}
+
+// LinuxSpecHasNvidiaControlDevice reports whether the OCI spec lists the
+// NVIDIA control device in Linux.Devices (e.g. GKE device plugin, CSV/CDI).
+func LinuxSpecHasNvidiaControlDevice(spec *specs.Spec) bool {
+	if spec == nil || spec.Linux == nil {
+		return false
+	}
+	for _, dev := range spec.Linux.Devices {
+		if dev.Path == "/dev/nvidiactl" {
+			return true
+		}
+	}
+	return false
+}
+
+// GPUFunctionalityNeedsNvidiaContainerCLIConfigure is true when runsc should
+// run nvidia-container-cli configure against the gofer (legacy Docker / hook
+// path). When the spec already includes /dev/nvidiactl from CSV/CDI or GKE,
+// the toolkit has applied equivalent edits and configure must be skipped.
+func GPUFunctionalityNeedsNvidiaContainerCLIConfigure(spec *specs.Spec, conf *config.Config) bool {
+	return GPUFunctionalityRequestedViaHook(spec, conf)
+}
+
+// GPUFunctionalityNeedsSyntheticNvidiaDevices is true when the sentry should
+// create /dev/nvidia* nodes by scanning the dev gofer (legacy hook path). When
+// Linux.Devices already lists /dev/nvidiactl, device nodes come from the spec.
+func GPUFunctionalityNeedsSyntheticNvidiaDevices(spec *specs.Spec, conf *config.Config) bool {
+	return GPUFunctionalityRequested(spec, conf) && !LinuxSpecHasNvidiaControlDevice(spec)
 }
 
 // GPUFunctionalityRequestedViaHook returns true if the container should have
@@ -117,7 +143,7 @@ func isNvidiaHookPresent(spec *specs.Spec, conf *config.Config) bool {
 // ParseNvidiaVisibleDevices parses NVIDIA_VISIBLE_DEVICES env var and returns
 // the devices specified in it. This can be passed to nvidia-container-cli.
 //
-// Precondition: conf.NVProxyDocker && GPUFunctionalityRequested(spec, conf).
+// Precondition: GPUFunctionalityNeedsNvidiaContainerCLIConfigure(spec, conf).
 func ParseNvidiaVisibleDevices(spec *specs.Spec) (string, error) {
 	nvd, _ := EnvVar(spec.Process.Env, nvidiaVisibleDevsEnv)
 	if nvd == "none" {

--- a/runsc/specutils/nvidia_test.go
+++ b/runsc/specutils/nvidia_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specutils
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gvisor.dev/gvisor/runsc/config"
+)
+
+func TestLinuxSpecHasNvidiaControlDevice(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec *specs.Spec
+		want bool
+	}{
+		{"nil spec", nil, false},
+		{"no linux", &specs.Spec{}, false},
+		{"empty devices", &specs.Spec{Linux: &specs.Linux{}}, false},
+		{"other device", &specs.Spec{Linux: &specs.Linux{Devices: []specs.LinuxDevice{{Path: "/dev/null"}}}}, false},
+		{"nvidiactl", &specs.Spec{Linux: &specs.Linux{Devices: []specs.LinuxDevice{{Path: "/dev/nvidiactl"}}}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LinuxSpecHasNvidiaControlDevice(tc.spec); got != tc.want {
+				t.Errorf("LinuxSpecHasNvidiaControlDevice() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGPUFunctionalityNeedsNvidiaContainerCLIConfigureMatchesViaHook(t *testing.T) {
+	conf := &config.Config{NVProxy: true}
+	base := &specs.Spec{
+		Process: &specs.Process{Env: []string{"NVIDIA_VISIBLE_DEVICES=all"}},
+		Hooks: &specs.Hooks{
+			Prestart: []specs.Hook{{Path: "/usr/bin/nvidia-container-runtime-hook"}},
+		},
+	}
+	if a, b := GPUFunctionalityNeedsNvidiaContainerCLIConfigure(base, conf), GPUFunctionalityRequestedViaHook(base, conf); a != b {
+		t.Errorf("mismatch: NeedsNvidiaContainerCLIConfigure=%v ViaHook=%v", a, b)
+	}
+}
+
+func TestGPUFunctionalityNeedsSyntheticNvidiaDevices(t *testing.T) {
+	nvproxyOn := &config.Config{NVProxy: true}
+	nvproxyOff := &config.Config{NVProxy: false}
+
+	legacyHook := &specs.Spec{
+		Process: &specs.Process{Env: []string{"NVIDIA_VISIBLE_DEVICES=0"}},
+		Hooks: &specs.Hooks{
+			Prestart: []specs.Hook{{Path: "/usr/bin/nvidia-container-runtime-hook"}},
+		},
+	}
+	if !GPUFunctionalityNeedsSyntheticNvidiaDevices(legacyHook, nvproxyOn) {
+		t.Error("legacy hook + no Linux.Devices: want synthetic devices")
+	}
+
+	csvLike := &specs.Spec{
+		Process: &specs.Process{Env: []string{"NVIDIA_VISIBLE_DEVICES=all"}},
+		Linux: &specs.Linux{
+			Devices: []specs.LinuxDevice{{Path: "/dev/nvidiactl", Type: "c", Major: 195, Minor: 255}},
+		},
+	}
+	if GPUFunctionalityNeedsSyntheticNvidiaDevices(csvLike, nvproxyOn) {
+		t.Error("spec with /dev/nvidiactl: should not need synthetic devices")
+	}
+
+	if GPUFunctionalityNeedsSyntheticNvidiaDevices(legacyHook, nvproxyOff) {
+		t.Error("nvproxy off: should not need synthetic devices")
+	}
+
+	noneWithHook := &specs.Spec{
+		Process: &specs.Process{Env: []string{"NVIDIA_VISIBLE_DEVICES=none"}},
+		Hooks: &specs.Hooks{
+			Prestart: []specs.Hook{{Path: "/usr/bin/nvidia-container-runtime-hook"}},
+		},
+	}
+	if !GPUFunctionalityNeedsSyntheticNvidiaDevices(noneWithHook, nvproxyOn) {
+		t.Error("NVIDIA_VISIBLE_DEVICES=none + hook: still need synthetic nodes for driver-only path")
+	}
+}


### PR DESCRIPTION
## Summary

nvproxy previously tied host prep, `nvidia-container-cli configure`, and synthetic `/dev/nvidia*` creation to the presence of `nvidia-container-runtime-hook`. **CSV mode** (and JIT CDI) removes that hook and injects devices/mounts via the OCI spec instead, so those steps were skipped.

This change:
- Runs **host prep** (`nvProxyPreGoferHostSetup`) whenever `GPUFunctionalityRequested` (including `/dev/nvidiactl` in `Linux.Devices`).
- Runs **`nvidia-container-cli configure`** only on the **legacy hook** path (`GPUFunctionalityNeedsNvidiaContainerCLIConfigure`).
- Creates **synthetic sentry device nodes** only when the spec does **not** already list `/dev/nvidiactl`.
- **Skips** prestart hooks: `nvidia-cdi-hook`, `nvidia-ctk`, `nvidia-container-toolkit` (same rationale as the legacy hook).
- Updates [GPU user guide](https://gvisor.dev/docs/user_guide/gpu/) to document CSV mode support.

## How to test locally

### Unit tests (Linux x86_64/arm64 recommended)

```bash
bazel test //runsc/specutils:specutils_test --test_output=errors
```

On **macOS**, the full gVisor build may fail on unrelated Darwin issues (`O_LARGEFILE`, etc.); use Linux or the project CI.

### Manual GPU / CSV smoke test (Linux host with NVIDIA driver + toolkit)

1. **Build `runsc`** with nvproxy (from repo root):

   ```bash
   make build TARGETS=runsc:runsc
   # or: bazel build //runsc:runsc
   ```

2. **Configure NVIDIA runtime** (`/etc/nvidia-container-runtime/config.toml`):
   - Set `mode = "csv"` (or `auto` if it selects CSV on your platform, e.g. some Jetson/Tegra setups).
   - Under `[nvidia-container-runtime]`, set `runtimes` so the first entry is your `runsc` wrapper, e.g. a script that runs:

     ```bash
     exec /path/to/runsc --nvproxy "$@"
     ```

3. **Run a GPU container** via the NVIDIA shim (not plain `runsc` alone), so the spec is modified:

   ```bash
   sudo nvidia-container-runtime run --bundle /path/to/bundle <container-id>
   ```

   Or with Docker using NVIDIA as default runtime (see [NVIDIA runtime README](https://github.com/NVIDIA/nvidia-container-toolkit/blob/main/cmd/nvidia-container-runtime/README.md) for csv vs `--gpus`).

4. **Confirm**: container starts, `nvidia-smi` or a CUDA sample runs, and debug logs show no failure from skipped NVIDIA hooks / duplicate device setup.

## Risk

**Low** — scoped to nvproxy detection, hook skipping, and docs; behavior unchanged for legacy hook path.

## Related

- Plan: CSV mode aligns with upstream `nvidia-container-toolkit` CSV → CDI spec injection.
- Public docs still say legacy-only until this merges and the site is republished.