### PR TITLE
shim, runsc: support resource update propagation for sub-containers

### DIFF
--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -492,11 +492,8 @@ func (s *runscService) Stats(ctx context.Context, r *taskAPI.StatsRequest) (*tas
 }
 
 // Update updates a running container.
-// CRI UpdateContainerResources sends the workload container ID, but runsc
-// update only accepts the root (sandbox) container. Route through s.id which
-// is the sandbox container ID assigned at shim startup.
 func (s *runscService) Update(ctx context.Context, r *taskAPI.UpdateTaskRequest) (*types.Empty, error) {
-	c, err := s.getContainer(s.id)
+	c, err := s.getContainer(r.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -589,21 +589,20 @@ func (c *Container) Update(res *specs.LinuxResources) error {
 		return fmt.Errorf("sandbox cannot be nil")
 	}
 
-	if !c.Sandbox.IsRootContainer(c.ID) {
-		return fmt.Errorf("update can only be called on the root container")
+	if c.Sandbox.IsRootContainer(c.ID) {
+		cg := c.Sandbox.CgroupJSON.Cgroup
+		if cg == nil {
+			return fmt.Errorf("cgroup cannot be nil")
+		}
+		if err := cg.Update(res); err != nil {
+			// set back to original
+			if err2 := cg.Update(c.Spec.Linux.Resources); err2 != nil {
+				return fmt.Errorf("setting back cgroup configs failed due to error: %v, your state file and actual configs might be inconsistent", err2)
+			}
+			return err
+		}
 	}
 
-	cg := c.Sandbox.CgroupJSON.Cgroup
-	if cg == nil {
-		return fmt.Errorf("cgroup cannot be nil")
-	}
-	if err := cg.Update(res); err != nil {
-		// set back to original
-		if err2 := cg.Update(c.Spec.Linux.Resources); err2 != nil {
-			return fmt.Errorf("setting back cgroup configs failed due to error: %v, your state file and actual configs might be inconsistent", err2)
-		}
-		return err
-	}
 	c.Spec.Linux.Resources = res
 
 	c.Saver.lock(BlockAcquire)


### PR DESCRIPTION
Currently, when Kubelet triggers an In-Place Pod Resize, it sends an update request to the workload container. The gVisor shim routes all updates to the root container, and `runsc` rejects updates on non-root containers. This causes resizing to fail with "update can only be called on the root container" (see the issue reported in https://github.com/google/gvisor/pull/12791#issuecomment-4361808972). 

This change allows resource updates to propagate effectively in Kubernetes:

1. Update the shim to direct the update to the specific workload container ID.
2. Modify `runsc update` to permit updates on non-root containers; however, for sub-containers, we skip altering the host Sandbox cgroup and the virtual cgroup (matching the boot-time creation state where these are left unconstrained), and only update the spec metadata and state file.

This keeps the Sandbox state after an Update analogous to its state at Creation.

### 📋 Testing Results

Tested with a local `kind` cluster running Kubernetes v1.35.0.

#### 1. Pre-Patch State
- Initial Pod Limits: Memory `256Mi`, CPU `500m`

| Test Location | Command / File | Result | Meaning |
|---|---|---|---|
| **Inside Pod** | `memory.limit_in_bytes` | `33650569216` (~31GB) | Virtual root unconstrained (defaults to host capacity) |
| **Inside Pod** | `cpu.cfs_quota_us` | `-1` | Virtual root unconstrained |
| **Host (Pod Slice)**| `memory.max` | `268435456` | **256Mi** strictly enforced by Kubernetes on the node |
| **Host (Pod Slice)**| `cpu.max` | `50000 100000` | **500m** strictly enforced by Kubernetes on the node |

#### 2. Applied Patch
Updated requirements to requests `200Mi`/`300m`, limits `512Mi`/`700m`:
```bash
kubectl patch pod resize-test-pod --subresource=resize -p '{"spec":{"containers":[{"name":"nginx","resources":{"requests":{"cpu":"300m","memory":"200Mi"},"limits":{"cpu":"700m","memory":"512Mi"}}}]}}'
```

#### 3. Post-Patch State
| Test Location | Command / File | Result | Meaning |
|---|---|---|---|
| **Inside Pod** | `memory.limit_in_bytes` | `33650569216` (~31GB) | **Unchanged** (Maintains analogous unconstrained state) |
| **Inside Pod** | `cpu.cfs_quota_us` | `-1` | **Unchanged** (Maintains analogous unconstrained state) |
| **Host (Pod Slice)**| `memory.max` | `536870912` | Successfully updated to **512Mi** on the host |
| **Host (Pod Slice)**| `cpu.max` | `70000 100000` | Successfully updated to **700m** on the host |

> [!NOTE]
> Kubernetes successfully updates the external `.slice` host cgroup, while gVisor's internal virtual limits correctly skip side-effects, retaining the same properties as a freshly created container.

---

AI disclosure note: This PR was created with the assistance of Antigravity. I made sure to understand the changes, went through several iterations with Antigravity where I gave a lot of feedback and also made some manual updates. The final diff looks reasonable to me, but I don't claim to be a gvisor expert.
