### PR TITLE
runsc: add reduce command exposing Usage.Reduce to operators

### DIFF
--- a/pkg/sentry/control/usage.go
+++ b/pkg/sentry/control/usage.go
@@ -141,18 +141,37 @@ type UsageReduceOpts struct {
 	DoNotGC bool `json:"do_not_gc"`
 }
 
-// UsageReduceOutput contains output from Usage.Reduce().
-type UsageReduceOutput struct{}
+// UsageReduceOutput contains output from Usage.Reduce(). BytesBefore and
+// BytesAfter report MemoryFile.TotalUsage before and after the call;
+// they are populated only when UsageReduceOpts.Wait is true.
+type UsageReduceOutput struct {
+	BytesBefore uint64 `json:"bytes_before,omitempty"`
+	BytesAfter  uint64 `json:"bytes_after,omitempty"`
+}
 
 // Reduce requests that the sentry attempt to reduce its memory usage.
 func (u *Usage) Reduce(opts *UsageReduceOpts, out *UsageReduceOutput) error {
 	mf := u.Kernel.MemoryFile()
+	if opts.Wait {
+		before, err := mf.TotalUsage()
+		if err != nil {
+			return err
+		}
+		out.BytesBefore = before
+	}
 	mf.StartEvictions()
 	if opts.Wait {
 		mf.WaitForEvictions()
 	}
 	if !opts.DoNotGC {
 		runtime.GC()
+	}
+	if opts.Wait {
+		after, err := mf.TotalUsage()
+		if err != nil {
+			return err
+		}
+		out.BytesAfter = after
 	}
 	return nil
 }

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -168,6 +168,7 @@ const (
 // Usage related commands (see usage.go for more details).
 const (
 	UsageCollect = "Usage.Collect"
+	UsageReduce  = "Usage.Reduce"
 	UsageUsageFD = "Usage.UsageFD"
 )
 

--- a/runsc/cli/maincli/maincli.go
+++ b/runsc/cli/maincli/maincli.go
@@ -74,6 +74,7 @@ func commands() (map[util.SubCommand]string, []subcommands.Command) {
 		new(cmd.CPUFeatures): helperGroup,
 
 		new(cmd.Debug):        debugGroup,
+		new(cmd.Reduce):       debugGroup,
 		new(cmd.Statefile):    debugGroup,
 		new(cmd.Symbolize):    debugGroup,
 		new(cmd.Usage):        debugGroup,

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -64,6 +64,7 @@ go_library(
         "portforward.go",
         "ps.go",
         "read_control.go",
+        "reduce.go",
         "restore.go",
         "resume.go",
         "run.go",

--- a/runsc/cmd/reduce.go
+++ b/runsc/cmd/reduce.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/subcommands"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gvisor.dev/gvisor/pkg/sentry/control"
+	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/container"
+	"gvisor.dev/gvisor/runsc/flag"
+)
+
+// Reduce implements subcommands.Command for the "reduce" command.
+type Reduce struct {
+	containerLoader
+	noGC  bool
+	quiet bool
+}
+
+// Name implements subcommands.Command.Name.
+func (*Reduce) Name() string {
+	return "reduce"
+}
+
+// Synopsis implements subcommands.Command.Synopsis.
+func (*Reduce) Synopsis() string {
+	return "reduce the sandbox's memory usage via the Usage.Reduce RPC"
+}
+
+// Usage implements subcommands.Command.Usage.
+func (*Reduce) Usage() string {
+	return "reduce [flags] <container id> - evict reclaimable MemoryFile ranges and run GC.\n"
+}
+
+// SetFlags implements subcommands.Command.SetFlags.
+func (r *Reduce) SetFlags(f *flag.FlagSet) {
+	f.BoolVar(&r.noGC, "no-gc", false, "skip the GC step")
+	f.BoolVar(&r.quiet, "quiet", false, "suppress JSON output")
+}
+
+// FetchSpec implements util.SubCommand.FetchSpec.
+func (r *Reduce) FetchSpec(conf *config.Config, f *flag.FlagSet) (string, *specs.Spec, error) {
+	c, err := r.loadContainer(conf, f, container.LoadOpts{SkipCheck: true})
+	if err != nil {
+		return "", nil, fmt.Errorf("loading container: %w", err)
+	}
+	return c.ID, c.Spec, nil
+}
+
+// Execute implements subcommands.Command.Execute.
+func (r *Reduce) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcommands.ExitStatus {
+	if f.NArg() != 1 {
+		f.Usage()
+		return subcommands.ExitUsageError
+	}
+
+	conf := args[0].(*config.Config)
+
+	c, err := r.loadContainer(conf, f, container.LoadOpts{SkipCheck: true})
+	if err != nil {
+		util.Fatalf("loading container: %v", err)
+	}
+
+	opts := control.UsageReduceOpts{Wait: true, DoNotGC: r.noGC}
+	out, err := c.Sandbox.Reduce(opts)
+	if err != nil {
+		util.Fatalf("reduce failed: %v", err)
+	}
+
+	if r.quiet {
+		return subcommands.ExitSuccess
+	}
+
+	encoder := json.NewEncoder(&util.Writer{})
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(out); err != nil {
+		util.Fatalf("encoding output: %v", err)
+	}
+	return subcommands.ExitSuccess
+}

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -2986,6 +2986,59 @@ func TestUsageFD(t *testing.T) {
 	}
 }
 
+// TestReduce checks that reduce drains the sandbox's MemoryFile.
+func TestReduce(t *testing.T) {
+	spec, conf := sleepSpecConf(t)
+	_, bundleDir, cleanup, err := testutil.SetupContainer(spec, conf)
+	if err != nil {
+		t.Fatalf("error setting up container: %v", err)
+	}
+	defer cleanup()
+
+	args := Args{
+		ID:        testutil.RandomContainerID(),
+		Spec:      spec,
+		BundleDir: bundleDir,
+	}
+	cont, err := New(conf, args)
+	if err != nil {
+		t.Fatalf("creating container: %v", err)
+	}
+	defer cont.Destroy()
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("starting container: %v", err)
+	}
+
+	// Wait for the container to accumulate some MemoryFile usage before
+	// asking the sandbox to reduce it.
+	if err := backoff.Retry(func() error {
+		m, err := cont.Sandbox.Usage(true /* Full */)
+		if err != nil {
+			return &backoff.PermanentError{Err: fmt.Errorf("usage: %v", err)}
+		}
+		if m.Total == 0 {
+			return fmt.Errorf("TotalUsage still zero")
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(100*time.Millisecond), 10)); err != nil {
+		t.Fatalf("waiting for initial memory usage: %v", err)
+	}
+
+	out, err := cont.Sandbox.Reduce(control.UsageReduceOpts{Wait: true})
+	if err != nil {
+		t.Fatalf("Reduce: %v", err)
+	}
+	if out.BytesBefore == 0 {
+		t.Errorf("Reduce: BytesBefore=0, want nonzero")
+	}
+	if out.BytesAfter == 0 {
+		t.Errorf("Reduce: BytesAfter=0, want nonzero")
+	}
+	if out.BytesAfter > out.BytesBefore {
+		t.Errorf("Reduce: BytesAfter=%d > BytesBefore=%d; reduce must not grow usage", out.BytesAfter, out.BytesBefore)
+	}
+}
+
 // TestProfile checks that profiling options generate profiles.
 func TestProfile(t *testing.T) {
 	// Perform a non-trivial amount of work so we actually capture

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -1807,6 +1807,16 @@ func (s *Sandbox) Usage(Full bool) (control.MemoryUsage, error) {
 	return m, nil
 }
 
+// Reduce sends the reduce call for a container in the sandbox.
+func (s *Sandbox) Reduce(opts control.UsageReduceOpts) (control.UsageReduceOutput, error) {
+	log.Debugf("Reduce sandbox %q: %+v", s.ID, opts)
+	var out control.UsageReduceOutput
+	if err := s.call(boot.UsageReduce, &opts, &out); err != nil {
+		return control.UsageReduceOutput{}, fmt.Errorf("reducing usage: %w", err)
+	}
+	return out, nil
+}
+
 // UsageFD sends the usagefd call for a container in the sandbox.
 func (s *Sandbox) UsageFD() (*control.MemoryUsageRecord, error) {
 	log.Debugf("Usage sandbox %q", s.ID)


### PR DESCRIPTION
`Usage.Reduce` implements the sentry's memory drain path (`MemoryFile.StartEvictions` / `WaitForEvictions` plus `runtime.GC`), but the RPC is not reachable from runsc today. This wires it up as a subcommand that asks the sentry to evict reclaimable `MemoryFile` ranges and run Go GC. Sandboxes that don't call it behave exactly as they do today.

The motivation is sandboxes that service many execs over their lifetime. On cgroup v2 hosts `hostmm.NotifyCurrentMemcgPressureCallback` is unavailable, so there is no pressure-driven pgalloc drain, and operators have no way to reclaim between execs short of recycling the whole sandbox. `runsc reduce` gives them an explicit, synchronous lever they can fire when their orchestrator knows a safe point has been reached — end of an exec, start of the next.

Mechanically, `StartEvictions` asks each registered user to release its evictable ranges, and the release path ends in `fallocate(FALLOC_FL_PUNCH_HOLE)` on the sentry's backing memfd so the kernel reclaims those pages immediately. The only ranges touched are those previously marked evictable — typically unmapped page-cache content pgalloc would drop on its own under memory pressure — so no live mappings or in-use data are affected, and sandbox semantics are unchanged.

The CLI is `runsc reduce <container id>`, registered in `debugGroup` alongside `runsc usage`. It runs synchronously and reports `BytesBefore` and `BytesAfter` on `UsageReduceOutput`, sampled from `MemoryFile.TotalUsage` around the eviction. `--no-gc` and `--quiet` are there for orchestration. Everything else follows `runsc usage`, and `TestReduce` in `runsc/container/container_test.go` mirrors `TestUsage`.

I landed on this as the smallest change I could find that doesn't disturb existing patterns. There's likely a case for a more general `runsc sanitize` that extends this to other kinds of eviction and subsystem cleanup (network, FDs, and the like), but there are complexities at various layers there, and this felt more tractable.

If this isn't the direction the team wants to take operator-triggered sentry reclamation, I'm happy to close this out or rework it with any alternatives in mind. The option space probably includes keeping the RPC internal, exposing a narrower knob, or something entirely different, and I'm open to any of those.