### PR TITLE
Add ConnectX RDMA device plug-in

### DIFF
--- a/pkg/sentry/devices/rdmaproxy/BUILD
+++ b/pkg/sentry/devices/rdmaproxy/BUILD
@@ -1,0 +1,52 @@
+load("//tools:defs.bzl", "go_library", "go_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_test(
+    name = "rdmaproxy_test",
+    size = "small",
+    srcs = ["driver_test.go"],
+    library = ":rdmaproxy",
+    deps = [
+        "//pkg/sentry/kernel",
+    ],
+)
+
+go_library(
+    name = "rdmaproxy",
+    srcs = [
+        "driver.go",
+        "rdmaproxy.go",
+        "rdmaproxy_ioctl.go",
+        "rdmaproxy_ioctl_unsafe.go",
+        "seccomp_filter.go",
+    ],
+    visibility = [
+        "//pkg/sentry:internal",
+        "//runsc:__subpackages__",
+    ],
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/cleanup",
+        "//pkg/context",
+        "//pkg/devutil",
+        "//pkg/errors/linuxerr",
+        "//pkg/fdnotifier",
+        "//pkg/hostarch",
+        "//pkg/log",
+        "//pkg/seccomp",
+        "//pkg/sentry/arch",
+        "//pkg/sentry/fsutil",
+        "//pkg/sentry/kernel",
+        "//pkg/sentry/kernel/auth",
+        "//pkg/sentry/memmap",
+        "//pkg/sentry/mm",
+        "//pkg/sentry/vfs",
+        "//pkg/usermem",
+        "//pkg/waiter",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)

--- a/pkg/sentry/devices/rdmaproxy/cxproxy/BUILD
+++ b/pkg/sentry/devices/rdmaproxy/cxproxy/BUILD
@@ -1,0 +1,23 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "cxproxy",
+    srcs = [
+        "cxproxy.go",
+    ],
+    visibility = [
+        "//pkg/sentry:internal",
+        "//runsc:__subpackages__",
+    ],
+    deps = [
+        "//pkg/cleanup",
+        "//pkg/hostarch",
+        "//pkg/sentry/devices/rdmaproxy",
+        "//pkg/sentry/kernel",
+    ],
+)

--- a/pkg/sentry/devices/rdmaproxy/cxproxy/cxproxy.go
+++ b/pkg/sentry/devices/rdmaproxy/cxproxy/cxproxy.go
@@ -1,0 +1,135 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cxproxy implements the rdmaproxy.Driver plug-in for Mellanox/NVIDIA
+// ConnectX adapters (mlx5_core / mlx5_ib). It exposes the driver-private
+// uverbs attribute layout that mlx5 uses to carry CQ/QP DMA buffer pointers
+// and registers itself with the rdmaproxy core at init() time.
+//
+// To make this driver available, the runsc binary must include this package
+// in its import graph (typically via an anonymous import alongside the
+// rdmaproxy core import).
+package cxproxy
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"gvisor.dev/gvisor/pkg/cleanup"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+)
+
+// driverName matches the value reported by the host's
+// /sys/class/infiniband/<ibdev>/device/uevent DRIVER= field for ConnectX
+// adapters bound to the upstream mlx5 stack. The runsc boot path looks up
+// this name through rdmaproxy.LookupDriver and attaches the resulting
+// rdmaproxy.Driver to the corresponding uverbs device.
+const driverName = "mlx5_core"
+
+// mlx5 driver attribute IDs (assigned by drivers/infiniband/hw/mlx5/main.c
+// via the UVERBS_ID_DRIVER_NS_WITH_NS_IDX macros). Other vendors use
+// different ranges and would register their own rdmaproxy.Driver.
+const (
+	mlx5DriverAttrIn  = 0x1000 // input driver-private attribute
+	mlx5DriverAttrOut = 0x1001 // output driver-private attribute (unused here)
+)
+
+// Field offsets inside the mlx5 driver-private input attribute payload, which
+// corresponds to struct mlx5_ib_create_cq / struct mlx5_ib_create_qp from the
+// upstream kernel. Both structs share the same prefix layout for buf_addr +
+// db_addr, which is all this proxy needs.
+const (
+	driverAttrBufAddr = 0  // __aligned_u64 buf_addr
+	driverAttrDBAddr  = 8  // __aligned_u64 db_addr
+	driverAttrMinLen  = 16 // minimum payload size to read both fields
+)
+
+// cxDriver is the rdmaproxy.Driver implementation for ConnectX adapters.
+type cxDriver struct{}
+
+// Name implements rdmaproxy.Driver.Name.
+func (cxDriver) Name() string { return driverName }
+
+// HasDriverCreateAttr implements rdmaproxy.Driver.HasDriverCreateAttr by
+// scanning for the mlx5 driver-private input attribute, which is present on
+// CQ/QP CREATE ioctls and absent on DESTROY/MODIFY.
+func (cxDriver) HasDriverCreateAttr(buf []byte, numAttrs int) bool {
+	return rdmaproxy.HasAttrID(buf, numAttrs, mlx5DriverAttrIn)
+}
+
+// PrepareCQQPCreate implements rdmaproxy.Driver.PrepareCQQPCreate. It mirrors
+// the work-queue and doorbell DMA buffers referenced by buf_addr / db_addr
+// inside the mlx5 driver-private input attribute, then rewrites those fields
+// to point at the corresponding sentry-side mappings before the ioctl is
+// forwarded to the host kernel.
+//
+// The action argument is one of rdmaproxy.ActionCQCreate or
+// rdmaproxy.ActionQPCreate. Both share the same buf_addr/db_addr prefix in
+// the mlx5 driver-private struct, so the action only matters for logging.
+func (cxDriver) PrepareCQQPCreate(t *kernel.Task, buf []byte, numAttrs int,
+	rewrites []rdmaproxy.AttrRewrite, action rdmaproxy.IoctlAction,
+) (*rdmaproxy.PinnedDMABufs, error) {
+	drv := rdmaproxy.FindRewrite(buf, numAttrs, rewrites, mlx5DriverAttrIn)
+	if drv == nil {
+		return nil, nil
+	}
+	if len(drv.Sentry) < driverAttrMinLen {
+		return nil, nil
+	}
+
+	bufAddr := binary.LittleEndian.Uint64(drv.Sentry[driverAttrBufAddr : driverAttrBufAddr+8])
+	dbAddr := binary.LittleEndian.Uint64(drv.Sentry[driverAttrDBAddr : driverAttrDBAddr+8])
+
+	var bufs rdmaproxy.PinnedDMABufs
+	var cu cleanup.Cleanup
+	defer cu.Clean()
+
+	if bufAddr != 0 {
+		vmaRange, err := t.MemoryManager().FindVMARange(hostarch.Addr(bufAddr))
+		if err != nil {
+			return nil, fmt.Errorf("FindVMARange(buf %#x): %w", bufAddr, err)
+		}
+		length := uint64(vmaRange.End) - bufAddr
+		mp, sentryVA, err := rdmaproxy.MirrorSandboxPages(t, bufAddr, length)
+		if err != nil {
+			return nil, fmt.Errorf("MirrorSandboxPages buf: %w", err)
+		}
+		bufs.Buf = mp
+		cu.Add(func() { mp.Release(t) })
+		binary.LittleEndian.PutUint64(drv.Sentry[driverAttrBufAddr:driverAttrBufAddr+8], uint64(sentryVA))
+	}
+
+	if dbAddr != 0 {
+		vmaRange, err := t.MemoryManager().FindVMARange(hostarch.Addr(dbAddr))
+		if err != nil {
+			return nil, fmt.Errorf("FindVMARange(db %#x): %w", dbAddr, err)
+		}
+		length := uint64(vmaRange.End) - dbAddr
+		mp, sentryVA, err := rdmaproxy.MirrorSandboxPages(t, dbAddr, length)
+		if err != nil {
+			return nil, fmt.Errorf("MirrorSandboxPages db: %w", err)
+		}
+		bufs.DB = mp
+		cu.Add(func() { mp.Release(t) })
+		binary.LittleEndian.PutUint64(drv.Sentry[driverAttrDBAddr:driverAttrDBAddr+8], uint64(sentryVA))
+	}
+
+	cu.Release()
+	_ = action // currently unused; reserved for future per-action behavior.
+	return &bufs, nil
+}
+
+func init() { rdmaproxy.RegisterDriver(cxDriver{}) }

--- a/pkg/sentry/devices/rdmaproxy/driver.go
+++ b/pkg/sentry/devices/rdmaproxy/driver.go
@@ -1,0 +1,98 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rdmaproxy
+
+import (
+	"sync"
+
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+)
+
+// Driver is the per-vendor plug-in interface for handling RDMA driver-private
+// uverbs attributes. The vendor-neutral RDMA core can route every standard
+// UVERBS object/method, but the driver-private input attrs that carry CQ/QP
+// DMA buffer pointers are vendor-specific (mlx5_ib_create_cq, bnxt_re_qp_req,
+// efa_ibv_create_qp, ...). Drivers register themselves at init() time and the
+// core dispatches CQ/QP CREATE classification + DMA buffer mirroring through
+// this interface.
+//
+// Implementations live in vendor-specific subpackages, e.g.
+// pkg/sentry/devices/rdmaproxy/cxproxy for ConnectX (mlx5).
+type Driver interface {
+	// Name returns the driver name as it appears in the host's
+	// /sys/class/infiniband/<ibdev>/device/uevent DRIVER= field. This is
+	// the same string passed to Register and used to look up the driver
+	// at registration time.
+	Name() string
+
+	// HasDriverCreateAttr returns true if the parsed UVERBS ioctl buffer
+	// contains the driver-private input attribute that signals a CQ/QP
+	// CREATE op. The core uses this to distinguish CREATE from
+	// DESTROY/MODIFY because modern UVERBS method IDs for these ops are
+	// not stable across kernel versions.
+	HasDriverCreateAttr(buf []byte, numAttrs int) bool
+
+	// PrepareCQQPCreate mirrors the DMA buffers (work queue + doorbell
+	// pages) referenced by the driver-private input attribute and
+	// rewrites the embedded sandbox addresses to the corresponding
+	// sentry-side mappings. Returns a handle that the caller stores
+	// against the new CQ/QP IDR handle on success and releases on
+	// teardown.
+	//
+	// The action argument is one of ActionCQCreate or ActionQPCreate.
+	// rewrites is the slice of attribute rewrites already performed by
+	// the core; the driver finds its own attribute by ID inside this
+	// slice.
+	PrepareCQQPCreate(t *kernel.Task, buf []byte, numAttrs int,
+		rewrites []AttrRewrite, action IoctlAction) (*PinnedDMABufs, error)
+}
+
+// driverRegistry holds Drivers registered by per-vendor packages at init()
+// time. Registration is keyed by Driver.Name(), which must match the host
+// PCI driver name plumbed into Register.
+type driverRegistry struct {
+	mu      sync.RWMutex
+	drivers map[string]Driver
+}
+
+var registry = &driverRegistry{drivers: make(map[string]Driver)}
+
+// RegisterDriver makes drv available for lookup by drv.Name(). Intended to
+// be called from a per-vendor package init(); duplicate registrations under
+// the same name overwrite the previous entry (last writer wins) so tests can
+// stub a driver out without running afoul of init-order constraints.
+func RegisterDriver(drv Driver) {
+	if drv == nil {
+		return
+	}
+	name := drv.Name()
+	registry.mu.Lock()
+	registry.drivers[name] = drv
+	registry.mu.Unlock()
+	log.Infof("rdmaproxy: registered driver name=%s", name)
+}
+
+// LookupDriver returns the driver registered under name, or nil if no such
+// driver was registered. An empty name always returns nil (the caller is
+// responsible for handling the no-driver case explicitly; see Register).
+func LookupDriver(name string) Driver {
+	if name == "" {
+		return nil
+	}
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	return registry.drivers[name]
+}

--- a/pkg/sentry/devices/rdmaproxy/rdmaproxy.go
+++ b/pkg/sentry/devices/rdmaproxy/rdmaproxy.go
@@ -1,0 +1,494 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rdmaproxy implements a passthrough proxy for /dev/infiniband/uverbs*
+// devices, enabling RDMA support inside gVisor sandboxes.
+//
+// # Host ABI requirements
+//
+// The proxy targets the modern UVERBS ioctl interface (RDMA_VERBS_IOCTL =
+// _IOWR(0x1b, 1, struct ib_uverbs_ioctl_hdr)). Minimum supported host
+// kernel is Linux 4.20 (released Dec 2018), which is when
+// include/uapi/rdma/ib_user_ioctl_cmds.h had reached mainline along with
+// the object/method/attribute IDs the proxy hardcodes; older kernels may
+// expose a partial or differently-numbered subset and are not supported.
+// Per upstream policy these IDs are additive only — old IDs are never
+// repurposed — so newer kernels remain compatible.
+//
+// At Register time the proxy reads the kernel's IB_USER_VERBS_ABI_VERSION
+// from /sys/class/infiniband_verbs/abi_version and refuses to attach if it
+// does not match the expected value. This file has been part of the stable
+// sysfs ABI since v2.6.14 (Sept 2005) and the value has been frozen at 6
+// since the early kernel.org era; the kernel only bumps it on a userspace-
+// breaking change. Per-device driver-specific ABI versions exposed at
+// /sys/class/infiniband_verbs/uverbsN/abi_version are logged for telemetry
+// but not gated on (driver plug-ins may impose their own checks).
+package rdmaproxy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/devutil"
+	"gvisor.dev/gvisor/pkg/fdnotifier"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsutil"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/mm"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+// expectedUverbsABIVersion is the value of IB_USER_VERBS_ABI_VERSION the
+// proxy is built against. The kernel publishes its value at
+// /sys/class/infiniband_verbs/abi_version and bumps it only on a
+// userspace-breaking change to the uverbs interface. Frozen at 6 in
+// upstream Linux for over a decade.
+const expectedUverbsABIVersion = 6
+
+// uverbsClassDir is the sysfs class directory for the uverbs subsystem.
+// The class-wide abi_version lives at uverbsClassDir/abi_version; per-device
+// driver ABI versions live at uverbsClassDir/uverbsN/abi_version.
+const uverbsClassDir = "/sys/class/infiniband_verbs"
+
+// readUverbsClassABIVersion returns the kernel's IB_USER_VERBS_ABI_VERSION
+// as advertised in sysfs, or (0, err) if the file is missing or unreadable.
+func readUverbsClassABIVersion() (int, error) {
+	data, err := os.ReadFile(filepath.Join(uverbsClassDir, "abi_version"))
+	if err != nil {
+		return 0, fmt.Errorf("ReadFile: %w", err)
+	}
+	v, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("ParseInt %q: %w", string(data), err)
+	}
+	return v, nil
+}
+
+// readUverbsDeviceABIVersion returns the per-device driver ABI version for
+// the given uverbsN device, or (0, err) on failure. The value is
+// driver-specific (e.g. mlx5_ib reports 1) and is only used for telemetry.
+func readUverbsDeviceABIVersion(devName string) (int, error) {
+	data, err := os.ReadFile(filepath.Join(uverbsClassDir, devName, "abi_version"))
+	if err != nil {
+		return 0, fmt.Errorf("ReadFile: %w", err)
+	}
+	v, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("ParseInt %q: %w", string(data), err)
+	}
+	return v, nil
+}
+
+// uverbsDevice implements vfs.Device for /dev/infiniband/uverbs*.
+type uverbsDevice struct {
+	// devName is the device filename, e.g. "uverbs0". This is distinct
+	// from the kernel minor number (e.g. 192) used for VFS registration.
+	devName string
+	// driver is the per-vendor plug-in attached to this device, looked
+	// up by name at Register time. May be nil if no driver is registered
+	// for the host's PCI driver, in which case CQ/QP CREATE ioctls will
+	// be forwarded without DMA buffer mirroring (and a warning is
+	// logged).
+	driver Driver
+}
+
+// Open implements vfs.Device.Open.
+func (dev *uverbsDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
+	devRelPath := filepath.Join("infiniband", dev.devName)
+	hostFD, err := openHostDevice(ctx, devRelPath, opts.Flags)
+	if err != nil {
+		log.Warningf("rdmaproxy: open host device %s: %v", devRelPath, err)
+		return nil, err
+	}
+	fd := &uverbsFD{
+		hostFD: int32(hostFD),
+		driver: dev.driver,
+	}
+	if err := fdnotifier.AddFD(fd.hostFD, &fd.queue); err != nil {
+		unix.Close(hostFD)
+		return nil, err
+	}
+	fd.memmapFile.SetFD(int(fd.hostFD))
+	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
+		UseDentryMetadata: true,
+	}); err != nil {
+		fdnotifier.RemoveFD(fd.hostFD)
+		unix.Close(hostFD)
+		return nil, err
+	}
+	return &fd.vfsfd, nil
+}
+
+// openHostDevice opens a host device using the dev gofer if available,
+// falling back to a direct open. devRelPath is relative to /dev/.
+func openHostDevice(ctx context.Context, devRelPath string, flags uint32) (int, error) {
+	if client := devutil.GoferClientFromContext(ctx); client != nil {
+		return client.OpenAt(ctx, devRelPath, flags)
+	}
+	devPath := filepath.Join("/dev", devRelPath)
+	openFlags := int(flags&unix.O_ACCMODE | unix.O_NOFOLLOW)
+	return unix.Openat(-1, devPath, openFlags, 0)
+}
+
+// MirroredPages tracks sandbox pages pinned and mapped into the sentry's
+// address space so the host kernel can pin_user_pages on them for DMA.
+//
+// Drivers receive this as an opaque return value from MirrorSandboxPages
+// and store it in PinnedDMABufs; they do not inspect its fields directly.
+type MirroredPages struct {
+	prs []mm.PinnedRange
+	// If m != 0, it's a sentry-side mmap we own and must munmap on release.
+	m   uintptr
+	len uintptr
+	// mrSummary is an optional compact registration summary emitted once the
+	// host returns an MR handle successfully.
+	mrSummary string
+}
+
+// Release tears down the sentry-side mapping and unpins the underlying
+// sandbox pages.
+func (mp *MirroredPages) Release(ctx context.Context) {
+	if mp.m != 0 {
+		if _, _, errno := unix.RawSyscall(unix.SYS_MUNMAP, mp.m, mp.len, 0); errno != 0 {
+			log.Warningf("rdmaproxy: munmap %#x-%#x: %v", mp.m, mp.m+mp.len, errno)
+		}
+	}
+	mm.Unpin(mp.prs)
+}
+
+// PinnedDMABufs tracks the buf + doorbell mirrors for a single CQ or QP.
+// Driver plug-ins return this from PrepareCQQPCreate; the core stores it
+// against the resulting CQ/QP IDR handle until DESTROY.
+type PinnedDMABufs struct {
+	// Buf is the work-queue buffer mirror, or nil if the driver did not
+	// produce one.
+	Buf *MirroredPages
+	// DB is the doorbell page mirror, or nil if the driver did not
+	// produce one.
+	DB *MirroredPages
+}
+
+// Release tears down both buffer mirrors. Safe to call with nil fields.
+func (p *PinnedDMABufs) Release(ctx context.Context) {
+	if p.Buf != nil {
+		p.Buf.Release(ctx)
+	}
+	if p.DB != nil {
+		p.DB.Release(ctx)
+	}
+}
+
+// pinnedResources tracks the sandbox memory mirrored on behalf of one
+// uverbs FD's MRs/CQs/QPs. Handles are scoped to the uverbs context (the
+// underlying host FD), so this state lives per-uverbsFD rather than in a
+// global registry — see the package docs for why a registry keyed on
+// sandbox FD numbers would race with FD recycling.
+type pinnedResources struct {
+	mu  sync.Mutex
+	mrs map[uint32]*MirroredPages
+	cqs map[uint32]*PinnedDMABufs
+	qps map[uint32]*PinnedDMABufs
+}
+
+// addMR records the page mirror for a successful REG_MR. Overwrites any
+// existing entry for the same handle (the kernel does not reuse handles
+// without an intervening DEREG, so this is just defensive).
+func (p *pinnedResources) addMR(handle uint32, mp *MirroredPages) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.mrs == nil {
+		p.mrs = make(map[uint32]*MirroredPages)
+	}
+	p.mrs[handle] = mp
+}
+
+// addCQ records the buf+db mirrors for a successful CQ CREATE.
+func (p *pinnedResources) addCQ(handle uint32, bufs *PinnedDMABufs) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cqs == nil {
+		p.cqs = make(map[uint32]*PinnedDMABufs)
+	}
+	p.cqs[handle] = bufs
+}
+
+// addQP records the buf+db mirrors for a successful QP CREATE.
+func (p *pinnedResources) addQP(handle uint32, bufs *PinnedDMABufs) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.qps == nil {
+		p.qps = make(map[uint32]*PinnedDMABufs)
+	}
+	p.qps[handle] = bufs
+}
+
+// takeMR removes and returns the mirror for handle, or nil if absent.
+// The caller must release the returned mirror outside any lock.
+func (p *pinnedResources) takeMR(handle uint32) *MirroredPages {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	mp, ok := p.mrs[handle]
+	if !ok {
+		return nil
+	}
+	delete(p.mrs, handle)
+	return mp
+}
+
+// takeCQ removes and returns the bufs for handle, or nil if absent.
+func (p *pinnedResources) takeCQ(handle uint32) *PinnedDMABufs {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	bufs, ok := p.cqs[handle]
+	if !ok {
+		return nil
+	}
+	delete(p.cqs, handle)
+	return bufs
+}
+
+// takeQP removes and returns the bufs for handle, or nil if absent.
+func (p *pinnedResources) takeQP(handle uint32) *PinnedDMABufs {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	bufs, ok := p.qps[handle]
+	if !ok {
+		return nil
+	}
+	delete(p.qps, handle)
+	return bufs
+}
+
+// releaseAll drains every tracked mirror and releases the underlying
+// pages. Used as a safety net at FD close for handles the application
+// neglected to DEREG/DESTROY. Subsequent calls are no-ops.
+func (p *pinnedResources) releaseAll(ctx context.Context) {
+	p.mu.Lock()
+	mrs, cqs, qps := p.mrs, p.cqs, p.qps
+	p.mrs, p.cqs, p.qps = nil, nil, nil
+	p.mu.Unlock()
+	for _, mp := range mrs {
+		mp.Release(ctx)
+	}
+	for _, bufs := range cqs {
+		bufs.Release(ctx)
+	}
+	for _, bufs := range qps {
+		bufs.Release(ctx)
+	}
+}
+
+// uverbsFD implements vfs.FileDescriptionImpl for an opened uverbs device.
+//
+// uverbsFD is not savable; we do not implement save/restore of RDMA state.
+type uverbsFD struct {
+	vfsfd vfs.FileDescription
+	vfs.FileDescriptionDefaultImpl
+	vfs.DentryMetadataFileDescriptionImpl
+	vfs.NoLockFD
+	memmap.MappableNoTrackMappings
+
+	hostFD     int32
+	queue      waiter.Queue
+	memmapFile fsutil.MmapNoInternalFile
+
+	// driver is the per-vendor plug-in inherited from the originating
+	// uverbsDevice, set at Open time. May be nil; see uverbsDevice.driver.
+	driver Driver
+
+	// pinned tracks sandbox memory mirrored on behalf of MRs, CQs, and QPs
+	// registered or created through this uverbs FD. Entries are added on
+	// successful REG/CREATE ioctls and drained on the matching DEREG/DESTROY,
+	// or in Release as a safety net.
+	pinned pinnedResources
+}
+
+// Release implements vfs.FileDescriptionImpl.Release.
+func (fd *uverbsFD) Release(ctx context.Context) {
+	fd.pinned.releaseAll(ctx)
+	fdnotifier.RemoveFD(fd.hostFD)
+	unix.Close(int(fd.hostFD))
+}
+
+// EventRegister implements waiter.Waitable.EventRegister.
+func (fd *uverbsFD) EventRegister(e *waiter.Entry) error {
+	fd.queue.EventRegister(e)
+	if err := fdnotifier.UpdateFD(fd.hostFD); err != nil {
+		fd.queue.EventUnregister(e)
+		return err
+	}
+	return nil
+}
+
+// EventUnregister implements waiter.Waitable.EventUnregister.
+func (fd *uverbsFD) EventUnregister(e *waiter.Entry) {
+	fd.queue.EventUnregister(e)
+	if err := fdnotifier.UpdateFD(fd.hostFD); err != nil {
+		panic(fmt.Sprint("UpdateFD:", err))
+	}
+}
+
+// Readiness implements waiter.Waitable.Readiness.
+func (fd *uverbsFD) Readiness(mask waiter.EventMask) waiter.EventMask {
+	return fdnotifier.NonBlockingPoll(fd.hostFD, mask)
+}
+
+// Register registers a uverbs device with the VFS and returns the dynamic
+// major number. devName is the device filename (e.g. "uverbs0"), minor is
+// the kernel device minor number (e.g. 192).
+//
+// driverName is the host PCI driver name (typically read from
+// /sys/class/infiniband/<ibdev>/device/uevent's DRIVER= field, e.g.
+// "mlx5_core") used to look up the vendor-specific plug-in via
+// LookupDriver. If driverName is empty or unrecognized, CQ/QP CREATE
+// ioctls on this device will be forwarded without DMA buffer mirroring
+// and a warning will be logged at ioctl time.
+//
+// The host RoCE netdev that backs each uverbs device is expected to have
+// been moved into the sandbox netns by the runsc-create parent process
+// (see runsc/sandbox.MoveRDMANetdevsIntoSandbox). With the netdev local to
+// the calling task's netns, ibv_modify_qp's GID-to-netdev resolution
+// succeeds without any setns or extra capabilities in the sentry.
+func Register(vfsObj *vfs.VirtualFilesystem, devName string, minor uint32, driverName string) (uint32, error) {
+	// Validate the kernel uverbs ABI version against what the proxy was
+	// built for. A mismatch here means the kernel either ships an
+	// unfamiliar UVERBS interface (we should refuse rather than risk
+	// misinterpreting attribute layouts) or the file is missing (we
+	// degrade to a warning, not a hard failure, since the file has been
+	// stable in sysfs for over a decade and any absence likely means the
+	// uverbs subsystem isn't loaded — letting the open succeed and fail
+	// later gives a clearer error than refusing here).
+	if v, err := readUverbsClassABIVersion(); err != nil {
+		log.Warningf("rdmaproxy: could not read %s/abi_version (%v); proceeding without ABI check — expected version %d", uverbsClassDir, err, expectedUverbsABIVersion)
+	} else if v != expectedUverbsABIVersion {
+		return 0, fmt.Errorf("rdmaproxy: kernel uverbs ABI version %d does not match expected %d (read from %s/abi_version) — refusing to register %s", v, expectedUverbsABIVersion, uverbsClassDir, devName)
+	}
+	if v, err := readUverbsDeviceABIVersion(devName); err == nil {
+		log.Infof("rdmaproxy: %s driver-specific ABI version %d", devName, v)
+	}
+
+	major, err := vfsObj.GetDynamicCharDevMajor()
+	if err != nil {
+		return 0, fmt.Errorf("rdmaproxy: obtaining dynamic major number: %w", err)
+	}
+	driver := LookupDriver(driverName)
+	driverDesc := "<none>"
+	if driver != nil {
+		driverDesc = driver.Name()
+	}
+	log.Infof("rdmaproxy: registering %s with major=%d minor=%d driver=%s (requested=%q)", devName, major, minor, driverDesc, driverName)
+	if err := vfsObj.RegisterDevice(vfs.CharDevice, major, minor, &uverbsDevice{devName: devName, driver: driver}, &vfs.RegisterDeviceOptions{
+		GroupName: "infiniband",
+		Pathname:  filepath.Join("infiniband", devName),
+		FilePerms: 0666,
+	}); err != nil {
+		return 0, err
+	}
+	return major, nil
+}
+
+// MayRegisterDevicePath returns true if path looks like a uverbs device.
+func MayRegisterDevicePath(path string) bool {
+	matched, _ := filepath.Match("/dev/infiniband/uverbs*", path)
+	return matched
+}
+
+// Async event FD rewriting is done per-task by resolving sandbox FDs
+// through the task's FD table at ioctl time (see handleRDMAVerbsIoctl).
+// This correctly handles FD number recycling across sandbox processes.
+
+// asyncEventFD wraps a host FD for RDMA async event delivery.
+// The kernel creates this FD via UVERBS_METHOD_ASYNC_EVENT_ALLOC;
+// rdma-core reads async events from it via read(2).
+type asyncEventFD struct {
+	vfsfd vfs.FileDescription
+	vfs.FileDescriptionDefaultImpl
+	vfs.DentryMetadataFileDescriptionImpl
+	vfs.NoLockFD
+
+	hostFD int32
+	queue  waiter.Queue
+}
+
+// Release implements vfs.FileDescriptionImpl.Release.
+func (fd *asyncEventFD) Release(ctx context.Context) {
+	fdnotifier.RemoveFD(fd.hostFD)
+	unix.Close(int(fd.hostFD))
+}
+
+// EventRegister implements waiter.Waitable.EventRegister.
+func (fd *asyncEventFD) EventRegister(e *waiter.Entry) error {
+	fd.queue.EventRegister(e)
+	if err := fdnotifier.UpdateFD(fd.hostFD); err != nil {
+		fd.queue.EventUnregister(e)
+		return err
+	}
+	return nil
+}
+
+// EventUnregister implements waiter.Waitable.EventUnregister.
+func (fd *asyncEventFD) EventUnregister(e *waiter.Entry) {
+	fd.queue.EventUnregister(e)
+	if err := fdnotifier.UpdateFD(fd.hostFD); err != nil {
+		panic(fmt.Sprint("UpdateFD:", err))
+	}
+}
+
+// Readiness implements waiter.Waitable.Readiness.
+func (fd *asyncEventFD) Readiness(mask waiter.EventMask) waiter.EventMask {
+	return fdnotifier.NonBlockingPoll(fd.hostFD, mask)
+}
+
+// newAsyncEventFD wraps a host async-event FD in a sentry FileDescription
+// and installs it in the task's FD table. Returns the sandbox FD number.
+func newAsyncEventFD(t *kernel.Task, hostFD int) (int32, error) {
+	vfsObj := t.Kernel().VFS()
+	vd := vfsObj.NewAnonVirtualDentry("[rdma-async-event]")
+	defer vd.DecRef(t)
+
+	if err := unix.SetNonblock(hostFD, true); err != nil {
+		return -1, fmt.Errorf("SetNonblock: %w", err)
+	}
+
+	afd := &asyncEventFD{
+		hostFD: int32(hostFD),
+	}
+	if err := fdnotifier.AddFD(afd.hostFD, &afd.queue); err != nil {
+		return -1, err
+	}
+	if err := afd.vfsfd.Init(afd, linux.O_RDONLY, t.Credentials(), vd.Mount(), vd.Dentry(), &vfs.FileDescriptionOptions{
+		UseDentryMetadata: true,
+		DenyPRead:         true,
+		DenyPWrite:        true,
+	}); err != nil {
+		fdnotifier.RemoveFD(afd.hostFD)
+		return -1, err
+	}
+	sentryFD, err := t.NewFDFrom(0, &afd.vfsfd, kernel.FDFlags{CloseOnExec: true})
+	if err != nil {
+		afd.vfsfd.DecRef(t)
+		return -1, err
+	}
+	return sentryFD, nil
+}

