### PR TITLE
overlay,gofer: support gofer filesystem as overlay upper layer

### DIFF
--- a/pkg/sentry/fsimpl/gofer/BUILD
+++ b/pkg/sentry/fsimpl/gofer/BUILD
@@ -126,6 +126,7 @@ go_library(
         "//pkg/sentry/socket/unix/transport",
         "//pkg/sentry/usage",
         "//pkg/sentry/vfs",
+        "//pkg/sentry/vfs/memxattr",
         "//pkg/sync",
         "//pkg/syserr",
         "//pkg/unet",

--- a/pkg/sentry/fsimpl/gofer/directfs_inode.go
+++ b/pkg/sentry/fsimpl/gofer/directfs_inode.go
@@ -560,17 +560,16 @@ func (i *directfsInode) mknod(ctx context.Context, name string, creds *auth.Cred
 	// "EPERM: [...] if the filesystem containing pathname does not support
 	// the type of node requested."
 	//
-	// Allow regular files and whiteout char devices (char 0,0). Whiteout
-	// devices are used by overlayfs to mark deleted files in the upper
-	// layer. This enables Docker overlay2 to use gofer as an upper layer.
+	// Allow regular files and overlayfs whiteouts (char 0,0). Linux's
+	// vfs_mknod() exempts whiteouts from the CAP_MKNOD check, so we do
+	// not need CAP_MKNOD on the gofer process. This enables Docker
+	// overlay2 to use gofer as an upper layer.
 	isWhiteout := opts.Mode.FileType() == linux.ModeCharacterDevice &&
-		linux.MakeDeviceID(uint16(opts.DevMajor), opts.DevMinor) == linux.WHITEOUT_DEV
+		opts.DevMajor == 0 && opts.DevMinor == 0
 	if opts.Mode.FileType() != linux.ModeRegular && !isWhiteout {
 		return nil, unix.EPERM
 	}
-
-	dev := int(linux.MakeDeviceID(uint16(opts.DevMajor), opts.DevMinor))
-	if err := unix.Mknodat(i.controlFD, name, uint32(opts.Mode), dev); err != nil {
+	if err := unix.Mknodat(i.controlFD, name, uint32(opts.Mode), 0); err != nil {
 		return nil, err
 	}
 	return i.getCreatedChild(name, creds.EffectiveKUID, creds.EffectiveKGID, false /* isDir */, true /* createDentry */, d)

--- a/pkg/sentry/fsimpl/gofer/directfs_inode.go
+++ b/pkg/sentry/fsimpl/gofer/directfs_inode.go
@@ -559,11 +559,18 @@ func (i *directfsInode) mknod(ctx context.Context, name string, creds *auth.Cred
 	// From mknod(2) man page:
 	// "EPERM: [...] if the filesystem containing pathname does not support
 	// the type of node requested."
-	if opts.Mode.FileType() != linux.ModeRegular {
+	//
+	// Allow regular files and whiteout char devices (char 0,0). Whiteout
+	// devices are used by overlayfs to mark deleted files in the upper
+	// layer. This enables Docker overlay2 to use gofer as an upper layer.
+	isWhiteout := opts.Mode.FileType() == linux.ModeCharacterDevice &&
+		linux.MakeDeviceID(uint16(opts.DevMajor), opts.DevMinor) == linux.WHITEOUT_DEV
+	if opts.Mode.FileType() != linux.ModeRegular && !isWhiteout {
 		return nil, unix.EPERM
 	}
 
-	if err := unix.Mknodat(i.controlFD, name, uint32(opts.Mode), 0); err != nil {
+	dev := int(linux.MakeDeviceID(uint16(opts.DevMajor), opts.DevMinor))
+	if err := unix.Mknodat(i.controlFD, name, uint32(opts.Mode), dev); err != nil {
 		return nil, err
 	}
 	return i.getCreatedChild(name, creds.EffectiveKUID, creds.EffectiveKGID, false /* isDir */, true /* createDentry */, d)

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -1493,9 +1493,14 @@ func (d *dentry) checkXattrPermissions(creds *auth.Credentials, name string, ats
 	// to the remote filesystem. This is inconsistent with Linux's 9p client,
 	// but consistent with other filesystems (e.g. FUSE).
 	//
-	// NOTE(b/202533394): Also disallow "trusted" namespace for now. This is
-	// consistent with the VFS1 gofer client.
-	if strings.HasPrefix(name, linux.XATTR_SYSTEM_PREFIX) || strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX) {
+	// NOTE(b/202533394): Disallow most of the "trusted" namespace.
+	// Allow "trusted.overlay." xattrs, which are used by overlayfs to
+	// mark opaque directories. This enables Docker overlay2 to use
+	// gofer as an upper layer.
+	if strings.HasPrefix(name, linux.XATTR_SYSTEM_PREFIX) {
+		return linuxerr.EOPNOTSUPP
+	}
+	if strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX) && !strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX+"overlay.") {
 		return linuxerr.EOPNOTSUPP
 	}
 	// Do not allow writes to the "security" namespace on the host filesystem.

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -68,12 +68,19 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
 	"gvisor.dev/gvisor/pkg/sentry/socket/unix/transport"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/sentry/vfs/memxattr"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/unet"
 )
 
 // Name is the default filesystem name.
 const Name = "9p"
+
+// Overlay xattr namespaces emulated in the sentry; see isOverlayXattr.
+const (
+	overlayTrustedPrefix = linux.XATTR_TRUSTED_PREFIX + "overlay."
+	overlayUserPrefix    = linux.XATTR_USER_PREFIX + "overlay."
+)
 
 // Mount option names for goferfs.
 const (
@@ -962,6 +969,14 @@ type inode struct {
 
 	locks vfs.FileLocks
 
+	// overlayXattrs stores trusted.overlay.* and user.overlay.* xattrs
+	// in the sentry rather than sending them to the gofer/host, because
+	// (a) the gofer process lacks CAP_SYS_ADMIN, which Linux requires for
+	// trusted.* xattrs, and (b) the overlay consumer is the sentry itself
+	// so host persistence is not required. The pointer is nil until the
+	// first setxattr allocates the map.
+	overlayXattrs atomic.Pointer[memxattr.SimpleExtendedAttributes] `state:"nosave"`
+
 	// Inotify watches for this inode.
 	//
 	// Note that inotify may behave unexpectedly in the presence of hard links,
@@ -1495,12 +1510,13 @@ func (d *dentry) checkXattrPermissions(creds *auth.Credentials, name string, ats
 	//
 	// NOTE(b/202533394): Disallow most of the "trusted" namespace.
 	// Allow "trusted.overlay." xattrs, which are used by overlayfs to
-	// mark opaque directories. This enables Docker overlay2 to use
-	// gofer as an upper layer.
+	// mark opaque directories; these are emulated in-sentry by
+	// overlayXattrs below. This enables Docker overlay2 to use gofer as
+	// an upper layer.
 	if strings.HasPrefix(name, linux.XATTR_SYSTEM_PREFIX) {
 		return linuxerr.EOPNOTSUPP
 	}
-	if strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX) && !strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX+"overlay.") {
+	if strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX) && !strings.HasPrefix(name, overlayTrustedPrefix) {
 		return linuxerr.EOPNOTSUPP
 	}
 	// Do not allow writes to the "security" namespace on the host filesystem.
@@ -1946,12 +1962,39 @@ func (d *dentry) listXattr(ctx context.Context, size uint64) ([]string, error) {
 	return d.listXattrImpl(ctx, size)
 }
 
+// isOverlayXattr reports whether name is an overlay metadata xattr that
+// this filesystem emulates in-memory rather than forwarding to the gofer.
+func isOverlayXattr(name string) bool {
+	return strings.HasPrefix(name, overlayTrustedPrefix) ||
+		strings.HasPrefix(name, overlayUserPrefix)
+}
+
+// overlayXattrsOrLazy returns the per-inode overlay xattr store, allocating
+// it on first use.
+func (i *inode) overlayXattrsOrLazy() *memxattr.SimpleExtendedAttributes {
+	if x := i.overlayXattrs.Load(); x != nil {
+		return x
+	}
+	nx := &memxattr.SimpleExtendedAttributes{}
+	if i.overlayXattrs.CompareAndSwap(nil, nx) {
+		return nx
+	}
+	return i.overlayXattrs.Load()
+}
+
 func (d *dentry) getXattr(ctx context.Context, creds *auth.Credentials, opts *vfs.GetXattrOptions) (string, error) {
 	if d.inode.isSynthetic() {
 		return "", linuxerr.ENODATA
 	}
 	if err := d.checkXattrPermissions(creds, opts.Name, vfs.MayRead); err != nil {
 		return "", err
+	}
+	if isOverlayXattr(opts.Name) {
+		x := d.inode.overlayXattrs.Load()
+		if x == nil {
+			return "", linuxerr.ENODATA
+		}
+		return x.GetXattr(creds, linux.FileMode(d.inode.mode.Load()), auth.KUID(d.inode.uid.Load()), opts)
 	}
 	return d.getXattrImpl(ctx, opts)
 }
@@ -1963,6 +2006,10 @@ func (d *dentry) setXattr(ctx context.Context, creds *auth.Credentials, opts *vf
 	if err := d.checkXattrPermissions(creds, opts.Name, vfs.MayWrite); err != nil {
 		return err
 	}
+	if isOverlayXattr(opts.Name) {
+		return d.inode.overlayXattrsOrLazy().SetXattr(
+			creds, linux.FileMode(d.inode.mode.Load()), auth.KUID(d.inode.uid.Load()), auth.KGID(d.inode.gid.Load()), opts)
+	}
 	return d.setXattrImpl(ctx, opts)
 }
 
@@ -1972,6 +2019,13 @@ func (d *dentry) removeXattr(ctx context.Context, creds *auth.Credentials, name 
 	}
 	if err := d.checkXattrPermissions(creds, name, vfs.MayWrite); err != nil {
 		return err
+	}
+	if isOverlayXattr(name) {
+		x := d.inode.overlayXattrs.Load()
+		if x == nil {
+			return linuxerr.ENODATA
+		}
+		return x.RemoveXattr(creds, linux.FileMode(d.inode.mode.Load()), auth.KUID(d.inode.uid.Load()), name)
 	}
 	return d.inode.removeXattrImpl(ctx, name)
 }

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -1278,6 +1278,40 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 		return err
 	}
 
+	// Before committing the rename into the overlay's dentry tree, perform
+	// the upper-layer bookkeeping that overlayfs semantics require:
+	//   1. A whiteout at the origin, so the lower layer's preexisting entry
+	//      (if any) does not reappear at oldpop.
+	//   2. The overlay opaque marker on the new directory, so lookups at
+	//      newpop do not merge the contents of a preexisting lower
+	//      directory of the same name into the renamed directory.
+	//
+	// If either step fails we undo the upper-layer rename and return the
+	// error. Only if the undo itself fails do we fall back to a panic --
+	// that represents a genuinely inconsistent upper filesystem that we
+	// cannot drive further.
+	renameUndo := func(reason error) error {
+		undoOpts := vfs.RenameOptions{}
+		if uerr := vfsObj.RenameAt(ctx, creds, &newpop, &oldpop, &undoOpts); uerr != nil {
+			panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: %v; undo rename also failed: %v", reason, uerr))
+		}
+		vfsObj.AbortRenameDentry(&renamed.vfsd, replacedVFSD)
+		return reason
+	}
+	if err := CreateWhiteout(ctx, vfsObj, fs.creds, &oldpop); err != nil {
+		return renameUndo(err)
+	}
+	if renamed.isDir() {
+		if err := vfsObj.SetXattrAt(ctx, fs.creds, &newpop, &vfs.SetXattrOptions{
+			Name:  fs.xattrOpaque,
+			Value: "y",
+		}); err != nil {
+			// Best-effort: remove the whiteout before undoing the rename.
+			_ = vfsObj.UnlinkAt(ctx, fs.creds, &oldpop)
+			return renameUndo(err)
+		}
+	}
+
 	// Below this point, the renamed dentry is now at newpop, and anything we
 	// replaced is gone forever. Commit the rename, update the overlay
 	// filesystem tree, and abandon attempts to recover from errors.
@@ -1306,18 +1340,6 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 	}
 	newParent.children[newName] = renamed
 	oldParent.dirents = nil
-
-	if err := CreateWhiteout(ctx, vfsObj, fs.creds, &oldpop); err != nil {
-		panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to create whiteout at origin after RenameAt: %v", err))
-	}
-	if renamed.isDir() {
-		if err := vfsObj.SetXattrAt(ctx, fs.creds, &newpop, &vfs.SetXattrOptions{
-			Name:  fs.xattrOpaque,
-			Value: "y",
-		}); err != nil {
-			panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to make renamed directory opaque: %v", err))
-		}
-	}
 
 	vfs.InotifyRename(ctx, &renamed.watches, &oldParent.watches, &newParent.watches, oldName, newName, renamed.isDir())
 	return nil

--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -235,13 +235,21 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			ctx.Infof("overlay.FilesystemType.GetFilesystem: failed to resolve upperdir %q: %v", upperPathname, err)
 			return nil, nil, err
 		}
-		// TODO(b/286942303): Only tmpfs supports whiteouts and overlay
-		// xattrs (trusted.overlay.* or user.overlay.*). Don't allow
-		// non-tmpfs mounts on upper levels for mounts created through
-		// the mount syscall. In gVisor configs, users can specify any
-		// configurations on their own risk.
-		if !opts.InternalMount && upperRoot.Mount().Filesystem().FilesystemType().Name() != "tmpfs" {
-			return nil, nil, linuxerr.EINVAL
+		// Only filesystems that support whiteouts (char 0,0 devices)
+		// and overlay xattrs (trusted.overlay.* or user.overlay.*) can
+		// be used as overlay upper layers. For mounts created through
+		// the mount syscall (not internal), restrict to tmpfs and gofer
+		// ("9p"). Gofer support enables Docker overlay2 inside gVisor
+		// containers when the rootfs overlay is disabled
+		// (--overlay2=none); the sentry emulates the overlay xattrs
+		// for gofer upper layers. See
+		// pkg/sentry/fsimpl/gofer/gofer.go:overlayXattrPrefix.
+		if !opts.InternalMount {
+			fsName := upperRoot.Mount().Filesystem().FilesystemType().Name()
+			if fsName != "tmpfs" && fsName != "9p" {
+				upperRoot.DecRef(ctx)
+				return nil, nil, linuxerr.EINVAL
+			}
 		}
 		privateUpperRoot, err := clonePrivateMount(vfsObj, upperRoot, false /* forceReadOnly */)
 		upperRoot.DecRef(ctx)

--- a/runsc/fsgofer/lisafs.go
+++ b/runsc/fsgofer/lisafs.go
@@ -648,10 +648,13 @@ func (fd *controlFDLisa) Mkdir(mode linux.FileMode, uid lisafs.UID, gid lisafs.G
 
 // Mknod implements lisafs.ControlFDImpl.Mknod.
 func (fd *controlFDLisa) Mknod(mode linux.FileMode, uid lisafs.UID, gid lisafs.GID, name string, minor uint32, major uint32) (*lisafs.ControlFD, lisafs.Statx, error) {
-	// From mknod(2) man page:
-	// "EPERM: [...] if the filesystem containing pathname does not support
-	// the type of node requested."
-	if mode.FileType() != linux.ModeRegular {
+	// Allow regular files and overlayfs whiteouts (char 0,0). Linux's
+	// vfs_mknod() exempts whiteouts from the CAP_MKNOD check, so we do
+	// not need CAP_MKNOD on the gofer process. See the matching change
+	// in pkg/sentry/fsimpl/gofer/directfs_inode.go:mknod.
+	isWhiteout := mode.FileType() == linux.ModeCharacterDevice &&
+		major == 0 && minor == 0
+	if mode.FileType() != linux.ModeRegular && !isWhiteout {
 		return nil, lisafs.Statx{}, unix.EPERM
 	}
 

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -2780,6 +2780,164 @@ TEST(MountTest, TrustedOverlayXattrOnGofer) {
       SyscallFailsWithErrno(EOPNOTSUPP));
 }
 
+// -- Regression tests for overlay-on-gofer --
+//
+// These tests document bugs that arise when 9p/gofer is allowed as an
+// overlay upper layer and exercise the fixes in:
+//   pkg/sentry/fsimpl/overlay/filesystem.go (rename panic -> EOPNOTSUPP)
+//   pkg/sentry/fsimpl/gofer/gofer.go       (trusted.overlay.* / user.overlay.*
+//                                           emulation)
+
+namespace gofer_overlay_regression {
+
+constexpr uint32_t kV9fsMagic = 0x01021997;
+
+inline bool IsGoferMount(const std::string& path) {
+  struct statfs s;
+  if (statfs(path.c_str(), &s) != 0) return false;
+  return static_cast<uint32_t>(s.f_type) == kV9fsMagic;
+}
+
+struct OverlayDirs {
+  TempPath base;
+  TempPath lower;
+  TempPath upper;
+  TempPath work;
+  TempPath merged;
+  std::string mount_opts;
+};
+
+inline PosixErrorOr<OverlayDirs> MakeOverlayDirsOnGofer() {
+  ASSIGN_OR_RETURN_ERRNO(auto base, TempPath::CreateDirIn("/"));
+  ASSIGN_OR_RETURN_ERRNO(auto lower, TempPath::CreateDirIn(base.path()));
+  ASSIGN_OR_RETURN_ERRNO(auto upper, TempPath::CreateDirIn(base.path()));
+  ASSIGN_OR_RETURN_ERRNO(auto work, TempPath::CreateDirIn(base.path()));
+  ASSIGN_OR_RETURN_ERRNO(auto merged, TempPath::CreateDirIn(base.path()));
+  std::string opts = "lowerdir=" + lower.path() + ",upperdir=" + upper.path() +
+                     ",workdir=" + work.path();
+  return OverlayDirs{std::move(base),   std::move(lower),  std::move(upper),
+                     std::move(work),   std::move(merged), std::move(opts)};
+}
+
+}  // namespace gofer_overlay_regression
+
+using gofer_overlay_regression::IsGoferMount;
+using gofer_overlay_regression::MakeOverlayDirsOnGofer;
+
+// trusted.overlay.opaque setxattr/getxattr/removexattr must roundtrip on a
+// gofer mount (emulated in the sentry since the gofer lacks CAP_SYS_ADMIN).
+TEST(MountTest, GoferOverlayOpaqueXattrRoundtrip) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+  SKIP_IF(!IsGoferMount("/"));
+
+  auto dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn("/"));
+
+  ASSERT_THAT(setxattr(dir.path().c_str(), "trusted.overlay.opaque", "y", 1,
+                       0),
+              SyscallSucceeds())
+      << "setxattr trusted.overlay.opaque must be supported on gofer for"
+         " the overlay filesystem to function correctly";
+
+  char buf[16] = {};
+  EXPECT_THAT(
+      getxattr(dir.path().c_str(), "trusted.overlay.opaque", buf, sizeof(buf)),
+      SyscallSucceedsWithValue(1));
+  EXPECT_EQ(buf[0], 'y');
+
+  EXPECT_THAT(removexattr(dir.path().c_str(), "trusted.overlay.opaque"),
+              SyscallSucceeds());
+  EXPECT_THAT(
+      getxattr(dir.path().c_str(), "trusted.overlay.opaque", buf, sizeof(buf)),
+      SyscallFailsWithErrno(ENODATA));
+}
+
+// mkdir over a whiteout on overlay-on-gofer must succeed. Requires the
+// overlay to be able to set trusted.overlay.opaque on the new upper dir.
+TEST(MountTest, OverlayOnGoferMkdirOverWhiteoutSucceeds) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+  SKIP_IF(!IsGoferMount("/"));
+
+  auto dirs = ASSERT_NO_ERRNO_AND_VALUE(MakeOverlayDirsOnGofer());
+  std::string dname = dirs.lower.path() + "/foo";
+  ASSERT_THAT(mkdir(dname.c_str(), 0755), SyscallSucceeds());
+
+  ASSERT_THAT(mount("overlay", dirs.merged.path().c_str(), "overlay", 0,
+                    dirs.mount_opts.c_str()),
+              SyscallSucceeds());
+  auto cleanup = Cleanup(
+      [&dirs] { umount2(dirs.merged.path().c_str(), MNT_DETACH); });
+
+  // Remove foo through the overlay -> whiteout appears in upper.
+  std::string mfoo = dirs.merged.path() + "/foo";
+  ASSERT_THAT(rmdir(mfoo.c_str()), SyscallSucceeds());
+
+  // Re-create foo through the overlay (ovl_create_over_whiteout path).
+  EXPECT_THAT(mkdir(mfoo.c_str(), 0755), SyscallSucceeds())
+      << "mkdir over a whiteout on overlay-on-gofer must succeed; this"
+         " pattern appears in Docker image layer extraction.";
+}
+
+// rename(2) of a directory through overlay-on-gofer must not panic the
+// sandbox. Prior to the fix this produced:
+//   panic("unrecoverable overlayfs inconsistency: failed to make renamed
+//          directory opaque: operation not supported on transport endpoint")
+// in pkg/sentry/fsimpl/overlay/filesystem.go.
+TEST(MountTest, OverlayOnGoferRenameDirDoesNotPanicSandbox) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+  SKIP_IF(!IsGoferMount("/"));
+
+  auto dirs = ASSERT_NO_ERRNO_AND_VALUE(MakeOverlayDirsOnGofer());
+  std::string src_lower = dirs.lower.path() + "/srcdir";
+  ASSERT_THAT(mkdir(src_lower.c_str(), 0755), SyscallSucceeds());
+  std::string src_lower_file = src_lower + "/f";
+  ASSERT_NO_ERRNO(CreateWithContents(src_lower_file, "x", 0644));
+
+  ASSERT_THAT(mount("overlay", dirs.merged.path().c_str(), "overlay", 0,
+                    dirs.mount_opts.c_str()),
+              SyscallSucceeds());
+  auto cleanup = Cleanup(
+      [&dirs] { umount2(dirs.merged.path().c_str(), MNT_DETACH); });
+
+  std::string m_src = dirs.merged.path() + "/srcdir";
+  std::string m_dst = dirs.merged.path() + "/dstdir";
+  EXPECT_THAT(rename(m_src.c_str(), m_dst.c_str()), SyscallSucceeds())
+      << "rename of a directory through overlay-on-gofer must not panic;"
+         " an EOPNOTSUPP here would still be better than a sandbox crash.";
+
+  struct stat st;
+  EXPECT_THAT(stat(m_dst.c_str(), &st), SyscallSucceeds());
+  EXPECT_THAT(stat(m_src.c_str(), &st), SyscallFailsWithErrno(ENOENT));
+}
+
+// When the overlay creates a fresh upper directory, it must set the
+// overlay opaque xattr for lookup optimisation. Before the fix, gofer
+// silently dropped the setxattr, so every lookup kept descending into
+// the lower layer.
+TEST(MountTest, OverlayOnGoferMkdirSetsOpaqueOnUpper) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+  SKIP_IF(!IsGoferMount("/"));
+
+  auto dirs = ASSERT_NO_ERRNO_AND_VALUE(MakeOverlayDirsOnGofer());
+
+  ASSERT_THAT(mount("overlay", dirs.merged.path().c_str(), "overlay", 0,
+                    dirs.mount_opts.c_str()),
+              SyscallSucceeds());
+  auto cleanup = Cleanup(
+      [&dirs] { umount2(dirs.merged.path().c_str(), MNT_DETACH); });
+
+  std::string m_sub = dirs.merged.path() + "/newdir";
+  ASSERT_THAT(mkdir(m_sub.c_str(), 0755), SyscallSucceeds());
+
+  std::string u_sub = dirs.upper.path() + "/newdir";
+  char buf[16] = {};
+  EXPECT_THAT(
+      getxattr(u_sub.c_str(), "trusted.overlay.opaque", buf, sizeof(buf)),
+      SyscallSucceedsWithValue(1))
+      << "freshly created overlay upper dir must carry trusted.overlay.opaque"
+         " so future lookups skip the lower layer";
+  EXPECT_EQ(buf[0], 'y');
+}
+
 }  // namespace
 
 }  // namespace testing

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -27,7 +27,9 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/sysmacros.h>
 #include <sys/un.h>
