### PR TITLE
lisafs: include file size in FlushReq

### DIFF
--- a/pkg/lisafs/client_file.go
+++ b/pkg/lisafs/client_file.go
@@ -413,12 +413,12 @@ func (f *ClientFD) ReadLinkAt(ctx context.Context) (string, error) {
 }
 
 // Flush makes the Flush RPC.
-func (f *ClientFD) Flush(ctx context.Context) error {
+func (f *ClientFD) Flush(ctx context.Context, size uint64) error {
 	if !f.client.IsSupported(Flush) {
 		// If Flush is not supported, it probably means that it would be a noop.
 		return nil
 	}
-	req := FlushReq{FD: f.fd}
+	req := FlushReq{FD: f.fd, Size: size}
 	var resp FlushResp
 	ctx.UninterruptibleSleepStart()
 	err := f.client.SndRcvMessage(Flush, uint32(req.SizeBytes()), req.MarshalUnsafe, resp.CheckedUnmarshal, nil, req.String, resp.String)

--- a/pkg/lisafs/fd.go
+++ b/pkg/lisafs/fd.go
@@ -615,10 +615,11 @@ type OpenFDImpl interface {
 	Allocate(mode, off, length uint64) error
 
 	// Flush can be used to clean up the file state. Behavior is
-	// implementation-specific.
+	// implementation-specific. size is the current file size as tracked by
+	// the sentry.
 	//
 	// On the server, Flush has a read concurrency guarantee.
-	Flush() error
+	Flush(size uint64) error
 
 	// Getdent64 fetches directory entries for this directory and calls
 	// recordDirent for each dirent read. If seek0 is true, then the directory FD

--- a/pkg/lisafs/handlers.go
+++ b/pkg/lisafs/handlers.go
@@ -1042,7 +1042,7 @@ func FlushHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 	defer fd.DecRef(nil)
 
 	return 0, fd.controlFD.safelyRead(func() error {
-		return fd.impl.Flush()
+		return fd.impl.Flush(req.Size)
 	})
 }
 

--- a/pkg/lisafs/message.go
+++ b/pkg/lisafs/message.go
@@ -1284,12 +1284,13 @@ func (r *ReadLinkAtResp) CheckedUnmarshal(src []byte) ([]byte, bool) {
 //
 // +marshal boundCheck
 type FlushReq struct {
-	FD FDID
+	FD   FDID
+	Size uint64 // Current file size as tracked by the sentry.
 }
 
 // String implements fmt.Stringer.String.
 func (f *FlushReq) String() string {
-	return fmt.Sprintf("FlushReq{FD: %d}", f.FD)
+	return fmt.Sprintf("FlushReq{FD: %d, Size: %d}", f.FD, f.Size)
 }
 
 // FlushResp is an empty response to FlushReq.

--- a/pkg/sentry/fsimpl/gofer/inode_impl.go
+++ b/pkg/sentry/fsimpl/gofer/inode_impl.go
@@ -430,7 +430,7 @@ func (i *inode) flush(ctx context.Context) error {
 	defer i.handleMu.RUnlock()
 	switch it := i.impl.(type) {
 	case *lisafsInode:
-		return flush(ctx, it.writeFDLisa)
+		return flush(ctx, it.writeFDLisa, i.size.Load())
 	case *directfsInode:
 		// Nothing to do here.
 		return nil

--- a/pkg/sentry/fsimpl/gofer/lisafs_inode.go
+++ b/pkg/sentry/fsimpl/gofer/lisafs_inode.go
@@ -580,9 +580,9 @@ func (i *lisafsInode) getDirentsLocked(ctx context.Context, recordDirent func(na
 	}
 }
 
-func flush(ctx context.Context, fd lisafs.ClientFD) error {
+func flush(ctx context.Context, fd lisafs.ClientFD, size uint64) error {
 	if fd.Ok() {
-		return fd.Flush(ctx)
+		return fd.Flush(ctx, size)
 	}
 	return nil
 }

--- a/pkg/sentry/fsimpl/gofer/special_file.go
+++ b/pkg/sentry/fsimpl/gofer/special_file.go
@@ -152,7 +152,7 @@ func (fd *specialFileFD) OnClose(ctx context.Context) error {
 	if !fd.vfsfd.IsWritable() {
 		return nil
 	}
-	return flush(ctx, fd.handle.fdLisa)
+	return flush(ctx, fd.handle.fdLisa, 0)
 }
 
 // Readiness implements waiter.Waitable.Readiness.

--- a/runsc/fsgofer/lisafs.go
+++ b/runsc/fsgofer/lisafs.go
@@ -1102,7 +1102,7 @@ func (fd *openFDLisa) Allocate(mode, off, length uint64) error {
 }
 
 // Flush implements lisafs.OpenFDImpl.Flush.
-func (fd *openFDLisa) Flush() error {
+func (fd *openFDLisa) Flush(size uint64) error {
 	return nil
 }
 


### PR DESCRIPTION
When host FDs are donated to the sentry, subsequent writes go directly to the donated FD via `pwritev2`, bypassing the gofer. The gofer's only close-time signal is the `Flush` RPC, which currently carries only the `FDID`. Custom gofer implementations that donate host FDs have no way to learn the resulting file size without an extra `fstat` on the backing FD.

This adds a `Size` field to `FlushReq`, populated from `inode.size` at flush time. The sentry already tracks file size through its write path (`regular_file.go` updates `inode.size` on every `PWrite` that extends the file), so the value is available at zero cost.

This is useful for custom gofers that use donated FDs as scratch space while maintaining their own metadata (e.g. a network-backed gofer that streams dirty regions to a remote store, or an encrypted-at-rest gofer that needs to know the plaintext extent). Without the size hint, these gofers must poll with `fstat` to detect file growth, typically on a timer, which adds latency and syscall overhead proportional to the number of open files. With the size hint, the gofer learns the final file size immediately on close without any additional syscall. This is the same principle as pNFS `LAYOUTCOMMIT` (RFC 5661 §18.42) and CephFS capability flush, where clients that write through a path the metadata server cannot observe report the resulting file size on commit.

The stock gofer does not advertise `Flush` support (`SupportedMessages` excludes it), so this field is never populated or sent in the default configuration. No behavior change for existing users. For special files (pipes, sockets) the size is passed as 0 since it has no meaningful value.

This becomes more useful alongside #12950 which adds a `Provider` interface for plugging custom gofer backends into the stock gofer binary.