### PR TITLE
runsc: Preserve host cgroup defaults in sandbox cgroupfs

### DIFF
--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -246,6 +246,11 @@ type Loader struct {
 	// /sys/devices/virtual/dmi/id/product_name.
 	productName string
 
+	// cpuQuota and cpuPeriod are the raw host CFS settings that should be
+	// exposed through sandbox cgroupfs.
+	cpuQuota  int64
+	cpuPeriod int64
+
 	hostTHP HostTHP
 
 	// mu guards the fields below.
@@ -387,6 +392,10 @@ type Args struct {
 	GoferMountConfs []GoferMountConf
 	// NumCPU is the number of CPUs to create inside the sandbox.
 	NumCPU int
+	// CPUQuota and CPUPeriod are the raw host CFS settings that should be
+	// reflected by sandbox cgroupfs.
+	CPUQuota  int64
+	CPUPeriod int64
 	// TotalMem is the initial amount of total memory to report back to the
 	// container.
 	TotalMem uint64
@@ -506,6 +515,8 @@ func New(args Args) (*Loader, error) {
 		sharedMounts:   make(map[string]*vfs.Mount),
 		stopProfiling:  stopProfiling,
 		productName:    args.ProductName,
+		cpuQuota:       args.CPUQuota,
+		cpuPeriod:      args.CPUPeriod,
 		hostTHP:        args.HostTHP,
 		containerIDs:   make(map[string]string),
 		containerSpecs: make(map[string]*specs.Spec),

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -61,6 +61,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/specutils"
@@ -88,6 +89,32 @@ func selfFilestoreName(sandboxID string) string {
 
 // tmpfs has some extra supported options that we must pass through.
 var tmpfsAllowedData = []string{"mode", "size", "uid", "gid"}
+
+func cgroupfsCPUDefaults(rawQuota, rawPeriod int64) map[string]int64 {
+	const defaultPeriod int64 = 100000
+	const defaultQuota int64 = -1
+	period := rawPeriod
+	if period <= 0 {
+		period = defaultPeriod
+	}
+	quota := rawQuota
+	if quota <= 0 {
+		quota = defaultQuota
+	}
+	return map[string]int64{
+		"cpu.cfs_quota_us":  quota,
+		"cpu.cfs_period_us": period,
+	}
+}
+
+func cgroupfsMemoryDefaults(memoryLimit uint64) map[string]int64 {
+	if memoryLimit == 0 {
+		return nil
+	}
+	return map[string]int64{
+		"memory.limit_in_bytes": int64(memoryLimit),
+	}
+}
 
 func registerFilesystems(k *kernel.Kernel, info *containerInfo) error {
 	ctx := k.SupervisorContext()
@@ -1202,10 +1229,27 @@ func (c *containerMounter) getSharedMount(ctx context.Context, spec *specs.Spec,
 func (l *Loader) mountCgroupMounts(conf *config.Config, creds *auth.Credentials) error {
 	ctx := l.k.SupervisorContext()
 	for _, sopts := range kernel.CgroupCtrls {
+		var internalData any
+		switch string(sopts) {
+		case "cpu":
+			if defaults := cgroupfsCPUDefaults(l.cpuQuota, l.cpuPeriod); defaults != nil {
+				internalData = &cgroupfs.InternalData{DefaultControlValues: defaults}
+				log.Infof("Setting cgroupfs cpu defaults: quota=%d, period=%d (raw quota=%d, raw period=%d)", defaults["cpu.cfs_quota_us"], defaults["cpu.cfs_period_us"], l.cpuQuota, l.cpuPeriod)
+			}
+		case "memory":
+			// Set memory limit from --total-memory if specified.
+			// This allows applications to see the correct memory limit in cgroup.
+			if defaults := cgroupfsMemoryDefaults(usage.MaximumTotalMemoryBytes); defaults != nil {
+				internalData = &cgroupfs.InternalData{DefaultControlValues: defaults}
+				log.Infof("Setting cgroupfs memory defaults: limit=%d bytes (%.2f GB)", usage.MaximumTotalMemoryBytes, float64(usage.MaximumTotalMemoryBytes)/(1<<30))
+			}
+		}
+
 		mopts := &vfs.MountOptions{
 			GetFilesystemOptions: vfs.GetFilesystemOptions{
 				Data:          string(sopts),
 				InternalMount: true,
+				InternalData:  internalData,
 			},
 		}
 		fs, root, err := l.k.VFS().NewFilesystem(ctx, creds, "cgroup", cgroupfs.Name, mopts)

--- a/runsc/boot/vfs_test.go
+++ b/runsc/boot/vfs_test.go
@@ -96,3 +96,46 @@ func TestGetMountAccessType(t *testing.T) {
 		})
 	}
 }
+
+func TestCgroupfsCPUDefaults(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		rawQuota  int64
+		rawPeriod int64
+		wantQuota int64
+		wantPeriod int64
+	}{
+		{
+			name:       "finite quota",
+			rawQuota:   150000,
+			rawPeriod:  100000,
+			wantQuota:  150000,
+			wantPeriod: 100000,
+		},
+		{
+			name:       "unlimited quota keeps linux default",
+			rawQuota:   -1,
+			rawPeriod:  100000,
+			wantQuota:  -1,
+			wantPeriod: 100000,
+		},
+		{
+			name:       "unset period falls back to linux default period",
+			rawQuota:   -1,
+			rawPeriod:  0,
+			wantQuota:  -1,
+			wantPeriod: 100000,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defaults := cgroupfsCPUDefaults(tc.rawQuota, tc.rawPeriod)
+			if got := defaults["cpu.cfs_quota_us"]; got != tc.wantQuota {
+				t.Errorf("quota = %d, want %d", got, tc.wantQuota)
+			}
+			if got := defaults["cpu.cfs_period_us"]; got != tc.wantPeriod {
+				t.Errorf("period = %d, want %d", got, tc.wantPeriod)
+			}
+		})
+	}
+}
+

--- a/runsc/cgroup/cgroup.go
+++ b/runsc/cgroup/cgroup.go
@@ -319,7 +319,8 @@ type Cgroup interface {
 	Update(res *specs.LinuxResources) error
 	Uninstall() error
 	Join() (func(), error)
-	CPUQuota() (float64, error)
+	CPUQuota() (int64, error)
+	CPUPeriod() (int64, error)
 	CPUUsage() (uint64, error)
 	NumCPU() (int, error)
 	MemoryLimit() (uint64, error)
@@ -681,21 +682,25 @@ func (c *cgroupV1) Join() (func(), error) {
 	return cu.Release(), nil
 }
 
-// CPUQuota returns the CFS CPU quota.
-func (c *cgroupV1) CPUQuota() (float64, error) {
+// CPUQuota returns the raw CFS CPU quota in microseconds.
+// A value of -1 means unlimited.
+func (c *cgroupV1) CPUQuota() (int64, error) {
 	path := c.MakePath("cpu")
 	quota, err := getInt(path, "cpu.cfs_quota_us")
 	if err != nil {
 		return -1, err
 	}
+	return int64(quota), nil
+}
+
+// CPUPeriod returns the raw CFS CPU period in microseconds.
+func (c *cgroupV1) CPUPeriod() (int64, error) {
+	path := c.MakePath("cpu")
 	period, err := getInt(path, "cpu.cfs_period_us")
 	if err != nil {
 		return -1, err
 	}
-	if quota <= 0 || period <= 0 {
-		return -1, err
-	}
-	return float64(quota) / float64(period), nil
+	return int64(period), nil
 }
 
 // CPUUsage returns the total CPU usage of the cgroup in nanoseconds.

--- a/runsc/cgroup/cgroup_v2.go
+++ b/runsc/cgroup/cgroup_v2.go
@@ -270,57 +270,83 @@ func (c *cgroupV2) Join() (func(), error) {
 	return cu.Release(), nil
 }
 
-func getCPUQuota(path string) (float64, error) {
+// readCPUQuotaAndPeriod reads and parses cpu.max from the given path.
+func readCPUQuotaAndPeriod(path string) (int64, int64, error) {
 	cpuMax, err := getValue(path, cpuLimitCgroup)
 	if err != nil {
-		return -1, err
+		return -1, -1, err
 	}
-	return parseCPUQuota(cpuMax)
+	return parseCPUQuotaAndPeriod(cpuMax)
 }
 
-// CPUQuota returns the CFS CPU quota.
-func (c *cgroupV2) CPUQuota() (float64, error) {
-	cpuQuota, err := getCPUQuota(c.MakePath(""))
+// CPUQuota returns the raw CFS CPU quota in microseconds.
+// A value of -1 means unlimited.
+func (c *cgroupV2) CPUQuota() (int64, error) {
+	quota, _, err := readCPUQuotaAndPeriod(c.MakePath(""))
 	if err != nil {
 		return -1, err
 	}
 	// In cgroupv2+systemd, limits are set in the parent slice rather
 	// than the leaf node. Check the parent to see if this is the case.
-	if cpuQuota == -1 {
-		cpuQuota, err = getCPUQuota(filepath.Dir(c.MakePath("")))
-		if err != nil && errors.Is(err, os.ErrNotExist) {
-			err = nil
+	if quota == -1 {
+		parentQuota, _, parentErr := readCPUQuotaAndPeriod(filepath.Dir(c.MakePath("")))
+		if parentErr != nil && !errors.Is(parentErr, os.ErrNotExist) {
+			return -1, parentErr
+		}
+		if parentErr == nil {
+			quota = parentQuota
 		}
 	}
-	return cpuQuota, nil
+	return quota, nil
 }
 
-func parseCPUQuota(cpuMax string) (float64, error) {
-	data := strings.SplitN(strings.TrimSpace(cpuMax), " ", 2)
-	if len(data) != 2 {
-		return -1, fmt.Errorf("invalid cpu.max data %q", cpuMax)
-	}
-
-	// no cpu limit if quota is max
-	if data[0] == maxLimitStr {
-		return -1, nil
-	}
-
-	quota, err := strconv.ParseInt(data[0], 10, 64)
+// CPUPeriod returns the raw CFS CPU period in microseconds.
+func (c *cgroupV2) CPUPeriod() (int64, error) {
+	quota, period, err := readCPUQuotaAndPeriod(c.MakePath(""))
 	if err != nil {
 		return -1, err
+	}
+	// In cgroupv2+systemd, limits are set in the parent slice rather
+	// than the leaf node. Check the parent to see if this is the case.
+	if quota == -1 {
+		_, parentPeriod, parentErr := readCPUQuotaAndPeriod(filepath.Dir(c.MakePath("")))
+		if parentErr != nil && !errors.Is(parentErr, os.ErrNotExist) {
+			return -1, parentErr
+		}
+		if parentErr == nil {
+			period = parentPeriod
+		}
+	}
+	return period, nil
+}
+
+func parseCPUQuotaAndPeriod(cpuMax string) (int64, int64, error) {
+	data := strings.SplitN(strings.TrimSpace(cpuMax), " ", 2)
+	if len(data) != 2 {
+		return -1, -1, fmt.Errorf("invalid cpu.max data %q", cpuMax)
 	}
 
 	period, err := strconv.ParseInt(data[1], 10, 64)
 	if err != nil {
-		return -1, err
+		return -1, -1, err
+	}
+	if period <= 0 {
+		return -1, -1, fmt.Errorf("invalid cpu.max data %q", cpuMax)
 	}
 
-	if quota <= 0 || period <= 0 {
-		return -1, err
+	// no cpu limit if quota is max
+	if data[0] == maxLimitStr {
+		return -1, period, nil
 	}
-	return float64(quota) / float64(period), nil
 
+	quota, err := strconv.ParseInt(data[0], 10, 64)
+	if err != nil {
+		return -1, -1, err
+	}
+	if quota <= 0 {
+		return -1, -1, fmt.Errorf("invalid cpu.max data %q", cpuMax)
+	}
+	return quota, period, nil
 }
 
 // CPUUsage returns the total CPU usage of the cgroup in nanoseconds.

--- a/runsc/cgroup/cgroup_v2_test.go
+++ b/runsc/cgroup/cgroup_v2_test.go
@@ -192,31 +192,48 @@ func TestLoadPathsCgroupv2(t *testing.T) {
 
 func TestGetLimits(t *testing.T) {
 	for _, tc := range []struct {
-		name      string
-		mem       string
-		cpu       string
-		expMem    uint64
-		expCPU    int
-		limitPath string
-		path      string
+		name           string
+		mem            string
+		cpu            string
+		expMem         uint64
+		expCPUQuota    int64
+		expCPUPeriod   int64
+		limitPath      string
+		path           string
+		writeParentCPU bool
 	}{
 		{
-			name:      "get limit from parent cgroup",
-			mem:       "150",
-			cpu:       "100 50",
-			limitPath: "user.slice",
-			path:      "user.slice/container.scope",
-			expMem:    150,
-			expCPU:    2,
+			name:           "get limit from parent cgroup",
+			mem:            "150",
+			cpu:            "100 50",
+			limitPath:      "user.slice",
+			path:           "user.slice/container.scope",
+			expMem:         150,
+			expCPUQuota:    100,
+			expCPUPeriod:   50,
+			writeParentCPU: true,
 		},
 		{
-			name:      "get limit from leaf cgroup",
-			mem:       "150",
-			cpu:       "100 50",
-			limitPath: "user.slice/container.scope",
-			path:      "user.slice/container.scope",
-			expMem:    150,
-			expCPU:    2,
+			name:           "get limit from leaf cgroup",
+			mem:            "150",
+			cpu:            "100 50",
+			limitPath:      "user.slice/container.scope",
+			path:           "user.slice/container.scope",
+			expMem:         150,
+			expCPUQuota:    100,
+			expCPUPeriod:   50,
+			writeParentCPU: true,
+		},
+		{
+			name:           "keep leaf period when parent cpu max is missing",
+			mem:            "150",
+			cpu:            "100 50",
+			limitPath:      "user.slice",
+			path:           "user.slice/container.scope",
+			expMem:         150,
+			expCPUQuota:    -1,
+			expCPUPeriod:   100000,
+			writeParentCPU: false,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -239,22 +256,31 @@ func TestGetLimits(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(dir, tc.path, "memory.max"), []byte("max"), 0o777); err != nil {
 				t.Fatalf("os.WriteFile(): %v", err)
 			}
-			if err := os.WriteFile(filepath.Join(dir, tc.path, "cpu.max"), []byte("max max"), 0o777); err != nil {
+			if err := os.WriteFile(filepath.Join(dir, tc.path, "cpu.max"), []byte("max 100000"), 0o777); err != nil {
 				t.Fatalf("os.WriteFile(): %v", err)
 			}
 			if err := os.WriteFile(filepath.Join(dir, tc.limitPath, "memory.max"), []byte(tc.mem), 0o655); err != nil {
 				t.Fatalf("os.WriteFile(): %v", err)
 			}
-			if err := os.WriteFile(filepath.Join(dir, tc.limitPath, "cpu.max"), []byte(tc.cpu), 0o655); err != nil {
-				t.Fatalf("os.WriteFile(): %v", err)
+			if tc.writeParentCPU {
+				if err := os.WriteFile(filepath.Join(dir, tc.limitPath, "cpu.max"), []byte(tc.cpu), 0o655); err != nil {
+					t.Fatalf("os.WriteFile(): %v", err)
+				}
 			}
 
-			quota, err := cg.CPUQuota()
+			rawQuota, err := cg.CPUQuota()
 			if err != nil {
 				t.Fatalf("cg.CPUQuota(): %v", err)
 			}
-			if int(quota) != tc.expCPU {
-				t.Errorf("cg.CPUQuota() = %v, want %v", quota, tc.expCPU)
+			if rawQuota != tc.expCPUQuota {
+				t.Errorf("cg.CPUQuota() = %d, want %d", rawQuota, tc.expCPUQuota)
+			}
+			rawPeriod, err := cg.CPUPeriod()
+			if err != nil {
+				t.Fatalf("cg.CPUPeriod(): %v", err)
+			}
+			if rawPeriod != tc.expCPUPeriod {
+				t.Errorf("cg.CPUPeriod() = %d, want %d", rawPeriod, tc.expCPUPeriod)
 			}
 			mem, err := cg.MemoryLimit()
 			if err != nil {
@@ -390,45 +416,42 @@ func TestConvertMemorySwapToCgroupV2Value(t *testing.T) {
 	}
 }
 
-func TestParseCPUQuota(t *testing.T) {
+func TestParseCPUQuotaAndPeriod(t *testing.T) {
 	cases := []struct {
-		quota    string
-		expected float64
-		expErr   bool
+		quota     string
+		expQuota  int64
+		expPeriod int64
+		expErr    bool
 	}{
 		{
-			quota:    "max 100000\n",
-			expected: -1,
+			quota:     "max 100000\n",
+			expQuota:  -1,
+			expPeriod: 100000,
 		},
 		{
-			quota:    "10000 100000",
-			expected: 0.1,
+			quota:     "150000 100000",
+			expQuota:  150000,
+			expPeriod: 100000,
 		},
 		{
-			quota:    "20000 100000\n",
-			expected: 0.2,
-		},
-
-		{
-			quota:    "-1",
-			expected: -1,
-			expErr:   true,
+			quota:  "-1",
+			expErr: true,
 		},
 	}
 
 	for _, c := range cases {
-		res, err := parseCPUQuota(c.quota)
+		quota, period, err := parseCPUQuotaAndPeriod(c.quota)
 		if c.expErr {
 			if err == nil {
-				t.Errorf("quota: %q, expected error, got %.2f, nil", c.quota, res)
+				t.Errorf("quota: %q, expected error, got (%d, %d), nil", c.quota, quota, period)
 			}
 			continue
 		}
 		if err != nil {
 			t.Errorf("quota: %q, expected success, got error %s", c.quota, err)
 		}
-		if res != c.expected {
-			t.Errorf("quota: %q, expected %.2f, got error %.2f", c.quota, c.expected, res)
+		if quota != c.expQuota || period != c.expPeriod {
+			t.Errorf("quota: %q, expected (%d, %d), got (%d, %d)", c.quota, c.expQuota, c.expPeriod, quota, period)
 		}
 	}
 }
@@ -439,7 +462,8 @@ func TestUpdate(t *testing.T) {
 		initialCPUMax    string
 		initialMemMax    string
 		updatedResources *specs.LinuxResources
-		wantCPUQuota     float64
+		wantCPUQuota     int64
+		wantCPUPeriod    int64
 		wantMemory       uint64
 	}{
 		{
@@ -455,8 +479,9 @@ func TestUpdate(t *testing.T) {
 					Limit: int64Ptr(2048),
 				},
 			},
-			wantCPUQuota: 2.0,
-			wantMemory:   2048,
+			wantCPUQuota:  100,
+			wantCPUPeriod: 50,
+			wantMemory:    2048,
 		},
 		{
 			name:          "update cpu only",
@@ -468,8 +493,9 @@ func TestUpdate(t *testing.T) {
 					Period: uint64Ptr(50),
 				},
 			},
-			wantCPUQuota: 3.0,
-			wantMemory:   1024,
+			wantCPUQuota:  150,
+			wantCPUPeriod: 50,
+			wantMemory:    1024,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -504,7 +530,14 @@ func TestUpdate(t *testing.T) {
 				t.Fatalf("CPUQuota(): %v", err)
 			}
 			if cpuQuota != tc.wantCPUQuota {
-				t.Fatalf("After Update(), CPUQuota() = %f, want %f", cpuQuota, tc.wantCPUQuota)
+				t.Fatalf("After Update(), CPUQuota() = %d, want %d", cpuQuota, tc.wantCPUQuota)
+			}
+			cpuPeriod, err := cg.CPUPeriod()
+			if err != nil {
+				t.Fatalf("CPUPeriod(): %v", err)
+			}
+			if cpuPeriod != tc.wantCPUPeriod {
+				t.Fatalf("After Update(), CPUPeriod() = %d, want %d", cpuPeriod, tc.wantCPUPeriod)
 			}
 
 			mem, err := cg.MemoryLimit()

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -130,6 +130,11 @@ type Boot struct {
 	// cpuNum number of CPUs to create inside the sandbox.
 	cpuNum int
 
+	// cpuQuota and cpuPeriod carry the raw host CFS CPU settings that should be
+	// exposed through sandbox cgroupfs.
+	cpuQuota  int64
+	cpuPeriod int64
+
 	// totalMem sets the initial amount of total memory to report back to the
 	// container.
 	totalMem uint64
@@ -233,6 +238,14 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&b.applyCaps, "apply-caps", false, "if true, apply capabilities defined in the spec to the process")
 	f.BoolVar(&b.setUpRoot, "setup-root", false, "if true, set up an empty root for the process")
 	f.IntVar(&b.cpuNum, "cpu-num", 0, "number of CPUs to create inside the sandbox")
+	// cpu-quota defaults to -1 (unlimited), matching the Linux CFS default
+	// for cpu.cfs_quota_us. A positive value is passed through as-is to sandbox
+	// cgroupfs.
+	f.Int64Var(&b.cpuQuota, "cpu-quota", -1, "raw CFS cpu quota in usecs to expose via sandbox cgroupfs (-1 means unlimited)")
+	// cpu-period defaults to 0 (unset). When unset, mountCgroupMounts
+	// uses the Linux default of 100000us (100ms). A positive value is
+	// passed through as-is.
+	f.Int64Var(&b.cpuPeriod, "cpu-period", 0, "raw CFS cpu period in usecs to expose via sandbox cgroupfs (0 means use default 100ms)")
 	f.IntVar(&b.procMountSyncFD, "proc-mount-sync-fd", -1, "file descriptor that has to be written to when /proc isn't needed anymore and can be unmounted")
 	f.IntVar(&b.syncUsernsFD, "sync-userns-fd", -1, "file descriptor used to synchronize rootless user namespace initialization.")
 	f.Uint64Var(&b.totalMem, "total-memory", 0, "sets the initial amount of total memory to report back to the container")
@@ -577,6 +590,8 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		GoferFilestoreFDs:   b.goferFilestoreFDs.GetArray(),
 		GoferMountConfs:     b.goferMountConfs.GetArray(),
 		NumCPU:              b.cpuNum,
+		CPUQuota:            b.cpuQuota,
+		CPUPeriod:           b.cpuPeriod,
 		TotalMem:            b.totalMem,
 		TotalHostMem:        b.totalHostMem,
 		UserLogFD:           b.userLogFD,

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -1257,16 +1257,21 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 		if err != nil {
 			return fmt.Errorf("getting cpu count from cgroups: %v", err)
 		}
-		if conf.CPUNumFromQuota {
+		cpuQuota, err := s.CgroupJSON.Cgroup.CPUQuota()
+		if err != nil {
+			return fmt.Errorf("getting raw cpu quota from cgroups: %v", err)
+		}
+		cpuPeriod, err := s.CgroupJSON.Cgroup.CPUPeriod()
+		if err != nil {
+			return fmt.Errorf("getting raw cpu period from cgroups: %v", err)
+		}
+		if conf.CPUNumFromQuota && cpuQuota > 0 && cpuPeriod > 0 {
 			// Dropping below 2 CPUs can trigger application to disable
 			// locks that can lead do hard to debug errors, so just
 			// leaving two cores as reasonable default.
 			const minCPUs = 2
 
-			quota, err := s.CgroupJSON.Cgroup.CPUQuota()
-			if err != nil {
-				return fmt.Errorf("getting cpu quota from cgroups: %v", err)
-			}
+			quota := float64(cpuQuota) / float64(cpuPeriod)
 			if n := int(math.Ceil(quota)); n > 0 {
 				if n < minCPUs {
 					n = minCPUs
@@ -1278,6 +1283,12 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 			}
 		}
 		cmd.Args = append(cmd.Args, "--cpu-num", strconv.Itoa(cpuNum))
+		if cpuQuota > 0 {
+			cmd.Args = append(cmd.Args, "--cpu-quota", strconv.FormatInt(cpuQuota, 10))
+		}
+		if cpuPeriod > 0 {
+			cmd.Args = append(cmd.Args, "--cpu-period", strconv.FormatInt(cpuPeriod, 10))
+		}
 
 		memLimit, err := s.CgroupJSON.Cgroup.MemoryLimit()
 		if err != nil {


### PR DESCRIPTION
Sandbox cgroupfs used synthesized defaults instead of the host cgroup settings. This could hide the configured CPU and memory limits from applications that read these files (e.g. pylint).
    
Add Cgroup.CPUQuota() and Cgroup.CPUPeriod() methods and plumb the raw values through sandbox -> boot -> loader so mountCgroupMounts() can expose the host values directly.
    
Update the memory controller: when --total-memory is specified, expose it via memory.limit_in_bytes (cgroupv1) / memory.max (cgroupv2).