### PR TITLE
systrap: hold sysmsgThreadsMu around map read in switchToApp

### DIFF
--- a/pkg/sentry/platform/systrap/shared_context.go
+++ b/pkg/sentry/platform/systrap/shared_context.go
@@ -133,8 +133,8 @@ func (sc *sharedContext) NotifyInterrupt() {
 		return
 	}
 	s := sc.subprocess
-	s.sysmsgThreadsMu.Lock()
-	defer s.sysmsgThreadsMu.Unlock()
+	s.sysmsgThreadsMu.RLock()
+	defer s.sysmsgThreadsMu.RUnlock()
 	sysmsgThread, ok := s.sysmsgThreads[threadID]
 	if !ok {
 		// This is either an invalidThreadID or another garbage value; either way we

--- a/pkg/sentry/platform/systrap/subprocess.go
+++ b/pkg/sentry/platform/systrap/subprocess.go
@@ -162,15 +162,19 @@ type subprocess struct {
 	syscallThreadMu sync.Mutex
 	syscallThread   *syscallThread
 
-	// sysmsgThreadsMu protects sysmsgThreads and numSysmsgThreads
-	sysmsgThreadsMu sync.Mutex
+	// sysmsgThreadsMu protects the sysmsgThreads map only.
+	// Read-locked on the hot SwitchToApp lookup path; write-locked when
+	// the map is mutated (createSysmsgThread).
+	sysmsgThreadsMu sync.RWMutex
 	// sysmsgThreads is a collection of all active sysmsg threads in the
 	// subprocess.
 	sysmsgThreads map[uint32]*sysmsgThread
 	// numSysmsgThreads counts the number of active sysmsg threads; we use a
-	// counter instead of using len(sysmsgThreads) because we need to synchronize
-	// how many threads get created _before_ the creation happens.
-	numSysmsgThreads int
+	// counter instead of len(sysmsgThreads) because we need to reserve a slot
+	// before the actual map insertion (createSysmsgThread). It is updated with
+	// atomic CAS in kickSysmsgThread to enforce the maxSysmsgThreads cap under
+	// concurrent kicks without holding sysmsgThreadsMu.
+	numSysmsgThreads atomicbitops.Int32
 
 	// contextQueue is a queue of all contexts that are ready to switch back to
 	// user mode.
@@ -399,7 +403,7 @@ func newSubprocess(create func() (*thread, error), memoryFile *pgalloc.MemoryFil
 		if err := sp.createSysmsgThread(); err != nil {
 			return nil, err
 		}
-		sp.numSysmsgThreads++
+		sp.numSysmsgThreads.Add(1)
 	}
 
 	return sp, nil
@@ -845,7 +849,16 @@ func (s *subprocess) switchToApp(c *platformContext, ac *arch.Context64) (isSysc
 	// Check if there's been an error.
 	threadID := ctx.threadID()
 	if threadID != invalidThreadID {
-		if sysThread, ok := s.sysmsgThreads[threadID]; ok && sysThread.msg.Err != 0 {
+		// s.sysmsgThreads is mutated under sysmsgThreadsMu (see e.g.
+		// subprocess.NewSysmsgThread) — concurrent read here without the
+		// lock is a Go map race that triggers `fatal error: concurrent
+		// map read and map write` in the runtime. Same class as #12927
+		// (TOCTOU on shared ThreadID). RLock is used so that concurrent
+		// SwitchToApp lookups don't serialize against each other.
+		s.sysmsgThreadsMu.RLock()
+		sysThread, ok := s.sysmsgThreads[threadID]
+		s.sysmsgThreadsMu.RUnlock()
+		if ok && sysThread.msg.Err != 0 {
 			sysmsgErr := sysThread.msg.ConvertSysmsgErr()
 			log.BugTraceback(sysmsgErr)
 			return false, false, hostarch.NoAccess, sysmsgErr
@@ -966,26 +979,33 @@ func (s *subprocess) kickSysmsgThread() bool {
 	if !kick {
 		return false
 	}
-
-	s.sysmsgThreadsMu.Lock()
-	kick, nrThreads := s.canKickSysmsgThread()
-	if !kick {
-		s.sysmsgThreadsMu.Unlock()
-		return false
-	}
 	numTimesStubKicked.Increment()
 	atomic.AddUint32(&s.contextQueue.numThreadsToWakeup, 1)
-	if s.numSysmsgThreads < maxSysmsgThreads && s.numSysmsgThreads < int(nrThreads) {
-		s.numSysmsgThreads++
-		s.sysmsgThreadsMu.Unlock()
+
+	// Atomically claim a sysmsg-thread slot below the cap. CAS prevents
+	// concurrent kickers from incrementing past maxSysmsgThreads when both
+	// observe numSysmsgThreads under the cap simultaneously.
+	owned := false
+	for {
+		kick, nrThreads := s.canKickSysmsgThread()
+		if !kick {
+			break
+		}
+		n := s.numSysmsgThreads.Load()
+		if n >= int32(maxSysmsgThreads) || n >= int32(nrThreads) {
+			break
+		}
+		if s.numSysmsgThreads.CompareAndSwap(n, n+1) {
+			owned = true
+			break
+		}
+		// Lost the race to another kicker; reread and try again.
+	}
+	if owned {
 		if err := s.createSysmsgThread(); err != nil {
 			log.Warningf("Unable to create a new stub thread: %s", err)
-			s.sysmsgThreadsMu.Lock()
-			s.numSysmsgThreads--
-			s.sysmsgThreadsMu.Unlock()
+			s.numSysmsgThreads.Add(-1)
 		}
-	} else {
-		s.sysmsgThreadsMu.Unlock()
 	}
 	s.contextQueue.wakeupSysmsgThread()
 


### PR DESCRIPTION
## Summary

`subprocess.switchToApp` reads `s.sysmsgThreads[threadID]` without holding `s.sysmsgThreadsMu`, while writes elsewhere (`NewSysmsgThread` at the same file:1200-1202) hold the mutex. Concurrent execution can therefore trigger Go runtime's `fatal error: concurrent map read and map write`, terminating the sentry.

This is the same exposure surface as #12927 (which fixed a sibling TOCTOU read of the guest-writable `ThreadID`).

## Reproduction window

The error path in `switchToApp` only fires when `ctx.threadID() != invalidThreadID` after `waitOnState` returns. In practice this means a malformed shared-context state from the stub thread. With the existing `s.sysmsgThreads[threadID] = sysThread` write under `sysmsgThreadsMu`, any concurrent thread spawn during a context-switch error reaches the unprotected read.

## Fix

Take `sysmsgThreadsMu` around the read, copy the entry out, release before the rest of the function runs. Critical section stays small (one map lookup) and mirrors the surrounding `s.sysmsgThreadsMu.Lock(); ...; s.sysmsgThreadsMu.Unlock()` block already used elsewhere in this file.

## Test plan

- [x] Build/test will be exercised by CI on this PR.
- [x] Pattern matches the merged precedent in #12927; reviewer is invited to run with `-race` against `pkg/sentry/platform/systrap/...` to confirm the race is gone.