### PR TITLE
cgroupfs: remove cgroup from CgroupRegistry on rmdir

### DIFF
--- a/pkg/sentry/fsimpl/cgroupfs/cgroupfs.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cgroupfs.go
@@ -640,6 +640,13 @@ func (d *dir) RmDir(ctx context.Context, name string, child kernfs.Inode) error 
 	err := d.OrderedChildren.RmDir(ctx, name, child)
 	if err == nil {
 		d.InodeAttrs.DecLinks()
+		// Drop the registry entry created by newCgroupInode so the inode is
+		// not pinned for the lifetime of the sentry. Lock order mirrors the
+		// mkdir path (kernfs.filesystem.mu -> CgroupRegistry.mu, see
+		// newCgroupInode); CgroupRegistry.mu is a leaf here so no cycle is
+		// possible.
+		kernel.KernelFromContext(ctx).CgroupRegistry().RemoveCgroup(cgi.id)
+		d.fs.numCgroups.Add(^uint64(0))
 	}
 	return err
 }

--- a/pkg/sentry/kernel/cgroup.go
+++ b/pkg/sentry/kernel/cgroup.go
@@ -553,6 +553,15 @@ func (r *CgroupRegistry) AddCgroup(cg CgroupImpl) {
 	r.mu.Unlock()
 }
 
+// RemoveCgroup drops the cgroup with the given ID from the registry. No-op if
+// the ID is not present. Called from cgroupfs when a cgroup directory is
+// removed so that destroyed cgroups are not retained across save/restore.
+func (r *CgroupRegistry) RemoveCgroup(cid uint32) {
+	r.mu.Lock()
+	delete(r.cgroups, cid)
+	r.mu.Unlock()
+}
+
 // GetCgroup returns the cgroup associated with the cgroup ID.
 func (r *CgroupRegistry) GetCgroup(cid uint32) (CgroupImpl, error) {
 	r.mu.Lock()


### PR DESCRIPTION
`kernel.CgroupRegistry.cgroups` is `+stateify savable` but had `AddCgroup` with no corresponding delete. Every cgroup directory ever created via mkdir was retained in the map for the lifetime of the sentry and serialised on every checkpoint, even after rmdir unlinked the directory from the filesystem tree.

Workloads that create and destroy a cgroup per subprocess (e.g. a PID-1 that wraps each child in its own memory cgroup) accumulate unbounded entries across long checkpoint/restore chains, eventually OOMing the sentry inside the state encoder. In one repro, `runsc debug` showed 196,262 `cgroupInode` + 196,262 `cgroupfs.dir` against only 17 live `kernel.Task` at checkpoint time, and the encoder allocated ~14 GB.

This change adds `CgroupRegistry.RemoveCgroup`, symmetric to `AddCgroup`, and calls it from `cgroupfs.dir.RmDir` after the child is successfully unlinked. It also decrements `filesystem.numCgroups` so `/proc/cgroups` reflects the live count rather than the historical high-water mark.

### Lock ordering

The package-level lock-order comment in `cgroupfs.go` lists `CgroupRegistry.mu` *before* `kernfs.filesystem.mu`, which on its face would forbid acquiring the registry lock from inside `RmDir`. That comment describes the hierarchy-lifecycle (mount/unmount) path. On the per-inode path the existing code already establishes the opposite order: `kernfs.MkdirAt` takes `fs.mu` → `cgroupfs.dir.NewDir` → `newCgroupInode` → `AddCgroup` takes `CgroupRegistry.mu`. `RmdirAt` → `RmDir` → `RemoveCgroup` follows the identical nesting. In both `AddCgroup` and `RemoveCgroup` the registry lock is a leaf — nothing is acquired while holding it — so no cycle can form.