### PR TITLE
fsimpl/gofer/tmpfs: Support statx btime

### DIFF
--- a/pkg/sentry/fsimpl/gofer/directfs_inode.go
+++ b/pkg/sentry/fsimpl/gofer/directfs_inode.go
@@ -119,19 +119,20 @@ type directfsInode struct {
 //
 // newDirectfsDentry takes ownership of controlFD
 func (fs *filesystem) newDirectfsDentry(controlFD int) (*dentry, error) {
-	var stat unix.Stat_t
-	if err := unix.Fstat(controlFD, &stat); err != nil {
-		log.Warningf("failed to fstat(2) FD %d: %v", controlFD, err)
+	// Directfs initialization only needs basic identity/metadata plus btime.
+	var stat unix.Statx_t
+	if err := unix.Statx(controlFD, "", unix.AT_EMPTY_PATH, unix.STATX_BASIC_STATS|unix.STATX_BTIME, &stat); err != nil {
+		log.Warningf("failed to stat FD %d: %v", controlFD, err)
 		_ = unix.Close(controlFD)
 		return nil, err
 	}
-	if err := checkSupportedFileType(stat.Mode); err != nil {
+	if err := checkSupportedFileType(uint32(stat.Mode)); err != nil {
 		log.Warningf("checkSupportedFileType() failed for controlFD %d with mode %#o: %v", controlFD, stat.Mode, err)
 		_ = unix.Close(controlFD)
 		return nil, err
 	}
-	isDir := stat.Mode&linux.FileTypeMask == linux.ModeDirectory
-	inoKey := inoKeyFromStat(&stat)
+	isDir := uint32(stat.Mode)&linux.FileTypeMask == linux.ModeDirectory
+	inoKey := inoKeyFromStatxT(&stat)
 
 	// Common case. Performance hack which is used to allocate the dentry
 	// and its inode together in the heap. This will help reduce allocations and memory
@@ -151,21 +152,23 @@ func (fs *filesystem) newDirectfsDentry(controlFD int) (*dentry, error) {
 		func() *inode {
 			temp.i = directfsInode{
 				inode: inode{
-					fs:        fs,
-					inoKey:    inoKey,
-					ino:       fs.inoFromKey(inoKey),
-					mode:      atomicbitops.FromUint32(stat.Mode),
-					uid:       atomicbitops.FromUint32(stat.Uid),
-					gid:       atomicbitops.FromUint32(stat.Gid),
-					blockSize: atomicbitops.FromUint32(uint32(stat.Blksize)),
-					readFD:    atomicbitops.FromInt32(-1),
-					writeFD:   atomicbitops.FromInt32(-1),
-					mmapFD:    atomicbitops.FromInt32(-1),
-					size:      atomicbitops.FromUint64(uint64(stat.Size)),
-					atime:     atomicbitops.FromInt64(dentryTimestampFromUnix(stat.Atim)),
-					mtime:     atomicbitops.FromInt64(dentryTimestampFromUnix(stat.Mtim)),
-					ctime:     atomicbitops.FromInt64(dentryTimestampFromUnix(stat.Ctim)),
-					nlink:     atomicbitops.FromUint32(uint32(stat.Nlink)),
+					fs:         fs,
+					inoKey:     inoKey,
+					ino:        fs.inoFromKey(inoKey),
+					mode:       atomicbitops.FromUint32(uint32(stat.Mode)),
+					uid:        atomicbitops.FromUint32(stat.Uid),
+					gid:        atomicbitops.FromUint32(stat.Gid),
+					blockSize:  atomicbitops.FromUint32(stat.Blksize),
+					readFD:     atomicbitops.FromInt32(-1),
+					writeFD:    atomicbitops.FromInt32(-1),
+					mmapFD:     atomicbitops.FromInt32(-1),
+					size:       atomicbitops.FromUint64(stat.Size),
+					atime:      atomicbitops.FromInt64(dentryTimestampFromStatx(stat.Atime)),
+					mtime:      atomicbitops.FromInt64(dentryTimestampFromStatx(stat.Mtime)),
+					ctime:      atomicbitops.FromInt64(dentryTimestampFromStatx(stat.Ctime)),
+					btime:      atomicbitops.FromInt64(dentryTimestampFromStatx(stat.Btime)),
+					btimeValid: atomicbitops.FromBool(stat.Mask&linux.STATX_BTIME != 0),
+					nlink:      atomicbitops.FromUint32(stat.Nlink),
 				},
 				controlFD: controlFD,
 			}

--- a/pkg/sentry/fsimpl/gofer/directory.go
+++ b/pkg/sentry/fsimpl/gofer/directory.go
@@ -128,20 +128,21 @@ func (fs *filesystem) newSyntheticDentry(opts *createSyntheticOpts) *dentry {
 	child := &dentry{
 		refs: atomicbitops.FromInt64(1), // held by parent.
 		inode: &inode{
-			fs:        fs,
-			ino:       fs.nextIno(),
-			mode:      atomicbitops.FromUint32(uint32(opts.mode)),
-			uid:       atomicbitops.FromUint32(uint32(opts.kuid)),
-			gid:       atomicbitops.FromUint32(uint32(opts.kgid)),
-			blockSize: atomicbitops.FromUint32(hostarch.PageSize), // arbitrary
-			atime:     atomicbitops.FromInt64(now),
-			mtime:     atomicbitops.FromInt64(now),
-			ctime:     atomicbitops.FromInt64(now),
-			btime:     atomicbitops.FromInt64(now),
-			readFD:    atomicbitops.FromInt32(-1),
-			writeFD:   atomicbitops.FromInt32(-1),
-			mmapFD:    atomicbitops.FromInt32(-1),
-			nlink:     atomicbitops.FromUint32(2),
+			fs:         fs,
+			ino:        fs.nextIno(),
+			mode:       atomicbitops.FromUint32(uint32(opts.mode)),
+			uid:        atomicbitops.FromUint32(uint32(opts.kuid)),
+			gid:        atomicbitops.FromUint32(uint32(opts.kgid)),
+			blockSize:  atomicbitops.FromUint32(hostarch.PageSize), // arbitrary
+			atime:      atomicbitops.FromInt64(now),
+			mtime:      atomicbitops.FromInt64(now),
+			ctime:      atomicbitops.FromInt64(now),
+			btime:      atomicbitops.FromInt64(now),
+			btimeValid: atomicbitops.FromBool(true),
+			readFD:     atomicbitops.FromInt32(-1),
+			writeFD:    atomicbitops.FromInt32(-1),
+			mmapFD:     atomicbitops.FromInt32(-1),
+			nlink:      atomicbitops.FromUint32(2),
 		},
 	}
 	switch opts.mode.FileType() {

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -824,6 +824,14 @@ func inoKeyFromStatx(stat *lisafs.Statx) inoKey {
 	}
 }
 
+func inoKeyFromStatxT(stat *unix.Statx_t) inoKey {
+	return inoKey{
+		ino:      stat.Ino,
+		devMinor: stat.Dev_minor,
+		devMajor: stat.Dev_major,
+	}
+}
+
 func inoKeyFromStat(stat *unix.Stat_t) inoKey {
 	return inoKey{
 		ino:      stat.Ino,
@@ -861,6 +869,14 @@ type inode struct {
 	mtime atomicbitops.Int64
 	ctime atomicbitops.Int64
 	btime atomicbitops.Int64
+
+	// btimeValid is true if btime contains a valid value reported by the
+	// underlying filesystem. statx(STATX_BTIME) on filesystems that don't
+	// track creation time (e.g. NFSv4) won't set STATX_BTIME in the result
+	// mask, so we cache that information here to avoid exposing a zero
+	// btime.
+	btimeValid atomicbitops.Bool
+
 	// File size, which differs from other metadata in two ways:
 	//
 	//	- We make a best-effort attempt to keep it up to date even if
@@ -1237,7 +1253,14 @@ func (i *inode) fileType() uint32 {
 }
 
 func (d *dentry) statTo(stat *linux.Statx) {
-	stat.Mask = linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_NLINK | linux.STATX_UID | linux.STATX_GID | linux.STATX_ATIME | linux.STATX_MTIME | linux.STATX_CTIME | linux.STATX_INO | linux.STATX_SIZE | linux.STATX_BLOCKS | linux.STATX_BTIME
+	stat.Mask = linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_NLINK |
+		linux.STATX_UID | linux.STATX_GID | linux.STATX_ATIME |
+		linux.STATX_MTIME | linux.STATX_CTIME | linux.STATX_INO |
+		linux.STATX_SIZE | linux.STATX_BLOCKS
+	if d.inode.btimeValid.Load() {
+		stat.Mask |= linux.STATX_BTIME
+		stat.Btime = linux.NsecToStatxTimestamp(d.inode.btime.Load())
+	}
 	stat.Blksize = d.inode.blockSize.Load()
 	stat.Nlink = d.inode.nlink.Load()
 	if stat.Nlink == 0 {
@@ -1257,7 +1280,6 @@ func (d *dentry) statTo(stat *linux.Statx) {
 	// as having no holes.
 	stat.Blocks = (stat.Size + 511) / 512
 	stat.Atime = linux.NsecToStatxTimestamp(d.inode.atime.Load())
-	stat.Btime = linux.NsecToStatxTimestamp(d.inode.btime.Load())
 	stat.Ctime = linux.NsecToStatxTimestamp(d.inode.ctime.Load())
 	stat.Mtime = linux.NsecToStatxTimestamp(d.inode.mtime.Load())
 	stat.DevMajor = linux.UNNAMED_MAJOR

--- a/pkg/sentry/fsimpl/gofer/lisafs_inode.go
+++ b/pkg/sentry/fsimpl/gofer/lisafs_inode.go
@@ -179,6 +179,7 @@ func (fs *filesystem) newLisafsDentry(ctx context.Context, ino *lisafs.Inode) (*
 			}
 			if ino.Stat.Mask&linux.STATX_BTIME != 0 {
 				inode.btime = atomicbitops.FromInt64(dentryTimestamp(ino.Stat.Btime))
+				inode.btimeValid = atomicbitops.FromBool(true)
 			}
 
 			if ino.Stat.Mask&linux.STATX_NLINK != 0 {
@@ -304,6 +305,9 @@ func (i *lisafsInode) updateMetadataFromStatxLocked(stat *lisafs.Statx) {
 	}
 	if stat.Mask&linux.STATX_BTIME != 0 {
 		i.inode.btime.Store(dentryTimestamp(stat.Btime))
+		i.inode.btimeValid.Store(true)
+	} else {
+		i.inode.btimeValid.Store(false)
 	}
 	if stat.Mask&linux.STATX_NLINK != 0 {
 		i.inode.nlink.Store(stat.Nlink)

--- a/pkg/sentry/fsimpl/gofer/time.go
+++ b/pkg/sentry/fsimpl/gofer/time.go
@@ -28,6 +28,10 @@ func dentryTimestampFromUnix(t unix.Timespec) int64 {
 	return dentryTimestamp(lisafs.StatxTimestamp{Sec: t.Sec, Nsec: uint32(t.Nsec)})
 }
 
+func dentryTimestampFromStatx(t unix.StatxTimestamp) int64 {
+	return dentryTimestamp(lisafs.StatxTimestamp{Sec: t.Sec, Nsec: t.Nsec})
+}
+
 // Preconditions: d.cachedMetadataAuthoritative() == true.
 func (d *dentry) touchAtime(mnt *vfs.Mount) {
 	if opts := mnt.Options(); opts.Flags.NoATime || opts.ReadOnly {

--- a/pkg/sentry/fsimpl/tmpfs/stat_test.go
+++ b/pkg/sentry/fsimpl/tmpfs/stat_test.go
@@ -65,9 +65,9 @@ func TestStatAfterCreate(t *testing.T) {
 				t.Errorf("got atime=%d, want non-zero", atime)
 			}
 
-			// Btime should be 0, as it is not set by tmpfs.
-			if btime := got.Btime.ToNsec(); btime != 0 {
-				t.Errorf("got btime %d, want 0", got.Btime.ToNsec())
+			// Btime should equal ctime at creation time.
+			if btime := got.Btime.ToNsec(); btime != ctime {
+				t.Errorf("got btime %d, want %d (same as ctime)", btime, ctime)
 			}
 
 			// Size should be 0 (except for directories, which make up a size

--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -611,8 +611,8 @@ type inode struct {
 	gid   atomicbitops.Uint32 // auth.KGID, but ...
 	ino   uint64              // immutable
 
-	// Linux's tmpfs has no concept of btime.
 	atime atomicbitops.Int64 // nanoseconds
+	btime atomicbitops.Int64 // nanoseconds
 	ctime atomicbitops.Int64 // nanoseconds
 	mtime atomicbitops.Int64 // nanoseconds
 
@@ -651,9 +651,10 @@ func (i *inode) init(impl any, fs *filesystem, kuid auth.KUID, kgid auth.KGID, m
 	i.uid = atomicbitops.FromUint32(uint32(kuid))
 	i.gid = atomicbitops.FromUint32(uint32(kgid))
 	i.ino = fs.nextInoMinusOne.Add(1)
-	// Tmpfs creation sets atime, ctime, and mtime to current time.
+	// Tmpfs creation sets atime, btime, ctime, and mtime to current time.
 	now := fs.clock.Now().Nanoseconds()
 	i.atime = atomicbitops.FromInt64(now)
+	i.btime = atomicbitops.FromInt64(now)
 	i.ctime = atomicbitops.FromInt64(now)
 	i.mtime = atomicbitops.FromInt64(now)
 	// i.nlink initialized by caller
@@ -738,8 +739,8 @@ func (i *inode) checkPermissions(creds *auth.Credentials, ats vfs.AccessTypes) e
 func (i *inode) statTo(stat *linux.Statx) {
 	stat.Mask = linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_NLINK |
 		linux.STATX_UID | linux.STATX_GID | linux.STATX_INO | linux.STATX_SIZE |
-		linux.STATX_BLOCKS | linux.STATX_ATIME | linux.STATX_CTIME |
-		linux.STATX_MTIME
+		linux.STATX_BLOCKS | linux.STATX_ATIME | linux.STATX_BTIME |
+		linux.STATX_CTIME | linux.STATX_MTIME
 	stat.Blksize = hostarch.PageSize
 	stat.Nlink = i.nlink.Load()
 	stat.UID = i.uid.Load()
@@ -747,6 +748,7 @@ func (i *inode) statTo(stat *linux.Statx) {
 	stat.Mode = uint16(i.mode.Load())
 	stat.Ino = i.ino
 	stat.Atime = linux.NsecToStatxTimestamp(i.atime.Load())
+	stat.Btime = linux.NsecToStatxTimestamp(i.btime.Load())
 	stat.Ctime = linux.NsecToStatxTimestamp(i.ctime.Load())
 	stat.Mtime = linux.NsecToStatxTimestamp(i.mtime.Load())
 	stat.DevMajor = linux.UNNAMED_MAJOR

--- a/runsc/boot/filter/config/config.go
+++ b/runsc/boot/filter/config/config.go
@@ -134,6 +134,7 @@ func Rules(opt Options) (seccomp.SyscallRules, seccomp.SyscallRules) {
 func rules(opt Options, vars precompiledseccomp.Values) (seccomp.SyscallRules, seccomp.SyscallRules) {
 	s := allowedSyscalls.Copy()
 	s.Merge(selfPIDFilters(vars.GetUint64(selfPIDVarName)))
+	s.Merge(statxFilters())
 	s.Merge(controlServerFilters(vars[controllerFDVarName]))
 
 	// Set of additional filters used by -race and -msan. Returns empty

--- a/runsc/boot/filter/config/config_main.go
+++ b/runsc/boot/filter/config/config_main.go
@@ -307,7 +307,6 @@ var allowedSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
 		seccomp.PerArg{seccomp.AnyValue{}, seccomp.EqualTo(unix.SHUT_RDWR)},
 	},
 	unix.SYS_SIGALTSTACK:     seccomp.MatchAll{},
-	unix.SYS_STATX:           seccomp.MatchAll{},
 	unix.SYS_SYNC_FILE_RANGE: seccomp.MatchAll{},
 	unix.SYS_TEE: seccomp.PerArg{
 		seccomp.AnyValue{},
@@ -341,6 +340,16 @@ var allowedSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
 		seccomp.GreaterThan(0),
 	},
 })
+
+func statxFilters() seccomp.SyscallRules {
+	return seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
+		unix.SYS_STATX: seccomp.PerArg{
+			seccomp.NonNegativeFD{},
+			seccomp.AnyValue{},
+			seccomp.MaskedEqual(unix.AT_EMPTY_PATH, unix.AT_EMPTY_PATH),
+		},
+	})
+}
 
 func controlServerFilters(fd uint32) seccomp.SyscallRules {
 	return seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{

--- a/runsc/fsgofer/filter/config.go
+++ b/runsc/fsgofer/filter/config.go
@@ -65,6 +65,11 @@ var allowedSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
 		},
 	},
 	unix.SYS_FSTAT: seccomp.MatchAll{},
+	unix.SYS_STATX: seccomp.PerArg{
+		seccomp.NonNegativeFD{},
+		seccomp.AnyValue{},
+		seccomp.MaskedEqual(unix.AT_EMPTY_PATH, unix.AT_EMPTY_PATH),
+	},
 	unix.SYS_FSYNC: seccomp.MatchAll{},
 	unix.SYS_FUTEX: seccomp.Or{
 		seccomp.PerArg{

--- a/runsc/fsgofer/lisafs.go
+++ b/runsc/fsgofer/lisafs.go
@@ -1315,36 +1315,39 @@ func fchown(hostFD int, uid lisafs.UID, gid lisafs.GID) error {
 }
 
 func fstatTo(hostFD int) (lisafs.Statx, error) {
-	var stat unix.Stat_t
-	if err := unix.Fstat(hostFD, &stat); err != nil {
+	var stat unix.Statx_t
+	if err := unix.Statx(hostFD, "", unix.AT_EMPTY_PATH, unix.STATX_ALL, &stat); err != nil {
 		return lisafs.Statx{}, err
 	}
-
 	return lisafs.Statx{
-		Mask:      unix.STATX_TYPE | unix.STATX_MODE | unix.STATX_INO | unix.STATX_NLINK | unix.STATX_UID | unix.STATX_GID | unix.STATX_SIZE | unix.STATX_BLOCKS | unix.STATX_ATIME | unix.STATX_MTIME | unix.STATX_CTIME,
-		Mode:      uint16(stat.Mode),
-		DevMinor:  unix.Minor(stat.Dev),
-		DevMajor:  unix.Major(stat.Dev),
+		Mask:      stat.Mask,
+		Mode:      stat.Mode,
+		DevMinor:  stat.Dev_minor,
+		DevMajor:  stat.Dev_major,
 		Ino:       stat.Ino,
-		Nlink:     uint32(stat.Nlink),
+		Nlink:     stat.Nlink,
 		UID:       stat.Uid,
 		GID:       stat.Gid,
-		RdevMinor: unix.Minor(stat.Rdev),
-		RdevMajor: unix.Major(stat.Rdev),
-		Size:      uint64(stat.Size),
-		Blksize:   uint32(stat.Blksize),
-		Blocks:    uint64(stat.Blocks),
+		RdevMinor: stat.Rdev_minor,
+		RdevMajor: stat.Rdev_major,
+		Size:      stat.Size,
+		Blksize:   stat.Blksize,
+		Blocks:    stat.Blocks,
 		Atime: lisafs.StatxTimestamp{
-			Sec:  stat.Atim.Sec,
-			Nsec: uint32(stat.Atim.Nsec),
+			Sec:  stat.Atime.Sec,
+			Nsec: stat.Atime.Nsec,
+		},
+		Btime: lisafs.StatxTimestamp{
+			Sec:  stat.Btime.Sec,
+			Nsec: stat.Btime.Nsec,
 		},
 		Mtime: lisafs.StatxTimestamp{
-			Sec:  stat.Mtim.Sec,
-			Nsec: uint32(stat.Mtim.Nsec),
+			Sec:  stat.Mtime.Sec,
+			Nsec: stat.Mtime.Nsec,
 		},
 		Ctime: lisafs.StatxTimestamp{
-			Sec:  stat.Ctim.Sec,
-			Nsec: uint32(stat.Ctim.Nsec),
+			Sec:  stat.Ctime.Sec,
+			Nsec: stat.Ctime.Nsec,
 		},
 	}, nil
 }


### PR DESCRIPTION
gVisor did not report valid statx btime: gofer/directfs used fstat(2), which has no btime, and tmpfs did not track creation time.

Use host statx(AT_EMPTY_PATH) for gofer/directfs metadata. Restrict host statx in gofer/sandbox seccomp filters to FD-only calls using a fixed empty path and AT_EMPTY_PATH.

Track optional STATX_BTIME availability so filesystems without btime support do not expose zero btime. For tmpfs, initialize btime at inode creation and report STATX_BTIME, matching Linux >= 5.18.

Reference: fs/stat.c:vfs_statx(), mm/shmem.c:shmem_getattr()