### PR TITLE
fix(shim): use per-container id for TaskOOM routing (fixes #12838)

### DIFF
--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -213,7 +213,13 @@ func (s *runscService) CreateWithFSRestore(ctx context.Context, rfs *extension.C
 		if err != nil {
 			return nil, fmt.Errorf("loading cgroup for %d: %w", pid, err)
 		}
-		if err := s.oomPoller.add(s.id, cg); err != nil {
+		// Register the sandbox cgroup with the OOM poller using this
+		// container's id (typically the pause/sandbox id on first Create).
+		// Do not use s.id: it is empty because the shim binary is spawned
+		// without `-id` (see manager.go:newCommand), which would cause
+		// every TaskOOM event to be published with an empty ContainerID
+		// and silently dropped by containerd (ErrEmptyPrefix).
+		if err := s.oomPoller.add(rfs.Create.ID, cg); err != nil {
 			return nil, fmt.Errorf("add cg to OOM monitor: %w", err)
 		}
 	}
@@ -523,37 +529,61 @@ func (s *runscService) processExits(ctx context.Context) {
 }
 
 func (s *runscService) checkProcesses(ctx context.Context, e proc.Exit) {
-	for _, p := range s.allProcessesForAllContainers() {
-		if p.ID() == e.ID {
-			ip, isInit := p.(*proc.Init)
-			if isInit {
-				// Ensure all children are killed.
-				log.L.Debugf("Container init process exited, killing all container processes")
-				ip.KillAll(ctx)
+	// Find the container whose process exited.
+	s.mu.Lock()
+	var (
+		exitingCID string
+		exitingP   process.Process
+	)
+	for cid, c := range s.containers {
+		for _, p := range c.All() {
+			if p.ID() == e.ID {
+				exitingCID = cid
+				exitingP = p
+				break
 			}
-			p.SetExited(e.Status)
-			// On init process exit, synchronously check the cgroup for OOM
-			// kills before publishing the exit event. The async OOM
-			// notification via EventChan (cgroups v2) can lose the race
-			// against the container exit on some architectures (notably
-			// aarch64), causing kubelet to report reason=Error instead of
-			// reason=OOMKilled. Only check on init exit — exec processes
-			// share the sandbox cgroup and would produce spurious events.
-			if isInit && s.oomPoller.isOOM(s.id) {
-				s.send(&events.TaskOOM{
-					ContainerID: s.id,
-				})
-			}
-			s.send(&events.TaskExit{
-				ContainerID: s.id,
-				ID:          p.ID(),
-				Pid:         uint32(p.Pid()),
-				ExitStatus:  uint32(e.Status),
-				ExitedAt:    p.ExitedAt(),
-			})
-			return
+		}
+		if exitingP != nil {
+			break
 		}
 	}
+	s.mu.Unlock()
+	if exitingP == nil {
+		return
+	}
+	p := exitingP
+
+	ip, isInit := p.(*proc.Init)
+	if isInit {
+		// Ensure all children are killed.
+		log.L.Debugf("Container init process exited, killing all container processes")
+		ip.KillAll(ctx)
+	}
+	p.SetExited(e.Status)
+	// On init process exit, synchronously check the cgroup for OOM kills
+	// before publishing the exit event. The async OOM notification via
+	// EventChan (cgroups v2) can lose the race against the container exit
+	// on some architectures (notably aarch64), causing kubelet to report
+	// reason=Error instead of reason=OOMKilled. Only check on init exit —
+	// exec processes share the sandbox cgroup and would produce spurious
+	// events.
+	//
+	// Use the per-container id for TaskOOM routing — not s.id, which is
+	// empty in the normal (non-grouping) shim spawn path because
+	// pkg/shim/v1/manager.go:newCommand() does not pass `-id`. With
+	// ContainerID="", containerd's CRI would drop the TaskOOM at
+	// containerStore.Get("") → ErrEmptyPrefix, and kubelet would report
+	// reason:Error instead of reason:OOMKilled.
+	if isInit && s.oomPoller.isOOM(exitingCID) {
+		s.send(&events.TaskOOM{ContainerID: exitingCID})
+	}
+	s.send(&events.TaskExit{
+		ContainerID: exitingCID,
+		ID:          p.ID(),
+		Pid:         uint32(p.Pid()),
+		ExitStatus:  uint32(e.Status),
+		ExitedAt:    p.ExitedAt(),
+	})
 }
 
 func (s *runscService) send(event any) {

--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -532,13 +532,13 @@ func (s *runscService) checkProcesses(ctx context.Context, e proc.Exit) {
 	// Find the container whose process exited.
 	s.mu.Lock()
 	var (
-		exitingCID string
-		exitingP   process.Process
+		containerID string
+		exitingP    process.Process
 	)
 	for cid, c := range s.containers {
 		for _, p := range c.All() {
 			if p.ID() == e.ID {
-				exitingCID = cid
+				containerID = cid
 				exitingP = p
 				break
 			}
@@ -574,11 +574,11 @@ func (s *runscService) checkProcesses(ctx context.Context, e proc.Exit) {
 	// ContainerID="", containerd's CRI would drop the TaskOOM at
 	// containerStore.Get("") → ErrEmptyPrefix, and kubelet would report
 	// reason:Error instead of reason:OOMKilled.
-	if isInit && s.oomPoller.isOOM(exitingCID) {
-		s.send(&events.TaskOOM{ContainerID: exitingCID})
+	if isInit && s.oomPoller.isOOM(containerID) {
+		s.send(&events.TaskOOM{ContainerID: containerID})
 	}
 	s.send(&events.TaskExit{
-		ContainerID: exitingCID,
+		ContainerID: containerID,
 		ID:          p.ID(),
 		Pid:         uint32(p.Pid()),
 		ExitStatus:  uint32(e.Status),


### PR DESCRIPTION
## Summary

Fixes #12838 for real. On aarch64 (and any architecture where the containerd race between TaskOOM and TaskExit routinely resolves OOM-last), OOM-killed pods run by gVisor are reported by kubelet with `reason:Error` instead of `reason:OOMKilled`.

PR #12843 added a synchronous cgroup check at init exit to close the async OOM-vs-exit race. That part works — but it also publishes `TaskOOM{ContainerID: s.id}`, and `s.id` is empty in the normal shim spawn path. So on aarch64 the symptom survives #12843 because the bug is routing, not just timing.

## Root cause

1. `pkg/shim/v1/manager.go:newCommand()` spawns the shim binary with `-namespace`, `-address`, and `-publish-binary` only — no `-id`.
2. In the spawned shim, containerd's vendored shim framework parses the flags; `-id` defaults to `""` (`runtime/v2/shim/shim.go`: `flag.StringVar(&id, "id", "", ...)`). With `manager == nil`, that empty id is threaded into `runsc.NewTaskService(ctx, id, ...)`, so `runscService.id = ""`.
3. Every `TaskOOM{ContainerID: s.id}` — from the async `oom_v2.go`'s `run()` and from the sync `service.go`'s `checkProcesses()` added by #12843 — ships with `ContainerID=""`.
4. containerd's CRI handler (`internal/cri/server/events.go`) routes TaskOOM via `containerStore.Get(e.ContainerID)`. `Get("")` returns `ErrEmptyPrefix` (from `internal/truncindex`). That is **not** `IsNotFound`, so `handleEvent` wraps and returns the error; containerd logs `can't find container for TaskOOM event: prefix can't be empty`, and the container's `Status.Reason` is never set.
5. `TaskExit` is unaffected because containerd routes TaskExit by `e.ID` (init process id), not `e.ContainerID` — different field, different lookup.

## Fix

Don't rely on `s.id` for TaskOOM routing. Use the per-container id that's already available at the point the OOM poller is wired up and at the point the exit is observed.

* `CreateWithFSRestore`: register the cgroup with `rfs.Create.ID` (the per-container id from the CreateTaskRequest) rather than `s.id`. The id stored in the watcher's `cgroups` and `lastOOM` maps is now non-empty and correctly keyed per container, so both the async (`EventChan -> run`) and sync (`isOOM` at exit) paths publish with a real `ContainerID`.
* `checkProcesses`: locate the container whose process matched the exit event, use that container's id for `isOOM`, and use it for both `TaskOOM.ContainerID` and `TaskExit.ContainerID`.

`oom_v2.go` is unchanged — with `add()` keyed by `rfs.Create.ID`, the existing async publish path already emits TaskOOM with the correct id via `i.id`.

## Validation

End-to-end in a prod-matching environment (AL2023 aarch64, kernel 6.12, containerd 2.2.1, kubelet 1.34, runsc built from this branch):

* **Before**: OOM'd pods show `reason:Error`; containerd journal shows `TaskOOM event ` (trailing space = empty ContainerID) and `Failed to handle backOff event for error="can't find container for TaskOOM event: prefix can't be empty"`.
* **After**: OOM'd pods show `reason:OOMKilled`; journal shows `TaskOOM event container_id:"<real-64-hex>"` and zero `prefix can't be empty` errors.

Also soaked on staging at Semgrep with real workloads across both x86_64 and aarch64 nodepools (multi-container gvisor pods, forced OOM on a 128Mi-limited python container alongside a busybox sidecar). Main-container OOMs now consistently report `reason:OOMKilled` on both arches.

## Scope

This PR touches only the cgroups v2 init-exit path (`CreateWithFSRestore` and `checkProcesses` in `runsc/service.go`). The cgroups v1 poller (`epoll.go`) has the same structural reliance on `s.id` and should get the equivalent treatment — happy to file a follow-up once this lands.

## Follow-ups noted in this work (separate PRs)

* cgroups v1 shim (`epoll.go`) has the same empty-id TaskOOM path.
* `pkg/shim/v1/runsccmd/utils.go:FormatShimLogPath` documents `%ID%` substitution but the implementation only appends a filename when the path ends in `/`. As a result the shim currently writes all container logs into a literal `/var/log/runsc/%ID%/` directory rather than per-container directories. Noticed while gathering logs for this PR.