--- a/pkg/sentry/devices/rdmaproxy/rdmaproxy.go
+++ b/pkg/sentry/devices/rdmaproxy/rdmaproxy.go
@@ -38,7 +38,6 @@ package rdmaproxy
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -66,39 +65,12 @@ import (
 // upstream Linux for over a decade.
 const expectedUverbsABIVersion = 6
 
-// uverbsClassDir is the sysfs class directory for the uverbs subsystem.
-// The class-wide abi_version lives at uverbsClassDir/abi_version; per-device
-// driver ABI versions live at uverbsClassDir/uverbsN/abi_version.
+// uverbsClassDir is the sysfs class directory for the uverbs subsystem,
+// where the host kernel publishes the class-wide abi_version. The sentry
+// cannot read it directly (it runs chrooted and seccomp-confined), so the
+// value is collected host-side by runsc create (see
+// sys.CollectRDMADeviceData) and passed to Register.
 const uverbsClassDir = "/sys/class/infiniband_verbs"
-
-// readUverbsClassABIVersion returns the kernel's IB_USER_VERBS_ABI_VERSION
-// as advertised in sysfs, or (0, err) if the file is missing or unreadable.
-func readUverbsClassABIVersion() (int, error) {
-	data, err := os.ReadFile(filepath.Join(uverbsClassDir, "abi_version"))
-	if err != nil {
-		return 0, fmt.Errorf("ReadFile: %w", err)
-	}
-	v, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return 0, fmt.Errorf("ParseInt %q: %w", string(data), err)
-	}
-	return v, nil
-}
-
-// readUverbsDeviceABIVersion returns the per-device driver ABI version for
-// the given uverbsN device, or (0, err) on failure. The value is
-// driver-specific (e.g. mlx5_ib reports 1) and is only used for telemetry.
-func readUverbsDeviceABIVersion(devName string) (int, error) {
-	data, err := os.ReadFile(filepath.Join(uverbsClassDir, devName, "abi_version"))
-	if err != nil {
-		return 0, fmt.Errorf("ReadFile: %w", err)
-	}
-	v, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return 0, fmt.Errorf("ParseInt %q: %w", string(data), err)
-	}
-	return v, nil
-}
 
 // uverbsDevice implements vfs.Device for /dev/infiniband/uverbs*.
 type uverbsDevice struct {
@@ -370,22 +342,23 @@ func (fd *uverbsFD) Readiness(mask waiter.EventMask) waiter.EventMask {
 // (see runsc/sandbox.MoveRDMANetdevsIntoSandbox). With the netdev local to
 // the calling task's netns, ibv_modify_qp's GID-to-netdev resolution
 // succeeds without any setns or extra capabilities in the sentry.
-func Register(vfsObj *vfs.VirtualFilesystem, devName string, minor uint32, driverName string) (uint32, error) {
+// verbsABIVersion is the host's IB_USER_VERBS_ABI_VERSION as collected
+// host-side from uverbsClassDir/abi_version before the sandbox started
+// (the sentry itself cannot read sysfs). An empty string means the value
+// could not be collected.
+func Register(vfsObj *vfs.VirtualFilesystem, devName string, minor uint32, driverName, verbsABIVersion string) (uint32, error) {
 	// Validate the kernel uverbs ABI version against what the proxy was
 	// built for. A mismatch here means the kernel either ships an
 	// unfamiliar UVERBS interface (we should refuse rather than risk
-	// misinterpreting attribute layouts) or the file is missing (we
+	// misinterpreting attribute layouts) or the value is missing (we
 	// degrade to a warning, not a hard failure, since the file has been
 	// stable in sysfs for over a decade and any absence likely means the
 	// uverbs subsystem isn't loaded — letting the open succeed and fail
 	// later gives a clearer error than refusing here).
-	if v, err := readUverbsClassABIVersion(); err != nil {
-		log.Warningf("rdmaproxy: could not read %s/abi_version (%v); proceeding without ABI check — expected version %d", uverbsClassDir, err, expectedUverbsABIVersion)
+	if v, err := strconv.Atoi(strings.TrimSpace(verbsABIVersion)); err != nil {
+		log.Warningf("rdmaproxy: no usable uverbs ABI version (collected %q from %s/abi_version); proceeding without ABI check — expected version %d", verbsABIVersion, uverbsClassDir, expectedUverbsABIVersion)
 	} else if v != expectedUverbsABIVersion {
-		return 0, fmt.Errorf("rdmaproxy: kernel uverbs ABI version %d does not match expected %d (read from %s/abi_version) — refusing to register %s", v, expectedUverbsABIVersion, uverbsClassDir, devName)
-	}
-	if v, err := readUverbsDeviceABIVersion(devName); err == nil {
-		log.Infof("rdmaproxy: %s driver-specific ABI version %d", devName, v)
+		return 0, fmt.Errorf("rdmaproxy: kernel uverbs ABI version %d does not match expected %d (collected from %s/abi_version) — refusing to register %s", v, expectedUverbsABIVersion, uverbsClassDir, devName)
 	}
 
 	major, err := vfsObj.GetDynamicCharDevMajor()

--- a/pkg/sentry/devices/rdmaproxy/rdmaproxy_ioctl.go
+++ b/pkg/sentry/devices/rdmaproxy/rdmaproxy_ioctl.go
@@ -1,0 +1,961 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rdmaproxy
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/cleanup"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/fdnotifier"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/usermem"
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+// ioctlBufPool reuses ioctl buffers to avoid per-call heap allocations.
+var ioctlBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, hostarch.PageSize)
+		return &b
+	},
+}
+
+// readBufPool reuses small per-read buffers for async event delivery on
+// uverbsFD/asyncEventFD.Read. Async event records are small (~16B for
+// struct ib_uverbs_async_event_desc); a 4 KiB buffer covers any practical
+// read length and avoids heap allocation in the common case.
+var readBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, hostarch.PageSize)
+		return &b
+	},
+}
+
+// borrowReadBuf returns a buffer of length n. If n fits in the pooled size,
+// the returned slice aliases a pooled []byte and the caller must invoke the
+// returned release function to put it back. For larger reads we fall back
+// to a heap allocation; release is a no-op.
+func borrowReadBuf(n int) (buf []byte, release func()) {
+	if n <= hostarch.PageSize {
+		bp := readBufPool.Get().(*[]byte)
+		return (*bp)[:n], func() { readBufPool.Put(bp) }
+	}
+	return make([]byte, n), func() {}
+}
+
+// ib_uverbs_ioctl_hdr layout constants.
+const (
+	rdmaIoctlMagic       = 0x1b
+	ibUverbsIoctlHdrSize = 24
+	ibUverbsAttrSize     = 16
+)
+
+// UVERBS object types (from include/uapi/rdma/ib_user_ioctl_cmds.h).
+const (
+	uverbsObjectDevice     = 0
+	uverbsObjectCQ         = 3
+	uverbsObjectQP         = 4
+	uverbsObjectMR         = 7
+	uverbsObjectAsyncEvent = 16
+)
+
+// UVERBS_OBJECT_DEVICE method IDs.
+const (
+	uverbsMethodInvokeWrite = 0
+)
+
+// UVERBS_OBJECT_MR method IDs.
+const (
+	uverbsMethodMRDestroy = 1
+	uverbsMethodRegMR     = 5 // modern path
+)
+
+// UVERBS_OBJECT_QP method IDs.
+//
+// These come from enum uverbs_methods_qp in include/uapi/rdma/ib_user_ioctl_cmds.h
+// and have been stable since the modern UVERBS ioctl ABI was introduced
+// (kernel 4.20). DESTROY=1, MODIFY=2.
+const (
+	uverbsMethodQPDestroy = 1
+	uverbsMethodQPModify  = 2
+)
+
+// UVERBS_OBJECT_ASYNC_EVENT method and attr IDs.
+const (
+	uverbsMethodAsyncEventAlloc = 0
+	uverbsAttrAsyncEventAllocFD = 0
+)
+
+// CQ CREATE attr IDs (from include/uapi/rdma/ib_user_ioctl_cmds.h, enum
+// uverbs_attrs_create_cq_cmd_attr_ids). UVERBS_ATTR_CREATE_CQ_HANDLE is the
+// IDR (output) handle returned by a successful CREATE_CQ.
+const (
+	uverbsAttrCreateCQHandle  = 0
+	uverbsAttrCreateCQEventFD = 7
+)
+
+// QP CREATE/DESTROY attr IDs (enum uverbs_attrs_create_qp_cmd_attr_ids).
+// UVERBS_ATTR_CREATE_QP_HANDLE is the IDR (output) handle returned by a
+// successful CREATE_QP. Both DESTROY_CQ_HANDLE and DESTROY_QP_HANDLE happen
+// to be id 0 by ABI; we keep distinct constants to keep call sites
+// self-documenting.
+const (
+	uverbsAttrCreateQPHandle  = 0
+	uverbsAttrDestroyCQHandle = 0
+	uverbsAttrDestroyQPHandle = 0
+)
+
+// INVOKE_WRITE attr IDs.
+const (
+	uverbsAttrCoreIn   = 0
+	uverbsAttrCoreOut  = 1
+	uverbsAttrWriteCmd = 2
+)
+
+// Legacy write command numbers (from include/uapi/rdma/ib_user_verbs.h).
+const (
+	ibUserVerbsCmdCreateCQ  = 6
+	ibUserVerbsCmdCreateQP  = 8
+	ibUserVerbsCmdModifyQP  = 26
+	ibUserVerbsCmdRegMR     = 9
+	ibUserVerbsCmdDestroyCQ = 11
+	ibUserVerbsCmdDeregMR   = 13
+	ibUserVerbsCmdDestroyQP = 14
+)
+
+// IoctlAction classifies what an ioctl does for page-mirroring purposes.
+// Exported so per-vendor Driver plug-ins can switch on the action passed
+// to PrepareCQQPCreate.
+type IoctlAction int
+
+// IoctlAction values. Only ActionCQCreate and ActionQPCreate are passed to
+// Driver.PrepareCQQPCreate; the rest are internal to the core dispatch
+// loop and never reach plug-ins.
+const (
+	ActionNone IoctlAction = iota
+	ActionMRReg
+	ActionMRDereg
+	ActionCQCreate
+	ActionCQDestroy
+	ActionQPCreate
+	ActionQPDestroy
+)
+
+// ib_uverbs_reg_mr struct field offsets.
+const (
+	regMROffStart  = 8  // __aligned_u64 start
+	regMROffLength = 16 // __aligned_u64 length
+	regMROffHcaVA  = 24 // __aligned_u64 hca_va
+)
+
+// ib_uverbs_reg_mr_resp field offsets.
+const (
+	regMRRespOffHandle = 0 // __u32 mr_handle
+)
+
+// ib_uverbs_dereg_mr field offsets.
+const (
+	deregMROffHandle = 0 // __u32 mr_handle
+)
+
+// REG_MR attr IDs (modern path).
+const (
+	uverbsAttrRegMRHandle = 0
+	uverbsAttrRegMRIova   = 3
+	uverbsAttrRegMRAddr   = 4
+	uverbsAttrRegMRLength = 5
+)
+
+// DESTROY_MR attr IDs.
+const (
+	uverbsAttrDestroyMRHandle = 0
+)
+
+// RDMA_VERBS_IOCTL = _IOWR(0x1b, 1, struct ib_uverbs_ioctl_hdr)
+var rdmaVerbsIoctl = linux.IOWR(rdmaIoctlMagic, 1, ibUverbsIoctlHdrSize)
+
+// AttrRewrite tracks a sandbox pointer that was rewritten to a sentry
+// buffer. Exported so per-vendor Driver plug-ins can find their own
+// driver-private attribute by ID inside the rewrites slice and read/write
+// the sentry-side bytes that get forwarded to the host.
+type AttrRewrite struct {
+	// AttrOff is the byte offset of this attribute within the ioctl
+	// header buffer, pointing at the 16-byte ib_uverbs_attr struct.
+	AttrOff int
+	// OrigData is the original sandbox pointer that was placed in the
+	// attr's data field; the core restores it before copying out so the
+	// sandbox sees its own pointer untouched.
+	OrigData uint64
+	// Sentry is the sentry-side buffer containing the attribute payload
+	// after CopyIn. The host kernel reads/writes through this, and
+	// drivers may rewrite individual fields in place (e.g. mlx5
+	// buf_addr/db_addr).
+	Sentry []byte
+}
+
+func taskLogFields(t *kernel.Task) string {
+	if t == nil {
+		return "tid=0 tgid_root=0"
+	}
+	return fmt.Sprintf("tid=%d tgid_root=%d", t.ThreadID(), t.TGIDInRoot())
+}
+
+func uverbsWriteCmdBase(w uint64) uint32 {
+	return uint32(w & 0x7fffffff)
+}
+
+func formatMRSummary(t *kernel.Task, sandboxVA, length uint64, sentryVA uintptr, oldHCAVA, newHCAVA, oldIOVA, newIOVA uint64) string {
+	relocated := sentryVA != uintptr(sandboxVA)
+	return fmt.Sprintf("app=%#x-%#x len=%d sentry=%#x-%#x relocated=%t hca_va=%#x->%#x iova=%#x->%#x %s",
+		sandboxVA, sandboxVA+length, length,
+		sentryVA, sentryVA+uintptr(length), relocated,
+		oldHCAVA, newHCAVA, oldIOVA, newIOVA, taskLogFields(t))
+}
+
+// Ioctl implements vfs.FileDescriptionImpl.Ioctl.
+func (fd *uverbsFD) Ioctl(ctx context.Context, uio usermem.IO, sysno uintptr, args arch.SyscallArguments) (uintptr, error) {
+	cmd := args[1].Uint()
+	argPtr := args[2].Pointer()
+
+	t := kernel.TaskFromContext(ctx)
+	if t == nil {
+		log.Warningf("rdmaproxy: ioctl called without task context")
+		return 0, unix.EINVAL
+	}
+
+	if cmd == rdmaVerbsIoctl {
+		return fd.handleRDMAVerbsIoctl(t, argPtr)
+	}
+	log.Warningf("rdmaproxy: unhandled ioctl cmd=0x%x (magic=0x%x nr=%d size=%d) on hostFD=%d",
+		cmd, (cmd>>8)&0xff, cmd&0xff, (cmd>>16)&0x3fff, fd.hostFD)
+	return 0, linuxerr.ENOSYS
+}
+
+// handleRDMAVerbsIoctl handles the modern RDMA_VERBS_IOCTL which uses a
+// self-describing header + variable-length attribute array.
+func (fd *uverbsFD) handleRDMAVerbsIoctl(t *kernel.Task, argPtr hostarch.Addr) (uintptr, error) {
+	// Single CopyIn: read first 8 bytes to get length, then full buffer.
+	var lenBuf [8]byte
+	if _, err := t.CopyInBytes(argPtr, lenBuf[:]); err != nil {
+		log.Warningf("rdmaproxy: ioctl CopyIn length from %#x: %v", argPtr, err)
+		return 0, err
+	}
+	length := binary.LittleEndian.Uint16(lenBuf[0:2])
+	numAttrs := binary.LittleEndian.Uint16(lenBuf[6:8])
+
+	expectedLen := uint16(ibUverbsIoctlHdrSize) + numAttrs*uint16(ibUverbsAttrSize)
+	if length != expectedLen || length > hostarch.PageSize {
+		log.Warningf("rdmaproxy: ioctl bad header: length=%d expected=%d (numAttrs=%d)",
+			length, expectedLen, numAttrs)
+		return 0, linuxerr.EINVAL
+	}
+
+	// Get buffer from pool to avoid per-ioctl allocation.
+	bufPtr := ioctlBufPool.Get().(*[]byte)
+	buf := (*bufPtr)[:length]
+	defer func() { ioctlBufPool.Put(bufPtr) }()
+
+	if _, err := t.CopyInBytes(argPtr, buf); err != nil {
+		log.Warningf("rdmaproxy: ioctl CopyIn full buffer (%d bytes) from %#x: %v",
+			length, argPtr, err)
+		return 0, err
+	}
+
+	objectID := binary.LittleEndian.Uint16(buf[2:4])
+	methodID := binary.LittleEndian.Uint16(buf[4:6])
+
+	// Walk attrs: probe each data field to determine if it's a sandbox
+	// pointer (CopyIn succeeds) or inline data (CopyIn fails).
+	// Pre-allocate rewrites on stack for the common case.
+	var rewritesBuf [16]AttrRewrite
+	rewrites := rewritesBuf[:0]
+	// Stack arena for attribute data to avoid per-attr heap allocation.
+	var attrArena [4096]byte
+	arenaOff := 0
+
+	for i := 0; i < int(numAttrs); i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrLen := binary.LittleEndian.Uint16(buf[off+2 : off+4])
+		attrData := binary.LittleEndian.Uint64(buf[off+8 : off+16])
+
+		if attrLen == 0 {
+			continue
+		}
+
+		// Use stack arena when possible, fall back to heap for large attrs.
+		var sb []byte
+		if arenaOff+int(attrLen) <= len(attrArena) {
+			sb = attrArena[arenaOff : arenaOff+int(attrLen)]
+			arenaOff += int(attrLen)
+		} else {
+			sb = make([]byte, attrLen)
+		}
+		_, copyErr := t.CopyInBytes(hostarch.Addr(attrData), sb)
+		if copyErr == nil {
+			binary.LittleEndian.PutUint64(buf[off+8:off+16], attrDataPtr(sb))
+			rewrites = append(rewrites, AttrRewrite{
+				AttrOff:  off,
+				OrigData: attrData,
+				Sentry:   sb,
+			})
+		}
+	}
+
+	// Rewrite inline FD attrs that reference proxied async event FDs.
+	// The application sees sentry FD numbers, but the host kernel needs
+	// the original host FDs (e.g. CQ CREATE's comp channel attr).
+	//
+	// IMPORTANT: Only rewrite attrs with known FD attr IDs. Other inline
+	// attrs carry kernel object handles (PD, CQ, QP handles) that have
+	// small numeric values which could collide with sandbox FD numbers.
+	// Rewriting those would corrupt the handles (e.g., PD handle 92 →
+	// host FD 3480 → ibv_create_qp ENOENT).
+	const (
+		uverbsAttrCQCompChannel = 0x0007 // CQ CREATE comp channel FD
+		uverbsAttrQPEventFD     = 0x000c // QP CREATE event FD
+	)
+	for i := 0; i < int(numAttrs); i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		attrLen := binary.LittleEndian.Uint16(buf[off+2 : off+4])
+		if attrLen != 0 {
+			continue
+		}
+		if attrID != uverbsAttrCQCompChannel && attrID != uverbsAttrQPEventFD {
+			continue
+		}
+		sentryVal := int32(binary.LittleEndian.Uint64(buf[off+8 : off+16]))
+		if sentryVal <= 0 {
+			continue
+		}
+		file, _ := t.FDTable().Get(sentryVal)
+		if file == nil {
+			continue
+		}
+		if afd, ok := file.Impl().(*asyncEventFD); ok {
+			binary.LittleEndian.PutUint64(buf[off+8:off+16], uint64(afd.hostFD))
+		}
+		file.DecRef(t)
+	}
+
+	// Classify and prepare DMA page mirroring before forwarding.
+	action, writeCmdVal := fd.classifyIoctl(buf, int(numAttrs), objectID, methodID)
+	// QP MODIFY needs the host netns for RoCE GID-to-netdev resolution.
+	// Match it precisely on (objectID, methodID) — UVERBS_METHOD_QP_MODIFY
+	// is methodID 2 on the modern ioctl path. On the legacy INVOKE_WRITE
+	// path the same op is encoded as IB_USER_VERBS_CMD_MODIFY_QP (cmd 26)
+	// in the WRITE_CMD attr.
+	isQPModify := (objectID == uverbsObjectQP && methodID == uverbsMethodQPModify) ||
+		(objectID == uverbsObjectDevice &&
+			methodID == uverbsMethodInvokeWrite &&
+			uverbsWriteCmdBase(writeCmdVal) == ibUserVerbsCmdModifyQP)
+
+	var mrMirror *MirroredPages
+	var cqqpMirror *PinnedDMABufs
+	var dmaCleanup cleanup.Cleanup
+	defer dmaCleanup.Clean()
+	// asyncFDCleanup is armed if proxyAsyncEventFD installs an FD. It
+	// fires on any error path between FD install and successful CopyOut
+	// of the response back to the sandbox (see proxyAsyncEventFD comment).
+	var asyncFDCleanup cleanup.Cleanup
+
+	switch action {
+	case ActionMRReg:
+		var err error
+		mrMirror, err = fd.prepareMRReg(t, buf, int(numAttrs), objectID, rewrites, writeCmdVal)
+		if err != nil {
+			log.Warningf("rdmaproxy: MR REG page mirroring: %v", err)
+			return 0, linuxerr.ENOMEM
+		}
+		if mrMirror != nil {
+			dmaCleanup = cleanup.Make(func() { mrMirror.Release(t) })
+		}
+
+	case ActionCQCreate, ActionQPCreate:
+		if fd.driver == nil {
+			// No driver attached — DMA buffer mirroring depends on the
+			// vendor-specific driver-private attribute layout. Forward
+			// the ioctl as-is; the host will fail or work depending on
+			// whether buf_addr/db_addr resolve in the sentry's address
+			// space (typically not).
+			log.Warningf("rdmaproxy: CQ/QP CREATE on uverbsFD with no driver attached - cannot mirror DMA buffers")
+			break
+		}
+		var err error
+		cqqpMirror, err = fd.driver.PrepareCQQPCreate(t, buf, int(numAttrs), rewrites, action)
+		if err != nil {
+			log.Warningf("rdmaproxy: CQ/QP CREATE page mirroring (driver=%s): %v", fd.driver.Name(), err)
+			return 0, linuxerr.ENOMEM
+		}
+		if cqqpMirror != nil {
+			dmaCleanup = cleanup.Make(func() { cqqpMirror.Release(t) })
+		}
+	}
+
+	if isQPModify && log.IsLogging(log.Debug) {
+		log.Debugf("rdmaproxy: forwarding MODIFY_QP obj=0x%04x method=%d write_cmd=%d hostFD=%d %s",
+			objectID, methodID, uverbsWriteCmdBase(writeCmdVal), fd.hostFD, taskLogFields(t))
+	}
+	n, errno := invokeUverbsIoctl(fd.hostFD, buf)
+	if isQPModify && log.IsLogging(log.Debug) {
+		log.Debugf("rdmaproxy: MODIFY_QP returned n=%d errno=%d hostFD=%d %s",
+			n, errno, fd.hostFD, taskLogFields(t))
+	}
+
+	if errno == unix.EFAULT {
+		// Extract the sentry VA that was passed to the host from the ioctl buffer.
+		var sentryVA, mrLen uint64
+		if action == ActionMRReg {
+			if rw := FindRewrite(buf, int(numAttrs), rewrites, uverbsAttrCoreIn); rw != nil && len(rw.Sentry) >= regMROffLength+8 {
+				sentryVA = binary.LittleEndian.Uint64(rw.Sentry[regMROffStart : regMROffStart+8])
+				mrLen = binary.LittleEndian.Uint64(rw.Sentry[regMROffLength : regMROffLength+8])
+			}
+		}
+		tgid := int32(t.TGIDInRoot())
+		log.Warningf("rdmaproxy: EFAULT from host ioctl obj=0x%04x method=%d action=%d hostFD=%d sentryVA=%#x mrLen=%d tgid=%d (%s)",
+			objectID, methodID, action, fd.hostFD, sentryVA, mrLen, tgid, taskLogFields(t))
+	}
+
+	// Post-ioctl tracking for successful operations.
+	if errno == 0 {
+		switch action {
+		case ActionMRReg:
+			if mrMirror != nil {
+				mrHandle := fd.extractMRHandle(buf, int(numAttrs), objectID, rewrites, writeCmdVal)
+				if mrHandle != 0 {
+					fd.pinned.addMR(mrHandle, mrMirror)
+					dmaCleanup.Release()
+					if log.IsLogging(log.Debug) {
+						log.Debugf("rdmaproxy: pinned MR handle=%d (%d ranges) %s", mrHandle, len(mrMirror.prs), mrMirror.mrSummary)
+					}
+				}
+			}
+
+		case ActionMRDereg:
+			mrHandle := fd.extractDeregMRHandle(buf, int(numAttrs), objectID, rewrites, writeCmdVal)
+			if mrHandle != 0 {
+				if mp := fd.pinned.takeMR(mrHandle); mp != nil {
+					mp.Release(t)
+					if log.IsLogging(log.Debug) {
+						log.Debugf("rdmaproxy: unpinned MR handle=%d", mrHandle)
+					}
+				}
+			}
+
+		case ActionCQCreate:
+			if cqqpMirror != nil {
+				handle := fd.extractCQQPHandle(buf, int(numAttrs), objectID, rewrites, action)
+				if handle != 0 {
+					fd.pinned.addCQ(handle, cqqpMirror)
+					dmaCleanup.Release()
+					if log.IsLogging(log.Debug) {
+						log.Debugf("rdmaproxy: pinned CQ handle=%d", handle)
+					}
+				}
+			}
+
+		case ActionQPCreate:
+			if cqqpMirror != nil {
+				handle := fd.extractCQQPHandle(buf, int(numAttrs), objectID, rewrites, action)
+				if handle != 0 {
+					fd.pinned.addQP(handle, cqqpMirror)
+					dmaCleanup.Release()
+					if log.IsLogging(log.Debug) {
+						log.Debugf("rdmaproxy: pinned QP handle=%d", handle)
+					}
+				}
+			}
+
+		case ActionCQDestroy:
+			handle := fd.extractCQQPDestroyHandle(buf, int(numAttrs), objectID, rewrites, action)
+			if handle != 0 {
+				if bufs := fd.pinned.takeCQ(handle); bufs != nil {
+					bufs.Release(t)
+					if log.IsLogging(log.Debug) {
+						log.Debugf("rdmaproxy: unpinned CQ handle=%d", handle)
+					}
+				}
+			}
+
+		case ActionQPDestroy:
+			handle := fd.extractCQQPDestroyHandle(buf, int(numAttrs), objectID, rewrites, action)
+			if handle != 0 {
+				if bufs := fd.pinned.takeQP(handle); bufs != nil {
+					bufs.Release(t)
+					if log.IsLogging(log.Debug) {
+						log.Debugf("rdmaproxy: unpinned QP handle=%d", handle)
+					}
+				}
+			}
+		}
+
+		// Proxy the async event FD returned by ASYNC_EVENT_ALLOC.
+		// The kernel created this FD in the sentry's host process;
+		// we must wrap it so the sandbox can read() async events.
+		// The FD is installed into the task's FD table here, but the
+		// sandbox only learns its number from the final CopyOut below;
+		// if that copy fails we'd leak a referenceable FD, so undo is
+		// armed and only released after a successful argPtr copy.
+		if objectID == uverbsObjectAsyncEvent && methodID == uverbsMethodAsyncEventAlloc {
+			if sentryFD, undo, err := fd.proxyAsyncEventFD(t, buf, int(numAttrs)); err != nil {
+				log.Warningf("rdmaproxy: async event FD proxy: %v", err)
+			} else if sentryFD >= 0 {
+				log.Infof("rdmaproxy: installed async event FD → sandbox fd %d", sentryFD)
+				asyncFDCleanup = cleanup.Make(undo)
+				defer asyncFDCleanup.Clean()
+			}
+		}
+	}
+
+	// Copy output data back and restore original pointers.
+	for _, rw := range rewrites {
+		t.CopyOutBytes(hostarch.Addr(rw.OrigData), rw.Sentry)
+		binary.LittleEndian.PutUint64(buf[rw.AttrOff+8:rw.AttrOff+16], rw.OrigData)
+	}
+	if _, copyErr := t.CopyOutBytes(argPtr, buf); copyErr != nil {
+		// argPtr CopyOut failed — abandon any async event FD we just
+		// installed (the sandbox never received the FD number).
+		return 0, copyErr
+	}
+	asyncFDCleanup.Release()
+
+	if errno != 0 {
+		return n, errno
+	}
+	return n, nil
+}
+
+// classifyIoctl determines what DMA-relevant action this ioctl represents.
+func (fd *uverbsFD) classifyIoctl(buf []byte, numAttrs int, objectID, methodID uint16) (action IoctlAction, writeCmdVal uint64) {
+	// Modern path: direct object methods.
+	switch objectID {
+	case uverbsObjectMR:
+		if methodID == uverbsMethodRegMR {
+			return ActionMRReg, 0
+		}
+		if methodID == uverbsMethodMRDestroy {
+			return ActionMRDereg, 0
+		}
+	case uverbsObjectCQ:
+		// Method IDs vary across kernel versions, so detect CREATE vs
+		// DESTROY by asking the driver if it sees its own driver-private
+		// input attribute. With no driver attached, conservatively treat
+		// every CQ ioctl as a DESTROY (the page-mirror for CREATE only
+		// fires through the driver path; this avoids spurious
+		// ActionCQDestroy releases of mirrors we never registered).
+		if fd.driver != nil && fd.driver.HasDriverCreateAttr(buf, numAttrs) {
+			return ActionCQCreate, 0
+		}
+		return ActionCQDestroy, 0
+	case uverbsObjectQP:
+		if fd.driver != nil && fd.driver.HasDriverCreateAttr(buf, numAttrs) {
+			return ActionQPCreate, 0
+		}
+		// Distinguish DESTROY (method=1) from MODIFY (method=2+).
+		// Returning ActionNone for MODIFY prevents the ActionQPDestroy
+		// post-ioctl page-release from firing incorrectly on MODIFY_QP.
+		if methodID == uverbsMethodQPDestroy {
+			return ActionQPDestroy, 0
+		}
+		return ActionNone, 0 // MODIFY_QP or unknown QP op
+	}
+
+	// Legacy path: INVOKE_WRITE on DEVICE object.
+	if objectID == uverbsObjectDevice && methodID == uverbsMethodInvokeWrite {
+		writeCmdVal = findInlineAttr(buf, numAttrs, uverbsAttrWriteCmd)
+		switch writeCmdVal {
+		case ibUserVerbsCmdRegMR:
+			return ActionMRReg, writeCmdVal
+		case ibUserVerbsCmdDeregMR:
+			return ActionMRDereg, writeCmdVal
+		case ibUserVerbsCmdCreateCQ:
+			return ActionCQCreate, writeCmdVal
+		case ibUserVerbsCmdCreateQP:
+			return ActionQPCreate, writeCmdVal
+		case ibUserVerbsCmdDestroyCQ:
+			return ActionCQDestroy, writeCmdVal
+		case ibUserVerbsCmdDestroyQP:
+			return ActionQPDestroy, writeCmdVal
+		default:
+			return ActionNone, writeCmdVal
+		}
+	}
+	return ActionNone, 0
+}
+
+// HasAttrID returns true if any attr in the ioctl buffer has the given ID.
+// Exported so per-vendor Driver.HasDriverCreateAttr implementations can
+// scan for their driver-private attribute without duplicating the
+// attribute-walking loop.
+func HasAttrID(buf []byte, numAttrs int, targetID uint16) bool {
+	for i := 0; i < numAttrs; i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		if attrID == targetID {
+			return true
+		}
+	}
+	return false
+}
+
+// findInlineAttr finds an attr by ID where CopyIn failed (inline data) and
+// returns its data field value. Returns 0 if not found.
+func findInlineAttr(buf []byte, numAttrs int, targetID uint16) uint64 {
+	for i := 0; i < numAttrs; i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		attrLen := binary.LittleEndian.Uint16(buf[off+2 : off+4])
+		if attrID == targetID {
+			// Inline attrs have len=0 or small len with non-pointer data.
+			// The data field is the value itself.
+			_ = attrLen
+			return binary.LittleEndian.Uint64(buf[off+8 : off+16])
+		}
+	}
+	return 0
+}
+
+// FindRewrite finds the rewrite entry for a given attr ID, or nil if no
+// rewrite was performed for that ID. Exported so per-vendor Driver
+// plug-ins can locate their driver-private input attribute and rewrite
+// the embedded sandbox addresses.
+func FindRewrite(buf []byte, numAttrs int, rewrites []AttrRewrite, targetID uint16) *AttrRewrite {
+	for i := range rewrites {
+		off := rewrites[i].AttrOff
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		if attrID == targetID {
+			return &rewrites[i]
+		}
+	}
+	return nil
+}
+
+// prepareMRReg detects the MR address in the ioctl and mirrors the sandbox
+// pages into the sentry's address space. The address in the ioctl buffer is
+// rewritten to the sentry-side mapping.
+func (fd *uverbsFD) prepareMRReg(t *kernel.Task, buf []byte, numAttrs int, objectID uint16, rewrites []AttrRewrite, writeCmdVal uint64) (*MirroredPages, error) {
+	if objectID == uverbsObjectDevice {
+		return fd.prepareMRRegInvokeWrite(t, buf, numAttrs, rewrites)
+	}
+	return fd.prepareMRRegModern(t, buf, numAttrs, rewrites)
+}
+
+// prepareMRRegInvokeWrite handles MR REG via the INVOKE_WRITE legacy path.
+// The CORE_IN attr contains an ib_uverbs_reg_mr struct with start/length.
+func (fd *uverbsFD) prepareMRRegInvokeWrite(t *kernel.Task, buf []byte, numAttrs int, rewrites []AttrRewrite) (*MirroredPages, error) {
+	rw := FindRewrite(buf, numAttrs, rewrites, uverbsAttrCoreIn)
+	if rw == nil {
+		log.Warningf("rdmaproxy: MR REG INVOKE_WRITE but no CORE_IN attr found")
+		return nil, nil
+	}
+	if len(rw.Sentry) < regMROffHcaVA+8 {
+		log.Warningf("rdmaproxy: MR REG CORE_IN too short: %d bytes", len(rw.Sentry))
+		return nil, nil
+	}
+
+	sandboxVA := binary.LittleEndian.Uint64(rw.Sentry[regMROffStart : regMROffStart+8])
+	length := binary.LittleEndian.Uint64(rw.Sentry[regMROffLength : regMROffLength+8])
+
+	if length == 0 {
+		return nil, nil
+	}
+
+	mp, sentryVA, err := MirrorSandboxPages(t, sandboxVA, length)
+	if err != nil {
+		return nil, fmt.Errorf("MirrorSandboxPages: %w", err)
+	}
+
+	oldHCAVA := binary.LittleEndian.Uint64(rw.Sentry[regMROffHcaVA : regMROffHcaVA+8])
+
+	binary.LittleEndian.PutUint64(rw.Sentry[regMROffStart:regMROffStart+8], uint64(sentryVA))
+	if mp != nil {
+		mp.mrSummary = formatMRSummary(t, sandboxVA, length, sentryVA, oldHCAVA, oldHCAVA, 0, 0)
+	}
+
+	return mp, nil
+}
+
+// prepareMRRegModern handles MR REG via the modern UVERBS_METHOD_REG_MR path.
+// The ADDR and LENGTH attrs carry the values.
+func (fd *uverbsFD) prepareMRRegModern(t *kernel.Task, buf []byte, numAttrs int, rewrites []AttrRewrite) (*MirroredPages, error) {
+	addrRW := FindRewrite(buf, numAttrs, rewrites, uverbsAttrRegMRAddr)
+	lengthRW := FindRewrite(buf, numAttrs, rewrites, uverbsAttrRegMRLength)
+	if addrRW == nil || lengthRW == nil {
+		// ADDR and LENGTH might be inline for small values.
+		// Try reading them as inline values from the raw buffer.
+		addrInline := findInlineAttr(buf, numAttrs, uverbsAttrRegMRAddr)
+		lengthInline := findInlineAttr(buf, numAttrs, uverbsAttrRegMRLength)
+		log.Warningf("rdmaproxy: MR REG (modern) ADDR/LENGTH not rewritten (addrRW=%v lenRW=%v inline addr=%#x len=%d) — forwarding without mirroring",
+			addrRW != nil, lengthRW != nil, addrInline, lengthInline)
+		return nil, nil
+	}
+	if len(addrRW.Sentry) < 8 || len(lengthRW.Sentry) < 8 {
+		return nil, nil
+	}
+
+	sandboxVA := binary.LittleEndian.Uint64(addrRW.Sentry[0:8])
+	length := binary.LittleEndian.Uint64(lengthRW.Sentry[0:8])
+
+	if length == 0 {
+		return nil, nil
+	}
+
+	mp, sentryVA, err := MirrorSandboxPages(t, sandboxVA, length)
+	if err != nil {
+		return nil, fmt.Errorf("MirrorSandboxPages: %w", err)
+	}
+
+	binary.LittleEndian.PutUint64(addrRW.Sentry[0:8], uint64(sentryVA))
+	if mp != nil {
+		mp.mrSummary = formatMRSummary(t, sandboxVA, length, sentryVA, 0, 0, sandboxVA, sandboxVA)
+	}
+
+	return mp, nil
+}
+
+// extractMRHandle reads the MR handle from the ioctl response after
+// a successful MR REG.
+func (fd *uverbsFD) extractMRHandle(buf []byte, numAttrs int, objectID uint16, rewrites []AttrRewrite, writeCmdVal uint64) uint32 {
+	if objectID == uverbsObjectDevice {
+		// INVOKE_WRITE: response in CORE_OUT attr.
+		rw := FindRewrite(buf, numAttrs, rewrites, uverbsAttrCoreOut)
+		if rw == nil || len(rw.Sentry) < regMRRespOffHandle+4 {
+			log.Warningf("rdmaproxy: MR REG success but no CORE_OUT to read handle")
+			return 0
+		}
+		return binary.LittleEndian.Uint32(rw.Sentry[regMRRespOffHandle : regMRRespOffHandle+4])
+	}
+	// Modern path: HANDLE attr (id=0) is an output IDR — the handle is
+	// returned in the data field of the attr in the response buffer.
+	for i := 0; i < numAttrs; i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		if attrID == uverbsAttrRegMRHandle {
+			return uint32(binary.LittleEndian.Uint64(buf[off+8 : off+16]))
+		}
+	}
+	return 0
+}
+
+// extractDeregMRHandle reads the MR handle from a DEREG_MR ioctl.
+func (fd *uverbsFD) extractDeregMRHandle(buf []byte, numAttrs int, objectID uint16, rewrites []AttrRewrite, writeCmdVal uint64) uint32 {
+	if objectID == uverbsObjectDevice {
+		// INVOKE_WRITE: mr_handle in CORE_IN attr.
+		rw := FindRewrite(buf, numAttrs, rewrites, uverbsAttrCoreIn)
+		if rw == nil || len(rw.Sentry) < deregMROffHandle+4 {
+			return 0
+		}
+		return binary.LittleEndian.Uint32(rw.Sentry[deregMROffHandle : deregMROffHandle+4])
+	}
+	// Modern path: DESTROY_MR_HANDLE attr (id=0).
+	for i := 0; i < numAttrs; i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		if attrID == uverbsAttrDestroyMRHandle {
+			return uint32(binary.LittleEndian.Uint64(buf[off+8 : off+16]))
+		}
+	}
+	return 0
+}
+
+// extractCQQPHandle reads the CQ or QP handle from the ioctl response after
+// a successful CREATE. action picks the per-method handle attr ID — both
+// happen to be 0 by ABI, but routing through named constants keeps the call
+// site self-documenting and avoids relying on "first attr with ID 0".
+func (fd *uverbsFD) extractCQQPHandle(buf []byte, numAttrs int, objectID uint16, rewrites []AttrRewrite, action IoctlAction) uint32 {
+	if objectID == uverbsObjectDevice {
+		// INVOKE_WRITE: handle is first __u32 of CORE_OUT for both CREATE_CQ
+		// (struct ib_uverbs_create_cq_resp.cq_handle) and CREATE_QP (struct
+		// ib_uverbs_create_qp_resp.qp_handle).
+		rw := FindRewrite(buf, numAttrs, rewrites, uverbsAttrCoreOut)
+		if rw == nil || len(rw.Sentry) < 4 {
+			return 0
+		}
+		return binary.LittleEndian.Uint32(rw.Sentry[0:4])
+	}
+	var attrID uint16
+	switch action {
+	case ActionCQCreate:
+		attrID = uverbsAttrCreateCQHandle
+	case ActionQPCreate:
+		attrID = uverbsAttrCreateQPHandle
+	default:
+		return 0
+	}
+	return findOutputHandle(buf, numAttrs, attrID)
+}
+
+// extractCQQPDestroyHandle reads the CQ or QP handle from a DESTROY ioctl.
+// INVOKE_WRITE path: handle is first __u32 of CORE_IN.
+// Modern path: per-method DESTROY handle attr (both happen to be id 0).
+func (fd *uverbsFD) extractCQQPDestroyHandle(buf []byte, numAttrs int, objectID uint16, rewrites []AttrRewrite, action IoctlAction) uint32 {
+	if objectID == uverbsObjectDevice {
+		rw := FindRewrite(buf, numAttrs, rewrites, uverbsAttrCoreIn)
+		if rw == nil || len(rw.Sentry) < 4 {
+			return 0
+		}
+		return binary.LittleEndian.Uint32(rw.Sentry[0:4])
+	}
+	var attrID uint16
+	switch action {
+	case ActionCQDestroy:
+		attrID = uverbsAttrDestroyCQHandle
+	case ActionQPDestroy:
+		attrID = uverbsAttrDestroyQPHandle
+	default:
+		return 0
+	}
+	return findOutputHandle(buf, numAttrs, attrID)
+}
+
+// findOutputHandle returns the data field (truncated to uint32) of the first
+// attr with the given ID. Used to extract IDR-output handles from CREATE
+// responses and DESTROY inputs.
+func findOutputHandle(buf []byte, numAttrs int, targetID uint16) uint32 {
+	for i := 0; i < numAttrs; i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		if attrID == targetID {
+			return uint32(binary.LittleEndian.Uint64(buf[off+8 : off+16]))
+		}
+	}
+	return 0
+}
+
+// proxyAsyncEventFD extracts the host FD from a successful
+// ASYNC_EVENT_ALLOC response, wraps it in a sentry FileDescription, installs
+// it in the task's FD table, and rewrites the ioctl buffer so the sandbox
+// receives the proxy FD number.
+//
+// Returns (sentryFD, undo, nil) on success. undo, when called, removes the
+// sentry FD from the task's FD table; the caller MUST invoke undo if the
+// final CopyOut to the sandbox argPtr fails (otherwise the sandbox would
+// hold a referenceable FD it never sees the number for). On the success
+// path the caller throws away undo.
+func (fd *uverbsFD) proxyAsyncEventFD(t *kernel.Task, buf []byte, numAttrs int) (int32, func(), error) {
+	for i := 0; i < numAttrs; i++ {
+		off := ibUverbsIoctlHdrSize + i*ibUverbsAttrSize
+		attrID := binary.LittleEndian.Uint16(buf[off : off+2])
+		if attrID != uverbsAttrAsyncEventAllocFD {
+			continue
+		}
+		hostFD := int(binary.LittleEndian.Uint64(buf[off+8 : off+16]))
+		if hostFD < 0 {
+			return -1, nil, fmt.Errorf("kernel returned invalid async event fd %d", hostFD)
+		}
+		sentryFD, err := newAsyncEventFD(t, hostFD)
+		if err != nil {
+			unix.Close(hostFD)
+			return -1, nil, fmt.Errorf("newAsyncEventFD: %w", err)
+		}
+		// No global map needed — the FD rewrite loop now resolves
+		// sandbox FDs through the task's FD table at ioctl time.
+		binary.LittleEndian.PutUint64(buf[off+8:off+16], uint64(sentryFD))
+		undo := func() {
+			if file := t.FDTable().Remove(t, sentryFD); file != nil {
+				file.DecRef(t)
+			}
+		}
+		return sentryFD, undo, nil
+	}
+	return -1, nil, fmt.Errorf("ASYNC_EVENT_ALLOC response missing FD attr")
+}
+
+// Read implements vfs.FileDescriptionImpl.Read.
+// Forwards reads to the host fd (used for async event notifications).
+func (fd *uverbsFD) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
+	buf, release := borrowReadBuf(int(dst.NumBytes()))
+	defer release()
+	n, errno := readHostFDNonblocking(fd.hostFD, buf)
+	if errno != 0 {
+		if errno == unix.EAGAIN || errno == unix.EWOULDBLOCK {
+			return 0, linuxerr.ErrWouldBlock
+		}
+		return 0, errno
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	written, err := dst.CopyOut(ctx, buf[:n])
+	return int64(written), err
+}
+
+// Write rejects direct writes to /dev/infiniband/uverbs*. The legacy
+// uverbs write() command interface is not implemented; modern rdma-core
+// uses RDMA_VERBS_IOCTL exclusively. Logged at Debug level because some
+// probes/diagnostics will speculatively try write(2) and we don't want
+// to spam Warning on every probe.
+func (fd *uverbsFD) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
+	if log.IsLogging(log.Debug) {
+		log.Debugf("rdmaproxy: direct write() on uverbs fd is unsupported size=%d hostFD=%d %s",
+			src.NumBytes(), fd.hostFD, taskLogFields(kernel.TaskFromContext(ctx)))
+	}
+	return 0, linuxerr.EINVAL
+}
+
+// Read implements vfs.FileDescriptionImpl.Read for asyncEventFD.
+// Uses fdnotifier to check readiness before reading, so we never
+// issue a blocking read() syscall on the host FD.
+func (fd *asyncEventFD) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
+	if fdnotifier.NonBlockingPoll(fd.hostFD, waiter.ReadableEvents) == 0 {
+		return 0, linuxerr.ErrWouldBlock
+	}
+	buf, release := borrowReadBuf(int(dst.NumBytes()))
+	defer release()
+	n, errno := readHostFDNonblocking(fd.hostFD, buf)
+	if errno != 0 {
+		if errno == unix.EAGAIN || errno == unix.EWOULDBLOCK {
+			return 0, linuxerr.ErrWouldBlock
+		}
+		return 0, errno
+	}
+	if n == 0 {
+		return 0, nil
+	}
+	written, err := dst.CopyOut(ctx, buf[:n])
+	return int64(written), err
+}
+
+// ConfigureMMap implements vfs.FileDescriptionImpl.ConfigureMMap.
+func (fd *uverbsFD) ConfigureMMap(ctx context.Context, opts *memmap.MMapOpts) error {
+	err := vfs.GenericProxyDeviceConfigureMMap(&fd.vfsfd, fd, opts)
+	if err != nil {
+		log.Warningf("rdmaproxy: mmap hostFD=%d: %v", fd.hostFD, err)
+	}
+	return err
+}
+
+// Translate implements memmap.Mappable.Translate.
+func (fd *uverbsFD) Translate(ctx context.Context, required, optional memmap.MappableRange, at hostarch.AccessType) ([]memmap.Translation, error) {
+	return []memmap.Translation{
+		{
+			Source: optional,
+			File:   &fd.memmapFile,
+			Offset: optional.Start,
+			Perms:  hostarch.AnyAccess,
+		},
+	}, nil
+}

