### PR TITLE
lisafs: reject FRemoveXattr on deleted files

### DIFF
--- a/pkg/lisafs/handlers.go
+++ b/pkg/lisafs/handlers.go
@@ -1557,6 +1557,9 @@ func FRemoveXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (u
 	defer fd.DecRef(nil)
 
 	return 0, fd.safelyWrite(func() error {
+		if fd.node.isDeleted() {
+			return unix.EINVAL
+		}
 		return fd.impl.RemoveXattr(string(req.Name))
 	})
 }


### PR DESCRIPTION
## Summary

`FRemoveXattrHandler` in `pkg/lisafs/handlers.go` is the only xattr handler that does not check `node.isDeleted()` before operating on the FD's inode. The three sibling xattr handlers `FGetXattrHandler`, `FSetXattrHandler`, and `FListXattrHandler` all return `unix.EINVAL` inside their `safelyRead` / `safelyWrite` blocks when the underlying node has been unlinked.

This is a regression-fix from the pre-lisafs `pkg/p9` design and a sibling-consistency fix within lisafs.

## Background

The pre-deletion `pkg/p9/handlers.go` had a `Tremovexattr` handler with an explicit author comment and matching rejection (`pkg/p9/handlers.go` at parent of commit `89dbb7b64f`, which deleted most of pkg/p9):

```go
func (t *Tremovexattr) handle(cs *connState) message {
    ref, ok := cs.LookupFID(t.FID)
    ...
    if err := ref.safelyWrite(func() error {
        // Don't allow removexattr on files that have been deleted.
        if ref.isDeleted() {
            return unix.EINVAL
        }
        return ref.file.RemoveXattr(t.Name)
    }); err != nil { ... }
    return &Rremovexattr{}
}
```

The same `// Don't allow Xxattr on files that have been deleted.` comment plus check appears in the pre-deletion p9 versions of `Tgetxattr`, `Tsetxattr`, and `Tlistxattr`. All four xattr handlers had the check.

When pkg/p9 was ported to lisafs, 3 of 4 sibling xattr handlers kept the `isDeleted` check (`FGetXattrHandler` at line 1476, `FSetXattrHandler` at line 1508, `FListXattrHandler` at line 1530). `FRemoveXattrHandler` is the only one that lost it.

## Change

Add three lines inside the existing `safelyWrite` block:

```go
return 0, fd.safelyWrite(func() error {
    if fd.node.isDeleted() {
        return unix.EINVAL
    }
    return fd.impl.RemoveXattr(string(req.Name))
})
```

This matches the pattern used by `FSetXattrHandler` exactly. No behavior change for non-deleted files.

## Tests

I have a test sketch ready (`testFRemoveXattrOnDeleted`): mknod a file, set a `user.test` xattr, unlink the file while holding an open FD, then call `RemoveXattr` and expect `EINVAL`. Skips gracefully if the backing filesystem does not support xattrs.

The current `pkg/lisafs/testsuite/testsuite.go` has no xattr tests, so this would be the first one. Happy to add it as a follow-up if the reviewer prefers the test go in this PR or as a separate hardening-tests PR.

## Why no CVE / security framing

The sentry-layer `vfs.CheckXattrPermissions` already gates the dangerous xattr namespaces (`security.*` writes return `EOPNOTSUPP` except for `security.capability`; `trusted.*` requires `CAP_SYS_ADMIN`). The remaining cases an unprivileged sandbox can remove on an orphan inode are `user.*` and `security.capability`, neither of which produces exploitable impact on a dangling inode (no path, cannot be exec'd). Submitting as hardening / regression fix only.