+#include <sys/xattr.h>
 #include <sys/vfs.h>
 #include <unistd.h>
 
@@ -2654,6 +2656,128 @@ TEST(MountTest, OverlayfsDirectoryRenameInUserNamespace) {
 
   EXPECT_THAT(InForkedUserMountNamespace(parent, child),
               IsPosixErrorOkAndHolds(0));
+}
+
+// Test that overlay can be mounted with a gofer upper layer when the gVisor
+// rootfs overlay is disabled (--overlay2=none). This is needed for Docker
+// overlay2 inside gVisor containers.
+//
+// The test creates overlay directories on the rootfs (which must be gofer,
+// not overlay or tmpfs) and verifies read, write, and delete (whiteout)
+// through the overlay.
+TEST(MountTest, OverlayWithGoferUpper) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // This test requires the rootfs to be gofer (9p), not overlay or tmpfs.
+  // Skip if / is not a gofer mount. V9FS_MAGIC = 0x01021997.
+  struct statfs rootfs_stat;
+  ASSERT_THAT(statfs("/", &rootfs_stat), SyscallSucceeds());
+  SKIP_IF(rootfs_stat.f_type != 0x01021997);  // V9FS_MAGIC
+
+  // Create directories on the gofer rootfs, not /tmp (which is tmpfs).
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn("/"));
+  auto lower = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto upper = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto work = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto merged = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+
+  std::string lower_file = lower.path() + "/testfile";
+  ASSERT_NO_ERRNO(CreateWithContents(lower_file, "lower_content", 0644));
+
+  std::string opts = "lowerdir=" + lower.path() + ",upperdir=" + upper.path() +
+                     ",workdir=" + work.path();
+  ASSERT_THAT(
+      mount("overlay", merged.path().c_str(), "overlay", 0, opts.c_str()),
+      SyscallSucceeds());
+  auto cleanup = Cleanup([&merged] {
+    umount2(merged.path().c_str(), MNT_DETACH);
+  });
+
+  // Read from lower.
+  std::string merged_file = merged.path() + "/testfile";
+  struct stat st;
+  ASSERT_THAT(stat(merged_file.c_str(), &st), SyscallSucceeds());
+
+  // Write a new file through the overlay.
+  std::string new_file = merged.path() + "/newfile";
+  ASSERT_NO_ERRNO(CreateWithContents(new_file, "new", 0644));
+  ASSERT_THAT(stat(new_file.c_str(), &st), SyscallSucceeds());
+
+  // Delete from merged (creates whiteout in upper).
+  ASSERT_THAT(unlink(merged_file.c_str()), SyscallSucceeds());
+  ASSERT_THAT(stat(merged_file.c_str(), &st), SyscallFailsWithErrno(ENOENT));
+
+  // New file still accessible.
+  ASSERT_THAT(stat(new_file.c_str(), &st), SyscallSucceeds());
+}
+
+// Test that whiteout char(0,0) devices can be created on a gofer filesystem.
+// Docker overlay2 creates these during image layer extraction.
+TEST(MountTest, WhiteoutDeviceOnGofer) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // Requires gofer rootfs.
+  struct statfs rootfs_stat;
+  ASSERT_THAT(statfs("/", &rootfs_stat), SyscallSucceeds());
+  SKIP_IF(rootfs_stat.f_type != 0x01021997);  // V9FS_MAGIC
+
+  auto dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn("/"));
+  std::string dev_path = dir.path() + "/whiteout";
+
+  // Create with mode S_IFCHR and dev 0 — exactly what Docker does.
+  ASSERT_THAT(mknod(dev_path.c_str(), S_IFCHR, makedev(0, 0)),
+              SyscallSucceeds());
+
+  struct stat st;
+  ASSERT_THAT(stat(dev_path.c_str(), &st), SyscallSucceeds());
+  EXPECT_TRUE(S_ISCHR(st.st_mode));
+  EXPECT_EQ(major(st.st_rdev), 0);
+  EXPECT_EQ(minor(st.st_rdev), 0);
+
+  // Must be visible in readdir.
+  auto dirp = opendir(dir.path().c_str());
+  ASSERT_NE(dirp, nullptr);
+  bool found = false;
+  while (auto* entry = readdir(dirp)) {
+    if (std::string(entry->d_name) == "whiteout") {
+      found = true;
+      break;
+    }
+  }
+  closedir(dirp);
+  EXPECT_TRUE(found) << "whiteout device not visible in readdir";
+
+  // Chown must succeed (Docker does this after mknod).
+  ASSERT_THAT(chown(dev_path.c_str(), 0, 0), SyscallSucceeds());
+  ASSERT_THAT(unlink(dev_path.c_str()), SyscallSucceeds());
+}
+
+// Test that trusted.overlay.* xattrs work on a gofer filesystem, while
+// other trusted.* xattrs remain blocked.
+TEST(MountTest, TrustedOverlayXattrOnGofer) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // Requires gofer rootfs.
+  struct statfs rootfs_stat;
+  ASSERT_THAT(statfs("/", &rootfs_stat), SyscallSucceeds());
+  SKIP_IF(rootfs_stat.f_type != 0x01021997);  // V9FS_MAGIC
+
+  auto dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn("/"));
+
+  // trusted.overlay.opaque must work.
+  ASSERT_THAT(
+      setxattr(dir.path().c_str(), "trusted.overlay.opaque", "y", 1, 0),
+      SyscallSucceeds());
+  char buf[16] = {};
+  ASSERT_THAT(
+      getxattr(dir.path().c_str(), "trusted.overlay.opaque", buf, sizeof(buf)),
+      SyscallSucceedsWithValue(1));
+  EXPECT_EQ(buf[0], 'y');
+
+  // Other trusted.* xattrs must still be blocked.
+  EXPECT_THAT(
+      setxattr(dir.path().c_str(), "trusted.other", "x", 1, 0),
+      SyscallFailsWithErrno(EOPNOTSUPP));
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem

