### PR TITLE
gofer: use ToNsecCapped for timestamp conversion from gofer

### DIFF
--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -1401,11 +1401,11 @@ func (d *dentry) setStat(ctx context.Context, creds *auth.Credentials, opts *vfs
 	// !d.inode.cachedMetadataAuthoritative() then we returned after calling
 	// d.file.setAttr(). For the same reason, now must have been initialized.
 	if stat.Mask&linux.STATX_ATIME != 0 && failureMask&linux.STATX_ATIME == 0 {
-		d.inode.atime.Store(stat.Atime.ToNsec())
+		d.inode.atime.Store(stat.Atime.ToNsecCapped())
 		d.inode.atimeDirty.Store(0)
 	}
 	if stat.Mask&linux.STATX_MTIME != 0 && failureMask&linux.STATX_MTIME == 0 {
-		d.inode.mtime.Store(stat.Mtime.ToNsec())
+		d.inode.mtime.Store(stat.Mtime.ToNsecCapped())
 		d.inode.mtimeDirty.Store(0)
 	}
 	d.inode.ctime.Store(now)

--- a/pkg/sentry/fsimpl/gofer/time.go
+++ b/pkg/sentry/fsimpl/gofer/time.go
@@ -21,7 +21,7 @@ import (
 )
 
 func dentryTimestamp(t lisafs.StatxTimestamp) int64 {
-	return t.ToNsec()
+	return t.ToNsecCapped()
 }
 
 func dentryTimestampFromUnix(t unix.Timespec) int64 {


### PR DESCRIPTION
`dentryTimestamp()` and direct stat timestamp conversions in `gofer.go:1404,1408` use `ToNsec()` which silently overflows `int64` when `Sec` exceeds ~9.2e9 seconds. A malicious gofer can supply extreme timestamp values causing wrap-around.

The safe variant `ToNsecCapped()` already exists in `pkg/abi/linux/time.go:275` and correctly saturates to `math.MaxInt64` for out-of-range values, but was not used in the gofer timestamp paths.

Switch all three call sites (`time.go:24`, `gofer.go:1404`, `gofer.go:1408`) from `ToNsec()` to `ToNsecCapped()`.