--- a/pkg/sentry/devices/rdmaproxy/rdmaproxy_ioctl_unsafe.go
+++ b/pkg/sentry/devices/rdmaproxy/rdmaproxy_ioctl_unsafe.go
@@ -1,0 +1,152 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file isolates the unsafe.Pointer and raw-syscall surface of the rdma
+// proxy: forwarding the RDMA_VERBS_IOCTL to the host, reading from host
+// FDs, and mirroring sandbox pages into the sentry's address space via
+// mmap/mremap. All other ioctl-handling logic lives in rdmaproxy_ioctl.go.
+
+package rdmaproxy
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/cleanup"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/mm"
+)
+
+// invokeUverbsIoctl forwards a pre-built RDMA_VERBS_IOCTL buffer to the host
+// kernel. buf must have its attr data pointers rewritten to sentry-side
+// addresses; see attrDataPtr.
+//
+// The ioctl runs in the calling sentry task's netns. For RoCE this is the
+// sandbox container's netns, which is expected to contain the netdev that
+// backs the uverbs device's ibdev (see runsc/sandbox.MoveRDMANetdevsIntoSandbox).
+// With the netdev local, ibv_modify_qp's GID-to-netdev resolution at
+// INIT→RTR succeeds without any namespace switching here.
+func invokeUverbsIoctl(hostFD int32, buf []byte) (uintptr, unix.Errno) {
+	n, _, errno := unix.Syscall(unix.SYS_IOCTL,
+		uintptr(hostFD),
+		uintptr(rdmaVerbsIoctl),
+		uintptr(unsafe.Pointer(&buf[0])))
+	return n, errno
+}
+
+// attrDataPtr returns the first-byte address of sb as a uint64 suitable for
+// placing into an ioctl attr data field.
+func attrDataPtr(sb []byte) uint64 {
+	return uint64(uintptr(unsafe.Pointer(&sb[0])))
+}
+
+// readHostFDNonblocking issues a read(2) on hostFD into buf. The host FD is
+// expected to be in O_NONBLOCK mode; callers translate EAGAIN/EWOULDBLOCK into
+// ErrWouldBlock.
+func readHostFDNonblocking(hostFD int32, buf []byte) (int, unix.Errno) {
+	if len(buf) == 0 {
+		return 0, 0
+	}
+	n, _, errno := unix.RawSyscall(unix.SYS_READ,
+		uintptr(hostFD),
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(len(buf)))
+	return int(n), errno
+}
+
+// MirrorSandboxPages pins the sandbox pages backing [addr, addr+length) and
+// maps them into the sentry's address space. Returns the mirrored pages and
+// the sentry VA corresponding to the original sandbox address.
+//
+// Exported so per-vendor Driver plug-ins can mirror the DMA buffers
+// referenced by their driver-private input attribute.
+func MirrorSandboxPages(t *kernel.Task, addr, length uint64) (*MirroredPages, uintptr, error) {
+	alignedStart := hostarch.Addr(addr).RoundDown()
+	alignedEnd, ok := hostarch.Addr(addr + length).RoundUp()
+	if !ok {
+		return nil, 0, linuxerr.EINVAL
+	}
+	alignedLen := uint64(alignedEnd - alignedStart)
+
+	appAR, ok := alignedStart.ToRange(alignedLen)
+	if !ok {
+		return nil, 0, linuxerr.EINVAL
+	}
+
+	at := hostarch.ReadWrite
+	prs, pinErr := t.MemoryManager().Pin(t, appAR, at, false /* ignorePermissions */)
+	if pinErr != nil {
+		return nil, 0, fmt.Errorf("Pin: %w", pinErr)
+	}
+
+	cu := cleanup.Make(func() { mm.Unpin(prs) })
+	defer cu.Clean()
+
+	// Try to get a single contiguous internal mapping.
+	var m uintptr
+	mOwned := false
+	if len(prs) == 1 {
+		pr := prs[0]
+		ims, err := pr.File.MapInternal(memmap.FileRange{pr.Offset, pr.Offset + uint64(pr.Source.Length())}, at)
+		if err == nil && ims.NumBlocks() == 1 {
+			m = ims.Head().Addr()
+		}
+	}
+
+	// If not contiguous, build a contiguous sentry mapping via mmap+mremap.
+	if m == 0 {
+		var errno unix.Errno
+		m, _, errno = unix.RawSyscall6(unix.SYS_MMAP, 0, uintptr(alignedLen), unix.PROT_NONE, unix.MAP_PRIVATE|unix.MAP_ANONYMOUS, ^uintptr(0), 0)
+		if errno != 0 {
+			return nil, 0, fmt.Errorf("mmap anon %d bytes: %w", alignedLen, errno)
+		}
+		mOwned = true
+		cu.Add(func() {
+			unix.RawSyscall(unix.SYS_MUNMAP, m, uintptr(alignedLen), 0)
+		})
+		sentryAddr := m
+		for _, pr := range prs {
+			ims, err := pr.File.MapInternal(memmap.FileRange{pr.Offset, pr.Offset + uint64(pr.Source.Length())}, at)
+			if err != nil {
+				return nil, 0, fmt.Errorf("MapInternal: %w", err)
+			}
+			for !ims.IsEmpty() {
+				im := ims.Head()
+				if _, _, errno := unix.RawSyscall6(unix.SYS_MREMAP, im.Addr(), 0, uintptr(im.Len()), linux.MREMAP_MAYMOVE|linux.MREMAP_FIXED, sentryAddr, 0); errno != 0 {
+					return nil, 0, fmt.Errorf("mremap %#x→%#x len %d: %w", im.Addr(), sentryAddr, im.Len(), errno)
+				}
+				sentryAddr += uintptr(im.Len())
+				ims = ims.Tail()
+			}
+		}
+	}
+
+	// Best-effort pre-fault to avoid mmap_lock contention.
+	unix.Syscall(unix.SYS_MADVISE, m, uintptr(alignedLen), unix.MADV_POPULATE_WRITE)
+
+	mp := &MirroredPages{prs: prs}
+	if mOwned {
+		mp.m = m
+		mp.len = uintptr(alignedLen)
+	}
+	cu.Release()
+
+	sentryVA := m + uintptr(addr-uint64(alignedStart))
+	return mp, sentryVA, nil
+}