Docker-in-Docker on gVisor cannot use the `overlay2` storage driver. gVisor's overlay filesystem only accepts `tmpfs` as an upper layer, but Docker's image layers live under `/var/lib/docker`, which is served as a gofer (9p) mount backed by the pod's emptyDir.

Docker 27 (classic graphdriver) notices the overlay probe failure and falls back to the `vfs` storage driver. `vfs` copies every file of every image layer individually. gVisor stores all file metadata as non-reclaimable Go heap, so the sandbox's heap grows linearly with file count until it OOMs.

Docker 29 (containerd-snapshotter, default since 29.0) does not fall back. Its overlay mount returns `EINVAL`, buildkit refuses to start, and the DinD container fails in seconds. Docker 29 DinD is unusable inside a gVisor sandbox with the standard volume layout.

## Fix

Allow gofer to serve as the upper layer of an `overlay` mount, and supply the small amount of functionality that overlayfs requires of an upper.

The overlay mount syscall now accepts `9p` (gofer) in addition to `tmpfs` for user-initiated mounts. Internally initiated overlays (sentry rootfs-overlay feature) continue to be unrestricted. The gofer filesystem gains two operations overlayfs needs from its upper:

- **Whiteouts.** Overlayfs represents a deleted lower-layer entry as a character device with major/minor `(0, 0)`. The gofer previously rejected all non-regular-file `mknod` calls with `EPERM`; it now permits this specific whiteout case and passes it through to the host's `mknodat`. Linux's `vfs_mknod` exempts whiteouts from the `CAP_MKNOD` check, so the gofer needs no additional capability, and arbitrary device creation stays blocked.
- **Overlay metadata xattrs.** Overlayfs tags directories with `trusted.overlay.opaque` (or `user.overlay.opaque` under `userxattr`) to hide preexisting lower-layer contents. We intercept these in the gofer client and store them per-inode in the sentry, using the same in-memory xattr primitive that tmpfs already uses. This avoids granting the gofer `CAP_SYS_ADMIN` (Linux requires it to set any `trusted.*` xattr on the host) and works on any backing filesystem or LSM configuration. gVisor's overlay is the only consumer of these xattrs inside the sandbox, and it does not need host-side persistence, so the behaviour is indistinguishable from the tmpfs-upper case.

