### PR TITLE
net: Ensure deterministic interface enumeration order

### DIFF
--- a/pkg/sentry/fsimpl/proc/task_net.go
+++ b/pkg/sentry/fsimpl/proc/task_net.go
@@ -109,7 +109,9 @@ var _ dynamicInode = (*ifinet6)(nil)
 func (n *ifinet6) contents() []string {
 	var lines []string
 	nics := n.stack.Interfaces()
-	for id, naddrs := range n.stack.InterfaceAddrs() {
+	ifAddrs := n.stack.InterfaceAddrs()
+	for _, id := range n.stack.InterfaceIDs() {
+		naddrs := ifAddrs[id]
 		nic, ok := nics[id]
 		if !ok {
 			// NIC was added after NICNames was called. We'll just ignore it.
@@ -160,7 +162,8 @@ func (n *netDevData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	buf.WriteString("Inter-|   Receive                                                |  Transmit\n")
 	buf.WriteString(" face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n")
 
-	for _, i := range interfaces {
+	for _, idx := range n.stack.InterfaceIDs() {
+		i := interfaces[idx]
 		// Implements the same format as
 		// net/core/net-procfs.c:dev_seq_printf_stats.
 		var stats inet.StatDev

--- a/pkg/sentry/inet/inet.go
+++ b/pkg/sentry/inet/inet.go
@@ -38,6 +38,12 @@ type Stack interface {
 	// interface indexes to a slice of associated interface address properties.
 	InterfaceAddrs() map[int32][]InterfaceAddr
 
+	// InterfaceIDs returns all network interface indexes in a
+	// deterministic order matching the interface registration order.
+	// This matches Linux kernel behavior where interfaces are ordered
+	// by their ifindex in the dev_index_head hash table.
+	InterfaceIDs() []int32
+
 	// AddInterfaceAddr adds an address to the network interface identified by
 	// idx.
 	AddInterfaceAddr(idx int32, addr InterfaceAddr) error

--- a/pkg/sentry/inet/test_stack.go
+++ b/pkg/sentry/inet/test_stack.go
@@ -17,6 +17,8 @@ package inet
 import (
 	"bytes"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	"gvisor.dev/gvisor/pkg/context"
@@ -74,6 +76,13 @@ func (s *TestStack) SetInterface(ctx context.Context, msg *nlmsg.Message) *syser
 // InterfaceAddrs implements Stack.
 func (s *TestStack) InterfaceAddrs() map[int32][]InterfaceAddr {
 	return s.InterfaceAddrsMap
+}
+
+// InterfaceIDs implements Stack.
+// TestStack stores interfaces in a map, so we sort by ID to ensure
+// a deterministic order.
+func (s *TestStack) InterfaceIDs() []int32 {
+	return slices.Sorted(maps.Keys(s.InterfacesMap))
 }
 
 // AddInterfaceAddr implements Stack.

--- a/pkg/sentry/socket/hostinet/stack.go
+++ b/pkg/sentry/socket/hostinet/stack.go
@@ -17,8 +17,10 @@ package hostinet
 import (
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -149,6 +151,13 @@ func (s *Stack) Interfaces() map[int32]inet.Interface {
 		return nil
 	}
 	return ifs
+}
+
+// InterfaceIDs implements inet.Stack.InterfaceIDs.
+// hostinet reads interfaces from the host each time, so we sort by ID to
+// ensure a deterministic order consistent with interface registration order.
+func (s *Stack) InterfaceIDs() []int32 {
+	return slices.Sorted(maps.Keys(s.Interfaces()))
 }
 
 // RemoveInterface implements inet.Stack.RemoveInterface.

--- a/pkg/sentry/socket/netlink/route/protocol.go
+++ b/pkg/sentry/socket/netlink/route/protocol.go
@@ -17,8 +17,6 @@ package route
 
 import (
 	"bytes"
-	"maps"
-	"slices"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
@@ -102,8 +100,7 @@ func (p *Protocol) dumpLinks(ctx context.Context, s *netlink.Socket, msg *nlmsg.
 	}
 
 	ifaces := stack.Interfaces()
-	indexes := slices.Sorted(maps.Keys(ifaces))
-	for _, idx := range indexes {
+	for _, idx := range stack.InterfaceIDs() {
 		p.AddNewLinkMessage(ms, idx, ifaces[idx])
 	}
 
@@ -305,8 +302,9 @@ func (p *Protocol) dumpAddrs(ctx context.Context, s *netlink.Socket, msg *nlmsg.
 		return nil
 	}
 
-	for id, as := range stack.InterfaceAddrs() {
-		for _, a := range as {
+	ifAddrs := stack.InterfaceAddrs()
+	for _, id := range stack.InterfaceIDs() {
+		for _, a := range ifAddrs[id] {
 			m := ms.AddMessage(linux.NetlinkMessageHeader{
 				Type: linux.RTM_NEWADDR,
 			})

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -3738,9 +3738,10 @@ func ifconfIoctl(ctx context.Context, t *kernel.Task, _ usermem.IO, ifc *linux.I
 
 	max := ifc.Len
 	ifc.Len = 0
-	for key, ifaceAddrs := range stk.InterfaceAddrs() {
+	ifAddrs := stk.InterfaceAddrs()
+	for _, key := range stk.InterfaceIDs() {
 		iface := stk.Interfaces()[key]
-		for _, ifaceAddr := range ifaceAddrs {
+		for _, ifaceAddr := range ifAddrs[key] {
 			// Don't write past the end of the buffer.
 			if ifc.Len+int32(linux.SizeOfIFReq) > max {
 				break

--- a/pkg/sentry/socket/netstack/stack.go
+++ b/pkg/sentry/socket/netstack/stack.go
@@ -16,6 +16,8 @@ package netstack
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
@@ -151,6 +153,13 @@ func (s *Stack) Interfaces() map[int32]inet.Interface {
 		is[int32(id)] = makeInterfaceInfo(&ni)
 	}
 	return is
+}
+
+// InterfaceIDs implements inet.Stack.InterfaceIDs.
+func (s *Stack) InterfaceIDs() []int32 {
+	// Since gVisor allocates NIC IDs monotonically (like Linux ifindex),
+	// sorting by ID is equivalent to registration order.
+	return slices.Sorted(maps.Keys(s.Interfaces()))
 }
 
 // RemoveInterface implements inet.Stack.RemoveInterface.

--- a/pkg/sentry/socket/plugin/stack/socket.go
+++ b/pkg/sentry/socket/plugin/stack/socket.go
@@ -422,7 +422,9 @@ func ifconfIoctlFromStack(ctx context.Context, io usermem.IO, ifc *linux.IFConf)
 
 	max := ifc.Len
 	ifc.Len = 0
-	for idx, iface := range s.Interfaces() {
+	ifaces := s.Interfaces()
+	for _, idx := range s.InterfaceIDs() {
+		iface := ifaces[idx]
 		ifaceAddrs := s.InterfaceAddrs()[idx]
 		for _, ifaceAddr := range ifaceAddrs {
 			if ifaceAddr.Family != syscall.AF_INET {

--- a/pkg/sentry/socket/plugin/stack/stack.go
+++ b/pkg/sentry/socket/plugin/stack/stack.go
@@ -64,6 +64,12 @@ func (s *Stack) InterfaceAddrs() map[int32][]inet.InterfaceAddr {
 	return make(map[int32][]inet.InterfaceAddr)
 }
 
+// InterfaceIDs implements inet.Stack.InterfaceIDs.
+func (s *Stack) InterfaceIDs() []int32 {
+	// TODO: support InterfaceIDs
+	return nil
+}
+
 // AddInterfaceAddr implements inet.Stack.AddInterfaceAddr.
 func (s *Stack) AddInterfaceAddr(idx int32, addr inet.InterfaceAddr) error {
 	return linuxerr.EACCES

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -3612,6 +3612,7 @@ cc_binary(
         "//test/util:capability_util",
         "//test/util:cleanup",
         "//test/util:file_descriptor",
+        "//test/util:fs_util",
         "//test/util:logging",
         "//test/util:multiprocess_util",
         "//test/util:posix_error",

--- a/test/syscalls/linux/socket_netlink_route.cc
+++ b/test/syscalls/linux/socket_netlink_route.cc
@@ -22,6 +22,7 @@
 #include <linux/veth.h>
 #include <net/if.h>
 #include <poll.h>
+#include <sstream>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -43,6 +44,7 @@
 #include "test/syscalls/linux/socket_netlink_util.h"
 #include "test/util/cleanup.h"
 #include "test/util/file_descriptor.h"
+#include "test/util/fs_util.h"
 #include "test/util/linux_capability_util.h"
 #include "test/util/logging.h"
 #include "test/util/multiprocess_util.h"
@@ -1795,6 +1797,61 @@ struct VethRequest GetVethRequest(uint32_t seq, const char* ifname_first,
   return req;
 }
 
+void DumpInetAddressSequence(std::vector<std::string>* sequence) {
+  struct ifaddrs* if_addr_list = nullptr;
+  ASSERT_THAT(getifaddrs(&if_addr_list), SyscallSucceeds());
+  auto cleanup = Cleanup([&if_addr_list]() { freeifaddrs(if_addr_list); });
+
+  sequence->clear();
+  for (struct ifaddrs* i = if_addr_list; i; i = i->ifa_next) {
+    if (!i->ifa_addr || (i->ifa_addr->sa_family != AF_INET &&
+                         i->ifa_addr->sa_family != AF_INET6)) {
+      continue;
+    }
+    char buf[INET6_ADDRSTRLEN] = {};
+    switch (i->ifa_addr->sa_family) {
+      case AF_INET:
+        inet_ntop(AF_INET,
+                  &(reinterpret_cast<const struct sockaddr_in*>(i->ifa_addr)
+                        ->sin_addr),
+                  buf, sizeof(buf));
+        break;
+      case AF_INET6:
+        inet_ntop(AF_INET6,
+                  &(reinterpret_cast<const struct sockaddr_in6*>(i->ifa_addr)
+                        ->sin6_addr),
+                  buf, sizeof(buf));
+        break;
+    }
+    sequence->push_back(absl::StrFormat("%s/%d/%s", i->ifa_name,
+                                        i->ifa_addr->sa_family, buf));
+  }
+}
+
+void ReadProcNetDevInterfaceNames(std::vector<std::string>* names) {
+  names->clear();
+  const std::string contents =
+      ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/net/dev"));
+  std::istringstream input(contents);
+  std::string line;
+  for (int line_no = 0; std::getline(input, line); ++line_no) {
+    if (line_no < 2) {
+      continue;
+    }
+    const size_t colon = line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    std::string name = line.substr(0, colon);
+    const size_t first = name.find_first_not_of(" \t");
+    if (first == std::string::npos) {
+      continue;
+    }
+    const size_t last = name.find_last_not_of(" \t");
+    names->push_back(name.substr(first, last - first + 1));
+  }
+}
+
 TEST(NetlinkRouteTest, VethAdd) {
   SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
   SKIP_IF(IsRunningWithHostinet());
@@ -1833,6 +1890,18 @@ TEST(NetlinkRouteTest, LookupAllAddrOrder) {
     }
     ASSERT_TRUE(std::is_sorted(addrs_family.begin(), addrs_family.end()));
     freeifaddrs(if_addr_list);
+  }
+}
+
+TEST(NetlinkRouteTest, LookupAllAddrStableAcrossCalls) {
+  std::vector<std::string> baseline;
+  DumpInetAddressSequence(&baseline);
+  ASSERT_FALSE(baseline.empty());
+
+  for (int i = 0; i < 10; ++i) {
+    std::vector<std::string> current;
+    DumpInetAddressSequence(&current);
+    EXPECT_EQ(current, baseline);
   }
 }
 
@@ -1880,6 +1949,35 @@ TEST(NetlinkRouteTest, LinIndexOrder) {
       << "Expected at least 3 veth pairs to be found";
   ASSERT_TRUE(std::is_sorted(found_indexes.begin(), found_indexes.end()))
       << "Link indexes are not in ascending order";
+}
+
+TEST(NetlinkRouteTest, ProcNetDevStableAcrossCalls) {
+  SKIP_IF(IsRunningWithHostinet());
+
+  // Avoid a temporary netns here: in gVisor `/proc/net/*` is not yet
+  // guaranteed to follow `unshare(CLONE_NEWNET)` (gvisor.dev/issue/1833).
+  // Native Linux may also see concurrent device churn, so only check that
+  // baseline interfaces keep the same relative order.
+  std::vector<std::string> baseline;
+  ReadProcNetDevInterfaceNames(&baseline);
+  ASSERT_FALSE(baseline.empty());
+
+  for (int i = 0; i < 10; ++i) {
+    std::vector<std::string> current;
+    ReadProcNetDevInterfaceNames(&current);
+
+    std::vector<size_t> baseline_positions;
+    baseline_positions.reserve(current.size());
+    for (const std::string& name : current) {
+      auto it = std::find(baseline.begin(), baseline.end(), name);
+      if (it == baseline.end()) {
+        continue;
+      }
+      baseline_positions.push_back(std::distance(baseline.begin(), it));
+    }
+    EXPECT_TRUE(std::is_sorted(baseline_positions.begin(),
+                               baseline_positions.end()));
+  }
 }
 
 struct NetNSRequest {


### PR DESCRIPTION
Go map iteration randomness causes network interface enumeration (getifaddrs, RTM_GETADDR, RTM_GETLINK, /proc/net/*, SIOCGIFCONF) to return nondeterministic order, breaking applications like asciidoctor that expect stable ordering across repeated calls.

Since gVisor allocates NIC IDs monotonically (like Linux ifindex), sorting by NICID is equivalent to registration order. Add InterfaceIDs() to inet.Stack so all consumer paths iterate in deterministic ascending-ID order without ad-hoc sorting at each call site.