--- a/pkg/sentry/devices/rdmaproxy/seccomp_filter.go
+++ b/pkg/sentry/devices/rdmaproxy/seccomp_filter.go
@@ -1,0 +1,98 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rdmaproxy
+
+import (
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/seccomp"
+)
+
+// Filters returns seccomp-bpf filters for the RDMA proxy.
+//
+// These filters are deliberately narrower than "any FD / any flags" on the
+// syscalls the sentry forwards to the host kernel. Every constraint below
+// matches the single concrete call shape used by this package (see the
+// corresponding call sites in rdmaproxy.go and rdmaproxy_ioctl_unsafe.go);
+// a future caller that needs broader semantics must relax the filter
+// explicitly rather than silently inheriting a permissive default.
+func Filters() seccomp.SyscallRules {
+	return seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
+		// openHostDevice opens /dev/infiniband/uverbs* with
+		//   flags = (caller_flags & O_ACCMODE) | O_NOFOLLOW
+		// and no other bits. The MaskedEqual below requires exactly
+		// O_NOFOLLOW outside the O_ACCMODE bits — this simultaneously
+		// forbids O_CREAT, O_PATH, O_DIRECTORY, O_TMPFILE, O_CLOEXEC,
+		// O_DIRECT, O_SYNC, O_NONBLOCK, O_ASYNC, etc.
+		unix.SYS_OPENAT: seccomp.PerArg{
+			seccomp.EqualTo(^uintptr(0)), // dirfd == AT_FDCWD
+			seccomp.AnyValue{},           // path (opaque to seccomp)
+			seccomp.MaskedEqual(^uintptr(unix.O_ACCMODE), unix.O_NOFOLLOW),
+			seccomp.AnyValue{}, // mode (unused when O_CREAT is forbidden)
+		},
+		// Only RDMA_VERBS_IOCTL is ever issued by the sentry on behalf
+		// of the sandbox. Tighter than a magic-byte match because a
+		// non-uverbs subsystem could in principle register the same
+		// 0x1B magic on a file the sentry happens to hold.
+		unix.SYS_IOCTL: seccomp.PerArg{
+			seccomp.NonNegativeFD{},
+			seccomp.EqualTo(uintptr(rdmaVerbsIoctl)),
+		},
+		// Async event forwarding: read(asyncEventFD.hostFD, buf, len).
+		// seccomp-bpf cannot validate the FD against the process's FD
+		// table, so we match the gofer/hostinet precedent of allowing
+		// any non-negative FD.
+		unix.SYS_READ: seccomp.PerArg{
+			seccomp.NonNegativeFD{},
+		},
+		// MirrorSandboxPages reserves a contiguous sentry-side range:
+		//   mmap(NULL, len, PROT_NONE,
+		//        MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
+		// Only `len` varies between calls.
+		unix.SYS_MMAP: seccomp.PerArg{
+			seccomp.EqualTo(0), // addr == NULL
+			seccomp.AnyValue{}, // length
+			seccomp.EqualTo(unix.PROT_NONE),
+			seccomp.EqualTo(unix.MAP_PRIVATE | unix.MAP_ANONYMOUS),
+			seccomp.EqualTo(^uintptr(0)), // fd == -1
+			seccomp.EqualTo(0),           // offset == 0
+		},
+		// munmap is only used to tear down the mirror range on cleanup.
+		// munmap(2) takes two args; the 3rd syscall-register value is
+		// runtime-dependent padding, so we don't constrain it.
+		unix.SYS_MUNMAP: seccomp.MatchAll{},
+		// MirrorSandboxPages remaps each per-page internal mapping into
+		// the reserved range:
+		//   mremap(old_addr, 0, new_len,
+		//          MREMAP_MAYMOVE|MREMAP_FIXED, new_addr, 0)
+		// old_size == 0 combined with MAYMOVE|FIXED asks the kernel to
+		// *duplicate* the mapping rather than move it. Matches nvproxy.
+		unix.SYS_MREMAP: seccomp.PerArg{
+			seccomp.AnyValue{},
+			seccomp.EqualTo(0), // old_size
+			seccomp.AnyValue{},
+			seccomp.EqualTo(linux.MREMAP_MAYMOVE | linux.MREMAP_FIXED),
+			seccomp.AnyValue{},
+			seccomp.EqualTo(0),
+		},
+		// Best-effort pre-fault of the mirrored range. Only this one
+		// advice value is ever issued.
+		unix.SYS_MADVISE: seccomp.PerArg{
+			seccomp.AnyValue{},
+			seccomp.AnyValue{},
+			seccomp.EqualTo(unix.MADV_POPULATE_WRITE),
+		},
+	})
+}

--- a/pkg/sentry/fsimpl/sys/BUILD
+++ b/pkg/sentry/fsimpl/sys/BUILD
@@ -22,6 +22,7 @@ go_library(
         "dir_refs.go",
         "kcov.go",
         "pci.go",
+        "rdma.go",
         "save_restore.go",
         "sys.go",
     ],

--- a/pkg/sentry/fsimpl/sys/BUILD
+++ b/pkg/sentry/fsimpl/sys/BUILD
@@ -21,7 +21,9 @@ go_library(
     srcs = [
         "dir_refs.go",
         "kcov.go",
+        "numa.go",
         "pci.go",
+        "pci_devices.go",
         "rdma.go",
         "save_restore.go",
         "sys.go",

--- a/pkg/sentry/fsimpl/sys/numa.go
+++ b/pkg/sentry/fsimpl/sys/numa.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// NUMANodeData contains the per-node sysfs attributes that NCCL reads from
+// /sys/devices/system/node/node<N>/ to build the topology XML's <cpu> blocks
+// (notably the affinity bitmap).
+type NUMANodeData struct {
+	// ID is the numeric node identifier, e.g. "0".
+	ID string `json:"id"`
+	// CPUMap is the hex bitmap from /sys/devices/system/node/nodeN/cpumap,
+	// e.g. "00000000,00000000,00ffffff,ffffffff".
+	CPUMap string `json:"cpumap"`
+	// CPUList is the range list from /sys/devices/system/node/nodeN/cpulist,
+	// e.g. "0-23,48-71".
+	CPUList string `json:"cpulist"`
+	// Distance is the space-separated NUMA distance vector from
+	// /sys/devices/system/node/nodeN/distance, e.g. "10 20".
+	Distance string `json:"distance,omitempty"`
+}
+
+// NUMAData holds all collected NUMA node attributes.
+type NUMAData struct {
+	// Nodes is sorted by numeric ID for deterministic sysfs output.
+	Nodes []NUMANodeData `json:"nodes"`
+	// Online, Possible, HasCPU, HasMemory, HasNormalMemory mirror the
+	// corresponding /sys/devices/system/node/* aggregate files. They are
+	// captured verbatim from the host so the sandbox sees the same node set
+	// as the kernel does, including any oddities like sparsely numbered nodes.
+	Online          string `json:"online,omitempty"`
+	Possible        string `json:"possible,omitempty"`
+	HasCPU          string `json:"has_cpu,omitempty"`
+	HasMemory       string `json:"has_memory,omitempty"`
+	HasNormalMemory string `json:"has_normal_memory,omitempty"`
+}
+
+// CollectNUMAData reads NUMA topology from /sys/devices/system/node/. Returns
+// nil if the host doesn't expose a node hierarchy (single-NUMA systems
+// without CONFIG_NUMA omit the tree entirely). Must be called before
+// pivot_root while host sysfs is still accessible.
+func CollectNUMAData() *NUMAData {
+	nodePath := "/sys/devices/system/node"
+	dents, err := os.ReadDir(nodePath)
+	if err != nil {
+		log.Infof("numa collect: %s not accessible: %v", nodePath, err)
+		return nil
+	}
+	data := &NUMAData{
+		Online:          readSysfsFile(path.Join(nodePath, "online")),
+		Possible:        readSysfsFile(path.Join(nodePath, "possible")),
+		HasCPU:          readSysfsFile(path.Join(nodePath, "has_cpu")),
+		HasMemory:       readSysfsFile(path.Join(nodePath, "has_memory")),
+		HasNormalMemory: readSysfsFile(path.Join(nodePath, "has_normal_memory")),
+	}
+	for _, d := range dents {
+		name := d.Name()
+		if !strings.HasPrefix(name, "node") {
+			continue
+		}
+		idStr := strings.TrimPrefix(name, "node")
+		if _, err := strconv.Atoi(idStr); err != nil {
+			continue
+		}
+		dir := path.Join(nodePath, name)
+		data.Nodes = append(data.Nodes, NUMANodeData{
+			ID:       idStr,
+			CPUMap:   readSysfsFile(path.Join(dir, "cpumap")),
+			CPUList:  readSysfsFile(path.Join(dir, "cpulist")),
+			Distance: readSysfsFile(path.Join(dir, "distance")),
+		})
+	}
+	sort.Slice(data.Nodes, func(i, j int) bool {
+		ai, _ := strconv.Atoi(data.Nodes[i].ID)
+		aj, _ := strconv.Atoi(data.Nodes[j].ID)
+		return ai < aj
+	})
+	if len(data.Nodes) == 0 {
+		log.Infof("numa collect: no node directories under %s", nodePath)
+		return nil
+	}
+	log.Infof("numa collect: collected %d node(s), online=%q", len(data.Nodes), data.Online)
+	return data
+}
+
+// NUMADataPath is the path within the chroot where serialized NUMA data is
+// stored between boot stages.
+const NUMADataPath = "/var/lib/gvisor/numa_data.json"
+
+// SerializeNUMAData writes the collected data as JSON to the given path.
+func SerializeNUMAData(data *NUMAData, filePath string) error {
+	if data == nil {
+		return nil
+	}
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return fmt.Errorf("MkdirAll %s: %w", path.Dir(filePath), err)
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("json.Marshal: %w", err)
+	}
+	return os.WriteFile(filePath, b, 0644)
+}
+
+// DeserializeNUMAData reads serialized NUMA data from the given path. Returns
+// nil if the file is absent or malformed; the sysfs tree then falls back to
+// having no /sys/devices/system/node/ subtree, which matches gVisor's
+// pre-existing behavior.
+func DeserializeNUMAData(filePath string) *NUMAData {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Infof("numa deserialize: %s: %v", filePath, err)
+		return nil
+	}
+	var data NUMAData
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Warningf("numa deserialize: unmarshal %s: %v", filePath, err)
+		return nil
+	}
+	log.Infof("numa deserialize: loaded %d node(s) from %s", len(data.Nodes), filePath)
+	return &data
+}
+
+// newNUMASysfsEntries builds the kernfs subtree to mount at
+// /sys/devices/system/node/. Returns nil if data is empty.
+//
+// Layout:
+//
+//	node/
+//	    online              -> aggregate range list
+//	    possible            -> aggregate range list
+//	    has_cpu             -> aggregate range list
+//	    has_memory          -> aggregate range list
+//	    has_normal_memory   -> aggregate range list
+//	    node<N>/
+//	        cpumap          -> hex bitmap
+//	        cpulist         -> range list
+//	        distance        -> space-separated distance vector
+func (fs *filesystem) newNUMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *NUMAData) map[string]kernfs.Inode {
+	if data == nil || len(data.Nodes) == 0 {
+		return nil
+	}
+	children := make(map[string]kernfs.Inode)
+	addAggregate := func(name, val string) {
+		if val == "" {
+			return
+		}
+		children[name] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(val))
+	}
+	addAggregate("online", data.Online)
+	addAggregate("possible", data.Possible)
+	addAggregate("has_cpu", data.HasCPU)
+	addAggregate("has_memory", data.HasMemory)
+	addAggregate("has_normal_memory", data.HasNormalMemory)
+
+	for _, n := range data.Nodes {
+		nodeChildren := make(map[string]kernfs.Inode)
+		if n.CPUMap != "" {
+			nodeChildren["cpumap"] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(n.CPUMap))
+		}
+		if n.CPUList != "" {
+			nodeChildren["cpulist"] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(n.CPUList))
+		}
+		if n.Distance != "" {
+			nodeChildren["distance"] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(n.Distance))
+		}
+		children["node"+n.ID] = fs.newDir(ctx, creds, defaultSysDirMode, nodeChildren)
+	}
+	log.Infof("numa sysfs: created %d node entries", len(data.Nodes))
+	return children
+}
+
+// ensureNewline appends a trailing newline if not already present, matching
+// the kernel's sysfs convention.
+func ensureNewline(s string) string {
+	if strings.HasSuffix(s, "\n") {
+		return s
+	}
+	return s + "\n"
+}

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -90,7 +90,7 @@ func pciClassRelevant(class string) bool {
 		return true
 	case 0x0604: // PCI bridge
 		return true
-	case "0680": // NVSwitch
+	case 0x0680: // NVSwitch
 		return true
 	}
 	return false
