### PR TITLE
socket: support more netdevice ioctls

### DIFF
--- a/pkg/sentry/socket/hostinet/socket_unsafe.go
+++ b/pkg/sentry/socket/hostinet/socket_unsafe.go
@@ -67,8 +67,11 @@ func ioctl(ctx context.Context, fd int, io usermem.IO, sysno uintptr, args arch.
 		_, err := io.CopyOut(ctx, args[2].Pointer(), buf[:], usermem.IOOpts{})
 		return 0, err
 	case linux.SIOCGIFFLAGS,
+		linux.SIOCGIFBRDADDR,
+		linux.SIOCGIFDSTADDR,
 		linux.SIOCGIFHWADDR,
 		linux.SIOCGIFINDEX,
+		linux.SIOCGIFMAP,
 		linux.SIOCGIFMTU,
 		linux.SIOCGIFNAME,
 		linux.SIOCGIFNETMASK,

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -3653,19 +3653,36 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 
 	case linux.SIOCGIFMAP:
 		// Gets the hardware parameters of the device.
-		// TODO(gvisor.dev/issue/505): Implement.
+		clear(ifr.Data[:])
 
 	case linux.SIOCGIFTXQLEN:
 		// Gets the transmit queue length of the device.
-		// TODO(gvisor.dev/issue/505): Implement.
+		hostarch.ByteOrder.PutUint32(ifr.Data[:4], 0)
 
 	case linux.SIOCGIFDSTADDR:
 		// Gets the destination address of a point-to-point device.
-		// TODO(gvisor.dev/issue/505): Implement.
+		addr, ok := firstIPv4InterfaceAddr(stk, index)
+		if !ok {
+			return syserr.ErrAddressNotAvailable
+		}
+		copyIPv4SockAddrOut(ifr, addr.Addr)
 
 	case linux.SIOCGIFBRDADDR:
 		// Gets the broadcast address of a device.
-		// TODO(gvisor.dev/issue/505): Implement.
+		addr, ok := firstIPv4InterfaceAddr(stk, index)
+		if !ok {
+			return syserr.ErrAddressNotAvailable
+		}
+		if iface.Flags&linux.IFF_BROADCAST == 0 || addr.PrefixLen >= 31 {
+			copyIPv4SockAddrOut(ifr, []byte{0, 0, 0, 0})
+			break
+		}
+		subnet := tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFrom4Slice(addr.Addr),
+			PrefixLen: int(addr.PrefixLen),
+		}.Subnet()
+		broadcast := subnet.Broadcast().As4()
+		copyIPv4SockAddrOut(ifr, broadcast[:])
 
 	case linux.SIOCGIFNETMASK:
 		// Gets the network mask of a device.
@@ -3698,6 +3715,21 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 	}
 
 	return nil
+}
+
+func firstIPv4InterfaceAddr(stk inet.Stack, index int32) (inet.InterfaceAddr, bool) {
+	for _, addr := range stk.InterfaceAddrs()[index] {
+		if addr.Family == linux.AF_INET && len(addr.Addr) == header.IPv4AddressSize {
+			return addr, true
+		}
+	}
+	return inet.InterfaceAddr{}, false
+}
+
+func copyIPv4SockAddrOut(ifr *linux.IFReq, addr []byte) {
+	clear(ifr.Data[:linux.SockAddrInetSize])
+	hostarch.ByteOrder.PutUint16(ifr.Data[0:], uint16(linux.AF_INET))
+	copy(ifr.Data[4:8], addr)
 }
 
 // ifconfIoctl populates a struct ifconf for the SIOCGIFCONF ioctl.

--- a/pkg/sentry/socket/plugin/stack/BUILD
+++ b/pkg/sentry/socket/plugin/stack/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//pkg/sentry/vfs",
         "//pkg/syserr",
         "//pkg/tcpip",
+        "//pkg/tcpip/header",
         "//pkg/tcpip/network/ipv4",
         "//pkg/tcpip/network/ipv6",
         "//pkg/usermem",

