### PR TITLE
gofer: cap directory entry cache to prevent memory exhaustion

### DIFF
--- a/pkg/sentry/fsimpl/gofer/directory.go
+++ b/pkg/sentry/fsimpl/gofer/directory.go
@@ -312,7 +312,10 @@ func (d *dentry) getDirents(ctx context.Context) ([]vfs.Dirent, error) {
 		}
 	}
 	// Cache dirents for future directoryFDs if permitted.
-	if d.inode.cachedMetadataAuthoritative() {
+	// Cap cached entries to prevent guest-controlled memory exhaustion
+	// via directories with millions of entries.
+	const maxCachedDirents = 100000
+	if d.inode.cachedMetadataAuthoritative() && len(dirents) <= maxCachedDirents {
 		d.dirents = dirents
 		d.childrenSet = make(map[string]struct{}, len(dirents))
 		for _, dirent := range d.dirents {


### PR DESCRIPTION
getDirents() caches the complete directory listing in d.dirents and d.childrenSet with no upper bound. A guest can create a directory with millions of entries and trigger caching via getdents64(), consuming ~150MB per million entries in the sentry.

Multiple such directories can exhaust sentry memory (OOM). The cache persists as long as the dentry is alive and the directory is not mutated.

Fix: add maxCachedDirents cap (100K entries). Directories exceeding this limit skip caching and re-read from the gofer on each getdents64 call.