@@ -101,14 +101,19 @@ func pciClassRelevant(class string) bool {
 // against RDMA availability — see rdmaUsablePCISlotNames for the rules on
 // which NIC PCI devices are kept in the virtual PCI tree.
 func pciClassIsNIC(class string) bool {
-	c := strings.TrimPrefix(class, "0x")
-	if len(c) < 4 {
+	c, err := strconv.ParseInt(strings.TrimSpace(class), 0, 0)
+	if err != nil {
 		return false
 	}
-	prefix := c[:4]
-	// 0200 Ethernet, 0207 InfiniBand network controller (Crusoe B200/EFA),
-	// 0c06 InfiniBand controller.
-	return prefix == "0200" || prefix == "0207" || prefix == "0c06"
+	switch c >> 8 {
+	case 0x0200: // Ethernet
+		return true
+	case 0x0207: // InfiniBand network controller (Crusoe B200/EFA)
+		return true
+	case 0x0c06: // InfiniBand controller
+		return true
+	}
+	return false
 }
 
 // rdmaUsablePCISlotNames returns the set of PCI slot names (lowercase) for

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
@@ -72,21 +73,22 @@ type PCIDevicesData struct {
 // Extend this switch when adding support for additional accelerator/NIC
 // families.
 func pciClassRelevant(class string) bool {
-	c := strings.TrimPrefix(class, "0x")
-	if len(c) < 4 {
+	c, err := strconv.ParseInt(strings.TrimSpace(class), 0, 0)
+	if err != nil {
 		return false
 	}
-	prefix := c[:4]
-	switch prefix {
-	case "0302", "0300": // GPU (3D controller, VGA)
+	// The last byte of the class string is the programming interface byte, which is too restrictive
+	// for our class matching control. We ignore it by truncating the last byte.
+	switch c >> 8 {
+	case 0x0302, 0x0300: // GPU (3D controller, VGA)
 		return true
-	case "0200": // Ethernet controller (NIC)
+	case 0x0200: // Ethernet controller (NIC)
 		return true
-	case "0c06": // InfiniBand controller
+	case 0x0c06: // InfiniBand controller
 		return true
-	case "0207": // InfiniBand network controller (e.g. Crusoe B200 RDMA NICs report 0x020700)
+	case 0x0207: // InfiniBand network controller (e.g. Crusoe B200 RDMA NICs report 0x020700)
 		return true
-	case "0604": // PCI bridge
+	case 0x0604: // PCI bridge
 		return true
 	}
 	return false
@@ -138,7 +140,11 @@ func CollectPCIDeviceData() *PCIDevicesData {
 		}
 		realPath, err := filepath.EvalSymlinks(devDir)
 		if err != nil {
-			realPath = devDir
+			// NCCL needs the resolved /sys/devices/pci... hierarchy to
+			// compute PCI distances. The flat bus path is not usable as a
+			// substitute, so skip rather than collect a broken RealPath.
+			log.Warningf("pci collect: EvalSymlinks(%s): %v; skipping", devDir, err)
+			continue
 		}
 		leaves = append(leaves, leafDev{addr: dent.Name(), realPath: realPath})
 	}

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -1,0 +1,354 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// PCIDeviceAttr contains sysfs attributes for a single PCI device,
+// including its position in the /sys/devices/pci*/ hierarchy.
+type PCIDeviceAttr struct {
+	// Address is the PCI BDF address, e.g. "0000:0f:00.0".
+	Address string `json:"address"`
+	// RealPath is the resolved sysfs path, e.g.
+	// "/sys/devices/pci0000:07/0000:07:01.0/.../0000:0f:00.0".
+	// NCCL uses this hierarchy to compute PCI distances between devices.
+	RealPath        string `json:"realpath"`
+	Class           string `json:"class"`
+	Vendor          string `json:"vendor"`
+	Device          string `json:"device"`
+	SubsystemVendor string `json:"subsystem_vendor"`
+	SubsystemDevice string `json:"subsystem_device"`
+	NumaNode        string `json:"numa_node"`
+	LocalCPUs       string `json:"local_cpus"`
+	LocalCPUList    string `json:"local_cpulist"`
+	MaxLinkSpeed    string `json:"max_link_speed"`
+	MaxLinkWidth    string `json:"max_link_width"`
+	// NCCL prefers current_link_* over max_link_* and only falls back to
+	// max when current is missing or "Unknown". Capturing both lets the
+	// virtual sysfs report the negotiated link, matching what NCCL would
+	// see on the host.
+	CurrentLinkSpeed string `json:"current_link_speed"`
+	CurrentLinkWidth string `json:"current_link_width"`
+}
+
+// PCIDevicesData holds all collected PCI device attributes.
+type PCIDevicesData struct {
+	Devices []PCIDeviceAttr `json:"devices"`
+}
+
+// pciClassRelevant returns true if the PCI class code is one that NCCL
+// needs for topology discovery.
+//
+// This allowlist is curated for NVIDIA GPU + Mellanox/InfiniBand setups. It
+// covers both InfiniBand controllers (class 0c06) and InfiniBand network
+// controllers (class 0207, reported by e.g. Crusoe B200 RDMA NICs and AWS
+// EFA). Other RDMA-capable adapters (Intel Gaudi class 1200, Broadcom
+// bnxt_re, Chelsio iWARP, etc.) are not currently surfaced to the sandbox.
+// Extend this switch when adding support for additional accelerator/NIC
+// families.
+func pciClassRelevant(class string) bool {
+	c := strings.TrimPrefix(class, "0x")
+	if len(c) < 4 {
+		return false
+	}
+	prefix := c[:4]
+	switch prefix {
+	case "0302", "0300": // GPU (3D controller, VGA)
+		return true
+	case "0200": // Ethernet controller (NIC)
+		return true
+	case "0c06": // InfiniBand controller
+		return true
+	case "0207": // InfiniBand network controller (e.g. Crusoe B200 RDMA NICs report 0x020700)
+		return true
+	case "0604": // PCI bridge
+		return true
+	}
+	return false
+}
+
+// collectDeviceAttrs reads sysfs attributes from the given directory path.
+func collectDeviceAttrs(addr, realPath, devDir string) PCIDeviceAttr {
+	return PCIDeviceAttr{
+		Address:          addr,
+		RealPath:         realPath,
+		Class:            readSysfsFile(path.Join(devDir, "class")),
+		Vendor:           readSysfsFile(path.Join(devDir, "vendor")),
+		Device:           readSysfsFile(path.Join(devDir, "device")),
+		SubsystemVendor:  readSysfsFile(path.Join(devDir, "subsystem_vendor")),
+		SubsystemDevice:  readSysfsFile(path.Join(devDir, "subsystem_device")),
+		NumaNode:         readSysfsFile(path.Join(devDir, "numa_node")),
+		LocalCPUs:        readSysfsFile(path.Join(devDir, "local_cpus")),
+		LocalCPUList:     readSysfsFile(path.Join(devDir, "local_cpulist")),
+		MaxLinkSpeed:     readSysfsFile(path.Join(devDir, "max_link_speed")),
+		MaxLinkWidth:     readSysfsFile(path.Join(devDir, "max_link_width")),
+		CurrentLinkSpeed: readSysfsFile(path.Join(devDir, "current_link_speed")),
+		CurrentLinkWidth: readSysfsFile(path.Join(devDir, "current_link_width")),
+	}
+}
+
+// CollectPCIDeviceData reads PCI device sysfs attributes for devices
+// relevant to NCCL topology discovery, including all ancestor bridge
+// devices in the PCI hierarchy. This must be called before pivot_root
+// while the host sysfs is still accessible.
+func CollectPCIDeviceData() *PCIDevicesData {
+	pciPath := "/sys/bus/pci/devices"
+	dents, err := os.ReadDir(pciPath)
+	if err != nil {
+		log.Infof("pci collect: %s not accessible: %v", pciPath, err)
+		return nil
+	}
+
+	// First pass: find relevant leaf devices and resolve their real paths.
+	type leafDev struct {
+		addr     string
+		realPath string
+	}
+	var leaves []leafDev
+	for _, dent := range dents {
+		devDir := path.Join(pciPath, dent.Name())
+		class := readSysfsFile(path.Join(devDir, "class"))
+		if class == "" || !pciClassRelevant(class) {
+			continue
+		}
+		realPath, err := filepath.EvalSymlinks(devDir)
+		if err != nil {
+			realPath = devDir
+		}
+		leaves = append(leaves, leafDev{addr: dent.Name(), realPath: realPath})
+	}
+
+	// Second pass: collect all unique paths in the ancestor chains.
+	// NCCL walks UP the /sys/devices/pci*/ hierarchy to compute PCI
+	// distances, so we need every bridge in the chain.
+	collected := make(map[string]bool)
+	data := &PCIDevicesData{}
+	for _, leaf := range leaves {
+		p := leaf.realPath
+		for p != "" && strings.Contains(p, "/pci") {
+			if collected[p] {
+				break
+			}
+			collected[p] = true
+			addr := filepath.Base(p)
+			dev := collectDeviceAttrs(addr, p, p)
+			data.Devices = append(data.Devices, dev)
+			p = filepath.Dir(p)
+		}
+	}
+
+	// Sort by path for deterministic output.
+	sort.Slice(data.Devices, func(i, j int) bool {
+		return data.Devices[i].RealPath < data.Devices[j].RealPath
+	})
+
+	log.Infof("pci collect: collected %d device(s) in hierarchy from %d leaf devices",
+		len(data.Devices), len(leaves))
+	return data
+}
+
+// PCIDevicesDataPath is the path within the chroot where serialized PCI
+// device data is stored between boot stages.
+const PCIDevicesDataPath = "/var/lib/gvisor/pci_devices_data.json"
+
+// SerializePCIDevicesData writes the collected data as JSON to the given path.
+func SerializePCIDevicesData(data *PCIDevicesData, filePath string) error {
+	if data == nil {
+		return nil
+	}
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, b, 0644)
+}
+
+// DeserializePCIDevicesData reads serialized PCI device data from the given path.
+func DeserializePCIDevicesData(filePath string) *PCIDevicesData {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Infof("pci deserialize: %s: %v", filePath, err)
+		return nil
+	}
+	var data PCIDevicesData
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Warningf("pci deserialize: unmarshal %s: %v", filePath, err)
+		return nil
+	}
+	log.Infof("pci deserialize: loaded %d device(s) from %s", len(data.Devices), filePath)
+	return &data
+}
+
+// newPCIDevicesSysfsEntries builds the virtual sysfs tree for PCI device
+// topology. It creates:
+//   - /sys/devices/pci<ROOT>/<BRIDGE>/.../<DEV>/ nested hierarchy with
+//     class, vendor, device, numa_node, local_cpulist, etc. at each level
+//   - /sys/devices/pci<ROOT>/.../<PARENT>/pci_bus/<BUS>/ directories so
+//     NCCL's "../../<DEV>" path resolution works
+//   - /sys/class/pci_bus/<BUS> symlinks into the devices hierarchy
+//   - /sys/bus/pci/devices/<ADDR> symlinks into the devices hierarchy
+//
+// NCCL discovers topology by:
+//  1. Constructing "/sys/class/pci_bus/<BUS>/../../<BUS:DEV.FN>"
+//  2. Calling realpath() which resolves through the symlink
+//  3. Walking UP the resolved path reading "class" to find bridges
+//  4. Using the hierarchy depth to compute PCI distance between devices
+func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth.Credentials, data *PCIDevicesData) (devicesSub, pciBusSub, busPCIDevicesSub map[string]kernfs.Inode, pciSlotToRelPath map[string]string) {
+	if data == nil || len(data.Devices) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	log.Infof("pci sysfs: building virtual sysfs for %d device(s)", len(data.Devices))
+
+	// Build a nested map representing the /sys/devices/ tree.
+	// Key: path relative to /sys/ (e.g., "devices/pci0000:07/0000:07:01.0")
+	// Value: map of child name -> inode
+	type dirNode struct {
+		children map[string]*dirNode
+		files    map[string]string // attribute files
+		symlinks map[string]string // child symlink name -> target
+	}
+	root := &dirNode{children: make(map[string]*dirNode), files: make(map[string]string), symlinks: make(map[string]string)}
+
+	getOrCreate := func(pathFromSys string) *dirNode {
+		parts := strings.Split(pathFromSys, "/")
+		cur := root
+		for _, part := range parts {
+			if part == "" {
+				continue
+			}
+			if cur.children[part] == nil {
+				cur.children[part] = &dirNode{
+					children: make(map[string]*dirNode),
+					files:    make(map[string]string),
+					symlinks: make(map[string]string),
+				}
+			}
+			cur = cur.children[part]
+		}
+		return cur
+	}
+
+	// pciBusEntries: bus number -> relative symlink target from /sys/class/pci_bus/<bus>
+	pciBusSymlinks := make(map[string]string)
+	// busPCIDevicesSymlinks: addr -> relative symlink target from /sys/bus/pci/devices/<addr>
+	busPCIDevicesSymlinks := make(map[string]string)
+	pciAddrToRelPath := make(map[string]string)
+
+	for _, dev := range data.Devices {
+
+		// dev.RealPath is e.g. "/sys/devices/pci0000:07/0000:07:01.0/0000:0f:00.0"
+		// Convert to relative path from /sys/
+		relPath := strings.TrimPrefix(dev.RealPath, "/sys/")
+		if relPath == dev.RealPath {
+			continue // not under /sys
+		}
+		pciAddrToRelPath[strings.ToLower(dev.Address)] = relPath
+		node := getOrCreate(relPath)
+		node.files["class"] = dev.Class
+		node.files["vendor"] = dev.Vendor
+		node.files["device"] = dev.Device
+		node.files["subsystem_vendor"] = dev.SubsystemVendor
+		node.files["subsystem_device"] = dev.SubsystemDevice
+		node.files["numa_node"] = dev.NumaNode
+		node.files["local_cpus"] = dev.LocalCPUs
+		node.files["local_cpulist"] = dev.LocalCPUList
+		node.files["max_link_speed"] = dev.MaxLinkSpeed
+		node.files["max_link_width"] = dev.MaxLinkWidth
+		node.files["current_link_speed"] = dev.CurrentLinkSpeed
+		node.files["current_link_width"] = dev.CurrentLinkWidth
+
+		// Create pci_bus entry for this device's secondary bus.
+		// The bus number is the first two hex groups of the address (domain:bus).
+		// E.g., for device "0000:0f:00.0", bus is "0000:0f".
+		addr := dev.Address
+		if len(addr) >= 7 && strings.Count(addr, ":") >= 2 {
+			bus := addr[:7] // "0000:0f"
+			// pci_bus/<bus> lives inside the PARENT device directory.
+			parentRelPath := filepath.Dir(relPath)
+			if parentRelPath != "." && parentRelPath != relPath {
+				// Create pci_bus/<bus> subdir in parent
+				pciBusNode := getOrCreate(parentRelPath + "/pci_bus/" + bus)
+				_ = pciBusNode // just ensure it exists
+
+				// Symlink: /sys/class/pci_bus/<bus> -> ../../devices/pci.../pci_bus/<bus>
+				pciBusSymlinks[bus] = "../../" + parentRelPath + "/pci_bus/" + bus
+			}
+
+			// Symlink: /sys/bus/pci/devices/<addr> -> ../../../devices/pci.../<addr>
+			busPCIDevicesSymlinks[addr] = "../../../" + relPath
+		}
+	}
+
+	// Convert the tree to kernfs inodes.
+	var buildDir func(node *dirNode) map[string]kernfs.Inode
+	buildDir = func(node *dirNode) map[string]kernfs.Inode {
+		entries := make(map[string]kernfs.Inode)
+		for name, val := range node.files {
+			if val != "" {
+				entries[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
+			}
+		}
+		for name, target := range node.symlinks {
+			entries[name] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+		}
+		for name, child := range node.children {
+			entries[name] = fs.newDir(ctx, creds, defaultSysDirMode, buildDir(child))
+		}
+		return entries
+	}
+
+	// Build /sys/devices/ subtree (pci0000:XX roots)
+	devicesSub = make(map[string]kernfs.Inode)
+	for name, child := range root.children {
+		if name == "devices" {
+			for devName, devChild := range child.children {
+				devicesSub[devName] = fs.newDir(ctx, creds, defaultSysDirMode, buildDir(devChild))
+			}
+		}
+	}
+
+	// Build /sys/class/pci_bus/ entries as symlinks
+	pciBusSub = make(map[string]kernfs.Inode)
+	for bus, target := range pciBusSymlinks {
+		pciBusSub[bus] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+	}
+
+	// Build /sys/bus/pci/devices/ entries as symlinks
+	busPCIDevicesSub = make(map[string]kernfs.Inode)
+	for addr, target := range busPCIDevicesSymlinks {
+		busPCIDevicesSub[addr] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+	}
+
+	log.Infof("pci sysfs: created %d device tree entries, %d pci_bus symlinks, %d bus/pci/devices symlinks",
+		len(devicesSub), len(pciBusSub), len(busPCIDevicesSub))
+	return devicesSub, pciBusSub, busPCIDevicesSub, pciAddrToRelPath
+}

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -90,8 +90,72 @@ func pciClassRelevant(class string) bool {
 		return true
 	case 0x0604: // PCI bridge
 		return true
+	case "0680": // NVSwitch
+		return true
 	}
 	return false
+}
+
+// pciClassIsNIC returns true if the PCI class code is a network device
+// (Ethernet or InfiniBand controller). Used to gate NIC-class devices
+// against RDMA availability — see rdmaUsablePCISlotNames for the rules on
+// which NIC PCI devices are kept in the virtual PCI tree.
+func pciClassIsNIC(class string) bool {
+	c := strings.TrimPrefix(class, "0x")
+	if len(c) < 4 {
+		return false
+	}
+	prefix := c[:4]
+	// 0200 Ethernet, 0207 InfiniBand network controller (Crusoe B200/EFA),
+	// 0c06 InfiniBand controller.
+	return prefix == "0200" || prefix == "0207" || prefix == "0c06"
+}
+
+// rdmaUsablePCISlotNames returns the set of PCI slot names (lowercase) for
+// RDMA devices that should remain in the virtual PCI tree. A NIC-class PCI
+// device is only useful to NCCL if it backs an RDMA device the sandbox can
+// actually use; the rules differ by link layer:
+//
+//   - InfiniBand link-layer devices are driven directly through uverbs and
+//     need no netdev in the sandbox netns, so they are always kept. Their PCI
+//     entry is required so /sys/class/infiniband/<dev>/device can be a symlink
+//     into the PCI tree (NCCL realpath()s it to place the NIC near its GPU).
+//   - RoCE (Ethernet link-layer) devices are only usable once their netdev has
+//     been moved into the sandbox netns, i.e. a GID entry has a valid ndev.
+//     RoCE NICs without a moved ndev are excluded so NCCL's topology graph
+//     doesn't create dangling NET nodes ("Could not find NET with id N").
+//
+// Returns nil when rdmaData is nil (no RDMA info => no NIC filtering).
+func rdmaUsablePCISlotNames(rdmaData *RDMAData) map[string]bool {
+	if rdmaData == nil {
+		return nil
+	}
+	slots := make(map[string]bool)
+	for _, dev := range rdmaData.Devices {
+		if dev.PCISlotName == "" {
+			continue
+		}
+		keep := false
+		for _, p := range dev.Ports {
+			if p.LinkLayer == "InfiniBand" {
+				keep = true
+				break
+			}
+			for _, g := range p.GIDs {
+				if g.NetDev != "" {
+					keep = true
+					break
+				}
+			}
+			if keep {
+				break
+			}
+		}
+		if keep {
+			slots[strings.ToLower(dev.PCISlotName)] = true
+		}
+	}
+	return slots
 }
 
 // collectDeviceAttrs reads sysfs attributes from the given directory path.
@@ -227,12 +291,26 @@ func DeserializePCIDevicesData(filePath string) *PCIDevicesData {
 //  2. Calling realpath() which resolves through the symlink
 //  3. Walking UP the resolved path reading "class" to find bridges
 //  4. Using the hierarchy depth to compute PCI distance between devices
-func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth.Credentials, data *PCIDevicesData) (devicesSub, pciBusSub, busPCIDevicesSub map[string]kernfs.Inode, pciSlotToRelPath map[string]string) {
+func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth.Credentials, data *PCIDevicesData, rdmaData *RDMAData) (devicesSub, pciBusSub, busPCIDevicesSub map[string]kernfs.Inode, pciSlotToRelPath map[string]string) {
 	if data == nil || len(data.Devices) == 0 {
 		return nil, nil, nil, nil
 	}
 
-	log.Infof("pci sysfs: building virtual sysfs for %d device(s)", len(data.Devices))
+	usableNICSlots := rdmaUsablePCISlotNames(rdmaData)
+
+	kept, skipped := 0, 0
+	for _, dev := range data.Devices {
+		if pciClassIsNIC(dev.Class) {
+			addr := strings.ToLower(dev.Address)
+			if usableNICSlots != nil && !usableNICSlots[addr] {
+				skipped++
+				continue
+			}
+		}
+		kept++
+	}
+
+	log.Infof("pci sysfs: building virtual sysfs for %d device(s) (%d unusable NIC(s) skipped)", kept, skipped)
 
 	// Build a nested map representing the /sys/devices/ tree.
 	// Key: path relative to /sys/ (e.g., "devices/pci0000:07/0000:07:01.0")
@@ -270,6 +348,12 @@ func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth
 	pciAddrToRelPath := make(map[string]string)
 
 	for _, dev := range data.Devices {
+		if pciClassIsNIC(dev.Class) {
+			addr := strings.ToLower(dev.Address)
+			if usableNICSlots != nil && !usableNICSlots[addr] {
+				continue
+			}
+		}
 
 		// dev.RealPath is e.g. "/sys/devices/pci0000:07/0000:07:01.0/0000:0f:00.0"
 		// Convert to relative path from /sys/
@@ -292,6 +376,37 @@ func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth
 		node.files["current_link_speed"] = dev.CurrentLinkSpeed
 		node.files["current_link_width"] = dev.CurrentLinkWidth
 
+		if pciClassIsNIC(dev.Class) && rdmaData != nil {
+			addr := strings.ToLower(dev.Address)
+			for _, rd := range rdmaData.Devices {
+				if strings.ToLower(rd.PCISlotName) != addr {
+					continue
+				}
+				if rd.Modalias != "" {
+					node.files["modalias"] = rd.Modalias
+				}
+				uevent := ""
+				if rd.PCIDriver != "" {
+					uevent += "DRIVER=" + rd.PCIDriver + "\n"
+				}
+				if dev.Class != "" {
+					uevent += "PCI_CLASS=" + strings.TrimPrefix(dev.Class, "0x") + "\n"
+				}
+				if dev.Vendor != "" && dev.Device != "" {
+					uevent += "PCI_ID=" + strings.TrimPrefix(strings.ToUpper(dev.Vendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.Device), "0X") + "\n"
+				}
+				if dev.SubsystemVendor != "" && dev.SubsystemDevice != "" {
+					uevent += "PCI_SUBSYS_ID=" + strings.TrimPrefix(strings.ToUpper(dev.SubsystemVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.SubsystemDevice), "0X") + "\n"
+				}
+				uevent += "PCI_SLOT_NAME=" + rd.PCISlotName + "\n"
+				if rd.Modalias != "" {
+					uevent += "MODALIAS=" + rd.Modalias + "\n"
+				}
+				node.files["uevent"] = uevent
+				break
+			}
+		}
+
 		// Create pci_bus entry for this device's secondary bus.
 		// The bus number is the first two hex groups of the address (domain:bus).
 		// E.g., for device "0000:0f:00.0", bus is "0000:0f".
@@ -307,10 +422,41 @@ func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth
 
 				// Symlink: /sys/class/pci_bus/<bus> -> ../../devices/pci.../pci_bus/<bus>
 				pciBusSymlinks[bus] = "../../" + parentRelPath + "/pci_bus/" + bus
+
+				upper := strings.ToUpper(bus)
+				if upper != bus {
+					pciBusSymlinks[upper] = "../../" + parentRelPath + "/pci_bus/" + upper
+					getOrCreate(parentRelPath + "/pci_bus/" + upper)
+				}
 			}
 
 			// Symlink: /sys/bus/pci/devices/<addr> -> ../../../devices/pci.../<addr>
 			busPCIDevicesSymlinks[addr] = "../../../" + relPath
+			upper := strings.ToUpper(addr)
+			if upper != addr {
+				busPCIDevicesSymlinks[upper] = "../../../" + relPath
+			}
+		}
+	}
+
+	if rdmaData != nil {
+		for _, dev := range rdmaData.Devices {
+			if dev.IBDev == "" || dev.PCISlotName == "" {
+				continue
+			}
+			relPath, ok := pciAddrToRelPath[strings.ToLower(dev.PCISlotName)]
+			if !ok {
+				continue
+			}
+			infinibandDir := getOrCreate(relPath + "/infiniband")
+			linkDir := filepath.Join("/sys", relPath, "infiniband")
+			target := filepath.Join("/sys/class/infiniband", dev.IBDev)
+			relTarget, err := filepath.Rel(linkDir, target)
+			if err != nil {
+				log.Warningf("pci sysfs: relative symlink for %s/%s: %v", relPath, dev.IBDev, err)
+				continue
+			}
+			infinibandDir.symlinks[dev.IBDev] = relTarget
 		}
 	}
 

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
@@ -64,8 +66,8 @@ type RDMADeviceData struct {
 	Ports      []RDMAPortData `json:"ports"`
 
 	// PCI device attributes from /sys/class/infiniband/<ibdev>/device/.
-	// libibverbs reads modalias for driver matching; NCCL reads
-	// PCI_SLOT_NAME from uevent to match NICs against GPU topology.
+	// NCCL reads these (especially PCI_SLOT_NAME from uevent) to match
+	// NIC PCI bus IDs against GPU bus IDs in the topology XML.
 	PCISlotName     string `json:"pci_slot_name,omitempty"`
 	PCIDriver       string `json:"pci_driver,omitempty"`
 	PCIClass        string `json:"pci_class,omitempty"`
@@ -81,10 +83,27 @@ type RDMADeviceData struct {
 	DynMajor uint32 `json:"-"`
 }
 
+// RDMANetDeviceData contains the minimal sysfs attributes NCCL/libibverbs read
+// from /sys/class/net/<name>/ when selecting and characterizing NICs.
+type RDMANetDeviceData struct {
+	Name       string `json:"name"`
+	Type       string `json:"type,omitempty"`
+	Address    string `json:"address,omitempty"`
+	MTU        string `json:"mtu,omitempty"`
+	DevID      string `json:"dev_id,omitempty"`
+	DevPort    string `json:"dev_port,omitempty"`
+	Speed      string `json:"speed,omitempty"`
+	Duplex     string `json:"duplex,omitempty"`
+	OperState  string `json:"operstate,omitempty"`
+	DevicePath string `json:"device_path,omitempty"`
+}
+
 // RDMAData holds all collected RDMA sysfs data.
 type RDMAData struct {
-	VerbsABIVersion string           `json:"verbs_abi_version"`
-	Devices         []RDMADeviceData `json:"devices"`
+	VerbsABIVersion string              `json:"verbs_abi_version"`
+	PeerMemVersion  string              `json:"peer_mem_version,omitempty"`
+	Devices         []RDMADeviceData    `json:"devices"`
+	NetDevices      []RDMANetDeviceData `json:"net_devices,omitempty"`
 }
 
 // CollectRDMADeviceData reads the specific sysfs files that libibverbs
@@ -101,6 +120,20 @@ func CollectRDMADeviceData() *RDMAData {
 		VerbsABIVersion: readSysfsFile(path.Join(verbsPath, "abi_version")),
 	}
 
+	peerMemPaths := []string{
+		"/sys/module/nvidia_peermem/version",
+		"/sys/kernel/mm/memory_peers/nv_mem/version",
+		"/sys/kernel/mm/memory_peers/nv_mem_nc/version",
+	}
+	for _, p := range peerMemPaths {
+		if v := readSysfsFile(p); v != "" {
+			data.PeerMemVersion = v
+			log.Infof("rdma collect: nvidia_peermem version=%q (from %s)", v, p)
+			break
+		}
+	}
+
+	netDevices := make(map[string]struct{})
 	log.Infof("rdma collect: scanning %s (%d entries), verbs_abi=%q",
 		verbsPath, len(dents), data.VerbsABIVersion)
 	for _, dent := range dents {
@@ -174,6 +207,9 @@ func CollectRDMADeviceData() *RDMAData {
 							Type:   typeVal,
 							NetDev: ndevVal,
 						})
+						if ndevVal != "" {
+							netDevices[ndevVal] = struct{}{}
+						}
 					}
 				}
 				log.Infof("rdma collect:   port %s: state=%q link_layer=%q rate=%q gids=%d",
@@ -183,8 +219,36 @@ func CollectRDMADeviceData() *RDMAData {
 		}
 		data.Devices = append(data.Devices, dev)
 	}
+	data.NetDevices = collectRDMANetDevices(netDevices)
 	log.Infof("rdma collect: collected %d device(s)", len(data.Devices))
 	return data
+}
+
+func collectRDMANetDevices(names map[string]struct{}) []RDMANetDeviceData {
+	if len(names) == 0 {
+		return nil
+	}
+	var netDevices []RDMANetDeviceData
+	for name := range names {
+		netDir := path.Join("/sys/class/net", name)
+		devicePath, err := filepath.EvalSymlinks(path.Join(netDir, "device"))
+		if err != nil {
+			devicePath = ""
+		}
+		netDevices = append(netDevices, RDMANetDeviceData{
+			Name:       name,
+			Type:       readSysfsFile(path.Join(netDir, "type")),
+			Address:    readSysfsFile(path.Join(netDir, "address")),
+			MTU:        readSysfsFile(path.Join(netDir, "mtu")),
+			DevID:      readSysfsFile(path.Join(netDir, "dev_id")),
+			DevPort:    readSysfsFile(path.Join(netDir, "dev_port")),
+			Speed:      readSysfsFile(path.Join(netDir, "speed")),
+			Duplex:     readSysfsFile(path.Join(netDir, "duplex")),
+			OperState:  readSysfsFile(path.Join(netDir, "operstate")),
+			DevicePath: devicePath,
+		})
+	}
+	return netDevices
 }
 
 // RDMADataPath is the path within the chroot where serialized RDMA data
@@ -301,7 +365,7 @@ func readSysfsFile(filePath string) string {
 
 // newRDMASysfsEntries creates /sys/class/infiniband_verbs/ and
 // /sys/class/infiniband/ directories from pre-collected device data.
-func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData) (ibVerbsDir, ibDir map[string]kernfs.Inode) {
+func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData, pciSlotToRelPath map[string]string) (ibVerbsDir, ibDir map[string]kernfs.Inode) {
 	if data == nil || len(data.Devices) == 0 {
 		log.Infof("rdma sysfs: no RDMA data, skipping sysfs construction")
 		return nil, nil
@@ -343,41 +407,28 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 		addFile(ibDevEntries, "node_guid", dev.NodeGUID)
 		addFile(ibDevEntries, "sys_image_guid", dev.SysImgGUID)
 		addFile(ibDevEntries, "fw_ver", dev.FWVer)
-		// Build the device/ subdirectory with PCI attributes.
-		// libibverbs reads modalias for driver matching; NCCL reads
-		// uevent for PCI_SLOT_NAME to match NICs against GPU topology.
-		deviceEntries := map[string]kernfs.Inode{}
-		addFile(deviceEntries, "modalias", dev.Modalias)
-		addFile(deviceEntries, "class", dev.PCIClass)
-		addFile(deviceEntries, "vendor", dev.PCIVendor)
-		addFile(deviceEntries, "device", dev.PCIDevice)
-		addFile(deviceEntries, "subsystem_vendor", dev.PCISubsysVendor)
-		addFile(deviceEntries, "subsystem_device", dev.PCISubsysDevice)
-		addFile(deviceEntries, "numa_node", dev.NUMANode)
-		addFile(deviceEntries, "local_cpulist", dev.LocalCPUList)
+		// Create the device/ entry. On real Linux this is a symlink from
+		// /sys/class/infiniband/<ibdev>/device -> /sys/devices/pci0000:XX/...
+		// NCCL calls realpath() on this to find the PCI device path and
+		// place NICs in the PCI topology tree for distance computation.
 		if dev.PCISlotName != "" {
-			uevent := ""
-			if dev.PCIDriver != "" {
-				uevent += "DRIVER=" + dev.PCIDriver + "\n"
+			if relPath, ok := pciSlotToRelPath[strings.ToLower(dev.PCISlotName)]; ok {
+				target := "../../../" + relPath
+				ibDevEntries["device"] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+				log.Infof("rdma sysfs: %s device -> %s (symlink to PCI tree)", dev.IBDev, target)
+			} else {
+				log.Warningf("rdma sysfs: %s PCI_SLOT_NAME=%s has no matching PCI device; creating device/ as directory (degraded topology)", dev.IBDev, dev.PCISlotName)
+				deviceEntries := map[string]kernfs.Inode{}
+				addFile(deviceEntries, "modalias", dev.Modalias)
+				addFile(deviceEntries, "class", dev.PCIClass)
+				addFile(deviceEntries, "vendor", dev.PCIVendor)
+				addFile(deviceEntries, "device", dev.PCIDevice)
+				addFile(deviceEntries, "subsystem_vendor", dev.PCISubsysVendor)
+				addFile(deviceEntries, "subsystem_device", dev.PCISubsysDevice)
+				addFile(deviceEntries, "numa_node", dev.NUMANode)
+				addFile(deviceEntries, "local_cpulist", dev.LocalCPUList)
+				ibDevEntries["device"] = fs.newDir(ctx, creds, defaultSysDirMode, deviceEntries)
 			}
-			if dev.PCIClass != "" {
-				uevent += "PCI_CLASS=" + strings.TrimPrefix(dev.PCIClass, "0x") + "\n"
-			}
-			if dev.PCIVendor != "" && dev.PCIDevice != "" {
-				uevent += "PCI_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCIVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCIDevice), "0X") + "\n"
-			}
-			if dev.PCISubsysVendor != "" && dev.PCISubsysDevice != "" {
-				uevent += "PCI_SUBSYS_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysDevice), "0X") + "\n"
-			}
-			uevent += "PCI_SLOT_NAME=" + dev.PCISlotName + "\n"
-			if dev.Modalias != "" {
-				uevent += "MODALIAS=" + dev.Modalias + "\n"
-			}
-			deviceEntries["uevent"] = fs.newStaticFile(ctx, creds, defaultSysMode, uevent)
-			log.Infof("rdma sysfs: %s device/uevent: PCI_SLOT_NAME=%s", dev.IBDev, dev.PCISlotName)
-		}
-		if len(deviceEntries) > 0 {
-			ibDevEntries["device"] = fs.newDir(ctx, creds, defaultSysDirMode, deviceEntries)
 		}
 		if len(dev.Ports) > 0 {
 			portsDir := map[string]kernfs.Inode{}
@@ -420,4 +471,34 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 		ibDir[dev.IBDev] = fs.newDir(ctx, creds, defaultSysDirMode, ibDevEntries)
 	}
 	return ibVerbsDir, ibDir
+}
+
+func (fs *filesystem) newRDMANetClassEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData) map[string]kernfs.Inode {
+	if data == nil || len(data.NetDevices) == 0 {
+		return nil
+	}
+	netDir := make(map[string]kernfs.Inode)
+	addFile := func(m map[string]kernfs.Inode, name, val string) {
+		if val != "" {
+			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
+		}
+	}
+	for _, dev := range data.NetDevices {
+		entries := make(map[string]kernfs.Inode)
+		addFile(entries, "type", dev.Type)
+		addFile(entries, "address", dev.Address)
+		addFile(entries, "mtu", dev.MTU)
+		addFile(entries, "dev_id", dev.DevID)
+		addFile(entries, "dev_port", dev.DevPort)
+		addFile(entries, "speed", dev.Speed)
+		addFile(entries, "duplex", dev.Duplex)
+		addFile(entries, "operstate", dev.OperState)
+		if strings.HasPrefix(dev.DevicePath, "/sys/") {
+			target := "../../../" + strings.TrimPrefix(dev.DevicePath, "/sys/")
+			entries["device"] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+		}
+		netDir[dev.Name] = fs.newDir(ctx, creds, defaultSysDirMode, entries)
+	}
+	log.Infof("rdma sysfs: built virtual /sys/class/net entries for %d device(s)", len(netDir))
+	return netDir
 }

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -379,6 +379,12 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
 		}
 	}
