### PR TITLE
sysfs: Add block and char subdirectories under /sys/dev

### DIFF
--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -192,10 +192,13 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		})
 	}
 	root := fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
-		"block":    fs.newDir(ctx, creds, defaultSysDirMode, nil),
-		"bus":      fs.newDir(ctx, creds, defaultSysDirMode, busSub),
-		"class":    fs.newDir(ctx, creds, defaultSysDirMode, classSub),
-		"dev":      fs.newDir(ctx, creds, defaultSysDirMode, nil),
+		"block": fs.newDir(ctx, creds, defaultSysDirMode, nil),
+		"bus":   fs.newDir(ctx, creds, defaultSysDirMode, busSub),
+		"class": fs.newDir(ctx, creds, defaultSysDirMode, classSub),
+		"dev": fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+			"block": fs.newDir(ctx, creds, defaultSysDirMode, nil),
+			"char":  fs.newDir(ctx, creds, defaultSysDirMode, nil),
+		}),
 		"devices":  fs.newDir(ctx, creds, defaultSysDirMode, devicesSub),
 		"firmware": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 		"fs":       fs.newDir(ctx, creds, defaultSysDirMode, fsDirChildren),

--- a/pkg/sentry/fsimpl/sys/sys_integration_test.go
+++ b/pkg/sentry/fsimpl/sys/sys_integration_test.go
@@ -103,6 +103,16 @@ func TestSysRootContainsExpectedEntries(t *testing.T) {
 	})
 }
 
+func TestSysDevContainsBlockAndChar(t *testing.T) {
+	s := newTestSystem(t, "" /*pciTestDir*/)
+	defer s.Destroy()
+	pop := s.PathOpAtRoot("/dev")
+	s.AssertAllDirentTypes(s.ListDirents(pop), map[string]testutil.DirentType{
+		"block": linux.DT_DIR,
+		"char":  linux.DT_DIR,
+	})
+}
+
 func TestCgroupMountpointExists(t *testing.T) {
 	// Note: The mountpoint is only created if cgroups are available.
 	s := newTestSystem(t, "" /*pciTestDir*/)


### PR DESCRIPTION
gVisor does not expose real block/char devices, the directories remain empty, but their existence is required for compatibility.

Tools like lsblk expect /sys/dev/block/ to exist in order to enumerate block devices. Currently, gVisor's sysfs creates /sys/dev/ as an empty directory without the standard block/ and char/ children, causing lsblk to fail with ENOENT.