### PR TITLE
tmpfs: Clear security.capability xattr on write

### DIFF
--- a/pkg/sentry/fsimpl/tmpfs/regular_file.go
+++ b/pkg/sentry/fsimpl/tmpfs/regular_file.go
@@ -587,6 +587,7 @@ func (fd *regularFileFD) pwrite(ctx context.Context, src usermem.IOSequence, off
 			break
 		}
 	}
+	f.inode.xattrs.KillPriv()
 	putRegularFileReadWriter(rw)
 	return n, n + offset, err
 }

--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -781,6 +781,9 @@ func (i *inode) setStat(ctx context.Context, creds *auth.Credentials, opts *vfs.
 		}
 		needsCtimeBump = true
 	}
+	if opts.ClearPrivs {
+		i.xattrs.KillPriv()
+	}
 
 	if needsMtimeBump {
 		i.mtime.Store(now)

--- a/pkg/sentry/vfs/memxattr/xattr.go
+++ b/pkg/sentry/vfs/memxattr/xattr.go
@@ -122,6 +122,15 @@ func (x *SimpleExtendedAttributes) ListXattr(creds *auth.Credentials, size uint6
 	return names, nil
 }
 
+// KillPriv removes the "security.capability" xattr if present. No permission
+// check is needed because the caller is removing privileges on behalf of the
+// kernel, not userspace.
+func (x *SimpleExtendedAttributes) KillPriv() {
+	x.mu.Lock()
+	delete(x.xattrs, linux.XATTR_SECURITY_CAPABILITY)
+	x.mu.Unlock()
+}
+
 // RemoveXattr removes the xattr at 'name'.
 func (x *SimpleExtendedAttributes) RemoveXattr(creds *auth.Credentials, mode linux.FileMode, kuid auth.KUID, name string) error {
 	if err := vfs.CheckXattrPermissions(creds, vfs.MayWrite, mode, kuid, name); err != nil {

--- a/pkg/sentry/vfs/options.go
+++ b/pkg/sentry/vfs/options.go
@@ -191,7 +191,7 @@ type SetStatOptions struct {
 
 	// ClearPrivs is a directive from the chown and truncate family of syscalls
 	// to the filesystem's SetStat implementation to clear the SUID and SGID
-	// bits on the file.
+	// bits on the file and other privilege-granting state.
 	ClearPrivs bool
 }
 

--- a/test/syscalls/linux/chown.cc
+++ b/test/syscalls/linux/chown.cc
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
+#include <stdint.h>
 #include <sys/types.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include <vector>
@@ -39,6 +42,33 @@ namespace gvisor {
 namespace testing {
 
 namespace {
+
+struct VfsCapData {
+  uint32_t magic_etc;
+  uint32_t permitted_lo;
+  uint32_t inheritable_lo;
+  uint32_t permitted_hi;
+  uint32_t inheritable_hi;
+};
+
+int SetSecurityCapability(const std::string& path) {
+  VfsCapData cap_data = {};
+  cap_data.magic_etc = 0x02000000 | 0x000001;
+  cap_data.permitted_lo = 1u << CAP_SETUID;
+
+  if (setxattr(path.c_str(), "security.capability", &cap_data,
+               sizeof(cap_data), 0) < 0) {
+    return errno;
+  }
+
+  char buf[sizeof(cap_data)] = {};
+  const ssize_t size =
+      getxattr(path.c_str(), "security.capability", buf, sizeof(buf));
+  if (size != sizeof(cap_data)) {
+    return size < 0 ? errno : EIO;
+  }
+  return 0;
+}
 
 TEST(ChownTest, FchownBadF) {
   ASSERT_THAT(fchown(-1, 0, 0), SyscallFailsWithErrno(EBADF));
@@ -125,6 +155,28 @@ TEST(ChownTest, FchownatEmptyPath) {
   const auto fd =
       ASSERT_NO_ERRNO_AND_VALUE(Open(dir.path(), O_DIRECTORY | O_RDONLY));
   ASSERT_THAT(fchownat(fd.get(), "", 0, 0, 0), SyscallFailsWithErrno(ENOENT));
+}
+
+TEST(ChownTest, ChownRemovesSecurityCapability) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_CHOWN)));
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETFCAP)));
+
+  const auto file = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateFile());
+  const int set_cap_errno = SetSecurityCapability(file.path());
+  if (set_cap_errno == EOPNOTSUPP || set_cap_errno == EPERM) {
+    GTEST_SKIP() << "setting security.capability failed with errno "
+                 << set_cap_errno;
+  }
+  ASSERT_EQ(set_cap_errno, 0);
+
+  ASSERT_THAT(chown(file.path().c_str(), absl::GetFlag(FLAGS_scratch_uid1),
+                    -1),
+              SyscallSucceeds());
+
+  char buf[sizeof(VfsCapData)] = {};
+  EXPECT_THAT(getxattr(file.path().c_str(), "security.capability", buf,
+                       sizeof(buf)),
+              SyscallFailsWithErrno(ENODATA));
 }
 
 TEST(ChownTest, SetGroupIdBitDeniedWithoutCapFsetIdOrRelevantGroup) {

--- a/test/syscalls/linux/xattr.cc
+++ b/test/syscalls/linux/xattr.cc
@@ -15,7 +15,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <stdint.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <sys/xattr.h>
 #include <unistd.h>
 
@@ -46,6 +49,7 @@ using ::gvisor::testing::IsTmpfs;
 using ::testing::AnyOf;
 
 constexpr char kUnshareAndSetTrustedXattrInNewUserns[] = "--set_trusted_xattr";
+constexpr int kNobodyUID = 65534;
 
 class XattrTest : public FileTest {};
 
@@ -123,6 +127,52 @@ TEST_F(XattrTest, SecurityCapacityXattr) {
   EXPECT_THAT(lgetxattr(path, name, &buf, /*size=*/128),
               SyscallFailsWithErrno(AnyOf(ENODATA, EOPNOTSUPP)));
   EXPECT_THAT(lremovexattr(path, name), SyscallFailsWithErrno(EOPNOTSUPP));
+}
+
+TEST_F(XattrTest, WriteRemovesSecurityCapability) {
+  SKIP_IF(getuid() != 0);
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETFCAP)));
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  const char* path = test_file_name_.c_str();
+  const char name[] = "security.capability";
+
+  struct {
+    uint32_t magic_etc;
+    uint32_t permitted_lo;
+    uint32_t inheritable_lo;
+    uint32_t permitted_hi;
+    uint32_t inheritable_hi;
+  } cap_data = {};
+  cap_data.magic_etc = 0x02000000 | 0x000001;  // VFS_CAP_REVISION_2 | VFS_CAP_FLAGS_EFFECTIVE
+  cap_data.permitted_lo = 1 << 7;               // CAP_SETUID
+
+  ASSERT_THAT(chmod(path, 0666), SyscallSucceeds());
+  ASSERT_THAT(setxattr(path, name, &cap_data, sizeof(cap_data), 0),
+              SyscallSucceeds());
+
+  char buf[sizeof(cap_data)] = {};
+  ASSERT_THAT(getxattr(path, name, buf, sizeof(buf)),
+              SyscallSucceedsWithValue(sizeof(cap_data)));
+
+  pid_t pid = fork();
+  ASSERT_THAT(pid, SyscallSucceeds());
+  if (pid == 0) {
+    if (syscall(SYS_setuid, kNobodyUID) < 0) _exit(1);
+    char data[] = "overwritten";
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) _exit(2);
+    if (write(fd, data, sizeof(data)) < 0) _exit(3);
+    close(fd);
+    _exit(0);
+  }
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  ASSERT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "child exited with status " << status;
+
+  EXPECT_THAT(getxattr(path, name, buf, sizeof(buf)),
+              SyscallFailsWithErrno(ENODATA));
 }
 
 // Do not allow save/restore cycles after making the test file read-only, as


### PR DESCRIPTION
When a non-privileged user writes to a file on tmpfs, Linux clears both the setuid/setgid mode bits and the `security.capability` xattr via `file_remove_privs`. The mode bit clearing was already implemented through `ClearSUIDAndSGID` in the pwrite path, but the xattr removal was missing, so file capabilities survived content replacement. An unprivileged user could overwrite a capability-bearing binary and execute it with the retained privileges.

The fix adds a `KillPriv` method on `SimpleExtendedAttributes` that removes `security.capability` without permission checks (matching Linux's `cap_inode_killpriv`, where the kernel is the actor), and calls it from the tmpfs pwrite path alongside the existing `ClearSUIDAndSGID`.

The gofer filesystem is not affected because it explicitly blocks `security.*` xattr writes to the host filesystem.

Fixes #13063