### PR TITLE
runsc/cgroup: discover and populate spec files for subcontainer compat dirs on systemd v2

### DIFF
--- a/runsc/cgroup/cgroup.go
+++ b/runsc/cgroup/cgroup.go
@@ -430,6 +430,23 @@ func new(pid, cgroupsPath string, useSystemd bool) (Cgroup, error) {
 	return cg, nil
 }
 
+// InstallSubcontainerCompatDir creates the host-side cgroup directory for a
+// subcontainer so cAdvisor (and other inotify-based tools) can discover it,
+// populating the container_spec_* limit files from res when non-nil. The
+// directory is tracked by cg for removal at Uninstall.
+//
+// systemd v2 is routed through installCompatDir, which mkdirs directly instead
+// of registering a process-less transient unit. cgroupfs (v1 / non-systemd v2)
+// delegates to Install, which already creates the directory and writes the
+// same files. The compat cgroup is process-less, so these limits have no
+// accounting effect; runtime counters stay zero (see #13067).
+func InstallSubcontainerCompatDir(cg Cgroup, res *specs.LinuxResources) error {
+	if sd, ok := cg.(*cgroupSystemd); ok {
+		return sd.installCompatDir(res)
+	}
+	return cg.Install(res)
+}
+
 // CgroupJSON is a wrapper for Cgroup that can be encoded to JSON.
 type CgroupJSON struct {
 	Cgroup Cgroup

--- a/runsc/cgroup/cgroup.go
+++ b/runsc/cgroup/cgroup.go
@@ -479,6 +479,23 @@ func new(pid, cgroupsPath string, useSystemd bool) (Cgroup, error) {
 	return cg, nil
 }
 
+// InstallSubcontainerCompatDir creates the host-side cgroup directory for a
+// subcontainer so cAdvisor (and other inotify-based tools) can discover it,
+// populating the container_spec_* limit files from res when non-nil. The
+// directory is tracked by cg for removal at Uninstall.
+//
+// systemd v2 is routed through installCompatDir, which mkdirs directly instead
+// of registering a process-less transient unit. cgroupfs (v1 / non-systemd v2)
+// delegates to Install, which already creates the directory and writes the
+// same files. The compat cgroup is process-less, so these limits have no
+// accounting effect; runtime counters stay zero (see #13067).
+func InstallSubcontainerCompatDir(cg Cgroup, res *specs.LinuxResources) error {
+	if sd, ok := cg.(*cgroupSystemd); ok {
+		return sd.installCompatDir(res)
+	}
+	return cg.Install(res)
+}
+
 // CgroupJSON is a wrapper for Cgroup that can be encoded to JSON.
 type CgroupJSON struct {
 	Cgroup Cgroup

--- a/runsc/cgroup/systemd.go
+++ b/runsc/cgroup/systemd.go
@@ -29,9 +29,19 @@ import (
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	dbus "github.com/godbus/dbus/v5"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
 )
+
+// compatDirControllers are the v2 controllers populated on the compat cgroup
+// directory created by installCompatDir for cAdvisor's container_spec_*
+// series. Limited to controllers whose interface files cAdvisor reads as
+// spec values (memory.max, cpu.max / cpu.weight, pids.max). Other controllers
+// (cpuset, io, hugetlb) are intentionally excluded: they don't surface as
+// container_spec_* and writing them widens the failure surface on hosts where
+// they aren't enabled in the parent slice's cgroup.subtree_control.
+var compatDirControllers = []string{"cpu", "memory", "pids"}
 
 var (
 	// ErrBadResourceSpec indicates that a cgroupSystemd function was
@@ -90,6 +100,63 @@ func newCgroupV2Systemd(cgv2 *cgroupV2) (*cgroupSystemd, error) {
 	}
 	cg.dbusConn = conn
 	return cg, err
+}
+
+// installCompatDir creates the compat cgroup directory under the parent slice
+// (tracked in c.Own so cgroupV2.Uninstall removes it at container destroy)
+// and, when res is non-nil, best-effort populates the spec-limit files
+// cAdvisor reads as container_spec_*. Used in place of Install for systemd v2,
+// where Install only stages dbus properties and the directory is otherwise
+// created by Join() via StartTransientUnit -- inappropriate for a
+// process-less compat cgroup.
+func (c *cgroupSystemd) installCompatDir(res *specs.LinuxResources) error {
+	path := c.MakePath("")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return fmt.Errorf("creating compat cgroup dir %q: %w", path, err)
+	}
+	alreadyTracked := false
+	for _, owned := range c.Own {
+		if owned == path {
+			alreadyTracked = true
+			break
+		}
+	}
+	if !alreadyTracked {
+		c.Own = append(c.Own, path)
+	}
+
+	// Best-effort spec-file population. Controllers that aren't enabled in
+	// the parent slice's cgroup.subtree_control don't have leaf interface
+	// files; setValue then returns ENOENT, which we swallow. The compat dir
+	// must always succeed at directory level (#6657 precedent: the compat
+	// path must never block container start).
+	if res == nil {
+		return nil
+	}
+	for _, name := range compatDirControllers {
+		ctrlr, ok := controllers2[name]
+		if !ok {
+			continue
+		}
+		if err := ctrlr.set(res, path); err != nil {
+			if isCompatDirIgnorableErr(err) {
+				log.Debugf("Skipping %q spec-file population for compat cgroup %q: %v", name, path, err)
+				continue
+			}
+			return fmt.Errorf("populating %q spec files for compat cgroup %q: %w", name, path, err)
+		}
+	}
+	return nil
+}
+
+// isCompatDirIgnorableErr reports whether err from a best-effort spec-file
+// write is safe to swallow: the interface file may not exist (controller not
+// in subtree_control), the mount may be read-only, or we may lack permission.
+// None of these should block container start.
+func isCompatDirIgnorableErr(err error) bool {
+	return errors.Is(err, os.ErrNotExist) ||
+		errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, unix.EROFS)
 }
 
 // Install configures the properties for a scope unit but does not start the

