### PR TITLE
feat: Support NVIDIA k8s-device-plugin with CDI

### DIFF
--- a/pkg/shim/v1/proc/init_state.go
+++ b/pkg/shim/v1/proc/init_state.go
@@ -89,7 +89,9 @@ func (s *createdState) Start(ctx context.Context, restoreConf *extension.Restore
 		// To work around that, we treat non-root container in start/restore
 		// failure state as stopped.
 		if !s.p.Sandbox {
-			s.p.io.Close()
+			if s.p.io != nil {
+				s.p.io.Close()
+			}
 			s.p.setExited(internalErrorCode)
 			s.transition(stopped)
 		}

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1379,11 +1379,11 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 	if err := c.initGoferConfs(conf.GetOverlay2(), mountHints, rootfsHint); err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("error initializing gofer confs: %w", err)
 	}
-	if !c.GoferMountConfs[0].ShouldUseLisafs() && specutils.GPUFunctionalityRequestedViaHook(c.Spec, conf) {
-		// nvidia-container-runtime-hook attempts to populate the container
-		// rootfs with NVIDIA libraries and devices. With EROFS, spec.Root.Path
-		// points to an empty directory and populating that has no effect.
-		return nil, nil, nil, nil, fmt.Errorf("nvidia-container-runtime-hook cannot be used together with non-lisafs backed root mount")
+	if !c.GoferMountConfs[0].ShouldUseLisafs() && specutils.GPUFunctionalityRequested(c.Spec, conf) {
+		// nvidia-container-cli configure bind-mounts NVIDIA libraries and
+		// devices into spec.Root.Path. With EROFS, spec.Root.Path points to an
+		// empty directory and those bind mounts have no effect.
+		return nil, nil, nil, nil, fmt.Errorf("NVIDIA GPU support cannot be used together with non-lisafs backed root mount")
 	}
 	if !shouldSpawnGofer(c.Spec, conf, c.GoferMountConfs) {
 		if !c.GoferMountConfs[0].ShouldUseErofs() {
@@ -2073,7 +2073,7 @@ func logIDMappings(mappings []specs.LinuxIDMapping, idType string) {
 // This should only be necessary once on the host. It should be run during the
 // root container setup sequence to make sure it has run at least once.
 func nvProxyPreGoferHostSetup(spec *specs.Spec, conf *config.Config) error {
-	if !specutils.GPUFunctionalityRequestedViaHook(spec, conf) {
+	if !specutils.GPUFunctionalityRequested(spec, conf) {
 		return nil
 	}
 
@@ -2162,7 +2162,7 @@ func nvproxyLoadKernelModules() {
 // Note that nvidia-container-cli will set up files in /proc which are useless,
 // since they will be hidden by sentry procfs.
 func nvproxySetup(spec *specs.Spec, conf *config.Config, goferPid int) error {
-	if !specutils.GPUFunctionalityRequestedViaHook(spec, conf) {
+	if !specutils.GPUFunctionalityRequested(spec, conf) {
 		return nil
 	}
 
@@ -2188,9 +2188,18 @@ func nvproxySetup(spec *specs.Spec, conf *config.Config, goferPid int) error {
 		ldconfigPath = "/sbin/ldconfig"
 	}
 
-	devices, err := specutils.ParseNvidiaVisibleDevices(spec, conf)
-	if err != nil {
-		return fmt.Errorf("failed to get nvidia device numbers: %w", err)
+	// Determine the set of GPU devices to configure. In the hook-based path
+	// (Docker/legacy), devices come from NVIDIA_VISIBLE_DEVICES. In the GKE
+	// path, the device plugin injects them directly into spec.Linux.Devices.
+	var devices string
+	if specutils.GPUFunctionalityRequestedViaHook(spec, conf) {
+		if devices, err = specutils.ParseNvidiaVisibleDevices(spec, conf); err != nil {
+			return fmt.Errorf("failed to get nvidia device numbers: %w", err)
+		}
+	} else {
+		if devices, err = specutils.NvidiaDevicesFromSpec(spec); err != nil {
+			return fmt.Errorf("failed to get nvidia device numbers from spec: %w", err)
+		}
 	}
 
 	argv := []string{

--- a/runsc/specutils/nvidia.go
+++ b/runsc/specutils/nvidia.go
@@ -153,6 +153,36 @@ func nvidiaVisibleDevsEnvVar(envs []string, kind nvidiaHookKind) string {
 	return nvds[len(nvds)-1]
 }
 
+// NvidiaDevicesFromSpec returns a comma-separated list of NVIDIA GPU device
+// indices derived from spec.Linux.Devices. This is used in the GKE path where
+// the device plugin injects devices directly into the spec rather than via
+// NVIDIA_VISIBLE_DEVICES. Only /dev/nvidiaX entries (where X is a decimal
+// index) are included; control/UVM/modeset devices are skipped.
+//
+// Precondition: GPUFunctionalityRequested(spec, conf) and not via hook.
+func NvidiaDevicesFromSpec(spec *specs.Spec) (string, error) {
+	if spec.Linux == nil {
+		return "", fmt.Errorf("spec missing Linux section")
+	}
+	var indices []string
+	for _, dev := range spec.Linux.Devices {
+		// Match /dev/nvidiaX where X is a decimal number.
+		// This excludes /dev/nvidiactl, /dev/nvidia-uvm, /dev/nvidia-modeset, etc.
+		suffix := strings.TrimPrefix(dev.Path, "/dev/nvidia")
+		if suffix == dev.Path {
+			continue
+		}
+		if _, err := strconv.ParseUint(suffix, 10, 32); err != nil {
+			continue
+		}
+		indices = append(indices, suffix)
+	}
+	if len(indices) == 0 {
+		return "", fmt.Errorf("no NVIDIA GPU devices (/dev/nvidiaX) found in spec.Linux.Devices")
+	}
+	return strings.Join(indices, ","), nil
+}
+
 // ParseNvidiaVisibleDevices parses NVIDIA_VISIBLE_DEVICES env var and returns
 // the devices specified in it. This can be passed to nvidia-container-cli.
 //


### PR DESCRIPTION
# Description

gVisor supports two paths for injecting NVIDIA devices:

1. Through the legacy OCI pre-start hook created by
   nvidia-container-runtime-hook (legacy)
2. Through CDI annotations.

When gVisor detected GPUs were being attached through the legacy hook
method, it would correctly run the nvidia-container-cli to modify the
container's rootfs to create the NVIDIA library symlinks that client
applications need (through ldconfig) to speak to the host driver. When
the NVIDIA k8s-device-plugin is used in CDI mode, it injects the client
libraries but not the symlinks. The only step that was missing was the
symlink creation with nvidia-container-cli.

This commit modifies the GPU detection logic to check both the CDI
annotations for the presence of GPUs and the legacy hook-based method.
If GPUs are detected in the CDI annotations, the code path to run the
symlinking step is performed.

The normal limitations apply in this scenario regarding
nvidia-container-cli, namely that the container's rootfs must be
writable. If it's not writable, like when using a readonly image
distribution mechanism (EROFS for example), this will not work. This
limitation applied in the legacy scenario anyway, so there is no
regression.

# Doesn't k8s-device-plugin already do symlinking?

You'll notice in k8s-device-plugin, it already has hooks for creating these symlinks. For example:

```
  "containerEdits": {
    "hooks": [
      {
        "hookName": "createContainer",
        "path": "/usr/bin/nvidia-ctk",
        "args": [
          "nvidia-ctk",
          "hook",
          "create-symlinks",
          "--link",
          "libnvidia-opticalflow.so.1::/usr/lib/x86_64-linux-gnu/libnvidia-opticalflow.so",
          "--link",
          "libGLX_nvidia.so.580.126.20::/usr/lib/x86_64-linux-gnu/libGLX_indirect.so.0",
          "--link",
          "libcuda.so.1::/usr/lib/x86_64-linux-gnu/libcuda.so"
        ]
      },
    ],
```

However, gVisor explicitly does not run [createContainer hooks](https://github.com/google/gvisor/blob/release-20260420.0/runsc/container/container.go#L408-L410) because they're not supported.

This is why gVisor must run `nvidia-container-cli configure` manually to create the symlinks and update the ldconfig cache.