### PR TITLE
systrap: fix TOCTOU on ThreadID in NotifyInterrupt

### DIFF
--- a/pkg/sentry/platform/systrap/shared_context.go
+++ b/pkg/sentry/platform/systrap/shared_context.go
@@ -126,14 +126,15 @@ func (sc *sharedContext) NotifyInterrupt() {
 	// If this context is not being worked on right now we need to mark it as
 	// interrupted so the next executor does not start working on it.
 	atomic.StoreUint32(&sc.shared.Interrupt, 1)
-	if sc.threadID() == invalidThreadID {
+	// Read ThreadID exactly once to avoid TOCTOU — the guest can modify
+	// shared memory between reads.
+	threadID := atomic.LoadUint32(&sc.shared.ThreadID)
+	if threadID == invalidThreadID {
 		return
 	}
 	s := sc.subprocess
 	s.sysmsgThreadsMu.Lock()
 	defer s.sysmsgThreadsMu.Unlock()
-
-	threadID := atomic.LoadUint32(&sc.shared.ThreadID)
 	sysmsgThread, ok := s.sysmsgThreads[threadID]
 	if !ok {
 		// This is either an invalidThreadID or another garbage value; either way we


### PR DESCRIPTION
NotifyInterrupt reads ThreadID from guest-writable shared memory twice: once to check for invalidThreadID (line 129) and again after acquiring the lock for the map lookup (line 136). A malicious guest can modify ThreadID between these two reads.

If the guest sets ThreadID to a recently-exited thread, TGKILL returns ESRCH which marks the subprocess as dead and kills the syscall thread. If the guest engineers a non-ESRCH error, the sentry panics (line 157).

Fix: read ThreadID exactly once into a local variable and use it for both the early-return check and the map lookup.