### PR TITLE
pty: Implement TCSBRK and TCFLSH

### DIFF
--- a/pkg/abi/linux/ioctl.go
+++ b/pkg/abi/linux/ioctl.go
@@ -156,6 +156,13 @@ func IOC_SIZE(nr uint32) uint32 {
 	return (nr >> IOC_SIZESHIFT) & ((1 << IOC_SIZEBITS) - 1)
 }
 
+// TCFLSH queue selector arguments.
+const (
+	TCIFLUSH  = 0
+	TCOFLUSH  = 1
+	TCIOFLUSH = 2
+)
+
 /* Used for packet mode */
 const (
 	TIOCPKT_DATA       = 0

--- a/pkg/sentry/fsimpl/devpts/line_discipline.go
+++ b/pkg/sentry/fsimpl/devpts/line_discipline.go
@@ -121,6 +121,13 @@ type lineDiscipline struct {
 
 	// packet indicates the master is in packet mode.
 	packet bool
+
+	// packetStatus contains pending TIOCPKT_* status bits for the next master
+	// read while packet mode is enabled.
+	//
+	// Currently only TIOCPKT_FLUSHREAD and TIOCPKT_FLUSHWRITE are emitted
+	// through packetStatus.
+	packetStatus uint8
 }
 
 func newLineDiscipline(termios linux.KernelTermios, terminal *Terminal) *lineDiscipline {
@@ -132,6 +139,13 @@ func newLineDiscipline(termios linux.KernelTermios, terminal *Terminal) *lineDis
 	ld.outQueue.transformer = &outputQueueTransformer{}
 	return &ld
 }
+
+type ptyEndpoint int
+
+const (
+	masterEndpoint ptyEndpoint = iota
+	replicaEndpoint
+)
 
 // getTermios gets the linux.Termios for the tty.
 func (l *lineDiscipline) getTermios(task *kernel.Task, args arch.SyscallArguments) (uintptr, error) {
@@ -226,6 +240,9 @@ func (l *lineDiscipline) masterReadiness() waiter.EventMask {
 	// The master termios is immutable so termiosMu is not needed.
 	res := l.inQueue.writeReadiness(&linux.MasterTermios) | l.outQueue.readReadiness(&linux.MasterTermios)
 	l.termiosMu.RLock()
+	if l.packet && l.packetStatus != 0 {
+		res |= waiter.EventPri | waiter.ReadableEvents
+	}
 	if l.numReplicas == 0 {
 		res |= waiter.EventHUp
 	}
@@ -295,6 +312,13 @@ func (l *lineDiscipline) outputQueueReadSize(t *kernel.Task, io usermem.IO, args
 }
 
 func (l *lineDiscipline) outputQueueRead(ctx context.Context, dst usermem.IOSequence) (int64, error) {
+	if dst.NumBytes() == 0 {
+		return 0, nil
+	}
+	if status, ok := l.consumePacketStatus(); ok {
+		n, err := dst.CopyOut(ctx, []byte{status})
+		return int64(n), err
+	}
 	l.termiosMu.RLock()
 	// Ignore notifyEcho, as it cannot happen when reading from the output queue.
 	n, pushed, _, err := l.outQueue.read(ctx, dst, l, l.packet)
@@ -677,9 +701,12 @@ func (l *lineDiscipline) setPacketMode(mode int) {
 	defer l.termiosMu.Unlock()
 	if mode == 0 {
 		l.packet = false
-	} else {
-		l.packet = true
+		return
 	}
+	if !l.packet {
+		l.packetStatus = 0
+	}
+	l.packet = true
 }
 
 func (l *lineDiscipline) getPacketMode() int {
@@ -689,4 +716,94 @@ func (l *lineDiscipline) getPacketMode() int {
 		return 1
 	}
 	return 0
+}
+
+func (l *lineDiscipline) consumePacketStatus() (byte, bool) {
+	l.termiosMu.Lock()
+	defer l.termiosMu.Unlock()
+	if !l.packet || l.packetStatus == 0 {
+		return 0, false
+	}
+	status := l.packetStatus
+	l.packetStatus = 0
+	return status, true
+}
+
+func (l *lineDiscipline) packetStatusForFlush(endpoint ptyEndpoint, arg uint32) uint8 {
+	if endpoint != replicaEndpoint {
+		return 0
+	}
+	switch arg {
+	case linux.TCIFLUSH:
+		return linux.TIOCPKT_FLUSHREAD
+	case linux.TCOFLUSH:
+		return linux.TIOCPKT_FLUSHWRITE
+	case linux.TCIOFLUSH:
+		return linux.TIOCPKT_FLUSHREAD | linux.TIOCPKT_FLUSHWRITE
+	default:
+		return 0
+	}
+}
+
+func (l *lineDiscipline) notifyPacketStatus(status uint8) {
+	if status == 0 {
+		return
+	}
+	l.termiosMu.Lock()
+	if !l.packet {
+		l.termiosMu.Unlock()
+		return
+	}
+	l.packetStatus |= status
+	l.termiosMu.Unlock()
+	l.masterWaiter.Notify(waiter.EventPri | waiter.ReadableEvents)
+}
+
+func (l *lineDiscipline) inputQueueForEndpoint(endpoint ptyEndpoint) *queue {
+	if endpoint == masterEndpoint {
+		return &l.outQueue
+	}
+	return &l.inQueue
+}
+
+func (l *lineDiscipline) outputQueueForEndpoint(endpoint ptyEndpoint) *queue {
+	if endpoint == masterEndpoint {
+		return &l.inQueue
+	}
+	return &l.outQueue
+}
+
+func (l *lineDiscipline) notifyWritableForFlushedQueue(q *queue) {
+	switch q {
+	case &l.inQueue:
+		l.masterWaiter.Notify(waiter.WritableEvents)
+	case &l.outQueue:
+		l.replicaWaiter.Notify(waiter.WritableEvents)
+	}
+}
+
+// tcFlush handles the TCFLSH ioctl from the perspective of the calling PTY
+// endpoint. Linux interprets TCIFLUSH/TCOFLUSH relative to the fd that issued
+// the ioctl, not relative to the internal queue names.
+func (l *lineDiscipline) tcFlush(endpoint ptyEndpoint, arg uint32) error {
+	inputQueue := l.inputQueueForEndpoint(endpoint)
+	outputQueue := l.outputQueueForEndpoint(endpoint)
+	flushAndNotify := func(q *queue) {
+		q.flush()
+		l.notifyWritableForFlushedQueue(q)
+	}
+
+	switch arg {
+	case linux.TCIFLUSH:
+		flushAndNotify(inputQueue)
+	case linux.TCOFLUSH:
+		flushAndNotify(outputQueue)
+	case linux.TCIOFLUSH:
+		flushAndNotify(inputQueue)
+		flushAndNotify(outputQueue)
+	default:
+		return linuxerr.EINVAL
+	}
+	l.notifyPacketStatus(l.packetStatusForFlush(endpoint, arg))
+	return nil
 }

--- a/pkg/sentry/fsimpl/devpts/master.go
+++ b/pkg/sentry/fsimpl/devpts/master.go
@@ -174,6 +174,13 @@ func (mfd *masterFileDescription) Ioctl(ctx context.Context, io usermem.IO, sysn
 		// first (and flush input for F), but we don't implement that
 		// yet.
 		return mfd.t.ld.setTermios2(t, args)
+	case linux.TCSBRK:
+		// TCSBRK with arg != 0 is tcdrain, which waits for output to
+		// drain. For a pty with no real hardware, this is a no-op.
+		// TCSBRK with arg == 0 sends a break, also a no-op for ptys.
+		return 0, nil
+	case linux.TCFLSH:
+		return 0, mfd.t.ld.tcFlush(masterEndpoint, args[2].Uint())
 	case linux.TIOCGPTN:
 		nP := primitive.Uint32(mfd.t.n)
 		_, err := nP.CopyOut(t, args[2].Pointer())
@@ -249,7 +256,6 @@ func maybeEmitUnimplementedEvent(ctx context.Context, sysno uintptr, cmd uint32)
 	case linux.TIOCSETD,
 		linux.TIOCSBRK,
 		linux.TIOCCBRK,
-		linux.TCSBRK,
 		linux.TCSBRKP,
 		linux.TIOCSTI,
 		linux.TIOCCONS,
@@ -266,7 +272,6 @@ func maybeEmitUnimplementedEvent(ctx context.Context, sysno uintptr, cmd uint32)
 		linux.TIOCMBIC,
 		linux.TIOCMBIS,
 		linux.TIOCGICOUNT,
-		linux.TCFLSH,
 		linux.TIOCSSERIAL,
 		linux.TIOCGPTPEER:
 

--- a/pkg/sentry/fsimpl/devpts/queue.go
+++ b/pkg/sentry/fsimpl/devpts/queue.go
@@ -254,3 +254,15 @@ func (q *queue) waitBufAppend(b []byte) {
 	q.waitBuf = append(q.waitBuf, b)
 	q.waitBufLen += uint64(len(b))
 }
+
+// flush discards all pending data in both the read buffer and the wait
+// buffer. This implements the TCFLSH ioctl behavior for clearing a
+// queue's data, analogous to __tty_perform_flush in Linux.
+func (q *queue) flush() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.readBuf = nil
+	q.readable = false
+	q.waitBuf = nil
+	q.waitBufLen = 0
+}

--- a/pkg/sentry/fsimpl/devpts/replica.go
+++ b/pkg/sentry/fsimpl/devpts/replica.go
@@ -169,6 +169,13 @@ func (rfd *replicaFileDescription) Ioctl(ctx context.Context, io usermem.IO, sys
 		// This should drain the output queue and clear the input queue
 		// first, but we don't implement that yet.
 		return rfd.inode.t.ld.setTermios2(t, args)
+	case linux.TCSBRK:
+		// TCSBRK with arg != 0 is tcdrain, which waits for output to
+		// drain. For a pty with no real hardware, this is a no-op.
+		// TCSBRK with arg == 0 sends a break, also a no-op for ptys.
+		return 0, nil
+	case linux.TCFLSH:
+		return 0, rfd.inode.t.ld.tcFlush(replicaEndpoint, args[2].Uint())
 	case linux.TIOCGPTN:
 		nP := primitive.Uint32(rfd.inode.t.n)
 		_, err := nP.CopyOut(t, args[2].Pointer())

--- a/test/syscalls/linux/pty.cc
+++ b/test/syscalls/linux/pty.cc
@@ -483,6 +483,71 @@ class PtyTest : public ::testing::Test {
     EXPECT_THAT(ioctl(replica_.get(), TCSETS, &t), SyscallSucceeds());
   }
 
+  void DisableCanonicalAndEcho() {
+    struct kernel_termios t = {};
+    EXPECT_THAT(ioctl(replica_.get(), TCGETS, &t), SyscallSucceeds());
+    t.c_lflag &= ~(ICANON | ECHO);
+    t.c_cc[VMIN] = 1;
+    t.c_cc[VTIME] = 0;
+    EXPECT_THAT(ioctl(replica_.get(), TCSETS, &t), SyscallSucceeds());
+  }
+
+  void FillUntilWriteReturnsEAGAIN(const FileDescriptor &fd) {
+    std::string buf(8192, 'x');
+    for (;;) {
+      ssize_t n = RetryEINTR(write)(fd.get(), buf.data(), buf.size());
+      if (n < 0) {
+        ASSERT_EQ(errno, EAGAIN);
+        break;
+      }
+      ASSERT_GT(n, 0);
+    }
+
+    // A short write returning EAGAIN is a stronger signal that the queue is
+    // close to full. For PTYs, a large write can fail once the remaining room
+    // drops below 8192 bytes even if there is still space for a few more
+    // bytes.
+    char byte = 'x';
+    for (;;) {
+      ssize_t n = RetryEINTR(write)(fd.get(), &byte, 1);
+      if (n < 0) {
+        ASSERT_EQ(errno, EAGAIN);
+        break;
+      }
+      ASSERT_EQ(n, 1);
+    }
+  }
+
+  void FillUntilBlocked(const FileDescriptor &fd) {
+    FillUntilWriteReturnsEAGAIN(fd);
+
+    struct pollfd pfd = {fd.get(), POLLOUT, 0};
+    ASSERT_THAT(RetryEINTR(poll)(&pfd, 1, 0), SyscallSucceedsWithValue(0));
+  }
+
+  void EnablePacketMode() {
+    int mode = 1;
+    ASSERT_THAT(ioctl(master_.get(), TIOCPKT, &mode), SyscallSucceeds());
+  }
+
+  void ExpectMasterPacketStatus(char expected) {
+    struct pollfd pfd = {master_.get(), POLLIN | POLLPRI, 0};
+    ASSERT_THAT(
+        RetryEINTR(poll)(&pfd, 1, absl::ToInt64Milliseconds(kTimeout)),
+        SyscallSucceedsWithValue(1));
+    EXPECT_EQ(pfd.revents & (POLLIN | POLLPRI), POLLIN | POLLPRI);
+
+    char status = 0;
+    EXPECT_THAT(ReadFd(master_.get(), &status, 1),
+                SyscallSucceedsWithValue(1));
+    EXPECT_EQ(status, expected);
+  }
+
+  void ExpectMasterHasNoPacketStatus() {
+    struct pollfd pfd = {master_.get(), POLLIN | POLLPRI, 0};
+    EXPECT_THAT(poll(&pfd, 1, 0), SyscallSucceedsWithValue(0));
+  }
+
   // Writes master_input to the master file descriptor and verifies that
   // the replica and the echo output match what is expected.
   void TestCanonicalIO(const char *master_input,
@@ -2157,6 +2222,182 @@ TEST_F(JobControlTest, ReuseControllingTTYAfterExit) {
     TEST_PCHECK(ioctl(replica_.get(), TIOCSCTTY, 0) >= 0);
   });
   ASSERT_NO_ERRNO(res2);
+}
+
+// TCSBRK ioctl should succeed on both master and replica PTY ends.
+// For PTYs, TCSBRK is a no-op (no real hardware break to send).
+TEST_F(PtyTest, TCSBRKSucceeds) {
+  // TCSBRK with arg=0 (send break) should be a no-op for PTYs.
+  EXPECT_THAT(ioctl(master_.get(), TCSBRK, 0), SyscallSucceeds());
+  EXPECT_THAT(ioctl(replica_.get(), TCSBRK, 0), SyscallSucceeds());
+
+  // TCSBRK with arg=1 (tcdrain) should also succeed.
+  EXPECT_THAT(ioctl(master_.get(), TCSBRK, 1), SyscallSucceeds());
+  EXPECT_THAT(ioctl(replica_.get(), TCSBRK, 1), SyscallSucceeds());
+}
+
+// TCFLSH ioctl should flush the appropriate queues.
+TEST_F(PtyTest, TCFLSHFlushesInput) {
+  DisableCanonicalAndEcho();
+
+  // Write data from master to replica input.
+  constexpr char kInput[] = "hello";
+  ASSERT_THAT(WriteFd(master_.get(), kInput, sizeof(kInput) - 1),
+              SyscallSucceedsWithValue(sizeof(kInput) - 1));
+  ASSERT_NO_ERRNO(WaitUntilReceived(replica_.get(), sizeof(kInput) - 1));
+
+  // Flush the replica input queue.
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, TCIFLUSH), SyscallSucceeds());
+
+  // Replica should have no data to read now.
+  char buf[16];
+  EXPECT_THAT(ReadFd(replica_.get(), buf, sizeof(buf)),
+              SyscallFailsWithErrno(EAGAIN));
+}
+
+// Test for caller-aware TCFLSH semantics on the master side.
+TEST_F(PtyTest, TCFLSHFlushesMasterInput) {
+  DisableCanonicalAndEcho();
+
+  constexpr char kInput[] = "bye";
+  ASSERT_THAT(WriteFd(replica_.get(), kInput, sizeof(kInput) - 1),
+              SyscallSucceedsWithValue(sizeof(kInput) - 1));
+  ASSERT_NO_ERRNO(WaitUntilReceived(master_.get(), sizeof(kInput) - 1));
+
+  EXPECT_THAT(ioctl(master_.get(), TCFLSH, TCIFLUSH), SyscallSucceeds());
+
+  char buf[16];
+  EXPECT_THAT(ReadFd(master_.get(), buf, sizeof(buf)),
+              SyscallFailsWithErrno(EAGAIN));
+}
+
+// TCOFLUSH on the replica drops data queued for the master.
+TEST_F(PtyTest, TCFLSHFlushesReplicaOutput) {
+  DisableCanonicalAndEcho();
+
+  constexpr char kOutput[] = "world";
+  ASSERT_THAT(WriteFd(replica_.get(), kOutput, sizeof(kOutput) - 1),
+              SyscallSucceedsWithValue(sizeof(kOutput) - 1));
+  ASSERT_NO_ERRNO(WaitUntilReceived(master_.get(), sizeof(kOutput) - 1));
+
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, TCOFLUSH), SyscallSucceeds());
+
+  char buf[16];
+  EXPECT_THAT(ReadFd(master_.get(), buf, sizeof(buf)),
+              SyscallFailsWithErrno(EAGAIN));
+}
+
+// TCIOFLUSH clears both directions from the caller's point of view.
+TEST_F(PtyTest, TCFLSHFlushesBothDirections) {
+  DisableCanonicalAndEcho();
+
+  constexpr char kInput[] = "input";
+  constexpr char kOutput[] = "output";
+  ASSERT_THAT(WriteFd(master_.get(), kInput, sizeof(kInput) - 1),
+              SyscallSucceedsWithValue(sizeof(kInput) - 1));
+  ASSERT_THAT(WriteFd(replica_.get(), kOutput, sizeof(kOutput) - 1),
+              SyscallSucceedsWithValue(sizeof(kOutput) - 1));
+  ASSERT_NO_ERRNO(WaitUntilReceived(replica_.get(), sizeof(kInput) - 1));
+  ASSERT_NO_ERRNO(WaitUntilReceived(master_.get(), sizeof(kOutput) - 1));
+
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, TCIOFLUSH), SyscallSucceeds());
+
+  char buf[16];
+  EXPECT_THAT(ReadFd(replica_.get(), buf, sizeof(buf)),
+              SyscallFailsWithErrno(EAGAIN));
+  EXPECT_THAT(ReadFd(master_.get(), buf, sizeof(buf)),
+              SyscallFailsWithErrno(EAGAIN));
+}
+
+// Replica-side flushes should surface TIOCPKT flush status to the master.
+TEST_F(PtyTest, TCFLSHReplicaReportsPacketModeStatus) {
+  EnablePacketMode();
+
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, TCIFLUSH), SyscallSucceeds());
+  ExpectMasterPacketStatus(TIOCPKT_FLUSHREAD);
+
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, TCOFLUSH), SyscallSucceeds());
+  ExpectMasterPacketStatus(TIOCPKT_FLUSHWRITE);
+
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, TCIOFLUSH), SyscallSucceeds());
+  ExpectMasterPacketStatus(TIOCPKT_FLUSHREAD | TIOCPKT_FLUSHWRITE);
+}
+
+// Master-side flushes should not generate packet mode status bytes.
+TEST_F(PtyTest, TCFLSHMasterDoesNotReportPacketModeStatus) {
+  EnablePacketMode();
+
+  EXPECT_THAT(ioctl(master_.get(), TCFLSH, TCIFLUSH), SyscallSucceeds());
+  ExpectMasterHasNoPacketStatus();
+
+  EXPECT_THAT(ioctl(master_.get(), TCFLSH, TCOFLUSH), SyscallSucceeds());
+  ExpectMasterHasNoPacketStatus();
+
+  EXPECT_THAT(ioctl(master_.get(), TCFLSH, TCIOFLUSH), SyscallSucceeds());
+  ExpectMasterHasNoPacketStatus();
+}
+
+// Flushing the master's input queue should wake a blocked replica writer.
+TEST_F(PtyTest, TCFLSHWakesReplicaPolloutAfterMasterInputFlush) {
+  DisableCanonicalAndEcho();
+  FillUntilBlocked(replica_);
+
+  struct pollfd initial = {replica_.get(), POLLOUT, 0};
+  EXPECT_THAT(poll(&initial, 1, 0), SyscallSucceedsWithValue(0));
+
+  absl::Notification notify;
+  int sfd = replica_.get();
+  ScopedThread th([sfd, &notify]() {
+    notify.Notify();
+
+    struct pollfd poll_fd = {sfd, POLLOUT, 0};
+    EXPECT_THAT(
+        RetryEINTR(poll)(&poll_fd, 1, absl::ToInt64Milliseconds(kTimeout)),
+        SyscallSucceedsWithValue(1));
+    EXPECT_EQ(poll_fd.revents & POLLOUT, POLLOUT);
+
+    constexpr char kByte = 'r';
+    EXPECT_THAT(RetryEINTR(write)(sfd, &kByte, 1),
+                SyscallSucceedsWithValue(1));
+  });
+
+  notify.WaitForNotification();
+  absl::SleepFor(absl::Seconds(1));
+  EXPECT_THAT(ioctl(master_.get(), TCFLSH, TCIFLUSH), SyscallSucceeds());
+}
+
+// Flushing the replica's input queue should wake a blocked master writer.
+// We use a blocking write() instead of poll(POLLOUT) because the master's
+// POLLOUT is unreliable on native Linux (flip-buffer is consumed async).
+TEST_F(PtyTest, TCFLSHWakesMasterWriteAfterReplicaInputFlush) {
+  DisableCanonicalAndEcho();
+  FillUntilWriteReturnsEAGAIN(master_);
+
+  absl::Notification notify;
+  int mfd = master_.get();
+  ScopedThread th([mfd, &notify]() {
+    // Clear O_NONBLOCK so write() blocks when the queue is full, rather than
+    // returning EAGAIN. This gives us a reliable "blocked writer" to wake.
+    int flags = fcntl(mfd, F_GETFL);
+    ASSERT_GE(flags, 0);
+    ASSERT_EQ(fcntl(mfd, F_SETFL, flags & ~O_NONBLOCK), 0);
+
+    notify.Notify();
+
+    constexpr char kByte = 'w';
+    EXPECT_THAT(RetryEINTR(write)(mfd, &kByte, 1),
+                SyscallSucceedsWithValue(1));
+  });
+
+  notify.WaitForNotification();
+  absl::SleepFor(absl::Seconds(1));
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, TCIFLUSH), SyscallSucceeds());
+}
+
+// TCFLSH with invalid argument should return EINVAL.
+TEST_F(PtyTest, TCFLSHInvalidArg) {
+  EXPECT_THAT(ioctl(replica_.get(), TCFLSH, 42),
+              SyscallFailsWithErrno(EINVAL));
 }
 
 // When ISIG is disabled, signal characters (Ctrl-C, Ctrl-Z, Ctrl-\) should


### PR DESCRIPTION
Linux PTYs accept TCSBRK as a no-op and implement TCFLSH by flushing the input and/or output queues. gVisor returned ENOTTY, which breaks programs such as pyserial during terminal setup.

Handle TCSBRK in the PTY ioctl paths and route TCFLSH through lineDiscipline.tcFlush(), including packet mode flush notification and queue wakeups, to match Linux PTY semantics.