While we're here: the rename path in the overlay implementation used to panic the sandbox if it failed to write the post-rename bookkeeping (whiteout at the origin, opaque marker on the new directory). Under the tmpfs-upper invariant that was unreachable; with a gofer upper it is trivially reachable, so a single unprivileged `rename(2)` on a directory could take the sandbox down. The rename path now performs that bookkeeping before committing the overlay's dentry-tree state, and undoes the upper-layer rename on failure. A sandbox-wide fatal condition becomes a normal errno to userspace.

## Performance

I/O-heavy workloads on gVisor already carry syscall-interception overhead (3x to 9x over runc). This change does not remove that overhead. It removes the cliff that came from falling back to `vfs` on Docker 27, and the hard failure on Docker 29.

Benchmark: 2 GB multi-arch `docker buildx build` of a Debian/Ruby image (15 layers x amd64 + arm64) at 6 GiB per container.

| Runtime | Docker | Time | Sandbox heap | Reclaim events | Result |
|---|---|---|---|---|---|
| runc | 27 | 1 m | n/a | 0 | baseline |
| runc | 29 | 1 m | n/a | 0 | baseline |
| **gVisor w/ this PR** | **27** | **4 m** | **67 MB** | 1,957 | success |
| **gVisor w/ this PR** | **29** | **4 m** | **68 MB** | 2,239 | success |
| gVisor stock | 27 | 15 m+ | 151 MB | 552,696 | stuck in reclaim, no build progress |
| gVisor stock | 29 | 4 s | 37 MB | 0 | build fails (overlay mount `EINVAL`) |

