### PR TITLE
runsc/fsgofer/filter: add Rules() for composable seccomp filters

### DIFF
--- a/runsc/fsgofer/filter/filter.go
+++ b/runsc/fsgofer/filter/filter.go
@@ -31,9 +31,13 @@ type Options struct {
 	CgoEnabled       bool
 }
 
-// Install installs seccomp filters.
-func Install(opt Options) error {
-	s := allowedSyscalls
+// Rules returns the seccomp rules for a gofer process without installing
+// them. Callers can merge additional rules before building and installing
+// the seccomp program. This is useful for custom gofer implementations
+// that need the stock gofer's baseline syscall allowlist but also require
+// additional syscalls (e.g. for networking or namespace switching).
+func Rules(opt Options) seccomp.SyscallRules {
+	s := allowedSyscalls.Copy()
 
 	if opt.ProfileEnabled {
 		report("profile enabled: syscall filters less restrictive!")
@@ -64,6 +68,13 @@ func Install(opt Options) error {
 	if !opt.DirectFS {
 		s.Merge(lisafsFilters)
 	}
+
+	return s
+}
+
+// Install installs seccomp filters.
+func Install(opt Options) error {
+	s := Rules(opt)
 
 	program := &seccomp.Program{
 		RuleSets: []seccomp.RuleSet{


### PR DESCRIPTION
Today `runsc/fsgofer/filter` exports only `Install(opt Options) error`, which builds and installs the seccomp program in one shot with no way to compose additional rules. I am looking into building a custom gofer over LisaFS that needs a small number of extra syscalls such as outbound TCP and `setns(CLONE_NEWNET)` for namespace switching but otherwise wants the stock seccomp baseline. The only option today is to fork `config.go` and its arch-specific files and manually track upstream changes, which is a security concern because if upstream tightens a rule forks silently diverge and may run with a wider-than-intended syscall surface.

This change adds `Rules(opt Options) seccomp.SyscallRules`, which returns the merged baseline without installing it so custom gofers can compose their own rules on top.

    rules := filter.Rules(opts)
    rules.Merge(myNetworkingRules)
    // build and install seccomp program with the merged rules

`Install()` now delegates to `Rules()` internally. The implementation uses `allowedSyscalls.Copy()` to deep-copy the package-level rules before merging, which also fixes a latent issue where calling `Install` more than once would double-merge rules through the shared underlying map.