### PR TITLE
gofer: don't cache directory inodes in inodeByKey on restore

### DIFF
--- a/pkg/sentry/fsimpl/gofer/directfs_inode.go
+++ b/pkg/sentry/fsimpl/gofer/directfs_inode.go
@@ -732,9 +732,12 @@ func (i *directfsInode) restoreFile(ctx context.Context, controlFD int, opts *vf
 	i.fs.inoMu.Lock()
 	i.fs.inoByKey[i.inoKey] = i.ino
 	i.fs.inoMu.Unlock()
-	i.fs.inodeMu.Lock()
-	i.fs.inodeByKey[i.inoKey] = &i.inode
-	i.fs.inodeMu.Unlock()
+	// inodeByKey contains non-directory inodes only.
+	if !d.isDir() {
+		i.fs.inodeMu.Lock()
+		i.fs.inodeByKey[i.inoKey] = &i.inode
+		i.fs.inodeMu.Unlock()
+	}
 
 	// Check metadata stability before updating metadata.
 	i.metadataMu.Lock()

--- a/pkg/sentry/fsimpl/gofer/lisafs_inode.go
+++ b/pkg/sentry/fsimpl/gofer/lisafs_inode.go
@@ -618,9 +618,12 @@ func (i *lisafsInode) restoreInode(ctx context.Context, inode *lisafs.Inode, opt
 	i.fs.inoMu.Lock()
 	i.fs.inoByKey[i.inoKey] = i.ino
 	i.fs.inoMu.Unlock()
-	i.fs.inodeMu.Lock()
-	i.fs.inodeByKey[i.inoKey] = &i.inode
-	i.fs.inodeMu.Unlock()
+	// inodeByKey contains non-directory inodes only.
+	if !d.isDir() {
+		i.fs.inodeMu.Lock()
+		i.fs.inodeByKey[i.inoKey] = &i.inode
+		i.fs.inodeMu.Unlock()
+	}
 
 	// Check metadata stability before updating metadata.
 	i.metadataMu.Lock()


### PR DESCRIPTION
`filesystem.inodeByKey` is documented as containing only non-directory inodes, and `dentry.destroyLocked` relies on this invariant — it skips the map delete when the dentry is a directory. The non-restore code paths honour this (inserts are guarded by `!d.isDir()`), but the checkpoint-restore paths in `directfsInode.restoreFile` and `lisafsInode.restoreInode` insert unconditionally.

After a restore, this can lead to a panic:

1. A directory inode is inserted into `inodeByKey` during restore.
2. The directory is later removed (`rmdir`). `destroyLocked` drops the refcount to 0 but does **not** remove the map entry, because it assumes directories were never inserted.
3. The host filesystem reuses that inode number for a newly created regular file.
4. `getOrCreateInode` finds the stale entry, calls `IncRef` on a refcount-0 inode, and panics.

This PR guards the two restore-path inserts with `!d.isDir()`, matching the non-restore behaviour.

Assisted-by: Claude Code
