### PR TITLE
proc: Add context switch fields to /proc/pid/status

### DIFF
--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -999,6 +999,10 @@ func (s *statusFD) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	// pkg/sentry/syscalls/linux/sys_mempolicy.go.
 	fmt.Fprintf(buf, "Mems_allowed:\t1\n")
 	fmt.Fprintf(buf, "Mems_allowed_list:\t0\n")
+	fmt.Fprintf(buf, "voluntary_ctxt_switches:\t%d\n", s.task.CPUStats().VoluntarySwitches)
+	// Involuntary context switches are unsupported because Go runtime
+	// preemption events are not exposed to gVisor.
+	fmt.Fprintf(buf, "nonvoluntary_ctxt_switches:\t0\n")
 	return nil
 }
 


### PR DESCRIPTION
Linux exposes voluntary_ctxt_switches and nonvoluntary_ctxt_switches in /proc/[pid]/status from fs/proc/array.c:task_context_switch_counts().

Python's psutil package parses these fields to implement Process.num_ctx_switches(), and ddtrace depends on psutil for runtime metrics.

gVisor already tracks voluntary context switches through Task.CPUStats().VoluntarySwitches, which is also used for getrusage(RUSAGE_THREAD). Reuse that value for voluntary_ctxt_switches.

Involuntary context switches remain reported as 0 because gVisor does not receive Go runtime preemption counts.