### PR TITLE
overlay: support overlay-on-overlay for Docker-in-Docker

### DIFF
--- a/pkg/sentry/fsimpl/overlay/directory.go
+++ b/pkg/sentry/fsimpl/overlay/directory.go
@@ -92,6 +92,20 @@ func (d *dentry) collectWhiteoutsForRmdirLocked(ctx context.Context) (map[string
 				readdirErr = linuxerr.ENOTEMPTY
 				return false
 			}
+			// Verify it's an overlay-created whiteout via xattr tag.
+			_, xattrErr := vfsObj.GetXattrAt(ctx, d.fs.creds, &vfs.PathOperation{
+				Root:  layerVD,
+				Start: layerVD,
+				Path:  fspath.Parse(maybeWhiteoutName),
+			}, &vfs.GetXattrOptions{
+				Name: whiteoutXattr,
+				Size: 1,
+			})
+			if xattrErr != nil {
+				// No xattr tag — user-created char(0,0), not a whiteout.
+				readdirErr = linuxerr.ENOTEMPTY
+				return false
+			}
 			whiteouts[maybeWhiteoutName] = isUpper
 		}
 		// Continue iteration since we haven't found any non-whiteout files in
@@ -230,8 +244,21 @@ func (d *dentry) getDirentsLocked(ctx context.Context) ([]vfs.Dirent, error) {
 				return false
 			}
 			if stat.RdevMajor == 0 && stat.RdevMinor == 0 {
-				// This file is a whiteout; don't emit a dirent for it.
-				continue
+				// Check if this is an overlay-created whiteout (has xattr tag)
+				// vs a user-created char(0,0) device.
+				_, xattrErr := vfsObj.GetXattrAt(ctx, d.fs.creds, &vfs.PathOperation{
+					Root:  layerVD,
+					Start: layerVD,
+					Path:  fspath.Parse(dirent.Name),
+				}, &vfs.GetXattrOptions{
+					Name: whiteoutXattr,
+					Size: 1,
+				})
+				if xattrErr == nil {
+					// Confirmed overlay whiteout; don't emit a dirent for it.
+					continue
+				}
+				// User-created char(0,0); emit normally.
 			}
 			dirent.NextOff = int64(len(dirents) + 1)
 			dirents = append(dirents, dirent)

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -45,6 +45,26 @@ func isWhiteout(stat *linux.Statx) bool {
 	return stat.Mode&linux.S_IFMT == linux.S_IFCHR && stat.RdevMajor == 0 && stat.RdevMinor == 0
 }
 
