### PR TITLE
proc: Add /proc/sys/kernel/randomize_va_space

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -49,11 +49,12 @@ const (
 func (fs *filesystem) newSysDir(ctx context.Context, root *auth.Credentials, k *kernel.Kernel) kernfs.Inode {
 	return fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 		"kernel": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
-			"cap_last_cap": fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", linux.CAP_LAST_CAP))),
-			"hostname":     fs.newInode(ctx, root, 0444, &hostnameData{}),
-			"overflowgid":  fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowGID))),
-			"overflowuid":  fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowUID))),
-			"pid_max":      fs.newInode(ctx, root, 0644, newStaticFile(fmt.Sprintf("%d\n", kernel.TasksLimit))),
+			"cap_last_cap":       fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", linux.CAP_LAST_CAP))),
+			"hostname":           fs.newInode(ctx, root, 0444, &hostnameData{}),
+			"overflowgid":        fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowGID))),
+			"overflowuid":        fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowUID))),
+			"pid_max":            fs.newInode(ctx, root, 0644, newStaticFile(fmt.Sprintf("%d\n", kernel.TasksLimit))),
+			"randomize_va_space": fs.newInode(ctx, root, 0644, newStaticFile("2\n")),
 			"random": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 				"boot_id": fs.newInode(ctx, root, 0444, newStaticFile(randUUID())),
 			}),

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -3188,6 +3188,20 @@ TEST(ProcSysKernelKeysMax, SetMaxKeys) {
   EXPECT_EQ(mk, 100);
 }
 
+TEST(ProcSysKernel, RandomizeVaSpace) {
+  std::string val = ASSERT_NO_ERRNO_AND_VALUE(
+      GetContents("/proc/sys/kernel/randomize_va_space"));
+  int32_t randomize_va;
+  ASSERT_TRUE(absl::SimpleAtoi(val, &randomize_va));
+  // 0 = no randomization, 1 = conservative, 2 = full.
+  EXPECT_GE(randomize_va, 0);
+  EXPECT_LE(randomize_va, 2);
+  if (IsRunningOnGvisor()) {
+    // gVisor always uses full ASLR, so expect 2.
+    EXPECT_EQ(randomize_va, 2);
+  }
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace gvisor


### PR DESCRIPTION
Expose randomize_va_space in procfs with a static value of 2 (full randomization), matching gVisor's actual ASLR behavior.

gVisor always applies full ASLR for user memory mappings, so we report the value 2 to match the actual behavior.

This fixes programs(e.g. https://github.com/psf/pyperf) that read this file to collect ASLR metadata and fail with ENOENT when the file is missing.