### PR TITLE
tun: add empty data check before AsSlice()[0] in TUN Write()

### DIFF
--- a/pkg/tcpip/link/tun/device.go
+++ b/pkg/tcpip/link/tun/device.go
@@ -257,6 +257,10 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 	case d.flags.TUN:
 		// TUN interface with IFF_NO_PI enabled, thus
 		// we need to determine protocol from version field
+		if data.Size() == 0 {
+			// Ignore bad packet.
+			return dataLen, nil
+		}
 		version := data.AsSlice()[0] >> 4
 		switch version {
 		case 4:


### PR DESCRIPTION
Device.Write() panics with index-out-of-range when a TUN device with IFF_NO_PI receives a zero-length write. The existing guards for PacketInfo and TAP modes do not cover the TUN+NO_PI case, leaving data.AsSlice()[0] unprotected.

Add a `data.Size() == 0` check before accessing the first byte for IP version detection. This matches the guard pattern used by the PacketInfo and TAP branches.

A second path exists when NoPacketInfo is false and exactly PacketInfoHeaderSize bytes are written — TrimFront leaves data empty. The same check covers both paths.

Fixes a guest-triggerable sentry panic via /dev/net/tun.