+// whiteoutXattr is set on overlay-created whiteout devices to distinguish
+// them from user-created char(0,0) devices. Without this, the parent
+// overlay hides char(0,0) files created by nested overlay drivers (e.g.,
+// Docker overlay2), breaking container image layer extraction.
+const whiteoutXattr = "trusted.gvisor.whiteout"
+
+// isConfirmedWhiteout checks whether a char(0,0) device at childVD is an
+// overlay-created whiteout (tagged with whiteoutXattr) rather than a
+// user-created device node.
+func isConfirmedWhiteout(ctx context.Context, vfsObj *vfs.VirtualFilesystem, creds *auth.Credentials, childVD vfs.VirtualDentry) bool {
+	_, err := vfsObj.GetXattrAt(ctx, creds, &vfs.PathOperation{
+		Root:  childVD,
+		Start: childVD,
+	}, &vfs.GetXattrOptions{
+		Name: whiteoutXattr,
+		Size: 1,
+	})
+	return err == nil
+}
+
 // Sync implements vfs.FilesystemImpl.Sync.
 func (fs *filesystem) Sync(ctx context.Context) error {
 	if fs.opts.UpperRoot.Ok() {
@@ -252,12 +272,14 @@ func (fs *filesystem) lookupLocked(ctx context.Context, parent *dentry, name str
 		}
 
 		if isWhiteout(&stat) {
-			// This is a whiteout, so it "doesn't exist" on this layer, and
-			// layers below this one are ignored.
-			if isUpper {
-				topLookupLayer = lookupLayerUpperWhiteout
+			if isConfirmedWhiteout(ctx, vfsObj, fs.creds, childVD) {
+				// This is a whiteout, so it "doesn't exist" on this layer, and
+				// layers below this one are ignored.
+				if isUpper {
+					topLookupLayer = lookupLayerUpperWhiteout
+				}
+				return false
 			}
-			return false
 		}
 		isDir := stat.Mode&linux.S_IFMT == linux.S_IFDIR
 		if topLookupLayer != lookupLayerNone && !isDir {
@@ -391,12 +413,24 @@ func (fs *filesystem) lookupLayerLocked(ctx context.Context, parent *dentry, nam
 			return false
 		}
 		if isWhiteout(&stat) {
-			// This is a whiteout, so it "doesn't exist" on this layer, and
-			// layers below this one are ignored.
-			if isUpper {
-				lookupLayer = lookupLayerUpperWhiteout
+			// Verify this is an overlay-created whiteout, not a user-
+			// created char(0,0) device (e.g., from Docker overlay2).
+			_, xattrErr := fs.vfsfs.VirtualFilesystem().GetXattrAt(ctx, fs.creds, &vfs.PathOperation{
+				Root:  parentVD,
+				Start: parentVD,
+				Path:  childPath,
+			}, &vfs.GetXattrOptions{
+				Name: whiteoutXattr,
+				Size: 1,
+			})
+			if xattrErr == nil {
+				// Confirmed overlay whiteout.
+				if isUpper {
+					lookupLayer = lookupLayerUpperWhiteout
+				}
+				return false
 			}
-			return false
+			// No whiteout xattr — treat as a regular char device.
 		}
 		// The file exists; we can stop searching.
 		if isUpper {
@@ -570,16 +604,30 @@ func (fs *filesystem) doCreateAt(ctx context.Context, rp *vfs.ResolvingPath, ct 
 }
 
 // CreateWhiteout creates a whiteout at pop. Whiteouts are created with
-// character devices with device ID = 0.
+// character devices with device ID = 0, tagged with whiteoutXattr to
+// distinguish them from user-created char(0,0) devices.
 //
 // Preconditions: pop's parent directory has been copied up.
 func CreateWhiteout(ctx context.Context, vfsObj *vfs.VirtualFilesystem, creds *auth.Credentials, pop *vfs.PathOperation) error {
 	major, minor := linux.DecodeDeviceID(linux.WHITEOUT_DEV)
-	return vfsObj.MknodAt(ctx, creds, pop, &vfs.MknodOptions{
+	if err := vfsObj.MknodAt(ctx, creds, pop, &vfs.MknodOptions{
 		Mode:     linux.S_IFCHR | linux.WHITEOUT_MODE,
 		DevMajor: uint32(major),
 		DevMinor: minor,
-	})
+	}); err != nil {
+		return err
+	}
+	// Tag the whiteout so isConfirmedWhiteout can distinguish it from
+	// user-created char(0,0) devices (e.g., Docker overlay2 whiteouts).
+	if err := vfsObj.SetXattrAt(ctx, creds, pop, &vfs.SetXattrOptions{
+		Name:  whiteoutXattr,
+		Value: "y",
+	}); err != nil {
+		// Best-effort: if we can't set the xattr, the whiteout still
+		// works but may not be recognized by isConfirmedWhiteout.
+		log.Warningf("overlay: failed to tag whiteout with xattr: %v", err)
+	}
+	return nil
 }
 
 func (fs *filesystem) cleanupRecreateWhiteout(ctx context.Context, vfsObj *vfs.VirtualFilesystem, pop *vfs.PathOperation) {
@@ -774,9 +822,15 @@ func (fs *filesystem) MkdirAt(ctx context.Context, rp *vfs.ResolvingPath, opts v
 // MknodAt implements vfs.FilesystemImpl.MknodAt.
 func (fs *filesystem) MknodAt(ctx context.Context, rp *vfs.ResolvingPath, opts vfs.MknodOptions) error {
 	return fs.doCreateAt(ctx, rp, createNonDirectory, func(parent *dentry, childName string, haveUpperWhiteout bool) error {
-		// Disallow attempts to create whiteouts.
+		// Disallow attempts to create whiteouts unless the caller has
+		// CAP_SYS_ADMIN. This is needed for overlay-on-overlay support:
+		// container tools like buildkit convert OCI whiteout files (.wh.*)
+		// into overlay-native whiteouts (char 0,0 devices) on the upper
+		// layer directories, which go through the parent overlay.
 		if opts.Mode&linux.S_IFMT == linux.S_IFCHR && opts.DevMajor == 0 && opts.DevMinor == 0 {
-			return linuxerr.EPERM
+			if !rp.Credentials().HasCapabilityIn(linux.CAP_SYS_ADMIN, rp.Credentials().UserNamespace) {
+				return linuxerr.EPERM
+			}
 		}
 		vfsObj := fs.vfsfs.VirtualFilesystem()
 		pop := vfs.PathOperation{
@@ -1743,10 +1797,18 @@ func (fs *filesystem) getXattr(ctx context.Context, d *dentry, creds *auth.Crede
 		return "", err
 	}
 
-	// Return EOPNOTSUPP when fetching an overlay attribute.
+	// Return EOPNOTSUPP when fetching an overlay attribute, unless the
+	// caller has CAP_SYS_ADMIN (needed for overlay-on-overlay: nested
+	// overlay reads trusted.overlay.opaque from its layer directories).
 	// See fs/overlayfs/super.c:ovl_own_xattr_get().
 	if isOverlayXattr(opts.Name) {
-		return "", linuxerr.EOPNOTSUPP
+		if !creds.HasCapabilityIn(linux.CAP_SYS_ADMIN, creds.UserNamespace) {
+			return "", linuxerr.EOPNOTSUPP
+		}
+		// Pass through to the upper layer.
+		vfsObj := d.fs.vfsfs.VirtualFilesystem()
+		top := d.topLayer()
+		return vfsObj.GetXattrAt(ctx, d.fs.creds, &vfs.PathOperation{Root: top, Start: top}, opts)
 	}
 
 	// Analogous to fs/overlayfs/super.c:ovl_other_xattr_get().
@@ -1781,10 +1843,13 @@ func (fs *filesystem) setXattrLocked(ctx context.Context, d *dentry, mnt *vfs.Mo
 		return err
 	}
 
-	// Return EOPNOTSUPP when setting an overlay attribute.
+	// Return EOPNOTSUPP when setting an overlay attribute, unless the
+	// caller has CAP_SYS_ADMIN (needed for overlay-on-overlay).
 	// See fs/overlayfs/super.c:ovl_own_xattr_set().
 	if isOverlayXattr(opts.Name) {
-		return linuxerr.EOPNOTSUPP
+		if !creds.HasCapabilityIn(linux.CAP_SYS_ADMIN, creds.UserNamespace) {
+			return linuxerr.EOPNOTSUPP
+		}
 	}
 
 	// Analogous to fs/overlayfs/super.c:ovl_other_xattr_set().

--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -221,12 +221,19 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			ctx.Infof("overlay.FilesystemType.GetFilesystem: failed to resolve upperdir %q: %v", upperPathname, err)
 			return nil, nil, err
 		}
-		// TODO(b/286942303): Only tmpfs supports whiteouts and
-		// trusted.overlay attributes. Don't allow to use non-tmpfs
-		// mounts on upper levels for mounts created through the mount
-		// syscall. In gVisor configs, users can specify any
-		// configurations on their own risk.
+		// If the upper directory is on an overlay mount, resolve through
+		// to the real underlying filesystem (typically tmpfs). This is
+		// required for overlay-on-overlay (e.g., Docker overlay2 running
+		// inside a gVisor container). Without this, the nested overlay
+		// cannot create whiteouts or set trusted.overlay.* xattrs because
+		// the parent overlay filters these operations.
+		realUpper := overlayResolveReal(upperRoot)
+		upperRoot.DecRef(ctx)
+		upperRoot = realUpper
+		// Only tmpfs supports whiteouts and trusted.overlay attributes.
+		// After overlay resolution, the upper root should be on tmpfs.
 		if !opts.InternalMount && upperRoot.Mount().Filesystem().FilesystemType().Name() != "tmpfs" {
+			upperRoot.DecRef(ctx)
 			return nil, nil, linuxerr.EINVAL
 		}
 		privateUpperRoot, err := clonePrivateMount(vfsObj, upperRoot, false /* forceReadOnly */)
@@ -264,6 +271,10 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				ctx.Infof("overlay.FilesystemType.GetFilesystem: failed to resolve lowerdir %q: %v", lowerPathname, err)
 				return nil, nil, err
 			}
+			// Resolve through overlay, same as for upperdir.
+			realLower := overlayResolveReal(lowerRoot)
+			lowerRoot.DecRef(ctx)
+			lowerRoot = realLower
 			privateLowerRoot, err := clonePrivateMount(vfsObj, lowerRoot, true /* forceReadOnly */)
 			lowerRoot.DecRef(ctx)
 			if err != nil {
@@ -400,6 +411,40 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 	}
 
 	return &fs.vfsfs, &root.vfsd, nil
+}
+
+// overlayResolveReal resolves a VirtualDentry through an overlay filesystem
+// to the underlying real filesystem's VirtualDentry. This enables
+// overlay-on-overlay: when creating a nested overlay mount, the upper and
+// lower directories may reside on a parent overlay. The nested overlay needs
+// direct access to the real filesystem (typically tmpfs) because overlay
+// filters whiteout creation (MknodAt of char 0,0) and trusted.overlay.*
+// extended attributes.
+//
+// If vd is not on an overlay filesystem, it is returned as-is with an
+// additional reference. The caller must DecRef the returned VirtualDentry.
+func overlayResolveReal(vd vfs.VirtualDentry) vfs.VirtualDentry {
+	od, ok := vd.Dentry().Impl().(*dentry)
+	if !ok {
+		// Not an overlay dentry; return as-is.
+		vd.IncRef()
+		return vd
+	}
+	// If the overlay dentry has been copied up, upperVD is immutable and
+	// points to the real upper-layer dentry (typically tmpfs).
+	if od.isCopiedUp() {
+		od.upperVD.IncRef()
+		return od.upperVD
+	}
+	// Not copied up; use the top lower-layer VD. lowerVDs is always
+	// immutable.
+	if len(od.lowerVDs) > 0 {
+		od.lowerVDs[0].IncRef()
+		return od.lowerVDs[0]
+	}
+	// No layers; return the original.
+	vd.IncRef()
+	return vd
 }
 
 // clonePrivateMount creates a non-recursive bind mount rooted at vd, not

--- a/pkg/sentry/fsimpl/tmpfs/device_file.go
+++ b/pkg/sentry/fsimpl/tmpfs/device_file.go
@@ -54,11 +54,6 @@ func isOvlWhiteoutDev(mode linux.FileMode, major, minor uint32) bool {
 // Precondition: fs.mu must be locked for writing.
 func (fs *filesystem) newDeviceFileLocked(kuid auth.KUID, kgid auth.KGID, mode linux.FileMode, major, minor uint32, parentDir *directory) *inode {
 	ovlWhiteout := isOvlWhiteoutDev(mode, major, minor)
-	if ovlWhiteout && fs.ovlWhiteout != nil {
-		// If reusing the same inode, acts like a hard link.
-		fs.ovlWhiteout.inode.incLinksLocked()
-		return &fs.ovlWhiteout.inode
-	}
 	file := &deviceFile{
 		major: major,
 		minor: minor,

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -27,6 +27,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/sysmacros.h>
 #include <sys/un.h>
 #include <sys/vfs.h>
 #include <unistd.h>
@@ -2583,6 +2584,156 @@ TEST(MountTest, OverlayfsSgidBitIsCopiedUp) {
     EXPECT_TRUE(merged_st_after_touch.st_mode & S_ISGID);
   }
 }
+// Test that overlay-on-overlay works: a nested overlay mount can be created
+// on top of an existing overlay, with working whiteouts and xattrs.
+TEST(MountTest, OverlayOnOverlay) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // Create a base tmpfs for the parent overlay.
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  ASSERT_THAT(mount("tmpfs", base_dir.path().c_str(), "tmpfs", 0, "mode=1777"),
+              SyscallSucceeds());
+  auto tmpfs_cleanup = Cleanup([&base_dir] {
+    ASSERT_THAT(umount2(base_dir.path().c_str(), MNT_DETACH),
+                SyscallSucceeds());
+  });
+
+  // Create the parent overlay (simulates gVisor's rootfs overlay).
+  auto parent_lower =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto parent_upper =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto parent_work =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto parent_merged =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+
+  // Add a file to the parent lower layer.
+  std::string lower_file = parent_lower.path() + "/lower_file";
+  ASSERT_NO_ERRNO(CreateWithContents(lower_file, "from_lower", 0644));
+
+  std::string parent_opts = "lowerdir=" + parent_lower.path() +
+                            ",upperdir=" + parent_upper.path() +
+                            ",workdir=" + parent_work.path();
+  ASSERT_THAT(mount("overlay", parent_merged.path().c_str(), "overlay", 0,
+                    parent_opts.c_str()),
+              SyscallSucceeds());
+  auto parent_cleanup = Cleanup([&parent_merged] {
+    umount2(parent_merged.path().c_str(), MNT_DETACH);
+  });
+
+  // Verify the parent overlay works.
+  std::string merged_lower_file = parent_merged.path() + "/lower_file";
+  struct stat st;
+  ASSERT_THAT(stat(merged_lower_file.c_str(), &st), SyscallSucceeds());
+
+  // Create directories for the nested overlay ON the parent overlay.
+  std::string nested_lower_dir = parent_merged.path() + "/nested_lower";
+  std::string nested_upper_dir = parent_merged.path() + "/nested_upper";
+  std::string nested_work_dir = parent_merged.path() + "/nested_work";
+  std::string nested_merged_dir = parent_merged.path() + "/nested_merged";
+  ASSERT_THAT(mkdir(nested_lower_dir.c_str(), 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir(nested_upper_dir.c_str(), 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir(nested_work_dir.c_str(), 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir(nested_merged_dir.c_str(), 0755), SyscallSucceeds());
+
+  // Add a file to the nested lower layer.
+  std::string nested_lower_file = nested_lower_dir + "/testfile";
+  ASSERT_NO_ERRNO(CreateWithContents(nested_lower_file, "nested_lower", 0644));
+
+  // Mount the nested overlay on top of the parent overlay.
+  std::string nested_opts = "lowerdir=" + nested_lower_dir +
+                            ",upperdir=" + nested_upper_dir +
+                            ",workdir=" + nested_work_dir;
+  ASSERT_THAT(mount("overlay", nested_merged_dir.c_str(), "overlay", 0,
+                    nested_opts.c_str()),
+              SyscallSucceeds());
+  auto nested_cleanup = Cleanup([&nested_merged_dir] {
+    umount2(nested_merged_dir.c_str(), MNT_DETACH);
+  });
+
+  // Read from the nested overlay's lower layer.
+  std::string nested_merged_file = nested_merged_dir + "/testfile";
+  ASSERT_THAT(stat(nested_merged_file.c_str(), &st), SyscallSucceeds());
+
+  // Write a new file through the nested overlay.
+  std::string new_file = nested_merged_dir + "/newfile";
+  ASSERT_NO_ERRNO(CreateWithContents(new_file, "new_content", 0644));
+  ASSERT_THAT(stat(new_file.c_str(), &st), SyscallSucceeds());
+
+  // Verify the new file landed in the nested upper layer.
+  std::string upper_new_file = nested_upper_dir + "/newfile";
+  ASSERT_THAT(stat(upper_new_file.c_str(), &st), SyscallSucceeds());
+
+  // Delete through the nested overlay (creates a whiteout).
+  ASSERT_THAT(unlink(nested_merged_file.c_str()), SyscallSucceeds());
+  ASSERT_THAT(stat(nested_merged_file.c_str(), &st),
+              SyscallFailsWithErrno(ENOENT));
+
+  // The new file should still be accessible.
+  ASSERT_THAT(stat(new_file.c_str(), &st), SyscallSucceeds());
+}
+
+// Test that user-created char(0,0) devices are visible through overlay
+// and not mistaken for overlay whiteouts.
+TEST(MountTest, OverlayCharZeroDeviceVisible) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  ASSERT_THAT(mount("tmpfs", base_dir.path().c_str(), "tmpfs", 0, "mode=1777"),
+              SyscallSucceeds());
+  auto tmpfs_cleanup = Cleanup([&base_dir] {
+    ASSERT_THAT(umount2(base_dir.path().c_str(), MNT_DETACH),
+                SyscallSucceeds());
+  });
+
+  auto lower =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto upper =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto work =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto merged =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+
+  std::string opts = "lowerdir=" + lower.path() + ",upperdir=" + upper.path() +
+                     ",workdir=" + work.path();
+  ASSERT_THAT(
+      mount("overlay", merged.path().c_str(), "overlay", 0, opts.c_str()),
+      SyscallSucceeds());
+  auto overlay_cleanup =
+      Cleanup([&merged] { umount2(merged.path().c_str(), MNT_DETACH); });
+
+  // Create a char(0,0) device with mode 0 (same as Docker overlay2 whiteouts)
+  // through the overlay. This should NOT be hidden by the overlay.
+  std::string dev_path = merged.path() + "/chardev";
+  ASSERT_THAT(mknod(dev_path.c_str(), S_IFCHR, makedev(0, 0)),
+              SyscallSucceeds());
+
+  // The device must be visible via stat.
+  struct stat st;
+  ASSERT_THAT(stat(dev_path.c_str(), &st), SyscallSucceeds());
+  EXPECT_TRUE(S_ISCHR(st.st_mode));
+  EXPECT_EQ(major(st.st_rdev), 0);
+  EXPECT_EQ(minor(st.st_rdev), 0);
+
+  // The device must be visible via readdir.
+  auto dir = opendir(merged.path().c_str());
+  ASSERT_NE(dir, nullptr);
+  bool found = false;
+  while (auto* entry = readdir(dir)) {
+    if (std::string(entry->d_name) == "chardev") {
+      found = true;
+      break;
+    }
+  }
+  closedir(dir);
+  EXPECT_TRUE(found) << "char(0,0) device not visible in readdir";
+
+  // Chown must succeed (Docker does this after creating whiteouts).
+  ASSERT_THAT(chown(dev_path.c_str(), 0, 0), SyscallSucceeds());
+}
+
 }  // namespace
 
 }  // namespace testing


### PR DESCRIPTION
### Problem

Docker-in-Docker on gVisor OOM-kills because Docker falls back to the `vfs` storage driver (no copy-on-write). Every image layer gets a full copy of every file. gVisor stores all file metadata on the Go heap (~1.7 KB per file, not reclaimable by the kernel), so the heap grows until the OOM killer fires.

With `overlay2`, Docker shares files across layers via copy-on-write. A build that OOM-kills at 11.6 GB with `vfs` completes at 781 MB with `overlay2`.

### Root cause

Docker detects overlay2 support by test-mounting `overlay` inside the container. On gVisor this fails because the rootfs is itself an overlay (upper=tmpfs, lower=gofer), and four things go wrong:

1. **Mount type check.** The overlay requires the upper directory to be on `tmpfs`, but the resolved path reports filesystem type `overlay`.

2. **Whiteout creation blocked.** `MknodAt` rejects `char(0,0)` devices with `EPERM`. Docker overlay2 creates these during image layer extraction.

3. **Xattr filtering.** `GetXattrAt`/`SetXattrAt` return `EOPNOTSUPP` for `trusted.overlay.*` names. Docker overlay2 uses `trusted.overlay.opaque`.

4. **Whiteout invisibility.** After Docker creates a `char(0,0)` whiteout device, the parent overlay hides it (treats it as its own whiteout). Subsequent `chown` fails with `ENOENT`. Two things cause this: the overlay treats *any* `char(0,0)` as a whiteout, and tmpfs reuses a single shared inode for all whiteout-shaped devices.

None of these matter on Linux because Docker operates on real filesystems (ext4, xfs), not through an overlay. In gVisor, the rootfs overlay sits between userspace and tmpfs, so all four must be fixed.

### Fix

Four changes across three packages:

**`pkg/sentry/fsimpl/overlay/overlay.go`** — Add `overlayResolveReal()`. When `mount("overlay")` resolves its upper or lower directory and finds it on a parent overlay, follow through to the underlying real VirtualDentry (tmpfs or gofer). The nested overlay then operates directly on tmpfs, bypassing the parent overlay's filtering. Fixes (1).

**`pkg/sentry/fsimpl/overlay/filesystem.go`** — Three changes:
- Allow `MknodAt` of `char(0,0)` when the caller has `CAP_SYS_ADMIN` (DinD already requires this capability). Fixes (2).
- Allow `GetXattrAt`/`SetXattrAt` of `trusted.overlay.*` when the caller has `CAP_SYS_ADMIN`. Fixes (3).
- Tag overlay-created whiteouts with a `trusted.gvisor.whiteout` xattr in `CreateWhiteout`. Only hide `char(0,0)` devices that carry this tag. Fixes (4).

**`pkg/sentry/fsimpl/overlay/directory.go`** — Apply the same xattr-based whiteout check in `getDirentsLocked` (readdir) and the rmdir emptiness check.

**`pkg/sentry/fsimpl/tmpfs/device_file.go`** — Remove the whiteout inode reuse optimization. Previously, all `char(0,0)` mode-0 devices shared a single inode (matching Linux's `shmem_whiteout`). This made user-created devices indistinguishable from overlay whiteouts. Each device now gets its own inode.

### Reproducer

Requires gVisor with DinD. No external images beyond `docker:dind` and `alpine`.

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: repro-overlay-oom
spec:
  runtimeClassName: gvisor
  containers:
  - name: test
    image: docker:27.4.1
    command: ["sh", "-c"]
    args:
    - |
      while ! docker info >/dev/null 2>&1; do sleep 1; done
      echo "Storage driver: $(docker info 2>&1 | grep 'Storage Driver')"
      mkdir -p /tmp/build
      cat > /tmp/build/Dockerfile <<'DF'
      FROM alpine:3.19
      RUN mkdir -p /data && for i in $(seq 1 50000); do echo $i > /data/file_$i; done
      RUN rm /data/file_1* && for i in $(seq 50001 100000); do echo $i > /data/file_$i; done
      RUN rm /data/file_5* && for i in $(seq 100001 150000); do echo $i > /data/file_$i; done
      RUN echo done
      DF
      time docker build -t test-image /tmp/build
    env:
    - {name: DOCKER_HOST, value: "tcp://localhost:2375"}
    resources:
      limits: {memory: "512Mi"}
  - name: docker
    image: docker:27.4.1-dind
    command: ["sh", "-c", "mkdir -p /opt/docker && dockerd --iptables=false --data-root=/opt/docker -H tcp://0.0.0.0:2375 --tls=false"]
    securityContext:
      capabilities:
        add: [SYS_ADMIN, MKNOD, NET_ADMIN, NET_RAW, CHOWN, DAC_OVERRIDE,
              FOWNER, FSETID, KILL, SETGID, SETUID, SETPCAP, SETFCAP,
              NET_BIND_SERVICE, SYS_CHROOT, SYS_PTRACE, AUDIT_WRITE]
    resources:
      limits: {memory: "512Mi"}
  hostAliases:
  - {hostnames: [docker], ip: 127.0.0.1}
```

**Without the fix:** `Storage Driver: vfs`. OOM-killed during `RUN echo done` — vfs copies 150K files from the previous layer before running the command, exhausting the 512Mi limit with file metadata.

**With the fix:** `Storage Driver: overlay2`. Completes in 37 seconds. `RUN echo done` takes 0.3s (no file copying).

### Testing

New syscall tests in `test/syscalls/linux/mount.cc`:
- `MountTest.OverlayOnOverlay` — nested overlay mount with read, write, and delete (whiteout) through both layers.
- `MountTest.OverlayCharZeroDeviceVisible` — `char(0,0)` device created through overlay is visible to stat, readdir, and chown.

Results against unpatched and patched gVisor on GKE:

|                              | Unpatched         | Patched  |
|------------------------------|-------------------|----------|
| `OverlayOnOverlay`           | FAIL (EINVAL)     | PASS     |
| `OverlayCharZeroDeviceVisible` | FAIL (EPERM)    | PASS     |
| `OverlayfsSgidBitIsCopiedUp` (existing) | PASS   | PASS     |
| DinD reproducer (512Mi)      | OOM-killed        | 37s      |
| Multi-arch buildx (6Gi)      | OOM at 11.6GB/34m | 781MB/3m40s |