### PR TITLE
net: Support getsockopt with small buffer for int TCP options

### DIFF
--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -355,6 +355,26 @@ const DefaultTTL = 64
 
 const sizeOfInt32 int = 4
 
+// truncateInt32Result truncates an int32 value to outLen bytes, mimicking
+// the Linux kernel's getsockopt behavior for small buffers. Linux's
+// do_tcp_getsockopt() clamps the user-supplied buflen via
+// len = min_t(unsigned int, len, sizeof(int)), then copies len bytes of
+// the little-endian integer value to user space. In particular, outLen=0
+// is a valid (though unusual) request that succeeds with a zero-length
+// write, so we must not reject it with EINVAL.
+func truncateInt32Result(v primitive.Int32, outLen int) (marshal.Marshallable, *syserr.Error) {
+	if outLen >= sizeOfInt32 {
+		return &v, nil
+	}
+	if outLen < 0 {
+		return nil, syserr.ErrInvalidArgument
+	}
+	buf := make([]byte, sizeOfInt32)
+	hostarch.ByteOrder.PutUint32(buf, uint32(v))
+	bufP := primitive.ByteSlice(buf[:outLen])
+	return &bufP, nil
+}
+
 var errStackType = syserr.New("expected but did not receive a netstack.Stack", errno.EINVAL)
 
 // commonEndpoint represents the intersection of a tcpip.Endpoint and a
