### PR TITLE
runsc/cmd/sandboxsetup: export gofer setup helpers for reuse

### DIFF
--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -35,7 +35,6 @@ go_library(
     srcs = [
         "boot.go",
         "boot_impl.go",
-        "capability.go",
         "checkpoint.go",
         "checkpoint_impl.go",
         "chroot.go",
@@ -113,6 +112,7 @@ go_library(
         "//pkg/urpc",
         "//runsc/boot",
         "//runsc/cmd/metricserver/metricservercmd",
+        "//runsc/cmd/sandboxsetup",
         "//runsc/cmd/util",
         "//runsc/config",
         "//runsc/console",
@@ -165,6 +165,7 @@ go_test(
         "//pkg/sentry/control",
         "//pkg/sentry/kernel/auth",
         "//pkg/test/testutil",
+        "//runsc/cmd/sandboxsetup",
         "//runsc/cmd/util",
         "//runsc/config",
         "//runsc/container",

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
@@ -44,6 +43,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/syscalls/linux"
 	"gvisor.dev/gvisor/pkg/tcpip/nftables"
 	"gvisor.dev/gvisor/runsc/boot"
+	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/flag"
@@ -96,14 +96,14 @@ type Boot struct {
 	deviceFD int
 
 	// ioFDs is the list of FDs used to connect to FS gofers.
-	ioFDs intFlags
+	ioFDs sandboxsetup.IntFlags
 
 	// devIoFD is the FD to connect to dev gofer.
 	devIoFD int
 
 	// goferFilestoreFDs are FDs to the regular files that will back the tmpfs or
 	// overlayfs mount for certain gofer mounts.
-	goferFilestoreFDs intFlags
+	goferFilestoreFDs sandboxsetup.IntFlags
 
 	// goferMountConfs contains information about how the gofer mounts have been
 	// configured. The first entry is for rootfs and the following entries are
@@ -112,7 +112,7 @@ type Boot struct {
 
 	// stdioFDs are the fds for stdin, stdout, and stderr. They must be
 	// provided in that order.
-	stdioFDs intFlags
+	stdioFDs sandboxsetup.IntFlags
 
 	// passFDs are mappings of user-supplied host to guest file descriptors.
 	passFDs fdMappings
@@ -152,11 +152,11 @@ type Boot struct {
 
 	podInitConfigFD int
 
-	sinkFDs intFlags
+	sinkFDs sandboxsetup.IntFlags
 
-	saveFDs intFlags
+	saveFDs sandboxsetup.IntFlags
 
-	fsRestoreFDs intFlags
+	fsRestoreFDs sandboxsetup.IntFlags
 
 	// attached is set to true to kill the sandbox process when the parent process
 	// terminates. This flag is set when the command execve's itself because
@@ -385,7 +385,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 			// /proc is umounted from a forked process, because the
 			// current one is going to re-execute itself without
 			// capabilities.
-			cmd, w := execProcUmounter()
+			cmd, w := sandboxsetup.ExecProcUmounter()
 			defer cmd.Wait()
 			defer w.Close()
 			if b.procMountSyncFD != -1 {
@@ -402,13 +402,13 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 			if !b.applyCaps {
 				// Remove the args that have already been done before calling self.
-				args := prepareArgs(b.Name(), f, argOverride)
+				args := sandboxsetup.PrepareArgs(b.Name(), f, argOverride)
 
 				// Note that we've already read the spec from the spec FD, and
 				// we will read it again after the exec call. This works
 				// because the ReadSpecFromFile function seeks to the beginning
 				// of the file before reading.
-				util.Fatalf("callSelfAsNobody(%v): %v", args, callSelfAsNobody(args))
+				util.Fatalf("callSelfAsNobody(%v): %v", args, sandboxsetup.CallSelfAsNobody(args))
 
 				// This prevents the specFile finalizer from running and closed
 				// the specFD, which we have passed to ourselves when
@@ -467,13 +467,13 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		argOverride["apply-caps"] = "false"
 
 		// Remove the args that have already been done before calling self.
-		args := prepareArgs(b.Name(), f, argOverride)
+		args := sandboxsetup.PrepareArgs(b.Name(), f, argOverride)
 
 		// Note that we've already read the spec from the spec FD, and
 		// we will read it again after the exec call. This works
 		// because the ReadSpecFromFile function seeks to the beginning
 		// of the file before reading.
-		util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, caps, setCapsAndCallSelf(args, caps))
+		util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, caps, sandboxsetup.SetCapsAndCallSelf(args, caps))
 
 		// This prevents the specFile finalizer from running and closed
 		// the specFD, which we have passed to ourselves when
@@ -609,7 +609,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 			// Call validateOpenFDs() before umounting /proc.
 			validateOpenFDs(bootArgs.PassFDs)
 			// Umount /proc right before installing seccomp filters.
-			umountProc(b.procMountSyncFD)
+			sandboxsetup.UmountProc(b.procMountSyncFD)
 		}
 	}
 
@@ -669,84 +669,6 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 	l.Destroy()
 	return subcommands.ExitSuccess
-}
-
-// prepareArgs returns the args that can be used to re-execute the current
-// program. It manipulates the flags of the subcommands.Command identified by
-// subCmdName and fSet is the flag.FlagSet of this subcommand. It applies the
-// flags specified by override map. In case of conflict, flag is overridden.
-//
-// Postcondition: prepareArgs() takes ownership of override map.
-func prepareArgs(subCmdName string, fSet *flag.FlagSet, override map[string]string) []string {
-	var args []string
-	// Add all args up until (and including) the sub command.
-	for _, arg := range os.Args {
-		args = append(args, arg)
-		if arg == subCmdName {
-			break
-		}
-	}
-	// Set sub command flags. Iterate through all the explicitly set flags.
-	fSet.Visit(func(gf *flag.Flag) {
-		// If a conflict is found with override, then prefer override flag.
-		if ov, ok := override[gf.Name]; ok {
-			args = append(args, fmt.Sprintf("--%s=%s", gf.Name, ov))
-			delete(override, gf.Name)
-			return
-		}
-		// Otherwise pass through the original flag.
-		args = append(args, fmt.Sprintf("--%s=%s", gf.Name, gf.Value))
-	})
-	// Apply remaining override flags (that didn't conflict above).
-	for of, ov := range override {
-		args = append(args, fmt.Sprintf("--%s=%s", of, ov))
-	}
-	// Add the non-flag arguments at the end.
-	args = append(args, fSet.Args()...)
-	return args
-}
-
-// execProcUmounter execute a child process that umounts /proc when the
-// returned pipe is closed.
-func execProcUmounter() (*exec.Cmd, *os.File) {
-	r, w, err := os.Pipe()
-	if err != nil {
-		util.Fatalf("error creating a pipe: %v", err)
-	}
-	defer r.Close()
-
-	cmd := exec.Command(specutils.ExePath)
-	cmd.Args = append(cmd.Args, "umount", "--sync-fd=3", "/proc")
-	cmd.ExtraFiles = append(cmd.ExtraFiles, r)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
-		util.Fatalf("error executing umounter: %v", err)
-	}
-	return cmd, w
-}
-
-// umountProc writes to syncFD signalling the process started by
-// execProcUmounter() to umount /proc.
-func umountProc(syncFD int) {
-	syncFile := os.NewFile(uintptr(syncFD), "procfs umount sync FD")
-	buf := make([]byte, 1)
-	if w, err := syncFile.Write(buf); err != nil || w != 1 {
-		util.Fatalf("unable to write into the proc umounter descriptor: %v", err)
-	}
-	syncFile.Close()
-
-	var waitStatus unix.WaitStatus
-	if _, err := unix.Wait4(0, &waitStatus, 0, nil); err != nil {
-		util.Fatalf("error waiting for the proc umounter process: %v", err)
-	}
-	if !waitStatus.Exited() || waitStatus.ExitStatus() != 0 {
-		util.Fatalf("the proc umounter process failed: %v", waitStatus)
-	}
-	if err := unix.Access("/proc/self", unix.F_OK); err != unix.ENOENT {
-		util.Fatalf("/proc is still accessible")
-	}
 }
 
 // validateOpenFDs checks that the sandbox process does not have any open

--- a/runsc/cmd/capability_test.go
+++ b/runsc/cmd/capability_test.go
@@ -25,6 +25,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/test/testutil"
+	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/container"
 	"gvisor.dev/gvisor/runsc/specutils"
@@ -47,7 +48,7 @@ func checkProcessCaps(pid int, wantCaps *specs.LinuxCapabilities) error {
 	}
 	fmt.Printf("Capabilities (PID: %d): %v\n", pid, curCaps)
 
-	for _, c := range allCapTypes {
+	for _, c := range sandboxsetup.AllCapTypes {
 		if err := checkCaps(c, curCaps, wantCaps); err != nil {
 			return err
 		}
@@ -56,8 +57,8 @@ func checkProcessCaps(pid int, wantCaps *specs.LinuxCapabilities) error {
 }
 
 func checkCaps(which capability.CapType, curCaps capability.Capabilities, wantCaps *specs.LinuxCapabilities) error {
-	wantNames := getCaps(which, wantCaps)
-	for name, c := range capFromName {
+	wantNames := sandboxsetup.GetCaps(which, wantCaps)
+	for name, c := range sandboxsetup.CapFromName {
 		want := slices.Contains(wantNames, name)
 		got := curCaps.Get(which, c)
 		if want != got {

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/abi/tpu"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/specutils"
@@ -40,46 +41,6 @@ func mountInChroot(chroot, src, dst, typ string, flags uint32) error {
 		return fmt.Errorf("error mounting %q at %q: %v", src, chrootDst, err)
 	}
 	return nil
-}
-
-func pivotRoot(root string) error {
-	if err := os.Chdir(root); err != nil {
-		return fmt.Errorf("error changing working directory: %v", err)
-	}
-	// pivot_root(new_root, put_old) moves the root filesystem (old_root)
-	// of the calling process to the directory put_old and makes new_root
-	// the new root filesystem of the calling process.
-	//
-	// pivot_root(".", ".") makes a mount of the working directory the new
-	// root filesystem, so it will be moved in "/" and then the old_root
-	// will be moved to "/" too. The parent mount of the old_root will be
-	// new_root, so after umounting the old_root, we will see only
-	// the new_root in "/".
-	if err := unix.PivotRoot(".", "."); err != nil {
-		return fmt.Errorf("pivot_root failed, make sure that the root mount has a parent: %v", err)
-	}
-
-	if err := unix.Unmount(".", unix.MNT_DETACH); err != nil {
-		return fmt.Errorf("error umounting the old root file system: %v", err)
-	}
-	return nil
-}
-
-func copyFile(dst, src string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	_, err = out.ReadFrom(in)
-	return err
 }
 
 // setupMinimalProcfs creates a minimal procfs-like tree at `${chroot}/proc`.
@@ -135,7 +96,7 @@ func setupMinimalProcfs(chroot string) error {
 		"/proc/sys/vm/mmap_min_addr",
 		"/proc/sys/kernel/cap_last_cap",
 	} {
-		if err := copyFile(filepath.Join(chroot, f), f); err != nil {
+		if err := sandboxsetup.CopyFile(filepath.Join(chroot, f), f); err != nil {
 			return fmt.Errorf("failed to copy %q -> %q: %w", f, filepath.Join(chroot, f), err)
 		}
 	}
@@ -175,7 +136,7 @@ func setUpChroot(spec *specs.Spec, conf *config.Config) error {
 		return fmt.Errorf("error creating /etc in chroot: %v", err)
 	}
 
-	if err := copyFile(filepath.Join(chroot, "etc/localtime"), "/etc/localtime"); err != nil {
+	if err := sandboxsetup.CopyFile(filepath.Join(chroot, "etc/localtime"), "/etc/localtime"); err != nil {
 		log.Warningf("Failed to copy /etc/localtime: %v. UTC timezone will be used.", err)
 	}
 
@@ -191,7 +152,7 @@ func setUpChroot(spec *specs.Spec, conf *config.Config) error {
 		return fmt.Errorf("error remounting chroot in read-only: %v", err)
 	}
 
-	return pivotRoot(chroot)
+	return sandboxsetup.PivotRoot(chroot)
 }
 
 func tpuProxyUpdateChroot(hostRoot, chroot string, spec *specs.Spec, conf *config.Config) error {

--- a/runsc/cmd/cmd.go
+++ b/runsc/cmd/cmd.go
@@ -17,20 +17,10 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"runtime"
-	"strconv"
-	"strings"
 
-	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
-	"gvisor.dev/gvisor/pkg/fd"
-	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/container"
 	"gvisor.dev/gvisor/runsc/flag"
-	"gvisor.dev/gvisor/runsc/specutils"
-	"gvisor.dev/gvisor/runsc/starttime"
 )
 
 // containerLoader is an embeddable struct for util.SubCommand implementations
@@ -58,95 +48,4 @@ func (c *containerLoader) loadContainer(conf *config.Config, f *flag.FlagSet, lo
 	}
 	c.cachedContainer = cont
 	return c.cachedContainer, nil
-}
-
-// intFlags can be used with int flags that appear multiple times. It supports
-// comma-separated lists too.
-type intFlags []int
-
-// String implements flag.Value.
-func (i *intFlags) String() string {
-	sInts := make([]string, 0, len(*i))
-	for _, fd := range *i {
-		sInts = append(sInts, strconv.Itoa(fd))
-	}
-	return strings.Join(sInts, ",")
-}
-
-// Get implements flag.Value.
-func (i *intFlags) Get() any {
-	return i
-}
-
-// GetArray returns an array of ints representing FDs.
-func (i *intFlags) GetArray() []int {
-	return *i
-}
-
-// GetFDs returns an array of *fd.FD.
-func (i *intFlags) GetFDs() []*fd.FD {
-	rv := make([]*fd.FD, 0, len(*i))
-	for _, val := range *i {
-		rv = append(rv, fd.New(val))
-	}
-	return rv
-}
-
-// Set implements flag.Value. Set(String()) should be idempotent.
-func (i *intFlags) Set(s string) error {
-	for _, sFD := range strings.Split(s, ",") {
-		fd, err := strconv.Atoi(sFD)
-		if err != nil {
-			return fmt.Errorf("invalid flag value: %v", err)
-		}
-		if fd < -1 {
-			return fmt.Errorf("flag value must be >= -1: %d", fd)
-		}
-		*i = append(*i, fd)
-	}
-	return nil
-}
-
-// setCapsAndCallSelf sets capabilities to the current thread and then execve's
-// itself again with the arguments specified in 'args' to restart the process
-// with the desired capabilities.
-func setCapsAndCallSelf(args []string, caps *specs.LinuxCapabilities) error {
-	// Keep thread locked while capabilities are changed.
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	if err := applyCaps(caps); err != nil {
-		return fmt.Errorf("applyCaps() failed: %v", err)
-	}
-	binPath := specutils.ExePath
-
-	log.Infof("Execve %q again, bye!", binPath)
-	err := unix.Exec(binPath, args, starttime.AppendEnviron(os.Environ()))
-	return fmt.Errorf("error executing %s: %v", binPath, err)
-}
-
-// callSelfAsNobody sets UID and GID to nobody and then execve's itself again.
-func callSelfAsNobody(args []string) error {
-	// Keep thread locked while user/group are changed.
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	const nobody = 65534
-
-	if _, _, err := unix.RawSyscall(unix.SYS_SETGID, uintptr(nobody), 0, 0); err != 0 {
-		return fmt.Errorf("error setting uid: %v", err)
-	}
-	if _, _, err := unix.RawSyscall(unix.SYS_SETUID, uintptr(nobody), 0, 0); err != 0 {
-		return fmt.Errorf("error setting gid: %v", err)
-	}
-	// Drop all capabilities.
-	if err := applyCaps(&specs.LinuxCapabilities{}); err != nil {
-		return fmt.Errorf("error dropping capabilities: %w", err)
-	}
-
-	binPath := specutils.ExePath
-
-	log.Infof("Execve %q again, bye!", binPath)
-	err := unix.Exec(binPath, args, starttime.AppendEnviron(os.Environ()))
-	return fmt.Errorf("error executing %s: %v", binPath, err)
 }

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -34,6 +33,7 @@ import (
 	"gvisor.dev/gvisor/pkg/unet"
 	"gvisor.dev/gvisor/pkg/urpc"
 	"gvisor.dev/gvisor/runsc/boot"
+	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/container"
@@ -100,7 +100,7 @@ type goferSyncFDs struct {
 type Gofer struct {
 	util.InternalSubCommand
 	bundleDir  string
-	ioFDs      intFlags
+	ioFDs      sandboxsetup.IntFlags
 	devIoFD    int
 	applyCaps  bool
 	setUpRoot  bool
@@ -202,12 +202,12 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 		overrides := g.syncFDs.flags()
 		overrides["apply-caps"] = "false"
 		overrides["setup-root"] = "false"
-		args := prepareArgs(g.Name(), f, overrides)
+		args := sandboxsetup.PrepareArgs(g.Name(), f, overrides)
 		capsToApply := goferCaps
 		if conf.GetHostUDS().AllowOpen() {
 			capsToApply = specutils.MergeCapabilities(capsToApply, goferUdsOpenCaps)
 		}
-		util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, capsToApply, setCapsAndCallSelf(args, capsToApply))
+		util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, capsToApply, sandboxsetup.SetCapsAndCallSelf(args, capsToApply))
 		panic("unreachable")
 	}
 
@@ -468,7 +468,7 @@ func (g *Gofer) setupRootFS(spec *specs.Spec, conf *config.Config, goferToHostRP
 			"", unix.MS_RDONLY|unix.MS_BIND|flags, ""); err != nil {
 			util.Fatalf("error mounting proc/self/fd: %v", err)
 		}
-		if err := copyFile("/proc/fs/etc/localtime", "/etc/localtime"); err != nil {
+		if err := sandboxsetup.CopyFile("/proc/fs/etc/localtime", "/etc/localtime"); err != nil {
 			log.Warningf("Failed to copy /etc/localtime: %v. UTC timezone will be used.", err)
 		}
 		root = "/proc/fs/root"
@@ -517,7 +517,7 @@ func (g *Gofer) setupRootFS(spec *specs.Spec, conf *config.Config, goferToHostRP
 	}
 
 	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
-		if err := pivotRoot("/proc/fs"); err != nil {
+		if err := sandboxsetup.PivotRoot("/proc/fs"); err != nil {
 			util.Fatalf("failed to change the root file system: %v", err)
 		}
 		if err := os.Chdir("/"); err != nil {
@@ -542,7 +542,7 @@ func (g *Gofer) setupMounts(conf *config.Config, mounts []specs.Mount, root, pro
 			continue
 		}
 
-		dst, err := resolveSymlinks(root, m.Destination)
+		dst, err := sandboxsetup.ResolveSymlinks(root, m.Destination)
 		if err != nil {
 			return fmt.Errorf("resolving symlinks to %q: %v", m.Destination, err)
 		}
@@ -705,7 +705,7 @@ func (g *Gofer) resolveMounts(conf *config.Config, mounts []specs.Mount, root st
 			cleanMounts = append(cleanMounts, m)
 			continue
 		}
-		dst, err := resolveSymlinks(root, m.Destination)
+		dst, err := sandboxsetup.ResolveSymlinks(root, m.Destination)
 		if err != nil {
 			return nil, fmt.Errorf("resolving symlinks to %q: %v", m.Destination, err)
 		}
@@ -714,7 +714,7 @@ func (g *Gofer) resolveMounts(conf *config.Config, mounts []specs.Mount, root st
 			panic(fmt.Sprintf("%q could not be made relative to %q: %v", dst, root, err))
 		}
 
-		opts, err := adjustMountOptions(conf, filepath.Join(root, relDst), m.Options)
+		opts, err := sandboxsetup.AdjustMountOptions(conf, filepath.Join(root, relDst), m.Options)
 		if err != nil {
 			return nil, err
 		}
@@ -725,81 +725,6 @@ func (g *Gofer) resolveMounts(conf *config.Config, mounts []specs.Mount, root st
 		cleanMounts = append(cleanMounts, cpy)
 	}
 	return cleanMounts, nil
-}
-
-// ResolveSymlinks walks 'rel' having 'root' as the root directory. If there are
-// symlinks, they are evaluated relative to 'root' to ensure the end result is
-// the same as if the process was running inside the container.
-func resolveSymlinks(root, rel string) (string, error) {
-	return resolveSymlinksImpl(root, root, rel, 255)
-}
-
-func resolveSymlinksImpl(root, base, rel string, followCount uint) (string, error) {
-	if followCount == 0 {
-		return "", fmt.Errorf("too many symlinks to follow, path: %q", filepath.Join(base, rel))
-	}
-
-	rel = filepath.Clean(rel)
-	for _, name := range strings.Split(rel, string(filepath.Separator)) {
-		if name == "" {
-			continue
-		}
-		// Note that Join() resolves things like ".." and returns a clean path.
-		path := filepath.Join(base, name)
-		if !strings.HasPrefix(path, root) {
-			// One cannot '..' their way out of root.
-			base = root
-			continue
-		}
-		fi, err := os.Lstat(path)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				return "", err
-			}
-			// Not found means there is no symlink to check. Just keep walking dirs.
-			base = path
-			continue
-		}
-		if fi.Mode()&os.ModeSymlink != 0 {
-			link, err := os.Readlink(path)
-			if err != nil {
-				return "", err
-			}
-			if filepath.IsAbs(link) {
-				base = root
-			}
-			base, err = resolveSymlinksImpl(root, base, link, followCount-1)
-			if err != nil {
-				return "", err
-			}
-			continue
-		}
-		base = path
-	}
-	return base, nil
-}
-
-// adjustMountOptions adds filesystem-specific gofer mount options.
-func adjustMountOptions(conf *config.Config, path string, opts []string) ([]string, error) {
-	rv := make([]string, len(opts))
-	copy(rv, opts)
-
-	statfs := unix.Statfs_t{}
-	if err := unix.Statfs(path, &statfs); err != nil {
-		return nil, err
-	}
-	switch statfs.Type {
-	case unix.OVERLAYFS_SUPER_MAGIC:
-		rv = append(rv, "overlayfs_stale_read")
-	case unix.NFS_SUPER_MAGIC, unix.FUSE_SUPER_MAGIC:
-		// The gofer client implements remote file handle sharing for performance.
-		// However, remote filesystems like NFS and FUSE rely on close(2) syscall
-		// for flushing file data to the server. Such handle sharing prevents the
-		// application's close(2) syscall from being propagated to the host. Hence
-		// disable file handle sharing, so remote files are flushed correctly.
-		rv = append(rv, "disable_file_handle_sharing")
-	}
-	return rv, nil
 }
 
 // setFlags sets sync FD flags on the given FlagSet.
@@ -819,21 +744,6 @@ func (g *goferSyncFDs) flags() map[string]string {
 	}
 }
 
-// waitForFD waits for the other end of a given FD to be closed.
-// `fd` is closed unconditionally after that.
-// This should only be called for actual FDs (i.e. `fd` >= 0).
-func waitForFD(fd int, fdName string) error {
-	log.Debugf("Waiting on %s %d...", fdName, fd)
-	f := os.NewFile(uintptr(fd), fdName)
-	defer f.Close()
-	var b [1]byte
-	if n, err := f.Read(b[:]); n != 0 || err != io.EOF {
-		return fmt.Errorf("failed to sync on %s: %v: %v", fdName, n, err)
-	}
-	log.Debugf("Synced on %s %d.", fdName, fd)
-	return nil
-}
-
 // spawnProcMounter executes the /proc unmounter process.
 // It returns a function to wait on the proc unmounter process, which
 // should be called (via defer) in case of errors in order to clean up the
@@ -845,7 +755,7 @@ func (g *goferSyncFDs) spawnProcUnmounter() func() {
 	}
 	// /proc is umounted from a forked process, because the
 	// current one may re-execute itself without capabilities.
-	cmd, w := execProcUmounter()
+	cmd, w := sandboxsetup.ExecProcUmounter()
 	// Clear FD_CLOEXEC. This process may be re-executed. procMountFD
 	// should remain open.
 	if _, _, errno := unix.RawSyscall(unix.SYS_FCNTL, w.Fd(), unix.F_SETFD, 0); errno != 0 {
@@ -865,7 +775,7 @@ func (g *goferSyncFDs) unmountProcfs() {
 	if g.procMountFD < 0 {
 		return
 	}
-	umountProc(g.procMountFD)
+	sandboxsetup.UmountProc(g.procMountFD)
 	g.procMountFD = -1
 }
 
@@ -888,7 +798,7 @@ func (g *goferSyncFDs) syncUsernsForRootless(uid, gid uint32) {
 //
 // Postcondition: All callers must re-exec themselves after this returns.
 func syncUsernsForRootless(fd int, uid uint32, gid uint32) {
-	if err := waitForFD(fd, "userns sync FD"); err != nil {
+	if err := sandboxsetup.WaitForFD(fd, "userns sync FD"); err != nil {
 		util.Fatalf("failed to sync on userns FD: %v", err)
 	}
 
@@ -911,7 +821,7 @@ func (g *goferSyncFDs) syncChroot() {
 	if g.chrootFD < 0 {
 		return
 	}
-	if err := waitForFD(g.chrootFD, "chroot sync FD"); err != nil {
+	if err := sandboxsetup.WaitForFD(g.chrootFD, "chroot sync FD"); err != nil {
 		util.Fatalf("failed to sync on chroot FD: %v", err)
 	}
 	g.chrootFD = -1

--- a/runsc/cmd/gofer_test.go
+++ b/runsc/cmd/gofer_test.go
@@ -20,6 +20,8 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+
+	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 )
 
 func tmpDir() string {
@@ -122,13 +124,13 @@ func TestResolveSymlinks(t *testing.T) {
 	}
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
-			got, err := resolveSymlinks(root, tst.rel)
+			got, err := sandboxsetup.ResolveSymlinks(root, tst.rel)
 			if err != nil {
-				t.Errorf("resolveSymlinks(root, %q) failed: %v", tst.rel, err)
+				t.Errorf("ResolveSymlinks(root, %q) failed: %v", tst.rel, err)
 			}
 			want := path.Join(root, tst.want)
 			if got != want {
-				t.Errorf("resolveSymlinks(root, %q) got: %q, want: %q", tst.rel, got, want)
+				t.Errorf("ResolveSymlinks(root, %q) got: %q, want: %q", tst.rel, got, want)
 			}
 			if tst.compareHost {
 				// Check that host got to the same end result.
@@ -137,7 +139,7 @@ func TestResolveSymlinks(t *testing.T) {
 					t.Errorf("path.EvalSymlinks(root, %q) failed: %v", tst.rel, err)
 				}
 				if host != got {
-					t.Errorf("resolveSymlinks(root, %q) got: %q, want: %q", tst.rel, host, got)
+					t.Errorf("ResolveSymlinks(root, %q) got: %q, want: %q", tst.rel, host, got)
 				}
 			}
 		})
@@ -156,7 +158,7 @@ func TestResolveSymlinksLoop(t *testing.T) {
 	if err := construct(root, dirs); err != nil {
 		t.Fatal("construct failed:", err)
 	}
-	if _, err := resolveSymlinks(root, "loop1"); err == nil {
-		t.Errorf("resolveSymlinks() should have failed")
+	if _, err := sandboxsetup.ResolveSymlinks(root, "loop1"); err == nil {
+		t.Errorf("ResolveSymlinks() should have failed")
 	}
 }

--- a/runsc/cmd/sandboxsetup/BUILD
+++ b/runsc/cmd/sandboxsetup/BUILD
@@ -1,0 +1,29 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "sandboxsetup",
+    srcs = [
+        "caps.go",
+        "flags.go",
+        "fs.go",
+        "process.go",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/fd",
+        "//pkg/log",
+        "//runsc/cmd/util",
+        "//runsc/config",
+        "//runsc/flag",
+        "//runsc/specutils",
+        "//runsc/starttime",
+        "@com_github_moby_sys_capability//:go_default_library",
+        "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)

--- a/runsc/cmd/sandboxsetup/caps.go
+++ b/runsc/cmd/sandboxsetup/caps.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmd
+package sandboxsetup
 
 import (
 	"fmt"
@@ -22,7 +22,8 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 )
 
-var allCapTypes = []capability.CapType{
+// AllCapTypes is the set of all Linux capability types.
+var AllCapTypes = []capability.CapType{
 	capability.BOUNDS,
 	capability.EFFECTIVE,
 	capability.PERMITTED,
@@ -30,10 +31,11 @@ var allCapTypes = []capability.CapType{
 	capability.AMBIENT,
 }
 
-// applyCaps applies the capabilities in the spec to the current thread.
+// ApplyCaps applies the capabilities in the spec to the current thread.
 //
-// Note that it must be called with current thread locked.
-func applyCaps(caps *specs.LinuxCapabilities) error {
+// Precondition: Must be called with the current OS thread locked
+// (runtime.LockOSThread).
+func ApplyCaps(caps *specs.LinuxCapabilities) error {
 	// Load current capabilities to trim the ones not permitted.
 	curCaps, err := capability.NewPid2(0)
 	if err != nil {
@@ -49,11 +51,11 @@ func applyCaps(caps *specs.LinuxCapabilities) error {
 		return err
 	}
 
-	for _, c := range allCapTypes {
+	for _, c := range AllCapTypes {
 		if !newCaps.Empty(c) {
 			panic("unloaded capabilities must be empty")
 		}
-		set, err := trimCaps(getCaps(c, caps), curCaps)
+		set, err := TrimCaps(GetCaps(c, caps), curCaps)
 		if err != nil {
 			return err
 		}
@@ -67,7 +69,9 @@ func applyCaps(caps *specs.LinuxCapabilities) error {
 	return nil
 }
 
-func getCaps(which capability.CapType, caps *specs.LinuxCapabilities) []string {
+// GetCaps returns the capability names for the given capability type from
+// the provided LinuxCapabilities spec.
+func GetCaps(which capability.CapType, caps *specs.LinuxCapabilities) []string {
 	switch which {
 	case capability.BOUNDS:
 		return caps.Bounding
@@ -83,8 +87,10 @@ func getCaps(which capability.CapType, caps *specs.LinuxCapabilities) []string {
 	panic(fmt.Sprint("invalid capability type:", which))
 }
 
-func trimCaps(names []string, setter capability.Capabilities) ([]capability.Cap, error) {
-	wantedCaps, err := capsFromNames(names)
+// TrimCaps filters the named capabilities to only those that are currently
+// permitted by the given Capabilities set.
+func TrimCaps(names []string, setter capability.Capabilities) ([]capability.Cap, error) {
+	wantedCaps, err := CapsFromNames(names)
 	if err != nil {
 		return nil, err
 	}
@@ -92,8 +98,9 @@ func trimCaps(names []string, setter capability.Capabilities) ([]capability.Cap,
 	// Trim down capabilities that aren't possible to acquire.
 	var caps []capability.Cap
 	for _, c := range wantedCaps {
-		// Capability rules are more complicated than this, but this catches most
-		// problems with tests running with non-privileged user.
+		// Capability rules are more complicated than this, but this
+		// catches most problems with tests running with non-privileged
+		// user.
 		if setter.Get(capability.PERMITTED, c) {
 			caps = append(caps, c)
 		} else {
@@ -103,10 +110,11 @@ func trimCaps(names []string, setter capability.Capabilities) ([]capability.Cap,
 	return caps, nil
 }
 
-func capsFromNames(names []string) ([]capability.Cap, error) {
+// CapsFromNames converts capability string names to capability.Cap values.
+func CapsFromNames(names []string) ([]capability.Cap, error) {
 	var caps []capability.Cap
 	for _, name := range names {
-		cap, ok := capFromName[name]
+		cap, ok := CapFromName[name]
 		if !ok {
 			return nil, fmt.Errorf("invalid capability %q", name)
 		}
@@ -115,7 +123,9 @@ func capsFromNames(names []string) ([]capability.Cap, error) {
 	return caps, nil
 }
 
-var capFromName = map[string]capability.Cap{
+// CapFromName maps Linux capability string names to their capability.Cap
+// values.
+var CapFromName = map[string]capability.Cap{
 	"CAP_CHOWN":              capability.CAP_CHOWN,
 	"CAP_DAC_OVERRIDE":       capability.CAP_DAC_OVERRIDE,
 	"CAP_DAC_READ_SEARCH":    capability.CAP_DAC_READ_SEARCH,

--- a/runsc/cmd/sandboxsetup/flags.go
+++ b/runsc/cmd/sandboxsetup/flags.go
@@ -1,0 +1,70 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandboxsetup
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/fd"
+)
+
+// IntFlags can be used with int flags that appear multiple times. It
+// supports comma-separated lists too.
+type IntFlags []int
+
+// String implements flag.Value.
+func (i *IntFlags) String() string {
+	sInts := make([]string, 0, len(*i))
+	for _, fd := range *i {
+		sInts = append(sInts, strconv.Itoa(fd))
+	}
+	return strings.Join(sInts, ",")
+}
+
+// Get implements flag.Value.
+func (i *IntFlags) Get() any {
+	return i
+}
+
+// GetArray returns an array of ints.
+func (i *IntFlags) GetArray() []int {
+	return *i
+}
+
+// GetFDs returns an array of *fd.FD.
+func (i *IntFlags) GetFDs() []*fd.FD {
+	rv := make([]*fd.FD, 0, len(*i))
+	for _, val := range *i {
+		rv = append(rv, fd.New(val))
+	}
+	return rv
+}
+
+// Set implements flag.Value. Set(String()) should be idempotent.
+func (i *IntFlags) Set(s string) error {
+	for _, sFD := range strings.Split(s, ",") {
+		fd, err := strconv.Atoi(sFD)
+		if err != nil {
+			return fmt.Errorf("invalid flag value: %v", err)
+		}
+		if fd < -1 {
+			return fmt.Errorf("flag value must be >= -1: %d", fd)
+		}
+		*i = append(*i, fd)
+	}
+	return nil
+}

--- a/runsc/cmd/sandboxsetup/fs.go
+++ b/runsc/cmd/sandboxsetup/fs.go
@@ -1,0 +1,164 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandboxsetup
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/runsc/config"
+)
+
+// PivotRoot changes the root filesystem to the given directory using
+// pivot_root(2). The old root is unmounted after the pivot.
+func PivotRoot(root string) error {
+	if err := os.Chdir(root); err != nil {
+		return fmt.Errorf("error changing working directory: %v", err)
+	}
+	// pivot_root(new_root, put_old) moves the root filesystem (old_root)
+	// of the calling process to the directory put_old and makes new_root
+	// the new root filesystem of the calling process.
+	//
+	// pivot_root(".", ".") makes a mount of the working directory the new
+	// root filesystem, so it will be moved in "/" and then the old_root
+	// will be moved to "/" too. The parent mount of the old_root will be
+	// new_root, so after umounting the old_root, we will see only
+	// the new_root in "/".
+	if err := unix.PivotRoot(".", "."); err != nil {
+		return fmt.Errorf("pivot_root failed, make sure that the root mount has a parent: %v", err)
+	}
+
+	if err := unix.Unmount(".", unix.MNT_DETACH); err != nil {
+		return fmt.Errorf("error umounting the old root file system: %v", err)
+	}
+	return nil
+}
+
+// CopyFile copies a file from src to dst.
+func CopyFile(dst, src string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = out.ReadFrom(in)
+	return err
+}
+
+// ResolveSymlinks walks 'rel' having 'root' as the root directory. If there
+// are symlinks, they are evaluated relative to 'root' to ensure the end
+// result is the same as if the process was running inside the container.
+func ResolveSymlinks(root, rel string) (string, error) {
+	return resolveSymlinksImpl(root, root, rel, 255)
+}
+
+func resolveSymlinksImpl(root, base, rel string, followCount uint) (string, error) {
+	if followCount == 0 {
+		return "", fmt.Errorf("too many symlinks to follow, path: %q", filepath.Join(base, rel))
+	}
+
+	rel = filepath.Clean(rel)
+	for _, name := range strings.Split(rel, string(filepath.Separator)) {
+		if name == "" {
+			continue
+		}
+		// Note that Join() resolves things like ".." and returns a
+		// clean path.
+		path := filepath.Join(base, name)
+		if !strings.HasPrefix(path, root) {
+			// One cannot '..' their way out of root.
+			base = root
+			continue
+		}
+		fi, err := os.Lstat(path)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return "", err
+			}
+			// Not found means there is no symlink to check. Just
+			// keep walking dirs.
+			base = path
+			continue
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return "", err
+			}
+			if filepath.IsAbs(link) {
+				base = root
+			}
+			base, err = resolveSymlinksImpl(root, base, link, followCount-1)
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+		base = path
+	}
+	return base, nil
+}
+
+// AdjustMountOptions adds filesystem-specific gofer mount options.
+func AdjustMountOptions(conf *config.Config, path string, opts []string) ([]string, error) {
+	rv := make([]string, len(opts))
+	copy(rv, opts)
+
+	statfs := unix.Statfs_t{}
+	if err := unix.Statfs(path, &statfs); err != nil {
+		return nil, err
+	}
+	switch statfs.Type {
+	case unix.OVERLAYFS_SUPER_MAGIC:
+		rv = append(rv, "overlayfs_stale_read")
+	case unix.NFS_SUPER_MAGIC, unix.FUSE_SUPER_MAGIC:
+		// The gofer client implements remote file handle sharing for
+		// performance. However, remote filesystems like NFS and FUSE
+		// rely on close(2) syscall for flushing file data to the
+		// server. Such handle sharing prevents the application's
+		// close(2) syscall from being propagated to the host. Hence
+		// disable file handle sharing, so remote files are flushed
+		// correctly.
+		rv = append(rv, "disable_file_handle_sharing")
+	}
+	return rv, nil
+}
+
+// WaitForFD waits for the other end of a given FD to be closed.
+// The FD is closed unconditionally after that.
+// This should only be called for actual FDs (i.e. fd >= 0).
+func WaitForFD(fd int, fdName string) error {
+	log.Debugf("Waiting on %s %d...", fdName, fd)
+	f := os.NewFile(uintptr(fd), fdName)
+	defer f.Close()
+	var b [1]byte
+	if n, err := f.Read(b[:]); n != 0 || err != io.EOF {
+		return fmt.Errorf("failed to sync on %s: %v: %v", fdName, n, err)
+	}
+	log.Debugf("Synced on %s %d.", fdName, fd)
+	return nil
+}

--- a/runsc/cmd/sandboxsetup/process.go
+++ b/runsc/cmd/sandboxsetup/process.go
@@ -1,0 +1,155 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandboxsetup
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/runsc/flag"
+	"gvisor.dev/gvisor/runsc/specutils"
+	"gvisor.dev/gvisor/runsc/starttime"
+)
+
+// SetCapsAndCallSelf sets capabilities to the current thread and then
+// execve's itself again with the arguments specified in 'args' to restart
+// the process with the desired capabilities.
+func SetCapsAndCallSelf(args []string, caps *specs.LinuxCapabilities) error {
+	// Keep thread locked while capabilities are changed.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := ApplyCaps(caps); err != nil {
+		return fmt.Errorf("ApplyCaps() failed: %v", err)
+	}
+	binPath := specutils.ExePath
+
+	log.Infof("Execve %q again, bye!", binPath)
+	err := unix.Exec(binPath, args, starttime.AppendEnviron(os.Environ()))
+	return fmt.Errorf("error executing %s: %v", binPath, err)
+}
+
+// CallSelfAsNobody sets UID and GID to nobody and then execve's itself
+// again.
+func CallSelfAsNobody(args []string) error {
+	// Keep thread locked while user/group are changed.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	const nobody = 65534
+
+	if _, _, err := unix.RawSyscall(unix.SYS_SETGID, uintptr(nobody), 0, 0); err != 0 {
+		return fmt.Errorf("error setting gid: %v", err)
+	}
+	if _, _, err := unix.RawSyscall(unix.SYS_SETUID, uintptr(nobody), 0, 0); err != 0 {
+		return fmt.Errorf("error setting uid: %v", err)
+	}
+	// Drop all capabilities.
+	if err := ApplyCaps(&specs.LinuxCapabilities{}); err != nil {
+		return fmt.Errorf("error dropping capabilities: %w", err)
+	}
+
+	binPath := specutils.ExePath
+
+	log.Infof("Execve %q again, bye!", binPath)
+	err := unix.Exec(binPath, args, starttime.AppendEnviron(os.Environ()))
+	return fmt.Errorf("error executing %s: %v", binPath, err)
+}
+
+// PrepareArgs returns the args that can be used to re-execute the current
+// program. It manipulates the flags of the subcommand identified by
+// subCmdName and fSet is the flag.FlagSet of this subcommand. It applies
+// the flags specified by override map. In case of conflict, flag is
+// overridden.
+//
+// Postcondition: PrepareArgs() takes ownership of override map.
+func PrepareArgs(subCmdName string, fSet *flag.FlagSet, override map[string]string) []string {
+	var args []string
+	// Add all args up until (and including) the sub command.
+	for _, arg := range os.Args {
+		args = append(args, arg)
+		if arg == subCmdName {
+			break
+		}
+	}
+	// Set sub command flags. Iterate through all the explicitly set flags.
+	fSet.Visit(func(gf *flag.Flag) {
+		// If a conflict is found with override, then prefer override
+		// flag.
+		if ov, ok := override[gf.Name]; ok {
+			args = append(args, fmt.Sprintf("--%s=%s", gf.Name, ov))
+			delete(override, gf.Name)
+			return
+		}
+		// Otherwise pass through the original flag.
+		args = append(args, fmt.Sprintf("--%s=%s", gf.Name, gf.Value))
+	})
+	// Apply remaining override flags (that didn't conflict above).
+	for of, ov := range override {
+		args = append(args, fmt.Sprintf("--%s=%s", of, ov))
+	}
+	// Add the non-flag arguments at the end.
+	args = append(args, fSet.Args()...)
+	return args
+}
+
+// ExecProcUmounter executes a child process that umounts /proc when the
+// returned pipe is closed.
+func ExecProcUmounter() (*exec.Cmd, *os.File) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		util.Fatalf("error creating a pipe: %v", err)
+	}
+	defer r.Close()
+
+	cmd := exec.Command(specutils.ExePath)
+	cmd.Args = append(cmd.Args, "umount", "--sync-fd=3", "/proc")
+	cmd.ExtraFiles = append(cmd.ExtraFiles, r)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		util.Fatalf("error executing umounter: %v", err)
+	}
+	return cmd, w
+}
+
+// UmountProc writes to syncFD signalling the process started by
+// ExecProcUmounter() to umount /proc.
+func UmountProc(syncFD int) {
+	syncFile := os.NewFile(uintptr(syncFD), "procfs umount sync FD")
+	buf := make([]byte, 1)
+	if w, err := syncFile.Write(buf); err != nil || w != 1 {
+		util.Fatalf("unable to write into the proc umounter descriptor: %v", err)
+	}
+	syncFile.Close()
+
+	var waitStatus unix.WaitStatus
+	if _, err := unix.Wait4(0, &waitStatus, 0, nil); err != nil {
+		util.Fatalf("error waiting for the proc umounter process: %v", err)
+	}
+	if !waitStatus.Exited() || waitStatus.ExitStatus() != 0 {
+		util.Fatalf("the proc umounter process failed: %v", waitStatus)
+	}
+	if err := unix.Access("/proc/self", unix.F_OK); err != unix.ENOENT {
+		util.Fatalf("/proc is still accessible")
+	}
+}


### PR DESCRIPTION
I am looking into building a custom gVisor gofer that serves storage volumes over LisaFS. Building the gofer process around `lisafs`, which works well as a public API, requires duplicating unexported setup helpers from `runsc/cmd/` like `applyCaps`, `resolveSymlinks`, `adjustMountOptions`, `pivotRoot`, `copyFile`, `prepareArgs`, `execProcUmounter`, `setCapsAndCallSelf`, and `intFlags`. These must be manually diffed and re-synced on every gVisor version bump.

The functions are already well-factored: they take explicit parameters, carry no hidden state, and are unexported only because they live in a CLI package rather than because they have invariants worth protecting. This change adds exported equivalents in a new `runsc/cmd/sandboxsetup/` package (with public visibility) and updates all internal callers to use the new package directly, leaving no stub wrappers behind. The `runsc/cmd/util/` package is left untouched.

Also fixes a pre-existing bug in `callSelfAsNobody` where the error messages for `SYS_SETGID` and `SYS_SETUID` were swapped.