+	// addHostFile serves attrs whose host values can change after collect.
+	// Requires the corresponding path to be bind-mounted into the sentry
+	// chroot (see rdmaProxyUpdateChroot).
+	addHostFile := func(m map[string]kernfs.Inode, name, hostPath string) {
+		m[name] = fs.newHostFile(ctx, creds, defaultSysMode, hostPath)
+	}
 	addFile(ibVerbsDir, "abi_version", data.VerbsABIVersion)
 
 	for _, dev := range data.Devices {
@@ -435,23 +441,24 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 			for _, port := range dev.Ports {
 				log.Infof("rdma sysfs:   port %s: state=%q link_layer=%q rate=%q",
 					port.Number, port.State, port.LinkLayer, port.Rate)
+				portBase := path.Join("/sys/class/infiniband", dev.IBDev, "ports", port.Number)
 				portEntries := map[string]kernfs.Inode{}
-				addFile(portEntries, "state", port.State)
-				addFile(portEntries, "phys_state", port.PhysState)
+				addHostFile(portEntries, "state", path.Join(portBase, "state"))
+				addHostFile(portEntries, "phys_state", path.Join(portBase, "phys_state"))
 				addFile(portEntries, "link_layer", port.LinkLayer)
-				addFile(portEntries, "rate", port.Rate)
-				addFile(portEntries, "lid", port.LID)
-				addFile(portEntries, "sm_lid", port.SMLID)
-				addFile(portEntries, "sm_sl", port.SMSL)
+				addHostFile(portEntries, "rate", path.Join(portBase, "rate"))
+				addHostFile(portEntries, "lid", path.Join(portBase, "lid"))
+				addHostFile(portEntries, "sm_lid", path.Join(portBase, "sm_lid"))
+				addHostFile(portEntries, "sm_sl", path.Join(portBase, "sm_sl"))
 				addFile(portEntries, "cap_mask", port.CapMask)
 				if len(port.GIDs) > 0 {
 					gidsEntries := map[string]kernfs.Inode{}
 					typesEntries := map[string]kernfs.Inode{}
 					ndevsEntries := map[string]kernfs.Inode{}
 					for _, gid := range port.GIDs {
-						addFile(gidsEntries, gid.Index, gid.GID)
+						addHostFile(gidsEntries, gid.Index, path.Join(portBase, "gids", gid.Index))
 						addFile(typesEntries, gid.Index, gid.Type)
-						addFile(ndevsEntries, gid.Index, gid.NetDev)
+						addHostFile(ndevsEntries, gid.Index, path.Join(portBase, "gid_attrs", "ndevs", gid.Index))
 					}
 					log.Infof("rdma sysfs:   port %s: %d gids, gidsEntries=%d typesEntries=%d ndevsEntries=%d",
 						port.Number, len(port.GIDs), len(gidsEntries), len(typesEntries), len(ndevsEntries))
@@ -483,16 +490,20 @@ func (fs *filesystem) newRDMANetClassEntries(ctx context.Context, creds *auth.Cr
 			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
 		}
 	}
+	addHostFile := func(m map[string]kernfs.Inode, name, hostPath string) {
+		m[name] = fs.newHostFile(ctx, creds, defaultSysMode, hostPath)
+	}
 	for _, dev := range data.NetDevices {
+		netBase := path.Join("/sys/class/net", dev.Name)
 		entries := make(map[string]kernfs.Inode)
 		addFile(entries, "type", dev.Type)
-		addFile(entries, "address", dev.Address)
-		addFile(entries, "mtu", dev.MTU)
+		addHostFile(entries, "address", path.Join(netBase, "address"))
+		addHostFile(entries, "mtu", path.Join(netBase, "mtu"))
 		addFile(entries, "dev_id", dev.DevID)
 		addFile(entries, "dev_port", dev.DevPort)
-		addFile(entries, "speed", dev.Speed)
-		addFile(entries, "duplex", dev.Duplex)
-		addFile(entries, "operstate", dev.OperState)
+		addHostFile(entries, "speed", path.Join(netBase, "speed"))
+		addHostFile(entries, "duplex", path.Join(netBase, "duplex"))
+		addHostFile(entries, "operstate", path.Join(netBase, "operstate"))
 		if strings.HasPrefix(dev.DevicePath, "/sys/") {
 			target := "../../../" + strings.TrimPrefix(dev.DevicePath, "/sys/")
 			entries["device"] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -1,0 +1,423 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// RDMAGIDEntry contains a single GID table entry and its RoCE type.
+type RDMAGIDEntry struct {
+	Index  string `json:"index"`
+	GID    string `json:"gid"`
+	Type   string `json:"type"`
+	NetDev string `json:"net_dev,omitempty"`
+}
+
+// RDMAPortData contains sysfs attributes for one port.
+type RDMAPortData struct {
+	Number    string         `json:"number"`
+	State     string         `json:"state"`
+	PhysState string         `json:"phys_state"`
+	LinkLayer string         `json:"link_layer"`
+	Rate      string         `json:"rate"`
+	LID       string         `json:"lid"`
+	SMLID     string         `json:"sm_lid"`
+	SMSL      string         `json:"sm_sl"`
+	CapMask   string         `json:"cap_mask"`
+	GIDs      []RDMAGIDEntry `json:"gids,omitempty"`
+}
+
+// RDMADeviceData contains sysfs data for a single RDMA uverbs device.
+type RDMADeviceData struct {
+	Name       string         `json:"name"`
+	IBDev      string         `json:"ibdev"`
+	ABIVersion string         `json:"abi_version"`
+	Dev        string         `json:"dev"`
+	NodeType   string         `json:"node_type"`
+	NodeGUID   string         `json:"node_guid"`
+	SysImgGUID string         `json:"sys_image_guid"`
+	FWVer      string         `json:"fw_ver"`
+	Modalias   string         `json:"modalias"`
+	Ports      []RDMAPortData `json:"ports"`
+
+	// PCI device attributes from /sys/class/infiniband/<ibdev>/device/.
+	// libibverbs reads modalias for driver matching; NCCL reads
+	// PCI_SLOT_NAME from uevent to match NICs against GPU topology.
+	PCISlotName     string `json:"pci_slot_name,omitempty"`
+	PCIDriver       string `json:"pci_driver,omitempty"`
+	PCIClass        string `json:"pci_class,omitempty"`
+	PCIVendor       string `json:"pci_vendor,omitempty"`
+	PCIDevice       string `json:"pci_device,omitempty"`
+	PCISubsysVendor string `json:"pci_subsys_vendor,omitempty"`
+	PCISubsysDevice string `json:"pci_subsys_device,omitempty"`
+	NUMANode        string `json:"numa_node,omitempty"`
+	LocalCPUList    string `json:"local_cpulist,omitempty"`
+
+	// DynMajor is the sentry-assigned dynamic major for this device.
+	// Set at runtime during device registration, not serialized.
+	DynMajor uint32 `json:"-"`
+}
+
+// RDMAData holds all collected RDMA sysfs data.
+type RDMAData struct {
+	VerbsABIVersion string           `json:"verbs_abi_version"`
+	Devices         []RDMADeviceData `json:"devices"`
+}
+
+// CollectRDMADeviceData reads the specific sysfs files that libibverbs
+// needs for device discovery. Only well-known paths are read — no
+// recursive traversal, no symlink following into PCI device trees.
+func CollectRDMADeviceData() *RDMAData {
+	verbsPath := "/sys/class/infiniband_verbs"
+	dents, err := os.ReadDir(verbsPath)
+	if err != nil {
+		log.Infof("rdma collect: %s not accessible: %v", verbsPath, err)
+		return nil
+	}
+	data := &RDMAData{
+		VerbsABIVersion: readSysfsFile(path.Join(verbsPath, "abi_version")),
+	}
+
+	log.Infof("rdma collect: scanning %s (%d entries), verbs_abi=%q",
+		verbsPath, len(dents), data.VerbsABIVersion)
+	for _, dent := range dents {
+		if !strings.HasPrefix(dent.Name(), "uverbs") {
+			continue
+		}
+		devDir := path.Join(verbsPath, dent.Name())
+		ibdev := readSysfsFile(path.Join(devDir, "ibdev"))
+		if ibdev == "" {
+			log.Warningf("rdma collect: %s has no ibdev, skipping", dent.Name())
+			continue
+		}
+		ibDir := path.Join("/sys/class/infiniband", ibdev)
+		deviceDir := path.Join(ibDir, "device")
+		dev := RDMADeviceData{
+			Name:            dent.Name(),
+			IBDev:           ibdev,
+			ABIVersion:      readSysfsFile(path.Join(devDir, "abi_version")),
+			Dev:             readSysfsFile(path.Join(devDir, "dev")),
+			NodeType:        readSysfsFile(path.Join(ibDir, "node_type")),
+			NodeGUID:        readSysfsFile(path.Join(ibDir, "node_guid")),
+			SysImgGUID:      readSysfsFile(path.Join(ibDir, "sys_image_guid")),
+			FWVer:           readSysfsFile(path.Join(ibDir, "fw_ver")),
+			Modalias:        readSysfsFile(path.Join(deviceDir, "modalias")),
+			PCISlotName:     parseUeventValue(path.Join(deviceDir, "uevent"), "PCI_SLOT_NAME"),
+			PCIDriver:       parseUeventValue(path.Join(deviceDir, "uevent"), "DRIVER"),
+			PCIClass:        readSysfsFile(path.Join(deviceDir, "class")),
+			PCIVendor:       readSysfsFile(path.Join(deviceDir, "vendor")),
+			PCIDevice:       readSysfsFile(path.Join(deviceDir, "device")),
+			PCISubsysVendor: readSysfsFile(path.Join(deviceDir, "subsystem_vendor")),
+			PCISubsysDevice: readSysfsFile(path.Join(deviceDir, "subsystem_device")),
+			NUMANode:        readSysfsFile(path.Join(deviceDir, "numa_node")),
+			LocalCPUList:    readSysfsFile(path.Join(deviceDir, "local_cpulist")),
+		}
+		log.Infof("rdma collect: %s → ibdev=%s dev=%s node_type=%q fw_ver=%q pci=%s numa=%s",
+			dent.Name(), ibdev, dev.Dev, dev.NodeType, dev.FWVer, dev.PCISlotName, dev.NUMANode)
+		portsPath := path.Join(ibDir, "ports")
+		portDents, err := os.ReadDir(portsPath)
+		if err == nil {
+			for _, portDent := range portDents {
+				portDir := path.Join(portsPath, portDent.Name())
+				pd := RDMAPortData{
+					Number:    portDent.Name(),
+					State:     readSysfsFile(path.Join(portDir, "state")),
+					PhysState: readSysfsFile(path.Join(portDir, "phys_state")),
+					LinkLayer: readSysfsFile(path.Join(portDir, "link_layer")),
+					Rate:      readSysfsFile(path.Join(portDir, "rate")),
+					LID:       readSysfsFile(path.Join(portDir, "lid")),
+					SMLID:     readSysfsFile(path.Join(portDir, "sm_lid")),
+					SMSL:      readSysfsFile(path.Join(portDir, "sm_sl")),
+					CapMask:   readSysfsFile(path.Join(portDir, "cap_mask")),
+				}
+				gidsPath := path.Join(portDir, "gids")
+				typesPath := path.Join(portDir, "gid_attrs", "types")
+				ndevsPath := path.Join(portDir, "gid_attrs", "ndevs")
+				gidDents, gerr := os.ReadDir(gidsPath)
+				if gerr == nil {
+					for _, gidDent := range gidDents {
+						gidVal := readSysfsFile(path.Join(gidsPath, gidDent.Name()))
+						typeVal := readSysfsFile(path.Join(typesPath, gidDent.Name()))
+						ndevVal := readSysfsFile(path.Join(ndevsPath, gidDent.Name()))
+						if gidVal == "" {
+							continue
+						}
+						if typeVal == "" && pd.LinkLayer == "Ethernet" {
+							typeVal = inferRoCEType(gidDent.Name())
+						}
+						pd.GIDs = append(pd.GIDs, RDMAGIDEntry{
+							Index:  gidDent.Name(),
+							GID:    gidVal,
+							Type:   typeVal,
+							NetDev: ndevVal,
+						})
+					}
+				}
+				log.Infof("rdma collect:   port %s: state=%q link_layer=%q rate=%q gids=%d",
+					pd.Number, pd.State, pd.LinkLayer, pd.Rate, len(pd.GIDs))
+				dev.Ports = append(dev.Ports, pd)
+			}
+		}
+		data.Devices = append(data.Devices, dev)
+	}
+	log.Infof("rdma collect: collected %d device(s)", len(data.Devices))
+	return data
+}
+
+// RDMADataPath is the path within the chroot where serialized RDMA data
+// is stored between boot stages.
+const RDMADataPath = "/var/lib/gvisor/rdma_data.json"
+
+// SerializeRDMAData writes the collected data as JSON to the given path.
+func SerializeRDMAData(data *RDMAData, filePath string) error {
+	if data == nil {
+		return nil
+	}
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, b, 0644)
+}
+
+// DeserializeRDMAData reads serialized RDMA data from the given path.
+func DeserializeRDMAData(filePath string) *RDMAData {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Infof("rdma deserialize: %s: %v", filePath, err)
+		return nil
+	}
+	var data RDMAData
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Warningf("rdma deserialize: unmarshal %s: %v", filePath, err)
+		return nil
+	}
+	log.Infof("rdma deserialize: loaded %d device(s) from %s (verbs_abi=%q)",
+		len(data.Devices), filePath, data.VerbsABIVersion)
+	for _, d := range data.Devices {
+		log.Infof("rdma deserialize:   %s ibdev=%s dev=%s ports=%d",
+			d.Name, d.IBDev, d.Dev, len(d.Ports))
+		for _, p := range d.Ports {
+			typesWithValues := 0
+			for _, g := range p.GIDs {
+				if g.Type != "" {
+					typesWithValues++
+				}
+			}
+			log.Infof("rdma deserialize:   %s port %s: %d gids, %d with types",
+				d.IBDev, p.Number, len(p.GIDs), typesWithValues)
+		}
+	}
+	return &data
+}
+
+// extractMinor returns the minor portion from a "major:minor" dev string.
+func extractMinor(dev string) string {
+	if idx := strings.IndexByte(dev, ':'); idx >= 0 {
+		return dev[idx+1:]
+	}
+	return "0"
+}
+
+// ExtractMinorUint32 parses the minor portion from a sysfs "major:minor" dev
+// string (e.g. "231:192") and returns it as a uint32. Returns (0, false) if
+// the string is malformed.
+func ExtractMinorUint32(dev string) (uint32, bool) {
+	idx := strings.IndexByte(dev, ':')
+	if idx < 0 {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(dev[idx+1:], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(v), true
+}
+
+// inferRoCEType returns the RoCE GID type based on GID table index.
+// The sandbox's restricted sysfs mount masks gid_attrs/types/ content,
+// so we infer from the well-known mlx5 kernel assignment:
+//   - index 0: RoCE v1 (link-local MAC-derived)
+//   - index 1+: RoCE v2
+//
+// NCCL reads types from sysfs but gets actual GID addresses via ioctl.
+func inferRoCEType(gidIndex string) string {
+	if gidIndex == "0" {
+		return "IB/RoCE v1"
+	}
+	return "RoCE v2"
+}
+
+// parseUeventValue reads a uevent file and extracts the value for the given
+// KEY (matched as "KEY="). Returns empty string if the file doesn't exist or
+// has no matching line.
+func parseUeventValue(ueventPath, key string) string {
+	data, err := os.ReadFile(ueventPath)
+	if err != nil {
+		return ""
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
+}
+
+func readSysfsFile(filePath string) string {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// newRDMASysfsEntries creates /sys/class/infiniband_verbs/ and
+// /sys/class/infiniband/ directories from pre-collected device data.
+func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData) (ibVerbsDir, ibDir map[string]kernfs.Inode) {
+	if data == nil || len(data.Devices) == 0 {
+		log.Infof("rdma sysfs: no RDMA data, skipping sysfs construction")
+		return nil, nil
+	}
+	log.Infof("rdma sysfs: building virtual sysfs for %d device(s), verbs_abi=%q",
+		len(data.Devices), data.VerbsABIVersion)
+	ibVerbsDir = map[string]kernfs.Inode{}
+	ibDir = map[string]kernfs.Inode{}
+	addFile := func(m map[string]kernfs.Inode, name, val string) {
+		if val != "" {
+			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
+		}
+	}
+	addFile(ibVerbsDir, "abi_version", data.VerbsABIVersion)
+
+	for _, dev := range data.Devices {
+		verbsEntries := map[string]kernfs.Inode{}
+		addFile(verbsEntries, "ibdev", dev.IBDev)
+		addFile(verbsEntries, "abi_version", dev.ABIVersion)
+		devVal := dev.Dev
+		if dev.DynMajor != 0 {
+			minor := extractMinor(dev.Dev)
+			devVal = fmt.Sprintf("%d:%s", dev.DynMajor, minor)
+			log.Infof("rdma sysfs: %s dev=%s (patched from host %s, dynMajor=%d)",
+				dev.Name, devVal, dev.Dev, dev.DynMajor)
+		} else {
+			log.Infof("rdma sysfs: %s dev=%s (no dynMajor, using host value)", dev.Name, devVal)
+		}
+		addFile(verbsEntries, "dev", devVal)
+		ibVerbsDir[dev.Name] = fs.newDir(ctx, creds, defaultSysDirMode, verbsEntries)
+
+		if dev.IBDev == "" {
+			continue
+		}
+		log.Infof("rdma sysfs: %s → ibdev=%s node_type=%q fw_ver=%q guid=%s ports=%d",
+			dev.Name, dev.IBDev, dev.NodeType, dev.FWVer, dev.NodeGUID, len(dev.Ports))
+		ibDevEntries := map[string]kernfs.Inode{}
+		addFile(ibDevEntries, "node_type", dev.NodeType)
+		addFile(ibDevEntries, "node_guid", dev.NodeGUID)
+		addFile(ibDevEntries, "sys_image_guid", dev.SysImgGUID)
+		addFile(ibDevEntries, "fw_ver", dev.FWVer)
+		// Build the device/ subdirectory with PCI attributes.
+		// libibverbs reads modalias for driver matching; NCCL reads
+		// uevent for PCI_SLOT_NAME to match NICs against GPU topology.
+		deviceEntries := map[string]kernfs.Inode{}
+		addFile(deviceEntries, "modalias", dev.Modalias)
+		addFile(deviceEntries, "class", dev.PCIClass)
+		addFile(deviceEntries, "vendor", dev.PCIVendor)
+		addFile(deviceEntries, "device", dev.PCIDevice)
+		addFile(deviceEntries, "subsystem_vendor", dev.PCISubsysVendor)
+		addFile(deviceEntries, "subsystem_device", dev.PCISubsysDevice)
+		addFile(deviceEntries, "numa_node", dev.NUMANode)
+		addFile(deviceEntries, "local_cpulist", dev.LocalCPUList)
+		if dev.PCISlotName != "" {
+			uevent := ""
+			if dev.PCIDriver != "" {
+				uevent += "DRIVER=" + dev.PCIDriver + "\n"
+			}
+			if dev.PCIClass != "" {
+				uevent += "PCI_CLASS=" + strings.TrimPrefix(dev.PCIClass, "0x") + "\n"
+			}
+			if dev.PCIVendor != "" && dev.PCIDevice != "" {
+				uevent += "PCI_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCIVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCIDevice), "0X") + "\n"
+			}
+			if dev.PCISubsysVendor != "" && dev.PCISubsysDevice != "" {
+				uevent += "PCI_SUBSYS_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysDevice), "0X") + "\n"
+			}
+			uevent += "PCI_SLOT_NAME=" + dev.PCISlotName + "\n"
+			if dev.Modalias != "" {
+				uevent += "MODALIAS=" + dev.Modalias + "\n"
+			}
+			deviceEntries["uevent"] = fs.newStaticFile(ctx, creds, defaultSysMode, uevent)
+			log.Infof("rdma sysfs: %s device/uevent: PCI_SLOT_NAME=%s", dev.IBDev, dev.PCISlotName)
+		}
+		if len(deviceEntries) > 0 {
+			ibDevEntries["device"] = fs.newDir(ctx, creds, defaultSysDirMode, deviceEntries)
+		}
+		if len(dev.Ports) > 0 {
+			portsDir := map[string]kernfs.Inode{}
+			for _, port := range dev.Ports {
+				log.Infof("rdma sysfs:   port %s: state=%q link_layer=%q rate=%q",
+					port.Number, port.State, port.LinkLayer, port.Rate)
+				portEntries := map[string]kernfs.Inode{}
+				addFile(portEntries, "state", port.State)
+				addFile(portEntries, "phys_state", port.PhysState)
+				addFile(portEntries, "link_layer", port.LinkLayer)
+				addFile(portEntries, "rate", port.Rate)
+				addFile(portEntries, "lid", port.LID)
+				addFile(portEntries, "sm_lid", port.SMLID)
+				addFile(portEntries, "sm_sl", port.SMSL)
+				addFile(portEntries, "cap_mask", port.CapMask)
+				if len(port.GIDs) > 0 {
+					gidsEntries := map[string]kernfs.Inode{}
+					typesEntries := map[string]kernfs.Inode{}
+					ndevsEntries := map[string]kernfs.Inode{}
+					for _, gid := range port.GIDs {
+						addFile(gidsEntries, gid.Index, gid.GID)
+						addFile(typesEntries, gid.Index, gid.Type)
+						addFile(ndevsEntries, gid.Index, gid.NetDev)
+					}
+					log.Infof("rdma sysfs:   port %s: %d gids, gidsEntries=%d typesEntries=%d ndevsEntries=%d",
+						port.Number, len(port.GIDs), len(gidsEntries), len(typesEntries), len(ndevsEntries))
+					gidAttrsEntries := map[string]kernfs.Inode{
+						"types": fs.newDir(ctx, creds, defaultSysDirMode, typesEntries),
+					}
+					if len(ndevsEntries) > 0 {
+						gidAttrsEntries["ndevs"] = fs.newDir(ctx, creds, defaultSysDirMode, ndevsEntries)
+					}
+					portEntries["gids"] = fs.newDir(ctx, creds, defaultSysDirMode, gidsEntries)
+					portEntries["gid_attrs"] = fs.newDir(ctx, creds, defaultSysDirMode, gidAttrsEntries)
+				}
+				portsDir[port.Number] = fs.newDir(ctx, creds, defaultSysDirMode, portEntries)
+			}
+			ibDevEntries["ports"] = fs.newDir(ctx, creds, defaultSysDirMode, portsDir)
+		}
+		ibDir[dev.IBDev] = fs.newDir(ctx, creds, defaultSysDirMode, ibDevEntries)
+	}
+	return ibVerbsDir, ibDir
+}

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -170,6 +170,15 @@ func CollectRDMADeviceData() *RDMAData {
 		}
 		log.Infof("rdma collect: %s → ibdev=%s dev=%s node_type=%q fw_ver=%q pci=%s numa=%s",
 			dent.Name(), ibdev, dev.Dev, dev.NodeType, dev.FWVer, dev.PCISlotName, dev.NUMANode)
+
+		// Primary netdev discovery: kernel lists RoCE/IPoIB netdevs under
+		// the IB device's PCI node at device/net/<name>. This does not
+		// depend on GID ndevs being populated (often empty at collect time)
+		// or on the ibdev2netdev host utility.
+		for _, name := range netdevsForIBDev(ibdev) {
+			netDevices[name] = struct{}{}
+		}
+
 		portsPath := path.Join(ibDir, "ports")
 		portDents, err := os.ReadDir(portsPath)
 		if err == nil {
@@ -207,6 +216,8 @@ func CollectRDMADeviceData() *RDMAData {
 							Type:   typeVal,
 							NetDev: ndevVal,
 						})
+						// Secondary: nonempty GID ndevs (may be blank when
+						// the netdev is in another netns at collect time).
 						if ndevVal != "" {
 							netDevices[ndevVal] = struct{}{}
 						}
@@ -220,8 +231,32 @@ func CollectRDMADeviceData() *RDMAData {
 		data.Devices = append(data.Devices, dev)
 	}
 	data.NetDevices = collectRDMANetDevices(netDevices)
-	log.Infof("rdma collect: collected %d device(s)", len(data.Devices))
+	log.Infof("rdma collect: collected %d device(s), %d netdev(s)", len(data.Devices), len(data.NetDevices))
 	return data
+}
+
+// netdevsForIBDev returns netdev names bound to ibdev via
+// /sys/class/infiniband/<ibdev>/device/net/*. This is the kernel's
+// ibdev↔netdev association (what ibdev2netdev prints) without requiring
+// that host utility.
+func netdevsForIBDev(ibdev string) []string {
+	netDir := path.Join("/sys/class/infiniband", ibdev, "device", "net")
+	dents, err := os.ReadDir(netDir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, dent := range dents {
+		// Entries are directories named after the netdev (e.g. rdma0).
+		if dent.Name() == "." || dent.Name() == ".." {
+			continue
+		}
+		names = append(names, dent.Name())
+	}
+	if len(names) > 0 {
+		log.Infof("rdma collect: %s device/net → %v", ibdev, names)
+	}
+	return names
 }
 
 func collectRDMANetDevices(names map[string]struct{}) []RDMANetDeviceData {
@@ -231,6 +266,10 @@ func collectRDMANetDevices(names map[string]struct{}) []RDMANetDeviceData {
 	var netDevices []RDMANetDeviceData
 	for name := range names {
 		netDir := path.Join("/sys/class/net", name)
+		if _, err := os.Stat(netDir); err != nil {
+			log.Infof("rdma collect: netdev %s not in this netns (%v), skipping attrs", name, err)
+			continue
+		}
 		devicePath, err := filepath.EvalSymlinks(path.Join(netDir, "device"))
 		if err != nil {
 			devicePath = ""

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -60,16 +60,19 @@ type InternalData struct {
 	// accelerators.
 	EnableTPUProxyPaths bool
 	// EnableRDMAProxyPaths is whether to populate sysfs paths used by
-	// RDMA/InfiniBand libibverbs device discovery.
+	// RDMA/InfiniBand devices.
 	EnableRDMAProxyPaths bool
-	// RDMADevices contains pre-collected RDMA sysfs data for constructing
-	// virtual /sys/class/infiniband_verbs/ and /sys/class/infiniband/ trees.
+	// RDMADevices contains pre-read sysfs data for RDMA devices, collected
+	// before the sandbox chroot is entered.
 	RDMADevices *RDMAData
-	// PCIDevicesData contains pre-read PCI device topology from the host,
-	// used for NCCL PCI distance computation.
+	// PCIDevicesData contains pre-read sysfs data for PCI devices (GPUs,
+	// NICs, bridges), collected before the sandbox chroot is entered.
+	// Used by NCCL for topology discovery.
 	PCIDevicesData *PCIDevicesData
-	// NUMAData contains pre-read NUMA node layout from the host, used for
-	// NCCL CPU-affinity and distance calculations.
+	// NUMAData contains pre-read NUMA topology, collected before the sandbox
+	// chroot is entered. Used by NCCL to populate the per-NUMA-node CPU
+	// affinity bitmaps in its topology XML; without this, NCCL falls back to
+	// a single-rail layout and loses NUMA-aware ring/tree placement.
 	NUMAData *NUMAData
 	// TestSysfsPathPrefix is a prefix for the sysfs paths. It is useful for
 	// unit testing.
@@ -136,7 +139,8 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		"power_supply": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 	}
 	// systemSub holds the children of /sys/devices/system/. It's populated
-	// initially with cpu and may be extended with NUMA node entries below.
+	// here with the cpu/ subtree and then potentially extended below with
+	// the per-NUMA-node directories before being installed into devicesSub.
 	systemSub := map[string]kernfs.Inode{
 		"cpu": cpuDir(ctx, fs, creds),
 	}
@@ -144,6 +148,7 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 
 	productName := ""
 	busSub := make(map[string]kernfs.Inode)
+	moduleSub := make(map[string]kernfs.Inode)
 	kernelSub := kernelDir(ctx, fs, creds)
 	if opts.InternalData != nil {
 		idata := opts.InternalData.(*InternalData)
@@ -189,17 +194,10 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			}
 			kernelSub["iommu_groups"] = fs.newDir(ctx, creds, defaultSysDirMode, iommuGroups)
 		}
-		if idata.EnableRDMAProxyPaths {
-			ibVerbsDir, ibDir := fs.newRDMASysfsEntries(ctx, creds, idata.RDMADevices)
-			if ibVerbsDir != nil {
-				classSub["infiniband_verbs"] = fs.newDir(ctx, creds, defaultSysDirMode, ibVerbsDir)
-			}
-			if ibDir != nil {
-				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
-			}
-		}
+		var pciSlotToRelPath map[string]string
 		if idata.PCIDevicesData != nil {
-			pciDeviceTreeSub, pciBusSub, busPCIDevSub, _ := fs.newPCIDevicesSysfsEntries(ctx, creds, idata.PCIDevicesData)
+			var pciDeviceTreeSub, pciBusSub, busPCIDevSub map[string]kernfs.Inode
+			pciDeviceTreeSub, pciBusSub, busPCIDevSub, pciSlotToRelPath = fs.newPCIDevicesSysfsEntries(ctx, creds, idata.PCIDevicesData, idata.RDMADevices)
 			for name, inode := range pciDeviceTreeSub {
 				devicesSub[name] = inode
 			}
@@ -207,11 +205,6 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				classSub["pci_bus"] = fs.newDir(ctx, creds, defaultSysDirMode, pciBusSub)
 			}
 			if len(busPCIDevSub) > 0 {
-				// On GPU nodes NVProxy enables EnableTPUProxyPaths, which
-				// already populates busSub["pci"] with the TPU/GPU PCI device
-				// symlinks above. Only fall back to the serialized PCI device
-				// tree when no PCI bus directory has been set, so we don't
-				// clobber those entries.
 				if _, ok := busSub["pci"]; !ok {
 					busSub["pci"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
 						"devices": fs.newDir(ctx, creds, defaultSysDirMode, busPCIDevSub),
@@ -222,7 +215,38 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		if nodeSub := fs.newNUMASysfsEntries(ctx, creds, idata.NUMAData); nodeSub != nil {
 			systemSub["node"] = fs.newDir(ctx, creds, defaultSysDirMode, nodeSub)
 		}
+		if idata.EnableRDMAProxyPaths {
+			ibVerbsDir, ibDir := fs.newRDMASysfsEntries(ctx, creds, idata.RDMADevices, pciSlotToRelPath)
+			if ibVerbsDir != nil {
+				classSub["infiniband_verbs"] = fs.newDir(ctx, creds, defaultSysDirMode, ibVerbsDir)
+			}
+			if ibDir != nil {
+				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
+			}
+			if netDir := fs.newRDMANetClassEntries(ctx, creds, idata.RDMADevices); netDir != nil {
+				classSub["net"] = fs.newDir(ctx, creds, defaultSysDirMode, netDir)
+			}
+			if idata.RDMADevices != nil && idata.RDMADevices.PeerMemVersion != "" {
+				peerMemVer := idata.RDMADevices.PeerMemVersion + "\n"
+				moduleSub["nvidia_peermem"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+					"version": fs.newStaticFile(ctx, creds, defaultSysMode, peerMemVer),
+				})
+				if kernelSub["mm"] == nil {
+					kernelSub["mm"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+						"memory_peers": fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+							"nv_mem": fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+								"version": fs.newStaticFile(ctx, creds, defaultSysMode, peerMemVer),
+							}),
+						}),
+					})
+				}
+			}
+		}
 	}
+
+	// Install /sys/devices/system/ now that systemSub may have been extended
+	// (e.g. with the per-NUMA-node directories above).
+	devicesSub["system"] = fs.newDir(ctx, creds, defaultSysDirMode, systemSub)
 
 	if len(productName) > 0 {
 		log.Debugf("Setting product_name: %q", productName)
@@ -237,10 +261,6 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			}),
 		})
 	}
