### PR TITLE
feat: Support running createContainer hooks in CDI spec

### DIFF
--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -126,7 +126,7 @@ func (g *Gofer) Synopsis() string {
 
 // Usage implements subcommands.Command.
 func (*Gofer) Usage() string {
-	return "gofer [flags]\n"
+	return "gofer [flags] <container ID>\n"
 }
 
 // SetFlags implements subcommands.Command.
@@ -160,6 +160,11 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 		f.Usage()
 		return subcommands.ExitUsageError
 	}
+	if f.NArg() != 1 {
+		f.Usage()
+		return subcommands.ExitUsageError
+	}
+	containerID := f.Arg(0)
 
 	conf := args[0].(*config.Config)
 
@@ -185,7 +190,7 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	defer goferToHostRPC.Close()
 
 	if g.setUpRoot {
-		if err := sandboxsetup.SetupRootFS(spec, conf, g.mountConfs, g.devIoFD, makeRPCMountOpener(goferToHostRPC)); err != nil {
+		if err := sandboxsetup.SetupRootFS(spec, conf, g.mountConfs, g.devIoFD, makeRPCMountOpener(goferToHostRPC), containerID, g.bundleDir); err != nil {
 			util.Fatalf("Error setting up root FS: %v", err)
 		}
 		if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {

--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -77,15 +77,42 @@ func WriteMounts(mountsFD int, mounts []specs.Mount) error {
 	return nil
 }
 
-// SetupRootFS prepares the root filesystem for the gofer process. It mounts
-// the container root, sets up submounts and /dev, and optionally remounts
-// root as read-only. If chroot mode is active, it also performs a
-// pivot_root.
+// SetupRootFS prepares the filesystem the gofer will serve to the sandbox.
+// There are some gVisor-specific quirks:
+//   - The gofer runs with minimal capabilities (see runsc/cmd/gofer.go).
+//     However, gofer startup requires more capabilities (for example,
+//     pivot_root(2) requires CAP_SYS_ADMIN).
+//   - As a result, the gofer sets up the container rootfs, does pivot_root(2),
+//     and then re-executes itself while dropping extra capabilities.
+//   - To re-execute itself, it requires access to `/proc/self/exe` after
+//     pivot_root(2).
+//
+// For this reason, we can't just pivot_root(2) into the container rootfs path
+// (i.e. spec.Root.Path), as it would mean bind-mounting host /proc inside
+// spec.Root.Path, which might be a read-only filesystem.
+//
+// Furthermore, createContainer hooks from the OCI spec need to run before the
+// pivot_root(2) and expect the container rootfs to be prepared at
+// spec.Root.Path with all the bind-mounts in place.
+//
+// To satisfy all of these requirements, this is the approach we take:
+//  1. We prepare all the bind-mounts in `spec.Root.Path` and execute the
+//     createContainer hooks.
+//  2. We create a new tmpfs mount at /proc/fs.
+//  3. We bind-mount host /proc and spec.Root.Path onto /proc/fs/proc and
+//     /proc/fs/root, respectively.
+//  4. We then pivot_root(2) into /proc/fs. Now host procfs is accessible via
+//     /proc/ and container rootfs is accessible via /root.
+//  5. We re-exec the gofer binary and drop extra capabilities.
+//  6. We unmount the /proc bind mount.
+//  7. We chroot(2) into /root (note that the gofer runs with CAP_SYS_CHROOT).
+//
+// This function does steps 1-4.
 //
 // mountConfs must be indexed such that mountConfs[0] is the root filesystem
 // configuration and subsequent entries correspond to spec mounts with
 // mount configs.
-func SetupRootFS(spec *specs.Spec, conf *config.Config, mountConfs []specutils.GoferMountConf, devIoFD int, mountOpener MountOpener) error {
+func SetupRootFS(spec *specs.Spec, conf *config.Config, mountConfs []specutils.GoferMountConf, devIoFD int, mountOpener MountOpener, containerID string, bundleDir string) error {
 	// Convert all shared mounts into slaves to be sure that nothing will be
 	// propagated outside of our namespace.
 	procPath := "/proc"
@@ -93,7 +120,9 @@ func SetupRootFS(spec *specs.Spec, conf *config.Config, mountConfs []specutils.G
 		util.Fatalf("error converting mounts: %v", err)
 	}
 
-	root := spec.Root.Path
+	goferRootFs := spec.Root.Path
+	containerRootFs := spec.Root.Path
+
 	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
 		// runsc can't be re-executed without /proc, so we create a tmpfs mount,
 		// mount ./proc and ./root there, then move this mount to the root and after
@@ -132,51 +161,87 @@ func SetupRootFS(spec *specs.Spec, conf *config.Config, mountConfs []specutils.G
 		if err := CopyFile("/proc/fs/etc/localtime", "/etc/localtime"); err != nil {
 			log.Warningf("Failed to copy /etc/localtime: %v. UTC timezone will be used.", err)
 		}
-		root = "/proc/fs/root"
+		goferRootFs = "/proc/fs/root"
 		procPath = "/proc/fs/proc"
 	}
 
 	rootfsConf := mountConfs[0]
-	if rootfsConf.ShouldUseLisafs() {
-		// Mount root path followed by submounts.
-		if err := specutils.SafeMount(spec.Root.Path, root, "bind", unix.MS_BIND|unix.MS_REC, "", procPath); err != nil {
-			return fmt.Errorf("mounting root on root (%q) err: %v", root, err)
-		}
+	if !rootfsConf.ShouldUseLisafs() {
+		// When not using gofer mount for rootfs, spec.Root.Path may not be set or may not be a
+		// writable directory. So set up the container rootfs directly in /proc/fs/root, which
+		// is a writable directory.
+		containerRootFs = goferRootFs
+	}
 
-		flags := uint32(unix.MS_SLAVE | unix.MS_REC)
-		if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
-			flags = specutils.PropOptionsToFlags([]string{spec.Linux.RootfsPropagation})
-		}
-		if err := specutils.SafeMount("", root, "", uintptr(flags), "", procPath); err != nil {
-			return fmt.Errorf("mounting root (%q) with flags: %#x, err: %v", root, flags, err)
-		}
+	// Many CDI createContainer hooks will pivot_root(2) into spec.Root.Path.
+	// pivot_root(2) requires the target to be a mount point, so we must self-bind-mount
+	// spec.Root.Path here. runc does this step unconditionally in
+	// libcontainer/rootfs_linux.go:prepareRoot()
+	if err := unix.Mount(containerRootFs, containerRootFs, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		return fmt.Errorf("self-bind-mounting rootfs %q for hooks: %w", containerRootFs, err)
+	}
+
+	// Ensure the containerRootFs is set to the RootfsPropagation that the user requested.
+	// Mounts added under SetupMounts inherit the propagation flags of the root.
+	flags := uint32(unix.MS_SLAVE | unix.MS_REC)
+	if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
+		flags = specutils.PropOptionsToFlags([]string{spec.Linux.RootfsPropagation})
+	}
+	if err := specutils.SafeMount("", containerRootFs, "", uintptr(flags), "", procPath); err != nil {
+		return fmt.Errorf("mounting root (%q) with flags: %#x, err: %v", containerRootFs, flags, err)
 	}
 
 	// Replace the current spec, with the clean spec with symlinks resolved.
-	if err := SetupMounts(conf, spec.Mounts, root, procPath, mountConfs, mountOpener); err != nil {
+	if err := SetupMounts(conf, spec.Mounts, containerRootFs, procPath, mountConfs, mountOpener); err != nil {
 		util.Fatalf("error setting up FS: %v", err)
 	}
 
 	// Set up /dev directory if needed.
 	if devIoFD >= 0 {
-		if err := SetupDev(spec, conf, root, procPath); err != nil {
+		if err := SetupDev(spec, conf, containerRootFs, procPath); err != nil {
 			util.Fatalf("error setting up /dev: %v", err)
 		}
 	}
 
-	// Check if root needs to be remounted as readonly.
-	if rootfsConf.ShouldUseLisafs() && (spec.Root.Readonly || rootfsConf.ShouldUseOverlayfs()) {
-		// If root is a mount point but not read-only, we can change mount options
-		// to make it read-only for extra safety.
-		// unix.MS_NOSUID and unix.MS_NODEV are included here not only
-		// for safety reasons but also because they can be locked and
-		// any attempts to unset them will fail.  See
-		// mount_namespaces(7) for more details.
-		log.Infof("Remounting root as readonly: %q", root)
-		flags := uintptr(unix.MS_BIND | unix.MS_REMOUNT | unix.MS_RDONLY | unix.MS_NOSUID | unix.MS_NODEV)
-		if err := specutils.SafeMount(root, root, "bind", flags, "", procPath); err != nil {
-			return fmt.Errorf("remounting root as read-only with source: %q, target: %q, flags: %#x, err: %v", root, root, flags, err)
+	if rootfsConf.ShouldUseLisafs() {
+		if spec.Hooks != nil && len(spec.Hooks.CreateContainer) > 0 {
+			state := specs.State{
+				Version: specs.Version,
+				ID:      containerID,
+				Status:  specs.StateCreating,
+				// The container pid is not easily available at this point. We'll set it to -1 to indicate that it's not available.
+				// A future improvement could plumb this value through to the gofer if it becomes necessary.
+				Pid:         -1,
+				Bundle:      bundleDir,
+				Annotations: spec.Annotations,
+			}
+			if err := specutils.ExecuteHooks(spec.Hooks.CreateContainer, state); err != nil {
+				util.Fatalf("error executing CreateContainer hooks: %v", err)
+			}
 		}
+
+		// Now that spec.Root.Path has been prepared, we can bind-mount it to the new root. This will
+		// make the container rootfs visible in the gofer root.
+		if err := unix.Mount(containerRootFs, goferRootFs, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+			return fmt.Errorf("binding prepared rootfs to gofer root: %v", err)
+		}
+
+		// Check if root needs to be remounted as readonly.
+		if spec.Root.Readonly || rootfsConf.ShouldUseOverlayfs() {
+			// If root is a mount point but not read-only, we can change mount options
+			// to make it read-only for extra safety.
+			// unix.MS_NOSUID and unix.MS_NODEV are included here not only
+			// for safety reasons but also because they can be locked and
+			// any attempts to unset them will fail.  See
+			// mount_namespaces(7) for more details.
+			log.Infof("Remounting root as readonly: %q", goferRootFs)
+			flags := uintptr(unix.MS_BIND | unix.MS_REMOUNT | unix.MS_RDONLY | unix.MS_NOSUID | unix.MS_NODEV)
+			if err := specutils.SafeMount(goferRootFs, goferRootFs, "bind", flags, "", procPath); err != nil {
+				return fmt.Errorf("remounting root as read-only with source: %q, target: %q, flags: %#x, err: %v", goferRootFs, goferRootFs, flags, err)
+			}
+		}
+	} else if spec.Hooks != nil && len(spec.Hooks.CreateContainer) > 0 {
+		log.Warningf("CreateContainer hooks are not executed since container rootfs is not on lisafs")
 	}
 
 	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {

--- a/runsc/container/BUILD
+++ b/runsc/container/BUILD
@@ -10,7 +10,6 @@ go_library(
     srcs = [
         "container.go",
         "gofer_to_host_rpc.go",
-        "hook.go",
         "state_file.go",
         "status.go",
     ],

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -311,14 +311,11 @@ func New(conf *config.Config, args Args) (*Container, error) {
 		// "For runtimes that implement the deprecated prestart hooks as
 		// createRuntime hooks, createRuntime hooks MUST be called after the
 		// prestart hooks."
-		if err := executeHooks(c.Spec.Hooks.Prestart, c.State()); err != nil {
+		if err := specutils.ExecuteHooks(c.Spec.Hooks.Prestart, c.State()); err != nil {
 			return nil, err
 		}
-		if err := executeHooks(c.Spec.Hooks.CreateRuntime, c.State()); err != nil {
+		if err := specutils.ExecuteHooks(c.Spec.Hooks.CreateRuntime, c.State()); err != nil {
 			return nil, err
-		}
-		if len(c.Spec.Hooks.CreateContainer) > 0 {
-			log.Warningf("CreateContainer hook skipped because running inside container namespace is not supported")
 		}
 	}
 
@@ -524,7 +521,7 @@ func (c *Container) startImpl(conf *config.Config, action string, startRoot func
 	// the remaining hooks and lifecycle continue as if the hook had
 	// succeeded" -OCI spec.
 	if c.Spec.Hooks != nil {
-		executeHooksBestEffort(c.Spec.Hooks.Poststart, c.State())
+		specutils.ExecuteHooksBestEffort(c.Spec.Hooks.Poststart, c.State())
 	}
 
 	c.changeStatus(Running)
@@ -999,7 +996,7 @@ func (c *Container) Destroy() error {
 	// 2) Make sure it only runs once, because the root has been deleted, the
 	// container can't be loaded again.
 	if c.Spec.Hooks != nil {
-		executeHooksBestEffort(c.Spec.Hooks.Poststop, c.State())
+		specutils.ExecuteHooksBestEffort(c.Spec.Hooks.Poststop, c.State())
 	}
 
 	if len(errs) == 0 {
@@ -1616,8 +1613,13 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 
 	donations.Transfer(cmd, nextFD)
 
+	// Add container ID as the last argument.
+	cmd.Args = append(cmd.Args, c.ID)
+	log.Infof("Starting gofer with command: %v", cmd.Args)
+
 	// Start the gofer in the given namespace.
 	donation.LogDonations(cmd)
+
 	log.Debugf("Starting gofer: %s %v", cmd.Path, cmd.Args)
 	if err := specutils.StartInNS(cmd, nss); err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("gofer: %v", err)

--- a/runsc/specutils/BUILD
+++ b/runsc/specutils/BUILD
@@ -11,6 +11,7 @@ go_library(
         "cri.go",
         "fs.go",
         "gofer_conf.go",
+        "hooks.go",
         "namespace.go",
         "nvidia.go",
         "restore.go",

--- a/runsc/specutils/hooks.go
+++ b/runsc/specutils/hooks.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package container
+package specutils
 
 import (
 	"bytes"
@@ -39,27 +39,27 @@ import (
 // 		}]
 // },
 
-// executeHooksBestEffort executes hooks and logs warning in case they fail.
+// ExecuteHooksBestEffort executes hooks and logs warning in case they fail.
 // Runs all hooks, always.
-func executeHooksBestEffort(hooks []specs.Hook, s specs.State) {
+func ExecuteHooksBestEffort(hooks []specs.Hook, s specs.State) {
 	for _, h := range hooks {
-		if err := executeHook(h, s); err != nil {
+		if err := ExecuteHook(h, s); err != nil {
 			log.Warningf("Failure to execute hook %+v, err: %v", h, err)
 		}
 	}
 }
 
-// executeHooks executes hooks until the first one fails or they all execute.
-func executeHooks(hooks []specs.Hook, s specs.State) error {
+// ExecuteHooks executes hooks until the first one fails or they all execute.
+func ExecuteHooks(hooks []specs.Hook, s specs.State) error {
 	for _, h := range hooks {
-		if err := executeHook(h, s); err != nil {
+		if err := ExecuteHook(h, s); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func executeHook(h specs.Hook, s specs.State) error {
+func ExecuteHook(h specs.Hook, s specs.State) error {
 	log.Debugf("Executing hook %+v, state: %+v", h, s)
 
 	if strings.TrimSpace(h.Path) == "" {


### PR DESCRIPTION
Description
------------

This commit adds the ability for gVisor to run createContainer hooks in the CDI spec. This is needed to support NVIDIA's k8s-device-plugin running in `DEVICE_LIST_STRATEGY=cdi-cri`. In this mode, the plugin creates a CDI spec file at `/var/run/cdi/[...].json` that contains instructions on how to mount GPU devices, which client libraries to bind-mount into the container, and which `nvidia-ctk` hooks need to be run.

While the device cdev and client library injection mechanism already worked with gVisor, the createContainer hooks that created the library symlinks (e.g. `/usr/lib/x86_64-linux-gnu/libcuda.so -> libcuda.so.1`) and updated the ldconfig cache (`nvidia-ctk hook update-ldcache`) were missing. This meant that processes inside the container could not resolve the client libraries and thus did not know how to communicate with the `/dev/nvidiactl` and `/dev/nvidia${n}` cdevs. The CDI spec file contains the instructions on how to do this, so now gVisor follows it.

gVisor previously solved this problem by using the `nvidia-container-cli configure` command. This largely did the same things that the CDI spec file instructs us to do, but it is a legacy path and is not using CDI at all.

How it Works
------------

In gofer_mount.go, the code is changed to have explicit understandings
as to what is the containerRootFs (usually under /var/lib/.../root) and
the goferRootFs (/proc/fs). The issue with nvidia-ctk hooks is that they
would pivot_root(2) into the containerRootFs while gVisor would operate
under the goferRootFs. This meant that nvidia-ctk did not see any CDI
devices mounted into the containerRootFs.

This commit changes gVisor such that all devices and setup is done under
the containerRootFs. We then bind-mount containerRootFs into goferRootFs
after running the CreateContainer hooks. The gofer pivot_roots into the
goferRootFs as before.

Note that createContainer hooks are only run if the underlying rootfs is
writable. There are many scenarios, such as when using EROFS, where
createContainer hooks can't be executed. This problem will be saved for
another day to solve.

Result
-------

I ran this on an H200 system and confirmed both nvidia-smi:

```
root@debug-pod:/# nvidia-smi
Tue Apr 28 19:34:25 2026       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.20             Driver Version: 580.126.20     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H200                    Off |   N/A              Off |                    0 |
| N/A   27C    P0             76W /  700W |       0MiB / 143771MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
root@debug-pod:/# 

```

And CUDA vectoradd:

```
lclipp@CW-HP216DG9DT-L gvisor % k logs cuda-vectoradd-kata-gvisor
[Vector addition of 50000 elements]
Copy input data from the host memory to the CUDA device
CUDA kernel launch with 196 blocks of 256 threads
Copy output data from the CUDA device to the host memory
Test PASSED
Done
```

both work.

This supersedes https://github.com/google/gvisor/pull/13024 because this method does not touch the legacy hook-based NVIDIA_DEVICES method. This PR makes gVisor fully compatible with the NVIDIA k8s-device-plugin when using it in cdi-cri mode.