With the fix, gVisor completes the build in 4 minutes (about 4x slower than runc) with the Go heap capped around 68 MB. On the original motivating workload (GitLab CI, same image, 6 GiB cgroup) the stock sandbox accumulates roughly 12 GB of heap before OOM. With the fix, heap stays under 70 MB and the build succeeds.

The previously recommended workaround, bind-mounting a tmpfs over `/var/lib/docker` so Docker sees a tmpfs upper, does not scale. Image layer data on tmpfs counts as non-reclaimable shmem against the pod's memory limit. Small workloads run out of cgroup memory and large ones run out of tmpfs space. It OOMs or ENOSPCs at every memory setting we tried.

## Security considerations

The gofer gains no new host capability. Overlay metadata xattrs live per-inode in the sentry only; host `trusted.*` and `security.*` semantics are unchanged.

Sandboxed processes can now create whiteout character devices on the gofer-backed directory. Whiteouts cannot be opened as device nodes, so nothing new is exposed. The gofer-backed directory is owned by the sandbox (the pod's emptyDir); whiteouts are a standard overlayfs artifact on any Linux host running overlay-on-ext4.

A guest-triggered sandbox panic on directory rename is replaced by a normal errno return.

## Reproducer

The full matrix in the performance table is automated by the [benchmark script](https://github.com/user-attachments/files/26831969/bench-v2.sh).

Standalone inline reproducers for the two stock failure modes:

- **Docker 29:** any `docker build` with at least one `RUN` step, driven by a `docker:29-dind` sidecar, fails in ~4 s with `failed to mount [...]: invalid argument`. A trivial `FROM alpine:3.19 / RUN echo hi` is enough; no memory pressure or real workload needed.
- **Docker 27:** `docker info` reports `Storage Driver: vfs`. At the 2 GB workload under 6 GiB, the build makes no forward progress; with tighter memory it OOM-kills during layer extraction.

With this PR applied, both Docker versions report `overlay2`/`overlayfs`, complete successfully, and keep the sandbox heap bounded.

## Context

Previous patch attempt: https://github.com/google/gvisor/pull/12941

The earlier PR tried to use an overlay mount as the upper layer of another overlay, which Linux itself rejects. @ayushr2 pointed out the right direction in https://github.com/google/gvisor/pull/12941#issuecomment-4255895597: disable the rootfs overlay for DinD (so `/var/lib/docker` is a raw gofer mount) and add the missing gofer support for what overlayfs needs from an upper (whiteout creation, overlay metadata xattrs, overlay accepting gofer as upper). This PR implements that direction. Emulating the overlay xattrs in the sentry instead of passing them through to the host is our specific design choice.

Internal tracking: https://gitlab.com/gitlab-com/gl-infra/production-engineering/-/work_items/28316

Fixes #12828
Fixes #12475
