### PR TITLE
ci: declare per-job permissions for build, labeler, and stale workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
     - name: bazel
       run: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,9 @@ name: "Labeler"
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # read labeler config
+      pull-requests: write # apply labels to the PR
     steps:
     - uses: actions/labeler@v6
       if: github.base_ref == null

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,9 @@ name: Mark stale issues and pull requests
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write        # label / comment / close stale issues
+      pull-requests: write # label / comment / close stale PRs
     steps:
     - uses: actions/stale@v10
       with:


### PR DESCRIPTION
Three workflows currently run without an explicit `permissions:` block, so `GITHUB_TOKEN` inherits whatever the repo default is. The other workflows in `.github/workflows/` (`codeql.yml`, `go.yml`, `issue_reviver.yml`) already use the per-job permissions pattern; this brings the remaining three in line.

| Workflow | Scope | Why |
|---|---|---|
| `build.yml` | `contents: read` | `actions/checkout` + bazel build + `actions/upload-artifact` — read is enough; artifact upload uses the artifact API which works with `contents: read` |
| `labeler.yml` | `contents: read`, `pull-requests: write` | [actions/labeler v6 docs](https://github.com/actions/labeler#permissions) require these scopes to read `.github/labeler.yml` and apply labels |
| `stale.yml` | `issues: write`, `pull-requests: write` | [actions/stale v10 docs](https://github.com/actions/stale#recommended-permissions) require these to label, comment, and close stale items |

All three YAML files parse cleanly with PyYAML.