### PR TITLE
overlay: support userxattr mount option for overlays in user namespaces

### DIFF
--- a/pkg/sentry/fsimpl/overlay/copy_up.go
+++ b/pkg/sentry/fsimpl/overlay/copy_up.go
@@ -388,7 +388,7 @@ func (d *dentry) copyXattrsLocked(ctx context.Context) error {
 
 	for _, name := range lowerXattrs {
 		// Do not copy up overlay attributes.
-		if isOverlayXattr(name) {
+		if d.fs.isOverlayXattr(name) {
 			continue
 		}
 

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -31,16 +31,6 @@ import (
 	"gvisor.dev/gvisor/pkg/sync"
 )
 
-// _OVL_XATTR_PREFIX is an extended attribute key prefix to identify overlayfs
-// attributes.
-// Linux: fs/overlayfs/overlayfs.h:OVL_XATTR_PREFIX
-const _OVL_XATTR_PREFIX = linux.XATTR_TRUSTED_PREFIX + "overlay."
-
-// _OVL_XATTR_OPAQUE is an extended attribute key whose value is set to "y" for
-// opaque directories.
-// Linux: fs/overlayfs/overlayfs.h:OVL_XATTR_OPAQUE
-const _OVL_XATTR_OPAQUE = _OVL_XATTR_PREFIX + "opaque"
-
 func isWhiteout(stat *linux.Statx) bool {
 	return stat.Mode&linux.S_IFMT == linux.S_IFCHR && stat.RdevMajor == 0 && stat.RdevMinor == 0
 }
@@ -310,7 +300,7 @@ func (fs *filesystem) lookupLocked(ctx context.Context, parent *dentry, name str
 			Root:  childVD,
 			Start: childVD,
 		}, &vfs.GetXattrOptions{
-			Name: _OVL_XATTR_OPAQUE,
+			Name: fs.xattrOpaque,
 			Size: 1,
 		})
 		return !(err == nil && opaqueVal == "y")
@@ -745,7 +735,7 @@ func (fs *filesystem) MkdirAt(ctx context.Context, rp *vfs.ResolvingPath, opts v
 			// the new directory should not be merged with, so mark as opaque.
 			// See fs/overlayfs/dir.c:ovl_create_over_whiteout() -> ovl_set_opaque().
 			if err := vfsObj.SetXattrAt(ctx, fs.creds, &pop, &vfs.SetXattrOptions{
-				Name:  _OVL_XATTR_OPAQUE,
+				Name:  fs.xattrOpaque,
 				Value: "y",
 			}); err != nil {
 				if cleanupErr := vfsObj.RmdirAt(ctx, fs.creds, &pop); cleanupErr != nil {
@@ -763,7 +753,7 @@ func (fs *filesystem) MkdirAt(ctx context.Context, rp *vfs.ResolvingPath, opts v
 			// fs.lookupLocked(). Allow it to fail since this is an optimization.
 			// See fs/overlayfs/dir.c:ovl_create_upper() -> ovl_set_opaque().
 			_ = vfsObj.SetXattrAt(ctx, fs.creds, &pop, &vfs.SetXattrOptions{
-				Name:  _OVL_XATTR_OPAQUE,
+				Name:  fs.xattrOpaque,
 				Value: "y",
 			})
 		}
@@ -1321,7 +1311,7 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 	}
 	if renamed.isDir() {
 		if err := vfsObj.SetXattrAt(ctx, fs.creds, &newpop, &vfs.SetXattrOptions{
-			Name:  _OVL_XATTR_OPAQUE,
+			Name:  fs.xattrOpaque,
 			Value: "y",
 		}); err != nil {
 			panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to make renamed directory opaque: %v", err))
@@ -1688,8 +1678,8 @@ func (fs *filesystem) UnlinkAt(ctx context.Context, rp *vfs.ResolvingPath) error
 
 // isOverlayXattr returns whether the given extended attribute configures the
 // overlay.
-func isOverlayXattr(name string) bool {
-	return strings.HasPrefix(name, _OVL_XATTR_PREFIX)
+func (fs *filesystem) isOverlayXattr(name string) bool {
+	return strings.HasPrefix(name, fs.xattrPrefix)
 }
 
 // ListXattrAt implements vfs.FilesystemImpl.ListXattrAt.
@@ -1716,7 +1706,7 @@ func (fs *filesystem) listXattr(ctx context.Context, d *dentry, size uint64) ([]
 	// Filter out all overlay attributes.
 	n := 0
 	for _, name := range names {
-		if !isOverlayXattr(name) {
+		if !fs.isOverlayXattr(name) {
 			names[n] = name
 			n++
 		}
@@ -1744,7 +1734,7 @@ func (fs *filesystem) getXattr(ctx context.Context, d *dentry, creds *auth.Crede
 
 	// Return EOPNOTSUPP when fetching an overlay attribute.
 	// See fs/overlayfs/super.c:ovl_own_xattr_get().
-	if isOverlayXattr(opts.Name) {
+	if fs.isOverlayXattr(opts.Name) {
 		return "", linuxerr.EOPNOTSUPP
 	}
 
@@ -1782,7 +1772,7 @@ func (fs *filesystem) setXattrLocked(ctx context.Context, d *dentry, mnt *vfs.Mo
 
 	// Return EOPNOTSUPP when setting an overlay attribute.
 	// See fs/overlayfs/super.c:ovl_own_xattr_set().
-	if isOverlayXattr(opts.Name) {
+	if fs.isOverlayXattr(opts.Name) {
 		return linuxerr.EOPNOTSUPP
 	}
 
@@ -1827,7 +1817,7 @@ func (fs *filesystem) removeXattrLocked(ctx context.Context, d *dentry, mnt *vfs
 	// Like SetXattrAt, return EOPNOTSUPP when removing an overlay attribute.
 	// Linux passes the remove request to xattr_handler->set.
 	// See fs/xattr.c:vfs_removexattr().
-	if isOverlayXattr(name) {
+	if fs.isOverlayXattr(name) {
 		return linuxerr.EOPNOTSUPP
 	}
 

--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -100,6 +100,13 @@ type filesystem struct {
 	// used for accesses to the filesystem's layers. creds is immutable.
 	creds *auth.Credentials
 
+	// xattrPrefix is the xattr key prefix for overlay metadata
+	// ("trusted.overlay." or "user.overlay."). xattrPrefix is immutable.
+	xattrPrefix string
+
+	// xattrOpaque is xattrPrefix + "opaque". xattrOpaque is immutable.
+	xattrOpaque string
+
 	// createCreds is a cache of credentials that is used for create operations.
 	createCredsMu createCredsMutex `state:"nosave"`
 	createCreds   map[createCredsKey]*auth.Credentials
@@ -173,6 +180,9 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		defer vfsroot.DecRef(ctx)
 	}
 
+	_, userXattr := mopts["userxattr"]
+	delete(mopts, "userxattr")
+
 	if upperPathname, ok := mopts["upperdir"]; ok {
 		if fsopts.UpperRoot.Ok() {
 			ctx.Infof("overlay.FilesystemType.GetFilesystem: both upperdir and FilesystemOptions.UpperRoot are specified")
@@ -221,10 +231,10 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			ctx.Infof("overlay.FilesystemType.GetFilesystem: failed to resolve upperdir %q: %v", upperPathname, err)
 			return nil, nil, err
 		}
-		// TODO(b/286942303): Only tmpfs supports whiteouts and
-		// trusted.overlay attributes. Don't allow to use non-tmpfs
-		// mounts on upper levels for mounts created through the mount
-		// syscall. In gVisor configs, users can specify any
+		// TODO(b/286942303): Only tmpfs supports whiteouts and overlay
+		// xattrs (trusted.overlay.* or user.overlay.*). Don't allow
+		// non-tmpfs mounts on upper levels for mounts created through
+		// the mount syscall. In gVisor configs, users can specify any
 		// configurations on their own risk.
 		if !opts.InternalMount && upperRoot.Mount().Filesystem().FilesystemType().Name() != "tmpfs" {
 			return nil, nil, linuxerr.EINVAL
@@ -308,9 +318,19 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		lowerRoot.IncRef()
 	}
 
+	// Use "user.overlay.*" xattrs instead of "trusted.overlay.*" when
+	// userxattr is explicitly set, matching Linux behavior.
+	// See fs/overlayfs/params.c:ovl_parse_param().
+	xattrPrefix := linux.XATTR_TRUSTED_PREFIX + "overlay."
+	if userXattr {
+		xattrPrefix = linux.XATTR_USER_PREFIX + "overlay."
+	}
+
 	fs := &filesystem{
 		opts:           fsopts,
 		creds:          creds.Fork(),
+		xattrPrefix:    xattrPrefix,
+		xattrOpaque:    xattrPrefix + "opaque",
 		dirDevMinor:    dirDevMinor,
 		lowerDevMinors: make(map[layerDevNumber]uint32),
 		dirInoCache:    make(map[layerDevNoAndIno]uint64),

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -2583,6 +2583,47 @@ TEST(MountTest, OverlayfsSgidBitIsCopiedUp) {
     EXPECT_TRUE(merged_st_after_touch.st_mode & S_ISGID);
   }
 }
+
+// Renaming a lower-layer directory on an overlay inside a user namespace
+// requires user.overlay.* xattrs to mark the directory opaque.
+TEST(MountTest, OverlayfsDirectoryRenameInUserNamespace) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  const std::function<void()> parent = [] {};
+  const std::function<void()> child = [] {
+    TEST_CHECK_SUCCESS(
+        mount("tmpfs", "/tmp", "tmpfs", 0, "mode=1777,size=10m"));
+    TEST_CHECK_SUCCESS(mkdir("/tmp/lower", 0755));
+    TEST_CHECK_SUCCESS(mkdir("/tmp/upper", 0755));
+    TEST_CHECK_SUCCESS(mkdir("/tmp/work", 0755));
+    TEST_CHECK_SUCCESS(mkdir("/tmp/merged", 0755));
+
+    TEST_CHECK_SUCCESS(mkdir("/tmp/lower/mydir", 0755));
+    int fd = open("/tmp/lower/mydir/file.txt", O_WRONLY | O_CREAT, 0644);
+    TEST_CHECK(fd >= 0);
+    TEST_CHECK_SUCCESS(close(fd));
+
+    TEST_CHECK_SUCCESS(mount(
+        "overlay", "/tmp/merged", "overlay", 0,
+        "lowerdir=/tmp/lower,upperdir=/tmp/upper,"
+        "workdir=/tmp/work,userxattr"));
+
+    // Rename a lower-layer directory, triggering copy-up and opaque xattr.
+    TEST_CHECK_SUCCESS(
+        rename("/tmp/merged/mydir", "/tmp/merged/renamed"));
+
+    struct stat st;
+    TEST_CHECK_SUCCESS(stat("/tmp/merged/renamed", &st));
+    TEST_CHECK(S_ISDIR(st.st_mode));
+    TEST_CHECK(stat("/tmp/merged/mydir", &st) == -1 && errno == ENOENT);
+    TEST_CHECK_SUCCESS(stat("/tmp/merged/renamed/file.txt", &st));
+    TEST_CHECK(S_ISREG(st.st_mode));
+  };
+  EXPECT_THAT(InForkedUserMountNamespace(parent, child),
+              IsPosixErrorOkAndHolds(0));
+}
+
 }  // namespace
 
 }  // namespace testing


### PR DESCRIPTION
I'm experiencing a sentry panic when I enter a user namespace and then attempt to mount an overlay filesystem. This is fundamentally because gVisor does not support the `userxattr` mount option, instead hardcoding `trusted.overlay` prefix, leading to a permission mismatch between the init namespace and the user namespace.

When an overlay is mounted inside a user namespace, setting these xattrs fails with EPERM, causing the sentry panic:

```
unrecoverable overlayfs inconsistency: failed to make renamed directory
   opaque: operation not permitted
```

This PR adds support for the userxattr mount option, which uses user.overlay.* xattrs instead of trusted.overlay.*. This appears to be very similar to the linked kernel commit that implements similar functionality except that the linked kernel commit is careful to disable `redirect_dir` and `metacopy` when `userxattr` is active but that isn't relevant here since gvisor does not support those currently.

Relevant kernel commit here, which I think is analagous.
"This is necessary for overlayfs to be able to be mounted in an unprivileged namepsace _[sic]_."

https://github.com/torvalds/linux/commit/2d2f2d7322ff43e0fe92bf8cccdc0b09449bf2e1

Discovered this while trying to set up some internal isolation within gVisor, I had AI produce a repro C file here:
https://github.com/google/gvisor/issues/1636#issuecomment-4131492295

I don't really use Go so I did make use of Claude for this PR, though I tried to be careful in comparing it to the kernel commit.