### PR TITLE
sandboxsetup: export gofer mount setup functions for reuse

### DIFF
--- a/pkg/sentry/devices/tpuproxy/vfio/vfio.go
+++ b/pkg/sentry/devices/tpuproxy/vfio/vfio.go
@@ -38,8 +38,6 @@ const (
 	tpuDeviceGroupName  = "vfio"
 	vfioDeviceGroupName = "vfio"
 
-	// VFIOPath is the valid path to a VFIO device.
-	VFIOPath = "/dev/vfio/vfio"
 )
 
 var (

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -17,7 +17,6 @@ go_library(
         "events.go",
         "fscheckpoint.go",
         "fscheckpoint_impl.go",
-        "gofer_conf.go",
         "limits.go",
         "loader.go",
         "loader_impl.go",
@@ -160,7 +159,6 @@ go_test(
     size = "small",
     srcs = [
         "compat_test.go",
-        "gofer_conf_test.go",
         "loader_test.go",
         "mount_hints_test.go",
         "vfs_test.go",

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -358,7 +358,7 @@ type StartArgs struct {
 	// GoferMountConfs contains information about how the gofer mounts have been
 	// configured. The first entry is for rootfs and the following entries are
 	// for bind mounts in Spec.Mounts (in the same order).
-	GoferMountConfs []GoferMountConf
+	GoferMountConfs []specutils.GoferMountConf
 
 	// IsRootfsUpperTarFilePresent indicates whether the rootfs upper tar file is present.
 	IsRootfsUpperTarFilePresent bool

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -146,7 +146,7 @@ type containerInfo struct {
 	// goferMountConfs contains information about how the gofer mounts have been
 	// configured. The first entry is for rootfs and the following entries are
 	// for bind mounts in Spec.Mounts (in the same order).
-	goferMountConfs []GoferMountConf
+	goferMountConfs []specutils.GoferMountConf
 
 	// nvidiaHostSettings holds information on the Nvidia GPU driver.
 	nvidiaHostSettings *nvconf.HostSettings
@@ -384,7 +384,7 @@ type Args struct {
 	// GoferMountConfs contains information about how the gofer mounts have been
 	// configured. The first entry is for rootfs and the following entries are
 	// for bind mounts in Spec.Mounts (in the same order).
-	GoferMountConfs []GoferMountConf
+	GoferMountConfs []specutils.GoferMountConf
 	// NumCPU is the number of CPUs to create inside the sandbox.
 	NumCPU int
 	// TotalMem is the initial amount of total memory to report back to the
@@ -1166,7 +1166,7 @@ func (l *Loader) createSubcontainer(cid string, tty *fd.FD) error {
 // startSubcontainer starts a child container. It returns the thread group ID of
 // the newly created process. Used FDs are either closed or released. It's safe
 // for the caller to close any remaining files upon return.
-func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdioFDs, goferFDs, goferFilestoreFDs []*fd.FD, devGoferFD *fd.FD, goferMountConfs []GoferMountConf, rootfsUpperTarFD *fd.FD) error {
+func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdioFDs, goferFDs, goferFilestoreFDs []*fd.FD, devGoferFD *fd.FD, goferMountConfs []specutils.GoferMountConf, rootfsUpperTarFD *fd.FD) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 

--- a/runsc/boot/loader_test.go
+++ b/runsc/boot/loader_test.go
@@ -38,6 +38,7 @@ import (
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/flag"
 	"gvisor.dev/gvisor/runsc/fsgofer"
+	"gvisor.dev/gvisor/runsc/specutils"
 )
 
 func init() {
@@ -142,7 +143,7 @@ func createLoader(conf *config.Config, spec *specs.Spec) (*Loader, func(), error
 		GoferFDs:         []int{sandEnd},
 		DevGoferFD:       -1,
 		StdioFDs:         stdio,
-		GoferMountConfs:  []GoferMountConf{{Lower: Lisafs, Upper: NoOverlay}},
+		GoferMountConfs:  []specutils.GoferMountConf{{Lower: specutils.Lisafs, Upper: specutils.NoOverlay}},
 		PodInitConfigFD:  -1,
 		ExecFD:           -1,
 		RootfsUpperTarFD: -1,

--- a/runsc/boot/restore.go
+++ b/runsc/boot/restore.go
@@ -114,7 +114,7 @@ type restorer struct {
 // restoreSubcontainer restores a subcontainer.
 // `subcontainerTimeline` must either be nil or an orphaned timeline.
 // It takes ownership of subcontainerTimeline and will end it.
-func (r *restorer) restoreSubcontainer(spec *specs.Spec, conf *config.Config, l *Loader, cid string, stdioFDs, goferFDs, goferFilestoreFDs []*fd.FD, devGoferFD *fd.FD, goferMountConfs []GoferMountConf, subcontainerTimeline *timing.Timeline) error {
+func (r *restorer) restoreSubcontainer(spec *specs.Spec, conf *config.Config, l *Loader, cid string, stdioFDs, goferFDs, goferFilestoreFDs []*fd.FD, devGoferFD *fd.FD, goferMountConfs []specutils.GoferMountConf, subcontainerTimeline *timing.Timeline) error {
 	containerName := l.registerContainer(spec, cid)
 	info := &containerInfo{
 		cid:               cid,

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -382,7 +382,7 @@ type containerMounter struct {
 	// goferMountConfs contains information about how the gofer mounts have been
 	// configured. The first entry is for rootfs and the following entries are
 	// for bind mounts in Spec.Mounts (in the same order).
-	goferMountConfs []GoferMountConf
+	goferMountConfs []specutils.GoferMountConf
 
 	// sharedMounts is a map of shared mounts that can be reused across
 	// containers.
@@ -588,7 +588,7 @@ func (c *containerMounter) createMountNamespace(ctx context.Context, conf *confi
 // layer using tmpfs, and return overlay mount options. "cleanup" must be called
 // after the options have been used to mount the overlay, to release refs on
 // lower and upper mounts.
-func (c *containerMounter) configureOverlay(ctx context.Context, conf *config.Config, creds *auth.Credentials, lowerOpts *vfs.MountOptions, lowerFSName string, filestoreFD *fd.FD, mountConf GoferMountConf, dst string, rootfsUpperTarFD *fd.FD) (*vfs.MountOptions, func(), error) {
+func (c *containerMounter) configureOverlay(ctx context.Context, conf *config.Config, creds *auth.Credentials, lowerOpts *vfs.MountOptions, lowerFSName string, filestoreFD *fd.FD, mountConf specutils.GoferMountConf, dst string, rootfsUpperTarFD *fd.FD) (*vfs.MountOptions, func(), error) {
 	// First copy options from lower layer to upper layer and overlay. Clear
 	// filesystem specific options.
 	upperOpts := *lowerOpts
@@ -793,7 +793,7 @@ type mountInfo struct {
 	mount          *specs.Mount
 	goferFD        *fd.FD
 	hint           *MountHint
-	goferMountConf GoferMountConf
+	goferMountConf specutils.GoferMountConf
 	filestoreFD    *fd.FD
 }
 

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -98,7 +98,6 @@ go_library(
         "//pkg/sentry/control",
         "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/devices/tpuproxy",
-        "//pkg/sentry/devices/tpuproxy/vfio",
         "//pkg/sentry/hostmm",
         "//pkg/sentry/kernel",
         "//pkg/sentry/kernel/auth",

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -108,7 +108,7 @@ type Boot struct {
 	// goferMountConfs contains information about how the gofer mounts have been
 	// configured. The first entry is for rootfs and the following entries are
 	// for bind mounts in Spec.Mounts (in the same order).
-	goferMountConfs boot.GoferMountConfFlags
+	goferMountConfs specutils.GoferMountConfFlags
 
 	// stdioFDs are the fds for stdin, stdout, and stderr. They must be
 	// provided in that order.

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -16,23 +16,18 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"runtime/debug"
-	"strings"
 
 	"github.com/google/subcommands"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/log"
-	"gvisor.dev/gvisor/pkg/sentry/devices/tpuproxy/vfio"
 	"gvisor.dev/gvisor/pkg/unet"
 	"gvisor.dev/gvisor/pkg/urpc"
-	"gvisor.dev/gvisor/runsc/boot"
 	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
@@ -104,7 +99,7 @@ type Gofer struct {
 	devIoFD    int
 	applyCaps  bool
 	setUpRoot  bool
-	mountConfs boot.GoferMountConfFlags
+	mountConfs specutils.GoferMountConfFlags
 
 	// uid and gid are the user and group IDs to switch to after setting up the
 	// user namespace.
@@ -190,7 +185,7 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	defer goferToHostRPC.Close()
 
 	if g.setUpRoot {
-		if err := g.setupRootFS(spec, conf, goferToHostRPC); err != nil {
+		if err := sandboxsetup.SetupRootFS(spec, conf, g.mountConfs, g.devIoFD, makeRPCMountOpener(goferToHostRPC)); err != nil {
 			util.Fatalf("Error setting up root FS: %v", err)
 		}
 		if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
@@ -248,13 +243,13 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	//
 	// Note that all mount points have been mounted in the proper location in
 	// setupRootFS().
-	cleanMounts, err := g.resolveMounts(conf, spec.Mounts, root)
+	cleanMounts, err := sandboxsetup.ResolveMounts(conf, spec.Mounts, root, g.mountConfs)
 	if err != nil {
 		util.Fatalf("Failure to resolve mounts: %v", err)
 	}
 	spec.Mounts = cleanMounts
 	go func() {
-		if err := g.writeMounts(cleanMounts); err != nil {
+		if err := sandboxsetup.WriteMounts(g.mountsFD, cleanMounts); err != nil {
 			panic(fmt.Sprintf("Failed to write mounts: %v", err))
 		}
 	}()
@@ -265,7 +260,7 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	// modes exactly as sent by the sandbox, which will have applied its own umask.
 	unix.Umask(0)
 
-	procFDPath := procFDBindMount
+	procFDPath := sandboxsetup.ProcFDBindMount
 	if conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
 		procFDPath = "/proc/self/fd"
 	}
@@ -305,14 +300,6 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	return g.serve(spec, conf, root, ruid, euid, rgid, egid)
 }
 
-func newSocket(ioFD int) *unet.Socket {
-	socket, err := unet.NewSocket(ioFD)
-	if err != nil {
-		util.Fatalf("creating server on FD %d: %v", ioFD, err)
-	}
-	return socket
-}
-
 func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid int, euid int, rgid int, egid int) subcommands.ExitStatus {
 	type connectionConfig struct {
 		sock      *unet.Socket
@@ -337,7 +324,7 @@ func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid i
 	if rootfsConf.ShouldUseLisafs() {
 		// Start with root mount, then add any other additional mount as needed.
 		cfgs = append(cfgs, connectionConfig{
-			sock:      newSocket(ioFDs[0]),
+			sock:      sandboxsetup.NewSocket(ioFDs[0]),
 			mountPath: "/", // fsgofer process is always chroot()ed. So serve root.
 			readonly:  spec.Root.Readonly || rootfsConf.ShouldUseOverlayfs(),
 		})
@@ -366,7 +353,7 @@ func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid i
 		ioFDs = ioFDs[1:]
 		readonly := specutils.IsReadonlyMount(m.Options) || mountConf.ShouldUseOverlayfs()
 		cfgs = append(cfgs, connectionConfig{
-			sock:      newSocket(ioFD),
+			sock:      sandboxsetup.NewSocket(ioFD),
 			mountPath: m.Destination,
 			readonly:  readonly,
 		})
@@ -379,7 +366,7 @@ func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid i
 
 	if g.devIoFD >= 0 {
 		cfgs = append(cfgs, connectionConfig{
-			sock:      newSocket(g.devIoFD),
+			sock:      sandboxsetup.NewSocket(g.devIoFD),
 			mountPath: "/dev",
 		})
 		log.Infof("Serving /dev mapped on FD %d (ro: false)", g.devIoFD)
@@ -401,330 +388,16 @@ func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid i
 	return subcommands.ExitSuccess
 }
 
-func (g *Gofer) writeMounts(mounts []specs.Mount) error {
-	bytes, err := json.Marshal(mounts)
-	if err != nil {
-		return err
+// makeRPCMountOpener returns a MountOpener that opens mount sources via the
+// gofer-to-host RPC channel.
+func makeRPCMountOpener(goferToHostRPC *urpc.Client) sandboxsetup.MountOpener {
+	return func(m *specs.Mount) (*os.File, error) {
+		var res container.OpenMountResult
+		if err := goferToHostRPC.Call("goferToHostRPC.OpenMount", m, &res); err != nil {
+			return nil, fmt.Errorf("opening %s: %w", m.Source, err)
+		}
+		return res.Files[0], nil
 	}
-
-	f := os.NewFile(uintptr(g.mountsFD), "mounts file")
-	defer f.Close()
-
-	for written := 0; written < len(bytes); {
-		w, err := f.Write(bytes[written:])
-		if err != nil {
-			return err
-		}
-		written += w
-	}
-	return nil
-}
-
-// Redhat distros don't allow to create bind-mounts in /proc/self directories.
-// It is protected by selinux rules.
-const procFDBindMount = "/proc/fs"
-
-func (g *Gofer) setupRootFS(spec *specs.Spec, conf *config.Config, goferToHostRPC *urpc.Client) error {
-	// Convert all shared mounts into slaves to be sure that nothing will be
-	// propagated outside of our namespace.
-	procPath := "/proc"
-	if err := specutils.SafeMount("", "/", "", unix.MS_SLAVE|unix.MS_REC, "", procPath); err != nil {
-		util.Fatalf("error converting mounts: %v", err)
-	}
-
-	root := spec.Root.Path
-	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
-		// runsc can't be re-executed without /proc, so we create a tmpfs mount,
-		// mount ./proc and ./root there, then move this mount to the root and after
-		// setCapsAndCallSelf, runsc will chroot into /root.
-		//
-		// We need a directory to construct a new root and we know that
-		// runsc can't start without /proc, so we can use it for this.
-		flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
-		if err := specutils.SafeMount("runsc-root", "/proc/fs", "tmpfs", flags, "", procPath); err != nil {
-			util.Fatalf("error mounting tmpfs: %v", err)
-		}
-		if err := unix.Mount("", "/proc/fs", "", unix.MS_UNBINDABLE, ""); err != nil {
-			util.Fatalf("error setting MS_UNBINDABLE")
-		}
-		// Prepare tree structure for pivot_root(2).
-		if err := os.Mkdir("/proc/fs/proc", 0755); err != nil {
-			util.Fatalf("error creating /proc/fs/proc: %v", err)
-		}
-		if err := os.Mkdir("/proc/fs/root", 0755); err != nil {
-			util.Fatalf("error creating /proc/fs/root: %v", err)
-		}
-		if err := os.Mkdir("/proc/fs/etc", 0755); err != nil {
-			util.Fatalf("error creating /proc/fs/etc: %v", err)
-		}
-		// This cannot use SafeMount because there's no available procfs. But we
-		// know that /proc/fs is an empty tmpfs mount, so this is safe.
-		if err := unix.Mount("/proc", "/proc/fs/proc", "", flags|unix.MS_RDONLY|unix.MS_BIND|unix.MS_REC, ""); err != nil {
-			util.Fatalf("error mounting /proc/fs/proc: %v", err)
-		}
-		// self/fd is bind-mounted, so that the FD return by
-		// OpenProcSelfFD() does not allow escapes with walking ".." .
-		if err := unix.Mount("/proc/fs/proc/self/fd", "/proc/fs/"+procFDBindMount,
-			"", unix.MS_RDONLY|unix.MS_BIND|flags, ""); err != nil {
-			util.Fatalf("error mounting proc/self/fd: %v", err)
-		}
-		if err := sandboxsetup.CopyFile("/proc/fs/etc/localtime", "/etc/localtime"); err != nil {
-			log.Warningf("Failed to copy /etc/localtime: %v. UTC timezone will be used.", err)
-		}
-		root = "/proc/fs/root"
-		procPath = "/proc/fs/proc"
-	}
-
-	rootfsConf := g.mountConfs[0]
-	if rootfsConf.ShouldUseLisafs() {
-		// Mount root path followed by submounts.
-		if err := specutils.SafeMount(spec.Root.Path, root, "bind", unix.MS_BIND|unix.MS_REC, "", procPath); err != nil {
-			return fmt.Errorf("mounting root on root (%q) err: %v", root, err)
-		}
-
-		flags := uint32(unix.MS_SLAVE | unix.MS_REC)
-		if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
-			flags = specutils.PropOptionsToFlags([]string{spec.Linux.RootfsPropagation})
-		}
-		if err := specutils.SafeMount("", root, "", uintptr(flags), "", procPath); err != nil {
-			return fmt.Errorf("mounting root (%q) with flags: %#x, err: %v", root, flags, err)
-		}
-	}
-
-	// Replace the current spec, with the clean spec with symlinks resolved.
-	if err := g.setupMounts(conf, spec.Mounts, root, procPath, goferToHostRPC); err != nil {
-		util.Fatalf("error setting up FS: %v", err)
-	}
-
-	// Set up /dev directory is needed.
-	if g.devIoFD >= 0 {
-		g.setupDev(spec, conf, root, procPath)
-	}
-
-	// Check if root needs to be remounted as readonly.
-	if rootfsConf.ShouldUseLisafs() && (spec.Root.Readonly || rootfsConf.ShouldUseOverlayfs()) {
-		// If root is a mount point but not read-only, we can change mount options
-		// to make it read-only for extra safety.
-		// unix.MS_NOSUID and unix.MS_NODEV are included here not only
-		// for safety reasons but also because they can be locked and
-		// any attempts to unset them will fail.  See
-		// mount_namespaces(7) for more details.
-		log.Infof("Remounting root as readonly: %q", root)
-		flags := uintptr(unix.MS_BIND | unix.MS_REMOUNT | unix.MS_RDONLY | unix.MS_NOSUID | unix.MS_NODEV)
-		if err := specutils.SafeMount(root, root, "bind", flags, "", procPath); err != nil {
-			return fmt.Errorf("remounting root as read-only with source: %q, target: %q, flags: %#x, err: %v", root, root, flags, err)
-		}
-	}
-
-	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
-		if err := sandboxsetup.PivotRoot("/proc/fs"); err != nil {
-			util.Fatalf("failed to change the root file system: %v", err)
-		}
-		if err := os.Chdir("/"); err != nil {
-			util.Fatalf("failed to change working directory")
-		}
-	}
-	return nil
-}
-
-// setupMounts bind mounts all mounts specified in the spec in their correct
-// location inside root. It will resolve relative paths and symlinks. It also
-// creates directories as needed.
-func (g *Gofer) setupMounts(conf *config.Config, mounts []specs.Mount, root, procPath string, goferToHostRPC *urpc.Client) (retErr error) {
-	mountIdx := 1 // First index is for rootfs.
-	for _, m := range mounts {
-		if !specutils.HasMountConfig(m) {
-			continue
-		}
-		mountConf := g.mountConfs[mountIdx]
-		mountIdx++
-		if !mountConf.ShouldUseLisafs() {
-			continue
-		}
-
-		dst, err := sandboxsetup.ResolveSymlinks(root, m.Destination)
-		if err != nil {
-			return fmt.Errorf("resolving symlinks to %q: %v", m.Destination, err)
-		}
-
-		flags := specutils.OptionsToFlags(m.Options) | unix.MS_BIND
-		if mountConf.ShouldUseOverlayfs() {
-			// Force mount read-only if writes are not going to be sent to it.
-			flags |= unix.MS_RDONLY
-		}
-
-		log.Infof("Mounting src: %q, dst: %q, flags: %#x", m.Source, dst, flags)
-		src := m.Source
-		var srcFile *os.File
-		if err := unix.Access(src, unix.R_OK); err != nil {
-			// The current process doesn't have enough permissions
-			// to open the mount, so let's try to open it in the
-			// parent user namespace.
-			var res container.OpenMountResult
-			if err := goferToHostRPC.Call("goferToHostRPC.OpenMount", &m, &res); err != nil {
-				return fmt.Errorf("opening %s: %w", m.Source, err)
-			}
-			srcFile = res.Files[0]
-			src = fmt.Sprintf("%s/self/fd/%d", procPath, srcFile.Fd())
-		}
-		err = specutils.SafeSetupAndMount(src, dst, m.Type, flags, procPath)
-		srcFile.Close()
-		if err != nil {
-			return fmt.Errorf("mounting %+v: %v", m, err)
-		}
-
-		dstFD, err := unix.Open(dst, unix.O_PATH|unix.O_CLOEXEC, 0)
-		if err != nil {
-			return fmt.Errorf("Open(%s, _, _): %w", dst, err)
-		}
-		defer unix.Close(dstFD)
-		// Apply mount options after creating all mount points.
-		// Otherwise they can be remounted into read-only.
-		defer func(dstFD int, flags uint32, dst string) {
-			path := fmt.Sprintf("/proc/self/fd/%d", dstFD)
-			// The gofer process doesn't execute anything natively.
-			flags |= unix.MS_NOSUID
-
-			statfs := unix.Statfs_t{}
-			if err := unix.Statfs(path, &statfs); err != nil {
-				retErr = fmt.Errorf("stat dst: %q", dst)
-				return
-			}
-			lockedFlags := uint32(0)
-			for _, f := range []struct {
-				st, ms int
-			}{
-				// MS_NOSUID are always set.
-				{unix.ST_RDONLY, unix.MS_RDONLY},
-				{unix.ST_NOEXEC, unix.MS_NOEXEC},
-				{unix.ST_NODEV, unix.MS_NODEV},
-				{unix.ST_NOATIME, unix.MS_NOATIME},
-				{unix.ST_NODIRATIME, unix.MS_NODIRATIME},
-				{unix.ST_RELATIME, unix.MS_RELATIME},
-			} {
-				if int(statfs.Flags)&f.st == f.st {
-					lockedFlags |= uint32(f.ms)
-				}
-			}
-			if lockedFlags&unix.MS_NOATIME|unix.MS_RELATIME == 0 {
-				lockedFlags |= unix.MS_STRICTATIME
-			}
-
-			// The previous SafeSetupAndMount creates a new bind-mount, but
-			// it doesn't change mount flags. A separate MS_BIND|MS_REMOUNT
-			// has to be done to apply the mount options.
-			if err := unix.Mount("", path, "", uintptr(flags|lockedFlags|unix.MS_REMOUNT), ""); err != nil {
-				retErr = fmt.Errorf("mount dst: %q, flags: %#x, err: %v", dst, flags, err)
-				return
-			}
-		}(dstFD, flags, dst)
-
-		// Set propagation options that cannot be set together with other options.
-		flags = specutils.PropOptionsToFlags(m.Options)
-		if flags != 0 {
-			if err := specutils.SafeMount("", dst, "", uintptr(flags), "", procPath); err != nil {
-				return fmt.Errorf("mount dst: %q, flags: %#x, err: %v", dst, flags, err)
-			}
-		}
-	}
-	return nil
-}
-
-// shouldExposeNvidiaDevice returns true if path refers to an Nvidia device
-// which should be exposed to the container.
-//
-// Precondition: nvproxy is enabled.
-func shouldExposeNvidiaDevice(path string) bool {
-	if !strings.HasPrefix(path, "/dev/nvidia") {
-		return false
-	}
-	if path == "/dev/nvidiactl" || path == "/dev/nvidia-uvm" {
-		return true
-	}
-	nvidiaDevPathReg := regexp.MustCompile(`^/dev/nvidia(\d+)$`)
-	return nvidiaDevPathReg.MatchString(path)
-}
-
-// shouldExposeVfioDevice returns true if path refers to an VFIO device
-// which should be exposed to the container.
-func shouldExposeVFIODevice(path string) bool {
-	return strings.HasPrefix(path, filepath.Dir(vfio.VFIOPath))
-}
-
-// shouldExposeTpuDevice returns true if path refers to a TPU device which
-// should be exposed to the container.
-//
-// Precondition: tpuproxy is enabled.
-func shouldExposeTpuDevice(path string) bool {
-	valid, _ := util.IsTPUDeviceValid(path)
-	return valid || shouldExposeVFIODevice(path)
-}
-
-func (g *Gofer) setupDev(spec *specs.Spec, conf *config.Config, root, procPath string) error {
-	if err := os.MkdirAll(filepath.Join(root, "dev"), 0777); err != nil {
-		return fmt.Errorf("creating dev directory: %v", err)
-	}
-	// Mount any devices specified in the spec.
-	if spec.Linux == nil {
-		return nil
-	}
-	nvproxyEnabled := specutils.NVProxyEnabled(spec, conf)
-	tpuproxyEnabled := specutils.TPUProxyIsEnabled(spec, conf)
-	for _, dev := range spec.Linux.Devices {
-		shouldMount := (nvproxyEnabled && shouldExposeNvidiaDevice(dev.Path)) ||
-			(tpuproxyEnabled && shouldExposeTpuDevice(dev.Path))
-		if !shouldMount {
-			continue
-		}
-		dst := filepath.Join(root, dev.Path)
-		log.Infof("Mounting device %q as bind mount at %q", dev.Path, dst)
-		if err := specutils.SafeSetupAndMount(dev.Path, dst, "bind", unix.MS_BIND, procPath); err != nil {
-			return fmt.Errorf("mounting %q: %v", dev.Path, err)
-		}
-	}
-	return nil
-}
-
-// resolveMounts resolved relative paths and symlinks to mount points.
-//
-// Note: mount points must already be in place for resolution to work.
-// Otherwise, it may follow symlinks to locations that would be overwritten
-// with another mount point and return the wrong location. In short, make sure
-// setupMounts() has been called before.
-func (g *Gofer) resolveMounts(conf *config.Config, mounts []specs.Mount, root string) ([]specs.Mount, error) {
-	mountIdx := 1 // First index is for rootfs.
-	cleanMounts := make([]specs.Mount, 0, len(mounts))
-	for _, m := range mounts {
-		if !specutils.HasMountConfig(m) {
-			cleanMounts = append(cleanMounts, m)
-			continue
-		}
-		mountConf := g.mountConfs[mountIdx]
-		mountIdx++
-		if !mountConf.ShouldUseLisafs() {
-			cleanMounts = append(cleanMounts, m)
-			continue
-		}
-		dst, err := sandboxsetup.ResolveSymlinks(root, m.Destination)
-		if err != nil {
-			return nil, fmt.Errorf("resolving symlinks to %q: %v", m.Destination, err)
-		}
-		relDst, err := filepath.Rel(root, dst)
-		if err != nil {
-			panic(fmt.Sprintf("%q could not be made relative to %q: %v", dst, root, err))
-		}
-
-		opts, err := sandboxsetup.AdjustMountOptions(conf, filepath.Join(root, relDst), m.Options)
-		if err != nil {
-			return nil, err
-		}
-
-		cpy := m
-		cpy.Destination = filepath.Join("/", relDst)
-		cpy.Options = opts
-		cleanMounts = append(cleanMounts, cpy)
-	}
-	return cleanMounts, nil
 }
 
 // setFlags sets sync FD flags on the given FlagSet.

--- a/runsc/cmd/sandboxsetup/BUILD
+++ b/runsc/cmd/sandboxsetup/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -11,12 +11,14 @@ go_library(
         "caps.go",
         "flags.go",
         "fs.go",
+        "gofer_mount.go",
         "process.go",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/fd",
         "//pkg/log",
+        "//pkg/unet",
         "//runsc/cmd/util",
         "//runsc/config",
         "//runsc/flag",
@@ -26,4 +28,11 @@ go_library(
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_test(
+    name = "sandboxsetup_test",
+    size = "small",
+    srcs = ["gofer_mount_test.go"],
+    library = ":sandboxsetup",
 )

--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -1,0 +1,403 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandboxsetup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/unet"
+	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/specutils"
+)
+
+// ProcFDBindMount is the path where /proc/self/fd is bind-mounted inside the
+// gofer's mount tree. Redhat distros don't allow bind-mounts in /proc/self
+// directories due to SELinux rules.
+const ProcFDBindMount = "/proc/fs"
+
+// vfioPathDir is the directory containing VFIO device nodes.
+const vfioPathDir = "/dev/vfio"
+
+// MountOpener opens a mount source when the gofer process cannot access it
+// directly (e.g. due to permission restrictions in a user namespace). It
+// returns the opened file for the mount source. The caller is responsible
+// for closing the returned file. It may be nil if all mounts are directly
+// accessible.
+type MountOpener func(m *specs.Mount) (*os.File, error)
+
+// NewSocket creates a unet.Socket from a file descriptor.
+// It fatally exits if the socket cannot be created.
+func NewSocket(ioFD int) *unet.Socket {
+	socket, err := unet.NewSocket(ioFD)
+	if err != nil {
+		util.Fatalf("creating server on FD %d: %v", ioFD, err)
+	}
+	return socket
+}
+
+// WriteMounts serializes the given mounts as JSON and writes them to the
+// given file descriptor.
+func WriteMounts(mountsFD int, mounts []specs.Mount) error {
+	bytes, err := json.Marshal(mounts)
+	if err != nil {
+		return err
+	}
+
+	f := os.NewFile(uintptr(mountsFD), "mounts file")
+	defer f.Close()
+
+	for written := 0; written < len(bytes); {
+		w, err := f.Write(bytes[written:])
+		if err != nil {
+			return err
+		}
+		written += w
+	}
+	return nil
+}
+
+// SetupRootFS prepares the root filesystem for the gofer process. It mounts
+// the container root, sets up submounts and /dev, and optionally remounts
+// root as read-only. If chroot mode is active, it also performs a
+// pivot_root.
+//
+// mountConfs must be indexed such that mountConfs[0] is the root filesystem
+// configuration and subsequent entries correspond to spec mounts with
+// mount configs.
+func SetupRootFS(spec *specs.Spec, conf *config.Config, mountConfs []specutils.GoferMountConf, devIoFD int, mountOpener MountOpener) error {
+	// Convert all shared mounts into slaves to be sure that nothing will be
+	// propagated outside of our namespace.
+	procPath := "/proc"
+	if err := specutils.SafeMount("", "/", "", unix.MS_SLAVE|unix.MS_REC, "", procPath); err != nil {
+		util.Fatalf("error converting mounts: %v", err)
+	}
+
+	root := spec.Root.Path
+	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
+		// runsc can't be re-executed without /proc, so we create a tmpfs mount,
+		// mount ./proc and ./root there, then move this mount to the root and after
+		// setCapsAndCallSelf, runsc will chroot into /root.
+		//
+		// We need a directory to construct a new root and we know that
+		// runsc can't start without /proc, so we can use it for this.
+		flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
+		if err := specutils.SafeMount("runsc-root", "/proc/fs", "tmpfs", flags, "", procPath); err != nil {
+			util.Fatalf("error mounting tmpfs: %v", err)
+		}
+		if err := unix.Mount("", "/proc/fs", "", unix.MS_UNBINDABLE, ""); err != nil {
+			util.Fatalf("error setting MS_UNBINDABLE")
+		}
+		// Prepare tree structure for pivot_root(2).
+		if err := os.Mkdir("/proc/fs/proc", 0755); err != nil {
+			util.Fatalf("error creating /proc/fs/proc: %v", err)
+		}
+		if err := os.Mkdir("/proc/fs/root", 0755); err != nil {
+			util.Fatalf("error creating /proc/fs/root: %v", err)
+		}
+		if err := os.Mkdir("/proc/fs/etc", 0755); err != nil {
+			util.Fatalf("error creating /proc/fs/etc: %v", err)
+		}
+		// This cannot use SafeMount because there's no available procfs. But we
+		// know that /proc/fs is an empty tmpfs mount, so this is safe.
+		if err := unix.Mount("/proc", "/proc/fs/proc", "", flags|unix.MS_RDONLY|unix.MS_BIND|unix.MS_REC, ""); err != nil {
+			util.Fatalf("error mounting /proc/fs/proc: %v", err)
+		}
+		// self/fd is bind-mounted, so that the FD returned by
+		// OpenProcSelfFD() does not allow escapes with walking ".." .
+		if err := unix.Mount("/proc/fs/proc/self/fd", "/proc/fs/"+ProcFDBindMount,
+			"", unix.MS_RDONLY|unix.MS_BIND|flags, ""); err != nil {
+			util.Fatalf("error mounting proc/self/fd: %v", err)
+		}
+		if err := CopyFile("/proc/fs/etc/localtime", "/etc/localtime"); err != nil {
+			log.Warningf("Failed to copy /etc/localtime: %v. UTC timezone will be used.", err)
+		}
+		root = "/proc/fs/root"
+		procPath = "/proc/fs/proc"
+	}
+
+	rootfsConf := mountConfs[0]
+	if rootfsConf.ShouldUseLisafs() {
+		// Mount root path followed by submounts.
+		if err := specutils.SafeMount(spec.Root.Path, root, "bind", unix.MS_BIND|unix.MS_REC, "", procPath); err != nil {
+			return fmt.Errorf("mounting root on root (%q) err: %v", root, err)
+		}
+
+		flags := uint32(unix.MS_SLAVE | unix.MS_REC)
+		if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
+			flags = specutils.PropOptionsToFlags([]string{spec.Linux.RootfsPropagation})
+		}
+		if err := specutils.SafeMount("", root, "", uintptr(flags), "", procPath); err != nil {
+			return fmt.Errorf("mounting root (%q) with flags: %#x, err: %v", root, flags, err)
+		}
+	}
+
+	// Replace the current spec, with the clean spec with symlinks resolved.
+	if err := SetupMounts(conf, spec.Mounts, root, procPath, mountConfs, mountOpener); err != nil {
+		util.Fatalf("error setting up FS: %v", err)
+	}
+
+	// Set up /dev directory if needed.
+	if devIoFD >= 0 {
+		if err := SetupDev(spec, conf, root, procPath); err != nil {
+			util.Fatalf("error setting up /dev: %v", err)
+		}
+	}
+
+	// Check if root needs to be remounted as readonly.
+	if rootfsConf.ShouldUseLisafs() && (spec.Root.Readonly || rootfsConf.ShouldUseOverlayfs()) {
+		// If root is a mount point but not read-only, we can change mount options
+		// to make it read-only for extra safety.
+		// unix.MS_NOSUID and unix.MS_NODEV are included here not only
+		// for safety reasons but also because they can be locked and
+		// any attempts to unset them will fail.  See
+		// mount_namespaces(7) for more details.
+		log.Infof("Remounting root as readonly: %q", root)
+		flags := uintptr(unix.MS_BIND | unix.MS_REMOUNT | unix.MS_RDONLY | unix.MS_NOSUID | unix.MS_NODEV)
+		if err := specutils.SafeMount(root, root, "bind", flags, "", procPath); err != nil {
+			return fmt.Errorf("remounting root as read-only with source: %q, target: %q, flags: %#x, err: %v", root, root, flags, err)
+		}
+	}
+
+	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
+		if err := PivotRoot("/proc/fs"); err != nil {
+			util.Fatalf("failed to change the root file system: %v", err)
+		}
+		if err := os.Chdir("/"); err != nil {
+			util.Fatalf("failed to change working directory")
+		}
+	}
+	return nil
+}
+
+// SetupMounts bind-mounts all mounts specified in the spec in their correct
+// location inside root. It resolves relative paths and symlinks, and creates
+// directories as needed.
+//
+// mountConfs is indexed such that mountConfs[0] is the root filesystem
+// configuration, and mount iteration starts at index 1.
+// mountOpener is called when the gofer process cannot directly access a mount
+// source. It may be nil if all mounts are directly accessible.
+func SetupMounts(conf *config.Config, mounts []specs.Mount, root, procPath string, mountConfs []specutils.GoferMountConf, mountOpener MountOpener) (retErr error) {
+	mountIdx := 1 // First index is for rootfs.
+	for _, m := range mounts {
+		if !specutils.HasMountConfig(m) {
+			continue
+		}
+		mountConf := mountConfs[mountIdx]
+		mountIdx++
+		if !mountConf.ShouldUseLisafs() {
+			continue
+		}
+
+		dst, err := ResolveSymlinks(root, m.Destination)
+		if err != nil {
+			return fmt.Errorf("resolving symlinks to %q: %v", m.Destination, err)
+		}
+
+		flags := specutils.OptionsToFlags(m.Options) | unix.MS_BIND
+		if mountConf.ShouldUseOverlayfs() {
+			// Force mount read-only if writes are not going to be sent to it.
+			flags |= unix.MS_RDONLY
+		}
+
+		log.Infof("Mounting src: %q, dst: %q, flags: %#x", m.Source, dst, flags)
+		src := m.Source
+		var srcFile *os.File
+		if err := unix.Access(src, unix.R_OK); err != nil {
+			if mountOpener == nil {
+				return fmt.Errorf("cannot access mount source %q and no mount opener provided: %v", src, err)
+			}
+			// The current process doesn't have enough permissions
+			// to open the mount, so let's try to open it via the
+			// caller-provided opener.
+			srcFile, err = mountOpener(&m)
+			if err != nil {
+				return fmt.Errorf("opening %s: %w", m.Source, err)
+			}
+			src = fmt.Sprintf("%s/self/fd/%d", procPath, srcFile.Fd())
+		}
+		err = specutils.SafeSetupAndMount(src, dst, m.Type, flags, procPath)
+		if srcFile != nil {
+			srcFile.Close()
+		}
+		if err != nil {
+			return fmt.Errorf("mounting %+v: %v", m, err)
+		}
+
+		dstFD, err := unix.Open(dst, unix.O_PATH|unix.O_CLOEXEC, 0)
+		if err != nil {
+			return fmt.Errorf("Open(%s, _, _): %w", dst, err)
+		}
+		defer unix.Close(dstFD)
+		// Apply mount options after creating all mount points.
+		// Otherwise they can be remounted into read-only.
+		defer func(dstFD int, flags uint32, dst string) {
+			path := fmt.Sprintf("/proc/self/fd/%d", dstFD)
+			// The gofer process doesn't execute anything natively.
+			flags |= unix.MS_NOSUID
+
+			statfs := unix.Statfs_t{}
+			if err := unix.Statfs(path, &statfs); err != nil {
+				retErr = fmt.Errorf("stat dst: %q", dst)
+				return
+			}
+			lockedFlags := uint32(0)
+			for _, f := range []struct {
+				st, ms int
+			}{
+				// MS_NOSUID are always set.
+				{unix.ST_RDONLY, unix.MS_RDONLY},
+				{unix.ST_NOEXEC, unix.MS_NOEXEC},
+				{unix.ST_NODEV, unix.MS_NODEV},
+				{unix.ST_NOATIME, unix.MS_NOATIME},
+				{unix.ST_NODIRATIME, unix.MS_NODIRATIME},
+				{unix.ST_RELATIME, unix.MS_RELATIME},
+			} {
+				if int(statfs.Flags)&f.st == f.st {
+					lockedFlags |= uint32(f.ms)
+				}
+			}
+			if lockedFlags&unix.MS_NOATIME|unix.MS_RELATIME == 0 {
+				lockedFlags |= unix.MS_STRICTATIME
+			}
+
+			// The previous SafeSetupAndMount creates a new bind-mount, but
+			// it doesn't change mount flags. A separate MS_BIND|MS_REMOUNT
+			// has to be done to apply the mount options.
+			if err := unix.Mount("", path, "", uintptr(flags|lockedFlags|unix.MS_REMOUNT), ""); err != nil {
+				retErr = fmt.Errorf("mount dst: %q, flags: %#x, err: %v", dst, flags, err)
+				return
+			}
+		}(dstFD, flags, dst)
+
+		// Set propagation options that cannot be set together with other options.
+		flags = specutils.PropOptionsToFlags(m.Options)
+		if flags != 0 {
+			if err := specutils.SafeMount("", dst, "", uintptr(flags), "", procPath); err != nil {
+				return fmt.Errorf("mount dst: %q, flags: %#x, err: %v", dst, flags, err)
+			}
+		}
+	}
+	return nil
+}
+
+// ShouldExposeNvidiaDevice returns true if path refers to an Nvidia device
+// which should be exposed to the container.
+//
+// Precondition: nvproxy is enabled.
+func ShouldExposeNvidiaDevice(path string) bool {
+	if !strings.HasPrefix(path, "/dev/nvidia") {
+		return false
+	}
+	if path == "/dev/nvidiactl" || path == "/dev/nvidia-uvm" {
+		return true
+	}
+	nvidiaDevPathReg := regexp.MustCompile(`^/dev/nvidia(\d+)$`)
+	return nvidiaDevPathReg.MatchString(path)
+}
+
+// ShouldExposeVFIODevice returns true if path refers to a VFIO device
+// which should be exposed to the container.
+func ShouldExposeVFIODevice(path string) bool {
+	return strings.HasPrefix(path, vfioPathDir)
+}
+
+// ShouldExposeTpuDevice returns true if path refers to a TPU device which
+// should be exposed to the container.
+//
+// Precondition: tpuproxy is enabled.
+func ShouldExposeTpuDevice(path string) bool {
+	valid, _ := util.IsTPUDeviceValid(path)
+	return valid || ShouldExposeVFIODevice(path)
+}
+
+// SetupDev mounts devices from the OCI spec into the gofer's /dev directory.
+func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) error {
+	if err := os.MkdirAll(filepath.Join(root, "dev"), 0777); err != nil {
+		return fmt.Errorf("creating dev directory: %v", err)
+	}
+	// Mount any devices specified in the spec.
+	if spec.Linux == nil {
+		return nil
+	}
+	nvproxyEnabled := specutils.NVProxyEnabled(spec, conf)
+	tpuproxyEnabled := specutils.TPUProxyIsEnabled(spec, conf)
+	for _, dev := range spec.Linux.Devices {
+		shouldMount := (nvproxyEnabled && ShouldExposeNvidiaDevice(dev.Path)) ||
+			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path))
+		if !shouldMount {
+			continue
+		}
+		dst := filepath.Join(root, dev.Path)
+		log.Infof("Mounting device %q as bind mount at %q", dev.Path, dst)
+		if err := specutils.SafeSetupAndMount(dev.Path, dst, "bind", unix.MS_BIND, procPath); err != nil {
+			return fmt.Errorf("mounting %q: %v", dev.Path, err)
+		}
+	}
+	return nil
+}
+
+// ResolveMounts resolves relative paths and symlinks in mount point
+// destinations. It also adjusts mount options based on the underlying
+// filesystem type.
+//
+// Note: mount points must already be in place for resolution to work.
+// Otherwise, it may follow symlinks to locations that would be overwritten
+// with another mount point and return the wrong location. In short, make sure
+// SetupMounts() has been called before.
+func ResolveMounts(conf *config.Config, mounts []specs.Mount, root string, mountConfs []specutils.GoferMountConf) ([]specs.Mount, error) {
+	mountIdx := 1 // First index is for rootfs.
+	cleanMounts := make([]specs.Mount, 0, len(mounts))
+	for _, m := range mounts {
+		if !specutils.HasMountConfig(m) {
+			cleanMounts = append(cleanMounts, m)
+			continue
+		}
+		mountConf := mountConfs[mountIdx]
+		mountIdx++
+		if !mountConf.ShouldUseLisafs() {
+			cleanMounts = append(cleanMounts, m)
+			continue
+		}
+		dst, err := ResolveSymlinks(root, m.Destination)
+		if err != nil {
+			return nil, fmt.Errorf("resolving symlinks to %q: %v", m.Destination, err)
+		}
+		relDst, err := filepath.Rel(root, dst)
+		if err != nil {
+			panic(fmt.Sprintf("%q could not be made relative to %q: %v", dst, root, err))
+		}
+
+		opts, err := AdjustMountOptions(conf, filepath.Join(root, relDst), m.Options)
+		if err != nil {
+			return nil, err
+		}
+
+		cpy := m
+		cpy.Destination = filepath.Join("/", relDst)
+		cpy.Options = opts
+		cleanMounts = append(cleanMounts, cpy)
+	}
+	return cleanMounts, nil
+}

--- a/runsc/cmd/sandboxsetup/gofer_mount_test.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount_test.go
@@ -1,0 +1,90 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandboxsetup
+
+import (
+	"testing"
+)
+
+func TestShouldExposeNvidiaDevice(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "nvidiactl", path: "/dev/nvidiactl", want: true},
+		{name: "nvidia-uvm", path: "/dev/nvidia-uvm", want: true},
+		{name: "nvidia0", path: "/dev/nvidia0", want: true},
+		{name: "nvidia1", path: "/dev/nvidia1", want: true},
+		{name: "nvidia42", path: "/dev/nvidia42", want: true},
+		{name: "nvidia-uvm-tools", path: "/dev/nvidia-uvm-tools", want: false},
+		{name: "nvidia-modeset", path: "/dev/nvidia-modeset", want: false},
+		{name: "not nvidia", path: "/dev/sda", want: false},
+		{name: "nvidia prefix but not device", path: "/dev/nvidia-cap1", want: false},
+		{name: "empty", path: "", want: false},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got := ShouldExposeNvidiaDevice(tst.path)
+			if got != tst.want {
+				t.Errorf("ShouldExposeNvidiaDevice(%q) = %v, want %v", tst.path, got, tst.want)
+			}
+		})
+	}
+}
+
+func TestShouldExposeVFIODevice(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "vfio dir", path: "/dev/vfio/vfio", want: true},
+		{name: "vfio group", path: "/dev/vfio/0", want: true},
+		{name: "vfio dir itself", path: "/dev/vfio", want: true},
+		{name: "not vfio", path: "/dev/sda", want: false},
+		{name: "empty", path: "", want: false},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got := ShouldExposeVFIODevice(tst.path)
+			if got != tst.want {
+				t.Errorf("ShouldExposeVFIODevice(%q) = %v, want %v", tst.path, got, tst.want)
+			}
+		})
+	}
+}
+
+func TestShouldExposeTpuDevice(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// VFIO devices are always detected as TPU devices regardless of sysfs.
+		{name: "vfio device", path: "/dev/vfio/0", want: true},
+		{name: "vfio vfio", path: "/dev/vfio/vfio", want: true},
+		{name: "not tpu", path: "/dev/sda", want: false},
+		{name: "empty", path: "", want: false},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got := ShouldExposeTpuDevice(tst.path)
+			if got != tst.want {
+				t.Errorf("ShouldExposeTpuDevice(%q) = %v, want %v", tst.path, got, tst.want)
+			}
+		})
+	}
+}

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -142,7 +142,7 @@ type Container struct {
 	// GoferMountConfs contains information about how the gofer mounts have been
 	// overlaid (with tmpfs or overlayfs). The first entry is for rootfs and the
 	// following entries are for bind mounts in Spec.Mounts (in the same order).
-	GoferMountConfs boot.GoferMountConfFlags `json:"goferMountConfs"`
+	GoferMountConfs specutils.GoferMountConfFlags `json:"goferMountConfs"`
 
 	//
 	// Fields below this line are not saved in the state file and will not
@@ -439,7 +439,7 @@ func (c *Container) Restore(conf *config.Config, imagePath string, direct, backg
 	return c.startImpl(conf, "restore", restore, c.Sandbox.RestoreSubcontainer)
 }
 
-func (c *Container) startImpl(conf *config.Config, action string, startRoot func(conf *config.Config, spec *specs.Spec) error, startSub func(spec *specs.Spec, conf *config.Config, cid string, stdios, goferFiles, goferFilestores []*os.File, devIOFile *os.File, goferConfs []boot.GoferMountConf) error) error {
+func (c *Container) startImpl(conf *config.Config, action string, startRoot func(conf *config.Config, spec *specs.Spec) error, startSub func(spec *specs.Spec, conf *config.Config, cid string, stdios, goferFiles, goferFilestores []*os.File, devIOFile *os.File, goferConfs []specutils.GoferMountConf) error) error {
 	if err := c.Saver.lock(BlockAcquire); err != nil {
 		return err
 	}
@@ -1018,38 +1018,38 @@ func (c *Container) forEachSelfMount(fn func(mountSrc string)) {
 	}
 }
 
-func createGoferConf(overlayMedium config.OverlayMedium, overlaySize string, mountType string, mountSrc string) (boot.GoferMountConf, error) {
-	var lower boot.GoferMountConfLowerType
+func createGoferConf(overlayMedium config.OverlayMedium, overlaySize string, mountType string, mountSrc string) (specutils.GoferMountConf, error) {
+	var lower specutils.GoferMountConfLowerType
 	switch mountType {
 	case boot.Bind:
-		lower = boot.Lisafs
+		lower = specutils.Lisafs
 	case tmpfs.Name:
-		lower = boot.NoneLower
+		lower = specutils.NoneLower
 	case erofs.Name:
-		lower = boot.Erofs
+		lower = specutils.Erofs
 	default:
-		return boot.GoferMountConf{}, fmt.Errorf("unsupported mount type %q in mount hint", mountType)
+		return specutils.GoferMountConf{}, fmt.Errorf("unsupported mount type %q in mount hint", mountType)
 	}
 	switch overlayMedium {
 	case config.NoOverlay:
-		return boot.GoferMountConf{Lower: lower, Upper: boot.NoOverlay}, nil
+		return specutils.GoferMountConf{Lower: lower, Upper: specutils.NoOverlay}, nil
 	case config.MemoryOverlay:
-		return boot.GoferMountConf{Lower: lower, Upper: boot.MemoryOverlay, Size: overlaySize}, nil
+		return specutils.GoferMountConf{Lower: lower, Upper: specutils.MemoryOverlay, Size: overlaySize}, nil
 	case config.SelfOverlay:
 		mountSrcInfo, err := os.Stat(mountSrc)
 		if err != nil {
-			return boot.GoferMountConf{}, fmt.Errorf("failed to stat mount %q to see if it were a directory: %v", mountSrc, err)
+			return specutils.GoferMountConf{}, fmt.Errorf("failed to stat mount %q to see if it were a directory: %v", mountSrc, err)
 		}
 		if !mountSrcInfo.IsDir() {
 			log.Warningf("self filestore is only supported for directory mounts, but mount %q is not a directory, falling back to memory", mountSrc)
-			return boot.GoferMountConf{Lower: lower, Upper: boot.MemoryOverlay, Size: overlaySize}, nil
+			return specutils.GoferMountConf{Lower: lower, Upper: specutils.MemoryOverlay, Size: overlaySize}, nil
 		}
-		return boot.GoferMountConf{Lower: lower, Upper: boot.SelfOverlay, Size: overlaySize}, nil
+		return specutils.GoferMountConf{Lower: lower, Upper: specutils.SelfOverlay, Size: overlaySize}, nil
 	default:
 		if overlayMedium.IsBackedByAnon() {
-			return boot.GoferMountConf{Lower: lower, Upper: boot.AnonOverlay, Size: overlaySize}, nil
+			return specutils.GoferMountConf{Lower: lower, Upper: specutils.AnonOverlay, Size: overlaySize}, nil
 		}
-		return boot.GoferMountConf{}, fmt.Errorf("unexpected overlay medium %q", overlayMedium)
+		return specutils.GoferMountConf{}, fmt.Errorf("unexpected overlay medium %q", overlayMedium)
 	}
 }
 
@@ -1156,14 +1156,14 @@ func (c *Container) createGoferFilestores(ovlConf config.Overlay2, mountHints *b
 	return goferFilestores, nil
 }
 
-func (c *Container) createGoferFilestore(goferRootfs string, ovlConf config.Overlay2, goferConf boot.GoferMountConf, mountSrc string, mountHints *boot.PodMountHints) (*os.File, error) {
+func (c *Container) createGoferFilestore(goferRootfs string, ovlConf config.Overlay2, goferConf specutils.GoferMountConf, mountSrc string, mountHints *boot.PodMountHints) (*os.File, error) {
 	if !goferConf.IsFilestorePresent() {
 		return nil, nil
 	}
 	switch goferConf.Upper {
-	case boot.SelfOverlay:
+	case specutils.SelfOverlay:
 		return c.createGoferFilestoreInSelf(goferRootfs, mountSrc, mountHints)
-	case boot.AnonOverlay:
+	case specutils.AnonOverlay:
 		return c.createGoferFilestoreInDir(goferRootfs, ovlConf.Medium().HostFileDir())
 	default:
 		return nil, fmt.Errorf("unexpected upper layer with filestore %s", goferConf)
@@ -1326,7 +1326,7 @@ func shouldCreateDeviceGofer(spec *specs.Spec, conf *config.Config) bool {
 }
 
 // shouldSpawnGofer indicates whether the gofer process should be spawned.
-func shouldSpawnGofer(spec *specs.Spec, conf *config.Config, goferConfs []boot.GoferMountConf) bool {
+func shouldSpawnGofer(spec *specs.Spec, conf *config.Config, goferConfs []specutils.GoferMountConf) bool {
 	// Lisafs mounts need the gofer.
 	for _, cfg := range goferConfs {
 		if cfg.ShouldUseLisafs() {

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -275,7 +275,7 @@ type Args struct {
 	// GoferMountConfs contains information about how the gofer mounts have been
 	// configured. The first entry is for rootfs and the following entries are
 	// for bind mounts in Spec.Mounts (in the same order).
-	GoferMountConfs boot.GoferMountConfFlags
+	GoferMountConfs specutils.GoferMountConfFlags
 
 	// MountHints provides extra information about containers mounts that apply
 	// to the entire pod.
@@ -469,7 +469,7 @@ func (s *Sandbox) StartRoot(conf *config.Config, spec *specs.Spec) error {
 }
 
 // StartSubcontainer starts running a sub-container inside the sandbox.
-func (s *Sandbox) StartSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdios, goferFiles, goferFilestores []*os.File, devIOFile *os.File, goferConfs []boot.GoferMountConf) error {
+func (s *Sandbox) StartSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdios, goferFiles, goferFilestores []*os.File, devIOFile *os.File, goferConfs []specutils.GoferMountConf) error {
 	log.Debugf("Start sub-container %q in sandbox %q, PID: %d", cid, s.ID, s.Pid.Load())
 
 	if err := s.configureStdios(conf, stdios); err != nil {
@@ -610,7 +610,7 @@ func (s *Sandbox) setRestoreOptsForLocalCheckpointFiles(conf *config.Config, ima
 }
 
 // RestoreSubcontainer sends the restore call for a sub-container in the sandbox.
-func (s *Sandbox) RestoreSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdios, goferFiles, goferFilestoreFiles []*os.File, devIOFile *os.File, goferMountConf []boot.GoferMountConf) error {
+func (s *Sandbox) RestoreSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdios, goferFiles, goferFilestoreFiles []*os.File, devIOFile *os.File, goferMountConf []specutils.GoferMountConf) error {
 	log.Debugf("Restore sub-container %q in sandbox %q, PID: %d", cid, s.ID, s.Pid.Load())
 
 	if err := s.configureStdios(conf, stdios); err != nil {

--- a/runsc/specutils/BUILD
+++ b/runsc/specutils/BUILD
@@ -10,6 +10,7 @@ go_library(
     srcs = [
         "cri.go",
         "fs.go",
+        "gofer_conf.go",
         "namespace.go",
         "nvidia.go",
         "restore.go",
@@ -35,7 +36,10 @@ go_library(
 go_test(
     name = "specutils_test",
     size = "small",
-    srcs = ["specutils_test.go"],
+    srcs = [
+        "gofer_conf_test.go",
+        "specutils_test.go",
+    ],
     library = ":specutils",
     deps = [
         "//pkg/sentry/devices/nvproxy/nvconf",

--- a/runsc/specutils/gofer_conf.go
+++ b/runsc/specutils/gofer_conf.go
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package boot
+package specutils
 
 import (
 	"fmt"
 	"strings"
-
-	"gvisor.dev/gvisor/pkg/sentry/fsimpl/erofs"
 )
 
 // GoferMountConfUpperType describes how upper layer is configured for the gofer mount.
@@ -102,7 +100,7 @@ func (l GoferMountConfLowerType) String() string {
 	case Lisafs:
 		return "lisafs"
 	case Erofs:
-		return erofs.Name
+		return "erofs"
 	}
 	panic(fmt.Sprintf("Invalid gofer mount config lower layer type: %d", l))
 }
@@ -114,7 +112,7 @@ func (l *GoferMountConfLowerType) Set(v string) error {
 		*l = NoneLower
 	case "lisafs":
 		*l = Lisafs
-	case erofs.Name:
+	case "erofs":
 		*l = Erofs
 	default:
 		return fmt.Errorf("invalid gofer mount config lower layer type: %s", v)

--- a/runsc/specutils/gofer_conf_test.go
+++ b/runsc/specutils/gofer_conf_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package boot
+package specutils
 
 import (
 	"testing"


### PR DESCRIPTION
Building a custom gVisor gofer that serves LisaFS-backed volumes requires
duplicating unexported mount setup code from runsc/cmd/gofer.go.
These are Gofer struct methods (setupRootFS, setupMounts, setupDev,
resolveMounts, writeMounts) that must be manually re-synced on every gVisor
version bump.

This is a continuation of the work in https://github.com/google/gvisor/pull/12902 which exported standalone utility
functions. The remaining methods only access struct fields for mount
configurations, device FDs, and mount FDs that can be passed as explicit
parameters.

To avoid importing the heavy runsc/boot package from sandboxsetup, this change
moves GoferMountConf and related types from runsc/boot to runsc/specutils
(replacing the erofs.Name import with a hardcoded "erofs" string, consistent
with specutils.IsErofsMount). The boot package re-exports these via type
aliases for backward compatibility. sandboxsetup now uses the concrete
specutils.GoferMountConf type directly instead of an interface.

Also introduces a MountOpener callback to avoid importing runsc/container.

And fixes a nil pointer dereference in setupMounts where srcFile.Close()
was called unconditionally, but srcFile is nil when unix.Access succeeds.