-	// Install /sys/devices/system/ now that systemSub may have been extended
-	// with NUMA node entries.
-	devicesSub["system"] = fs.newDir(ctx, creds, defaultSysDirMode, systemSub)
-
 	root := fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
 		"block": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 		"bus":   fs.newDir(ctx, creds, defaultSysDirMode, busSub),
@@ -253,7 +273,7 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		"firmware": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 		"fs":       fs.newDir(ctx, creds, defaultSysDirMode, fsDirChildren),
 		"kernel":   fs.newDir(ctx, creds, defaultSysDirMode, kernelSub),
-		"module":   fs.newDir(ctx, creds, defaultSysDirMode, nil),
+		"module":   fs.newDir(ctx, creds, defaultSysDirMode, moduleSub),
 		"power":    fs.newDir(ctx, creds, defaultSysDirMode, nil),
 	})
 	fs.root = root.(*dir)

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -65,6 +65,12 @@ type InternalData struct {
 	// RDMADevices contains pre-collected RDMA sysfs data for constructing
 	// virtual /sys/class/infiniband_verbs/ and /sys/class/infiniband/ trees.
 	RDMADevices *RDMAData
+	// PCIDevicesData contains pre-read PCI device topology from the host,
+	// used for NCCL PCI distance computation.
+	PCIDevicesData *PCIDevicesData
+	// NUMAData contains pre-read NUMA node layout from the host, used for
+	// NCCL CPU-affinity and distance calculations.
+	NUMAData *NUMAData
 	// TestSysfsPathPrefix is a prefix for the sysfs paths. It is useful for
 	// unit testing.
 	TestSysfsPathPrefix string
@@ -129,11 +135,12 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 	classSub := map[string]kernfs.Inode{
 		"power_supply": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 	}
-	devicesSub := map[string]kernfs.Inode{
-		"system": fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
-			"cpu": cpuDir(ctx, fs, creds),
-		}),
+	// systemSub holds the children of /sys/devices/system/. It's populated
+	// initially with cpu and may be extended with NUMA node entries below.
+	systemSub := map[string]kernfs.Inode{
+		"cpu": cpuDir(ctx, fs, creds),
 	}
+	devicesSub := map[string]kernfs.Inode{}
 
 	productName := ""
 	busSub := make(map[string]kernfs.Inode)
@@ -191,6 +198,30 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
 			}
 		}
+		if idata.PCIDevicesData != nil {
+			pciDeviceTreeSub, pciBusSub, busPCIDevSub, _ := fs.newPCIDevicesSysfsEntries(ctx, creds, idata.PCIDevicesData)
+			for name, inode := range pciDeviceTreeSub {
+				devicesSub[name] = inode
+			}
+			if len(pciBusSub) > 0 {
+				classSub["pci_bus"] = fs.newDir(ctx, creds, defaultSysDirMode, pciBusSub)
+			}
+			if len(busPCIDevSub) > 0 {
+				// On GPU nodes NVProxy enables EnableTPUProxyPaths, which
+				// already populates busSub["pci"] with the TPU/GPU PCI device
+				// symlinks above. Only fall back to the serialized PCI device
+				// tree when no PCI bus directory has been set, so we don't
+				// clobber those entries.
+				if _, ok := busSub["pci"]; !ok {
+					busSub["pci"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+						"devices": fs.newDir(ctx, creds, defaultSysDirMode, busPCIDevSub),
+					})
+				}
+			}
+		}
+		if nodeSub := fs.newNUMASysfsEntries(ctx, creds, idata.NUMAData); nodeSub != nil {
+			systemSub["node"] = fs.newDir(ctx, creds, defaultSysDirMode, nodeSub)
+		}
 	}
 
 	if len(productName) > 0 {
@@ -206,6 +237,10 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			}),
 		})
 	}
+	// Install /sys/devices/system/ now that systemSub may have been extended
+	// with NUMA node entries.
+	devicesSub["system"] = fs.newDir(ctx, creds, defaultSysDirMode, systemSub)
+
 	root := fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
 		"block": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 		"bus":   fs.newDir(ctx, creds, defaultSysDirMode, busSub),

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -59,6 +59,12 @@ type InternalData struct {
 	// EnableTPUProxyPaths is whether to populate sysfs paths used by hardware
 	// accelerators.
 	EnableTPUProxyPaths bool
+	// EnableRDMAProxyPaths is whether to populate sysfs paths used by
+	// RDMA/InfiniBand libibverbs device discovery.
+	EnableRDMAProxyPaths bool
+	// RDMADevices contains pre-collected RDMA sysfs data for constructing
+	// virtual /sys/class/infiniband_verbs/ and /sys/class/infiniband/ trees.
+	RDMADevices *RDMAData
 	// TestSysfsPathPrefix is a prefix for the sysfs paths. It is useful for
 	// unit testing.
 	TestSysfsPathPrefix string
@@ -175,6 +181,15 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				return nil, nil, err
 			}
 			kernelSub["iommu_groups"] = fs.newDir(ctx, creds, defaultSysDirMode, iommuGroups)
+		}
+		if idata.EnableRDMAProxyPaths {
+			ibVerbsDir, ibDir := fs.newRDMASysfsEntries(ctx, creds, idata.RDMADevices)
+			if ibVerbsDir != nil {
+				classSub["infiniband_verbs"] = fs.newDir(ctx, creds, defaultSysDirMode, ibVerbsDir)
+			}
+			if ibDir != nil {
+				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
+			}
 		}
 	}
 

--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -1521,6 +1521,23 @@ func (mm *MemoryManager) IsMembarrierRSeqEnabled() bool {
 	return mm.membarrierRSeqEnabled.Load() != 0
 }
 
