### PR TITLE
sentry: Bump LinuxRelease from 4.4.0 to 4.19.0-gvisor

### DIFF
--- a/pkg/sentry/kernel/version/version.go
+++ b/pkg/sentry/kernel/version/version.go
@@ -20,7 +20,15 @@ const (
 	LinuxSysname = "Linux"
 
 	// LinuxRelease is the Linux release version number advertised by gVisor.
-	LinuxRelease = "4.4.0"
+	//
+	// Must be high enough to satisfy the NT_GNU_ABI_TAG minimum-kernel check
+	// performed by glibc's dynamic linker; otherwise dlopen() rejects modern
+	// shared libraries (e.g. libQt6Core.so.6 requires >= 4.11.0) with a
+	// misleading ENOENT. 4.19 is the final LTS of the Linux 4.x series,
+	// which keeps us on a 4.x base consistent with the syscall table ABI
+	// while providing headroom for typical modern userspace. The "-gvisor"
+	// suffix follows the distro-kernel convention (e.g. "-generic", "-azure").
+	LinuxRelease = "4.19.0-gvisor"
 
 	// LinuxVersion is the version info advertised by gVisor.
 	LinuxVersion = "#1 SMP Sun Jan 10 15:06:54 PST 2016"


### PR DESCRIPTION
glibc's dynamic linker checks NT_GNU_ABI_TAG against uname() and rejects shared libraries requiring a kernel newer than the reported version. This broke loading libraries like libQt6Core.so.6 (requires >= 4.11.0) under gVisor.

Bump the advertised release to 4.19.0-gvisor to provide headroom above modern userspace requirements, while staying on a 4.x base consistent with the syscall table. The "-gvisor" suffix follows the distro-kernel convention (e.g. "-generic", "-azure").