--- a/runsc/cgroup/systemd.go
+++ b/runsc/cgroup/systemd.go
@@ -29,10 +29,20 @@ import (
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	dbus "github.com/godbus/dbus/v5"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
 )
+
+// compatDirControllers are the v2 controllers populated on the compat cgroup
+// directory created by installCompatDir for cAdvisor's container_spec_*
+// series. Limited to controllers whose interface files cAdvisor reads as
+// spec values (memory.max, cpu.max / cpu.weight, pids.max). Other controllers
+// (cpuset, io, hugetlb) are intentionally excluded: they don't surface as
+// container_spec_* and writing them widens the failure surface on hosts where
+// they aren't enabled in the parent slice's cgroup.subtree_control.
+var compatDirControllers = []string{"cpu", "memory", "pids"}
 
 var (
 	// ErrBadResourceSpec indicates that a cgroupSystemd function was
@@ -91,6 +101,63 @@ func newCgroupV2Systemd(cgv2 *cgroupV2) (*cgroupSystemd, error) {
 	}
 	cg.dbusConn = conn
 	return cg, err
+}
+
+// installCompatDir creates the compat cgroup directory under the parent slice
+// (tracked in c.Own so cgroupV2.Uninstall removes it at container destroy)
+// and, when res is non-nil, best-effort populates the spec-limit files
+// cAdvisor reads as container_spec_*. Used in place of Install for systemd v2,
+// where Install only stages dbus properties and the directory is otherwise
+// created by Join() via StartTransientUnit -- inappropriate for a
+// process-less compat cgroup.
+func (c *cgroupSystemd) installCompatDir(res *specs.LinuxResources) error {
+	path := c.MakePath("")
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return fmt.Errorf("creating compat cgroup dir %q: %w", path, err)
+	}
+	alreadyTracked := false
+	for _, owned := range c.Own {
+		if owned == path {
+			alreadyTracked = true
+			break
+		}
+	}
+	if !alreadyTracked {
+		c.Own = append(c.Own, path)
+	}
+
+	// Best-effort spec-file population. Controllers that aren't enabled in
+	// the parent slice's cgroup.subtree_control don't have leaf interface
+	// files; setValue then returns ENOENT, which we swallow. The compat dir
+	// must always succeed at directory level (#6657 precedent: the compat
+	// path must never block container start).
+	if res == nil {
+		return nil
+	}
+	for _, name := range compatDirControllers {
+		ctrlr, ok := controllers2[name]
+		if !ok {
+			continue
+		}
+		if err := ctrlr.set(res, path); err != nil {
+			if isCompatDirIgnorableErr(err) {
+				log.Debugf("Skipping %q spec-file population for compat cgroup %q: %v", name, path, err)
+				continue
+			}
+			return fmt.Errorf("populating %q spec files for compat cgroup %q: %w", name, path, err)
+		}
+	}
+	return nil
+}
+
+// isCompatDirIgnorableErr reports whether err from a best-effort spec-file
+// write is safe to swallow: the interface file may not exist (controller not
+// in subtree_control), the mount may be read-only, or we may lack permission.
+// None of these should block container start.
+func isCompatDirIgnorableErr(err error) bool {
+	return errors.Is(err, os.ErrNotExist) ||
+		errors.Is(err, os.ErrPermission) ||
+		errors.Is(err, unix.EROFS)
 }
 
 // Install configures the properties for a scope unit but does not start the

