### PR TITLE
test: Use named constants for VFS capability values

### DIFF
--- a/test/syscalls/linux/chown.cc
+++ b/test/syscalls/linux/chown.cc
@@ -15,11 +15,13 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
+#include <linux/capability.h>
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/xattr.h>
 #include <unistd.h>
 
+#include <string>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -53,7 +55,7 @@ struct VfsCapData {
 
 int SetSecurityCapability(const std::string& path) {
   VfsCapData cap_data = {};
-  cap_data.magic_etc = 0x02000000 | 0x000001;
+  cap_data.magic_etc = VFS_CAP_REVISION_2 | VFS_CAP_FLAGS_EFFECTIVE;
   cap_data.permitted_lo = 1u << CAP_SETUID;
 
   if (setxattr(path.c_str(), "security.capability", &cap_data, sizeof(cap_data),

--- a/test/syscalls/linux/xattr.cc
+++ b/test/syscalls/linux/xattr.cc
@@ -15,6 +15,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <linux/capability.h>
 #include <stdint.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -144,9 +145,8 @@ TEST_F(XattrTest, WriteRemovesSecurityCapability) {
     uint32_t permitted_hi;
     uint32_t inheritable_hi;
   } cap_data = {};
-  cap_data.magic_etc =
-      0x02000000 | 0x000001;  // VFS_CAP_REVISION_2 | VFS_CAP_FLAGS_EFFECTIVE
-  cap_data.permitted_lo = 1 << 7;  // CAP_SETUID
+  cap_data.magic_etc = VFS_CAP_REVISION_2 | VFS_CAP_FLAGS_EFFECTIVE;
+  cap_data.permitted_lo = 1 << CAP_SETUID;
 
   ASSERT_THAT(chmod(path, 0666), SyscallSucceeds());
   ASSERT_THAT(setxattr(path, name, &cap_data, sizeof(cap_data), 0),


### PR DESCRIPTION
Follow-up to #13072. The internal linter was blocking submit because chown.cc uses std::string without directly including <string>, and ayushr2 flagged that both test files were defining VFS_CAP_REVISION_2 and VFS_CAP_FLAGS_EFFECTIVE as raw hex literals instead of using the constants from linux/capability.h.

This adds the missing include and replaces the magic numbers in both chown.cc and xattr.cc.