### PR TITLE
x86/arm64: allow partial PTRACE_GETREGSET NT_PRSTATUS reads

### DIFF
--- a/pkg/sentry/arch/arch_aarch64.go
+++ b/pkg/sentry/arch/arch_aarch64.go
@@ -226,10 +226,19 @@ const (
 func (s *State) PtraceGetRegSet(regset uintptr, dst io.Writer, maxlen int, _ cpuid.FeatureSet) (int, error) {
 	switch regset {
 	case _NT_PRSTATUS:
-		if maxlen < ptraceRegistersSize {
+		if maxlen <= 0 {
 			return 0, linuxerr.EFAULT
 		}
-		return s.PtraceGetRegs(dst)
+		// Match Linux kernel behavior (kernel/ptrace.c:ptrace_regset()): write
+		// min(maxlen, sizeof(user_regs_struct)) bytes rather than returning
+		// EFAULT for buffers smaller than the full register set.
+		if maxlen >= ptraceRegistersSize {
+			return s.PtraceGetRegs(dst)
+		}
+		regs := s.ptraceGetRegs()
+		buf := make([]byte, regs.SizeBytes())
+		regs.MarshalBytes(buf)
+		return dst.Write(buf[:maxlen])
 	default:
 		return 0, linuxerr.EINVAL
 	}

--- a/pkg/sentry/arch/arch_x86.go
+++ b/pkg/sentry/arch/arch_x86.go
@@ -18,6 +18,7 @@
 package arch
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 
@@ -333,10 +334,24 @@ const (
 func (s *State) PtraceGetRegSet(regset uintptr, dst io.Writer, maxlen int, fs cpuid.FeatureSet) (int, error) {
 	switch regset {
 	case _NT_PRSTATUS:
-		if maxlen < ptraceRegistersSize {
+		if maxlen <= 0 {
 			return 0, linuxerr.EFAULT
 		}
-		return s.PtraceGetRegs(dst)
+		// Match Linux kernel behavior (kernel/ptrace.c:ptrace_regset()): write
+		// min(maxlen, sizeof(user_regs_struct)) bytes rather than returning
+		// EFAULT for buffers smaller than the full register set.
+		n := maxlen
+		if n > ptraceRegistersSize {
+			n = ptraceRegistersSize
+		}
+		if n == ptraceRegistersSize {
+			return s.PtraceGetRegs(dst)
+		}
+		var buf bytes.Buffer
+		if _, err := s.PtraceGetRegs(&buf); err != nil {
+			return 0, err
+		}
+		return dst.Write(buf.Bytes()[:n])
 	case _NT_PRFPREG:
 		return s.fpState.PtraceGetFPRegs(dst, maxlen)
 	case _NT_X86_XSTATE:

--- a/pkg/sentry/arch/arch_x86.go
+++ b/pkg/sentry/arch/arch_x86.go
@@ -333,10 +333,19 @@ const (
 func (s *State) PtraceGetRegSet(regset uintptr, dst io.Writer, maxlen int, fs cpuid.FeatureSet) (int, error) {
 	switch regset {
 	case _NT_PRSTATUS:
-		if maxlen < ptraceRegistersSize {
+		if maxlen <= 0 {
 			return 0, linuxerr.EFAULT
 		}
-		return s.PtraceGetRegs(dst)
+		// Match Linux kernel behavior (kernel/ptrace.c:ptrace_regset()): write
+		// min(maxlen, sizeof(user_regs_struct)) bytes rather than returning
+		// EFAULT for buffers smaller than the full register set.
+		if maxlen >= ptraceRegistersSize {
+			return s.PtraceGetRegs(dst)
+		}
+		regs := s.ptraceGetRegs()
+		buf := make([]byte, regs.SizeBytes())
+		regs.MarshalBytes(buf)
+		return dst.Write(buf[:maxlen])
 	case _NT_PRFPREG:
 		return s.fpState.PtraceGetFPRegs(dst, maxlen)
 	case _NT_X86_XSTATE:

--- a/test/syscalls/linux/ptrace.cc
+++ b/test/syscalls/linux/ptrace.cc
@@ -1403,6 +1403,57 @@ TEST(PtraceTest, GetRegSet) {
   EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
       << " status " << status;
 }
+
+// PTRACE_GETREGSET with NT_PRSTATUS must accept a buffer smaller than
+// sizeof(user_regs_struct) and write only the requested number of bytes,
+// matching Linux kernel behavior (kernel/ptrace.c:ptrace_regset()).
+TEST(PtraceTest, GetRegSetPartialRead) {
+  pid_t const child_pid = fork();
+  if (child_pid == 0) {
+    TEST_PCHECK(ptrace(PTRACE_TRACEME, 0, 0, 0) == 0);
+    MaybeSave();
+    kill(getpid(), SIGSTOP);
+    _exit(0);
+  }
+
+  // In parent process.
+  ASSERT_THAT(child_pid, SyscallSucceeds());
+
+  int status;
+  ASSERT_THAT(waitpid(child_pid, &status, 0),
+              SyscallSucceedsWithValue(child_pid));
+  EXPECT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP)
+      << " status " << status;
+
+  // Read the full register set for reference.
+  struct user_regs_struct full_regs;
+  struct iovec full_iov;
+  full_iov.iov_base = &full_regs;
+  full_iov.iov_len = sizeof(full_regs);
+  ASSERT_THAT(ptrace(PTRACE_GETREGSET, child_pid, NT_PRSTATUS, &full_iov),
+              SyscallSucceeds());
+  EXPECT_EQ(full_iov.iov_len, sizeof(full_regs));
+
+  // Read only the first sizeof(long) bytes (e.g. just the first register).
+  // This must succeed and return exactly the requested number of bytes,
+  // which must match the beginning of the full register set.
+  unsigned long first_reg = 0;
+  struct iovec partial_iov;
+  partial_iov.iov_base = &first_reg;
+  partial_iov.iov_len = sizeof(first_reg);
+  EXPECT_THAT(ptrace(PTRACE_GETREGSET, child_pid, NT_PRSTATUS, &partial_iov),
+              SyscallSucceeds());
+  EXPECT_EQ(partial_iov.iov_len, sizeof(first_reg));
+  EXPECT_EQ(first_reg,
+            *reinterpret_cast<unsigned long*>(&full_regs));
+
+  ASSERT_THAT(ptrace(PTRACE_CONT, child_pid, 0, 0), SyscallSucceeds());
+  ASSERT_THAT(waitpid(child_pid, &status, 0),
+              SyscallSucceedsWithValue(child_pid));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << " status " << status;
+}
+
 #if defined(__x86_64__)
 #define SYSNO_STR1(x) #x
 #define SYSNO_STR(x) SYSNO_STR1(x)

--- a/test/syscalls/linux/ptrace.cc
+++ b/test/syscalls/linux/ptrace.cc
@@ -1403,6 +1403,57 @@ TEST(PtraceTest, GetRegSet) {
   EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
       << " status " << status;
 }
+
+// PTRACE_GETREGSET with NT_PRSTATUS must accept a buffer smaller than
+// sizeof(user_regs_struct) and write only the requested number of bytes,
+// matching Linux kernel behavior (kernel/ptrace.c:ptrace_regset()).
+TEST(PtraceTest, GetRegSetPartialRead) {
+  pid_t const child_pid = fork();
+  if (child_pid == 0) {
+    TEST_PCHECK(ptrace(PTRACE_TRACEME, 0, 0, 0) == 0);
+    MaybeSave();
+    kill(getpid(), SIGSTOP);
+    _exit(0);
+  }
+
+  // In parent process.
+  ASSERT_THAT(child_pid, SyscallSucceeds());
+
+  int status;
+  ASSERT_THAT(waitpid(child_pid, &status, 0),
+              SyscallSucceedsWithValue(child_pid));
+  EXPECT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP)
+      << " status " << status;
+
+  // Read the full register set for reference.
+  struct user_regs_struct full_regs;
+  struct iovec full_iov;
+  full_iov.iov_base = &full_regs;
+  full_iov.iov_len = sizeof(full_regs);
+  ASSERT_THAT(ptrace(PTRACE_GETREGSET, child_pid, NT_PRSTATUS, &full_iov),
+              SyscallSucceeds());
+  EXPECT_EQ(full_iov.iov_len, sizeof(full_regs));
+
+  // Read only the first sizeof(uint64_t) bytes (e.g. just the first register).
+  // This must succeed and return exactly the requested number of bytes,
+  // which must match the beginning of the full register set.
+  uint64_t first_reg = 0;
+  struct iovec partial_iov;
+  partial_iov.iov_base = &first_reg;
+  partial_iov.iov_len = sizeof(first_reg);
+  EXPECT_THAT(ptrace(PTRACE_GETREGSET, child_pid, NT_PRSTATUS, &partial_iov),
+              SyscallSucceeds());
+  EXPECT_EQ(partial_iov.iov_len, sizeof(first_reg));
+  EXPECT_EQ(first_reg,
+            *reinterpret_cast<uint64_t*>(&full_regs));
+
+  ASSERT_THAT(ptrace(PTRACE_CONT, child_pid, 0, 0), SyscallSucceeds());
+  ASSERT_THAT(waitpid(child_pid, &status, 0),
+              SyscallSucceedsWithValue(child_pid));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << " status " << status;
+}
+
 #if defined(__x86_64__)
 #define SYSNO_STR1(x) #x
 #define SYSNO_STR(x) SYSNO_STR1(x)


### PR DESCRIPTION
The Linux kernel's ptrace_regset() (kernel/ptrace.c) writes min(iov_len, actual_size) bytes and returns success for any non-zero buffer; it never rejects a PTRACE_GETREGSET request solely because the buffer is smaller than the full register set.

gVisor's PtraceGetRegSet previously returned EFAULT when maxlen was less than ptraceRegistersSize (216 bytes for x86_64).  This broke any tool that passes a smaller buffer, most notably libunwind whose _UPT_access_reg() allocates gregset_t (184 bytes) rather than struct user_regs_struct (216 bytes) for the PTRACE_GETREGSET call.  The result was that unw_init_remote() failed with UNW_EBADREG ("bad register number"), making ptrace-based stack unwinding completely non-functional inside gVisor containers. The corresponding fix to libunwind: https://github.com/libunwind/libunwind/pull/977

Fix: when maxlen is in the range (0, ptraceRegistersSize), serialize the full register set to a temporary buffer and write only maxlen bytes to dst, matching the kernel's truncation semantics.  The fast path (maxlen
>= ptraceRegistersSize) is unchanged.