### PR TITLE
fix(shim): return cgroup v2 stats on unified hierarchy

### DIFF
--- a/pkg/shim/v1/runsc/BUILD
+++ b/pkg/shim/v1/runsc/BUILD
@@ -88,6 +88,7 @@ go_test(
         "@com_github_containerd_containerd//runtime/v2/task:go_default_library",
         "@com_github_containerd_errdefs//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_containerd_go_runc//:go_default_library",
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
     ],
 )

--- a/pkg/shim/v1/runsc/container.go
+++ b/pkg/shim/v1/runsc/container.go
@@ -203,9 +203,11 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 	if err := process.Create(ctx, config); err != nil {
 		return nil, err
 	}
-	// Set up cgroup mode.
+	// Set up cgroup mode for stats protobuf layout: match host hierarchy (same as
+	// OOM/cgroup handling in the shim), not runsc's systemd-cgroup flag. Otherwise
+	// containerd on unified v2 hosts may fail unmarshaling v1.Metrics into v2.Metrics.
 	cgroupMode := CgroupMode(cgroups.Legacy)
-	if opts.RunscConfig["systemd-cgroup"] == "true" {
+	if cgroups.Mode() == cgroups.Unified {
 		cgroupMode = CgroupMode(cgroups.Unified)
 	}
 

--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -484,8 +484,7 @@ func (s *runscService) Stats(ctx context.Context, r *taskAPI.StatsRequest) (*tas
 	// gvisor currently (as of 2020-03-03) only returns the total memory
 	// usage and current PID value[0]. However, we copy the common fields here
 	// so that future updates will propagate correct information.  We're
-	// using the cgroups.Metrics structure so we're returning the same type
-	// as runc.
+	// using the same cgroup Metrics protobuf types as runc (v1 or v2 layout).
 	//
 	// [0]: https://github.com/google/gvisor/blob/277a0d5a1fbe8272d4729c01ee4c6e374d047ebc/runsc/boot/events.go#L61-L81
 	return c.Stats(ctx)

--- a/pkg/shim/v1/runsc/service_test.go
+++ b/pkg/shim/v1/runsc/service_test.go
@@ -16,10 +16,12 @@ package runsc
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/containerd/containerd/runtime/v2/task"
 	"github.com/containerd/errdefs"
+	runc "github.com/containerd/go-runc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/shim/v1/utils"
 )
@@ -29,6 +31,30 @@ func TestContainerUpdateNilResources(t *testing.T) {
 	err := c.Update(t.Context(), &task.UpdateTaskRequest{ID: "x", Resources: nil})
 	if !errors.Is(err, errdefs.ErrInvalidArgument) {
 		t.Fatalf("Update(nil Resources): %v, want ErrInvalidArgument", err)
+	}
+}
+
+// TestTaskStatsProtobufTypeURLs checks that v1 and v2 stats marshal to distinct type
+// URLs, matching what containerd expects for cgroup v1 vs unified v2 hosts.
+func TestTaskStatsProtobufTypeURLs(t *testing.T) {
+	c := &Container{ID: "test"}
+	var st runc.Stats
+	v1resp, err := c.getV1Stats(&st)
+	if err != nil {
+		t.Fatalf("getV1Stats: %v", err)
+	}
+	v2resp, err := c.getV2Stats(&st)
+	if err != nil {
+		t.Fatalf("getV2Stats: %v", err)
+	}
+	if v1resp.Stats.TypeUrl == v2resp.Stats.TypeUrl {
+		t.Fatalf("v1 and v2 TypeUrl must differ, both %q", v1resp.Stats.TypeUrl)
+	}
+	if !strings.Contains(v1resp.Stats.TypeUrl, "cgroups.v1") {
+		t.Errorf("v1 TypeUrl = %q, want substring cgroups.v1", v1resp.Stats.TypeUrl)
+	}
+	if !strings.Contains(v2resp.Stats.TypeUrl, "cgroups.v2") {
+		t.Errorf("v2 TypeUrl = %q, want substring cgroups.v2", v2resp.Stats.TypeUrl)
 	}
 }
 


### PR DESCRIPTION
## Problem

On cgroup v2 (unified) hosts, containerd unmarshals task `Stats` as `io.containerd.cgroups.v2.Metrics`. The runsc v2 shim was choosing v1 vs v2 protobuf layout only from `systemd-cgroup`, so with cgroupfs (`systemd-cgroup` false) it returned v1 metrics and containerd logged errors such as:

```
can't unmarshal type "io.containerd.cgroups.v1.Metrics" to output "io.containerd.cgroups.v2.Metrics"
```

I also realized that I hadn't set system-cgroup in the config so alternatively that would have fixed it

## Fix

Use `cgroups.Mode() == cgroups.Unified` (same signal as OOM / cgroup load in this package) to pick `getV2Stats` vs `getV1Stats`.

## Tests

- `TestTaskStatsProtobufTypeURLs` asserts v1 and v2 marshal to distinct type URLs containing `cgroups.v1` / `cgroups.v2`.

## Risk

Low: stats wire format only; behavior aligns with host cgroup mode and containerd expectations.

## Workaround (before this lands)

Run runsc with `systemd-cgroup=true` so the previous logic returns v2-shaped stats on affected nodes.