+// FindVMARange returns the address range of the VMA containing addr.
+//
+// Used by RDMA uverbs plug-ins (rdmaproxy/cxproxy etc.) to determine the
+// length of a DMA buffer when only its starting address is known. The mlx5
+// uverbs protocol carries buf_addr and db_addr but not the buffer length,
+// so the proxy queries the VMA range to find the implicit end set by the
+// app's mmap() call.
+func (mm *MemoryManager) FindVMARange(addr hostarch.Addr) (hostarch.AddrRange, error) {
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
+	vseg := mm.vmas.FindSegment(addr)
+	if !vseg.Ok() {
+		return hostarch.AddrRange{}, linuxerr.EFAULT
+	}
+	return vseg.Range(), nil
+}
+
 // FindVMAByName finds a vma with the specified name and returns its start address and offset.
 func (mm *MemoryManager) FindVMAByName(ar hostarch.AddrRange, name string) (hostarch.Addr, uint64, error) {
 	mm.mappingMu.RLock()

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -64,6 +64,7 @@ go_library(
         "//pkg/sentry/devices/memdev",
         "//pkg/sentry/devices/nvproxy",
         "//pkg/sentry/devices/nvproxy/nvconf",
+        "//pkg/sentry/devices/rdmaproxy",
         "//pkg/sentry/devices/tpuproxy",
         "//pkg/sentry/devices/tpuproxy/vfio",
         "//pkg/sentry/devices/ttydev",

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -65,6 +65,7 @@ go_library(
         "//pkg/sentry/devices/nvproxy",
         "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/devices/rdmaproxy",
+        "//pkg/sentry/devices/rdmaproxy/cxproxy",
         "//pkg/sentry/devices/tpuproxy",
         "//pkg/sentry/devices/tpuproxy/vfio",
         "//pkg/sentry/devices/ttydev",

--- a/runsc/boot/filter/config/BUILD
+++ b/runsc/boot/filter/config/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/seccomp/precompiledseccomp",
         "//pkg/sentry/devices/nvproxy",
         "//pkg/sentry/devices/nvproxy/nvconf",
+        "//pkg/sentry/devices/rdmaproxy",
         "//pkg/sentry/devices/tpuproxy",
         "//pkg/sentry/platform",
         "//pkg/sentry/platform/platforms",

--- a/runsc/boot/filter/config/config.go
+++ b/runsc/boot/filter/config/config.go
@@ -27,6 +27,7 @@ import (
 	"gvisor.dev/gvisor/pkg/seccomp/precompiledseccomp"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
+	"gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/tpuproxy"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
 	"gvisor.dev/gvisor/pkg/sentry/socket/plugin"
@@ -42,6 +43,7 @@ type Options struct {
 	NVProxy               bool
 	NVProxyCaps           nvconf.DriverCaps
 	TPUProxy              bool
+	RDMAProxy             bool
 	ControllerFD          uint32
 	CgoEnabled            bool
 	PluginNetwork         bool
@@ -71,6 +73,7 @@ func (opt Options) ConfigKey() string {
 	fmt.Fprintf(&sb, "NVProxy=%t ", opt.NVProxy)
 	fmt.Fprintf(&sb, "NVProxyCaps=%v ", opt.NVProxyCaps)
 	fmt.Fprintf(&sb, "TPUProxy=%t ", opt.TPUProxy)
+	fmt.Fprintf(&sb, "RDMAProxy=%t ", opt.RDMAProxy)
 	fmt.Fprintf(&sb, "CgoEnabled=%t ", opt.CgoEnabled)
 	fmt.Fprintf(&sb, "PluginNetwork=%t ", opt.PluginNetwork)
 	return strings.TrimSpace(sb.String())
@@ -101,6 +104,10 @@ func Warnings(opt Options) []string {
 	}
 	if opt.TPUProxy {
 		warnings = append(warnings, "TPU device proxy enabled: syscall filters less restrictive!")
+	}
+	if opt.RDMAProxy {
+		warnings = append(warnings, "RDMA device proxy enabled: syscall filters less restrictive!")
+		warnings = append(warnings, "RDMA passthrough enabled: host hardware identifiers (PCI BDFs, NIC GUIDs, MAC addresses, NUMA topology) are exposed to the sandbox")
 	}
 	if opt.CgoEnabled {
 		warnings = append(warnings, "CGO enabled: syscall filters less restrictive!")
@@ -154,6 +161,9 @@ func rules(opt Options, vars precompiledseccomp.Values) (seccomp.SyscallRules, s
 	}
 	if opt.TPUProxy {
 		s.Merge(tpuproxy.Filters())
+	}
+	if opt.RDMAProxy {
+		s.Merge(rdmaproxy.Filters())
 	}
 	if opt.CgoEnabled {
 		s.Merge(cgoFilters())

--- a/runsc/boot/filter/config/config_precompiled.go
+++ b/runsc/boot/filter/config/config_precompiled.go
@@ -111,6 +111,15 @@ func optionsToPrecompile() ([]Options, error) {
 			tpuProxyNo.TPUProxy = false
 			return []Options{tpuProxyYes, tpuProxyNo}, nil
 		},
+
+		// Expand RDMAProxy vs not.
+		func(opt Options) ([]Options, error) {
+			rdmaProxyYes := opt
+			rdmaProxyYes.RDMAProxy = true
+			rdmaProxyNo := opt
+			rdmaProxyNo.RDMAProxy = false
+			return []Options{rdmaProxyYes, rdmaProxyNo}, nil
+		},
 	} {
 		var newOpts []Options
 		for _, opt := range opts {

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -45,6 +45,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/fdimport"
 	cgroup2fs "gvisor.dev/gvisor/pkg/sentry/fsimpl/cgroup2fs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/host"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/user"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
@@ -246,6 +247,9 @@ type Loader struct {
 	// productName is the value to show in
 	// /sys/devices/virtual/dmi/id/product_name.
 	productName string
+
+	// rdmaDevices contains pre-collected sysfs data for RDMA devices.
+	rdmaDevices *sys.RDMAData
 
 	// cpuQuota and cpuPeriod are the raw host CFS settings that should be
 	// exposed through sandbox cgroupfs.
@@ -449,6 +453,9 @@ type Args struct {
 	// RootfsUpperTarFD is the file descriptor to the tar file containing the rootfs
 	// upper layer changes.
 	RootfsUpperTarFD int
+
+	// RDMADevices contains pre-collected sysfs data for RDMA devices.
+	RDMADevices *sys.RDMAData
 }
 
 // HostTHP holds host transparent hugepage settings.
@@ -532,6 +539,7 @@ func New(args Args) (*Loader, error) {
 		sharedMounts:          make(map[string]*vfs.Mount),
 		stopProfiling:         stopProfiling,
 		productName:           args.ProductName,
+		rdmaDevices:           args.RDMADevices,
 		cpuQuota:              args.CPUQuota,
 		cpuPeriod:             args.CPUPeriod,
 		hostTHP:               args.HostTHP,

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -251,6 +251,12 @@ type Loader struct {
 	// rdmaDevices contains pre-collected sysfs data for RDMA devices.
 	rdmaDevices *sys.RDMAData
 
+	// pciDevicesData contains pre-collected PCI topology from the host.
+	pciDevicesData *sys.PCIDevicesData
+
+	// numaData contains pre-collected NUMA node layout from the host.
+	numaData *sys.NUMAData
+
 	// cpuQuota and cpuPeriod are the raw host CFS settings that should be
 	// exposed through sandbox cgroupfs.
 	cpuQuota  int64
@@ -456,6 +462,10 @@ type Args struct {
 
 	// RDMADevices contains pre-collected sysfs data for RDMA devices.
 	RDMADevices *sys.RDMAData
+	// PCIDevicesData contains pre-collected PCI topology from the host.
+	PCIDevicesData *sys.PCIDevicesData
+	// NUMAData contains pre-collected NUMA node layout from the host.
+	NUMAData *sys.NUMAData
 }
 
 // HostTHP holds host transparent hugepage settings.
@@ -540,6 +550,8 @@ func New(args Args) (*Loader, error) {
 		stopProfiling:         stopProfiling,
 		productName:           args.ProductName,
 		rdmaDevices:           args.RDMADevices,
+		pciDevicesData:        args.PCIDevicesData,
+		numaData:              args.NUMAData,
 		cpuQuota:              args.CPUQuota,
 		cpuPeriod:             args.CPUPeriod,
 		hostTHP:               args.HostTHP,

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -1056,6 +1056,7 @@ func (l *Loader) installSeccompFilters() error {
 			NVProxy:               nvproxyEnabled,
 			NVProxyCaps:           nvproxyCaps,
 			TPUProxy:              specutils.TPUProxyEnabled(l.root.spec, l.root.conf),
+			RDMAProxy:             specutils.RDMAFunctionalityRequested(l.root.spec, l.root.conf),
 			ControllerFD:          uint32(l.ctrl.srv.FD()),
 			CgoEnabled:            config.CgoEnabled,
 			PluginNetwork:         l.root.conf.Network == config.NetworkPlugin,

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -921,7 +921,7 @@ func (c *containerMounter) getPathMode(ctx context.Context, creds *auth.Credenti
 }
 
 func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) (*vfs.Mount, error) {
-	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
 	if err != nil {
 		return nil, fmt.Errorf("mountOptions failed: %w", err)
 	}
@@ -984,7 +984,7 @@ func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, 
 
 // getMountNameAndOptions retrieves the fsName, opts, and useOverlay values
 // used for mounts.
-func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore) (string, *vfs.MountOptions, error) {
+func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaDevices *sys.RDMAData) (string, *vfs.MountOptions, error) {
 	fsName := m.mount.Type
 	var (
 		mopts        = m.mount.Options
@@ -1004,7 +1004,11 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 		internalData = newProcInternalData(conf, spec)
 
 	case sys.Name:
-		sysData := &sys.InternalData{EnableTPUProxyPaths: specutils.TPUProxyEnabled(spec, conf)}
+		sysData := &sys.InternalData{
+			EnableTPUProxyPaths:  specutils.TPUProxyEnabled(spec, conf),
+			EnableRDMAProxyPaths: conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec),
+			RDMADevices:          rdmaDevices,
+		}
 		if len(productName) > 0 {
 			sysData.ProductName = productName
 		}
@@ -1385,7 +1389,7 @@ func (c *containerMounter) mountSharedMaster(ctx context.Context, spec *specs.Sp
 	// Mount the master using the options from the hint (mount annotations).
 	origOpts := mntInfo.mount.Options
 	mntInfo.mount.Options = mntInfo.hint.Mount.Options
-	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
 	mntInfo.mount.Options = origOpts
 	if err != nil {
 		return nil, err

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -921,7 +921,7 @@ func (c *containerMounter) getPathMode(ctx context.Context, creds *auth.Credenti
 }
 
 func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) (*vfs.Mount, error) {
-	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices, c.l.pciDevicesData, c.l.numaData)
 	if err != nil {
 		return nil, fmt.Errorf("mountOptions failed: %w", err)
 	}
@@ -984,7 +984,7 @@ func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, 
 
 // getMountNameAndOptions retrieves the fsName, opts, and useOverlay values
 // used for mounts.
-func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaDevices *sys.RDMAData) (string, *vfs.MountOptions, error) {
+func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaDevices *sys.RDMAData, pciDevicesData *sys.PCIDevicesData, numaData *sys.NUMAData) (string, *vfs.MountOptions, error) {
 	fsName := m.mount.Type
 	var (
 		mopts        = m.mount.Options
@@ -1008,6 +1008,8 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 			EnableTPUProxyPaths:  specutils.TPUProxyEnabled(spec, conf),
 			EnableRDMAProxyPaths: conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec),
 			RDMADevices:          rdmaDevices,
+			PCIDevicesData:       pciDevicesData,
+			NUMAData:             numaData,
 		}
 		if len(productName) > 0 {
 			sysData.ProductName = productName
@@ -1389,7 +1391,7 @@ func (c *containerMounter) mountSharedMaster(ctx context.Context, spec *specs.Sp
 	// Mount the master using the options from the hint (mount annotations).
 	origOpts := mntInfo.mount.Options
 	mntInfo.mount.Options = mntInfo.hint.Mount.Options
-	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices, c.l.pciDevicesData, c.l.numaData)
 	mntInfo.mount.Options = origOpts
 	if err != nil {
 		return nil, err

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -40,6 +40,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/devices/memdev"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
+	"gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/tpuproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/tpuproxy/vfio"
 	"gvisor.dev/gvisor/pkg/sentry/devices/ttydev"
@@ -205,6 +206,11 @@ func setupContainerVFS(ctx context.Context, info *containerInfo, mntr *container
 	rootProcArgs.Umask = 0022
 	rootProcArgs.MaxSymlinkTraversals = linux.MaxSymlinkTraversals
 	rootCtx := rootProcArgs.NewContext(mntr.l.k)
+
+	// Pre-register RDMA devices to obtain dynamic majors before sysfs is
+	// mounted, so the virtual sysfs "dev" files reflect container-side
+	// major:minor values that libibverbs can match against /dev nodes.
+	mntr.preRegisterRDMADevices(info.spec)
 
 	mns, err := mntr.mountAll(rootCtx, rootCreds, info.spec, info.conf, &rootProcArgs)
 	if err != nil {
@@ -434,6 +440,19 @@ type containerMounter struct {
 	// annotation.
 	sharedMounts map[string]*vfs.Mount
 
+	// rdmaDevices contains pre-collected sysfs data for RDMA devices.
+	rdmaDevices *sys.RDMAData
+
+	// pciDevicesData contains pre-collected PCI device topology data.
+	pciDevicesData *sys.PCIDevicesData
+
+	// numaData contains pre-collected host NUMA topology.
+	numaData *sys.NUMAData
+
+	// rdmaDynMajors caches dynamic VFS majors for pre-registered RDMA
+	// devices, keyed by host minor number.
+	rdmaDynMajors map[uint32]uint32
+
 	// containerID is the ID for the container.
 	containerID   string
 	containerName string
@@ -459,6 +478,9 @@ func (l *Loader) newContainerMounter(info *containerInfo) *containerMounter {
 		devGoferFD:        info.devGoferFD,
 		goferMountConfs:   info.goferMountConfs,
 		sharedMounts:      l.sharedMounts,
+		rdmaDevices:       l.rdmaDevices,
+		pciDevicesData:    l.pciDevicesData,
+		numaData:          l.numaData,
 		containerID:       info.cid,
 		containerName:     info.containerName,
 		rootfsUpperTarFD:  info.rootfsUpperTarFD,
@@ -921,7 +943,7 @@ func (c *containerMounter) getPathMode(ctx context.Context, creds *auth.Credenti
 }
 
 func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) (*vfs.Mount, error) {
-	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices, c.l.pciDevicesData, c.l.numaData)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.rdmaDevices, c.pciDevicesData, c.numaData)
 	if err != nil {
 		return nil, fmt.Errorf("mountOptions failed: %w", err)
 	}
@@ -1006,7 +1028,7 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 	case sys.Name:
 		sysData := &sys.InternalData{
 			EnableTPUProxyPaths:  specutils.TPUProxyEnabled(spec, conf),
-			EnableRDMAProxyPaths: conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec),
+			EnableRDMAProxyPaths: specutils.RDMAFunctionalityRequested(spec, conf),
 			RDMADevices:          rdmaDevices,
 			PCIDevicesData:       pciDevicesData,
 			NUMAData:             numaData,
@@ -1391,7 +1413,7 @@ func (c *containerMounter) mountSharedMaster(ctx context.Context, spec *specs.Sp
 	// Mount the master using the options from the hint (mount annotations).
 	origOpts := mntInfo.mount.Options
 	mntInfo.mount.Options = mntInfo.hint.Mount.Options
-	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices, c.l.pciDevicesData, c.l.numaData)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.rdmaDevices, c.pciDevicesData, c.numaData)
 	mntInfo.mount.Options = origOpts
 	if err != nil {
 		return nil, err
@@ -1547,6 +1569,47 @@ func (c *containerMounter) configureRestore(fdmap map[checkpoint.ResourceID]int,
 		}
 	}
 	return nil
+}
+
+func (c *containerMounter) preRegisterRDMADevices(spec *specs.Spec) {
+	if c.rdmaDevices == nil || spec.Linux == nil {
+		return
+	}
+	c.rdmaDynMajors = make(map[uint32]uint32)
+	vfsObj := c.l.k.VFS()
+	driverByMinor := make(map[uint32]string)
+	for i := range c.rdmaDevices.Devices {
+		dev := &c.rdmaDevices.Devices[i]
+		if kernMinor, ok := sys.ExtractMinorUint32(dev.Dev); ok && dev.PCIDriver != "" {
+			driverByMinor[kernMinor] = dev.PCIDriver
+		}
+	}
+	for _, devSpec := range spec.Linux.Devices {
+		if !strings.HasPrefix(devSpec.Path, "/dev/infiniband/uverbs") {
+			continue
+		}
+		minor := uint32(devSpec.Minor)
+		devName := filepath.Base(devSpec.Path)
+		driverName := driverByMinor[minor]
+		dynMajor, err := rdmaproxy.Register(vfsObj, devName, minor, driverName)
+		if err != nil {
+			log.Warningf("rdma: pre-register %s: %v", devSpec.Path, err)
+			continue
+		}
+		c.rdmaDynMajors[minor] = dynMajor
+		log.Infof("rdma: pre-registered %s (minor=%d) with dynamic major %d driver=%q", devSpec.Path, minor, dynMajor, driverName)
+	}
+	for i := range c.rdmaDevices.Devices {
+		dev := &c.rdmaDevices.Devices[i]
+		kernMinor, ok := sys.ExtractMinorUint32(dev.Dev)
+		if !ok {
+			continue
+		}
+		if dynMajor, ok := c.rdmaDynMajors[kernMinor]; ok {
+			dev.DynMajor = dynMajor
+			log.Infof("rdma: patched sysfs %s dev=%s → dynMajor=%d", dev.Name, dev.Dev, dynMajor)
+		}
+	}
 }
 
 func createDeviceFiles(ctx context.Context, creds *auth.Credentials, info *containerInfo, vfsObj *vfs.VirtualFilesystem, root vfs.VirtualDentry) error {

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -1591,7 +1591,7 @@ func (c *containerMounter) preRegisterRDMADevices(spec *specs.Spec) {
 		minor := uint32(devSpec.Minor)
 		devName := filepath.Base(devSpec.Path)
 		driverName := driverByMinor[minor]
-		dynMajor, err := rdmaproxy.Register(vfsObj, devName, minor, driverName)
+		dynMajor, err := rdmaproxy.Register(vfsObj, devName, minor, driverName, c.rdmaDevices.VerbsABIVersion)
 		if err != nil {
 			log.Warningf("rdma: pre-register %s: %v", devSpec.Path, err)
 			continue

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -41,6 +41,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 	"gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy"
+	_ "gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy/cxproxy" // registers the ConnectX/mlx5 plug-in
 	"gvisor.dev/gvisor/pkg/sentry/devices/tpuproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/tpuproxy/vfio"
 	"gvisor.dev/gvisor/pkg/sentry/devices/ttydev"

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -100,6 +100,7 @@ go_library(
         "//pkg/sentry/control",
         "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/devices/tpuproxy",
+        "//pkg/sentry/fsimpl/sys",
         "//pkg/sentry/hostmm",
         "//pkg/sentry/kernel",
         "//pkg/sentry/kernel/auth",

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -584,13 +584,21 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 	// Read RDMA device data serialized by stage 1 (rdmaProxyUpdateChroot).
 	var rdmaDevices *sys.RDMAData
-	if conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec) {
+	if conf.RDMAProxy {
 		rdmaDevices = sys.DeserializeRDMAData(sys.RDMADataPath)
 	}
 
-	// Read PCI/NUMA topology data serialized by stage 1.
-	pciDevicesData := sys.DeserializePCIDevicesData(sys.PCIDevicesDataPath)
-	numaData := sys.DeserializeNUMAData(sys.NUMADataPath)
+	// Read PCI device topology data serialized by stage 1 (pciDevicesUpdateChroot).
+	var pciDevicesData *sys.PCIDevicesData
+	if conf.NVProxy || conf.RDMAProxy {
+		pciDevicesData = sys.DeserializePCIDevicesData(sys.PCIDevicesDataPath)
+	}
+
+	// Read host NUMA topology serialized by stage 1 (numaUpdateChroot).
+	var numaData *sys.NUMAData
+	if conf.NVProxy || conf.RDMAProxy {
+		numaData = sys.DeserializeNUMAData(sys.NUMADataPath)
+	}
 
 	// Create the loader.
 	bootArgs := boot.Args{

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -38,6 +38,7 @@ import (
 	"gvisor.dev/gvisor/pkg/prometheus"
 	"gvisor.dev/gvisor/pkg/ring0"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/pkg/sentry/hostmm"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
 	"gvisor.dev/gvisor/pkg/sentry/syscalls/linux"
@@ -581,6 +582,12 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 	linux.SetAFSSyscallPanic(conf.TestOnlyAFSSyscallPanic)
 
+	// Read RDMA device data serialized by stage 1 (rdmaProxyUpdateChroot).
+	var rdmaDevices *sys.RDMAData
+	if conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec) {
+		rdmaDevices = sys.DeserializeRDMAData(sys.RDMADataPath)
+	}
+
 	// Create the loader.
 	bootArgs := boot.Args{
 		ID:                  f.Arg(0),
@@ -619,6 +626,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		FSRestoreFDs:             b.fsRestoreFDs.GetFDs(),
 		FSRestoreCheckpointGofer: b.fsRestoreCheckpointGofer,
 		RootfsUpperTarFD:         b.rootfsUpperTarFD,
+		RDMADevices:              rdmaDevices,
 	}
 	l, err := boot.New(bootArgs)
 	if err != nil {

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -588,6 +588,10 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		rdmaDevices = sys.DeserializeRDMAData(sys.RDMADataPath)
 	}
 
+	// Read PCI/NUMA topology data serialized by stage 1.
+	pciDevicesData := sys.DeserializePCIDevicesData(sys.PCIDevicesDataPath)
+	numaData := sys.DeserializeNUMAData(sys.NUMADataPath)
+
 	// Create the loader.
 	bootArgs := boot.Args{
 		ID:                  f.Arg(0),
@@ -627,6 +631,8 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		FSRestoreCheckpointGofer: b.fsRestoreCheckpointGofer,
 		RootfsUpperTarFD:         b.rootfsUpperTarFD,
 		RDMADevices:              rdmaDevices,
+		PCIDevicesData:           pciDevicesData,
+		NUMAData:                 numaData,
 	}
 	l, err := boot.New(bootArgs)
 	if err != nil {

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -228,7 +228,7 @@ func tpuProxyUpdateChroot(hostRoot, chroot string, spec *specs.Spec, conf *confi
 }
 
 func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
-	if !conf.RDMAProxy || !specutils.HasRDMADevicesInSpec(spec) {
+	if !specutils.RDMAFunctionalityRequested(spec, conf) {
 		return nil
 	}
 	// Collect RDMA device data from the real host sysfs (accessible now,
@@ -296,7 +296,7 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 }
 
 func pciDevicesUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
-	if !conf.NVProxy && !specutils.HasRDMADevicesInSpec(spec) {
+	if !conf.NVProxy && !specutils.RDMAFunctionalityRequested(spec, conf) {
 		return nil
 	}
 	data := sys.CollectPCIDeviceData()
@@ -311,7 +311,7 @@ func pciDevicesUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config
 }
 
 func numaUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
-	if !conf.NVProxy && !specutils.HasRDMADevicesInSpec(spec) {
+	if !conf.NVProxy && !specutils.RDMAFunctionalityRequested(spec, conf) {
 		return nil
 	}
 	data := sys.CollectNUMAData()

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -252,9 +252,9 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 
 	const bindFlags = unix.MS_BIND | unix.MS_RDONLY
 
-	// Only bind-mount RDMA-backed netdevs discovered via GID ndevs — not
-	// all of /sys/class/net, which would expose unrelated host interfaces
-	// (and confuse --network=sandbox / hostinet modes).
+	// Only bind-mount RDMA-backed netdevs from CollectRDMADeviceData
+	// (primarily /sys/class/infiniband/<ibdev>/device/net/*) — not all of
+	// /sys/class/net, which would expose unrelated host interfaces.
 	seenNetDev := make(map[string]struct{})
 	for _, netDev := range data.NetDevices {
 		if netDev.Name == "" {

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -27,6 +27,7 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/specutils"
 )
@@ -148,6 +149,10 @@ func setUpChroot(spec *specs.Spec, conf *config.Config) error {
 		return fmt.Errorf("error configuring chroot for TPU devices: %w", err)
 	}
 
+	if err := rdmaProxyUpdateChroot(chroot, spec, conf); err != nil {
+		return fmt.Errorf("error configuring chroot for RDMA devices: %w", err)
+	}
+
 	if err := specutils.SafeMount("", chroot, "", unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_BIND, "", "/proc"); err != nil {
 		return fmt.Errorf("error remounting chroot in read-only: %v", err)
 	}
@@ -212,4 +217,27 @@ func tpuProxyUpdateChroot(hostRoot, chroot string, spec *specs.Spec, conf *confi
 		}
 	}
 	return err
+}
+
+func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
+	if !conf.RDMAProxy || !specutils.HasRDMADevicesInSpec(spec) {
+		return nil
+	}
+	// Collect RDMA device data from the real host sysfs (accessible now,
+	// before pivot_root) and serialize it as JSON into the chroot. Stage 2
+	// deserializes this instead of trying to read sysfs — avoids all the
+	// symlink resolution and depth-limiting complexity of copying sysfs
+	// trees. The RoCE netdev backing each ibdev should have already been
+	// moved into the sandbox netns by MoveRDMANetdevsIntoSandbox; the GID
+	// sysfs entries we read here therefore include the kernel's normal
+	// IPv4-mapped RoCE v2 entries.
+	data := sys.CollectRDMADeviceData()
+	if data == nil {
+		return nil
+	}
+	jsonPath := filepath.Join(chroot, sys.RDMADataPath)
+	if err := sys.SerializeRDMAData(data, jsonPath); err != nil {
+		return fmt.Errorf("serializing RDMA data: %w", err)
+	}
+	return nil
 }

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -233,11 +233,13 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 	}
 	// Collect RDMA device data from the real host sysfs (accessible now,
 	// before pivot_root) and serialize it as JSON into the chroot. Stage 2
-	// deserializes this instead of trying to read sysfs — avoids all the
-	// symlink resolution and depth-limiting complexity of copying sysfs
-	// trees. The RoCE netdev backing each ibdev should have already been
-	// moved into the sandbox netns by MoveRDMANetdevsIntoSandbox; the GID
-	// sysfs entries we read here therefore include the kernel's normal
+	// deserializes this for mostly-static attrs. Dynamic port/netdev attrs
+	// are served via hostFile and need the bind mounts below so those
+	// paths remain openable after pivot_root.
+	//
+	// The RoCE netdev backing each ibdev should have already been moved
+	// into the sandbox netns by MoveRDMANetdevsIntoSandbox; the GID sysfs
+	// entries we read here therefore include the kernel's normal
 	// IPv4-mapped RoCE v2 entries.
 	data := sys.CollectRDMADeviceData()
 	if data == nil {
@@ -246,6 +248,49 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 	jsonPath := filepath.Join(chroot, sys.RDMADataPath)
 	if err := sys.SerializeRDMAData(data, jsonPath); err != nil {
 		return fmt.Errorf("serializing RDMA data: %w", err)
+	}
+
+	const bindFlags = unix.MS_BIND | unix.MS_RDONLY
+
+	// Only bind-mount RDMA-backed netdevs discovered via GID ndevs — not
+	// all of /sys/class/net, which would expose unrelated host interfaces
+	// (and confuse --network=sandbox / hostinet modes).
+	seenNetDev := make(map[string]struct{})
+	for _, netDev := range data.NetDevices {
+		if netDev.Name == "" {
+			continue
+		}
+		if _, ok := seenNetDev[netDev.Name]; ok {
+			continue
+		}
+		seenNetDev[netDev.Name] = struct{}{}
+		netPath := path.Join("/sys/class/net", netDev.Name)
+		if _, err := os.Stat(netPath); err != nil {
+			log.Infof("rdma chroot: %s not present, skipping bind mount: %v", netPath, err)
+			continue
+		}
+		if err := mountInChroot(chroot, netPath, netPath, "bind", bindFlags); err != nil {
+			return fmt.Errorf("error mounting %q in chroot: %w", netPath, err)
+		}
+	}
+
+	seenIBDev := make(map[string]struct{})
+	for _, dev := range data.Devices {
+		if dev.IBDev == "" {
+			continue
+		}
+		if _, ok := seenIBDev[dev.IBDev]; ok {
+			continue
+		}
+		seenIBDev[dev.IBDev] = struct{}{}
+		portsPath := path.Join("/sys/class/infiniband", dev.IBDev, "ports")
+		if _, err := os.Stat(portsPath); err != nil {
+			log.Infof("rdma chroot: %s not present, skipping bind mount: %v", portsPath, err)
+			continue
+		}
+		if err := mountInChroot(chroot, portsPath, portsPath, "bind", bindFlags); err != nil {
+			return fmt.Errorf("error mounting %q in chroot: %w", portsPath, err)
+		}
 	}
 	return nil
 }

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -153,6 +153,14 @@ func setUpChroot(spec *specs.Spec, conf *config.Config) error {
 		return fmt.Errorf("error configuring chroot for RDMA devices: %w", err)
 	}
 
+	if err := pciDevicesUpdateChroot(chroot, spec, conf); err != nil {
+		return fmt.Errorf("error configuring chroot for PCI topology: %w", err)
+	}
+
+	if err := numaUpdateChroot(chroot, spec, conf); err != nil {
+		return fmt.Errorf("error configuring chroot for NUMA topology: %w", err)
+	}
+
 	if err := specutils.SafeMount("", chroot, "", unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_BIND, "", "/proc"); err != nil {
 		return fmt.Errorf("error remounting chroot in read-only: %v", err)
 	}
@@ -238,6 +246,36 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 	jsonPath := filepath.Join(chroot, sys.RDMADataPath)
 	if err := sys.SerializeRDMAData(data, jsonPath); err != nil {
 		return fmt.Errorf("serializing RDMA data: %w", err)
+	}
+	return nil
+}
+
+func pciDevicesUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
+	if !conf.NVProxy && !specutils.HasRDMADevicesInSpec(spec) {
+		return nil
+	}
+	data := sys.CollectPCIDeviceData()
+	if data == nil {
+		return nil
+	}
+	jsonPath := filepath.Join(chroot, sys.PCIDevicesDataPath)
+	if err := sys.SerializePCIDevicesData(data, jsonPath); err != nil {
+		return fmt.Errorf("serializing PCI devices data: %w", err)
+	}
+	return nil
+}
+
+func numaUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
+	if !conf.NVProxy && !specutils.HasRDMADevicesInSpec(spec) {
+		return nil
+	}
+	data := sys.CollectNUMAData()
+	if data == nil {
+		return nil
+	}
+	jsonPath := filepath.Join(chroot, sys.NUMADataPath)
+	if err := sys.SerializeNUMAData(data, jsonPath); err != nil {
+		return fmt.Errorf("serializing NUMA data: %w", err)
 	}
 	return nil
 }

--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -506,6 +506,13 @@ func ShouldExposeTpuDevice(path string) bool {
 	return valid || ShouldExposeVFIODevice(path)
 }
 
+// ShouldExposeRDMADevice returns true if path refers to an RDMA uverbs device.
+//
+// Precondition: rdmaproxy is enabled.
+func ShouldExposeRDMADevice(path string) bool {
+	return strings.HasPrefix(path, "/dev/infiniband/uverbs")
+}
+
 // SetupDev mounts devices from the OCI spec into the gofer's /dev directory.
 func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) error {
 	if err := os.MkdirAll(filepath.Join(root, "dev"), 0777); err != nil {
@@ -517,9 +524,11 @@ func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) erro
 	}
 	nvproxyEnabled := specutils.NVProxyEnabled(spec, conf)
 	tpuproxyEnabled := specutils.TPUProxyEnabled(spec, conf)
+	rdmaproxyEnabled := conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec)
 	for _, dev := range spec.Linux.Devices {
 		shouldMount := (nvproxyEnabled && ShouldExposeNvidiaDevice(dev.Path)) ||
-			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path))
+			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path)) ||
+			(rdmaproxyEnabled && ShouldExposeRDMADevice(dev.Path))
 		if !shouldMount {
 			continue
 		}

--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -524,7 +524,7 @@ func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) erro
 	}
 	nvproxyEnabled := specutils.NVProxyEnabled(spec, conf)
 	tpuproxyEnabled := specutils.TPUProxyEnabled(spec, conf)
-	rdmaproxyEnabled := conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec)
+	rdmaproxyEnabled := specutils.RDMAFunctionalityRequested(spec, conf)
 	for _, dev := range spec.Linux.Devices {
 		shouldMount := (nvproxyEnabled && ShouldExposeNvidiaDevice(dev.Path)) ||
 			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path)) ||

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -367,6 +367,9 @@ type Config struct {
 	// TPUProxy enables support for TPUs.
 	TPUProxy bool `flag:"tpuproxy"`
 
+	// RDMAProxy enables support for RDMA device passthrough.
+	RDMAProxy bool `flag:"rdmaproxy"`
+
 	// TestOnlyAllowRunAsCurrentUserWithoutChroot should only be used in
 	// tests. It allows runsc to start the sandbox process as the current
 	// user, and without chrooting the sandbox process. This can be

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -180,6 +180,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("nvproxy-allow-unsupported-driver", false, "allow nvproxy to be initialized with an unsupported driver version.")
 	flagSet.String("nvproxy-allowed-driver-capabilities", "utility,compute", "Comma separated list of NVIDIA driver capabilities that are allowed to be requested by the container. If 'all' is specified here, it is resolved to all driver capabilities supported in nvproxy. If 'all' is requested by the container, it is resolved to this list.")
 	flagSet.Bool("tpuproxy", false, "LEGACY: enable support for TPU devices. TPU support gets automatically enabled if TPU devices are present in the OCI spec.")
+	flagSet.Bool("rdmaproxy", false, "EXPERIMENTAL: enable support for RDMA device passthrough.")
 
 	// Test flags, not to be used outside tests, ever.
 	flagSet.Bool("TESTONLY-unsafe-nonroot", false, "TEST ONLY; do not ever use! This skips many security measures that isolate the host from the sandbox.")

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1333,7 +1333,7 @@ func (c *Container) waitForStopped() error {
 // shouldCreateDeviceGofer indicates whether a device gofer connection should
 // be created.
 func shouldCreateDeviceGofer(spec *specs.Spec, conf *config.Config) bool {
-	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf) || (conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec))
+	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf) || specutils.RDMAFunctionalityRequested(spec, conf)
 }
 
 // shouldSpawnGofer indicates whether the gofer process should be spawned.

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1333,7 +1333,7 @@ func (c *Container) waitForStopped() error {
 // shouldCreateDeviceGofer indicates whether a device gofer connection should
 // be created.
 func shouldCreateDeviceGofer(spec *specs.Spec, conf *config.Config) bool {
-	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf)
+	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf) || (conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec))
 }
 
 // shouldSpawnGofer indicates whether the gofer process should be spawned.

--- a/runsc/specutils/BUILD
+++ b/runsc/specutils/BUILD
@@ -14,6 +14,7 @@ go_library(
         "hooks.go",
         "namespace.go",
         "nvidia.go",
+        "rdma.go",
         "restore.go",
         "specutils.go",
     ],

--- a/runsc/specutils/rdma.go
+++ b/runsc/specutils/rdma.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specutils
+
+import (
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// HasRDMADevicesInSpec returns true if the OCI spec lists at least one
+// /dev/infiniband/uverbs* device. Used to gate sysfs RDMA topology
+// serialization at chroot time, so PCI/RDMA/NUMA snapshot data is only
+// collected when the container actually requests RDMA devices.
+//
+// This intentionally does NOT consult the runtime rdmaproxy enable flag
+// (which lives in the rdmaproxy package, downstream of this PR) — sysfs
+// data collection is harmless without rdmaproxy and shipping serialize
+// alone should not require rdmaproxy.
+func HasRDMADevicesInSpec(spec *specs.Spec) bool {
+	if spec.Linux == nil {
+		return false
+	}
+	for _, dev := range spec.Linux.Devices {
+		if strings.HasPrefix(dev.Path, "/dev/infiniband/uverbs") {
+			return true
+		}
+	}
+	return false
+}

--- a/runsc/specutils/rdma.go
+++ b/runsc/specutils/rdma.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gvisor.dev/gvisor/runsc/config"
 )
 
 // HasRDMADevicesInSpec returns true if the OCI spec lists at least one
@@ -39,4 +40,30 @@ func HasRDMADevicesInSpec(spec *specs.Spec) bool {
 		}
 	}
 	return false
+}
+
+// AnnotationRDMAProxy enables rdmaproxy via OCI annotation as an alternative
+// to the --rdmaproxy runtime flag. Useful when only some containers should
+// use rdmaproxy on a runtime that otherwise has it disabled by default.
+const AnnotationRDMAProxy = "dev.gvisor.internal.rdmaproxy"
+
+// RDMAProxyEnabled returns true if rdmaproxy should be enabled for this
+// container, either via the --rdmaproxy runtime flag or via the
+// dev.gvisor.internal.rdmaproxy OCI annotation.
+func RDMAProxyEnabled(spec *specs.Spec, conf *config.Config) bool {
+	if conf.RDMAProxy {
+		return true
+	}
+	return AnnotationToBool(spec, AnnotationRDMAProxy)
+}
+
+// RDMAFunctionalityRequested returns true if the container should have
+// access to RDMA functionality. Requires both rdmaproxy to be enabled
+// (via flag or annotation) AND at least one /dev/infiniband/uverbs*
+// device to be present in the OCI spec.
+func RDMAFunctionalityRequested(spec *specs.Spec, conf *config.Config) bool {
+	if !RDMAProxyEnabled(spec, conf) {
+		return false
+	}
+	return HasRDMADevicesInSpec(spec)
 }


### PR DESCRIPTION
`mlx5` device specific plug-in for RDMAProxy (#13125). Handles CQ/QP creation by mirroring the DMA buffers for work-queue and doorbell pages on the host. RDMAProxy registers plug-in upon runsc `init()`. 

Stacks on #13125. 