--- a/pkg/sentry/socket/plugin/stack/socket.go
+++ b/pkg/sentry/socket/plugin/stack/socket.go
@@ -366,20 +366,26 @@ func interfaceIoctl(ctx context.Context, io usermem.IO, cmd uint32, ifr *linux.I
 
 	case syscall.SIOCGIFMAP:
 		// Gets the hardware parameters of the device.
-		hostarch.ByteOrder.PutUint64(ifr.Data[:8], 0)
-		hostarch.ByteOrder.PutUint32(ifr.Data[8:12], 0)
-		ifr.Data[12] = 0
+		clear(ifr.Data[:])
 
 	case syscall.SIOCGIFTXQLEN:
-		hostarch.ByteOrder.PutUint32(ifr.Data[:4], 1024)
+		hostarch.ByteOrder.PutUint32(ifr.Data[:4], 0)
 
 	case syscall.SIOCGIFDSTADDR:
 		// Gets the destination address of a point-to-point device.
-		// TODO: Implement SIOCGIFDSTADDR handler.
+		addr, ok := firstIPv4InterfaceAddr(stack, index)
+		if !ok {
+			return syserr.ErrAddressNotAvailable
+		}
+		copyIPv4SockAddrOut(ifr, addr.Addr)
 
 	case syscall.SIOCGIFBRDADDR:
 		// Gets the broadcast address of a device.
-		// TODO: Implement SIOCGIFBRDADDR handler.
+		addr, ok := firstIPv4InterfaceAddr(stack, index)
+		if !ok {
+			return syserr.ErrAddressNotAvailable
+		}
+		copyBroadcastAddrOut(ifr, iface, addr)
 
 	case syscall.SIOCGIFNETMASK:
 		// Gets the network mask of a device.

--- a/pkg/sentry/socket/plugin/stack/util.go
+++ b/pkg/sentry/socket/plugin/stack/util.go
@@ -26,6 +26,8 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/socket"
 	"gvisor.dev/gvisor/pkg/sentry/socket/plugin/cgo"
 	"gvisor.dev/gvisor/pkg/syserr"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
 )
 
 func int2err(from int64) *syserr.Error {
@@ -58,6 +60,34 @@ func copyAddrOut(ifr *linux.IFReq, ifaceAddr *inet.InterfaceAddr) {
 	} else {
 		copy(ifr.Data[8:24], ifaceAddr.Addr[:16])
 	}
+}
+
+func firstIPv4InterfaceAddr(stack inet.Stack, index int32) (inet.InterfaceAddr, bool) {
+	for _, addr := range stack.InterfaceAddrs()[index] {
+		if addr.Family == linux.AF_INET && len(addr.Addr) == header.IPv4AddressSize {
+			return addr, true
+		}
+	}
+	return inet.InterfaceAddr{}, false
+}
+
+func copyIPv4SockAddrOut(ifr *linux.IFReq, addr []byte) {
+	clear(ifr.Data[:linux.SockAddrInetSize])
+	hostarch.ByteOrder.PutUint16(ifr.Data[0:2], uint16(linux.AF_INET))
+	copy(ifr.Data[4:8], addr)
+}
+
+func copyBroadcastAddrOut(ifr *linux.IFReq, iface inet.Interface, addr inet.InterfaceAddr) {
+	if iface.Flags&linux.IFF_BROADCAST == 0 || addr.PrefixLen >= 31 {
+		copyIPv4SockAddrOut(ifr, []byte{0, 0, 0, 0})
+		return
+	}
+	subnet := tcpip.AddressWithPrefix{
+		Address:   tcpip.AddrFrom4Slice(addr.Addr),
+		PrefixLen: int(addr.PrefixLen),
+	}.Subnet()
+	broadcast := subnet.Broadcast().As4()
+	copyIPv4SockAddrOut(ifr, broadcast[:])
 }
 
 func iovecsFromBlockSeq(bs safemem.BlockSeq, rw *pluginStackRW) []syscall.Iovec {

--- a/runsc/boot/filter/config/extra_filters_hostinet.go
+++ b/runsc/boot/filter/config/extra_filters_hostinet.go
@@ -45,6 +45,14 @@ func hostInetFilters(allowRawSockets bool) seccomp.SyscallRules {
 			},
 			seccomp.PerArg{
 				seccomp.NonNegativeFD{},
+				seccomp.EqualTo(linux.SIOCGIFBRDADDR),
+			},
+			seccomp.PerArg{
+				seccomp.NonNegativeFD{},
+				seccomp.EqualTo(linux.SIOCGIFDSTADDR),
+			},
+			seccomp.PerArg{
+				seccomp.NonNegativeFD{},
 				seccomp.EqualTo(unix.SIOCGIFFLAGS),
 			},
 			seccomp.PerArg{
@@ -54,6 +62,10 @@ func hostInetFilters(allowRawSockets bool) seccomp.SyscallRules {
 			seccomp.PerArg{
 				seccomp.NonNegativeFD{},
 				seccomp.EqualTo(unix.SIOCGIFINDEX),
+			},
+			seccomp.PerArg{
+				seccomp.NonNegativeFD{},
+				seccomp.EqualTo(linux.SIOCGIFMAP),
 			},
 			seccomp.PerArg{
 				seccomp.NonNegativeFD{},

--- a/test/syscalls/linux/socket_netdevice.cc
+++ b/test/syscalls/linux/socket_netdevice.cc
@@ -16,8 +16,11 @@
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/sockios.h>
+#include <netinet/in.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+
+#include <cstring>
 
 #include "gtest/gtest.h"
 #include "test/syscalls/linux/socket_netlink_util.h"
@@ -184,7 +187,8 @@ TEST(NetdeviceTest, InterfaceQLEN) {
       ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_STREAM, 0));
 
   // Prepare the request.
-  struct ifreq ifr = {};
+  struct ifreq ifr;
+  memset(&ifr, 0xaa, sizeof(ifr));
   snprintf(ifr.ifr_name, IFNAMSIZ, "lo");
 
   // Check that SIOCGIFTXQLEN returns without error.
@@ -195,6 +199,58 @@ TEST(NetdeviceTest, InterfaceQLEN) {
   if (IsRunningOnGvisor() && !IsRunningWithHostinet()) {
     EXPECT_EQ(ifr.ifr_qlen, 0);
   }
+}
+
+TEST(NetdeviceTest, InterfaceMap) {
+  FileDescriptor sock =
+      ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_DGRAM, 0));
+
+  struct ifreq ifr;
+  memset(&ifr, 0xaa, sizeof(ifr));
+  snprintf(ifr.ifr_name, IFNAMSIZ, "lo");
+
+  ASSERT_THAT(ioctl(sock.get(), SIOCGIFMAP, &ifr), SyscallSucceeds());
+  EXPECT_EQ(ifr.ifr_map.mem_start, 0);
+  EXPECT_EQ(ifr.ifr_map.mem_end, 0);
+  EXPECT_EQ(ifr.ifr_map.base_addr, 0);
+  EXPECT_EQ(ifr.ifr_map.irq, 0);
+  EXPECT_EQ(ifr.ifr_map.dma, 0);
+  EXPECT_EQ(ifr.ifr_map.port, 0);
+}
+
+TEST(NetdeviceTest, InterfaceDestinationAddress) {
+  FileDescriptor sock =
+      ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_DGRAM, 0));
+
+  struct ifreq ifr;
+  memset(&ifr, 0xaa, sizeof(ifr));
+  snprintf(ifr.ifr_name, IFNAMSIZ, "lo");
+
+  ASSERT_THAT(ioctl(sock.get(), SIOCGIFDSTADDR, &ifr), SyscallSucceeds());
+  EXPECT_EQ(ifr.ifr_dstaddr.sa_family, AF_INET);
+  struct sockaddr_in* sin =
+      reinterpret_cast<struct sockaddr_in*>(&ifr.ifr_dstaddr);
+  const unsigned char* addr =
+      reinterpret_cast<const unsigned char*>(&sin->sin_addr.s_addr);
+  EXPECT_EQ(addr[0], 127);
+  EXPECT_EQ(addr[1], 0);
+  EXPECT_EQ(addr[2], 0);
+  EXPECT_EQ(addr[3], 1);
+}
+
+TEST(NetdeviceTest, InterfaceBroadcastAddress) {
+  FileDescriptor sock =
+      ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_DGRAM, 0));
+
+  struct ifreq ifr;
+  memset(&ifr, 0xaa, sizeof(ifr));
+  snprintf(ifr.ifr_name, IFNAMSIZ, "lo");
+
+  ASSERT_THAT(ioctl(sock.get(), SIOCGIFBRDADDR, &ifr), SyscallSucceeds());
+  EXPECT_EQ(ifr.ifr_broadaddr.sa_family, AF_INET);
+  struct sockaddr_in* sin =
+      reinterpret_cast<struct sockaddr_in*>(&ifr.ifr_broadaddr);
+  EXPECT_EQ(sin->sin_addr.s_addr, 0);
 }
 
 TEST(NetdeviceTest, EthtoolGetTSInfo) {


### PR DESCRIPTION
## What changed

This fills in a few netdevice ioctl cases that were still stubbed out for gVisor-backed networking:

- `SIOCGIFMAP`
- `SIOCGIFTXQLEN`
- `SIOCGIFDSTADDR`
- `SIOCGIFBRDADDR`

For the virtual stack, hardware map and tx queue length are reported as zero. The IPv4 address ioctls return `AF_INET` socket addresses from the interface address list, and broadcast handling avoids fabricating a broadcast address for non-broadcast interfaces or `/31` and `/32` prefixes.

I also wired the same read-only ioctls through hostinet and updated the hostinet seccomp filter so those calls keep using host kernel behavior.

Updates #505

## Testing

```sh
bazelisk test //pkg/sentry/socket/netstack:netstack_test \
  //pkg/sentry/socket/plugin/stack:stack_nogo \
  //runsc/boot/filter/config:config_test \
  //test/syscalls:socket_netdevice_test_runsc_systrap_shared \
  //test/syscalls:socket_netdevice_test_runsc_systrap_hostnet \
  //test/syscalls:socket_netdevice_test_native

bazel-bin/test/syscalls/linux/socket_netdevice_test
```