### PR TITLE
hostinet: cap guest-controlled allocation sizes in ioctl and sockopt

### DIFF
--- a/pkg/sentry/socket/hostinet/socket_unsafe.go
+++ b/pkg/sentry/socket/hostinet/socket_unsafe.go
@@ -96,15 +96,16 @@ func ioctl(ctx context.Context, fd int, io usermem.IO, sysno uintptr, args arch.
 			return 0, err
 		}
 
-		// The user's ifconf can have a nullable pointer to a buffer. Use a Sentry array if non-null.
-		ifcNested := linux.IFConf{Len: ifc.Len}
-		var ifcBuf []byte
 		// Cap IFConf buffer size to prevent guest-controlled OOM.
 		// 64KB is sufficient for ~1000 network interfaces.
 		const maxIFConfLen = 64 * 1024
 		if ifc.Len > maxIFConfLen {
 			ifc.Len = maxIFConfLen
 		}
+		// The user's ifconf can have a nullable pointer to a buffer. Use a Sentry array if non-null.
+		// Use capped ifc.Len so host ioctl cannot write past ifcBuf.
+		ifcNested := linux.IFConf{Len: ifc.Len}
+		var ifcBuf []byte
 		if ifc.Ptr != 0 && ifc.Len > 0 {
 			ifcBuf = make([]byte, ifc.Len)
 			ifcNested.Ptr = uint64(uintptr(unsafe.Pointer(&ifcBuf[0])))

--- a/pkg/sentry/socket/hostinet/socket_unsafe.go
+++ b/pkg/sentry/socket/hostinet/socket_unsafe.go
@@ -99,6 +99,12 @@ func ioctl(ctx context.Context, fd int, io usermem.IO, sysno uintptr, args arch.
 		// The user's ifconf can have a nullable pointer to a buffer. Use a Sentry array if non-null.
 		ifcNested := linux.IFConf{Len: ifc.Len}
 		var ifcBuf []byte
+		// Cap IFConf buffer size to prevent guest-controlled OOM.
+		// 64KB is sufficient for ~1000 network interfaces.
+		const maxIFConfLen = 64 * 1024
+		if ifc.Len > maxIFConfLen {
+			ifc.Len = maxIFConfLen
+		}
 		if ifc.Ptr != 0 && ifc.Len > 0 {
 			ifcBuf = make([]byte, ifc.Len)
 			ifcNested.Ptr = uint64(uintptr(unsafe.Pointer(&ifcBuf[0])))

--- a/pkg/sentry/socket/hostinet/sockopt.go
+++ b/pkg/sentry/socket/hostinet/sockopt.go
@@ -199,9 +199,10 @@ func (s *Socket) GetSockOpt(t *kernel.Task, level, name int, optValAddr hostarch
 	} else {
 		// Variable-length option (e.g. SO_BINDTODEVICE, TCP_CONGESTION).
 		// Cap to prevent guest-controlled OOM via large optLen.
+		// Clamp rather than reject to match Linux semantics (min_t).
 		const maxVarOptLen = 4096
 		if optLen > maxVarOptLen {
-			return nil, syserr.ErrInvalidArgument
+			optLen = maxVarOptLen
 		}
 		opt = make([]byte, optLen)
 	}

--- a/pkg/sentry/socket/hostinet/sockopt.go
+++ b/pkg/sentry/socket/hostinet/sockopt.go
@@ -197,8 +197,12 @@ func (s *Socket) GetSockOpt(t *kernel.Task, level, name int, optValAddr hostarch
 		}
 		opt = make([]byte, sockOpt.Size)
 	} else {
-		// No size checking. This is probably a string. Use the size
-		// they gave us.
+		// Variable-length option (e.g. SO_BINDTODEVICE, TCP_CONGESTION).
+		// Cap to prevent guest-controlled OOM via large optLen.
+		const maxVarOptLen = 4096
+		if optLen > maxVarOptLen {
+			return nil, syserr.ErrInvalidArgument
+		}
 		opt = make([]byte, optLen)
 	}
 	if err := preGetSockOpt(t, level, name, optValAddr, opt); err != nil {


### PR DESCRIPTION
SIOCGIFCONF ioctl copies `ifc.Len` from guest memory and uses it directly in `make([]byte, ifc.Len)` without an upper bound (`socket_unsafe.go:103`). A guest can pass a large Len value to force excessive sentry memory allocation.

GetSockOpt for variable-length options (`Size == 0`, e.g. `SO_BINDTODEVICE`, `TCP_CONGESTION`) allocates `make([]byte, optLen)` from guest-controlled `optLen` after only a negative check (`sockopt.go:202`). A guest can request `optLen = MaxInt` to cause sentry OOM.

Fixes:
- Cap `ifc.Len` to 64KB (sufficient for ~1000 interfaces) before allocation
- Cap variable-length `optLen` to 4KB and reject larger values with `EINVAL`

Both patterns allow a guest process to cause sentry OOM via repeated calls with large sizes.