### PR TITLE
runsc/boot: add per-mount directfs opt-out

### DIFF
--- a/g3doc/user_guide/containerd/configuration.md
+++ b/g3doc/user_guide/containerd/configuration.md
@@ -188,6 +188,12 @@ to handle each volume:
     -   `bind`: Indicates a bind mount from the host.
 -   `dev.gvisor.spec.mount.<NAME>.options`: Comma-separated volume-mount options
     (e.g., `rw,rprivate`).
+-   `dev.gvisor.spec.mount.<NAME>.directfs`: `default` or `off`. `default`
+    (or unset) follows the global `--directfs` setting. `off` suppresses the
+    `directfs` mount option for this mount even when `--directfs` is enabled
+    globally. Use this for mounts served by a custom gofer that cannot donate a
+    host file descriptor for the mount root (for example, virtual or
+    network-backed filesystems). Other mounts continue to use directfs.
 
 Below is an example Pod spec for a shared `emptyDir` volume named
 `shared-folder`, with annotations that enable cross-container inotify:

--- a/runsc/boot/mount_hints.go
+++ b/runsc/boot/mount_hints.go
@@ -102,7 +102,7 @@ func NewPodMountHints(spec *specs.Spec) (*PodMountHints, error) {
 
 	// Validate all the parsed hints.
 	for name, m := range mnts {
-		log.Infof("Mount annotation found, name: %s, source: %q, type: %s, share: %v", name, m.Mount.Source, m.Mount.Type, m.Share)
+		log.Infof("Mount annotation found, name: %s, source: %q, type: %s, share: %v, suppress_directfs: %t", name, m.Mount.Source, m.Mount.Type, m.Share, m.SuppressDirectFS)
 		if m.Share == invalid || len(m.Mount.Source) == 0 || len(m.Mount.Type) == 0 {
 			log.Warningf("ignoring mount annotations for %q because of missing required field(s)", name)
 			delete(mnts, name)
@@ -121,13 +121,21 @@ func NewPodMountHints(spec *specs.Spec) (*PodMountHints, error) {
 }
 
 // MountHint represents extra information about mounts that are provided via
-// annotations. They can override mount type, and provide sharing information
-// so that mounts can be correctly shared inside the pod.
+// annotations. They can override mount type, provide sharing information so
+// that mounts can be correctly shared inside the pod, and tune gofer-specific
+// behavior such as suppressing directfs.
 // It is part of the sandbox.Sandbox struct, so it must be serializable.
 type MountHint struct {
 	Name  string      `json:"name"`
 	Share ShareType   `json:"share"`
 	Mount specs.Mount `json:"mount"`
+
+	// SuppressDirectFS suppresses the "directfs" gofer mount option for this
+	// mount even if --directfs is enabled globally. It does not enable directfs
+	// when --directfs is disabled because directfs requires some sandbox-wide
+	// settings (like seccomp filters) that can not be selectively enabled on
+	// containers.
+	SuppressDirectFS bool `json:"suppressDirectFS"`
 }
 
 func (m *MountHint) setField(key, val string) error {
@@ -143,6 +151,8 @@ func (m *MountHint) setField(key, val string) error {
 		return m.setShare(val)
 	case "options":
 		m.Mount.Options = specutils.FilterMountOptions(strings.Split(val, ","))
+	case "directfs":
+		return m.setDirectFS(val)
 	default:
 		return fmt.Errorf("invalid mount annotation: %s=%s", key, val)
 	}
@@ -169,6 +179,18 @@ func (m *MountHint) setShare(val string) error {
 		m.Share = shared
 	default:
 		return fmt.Errorf("invalid share value %q", val)
+	}
+	return nil
+}
+
+func (m *MountHint) setDirectFS(val string) error {
+	switch val {
+	case "default":
+		m.SuppressDirectFS = false
+	case "off":
+		m.SuppressDirectFS = true
+	default:
+		return fmt.Errorf("invalid directfs value %q, want \"default\" or \"off\"", val)
 	}
 	return nil
 }
@@ -244,6 +266,8 @@ type RootfsHint struct {
 	// Size of overlay tmpfs. Passed as `size={Size}` to tmpfs mount.
 	// Use default if unspecified.
 	Size string
+
+	SuppressDirectFS bool
 }
 
 func (r *RootfsHint) setSource(val string) error {
@@ -288,6 +312,18 @@ func (r *RootfsHint) setOptions(val string) error {
 	return nil
 }
 
+func (r *RootfsHint) setDirectFS(val string) error {
+	switch val {
+	case "default":
+		r.SuppressDirectFS = false
+	case "off":
+		r.SuppressDirectFS = true
+	default:
+		return fmt.Errorf("invalid directfs value %q, want \"default\" or \"off\"", val)
+	}
+	return nil
+}
+
 func (r *RootfsHint) setField(key, val string) error {
 	switch key {
 	case "source":
@@ -298,6 +334,8 @@ func (r *RootfsHint) setField(key, val string) error {
 		return r.Overlay.Set(val)
 	case "options":
 		return r.setOptions(val)
+	case "directfs":
+		return r.setDirectFS(val)
 	default:
 		return fmt.Errorf("invalid rootfs annotation: %s=%s", key, val)
 	}
@@ -322,7 +360,7 @@ func NewRootfsHint(spec *specs.Spec) (*RootfsHint, error) {
 	}
 	// Validate the parsed hint.
 	if hint != nil {
-		log.Infof("Rootfs annotations found, source: %q, type: %q, overlay: %q", hint.Mount.Source, hint.Mount.Type, hint.Overlay)
+		log.Infof("Rootfs annotations found, source: %q, type: %q, overlay: %q, suppress_directfs: %t", hint.Mount.Source, hint.Mount.Type, hint.Overlay, hint.SuppressDirectFS)
 		if len(hint.Mount.Source) == 0 || len(hint.Mount.Type) == 0 {
 			return nil, fmt.Errorf("rootfs annotations missing required field(s): %+v", hint)
 		}

--- a/runsc/boot/mount_hints_test.go
+++ b/runsc/boot/mount_hints_test.go
@@ -59,6 +59,9 @@ func TestPodMountHintsHappy(t *testing.T) {
 	if want := []string(nil); !slices.Equal(want, mount1.Mount.Options) {
 		t.Errorf("mount1 type, want: %q, got: %q", want, mount1.Mount.Options)
 	}
+	if mount1.SuppressDirectFS {
+		t.Errorf("mount1 SuppressDirectFS, want: false, got: true")
+	}
 
 	mount2 := podHints.Mounts["mount2"]
 	if want := "mount2"; want != mount2.Name {
@@ -166,6 +169,77 @@ func TestPodMountHintsIgnore(t *testing.T) {
 				if hint, ok := podHints.Mounts["mount1"]; ok {
 					t.Errorf("hint was provided when it should have been omitted: %+v", hint)
 				}
+			}
+		})
+	}
+}
+
+func TestPodMountHintsDirectFSInvalid(t *testing.T) {
+	spec := &specs.Spec{
+		Annotations: map[string]string{
+			MountPrefix + "mount1.source":   "foo",
+			MountPrefix + "mount1.type":     "bind",
+			MountPrefix + "mount1.share":    "container",
+			MountPrefix + "mount1.directfs": "maybe",
+
+			MountPrefix + "mount2.source":   "bar",
+			MountPrefix + "mount2.type":     "bind",
+			MountPrefix + "mount2.share":    "container",
+			MountPrefix + "mount2.directfs": "off",
+		},
+	}
+	podHints, err := NewPodMountHints(spec)
+	if err != nil {
+		t.Fatalf("NewPodMountHints failed: %v", err)
+	}
+	mount1, ok := podHints.Mounts["mount1"]
+	if !ok {
+		t.Fatalf("mount1 hint should be retained when directfs value is invalid")
+	}
+	if mount1.SuppressDirectFS {
+		t.Errorf("mount1 SuppressDirectFS, want: false, got: true")
+	}
+	mount2, ok := podHints.Mounts["mount2"]
+	if !ok {
+		t.Fatalf("mount2 hint should be retained when sibling has invalid directfs")
+	}
+	if !mount2.SuppressDirectFS {
+		t.Errorf("mount2 SuppressDirectFS, want: true, got: false")
+	}
+}
+
+func TestPodMountHintsDirectFS(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		value    string
+		suppress bool
+	}{
+		{
+			name:     "default",
+			value:    "default",
+			suppress: false,
+		},
+		{
+			name:     "off",
+			value:    "off",
+			suppress: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &specs.Spec{
+				Annotations: map[string]string{
+					MountPrefix + "mount1.source":   "foo",
+					MountPrefix + "mount1.type":     "bind",
+					MountPrefix + "mount1.share":    "container",
+					MountPrefix + "mount1.directfs": tc.value,
+				},
+			}
+			podHints, err := NewPodMountHints(spec)
+			if err != nil {
+				t.Fatalf("NewPodMountHints failed: %v", err)
+			}
+			if got := podHints.Mounts["mount1"].SuppressDirectFS; got != tc.suppress {
+				t.Errorf("SuppressDirectFS = %t, want %t", got, tc.suppress)
 			}
 		})
 	}
@@ -281,6 +355,34 @@ func TestRootfsHintHappy(t *testing.T) {
 	}
 }
 
+func TestRootfsHintDirectFS(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		value    string
+		suppress bool
+	}{
+		{name: "default", value: "default", suppress: false},
+		{name: "off", value: "off", suppress: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &specs.Spec{
+				Annotations: map[string]string{
+					RootfsPrefix + "source":   "/tmp/rootfs.img",
+					RootfsPrefix + "type":     erofs.Name,
+					RootfsPrefix + "directfs": tc.value,
+				},
+			}
+			hint, err := NewRootfsHint(spec)
+			if err != nil {
+				t.Fatalf("NewRootfsHint failed: %v", err)
+			}
+			if hint.SuppressDirectFS != tc.suppress {
+				t.Errorf("SuppressDirectFS = %t, want %t", hint.SuppressDirectFS, tc.suppress)
+			}
+		})
+	}
+}
+
 // TestRootfsHintErrors tests that proper errors will be returned when parsing
 // invalid rootfs annotations.
 func TestRootfsHintErrors(t *testing.T) {
@@ -340,6 +442,15 @@ func TestRootfsHintErrors(t *testing.T) {
 				RootfsPrefix + "overlay": config.MemoryOverlay.String(),
 			},
 			error: "rootfs annotations missing required field",
+		},
+		{
+			name: "invalid directfs",
+			annotations: map[string]string{
+				RootfsPrefix + "source":   imagePath,
+				RootfsPrefix + "type":     erofs.Name,
+				RootfsPrefix + "directfs": "maybe",
+			},
+			error: "invalid directfs value",
 		},
 	} {
 		t.Run(tst.name, func(t *testing.T) {

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -322,7 +322,7 @@ func compileMounts(spec *specs.Spec, conf *config.Config, containerID string) []
 }
 
 // goferMountData creates a slice of gofer mount data.
-func goferMountData(fd int, fa config.FileAccessType, conf *config.Config) []string {
+func goferMountData(fd int, fa config.FileAccessType, conf *config.Config, suppressDirectFS bool) []string {
 	opts := []string{
 		"trans=fd",
 		"rfdno=" + strconv.Itoa(fd),
@@ -331,7 +331,7 @@ func goferMountData(fd int, fa config.FileAccessType, conf *config.Config) []str
 	if fa == config.FileAccessShared {
 		opts = append(opts, "cache=remote_revalidating")
 	}
-	if conf.DirectFS {
+	if conf.DirectFS && !suppressDirectFS {
 		opts = append(opts, "directfs")
 	}
 	if !conf.HostFifo.AllowOpen() {
@@ -472,7 +472,7 @@ func getMountAccessType(conf *config.Config, hint *MountHint) config.FileAccessT
 func (c *containerMounter) mountAll(rootCtx context.Context, rootCreds *auth.Credentials, spec *specs.Spec, conf *config.Config, rootProcArgs *kernel.CreateProcessArgs) (*vfs.MountNamespace, error) {
 	log.Infof("Configuring container's file system")
 
-	mns, err := c.createMountNamespace(rootCtx, conf, rootCreds)
+	mns, err := c.createMountNamespace(rootCtx, spec, conf, rootCreds)
 	if err != nil {
 		return nil, fmt.Errorf("creating mount namespace: %w", err)
 	}
@@ -502,9 +502,15 @@ func (c *containerMounter) mountAll(rootCtx context.Context, rootCreds *auth.Cre
 }
 
 // createMountNamespace creates the container's root mount and namespace.
-func (c *containerMounter) createMountNamespace(ctx context.Context, conf *config.Config, creds *auth.Credentials) (*vfs.MountNamespace, error) {
+func (c *containerMounter) createMountNamespace(ctx context.Context, spec *specs.Spec, conf *config.Config, creds *auth.Credentials) (*vfs.MountNamespace, error) {
 	ioFD := c.goferFDs.remove()
 	rootfsConf := c.goferMountConfs[0]
+
+	rootfsHint, err := NewRootfsHint(spec)
+	if err != nil {
+		return nil, fmt.Errorf("parsing rootfs hint: %w", err)
+	}
+	suppressDirectFS := rootfsHint != nil && rootfsHint.SuppressDirectFS
 
 	var (
 		fsName string
@@ -514,7 +520,7 @@ func (c *containerMounter) createMountNamespace(ctx context.Context, conf *confi
 	case rootfsConf.ShouldUseLisafs():
 		fsName = gofer.Name
 
-		data := goferMountData(ioFD, conf.FileAccess, conf)
+		data := goferMountData(ioFD, conf.FileAccess, conf, suppressDirectFS)
 
 		// We can't check for overlayfs here because sandbox is chroot'ed and gofer
 		// can only send mount options for specs.Mounts (specs.Root is missing
@@ -1014,7 +1020,7 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 		if err != nil {
 			return "", nil, err
 		}
-		data = append(data, goferMountData(m.goferFD.Release(), getMountAccessType(conf, m.hint), conf)...)
+		data = append(data, goferMountData(m.goferFD.Release(), getMountAccessType(conf, m.hint), conf, m.hint != nil && m.hint.SuppressDirectFS)...)
 		internalData = gofer.InternalFilesystemOptions{
 			UniqueID: checkpoint.ResourceID{
 				ContainerName: containerName,

--- a/runsc/boot/vfs_test.go
+++ b/runsc/boot/vfs_test.go
@@ -15,6 +15,7 @@
 package boot
 
 import (
+	"slices"
 	"testing"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -92,6 +93,47 @@ func TestGetMountAccessType(t *testing.T) {
 			conf := &config.Config{FileAccessMounts: config.FileAccessShared}
 			if got := getMountAccessType(conf, podHints.FindMount(source)); got != tst.want {
 				t.Errorf("getMountAccessType(), got: %v, want: %v", got, tst.want)
+			}
+		})
+	}
+}
+
+func TestGoferMountDataDirectFS(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		directFS         bool
+		suppressDirectFS bool
+		wantEnabled      bool
+	}{
+		{
+			name:        "global on, not suppressed",
+			directFS:    true,
+			wantEnabled: true,
+		},
+		{
+			name:             "global on, suppressed",
+			directFS:         true,
+			suppressDirectFS: true,
+			wantEnabled:      false,
+		},
+		{
+			name:             "global off, suppressed",
+			directFS:         false,
+			suppressDirectFS: true,
+			wantEnabled:      false,
+		},
+		{
+			name:        "global off, not suppressed",
+			directFS:    false,
+			wantEnabled: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := &config.Config{DirectFS: tc.directFS, HostFifo: config.HostFifoOpen}
+			opts := goferMountData(7, config.FileAccessExclusive, conf, tc.suppressDirectFS)
+			gotEnabled := slices.Contains(opts, "directfs")
+			if gotEnabled != tc.wantEnabled {
+				t.Errorf("directfs option present = %t, want %t (opts=%v)", gotEnabled, tc.wantEnabled, opts)
 			}
 		})
 	}

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -172,6 +172,7 @@ go_test(
         "//pkg/sentry/control",
         "//pkg/sentry/kernel/auth",
         "//pkg/test/testutil",
+        "//runsc/boot",
         "//runsc/cmd/sandboxsetup",
         "//runsc/cmd/util",
         "//runsc/config",

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -28,6 +28,7 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/unet"
 	"gvisor.dev/gvisor/pkg/urpc"
+	"gvisor.dev/gvisor/runsc/boot"
 	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
@@ -172,6 +173,15 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	if err != nil {
 		util.Fatalf("reading spec: %v", err)
 	}
+	mountHints, err := boot.NewPodMountHints(spec)
+	if err != nil {
+		util.Fatalf("parsing mount hints: %v", err)
+	}
+	rootfsHint, err := boot.NewRootfsHint(spec)
+	if err != nil {
+		util.Fatalf("parsing rootfs hint: %v", err)
+	}
+	lisafsNeeded := lisafsNeededForDirectFSSuppression(spec, mountHints, rootfsHint, g.mountConfs)
 
 	g.syncFDs.syncChroot()
 	g.syncFDs.syncUsernsForRootless(uint32(g.uid), uint32(g.gid))
@@ -291,6 +301,7 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 		UDSCreateEnabled: conf.GetHostUDS().AllowCreate(),
 		ProfileEnabled:   profileOpts.Enabled(),
 		DirectFS:         conf.DirectFS,
+		LisafsNeeded:     lisafsNeeded,
 		CgoEnabled:       config.CgoEnabled,
 	}
 	if err := filter.Install(opts); err != nil {
@@ -386,6 +397,33 @@ func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid i
 		g.stopProfiling()
 	}
 	return subcommands.ExitSuccess
+}
+
+// lisafsNeededForDirectFSSuppression returns true if this gofer serves a mount
+// that suppresses directfs and therefore still needs LisaFS syscalls.
+func lisafsNeededForDirectFSSuppression(spec *specs.Spec, mountHints *boot.PodMountHints, rootfsHint *boot.RootfsHint, mountConfs []specutils.GoferMountConf) bool {
+	if len(mountConfs) > 0 && mountConfs[0].ShouldUseLisafs() &&
+		rootfsHint != nil && rootfsHint.SuppressDirectFS {
+		return true
+	}
+	if mountHints == nil {
+		return false
+	}
+	mountIdx := 1 // First mount config is the root.
+	for _, m := range spec.Mounts {
+		if !specutils.HasMountConfig(m) {
+			continue
+		}
+		mountConf := mountConfs[mountIdx]
+		mountIdx++
+		if !mountConf.ShouldUseLisafs() {
+			continue
+		}
+		if hint := mountHints.FindMount(m.Source); hint != nil && hint.SuppressDirectFS {
+			return true
+		}
+	}
+	return false
 }
 
 // makeRPCMountOpener returns a MountOpener that opens mount sources via the

--- a/runsc/cmd/gofer_test.go
+++ b/runsc/cmd/gofer_test.go
@@ -21,7 +21,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gvisor.dev/gvisor/runsc/boot"
 	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
+	"gvisor.dev/gvisor/runsc/specutils"
 )
 
 func tmpDir() string {
@@ -160,5 +163,110 @@ func TestResolveSymlinksLoop(t *testing.T) {
 	}
 	if _, err := sandboxsetup.ResolveSymlinks(root, "loop1"); err == nil {
 		t.Errorf("ResolveSymlinks() should have failed")
+	}
+}
+
+func TestLisafsNeededForDirectFSSuppression(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		spec       *specs.Spec
+		mountConfs []specutils.GoferMountConf
+		want       bool
+	}{
+		{
+			name:       "no suppression",
+			spec:       suppressedMountSpec("foo", "default"),
+			mountConfs: lisafsMountConfs(),
+		},
+		{
+			name:       "suppressed lisafs mount",
+			spec:       suppressedMountSpec("foo", "off"),
+			mountConfs: lisafsMountConfs(),
+			want:       true,
+		},
+		{
+			name:       "suppressed mount not in spec",
+			spec:       suppressedMountSpec("bar", "off"),
+			mountConfs: lisafsMountConfs(),
+		},
+		{
+			name: "suppressed erofs mount",
+			spec: suppressedMountSpec("foo", "off"),
+			mountConfs: []specutils.GoferMountConf{
+				{Lower: specutils.Lisafs, Upper: specutils.NoOverlay},
+				{Lower: specutils.Erofs, Upper: specutils.NoOverlay},
+			},
+		},
+		{
+			name:       "suppressed bind rootfs",
+			spec:       suppressedRootfsSpec("bind", "off"),
+			mountConfs: rootfsOnlyMountConfs(specutils.Lisafs),
+			want:       true,
+		},
+		{
+			name:       "rootfs hint without suppression",
+			spec:       suppressedRootfsSpec("bind", "default"),
+			mountConfs: rootfsOnlyMountConfs(specutils.Lisafs),
+		},
+		{
+			name:       "suppressed erofs rootfs",
+			spec:       suppressedRootfsSpec("erofs", "off"),
+			mountConfs: rootfsOnlyMountConfs(specutils.Erofs),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mountHints, err := boot.NewPodMountHints(tc.spec)
+			if err != nil {
+				t.Fatalf("NewPodMountHints failed: %v", err)
+			}
+			rootfsHint, err := boot.NewRootfsHint(tc.spec)
+			if err != nil {
+				t.Fatalf("NewRootfsHint failed: %v", err)
+			}
+			if got := lisafsNeededForDirectFSSuppression(tc.spec, mountHints, rootfsHint, tc.mountConfs); got != tc.want {
+				t.Errorf("lisafsNeededForDirectFSSuppression = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func suppressedMountSpec(hintSource, directfs string) *specs.Spec {
+	return &specs.Spec{
+		Annotations: map[string]string{
+			boot.MountPrefix + "mount1.source":   hintSource,
+			boot.MountPrefix + "mount1.type":     "bind",
+			boot.MountPrefix + "mount1.share":    "container",
+			boot.MountPrefix + "mount1.directfs": directfs,
+		},
+		Mounts: []specs.Mount{
+			{
+				Source:      "foo",
+				Type:        "bind",
+				Destination: "/mnt",
+			},
+		},
+	}
+}
+
+func suppressedRootfsSpec(rootfsType, directfs string) *specs.Spec {
+	return &specs.Spec{
+		Annotations: map[string]string{
+			boot.RootfsPrefix + "source":   "/tmp/rootfs",
+			boot.RootfsPrefix + "type":     rootfsType,
+			boot.RootfsPrefix + "directfs": directfs,
+		},
+	}
+}
+
+func lisafsMountConfs() []specutils.GoferMountConf {
+	return []specutils.GoferMountConf{
+		{Lower: specutils.Lisafs, Upper: specutils.NoOverlay},
+		{Lower: specutils.Lisafs, Upper: specutils.NoOverlay},
+	}
+}
+
+func rootfsOnlyMountConfs(lower specutils.GoferMountConfLowerType) []specutils.GoferMountConf {
+	return []specutils.GoferMountConf{
+		{Lower: lower, Upper: specutils.NoOverlay},
 	}
 }

--- a/runsc/fsgofer/filter/BUILD
+++ b/runsc/fsgofer/filter/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -28,6 +28,16 @@ go_library(
         "//pkg/flipcall",
         "//pkg/log",
         "//pkg/seccomp",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
+go_test(
+    name = "filter_test",
+    size = "small",
+    srcs = ["filter_test.go"],
+    library = ":filter",
+    deps = [
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/runsc/fsgofer/filter/filter.go
+++ b/runsc/fsgofer/filter/filter.go
@@ -28,6 +28,7 @@ type Options struct {
 	UDSCreateEnabled bool
 	ProfileEnabled   bool
 	DirectFS         bool
+	LisafsNeeded     bool
 	CgoEnabled       bool
 }
 
@@ -64,8 +65,9 @@ func Rules(opt Options) seccomp.SyscallRules {
 	// when not enabled.
 	s.Merge(instrumentationFilters())
 
-	// When DirectFS is not enabled, filters for LisaFS are installed.
-	if !opt.DirectFS {
+	// When DirectFS is not enabled, filters for LisaFS are installed. They are
+	// also needed when this gofer serves a mount that suppresses DirectFS.
+	if !opt.DirectFS || opt.LisafsNeeded {
 		s.Merge(lisafsFilters)
 	}
 

--- a/runsc/fsgofer/filter/filter_test.go
+++ b/runsc/fsgofer/filter/filter_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestRulesLisaFSFilters(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		directFS     bool
+		lisafsNeeded bool
+		wantAllowed  bool
+	}{
+		{
+			name:        "directfs disabled",
+			wantAllowed: true,
+		},
+		{
+			name:        "directfs enabled",
+			directFS:    true,
+			wantAllowed: false,
+		},
+		{
+			name:         "directfs enabled with lisafs mount",
+			directFS:     true,
+			lisafsNeeded: true,
+			wantAllowed:  true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rules := Rules(Options{
+				DirectFS:     tc.directFS,
+				LisafsNeeded: tc.lisafsNeeded,
+			})
+			// SYS_FGETXATTR is part of lisafsFilters but not the base gofer
+			// rules, so it proves whether the LisaFS filter block was merged.
+			if got := rules.Has(unix.SYS_FGETXATTR); got != tc.wantAllowed {
+				t.Errorf("Rules().Has(SYS_FGETXATTR) = %t, want %t", got, tc.wantAllowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The --directfs flag is global. When it is enabled, every gofer mount in
the sandbox includes the "directfs" option, which causes the sentry to
require a host FD for the mount root from the gofer's Mount RPC reply.
Custom gofer servers that back virtual or network-backed filesystems
(e.g. a blob-store-backed volume gofer) cannot donate such an FD and
currently have to disable --directfs globally to coexist with the stock
gofer, which loses the directfs performance benefit on every other
mount.

This PR adds a new "directfs" key to the
dev.gvisor.spec.mount.<NAME>.* and dev.gvisor.spec.rootfs.* annotations.
When set to "off", the sentry suppresses the directfs mount option for
that mount only. When unset or set to "default", the mount follows the
global --directfs setting.

This remains an opt-out rather than a full per-mount override. The
annotation does not enable directfs when --directfs is disabled because
directfs requires some sandbox-wide settings (like seccomp filters)
that can not be selectively enabled on containers.

Plumbing reuses the existing MountHint and RootfsHint mechanisms in
runsc/boot. Both the rootfs and submount paths read the per-mount
suppression and pass it into goferMountData. For stock fsgofer mixed
mode, the gofer keeps LisaFS seccomp filters when a fsgofer-handled
mount or bind rootfs opts out, because that mount can still issue
LisaFS RPCs.

Tests cover annotation parsing for both mount and rootfs hints, invalid
directfs values, goferMountData behavior, and the gofer seccomp filter
behavior for mixed DirectFS and LisaFS mounts including the bind-rootfs
case.

Fixes #13098.