@@ -1166,88 +1186,56 @@ func (s *sock) getSockOptTCP(t *kernel.Task, ep commonEndpoint, name, outLen int
 
 	switch name {
 	case linux.TCP_NODELAY:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		v := primitive.Int32(boolToInt32(!ep.SocketOptions().GetDelayOption()))
-		return &v, nil
+		return truncateInt32Result(v, outLen)
 
 	case linux.TCP_CORK:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		v := primitive.Int32(boolToInt32(ep.SocketOptions().GetCorkOption()))
-		return &v, nil
+		return truncateInt32Result(v, outLen)
 
 	case linux.TCP_QUICKACK:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		v := primitive.Int32(boolToInt32(ep.SocketOptions().GetQuickAck()))
-		return &v, nil
+		return truncateInt32Result(v, outLen)
 
 	case linux.TCP_MAXSEG:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		v, err := ep.GetSockOptInt(tcpip.MaxSegOption)
 		if err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
 		vP := primitive.Int32(v)
-		return &vP, nil
+		return truncateInt32Result(vP, outLen)
 
 	case linux.TCP_KEEPIDLE:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		var v tcpip.KeepaliveIdleOption
 		if err := ep.GetSockOpt(&v); err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
 		keepAliveIdle := primitive.Int32(time.Duration(v) / time.Second)
-		return &keepAliveIdle, nil
+		return truncateInt32Result(keepAliveIdle, outLen)
 
 	case linux.TCP_KEEPINTVL:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		var v tcpip.KeepaliveIntervalOption
 		if err := ep.GetSockOpt(&v); err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
 		keepAliveInterval := primitive.Int32(time.Duration(v) / time.Second)
-		return &keepAliveInterval, nil
+		return truncateInt32Result(keepAliveInterval, outLen)
 
 	case linux.TCP_KEEPCNT:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		v, err := ep.GetSockOptInt(tcpip.KeepaliveCountOption)
 		if err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
 		vP := primitive.Int32(v)
-		return &vP, nil
+		return truncateInt32Result(vP, outLen)
 
 	case linux.TCP_USER_TIMEOUT:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		var v tcpip.TCPUserTimeoutOption
 		if err := ep.GetSockOpt(&v); err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
 		tcpUserTimeout := primitive.Int32(time.Duration(v) / time.Millisecond)
-		return &tcpUserTimeout, nil
+		return truncateInt32Result(tcpUserTimeout, outLen)
 
 	case linux.TCP_INFO:
 		var v tcpip.TCPInfoOption
@@ -1324,10 +1312,6 @@ func (s *sock) getSockOptTCP(t *kernel.Task, ep commonEndpoint, name, outLen int
 		return &bP, nil
 
 	case linux.TCP_LINGER2:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		var v tcpip.TCPLingerTimeoutOption
 		if err := ep.GetSockOpt(&v); err != nil {
 			return nil, syserr.TranslateNetstackError(err)
@@ -1338,44 +1322,31 @@ func (s *sock) getSockOptTCP(t *kernel.Task, ep commonEndpoint, name, outLen int
 		} else {
 			lingerTimeout = -1
 		}
-		return &lingerTimeout, nil
+		return truncateInt32Result(lingerTimeout, outLen)
 
 	case linux.TCP_DEFER_ACCEPT:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		var v tcpip.TCPDeferAcceptOption
 		if err := ep.GetSockOpt(&v); err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
-
 		tcpDeferAccept := primitive.Int32(time.Duration(v) / time.Second)
-		return &tcpDeferAccept, nil
+		return truncateInt32Result(tcpDeferAccept, outLen)
 
 	case linux.TCP_SYNCNT:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		v, err := ep.GetSockOptInt(tcpip.TCPSynCountOption)
 		if err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
 		vP := primitive.Int32(v)
-		return &vP, nil
+		return truncateInt32Result(vP, outLen)
 
 	case linux.TCP_WINDOW_CLAMP:
-		if outLen < sizeOfInt32 {
-			return nil, syserr.ErrInvalidArgument
-		}
-
 		v, err := ep.GetSockOptInt(tcpip.TCPWindowClampOption)
 		if err != nil {
 			return nil, syserr.TranslateNetstackError(err)
 		}
 		vP := primitive.Int32(v)
-		return &vP, nil
+		return truncateInt32Result(vP, outLen)
 	}
 	return nil, syserr.ErrProtocolNotAvailable
 }

--- a/test/syscalls/linux/tcp_socket.cc
+++ b/test/syscalls/linux/tcp_socket.cc
@@ -715,6 +715,65 @@ TEST_P(TcpSocketTest, SetNoDelay) {
   EXPECT_EQ(get, kSockOptOff);
 }
 
+// Linux's do_tcp_getsockopt() clamps the user-supplied buflen with
+// len = min_t(unsigned int, len, sizeof(int)) and copies that many bytes of
+// the integer value to user space (see net/ipv4/tcp.c). Verify that gVisor
+// truncates to the requested buflen for all integer TCP options instead of
+// rejecting sub-int buffers with EINVAL.
+TEST_P(TcpSocketTest, IntegerOptGetsockoptSmallBuffer) {
+  struct {
+    int optname;
+    const char* name;
+  } kOpts[] = {
+      {TCP_NODELAY, "TCP_NODELAY"},
+      {TCP_CORK, "TCP_CORK"},
+      {TCP_QUICKACK, "TCP_QUICKACK"},
+      {TCP_MAXSEG, "TCP_MAXSEG"},
+      {TCP_KEEPIDLE, "TCP_KEEPIDLE"},
+      {TCP_KEEPINTVL, "TCP_KEEPINTVL"},
+      {TCP_KEEPCNT, "TCP_KEEPCNT"},
+      {TCP_USER_TIMEOUT, "TCP_USER_TIMEOUT"},
+      {TCP_LINGER2, "TCP_LINGER2"},
+      {TCP_DEFER_ACCEPT, "TCP_DEFER_ACCEPT"},
+      {TCP_SYNCNT, "TCP_SYNCNT"},
+      {TCP_WINDOW_CLAMP, "TCP_WINDOW_CLAMP"},
+  };
+  constexpr socklen_t kBuflens[] = {0, 1, 2, 3, 5};
+
+  for (const auto& opt : kOpts) {
+    SCOPED_TRACE(opt.name);
+
+    // Baseline: read the full 4-byte value.
+    uint8_t full[sizeof(int)] = {};
+    socklen_t full_len = sizeof(full);
+    ASSERT_THAT(getsockopt(connected_.get(), IPPROTO_TCP, opt.optname, full,
+                           &full_len),
+                SyscallSucceeds());
+    ASSERT_EQ(full_len, sizeof(int));
+
+    for (const socklen_t buflen : kBuflens) {
+      SCOPED_TRACE(buflen);
+      uint8_t buf[8];
+      memset(buf, 0xcd, sizeof(buf));
+      socklen_t outlen = buflen;
+      EXPECT_THAT(getsockopt(connected_.get(), IPPROTO_TCP, opt.optname, buf,
+                             &outlen),
+                  SyscallSucceeds());
+      const socklen_t want_outlen =
+          buflen < sizeof(int) ? buflen : socklen_t{sizeof(int)};
+      EXPECT_EQ(outlen, want_outlen);
+      // The first want_outlen bytes must match the baseline.
+      for (socklen_t i = 0; i < want_outlen; i++) {
+        EXPECT_EQ(buf[i], full[i]) << "byte " << i;
+      }
+      // Bytes past want_outlen must not be written.
+      for (socklen_t i = want_outlen; i < sizeof(buf); i++) {
+        EXPECT_EQ(buf[i], 0xcd) << "byte " << i;
+      }
+    }
+  }
+}
+
 #ifndef TCP_INQ
 #define TCP_INQ 36
 #endif


### PR DESCRIPTION
Linux's do_tcp_getsockopt() clamps the user-supplied buflen via len = min_t(unsigned int, len, sizeof(int)) and copies that many bytes of the integer value, so a sub-int (or zero-length) buffer returns a truncated result rather than EINVAL. gVisor instead rejects any outLen < 4 with EINVAL, which breaks real callers: python-trio probes TCP_NODELAY with buflen=1 to detect its availability and fails with OSError(EINVAL).

Route all 12 integer TCP options (TCP_NODELAY, TCP_CORK, TCP_QUICKACK, TCP_MAXSEG, TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT, TCP_USER_TIMEOUT, TCP_LINGER2, TCP_DEFER_ACCEPT, TCP_SYNCNT, TCP_WINDOW_CLAMP) through a shared helper that truncates the value to outLen bytes, matching Linux. outLen == 0 is a valid (zero-byte) read and must not be rejected.

Reference: net/ipv4/tcp.c:do_tcp_getsockopt()