### PR TITLE
runsc/specutils: reject host UTS namespaces

### DIFF
--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -158,6 +158,9 @@ func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
 			return err
 		}
 	}
+	if utsns, ok := GetNS(specs.UTSNamespace, spec); ok && utsns.Path != "" {
+		return fmt.Errorf("joining UTS namespace %q is not supported", utsns.Path)
+	}
 	for _, m := range spec.Mounts {
 		if err := validateMount(&m); err != nil {
 			return err

--- a/runsc/specutils/specutils_test.go
+++ b/runsc/specutils/specutils_test.go
@@ -146,6 +146,51 @@ func TestSpecInvalid(t *testing.T) {
 			error: "",
 		},
 		{
+			name: "valid with no uts namespace",
+			spec: specs.Spec{
+				Root: &specs.Root{Path: "/"},
+				Process: &specs.Process{
+					Args: []string{"/bin/true"},
+				},
+				Linux: &specs.Linux{
+					Namespaces: []specs.LinuxNamespace{
+						{Type: specs.PIDNamespace},
+					},
+				},
+			},
+			error: "",
+		},
+		{
+			name: "valid with new uts namespace",
+			spec: specs.Spec{
+				Root: &specs.Root{Path: "/"},
+				Process: &specs.Process{
+					Args: []string{"/bin/true"},
+				},
+				Linux: &specs.Linux{
+					Namespaces: []specs.LinuxNamespace{
+						{Type: specs.UTSNamespace},
+					},
+				},
+			},
+			error: "",
+		},
+		{
+			name: "host uts namespace",
+			spec: specs.Spec{
+				Root: &specs.Root{Path: "/"},
+				Process: &specs.Process{
+					Args: []string{"/bin/true"},
+				},
+				Linux: &specs.Linux{
+					Namespaces: []specs.LinuxNamespace{
+						{Type: specs.UTSNamespace, Path: "/proc/1/ns/uts"},
+					},
+				},
+			},
+			error: "joining UTS namespace",
+		},
+		{
 			name: "no root",
 			spec: specs.Spec{
 				Process: &specs.Process{


### PR DESCRIPTION
gVisor virtualizes UTS state, so joining an existing host UTS namespace cannot provide the expected host namespace semantics. Reject OCI specs that set a UTS namespace path during spec validation, so --uts=host fails early with a clear error.

Supported behavior is unchanged for specs that create a new UTS namespace or omit the UTS namespace entry.

Fixes #7995

Tested:
make SHELL=/run/current-system/sw/bin/bash test TARGETS="//runsc/specutils:specutils_test"