### PR TITLE
fsimpl: Fix Linux rmdir inotify event ordering

### DIFF
--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -707,10 +707,7 @@ func (fs *filesystem) unlinkAt(ctx context.Context, rp *vfs.ResolvingPath, dir b
 		}
 	}
 
-	// Generate inotify events for rmdir or unlink.
-	if dir {
-		parent.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
-	} else {
+	if !dir {
 		var cw *vfs.Watches
 		if child != nil {
 			cw = &child.inode.watches
@@ -737,7 +734,19 @@ func (fs *filesystem) unlinkAt(ctx context.Context, rp *vfs.ResolvingPath, dir b
 		} else if child.inode.endpoint != nil {
 			child.decRefNoCaching()
 		}
+		if dir && child.refs.Load() == 0 {
+			// Match Linux's inotify event ordering for rmdir. Once the child is
+			// removed from the tree and any existence ref has been dropped,
+			// refs==0 means no extra refs remain, so IN_DELETE_SELF/IN_IGNORED
+			// should precede the parent's IN_DELETE|IN_ISDIR. Otherwise defer to
+			// destroyLocked(), where HandleDeletion() remains safe because it is
+			// idempotent.
+			child.inode.watches.HandleDeletion(ctx)
+		}
 		ds = appendDentry(ds, child)
+	}
+	if dir {
+		parent.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
 	}
 	parent.cacheNegativeLookupLocked(name)
 	if parent.inode.cachedMetadataAuthoritative() {

--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -707,10 +707,7 @@ func (fs *filesystem) unlinkAt(ctx context.Context, rp *vfs.ResolvingPath, dir b
 		}
 	}
 
-	// Generate inotify events for rmdir or unlink.
-	if dir {
-		parent.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
-	} else {
+	if !dir {
 		var cw *vfs.Watches
 		if child != nil {
 			cw = &child.inode.watches
@@ -737,7 +734,18 @@ func (fs *filesystem) unlinkAt(ctx context.Context, rp *vfs.ResolvingPath, dir b
 		} else if child.inode.endpoint != nil {
 			child.decRefNoCaching()
 		}
+		if dir && child.refs.Load() == 0 {
+			// Linux sends the parent's IN_DELETE|IN_ISDIR at rmdir() time,
+			// but sends the child's IN_DELETE_SELF/IN_IGNORED when the
+			// last reference is dropped. refs==0 means no extra refs
+			// remain, so emit the child notifications now. Otherwise
+			// defer to destroyLocked(). HandleDeletion() is idempotent.
+			child.inode.watches.HandleDeletion(ctx)
+		}
 		ds = appendDentry(ds, child)
+	}
+	if dir {
+		parent.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
 	}
 	parent.cacheNegativeLookupLocked(name)
 	if parent.inode.cachedMetadataAuthoritative() {

--- a/pkg/sentry/fsimpl/kernfs/BUILD
+++ b/pkg/sentry/fsimpl/kernfs/BUILD
@@ -166,6 +166,7 @@ go_test(
         "//pkg/context",
         "//pkg/errors/linuxerr",
         "//pkg/fspath",
+        "//pkg/hostarch",
         "//pkg/log",
         "//pkg/refs",
         "//pkg/sentry/contexttest",

--- a/pkg/sentry/fsimpl/kernfs/filesystem.go
+++ b/pkg/sentry/fsimpl/kernfs/filesystem.go
@@ -911,6 +911,14 @@ func (fs *Filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 		return err
 	}
 	delete(parent.children, child.name)
+	// Match Linux's inotify event ordering for rmdir. A removed kernfs dentry
+	// keeps exactly one tree reference until we drop it below, so refs==1 means
+	// no external refs remain and IN_DELETE_SELF/IN_IGNORED should precede the
+	// parent's IN_DELETE|IN_ISDIR. If refs remain, defer to cacheLocked(),
+	// where HandleDeletion() is still safe because it is idempotent.
+	if child.refs.Load() == 1 {
+		child.inode.Watches().HandleDeletion(ctx)
+	}
 	parent.inode.Watches().Notify(ctx, child.name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
 	// Defer decref so that fs.mu and parentDentry.dirMu are unlocked by then.
 	fs.deferDecRef(child)

--- a/pkg/sentry/fsimpl/kernfs/filesystem.go
+++ b/pkg/sentry/fsimpl/kernfs/filesystem.go
@@ -911,6 +911,14 @@ func (fs *Filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 		return err
 	}
 	delete(parent.children, child.name)
+	// Linux sends the parent's IN_DELETE|IN_ISDIR at rmdir() time, but
+	// defers the child's IN_DELETE_SELF/IN_IGNORED until the last ref is
+	// dropped. A removed kernfs dentry keeps one tree ref until we drop it
+	// below, so refs==1 means no external refs remain. Otherwise defer to
+	// cacheLocked(). HandleDeletion() is idempotent.
+	if child.refs.Load() == 1 {
+		child.inode.Watches().HandleDeletion(ctx)
+	}
 	parent.inode.Watches().Notify(ctx, child.name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
 	// Defer decref so that fs.mu and parentDentry.dirMu are unlocked by then.
 	fs.deferDecRef(child)

--- a/pkg/sentry/fsimpl/kernfs/kernfs_test.go
+++ b/pkg/sentry/fsimpl/kernfs/kernfs_test.go
@@ -24,6 +24,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/fspath"
+	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/testutil"
@@ -202,6 +203,29 @@ func (d *dir) NewFile(ctx context.Context, name string, opts vfs.OpenOptions) (k
 	return f, nil
 }
 
+type keptDir struct {
+	dir
+}
+
+func (fs *filesystem) newKeptDir(ctx context.Context, creds *auth.Credentials, mode linux.FileMode, contents map[string]kernfs.Inode) kernfs.Inode {
+	kdir := &keptDir{}
+	kdir.dir.fs = fs
+	kdir.dir.attrs.Init(ctx, creds, 0 /* devMajor */, 0 /* devMinor */, fs.NextIno(), linux.ModeDirectory|mode)
+	kdir.dir.OrderedChildren.Init(kernfs.OrderedChildrenOptions{Writable: true})
+	kdir.dir.InitRefs()
+	for name, child := range contents {
+		if err := kdir.dir.OrderedChildren.Insert(name, child); err != nil {
+			panic(fmt.Sprintf("newKeptDir Insert(%q): %v", name, err))
+		}
+		kdir.dir.IncLinks(1)
+	}
+	return kdir
+}
+
+func (*keptDir) Keep() bool {
+	return true
+}
+
 func (*dir) NewLink(context.Context, string, kernfs.Inode) (kernfs.Inode, error) {
 	return nil, linuxerr.EPERM
 }
@@ -227,6 +251,42 @@ func (fst fsType) GetFilesystem(ctx context.Context, vfsObj *vfs.VirtualFilesyst
 	var d kernfs.Dentry
 	d.Init(&fs.Filesystem, root)
 	return fs.VFSFilesystem(), d.VFSDentry(), nil
+}
+
+type inotifyEvent struct {
+	WD   int32
+	Mask uint32
+	Name string
+}
+
+func readInotifyEvents(t *testing.T, ctx context.Context, fd *vfs.FileDescription) []inotifyEvent {
+	t.Helper()
+
+	buf := make([]byte, 4096)
+	n, err := fd.Read(ctx, usermem.BytesIOSequence(buf), vfs.ReadOptions{})
+	if err != nil {
+		t.Fatalf("inotify read failed: %v", err)
+	}
+	buf = buf[:n]
+
+	var events []inotifyEvent
+	for len(buf) != 0 {
+		if len(buf) < 16 {
+			t.Fatalf("short inotify event buffer: got %d bytes", len(buf))
+		}
+		nameLen := int(hostarch.ByteOrder.Uint32(buf[12:16]))
+		eventLen := 16 + nameLen
+		if len(buf) < eventLen {
+			t.Fatalf("truncated inotify event buffer: got %d bytes, need %d", len(buf), eventLen)
+		}
+		events = append(events, inotifyEvent{
+			WD:   int32(hostarch.ByteOrder.Uint32(buf[0:4])),
+			Mask: hostarch.ByteOrder.Uint32(buf[4:8]),
+			Name: string(bytes.TrimRight(buf[16:eventLen], "\x00")),
+		})
+		buf = buf[eventLen:]
+	}
+	return events
 }
 
 // -------------------- Remainder of the file are test cases --------------------
@@ -412,4 +472,101 @@ func TestDirWalkDentryTree(t *testing.T) {
 	testWalk(dir2D, "dir2/dir3", "/../../../dir3", nil)
 	testWalk(dir2D, "dir2/file1", "/file1", nil)
 	testWalk(dir2D, "dir2/file1", "file1", nil)
+}
+
+func TestRmdirInotifyDeleteSelfBeforeParentDelete(t *testing.T) {
+	sys := newTestSystem(t, func(ctx context.Context, creds *auth.Credentials, fs *filesystem) kernfs.Inode {
+		return fs.newKeptDir(ctx, creds, 0755, map[string]kernfs.Inode{
+			"parent": fs.newKeptDir(ctx, creds, 0755, map[string]kernfs.Inode{
+				"child": fs.newKeptDir(ctx, creds, 0755, nil),
+			}),
+		})
+	})
+	defer sys.Destroy()
+	ctx := vfs.WithMountNamespace(sys.Ctx, sys.MntNs)
+
+	inotifyFD, err := vfs.NewInotifyFD(ctx, sys.VFS, linux.O_NONBLOCK)
+	if err != nil {
+		t.Fatalf("NewInotifyFD failed: %v", err)
+	}
+	defer inotifyFD.DecRef(ctx)
+	ino := inotifyFD.Impl().(*vfs.Inotify)
+
+	parentVD := sys.GetDentryOrDie(sys.PathOpAtRoot("parent"))
+	defer parentVD.DecRef(sys.Ctx)
+	childVD := sys.GetDentryOrDie(sys.PathOpAtRoot("parent/child"))
+	parentWD := ino.AddWatch(parentVD.Dentry(), linux.IN_ALL_EVENTS)
+	childWD := ino.AddWatch(childVD.Dentry(), linux.IN_ALL_EVENTS)
+	childVD.DecRef(sys.Ctx)
+
+	if err := sys.VFS.RmdirAt(ctx, sys.Creds, sys.PathOpAtRoot("parent/child")); err != nil {
+		t.Fatalf("RmdirAt failed: %v", err)
+	}
+
+	got := readInotifyEvents(t, ctx, inotifyFD)
+	want := []inotifyEvent{
+		{WD: childWD, Mask: linux.IN_DELETE_SELF},
+		{WD: childWD, Mask: linux.IN_IGNORED},
+		{WD: parentWD, Mask: linux.IN_DELETE | linux.IN_ISDIR, Name: "child"},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected inotify events after rmdir (-want +got):\n%s", diff)
+	}
+}
+
+func TestRmdirInotifyWithOpenFDDefersDeleteSelf(t *testing.T) {
+	sys := newTestSystem(t, func(ctx context.Context, creds *auth.Credentials, fs *filesystem) kernfs.Inode {
+		return fs.newKeptDir(ctx, creds, 0755, map[string]kernfs.Inode{
+			"parent": fs.newKeptDir(ctx, creds, 0755, map[string]kernfs.Inode{
+				"child": fs.newKeptDir(ctx, creds, 0755, nil),
+			}),
+		})
+	})
+	defer sys.Destroy()
+	ctx := vfs.WithMountNamespace(sys.Ctx, sys.MntNs)
+
+	inotifyFD, err := vfs.NewInotifyFD(ctx, sys.VFS, linux.O_NONBLOCK)
+	if err != nil {
+		t.Fatalf("NewInotifyFD failed: %v", err)
+	}
+	defer inotifyFD.DecRef(ctx)
+	ino := inotifyFD.Impl().(*vfs.Inotify)
+
+	parentVD := sys.GetDentryOrDie(sys.PathOpAtRoot("parent"))
+	defer parentVD.DecRef(sys.Ctx)
+	childVD := sys.GetDentryOrDie(sys.PathOpAtRoot("parent/child"))
+	parentWD := ino.AddWatch(parentVD.Dentry(), linux.IN_ALL_EVENTS)
+	childWD := ino.AddWatch(childVD.Dentry(), linux.IN_ALL_EVENTS)
+	childVD.DecRef(sys.Ctx)
+
+	childFD, err := sys.VFS.OpenAt(ctx, sys.Creds, sys.PathOpAtRoot("parent/child"), &vfs.OpenOptions{Flags: linux.O_RDONLY})
+	if err != nil {
+		t.Fatalf("OpenAt failed: %v", err)
+	}
+	// Opening the watched directory generates IN_OPEN events; they are not part
+	// of the rmdir ordering being validated below.
+	_ = readInotifyEvents(t, ctx, inotifyFD)
+
+	if err := sys.VFS.RmdirAt(ctx, sys.Creds, sys.PathOpAtRoot("parent/child")); err != nil {
+		t.Fatalf("RmdirAt failed: %v", err)
+	}
+
+	got := readInotifyEvents(t, ctx, inotifyFD)
+	want := []inotifyEvent{{WD: parentWD, Mask: linux.IN_DELETE | linux.IN_ISDIR, Name: "child"}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected inotify events after rmdir with open fd (-want +got):\n%s", diff)
+	}
+
+	childFD.DecRef(ctx)
+	got = readInotifyEvents(t, ctx, inotifyFD)
+	if len(got) < 2 {
+		t.Fatalf("expected at least delete-self and ignored events after close, got: %+v", got)
+	}
+	wantTail := []inotifyEvent{
+		{WD: childWD, Mask: linux.IN_DELETE_SELF},
+		{WD: childWD, Mask: linux.IN_IGNORED},
+	}
+	if diff := cmp.Diff(wantTail, got[len(got)-2:]); diff != "" {
+		t.Fatalf("unexpected trailing inotify events after close (-want +got):\n%s\nall events: %+v", diff, got)
+	}
 }

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -1462,6 +1462,13 @@ func (fs *filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 	fs.releaseDirIno(child.dirInoHash)
 	ds = appendDentry(ds, child)
 	parent.dirents = nil
+	// Match Linux's inotify event ordering: IN_DELETE_SELF on the child
+	// must precede IN_DELETE on the parent. Eagerly send it when no other
+	// refs exist; otherwise defer to destroyLocked (HandleDeletion is
+	// idempotent).
+	if child.refs.Load() == 0 {
+		child.watches.HandleDeletion(ctx)
+	}
 	parent.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0 /* cookie */, vfs.InodeEvent, true /* unlinked */)
 	return nil
 }

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -1462,6 +1462,13 @@ func (fs *filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 	fs.releaseDirIno(child.dirInoHash)
 	ds = appendDentry(ds, child)
 	parent.dirents = nil
+	// Linux sends the parent's IN_DELETE|IN_ISDIR at rmdir() time, but
+	// defers the child's IN_DELETE_SELF/IN_IGNORED until the last ref is
+	// dropped. Emit the child notifications now only when no extra refs
+	// remain; otherwise defer to destroyLocked().
+	if child.refs.Load() == 0 {
+		child.watches.HandleDeletion(ctx)
+	}
 	parent.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0 /* cookie */, vfs.InodeEvent, true /* unlinked */)
 	return nil
 }

--- a/pkg/sentry/fsimpl/tmpfs/filesystem.go
+++ b/pkg/sentry/fsimpl/tmpfs/filesystem.go
@@ -733,11 +733,14 @@ func (fs *filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 		return err
 	}
 	parentDir.removeChildLocked(child)
-	parentDir.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
-	// Remove links for child, child/., and child/..
+	// Match Linux's inotify event ordering for rmdir. Dropping the child's
+	// links may synchronously trigger HandleDeletion() when no extra refs
+	// exist, so notify the parent only after decLinksLocked(). If refs
+	// remain, deletion stays deferred until the last one is dropped.
 	child.inode.decLinksLocked(ctx)
 	child.inode.decLinksLocked(ctx)
 	parentDir.inode.decLinksLocked(ctx)
+	parentDir.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
 	toDecRef = vfsObj.CommitDeleteDentry(ctx, &child.vfsd)
 	parentDir.inode.touchCMtime()
 	return nil

--- a/pkg/sentry/fsimpl/tmpfs/filesystem.go
+++ b/pkg/sentry/fsimpl/tmpfs/filesystem.go
@@ -733,11 +733,14 @@ func (fs *filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 		return err
 	}
 	parentDir.removeChildLocked(child)
-	parentDir.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
-	// Remove links for child, child/., and child/..
+	// Linux sends the parent's IN_DELETE|IN_ISDIR at rmdir() time, but
+	// defers the child's IN_DELETE_SELF/IN_IGNORED until the last ref is
+	// dropped. decLinksLocked() may emit the child notifications
+	// immediately when no extra refs remain, so notify the parent after it.
 	child.inode.decLinksLocked(ctx)
 	child.inode.decLinksLocked(ctx)
 	parentDir.inode.decLinksLocked(ctx)
+	parentDir.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
 	toDecRef = vfsObj.CommitDeleteDentry(ctx, &child.vfsd)
 	parentDir.inode.touchCMtime()
 	return nil

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -1110,9 +1110,11 @@ cc_binary(
     linkstatic = 1,
     malloc = "//test/util:errno_safe_allocator",
     deps = [
+        "//test/util:capability_util",
         "//test/util:epoll_util",
         "//test/util:file_descriptor",
         "//test/util:fs_util",
+        "//test/util:mount_util",
         "//test/util:multiprocess_util",
         "//test/util:posix_error",
         "//test/util:temp_path",

--- a/test/syscalls/linux/inotify.cc
+++ b/test/syscalls/linux/inotify.cc
@@ -33,9 +33,11 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "test/util/capability_util.h"
 #include "test/util/epoll_util.h"
 #include "test/util/file_descriptor.h"
 #include "test/util/fs_util.h"
+#include "test/util/mount_util.h"
 #include "test/util/multiprocess_util.h"
 #include "test/util/posix_error.h"
 #include "test/util/temp_path.h"
@@ -698,6 +700,125 @@ TEST(Inotify, RmdirOnWatchedTargetGeneratesEvent) {
   const std::vector<Event> events =
       ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
   ASSERT_THAT(events, Are({Event(IN_DELETE_SELF, wd), Event(IN_IGNORED, wd)}));
+}
+
+TEST(Inotify, RmdirGeneratesDeleteSelfBeforeParentDelete) {
+  const TempPath parent = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  TempPath child = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(parent.path()));
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+
+  const int parent_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), parent.path(), IN_ALL_EVENTS));
+  const int child_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), child.path(), IN_ALL_EVENTS));
+
+  const std::string child_path = child.release();
+  EXPECT_THAT(rmdir(child_path.c_str()), SyscallSucceeds());
+
+  const std::vector<Event> events =
+      ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_THAT(events,
+              Are({Event(IN_DELETE_SELF, child_wd), Event(IN_IGNORED, child_wd),
+                   Event(IN_DELETE | IN_ISDIR, parent_wd,
+                         Basename(child_path))}));
+}
+
+TEST(Inotify, RmdirWithOpenDirFdDefersDeleteSelfUntilClose) {
+  const TempPath parent = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  TempPath child = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(parent.path()));
+  FileDescriptor child_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open(child.path(), O_RDONLY | O_DIRECTORY));
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+
+  const int parent_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), parent.path(), IN_ALL_EVENTS));
+  const int child_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), child.path(), IN_ALL_EVENTS));
+
+  const std::string child_path = child.release();
+  EXPECT_THAT(rmdir(child_path.c_str()), SyscallSucceeds());
+
+  std::vector<Event> events = ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_THAT(events,
+              Are({Event(IN_DELETE | IN_ISDIR, parent_wd,
+                         Basename(child_path))}));
+
+  child_fd.reset();
+  events = ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_GE(events.size(), 2);
+  EXPECT_EQ(events[events.size() - 2].wd, child_wd);
+  EXPECT_EQ(events[events.size() - 2].mask, IN_DELETE_SELF);
+  EXPECT_TRUE(events[events.size() - 2].name.empty());
+  EXPECT_EQ(events[events.size() - 1].wd, child_wd);
+  EXPECT_EQ(events[events.size() - 1].mask, IN_IGNORED);
+  EXPECT_TRUE(events[events.size() - 1].name.empty());
+}
+
+TEST(Inotify, TmpfsRmdirGeneratesDeleteSelfBeforeParentDelete) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  const TempPath mountpoint = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  const auto mount = ASSERT_NO_ERRNO_AND_VALUE(
+      Mount("", mountpoint.path(), "tmpfs", 0, "", 0));
+  const TempPath parent =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(mountpoint.path()));
+  TempPath child = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(parent.path()));
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+
+  const int parent_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), parent.path(), IN_ALL_EVENTS));
+  const int child_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), child.path(), IN_ALL_EVENTS));
+
+  const std::string child_path = child.release();
+  EXPECT_THAT(rmdir(child_path.c_str()), SyscallSucceeds());
+
+  const std::vector<Event> events =
+      ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_THAT(events,
+              Are({Event(IN_DELETE_SELF, child_wd), Event(IN_IGNORED, child_wd),
+                   Event(IN_DELETE | IN_ISDIR, parent_wd,
+                         Basename(child_path))}));
+}
+
+TEST(Inotify, TmpfsRmdirWithOpenDirFdDefersDeleteSelfUntilClose) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  const TempPath mountpoint = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  const auto mount = ASSERT_NO_ERRNO_AND_VALUE(
+      Mount("", mountpoint.path(), "tmpfs", 0, "", 0));
+  const TempPath parent =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(mountpoint.path()));
+  TempPath child = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(parent.path()));
+  FileDescriptor child_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open(child.path(), O_RDONLY | O_DIRECTORY));
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+
+  const int parent_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), parent.path(), IN_ALL_EVENTS));
+  const int child_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), child.path(), IN_ALL_EVENTS));
+
+  const std::string child_path = child.release();
+  EXPECT_THAT(rmdir(child_path.c_str()), SyscallSucceeds());
+
+  std::vector<Event> events = ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_THAT(events,
+              Are({Event(IN_DELETE | IN_ISDIR, parent_wd,
+                         Basename(child_path))}));
+
+  child_fd.reset();
+  events = ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_THAT(events,
+              Are({Event(IN_CLOSE_NOWRITE | IN_ISDIR, parent_wd,
+                         Basename(child_path)),
+                   Event(IN_CLOSE_NOWRITE | IN_ISDIR, child_wd),
+                   Event(IN_DELETE_SELF, child_wd),
+                   Event(IN_IGNORED, child_wd)}));
 }
 
 TEST(Inotify, MoveGeneratesEvents) {

--- a/test/syscalls/linux/inotify.cc
+++ b/test/syscalls/linux/inotify.cc
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 
+#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
@@ -698,6 +699,67 @@ TEST(Inotify, RmdirOnWatchedTargetGeneratesEvent) {
   const std::vector<Event> events =
       ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
   ASSERT_THAT(events, Are({Event(IN_DELETE_SELF, wd), Event(IN_IGNORED, wd)}));
+}
+
+// No extra references: Linux emits the watched child's delete-self events
+// before the parent's IN_DELETE|IN_ISDIR.
+TEST(Inotify, RmdirGeneratesDeleteSelfBeforeParentDelete) {
+  const TempPath parent = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  TempPath child = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(parent.path()));
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+
+  const int parent_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), parent.path(), IN_ALL_EVENTS));
+  const int child_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), child.path(), IN_ALL_EVENTS));
+
+  const std::string child_path = child.release();
+  EXPECT_THAT(rmdir(child_path.c_str()), SyscallSucceeds());
+
+  const std::vector<Event> events =
+      ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_THAT(events,
+              Are({Event(IN_DELETE_SELF, child_wd), Event(IN_IGNORED, child_wd),
+                   Event(IN_DELETE | IN_ISDIR, parent_wd,
+                         Basename(child_path))}));
+}
+
+// An open directory FD keeps the child alive: Linux still emits the
+// parent's IN_DELETE|IN_ISDIR at rmdir() time and defers delete-self
+// until close.
+TEST(Inotify, RmdirWithOpenDirFdDefersDeleteSelfUntilClose) {
+  const TempPath parent = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  TempPath child = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(parent.path()));
+  FileDescriptor child_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open(child.path(), O_RDONLY | O_DIRECTORY));
+  const FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+
+  const int parent_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), parent.path(), IN_ALL_EVENTS));
+  const int child_wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(fd.get(), child.path(), IN_ALL_EVENTS));
+
+  const std::string child_path = child.release();
+  EXPECT_THAT(rmdir(child_path.c_str()), SyscallSucceeds());
+
+  std::vector<Event> events = ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_THAT(events,
+              Are({Event(IN_DELETE | IN_ISDIR, parent_wd,
+                         Basename(child_path))}));
+
+  child_fd.reset();
+  // Some filesystems may also report close events here. The Linux behavior
+  // we care about is that delete-self is deferred until the final close.
+  events = ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(fd.get()));
+  ASSERT_GE(events.size(), 2);
+  EXPECT_EQ(events[events.size() - 2].wd, child_wd);
+  EXPECT_EQ(events[events.size() - 2].mask, IN_DELETE_SELF);
+  EXPECT_TRUE(events[events.size() - 2].name.empty());
+  EXPECT_EQ(events[events.size() - 1].wd, child_wd);
+  EXPECT_EQ(events[events.size() - 1].mask, IN_IGNORED);
+  EXPECT_TRUE(events[events.size() - 1].name.empty());
 }
 
 TEST(Inotify, MoveGeneratesEvents) {


### PR DESCRIPTION
Gradle File System Watching relies on the child watch receiving IN_DELETE_SELF/IN_IGNORED before the parent's IN_DELETE|IN_ISDIR to invalidate its VFS snapshot when a watched directory is removed.

Linux does not emit rmdir inotify events with a single unconditional ordering.

If the removed directory has no extra references, the child receives IN_DELETE_SELF/IN_IGNORED before the parent's IN_DELETE|IN_ISDIR.

If an extra reference remains, such as an open directory FD, Linux still emits the parent's IN_DELETE|IN_ISDIR at rmdir() time and defers the child's IN_DELETE_SELF/IN_IGNORED until the final reference is dropped.

Match that behavior across overlay, tmpfs, gofer, and kernfs by eagerly sending child deletion notifications only in the no-extra-ref case, and keeping the parent delete notification on the rmdir path.