--- a/runsc/cgroup/systemd_test.go
+++ b/runsc/cgroup/systemd_test.go
@@ -18,6 +18,9 @@ package cgroup
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
@@ -266,6 +269,222 @@ func TestInstall(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// newCompatDirTestCgroup constructs a cgroupSystemd anchored at a temporary
+// mountpoint with its parent slice pre-created, mirroring what kubelet+systemd
+// arrange on a real host. The leaf scope directory itself is intentionally
+// not created -- installCompatDir is the unit under test for that.
+func newCompatDirTestCgroup(t *testing.T) (*cgroupSystemd, string) {
+	t.Helper()
+	mountpoint := t.TempDir()
+	parentSlicePath := filepath.Join(mountpoint, "/parent.slice")
+	if err := os.MkdirAll(parentSlicePath, 0o755); err != nil {
+		t.Fatalf("mkdir parent slice: %v", err)
+	}
+	cg := &cgroupSystemd{
+		Name:        "abc",
+		ScopePrefix: "cri-containerd",
+		Parent:      "parent.slice",
+		cgroupV2: cgroupV2{
+			Mountpoint: mountpoint,
+			// Path is set by newCgroupV2Systemd to expanded slice + unitName.
+			Path: filepath.Join(expandSlice("parent.slice"), "cri-containerd-abc.scope"),
+		},
+	}
+	return cg, cg.MakePath("")
+}
+
+// seedCompatLeafFiles touches the v2 controller interface files in the leaf
+// scope directory that the kernel would auto-create on a real cgroupfs mount
+// when the corresponding controllers are enabled in the parent's
+// cgroup.subtree_control. Without these, setValue (which uses O_WRONLY|
+// O_TRUNC and does not create) returns ENOENT, which is the
+// controller-not-enabled path.
+func seedCompatLeafFiles(t *testing.T, leafDir string, names ...string) {
+	t.Helper()
+	if err := os.MkdirAll(leafDir, 0o755); err != nil {
+		t.Fatalf("mkdir leaf dir: %v", err)
+	}
+	for _, name := range names {
+		f, err := os.Create(filepath.Join(leafDir, name))
+		if err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+		f.Close()
+	}
+}
+
+// readCgroupFile reads a single cgroup interface file under leafDir and
+// returns its contents.
+func readCgroupFile(t *testing.T, leafDir, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(leafDir, name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// TestInstallCompatDir verifies that installCompatDir creates the cgroup
+// directory at the resolved scope path under the parent slice (so cAdvisor
+// can discover it via inotify), and that the embedded cgroupV2.Uninstall
+// removes it via the c.Own bookkeeping. This is the cgroup v2 + systemd
+// counterpart of #6500 / PR #6657, which created cAdvisor compat
+// directories on cgroup v1.
+func TestInstallCompatDir(t *testing.T) {
+	cg, wantDir := newCompatDirTestCgroup(t)
+	if got, want := wantDir, filepath.Join(cg.Mountpoint, "/parent.slice", "cri-containerd-abc.scope"); got != want {
+		t.Fatalf("MakePath() = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(wantDir); !os.IsNotExist(err) {
+		t.Fatalf("compat dir already exists or unexpected error before install: %v", err)
+	}
+
+	if err := cg.installCompatDir(nil); err != nil {
+		t.Fatalf("installCompatDir(nil) error: %v", err)
+	}
+	info, err := os.Stat(wantDir)
+	if err != nil {
+		t.Fatalf("compat dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("compat dir %q is not a directory", wantDir)
+	}
+	// The path must be tracked in Own so Uninstall can clean it up.
+	if got := len(cg.Own); got != 1 || cg.Own[0] != wantDir {
+		t.Fatalf("c.Own = %v, want exactly [%q]", cg.Own, wantDir)
+	}
+
+	// Idempotency: calling again on an existing dir should not error and
+	// should not double-track the path (avoid leaking entries on retries).
+	if err := cg.installCompatDir(nil); err != nil {
+		t.Fatalf("installCompatDir(nil) second call error: %v", err)
+	}
+	if got := len(cg.Own); got != 1 {
+		t.Fatalf("len(c.Own) after second installCompatDir = %d, want 1", got)
+	}
+
+	// Uninstall must remove the dir we created.
+	if err := cg.Uninstall(); err != nil {
+		t.Fatalf("Uninstall() error: %v", err)
+	}
+	if _, err := os.Stat(wantDir); !os.IsNotExist(err) {
+		t.Fatalf("compat dir still exists after Uninstall: %v", err)
+	}
+}
+
+// TestInstallCompatDirSpecFiles verifies that installCompatDir populates the
+// cgroup interface files cAdvisor reads as container_spec_* (memory.max,
+// cpu.max, cpu.weight, pids.max, memory.swap.max) when handed a non-nil
+// LinuxResources. The leaf interface files are pre-touched to simulate what
+// the kernel auto-creates when the corresponding controllers are enabled in
+// the parent slice's cgroup.subtree_control on a real cgroupfs mount.
+func TestInstallCompatDirSpecFiles(t *testing.T) {
+	cg, leafDir := newCompatDirTestCgroup(t)
+	seedCompatLeafFiles(t, leafDir,
+		"memory.max", "memory.swap.max", "memory.low",
+		"cpu.max", "cpu.weight",
+		"pids.max",
+	)
+
+	memLimit := int64(536870912) // 512 MiB
+	memSwap := int64(1073741824) // 1 GiB combined memory+swap (runc-style)
+	cpuQuota := int64(50000)
+	cpuPeriod := uint64(100000)
+	cpuShares := uint64(2048)
+	pidsLimit := int64(100)
+	res := &specs.LinuxResources{
+		Memory: &specs.LinuxMemory{
+			Limit: &memLimit,
+			Swap:  &memSwap,
+		},
+		CPU: &specs.LinuxCPU{
+			Quota:  &cpuQuota,
+			Period: &cpuPeriod,
+			Shares: &cpuShares,
+		},
+		Pids: &specs.LinuxPids{
+			Limit: pidsLimit,
+		},
+	}
+	if err := cg.installCompatDir(res); err != nil {
+		t.Fatalf("installCompatDir(res) error: %v", err)
+	}
+
+	if got, want := readCgroupFile(t, leafDir, "memory.max"), "536870912"; got != want {
+		t.Errorf("memory.max = %q, want %q", got, want)
+	}
+	// Swap in v2 is the swap-only value (memorySwap - memory).
+	if got, want := readCgroupFile(t, leafDir, "memory.swap.max"), "536870912"; got != want {
+		t.Errorf("memory.swap.max = %q, want %q", got, want)
+	}
+	if got, want := readCgroupFile(t, leafDir, "cpu.max"), "50000 100000"; got != want {
+		t.Errorf("cpu.max = %q, want %q", got, want)
+	}
+	// cpu.shares=2048 maps to cpu.weight via the runc-compatible formula.
+	wantWeight := strconv.FormatUint(convertCPUSharesToCgroupV2Value(cpuShares), 10)
+	if got := readCgroupFile(t, leafDir, "cpu.weight"); got != wantWeight {
+		t.Errorf("cpu.weight = %q, want %q", got, wantWeight)
+	}
+	if got, want := readCgroupFile(t, leafDir, "pids.max"), "100"; got != want {
+		t.Errorf("pids.max = %q, want %q", got, want)
+	}
+}
+
+// TestInstallCompatDirBestEffort verifies installCompatDir is best-effort:
+// when controller interface files are absent (controller not enabled in the
+// parent slice's cgroup.subtree_control on a real host), the missing-file
+// errors from setValue are swallowed, the directory is still created, and
+// installCompatDir returns success. This preserves the #6657 invariant that
+// the compat path must never block container start.
+func TestInstallCompatDirBestEffort(t *testing.T) {
+	cg, leafDir := newCompatDirTestCgroup(t)
+
+	memLimit := int64(536870912)
+	res := &specs.LinuxResources{
+		Memory: &specs.LinuxMemory{Limit: &memLimit},
+	}
+
+	// Deliberately do NOT seed any leaf interface files. set() will hit
+	// ENOENT for every controller it tries to write; installCompatDir must
+	// swallow that and still report success.
+	if err := cg.installCompatDir(res); err != nil {
+		t.Fatalf("installCompatDir(res) with no leaf files: got error %v, want nil (best-effort)", err)
+	}
+	if _, err := os.Stat(leafDir); err != nil {
+		t.Fatalf("compat dir not created: %v", err)
+	}
+	if got := len(cg.Own); got != 1 || cg.Own[0] != leafDir {
+		t.Fatalf("c.Own = %v, want exactly [%q]", cg.Own, leafDir)
+	}
+}
+
+// TestInstallSubcontainerCompatDirSystemd verifies the public dispatcher
+// routes systemd cgroups to installCompatDir (not the dbus Install path) and
+// that resources reach spec-file population on the leaf. Uninstall is covered
+// by TestInstallCompatDir; it isn't exercised here because the spec files
+// written into the tmpdir leaf would block rmdir (a real cgroupfs removes
+// them atomically).
+func TestInstallSubcontainerCompatDirSystemd(t *testing.T) {
+	cg, leafDir := newCompatDirTestCgroup(t)
+	// Pre-create only memory.max so we can assert end-to-end that resources
+	// passed via the dispatcher reach the per-controller set() methods.
+	seedCompatLeafFiles(t, leafDir, "memory.max")
+
+	memLimit := int64(123456789)
+	res := &specs.LinuxResources{
+		Memory: &specs.LinuxMemory{Limit: &memLimit},
+	}
+	if err := InstallSubcontainerCompatDir(cg, res); err != nil {
+		t.Fatalf("InstallSubcontainerCompatDir(systemd, res) error: %v", err)
+	}
+	if _, err := os.Stat(leafDir); err != nil {
+		t.Fatalf("compat dir not created via InstallSubcontainerCompatDir: %v", err)
+	}
+	if got, want := readCgroupFile(t, leafDir, "memory.max"), "123456789"; got != want {
+		t.Errorf("memory.max = %q, want %q", got, want)
 	}
 }
 

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1962,8 +1962,29 @@ func (c *Container) setupCgroupForSubcontainer(conf *config.Config, spec *specs.
 	if cg == nil || err != nil {
 		return nil, err
 	}
-	// Use empty resources, just want the directory structure created.
-	return cgroupInstall(conf, cg, &specs.LinuxResources{})
+	// Create the directory (and populate the spec-limit files from the OCI
+	// resources) so cAdvisor and other inotify-based tools can discover the
+	// subcontainer and report its container_spec_* series. The compat cgroup
+	// is process-less, so these limits have no kernel-side effect.
+	// InstallSubcontainerCompatDir handles the systemd v2 case (where Install
+	// does not create the directory) while keeping the existing cgroupfs
+	// behavior for v1 / non-systemd v2.
+	if err := cgroup.InstallSubcontainerCompatDir(cg, spec.Linux.Resources); err != nil {
+		return nil, handleCgroupInstallErr(conf, "subcontainer cgroup", err)
+	}
+	return cg, nil
+}
+
+// handleCgroupInstallErr maps an error from a cgroup install operation. In
+// rootless mode, EACCES/EROFS mean we lack permission to configure cgroups,
+// which is non-fatal: it logs and returns nil so the caller proceeds without a
+// cgroup. All other errors are wrapped with what.
+func handleCgroupInstallErr(conf *config.Config, what string, err error) error {
+	if (errors.Is(err, unix.EACCES) || errors.Is(err, unix.EROFS)) && conf.Rootless {
+		log.Warningf("Skipping %s configuration in rootless mode: %v", what, err)
+		return nil
+	}
+	return fmt.Errorf("configuring %s: %v", what, err)
 }
 
 // cgroupInstall creates cgroups dir structure and sets their respective
@@ -1973,13 +1994,7 @@ func (c *Container) setupCgroupForSubcontainer(conf *config.Config, spec *specs.
 // no cgroups was configured.
 func cgroupInstall(conf *config.Config, cg cgroup.Cgroup, res *specs.LinuxResources) (cgroup.Cgroup, error) {
 	if err := cg.Install(res); err != nil {
-		switch {
-		case (errors.Is(err, unix.EACCES) || errors.Is(err, unix.EROFS)) && conf.Rootless:
-			log.Warningf("Skipping cgroup configuration in rootless mode: %v", err)
-			return nil, nil
-		default:
-			return nil, fmt.Errorf("configuring cgroup: %v", err)
-		}
+		return nil, handleCgroupInstallErr(conf, "cgroup", err)
 	}
 	return cg, nil
 }

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -2088,8 +2088,29 @@ func (c *Container) setupCgroupForSubcontainer(conf *config.Config, spec *specs.
 	if cg == nil || err != nil {
 		return nil, err
 	}
-	// Use empty resources, just want the directory structure created.
-	return cgroupInstall(conf, cg, &specs.LinuxResources{})
+	// Create the directory (and populate the spec-limit files from the OCI
+	// resources) so cAdvisor and other inotify-based tools can discover the
+	// subcontainer and report its container_spec_* series. The compat cgroup
+	// is process-less, so these limits have no kernel-side effect.
+	// InstallSubcontainerCompatDir handles the systemd v2 case (where Install
+	// does not create the directory) while keeping the existing cgroupfs
+	// behavior for v1 / non-systemd v2.
+	if err := cgroup.InstallSubcontainerCompatDir(cg, spec.Linux.Resources); err != nil {
+		return nil, handleCgroupInstallErr(conf, "subcontainer cgroup", err)
+	}
+	return cg, nil
+}
+
+// handleCgroupInstallErr maps an error from a cgroup install operation. In
+// rootless mode, EACCES/EROFS mean we lack permission to configure cgroups,
+// which is non-fatal: it logs and returns nil so the caller proceeds without a
+// cgroup. All other errors are wrapped with what.
+func handleCgroupInstallErr(conf *config.Config, what string, err error) error {
+	if (errors.Is(err, unix.EACCES) || errors.Is(err, unix.EROFS)) && conf.Rootless {
+		log.Warningf("Skipping %s configuration in rootless mode: %v", what, err)
+		return nil
+	}
+	return fmt.Errorf("configuring %s: %v", what, err)
 }
 
 // cgroupInstall creates cgroups dir structure and sets their respective
@@ -2099,13 +2120,7 @@ func (c *Container) setupCgroupForSubcontainer(conf *config.Config, spec *specs.
 // no cgroups was configured.
 func cgroupInstall(conf *config.Config, cg cgroup.Cgroup, res *specs.LinuxResources) (cgroup.Cgroup, error) {
 	if err := cg.Install(res); err != nil {
-		switch {
-		case (errors.Is(err, unix.EACCES) || errors.Is(err, unix.EROFS)) && conf.Rootless:
-			log.Warningf("Skipping cgroup configuration in rootless mode: %v", err)
-			return nil, nil
-		default:
-			return nil, fmt.Errorf("configuring cgroup: %v", err)
-		}
+		return nil, handleCgroupInstallErr(conf, "cgroup", err)
 	}
 	return cg, nil
 }


### PR DESCRIPTION
## What

Two-commit fix that makes runsc pods on cgroup v2 + systemd report `container_*` cAdvisor series equivalent in shape and spec values to what `runc`-managed pods produce on the same node:

- **Commit 1 — `runsc/cgroup: create host-side compat dir for subcontainers on systemd v2`**: mkdir an empty per-subcontainer cgroup directory under the pod slice so cAdvisor (and other inotify-based discoverers under `/sys/fs/cgroup`) report metrics for non-pause containers.
- **Commit 2 — `runsc/cgroup: populate spec files on subcontainer compat dirs`**: thread `spec.Linux.Resources` through the dispatcher so the limit/spec interface files cAdvisor reads as `container_spec_*` (`memory.max`, `cpu.max`, `cpu.weight`, `memory.swap.max`, `memory.low`, `pids.max`) are populated from the OCI resources on a best-effort basis.

## Why

cAdvisor discovers per-container cgroups by inotify-watching `/sys/fs/cgroup`, and reads spec values for the `container_spec_*` series from the leaf cgroup files. Tools that consume those metrics (kubelet's `/metrics/cadvisor`, `kubectl top`, `container_cpu_usage_seconds_total`, `container_memory_working_set_bytes`, `container_network_*`, VPA recommendations sourced from cAdvisor, etc.) all depend on a host-side cgroup directory existing for each user container _and_ the spec files being populated.

#6500 / #6657 added empty subcontainer cgroup directories so cAdvisor would discover containers running inside a runsc sandbox. That fix only covers cgroup v1 (and non-systemd v2). On a cgroup v2 host with the systemd cgroup driver — the default for kubelet on most current distros — per-container cAdvisor metrics regress to "pause-only" for every gVisor pod, and even where the directory does exist (cgroup v1 today), the spec files end up empty because `Install({})` is passed empty resources.

Reproduction and broader analysis are in the parent issue (#13067).

## Commit 1: discoverability — root cause and fix

`setupCgroupForSubcontainer` calls `cgroupInstall(...).Install({})` intending to mkdir an empty subcontainer cgroup directory for cAdvisor compat. On systemd v2, that lands in `cgroupSystemd.Install` (in `runsc/cgroup/systemd.go`), which only stages dbus properties; the cgroup directory is otherwise created by `Join()` via `StartTransientUnitContext`. `Join()` is wrong here: the compat cgroup is intentionally process-less, registering a transient unit for it would conflict with systemd's lifecycle expectations, and it'd be reaped the moment the dbus connection drops.

So no host-side directory is ever created for non-pause containers in a runsc pod on systemd v2. cAdvisor's inotify watcher under `/sys/fs/cgroup` therefore never discovers them, and per-container series are missing from `/metrics/cadvisor`. The pause container's scope is visible because containerd creates it itself before invoking the shim, independent of runsc.

**Fix:**

1. Add `cgroupSystemd.installCompatDir` which `os.MkdirAll`'s the resolved scope path under the parent slice and tracks it in `c.Own` so the inherited `cgroupV2.Uninstall` reaps it at container destroy. Idempotent (won't double-track on retries).
2. Expose a single dispatcher `cgroup.InstallSubcontainerCompatDir` that routes systemd v2 cgroups to `installCompatDir` and falls back to the existing `Install` path for v1 / non-systemd v2 (which already mkdir the directory inside `Install`).
3. Wire `setupCgroupForSubcontainer` to use the dispatcher.

The shim's `setPodCgroup` is left alone; it doesn't need to change for this fix. Non-root containers reach `setupCgroupForSubcontainer` regardless of `dev.gvisor.spec.cgroup-parent`, and the pause scope is already created by containerd before the shim runs.

## Commit 2: populate spec files

After commit 1, the new compat directories exist but their interface files are empty (or read kernel defaults of `max`), so cAdvisor's `container_spec_*` series for runsc pods read `0` / missing for the limit-bearing fields. The same shape applies on cgroup v1 today — `Install({})` is passed empty resources, so v1 compat dirs also have no spec values.

Thread `spec.Linux.Resources` through `InstallSubcontainerCompatDir`:

- **v1 / non-systemd v2:** `Install(res)` already iterates per-controller `set()` methods that write the limit files; just hand it real resources instead of empty.
- **systemd v2:** extend `installCompatDir` to call `controllers2["cpu"|"memory"|"pids"].set(res, path)` after mkdir. Reuses all the existing runc-compatible conversion (`convertCPUSharesToCgroupV2Value`, `convertMemorySwapToCgroupV2Value`, `cpu.max` formatting). Limited to `{cpu, memory, pids}` — the controllers whose interface files cAdvisor reads as spec values; cpuset / io / hugetlb are intentionally excluded (don't surface as `container_spec_*` and widen the failure surface on hosts where they aren't enabled in the parent slice's `cgroup.subtree_control`).

Mapping (cgroup file written ↔ cAdvisor series populated):

| cgroup file (v2 / v1) | cAdvisor series | OCI source |
|---|---|---|
| `memory.max` / `memory.limit_in_bytes` | `container_spec_memory_limit_bytes` | `Memory.Limit` |
| `memory.swap.max` / `memory.memsw.limit_in_bytes` | `container_spec_memory_swap_limit_bytes` | `Memory.Swap` (computed runc-style on v2) |
| `memory.low` / `memory.soft_limit_in_bytes` | `container_spec_memory_reservation_limit_bytes` | `Memory.Reservation` |
| `cpu.max` (quota) / `cpu.cfs_quota_us` | `container_spec_cpu_quota` | `CPU.Quota` |
| `cpu.max` (period) / `cpu.cfs_period_us` | `container_spec_cpu_period` | `CPU.Period` |
| `cpu.weight` / `cpu.shares` | `container_spec_cpu_shares` | `CPU.Shares` (back-converted on v2) |
| `pids.max` | (no cAdvisor series today; written for runc parity) | `Pids.Limit` |

The compat cgroup is process-less, so any limits written here have no kernel-side accounting effect; they exist solely so cAdvisor's `container_spec_*` series report real values for runsc pods, matching what runc produces on the same node.

**Best-effort writes on systemd v2.** If a controller is not enabled in the parent slice's `cgroup.subtree_control`, `setValue` returns `ENOENT` / `EROFS` / `EACCES`, which we swallow and log. The compat path must never block container start (#6657 invariant).

## Backwards compatibility

Commit 1 only diverges from the existing path when the underlying cgroup is `*cgroupSystemd`; v1 and non-systemd v2 still flow through the existing `Install` path. Compat directories created by either commit are tracked in `c.Own` so existing `Uninstall` removes them at container destroy. No new lifecycle.

Commit 2 changes `InstallSubcontainerCompatDir`'s signature from `(cg Cgroup) error` to `(cg Cgroup, res *specs.LinuxResources) error`. The dispatcher has a single internal caller (`setupCgroupForSubcontainer`); no external callers.

## Tests

Commit 1:

- `TestInstallCompatDir`: directory is created at `MakePath("")`, tracked in `c.Own`, second call is idempotent (no double-track), `Uninstall` removes it.
- `TestInstallSubcontainerCompatDirSystemd`: public dispatcher routes systemd v2 cgroups to the compat-dir path.

Commit 2:

- `TestInstallCompatDirSpecFiles`: pre-touch leaf interface files (simulating kernel auto-creation when controllers are enabled in parent's `subtree_control` on a real cgroupfs mount), pass a full `LinuxResources`, assert each interface file contains the expected serialized value (incl. the runc-style swap-only computation and the `cpu_shares` → `cpu.weight` conversion).
- `TestInstallCompatDirBestEffort`: deliberately do not seed leaf files, assert `installCompatDir(res)` swallows the resulting `ENOENT`s and still returns success with the directory created and tracked.
- `TestInstallSubcontainerCompatDirSystemd` (extended): public dispatcher propagates non-nil resources end-to-end through to the per-controller `set()` methods.

Built and tested locally on aarch64 (lima). Unit tests pass; manual end-to-end verification on a Kubernetes cluster running cgroup v2 + systemd is in the comment below.

Refs: #6500, #6657, #13067

## Out of scope: runtime accounting series (follow-up)

This PR restores cAdvisor _discoverability_ (commit 1) and populates the cgroup limit files cAdvisor reads as `container_spec_*` (commit 2). It does **not** populate kernel-accounted runtime series — `container_cpu_*_seconds_total`, `container_memory_*` (instantaneous gauges), `container_pressure_*`, `container_processes` / `container_threads` / `container_sockets` / `container_file_descriptors`, network counters, etc.

Those stay zero because the compat scopes this PR creates are intentionally process-less: the user workload runs inside the gVisor sandbox (a single Linux process), so the host kernel has nothing to attribute to the per-container scopes. The data isn't lost — gVisor publishes per-container values via `runsc events --stats`, which is what containerd's CRI-stats plugin already consumes for `/stats/summary` (powering `kubectl top`, metrics-server, HPA). The remaining gap is plumbing those values into cAdvisor's output.

A reasonable follow-up shape: a coordinated cAdvisor + gVisor change that registers a cAdvisor `ContainerHandlerFactory` for runsc-managed cgroups, bypassing libcontainer's `/sys/fs/cgroup` reads and consulting `runsc events --stats` (or a stable equivalent), emitting the same metric names with the same label set as the kernel-cgroup-backed path so consumers need no code changes. Happy to drive both PRs as a follow-up to this one if maintainers think that's the right direction. The same shape would also help Kata and other runtimes whose user processes don't live in host cgroups.

This PR remains a strict prerequisite for that follow-up: without per-container scope dirs and populated spec files on the host, cAdvisor has no `ContainerHandler` to attach a runsc-aware stats source to.
