### PR TITLE
vfs: skip write tracking for special files on open

### DIFF
--- a/pkg/sentry/fsimpl/devpts/master.go
+++ b/pkg/sentry/fsimpl/devpts/master.go
@@ -65,7 +65,9 @@ func (mi *masterInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernf
 		t:     t,
 	}
 	fd.LockFD.Init(&mi.locks)
-	if err := fd.vfsfd.Init(fd, opts.Flags, rp.Credentials(), rp.Mount(), d.VFSDentry(), &vfs.FileDescriptionOptions{}); err != nil {
+	if err := fd.vfsfd.Init(fd, opts.Flags, rp.Credentials(), rp.Mount(), d.VFSDentry(), &vfs.FileDescriptionOptions{
+		SpecialFile: true,
+	}); err != nil {
 		return nil, err
 	}
 	return &fd.vfsfd, nil

--- a/pkg/sentry/fsimpl/devpts/terminal.go
+++ b/pkg/sentry/fsimpl/devpts/terminal.go
@@ -64,7 +64,9 @@ func (t *Terminal) OpenTTY(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry
 		inode: ri,
 	}
 	fd.LockFD.Init(&ri.locks)
-	if err := fd.vfsfd.Init(fd, opts.Flags, tsk.Credentials(), mnt, vfsd, &vfs.FileDescriptionOptions{}); err != nil {
+	if err := fd.vfsfd.Init(fd, opts.Flags, tsk.Credentials(), mnt, vfsd, &vfs.FileDescriptionOptions{
+		SpecialFile: true,
+	}); err != nil {
 		return nil, err
 	}
 	if opts.Flags&linux.O_NOCTTY == 0 {

--- a/pkg/sentry/fsimpl/host/host.go
+++ b/pkg/sentry/fsimpl/host/host.go
@@ -724,7 +724,9 @@ func (i *inode) open(ctx context.Context, d *kernfs.Dentry, mnt *vfs.Mount, file
 		fd := &fileDescription{inode: i}
 		fd.LockFD.Init(&i.locks)
 		vfsfd := &fd.vfsfd
-		if err := vfsfd.Init(fd, flags, auth.CredentialsFromContext(ctx), mnt, d.VFSDentry(), &vfs.FileDescriptionOptions{}); err != nil {
+		if err := vfsfd.Init(fd, flags, auth.CredentialsFromContext(ctx), mnt, d.VFSDentry(), &vfs.FileDescriptionOptions{
+			SpecialFile: linux.FileMode(fileType).IsSpecialFile(),
+		}); err != nil {
 			return nil, err
 		}
 		return vfsfd, nil
@@ -747,7 +749,9 @@ func (i *inode) OpenTTY(ctx context.Context, mnt *vfs.Mount, d *vfs.Dentry, opts
 	}
 	fd.LockFD.Init(&i.locks)
 	vfsfd := &fd.vfsfd
-	if err := vfsfd.Init(fd, flags, auth.CredentialsFromContext(ctx), mnt, d, &vfs.FileDescriptionOptions{}); err != nil {
+	if err := vfsfd.Init(fd, flags, auth.CredentialsFromContext(ctx), mnt, d, &vfs.FileDescriptionOptions{
+		SpecialFile: true,
+	}); err != nil {
 		return nil, err
 	}
 	return vfsfd, nil

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -896,7 +896,7 @@ func (d *dentry) ensureOpenableLocked(ctx context.Context, rp *vfs.ResolvingPath
 		return nil
 	}
 
-	if !ats.MayWrite() {
+	if !ats.MayWrite() || linux.FileMode(d.mode.Load()).IsSpecialFile() {
 		return nil
 	}
 
@@ -908,8 +908,8 @@ func (d *dentry) ensureOpenableLocked(ctx context.Context, rp *vfs.ResolvingPath
 	return d.copyUpLocked(ctx)
 }
 
-// Preconditions: If vfs.AccessTypesForOpenFlags(opts).MayWrite(), then d has
-// been copied up.
+// Preconditions: If vfs.AccessTypesForOpenFlags(opts).MayWrite() and d is not a
+// special file, then d has been copied up.
 func (d *dentry) openCopiedUp(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.OpenOptions) (*vfs.FileDescription, error) {
 	mnt := rp.Mount()
 

--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -171,6 +171,7 @@ func newSocket(t *kernel.Task, family int, stype linux.SockType, protocol int, f
 		DenyPRead:         true,
 		DenyPWrite:        true,
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		fdnotifier.RemoveFD(int32(s.fd))
 		return nil, syserr.FromError(err)

--- a/pkg/sentry/socket/netlink/provider.go
+++ b/pkg/sentry/socket/netlink/provider.go
@@ -121,6 +121,7 @@ func (*socketProvider) Socket(t *kernel.Task, stype linux.SockType, protocol int
 		DenyPRead:         true,
 		DenyPWrite:        true,
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, syserr.FromError(err)
 	}

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -484,6 +484,7 @@ func New(t *kernel.Task, family int, skType linux.SockType, protocol int, queue 
 		DenyPRead:         true,
 		DenyPWrite:        true,
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, syserr.FromError(err)
 	}

--- a/pkg/sentry/socket/plugin/stack/socket.go
+++ b/pkg/sentry/socket/plugin/stack/socket.go
@@ -98,6 +98,7 @@ func newSocket(t *kernel.Task, family int, skType linux.SockType, protocol int, 
 		DenyPRead:         true,
 		DenyPWrite:        true,
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, syserr.FromError(err)
 	}

--- a/pkg/sentry/socket/unix/unix.go
+++ b/pkg/sentry/socket/unix/unix.go
@@ -110,6 +110,7 @@ func NewFileDescription(ep transport.Endpoint, stype linux.SockType, flags uint3
 		DenyPRead:         true,
 		DenyPWrite:        true,
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -546,6 +546,51 @@ TEST(MountTest, DeviceFileWritableOnReadonlyMount) {
   EXPECT_THAT(write(dev_fd.get(), "x", 1), SyscallSucceedsWithValue(1));
 }
 
+TEST(MountTest, ReadOnlyBindMountAllowsWriteOpenOfCharDevice) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto const bindDir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  auto const mnt = ASSERT_NO_ERRNO_AND_VALUE(
+      Mount("/dev", bindDir.path(), "", MS_BIND, "", 0));
+  ASSERT_THAT(mount("/dev", bindDir.path().c_str(), nullptr,
+                    MS_BIND | MS_REMOUNT | MS_RDONLY, nullptr),
+              SyscallSucceeds());
+
+  std::string const nullPath = JoinPath(bindDir.path(), "null");
+  FileDescriptor wfd = ASSERT_NO_ERRNO_AND_VALUE(Open(nullPath, O_WRONLY));
+  char msg[] = "hello";
+  EXPECT_THAT(write(wfd.get(), msg, sizeof(msg)),
+              SyscallSucceedsWithValue(sizeof(msg)));
+
+  FileDescriptor rwfd = ASSERT_NO_ERRNO_AND_VALUE(Open(nullPath, O_RDWR));
+  EXPECT_THAT(write(rwfd.get(), msg, sizeof(msg)),
+              SyscallSucceedsWithValue(sizeof(msg)));
+}
+
+TEST(MountTest, ReadOnlyBindMountAllowsWriteOpenOfFIFO) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto const dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  std::string const fifoPath = JoinPath(dir.path(), "fifo");
+  ASSERT_THAT(mkfifo(fifoPath.c_str(), 0666), SyscallSucceeds());
+
+  auto const bindDir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  auto const mnt = ASSERT_NO_ERRNO_AND_VALUE(
+      Mount(dir.path(), bindDir.path(), "", MS_BIND, "", 0));
+  ASSERT_THAT(mount(dir.path().c_str(), bindDir.path().c_str(), nullptr,
+                    MS_BIND | MS_REMOUNT | MS_RDONLY, nullptr),
+              SyscallSucceeds());
+
+  std::string const boundFifoPath = JoinPath(bindDir.path(), "fifo");
+  FileDescriptor rfd = ASSERT_NO_ERRNO_AND_VALUE(
+      Open(boundFifoPath, O_RDONLY | O_NONBLOCK));
+  FileDescriptor wfd = ASSERT_NO_ERRNO_AND_VALUE(
+      Open(boundFifoPath, O_WRONLY | O_NONBLOCK));
+  char msg[] = "hello";
+  EXPECT_THAT(write(wfd.get(), msg, sizeof(msg)),
+              SyscallSucceedsWithValue(sizeof(msg)));
+}
+
 // Test that bind mounting a directory onto a regular file fails with ENOTDIR.
 TEST(MountTest, BindMountDirectoryOntoFileFails) {
   SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));


### PR DESCRIPTION
Linux skips the mount-level write check when opening a character device, block device, FIFO, or socket, so write-opening /dev/null on a read-only bind mount succeeds. gVisor was running that check unconditionally and returning EROFS, which breaks buildah's mount-bind-then-RO-remount hardening pattern when used under runsc.

This adds an `IsSpecialFile` option on `FileDescription`, paired across the open and close paths so the writer counter stays balanced, and set it on every open path that backs a special-file inode. The socket and host-imported FDs live on internal disconnected mounts that are never remounted RO, so flagging them is a no-op today and exists for parity with the kernel's predicate.

Fixes: https://github.com/google/gvisor/issues/13148