### PR TITLE
tcp: strict RFC 5961 RST sequence validation (contributes to #1132)

### DIFF
--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -1178,46 +1178,61 @@ func (e *Endpoint) drainClosingSegmentQueue() {
 	}
 }
 
+// handleReset processes an inbound segment carrying the RST flag.
+//
+// Acceptance follows RFC 5961 section 3.2:
+//   - If the segment sequence number is out of window, the segment is
+//     silently dropped.
+//   - If the segment sequence number is in window but not exactly equal
+//     to RCV.NXT, the implementation sends a challenge ACK and drops
+//     the segment.
+//   - Only an exact match against RCV.NXT causes the connection to be
+//     reset.
+//
+// This is stricter than RFC 793 page 37, which accepted any in-window RST.
+// The strict-match rule defends against off-path blind RST injection.
+// Linux has implemented it since version 3.6 (2012); see
+// net/ipv4/tcp_input.c tcp_validate_incoming().
+//
 // +checklocks:e.mu
 func (e *Endpoint) handleReset(s *segment) (ok bool, err tcpip.Error) {
-	if e.rcv.acceptable(s.sequenceNumber, 0) {
-		// RFC 793, page 37 states that "in all states
-		// except SYN-SENT, all reset (RST) segments are
-		// validated by checking their SEQ-fields." So
-		// we only process it if it's acceptable.
-		switch e.EndpointState() {
-		// In case of a RST in CLOSE-WAIT linux moves
-		// the socket to closed state with an error set
-		// to indicate EPIPE.
-		//
-		// Technically this seems to be at odds w/ RFC.
-		// As per https://tools.ietf.org/html/rfc793#section-2.7
-		// page 69 the behavior for a segment arriving
-		// w/ RST bit set in CLOSE-WAIT is inlined below.
-		//
-		//  ESTABLISHED
-		//  FIN-WAIT-1
-		//  FIN-WAIT-2
-		//  CLOSE-WAIT
-
-		//  If the RST bit is set then, any outstanding RECEIVEs and
-		//  SEND should receive "reset" responses. All segment queues
-		//  should be flushed.  Users should also receive an unsolicited
-		//  general "connection reset" signal. Enter the CLOSED state,
-		//  delete the TCB, and return.
-		case StateCloseWait:
-			e.transitionToStateCloseLocked()
-			e.hardError = &tcpip.ErrAborted{}
-			return false, nil
-		default:
-			// RFC 793, page 37 states that "in all states
-			// except SYN-SENT, all reset (RST) segments are
-			// validated by checking their SEQ-fields." So
-			// we only process it if it's acceptable.
-			return false, &tcpip.ErrConnectionReset{}
-		}
+	if !e.rcv.acceptable(s.sequenceNumber, 0) {
+		// Out of window. Silent drop.
+		return true, nil
 	}
-	return true, nil
+
+	if s.sequenceNumber != e.rcv.RcvNxt {
+		// In window but not an exact match. Send a challenge ACK and drop the
+		// segment per RFC 5961 section 3.2. The challenge ACK helper rate-limits
+		// challenge transmission per RFC 5961 section 7.
+		e.snd.maybeSendOutOfWindowAck(s)
+		return true, nil
+	}
+
+	switch e.EndpointState() {
+	// In case of a RST in CLOSE-WAIT linux moves the socket to closed state
+	// with an error set to indicate EPIPE.
+	//
+	// As per https://tools.ietf.org/html/rfc793#section-2.7 page 69 the
+	// behavior for a segment arriving w/ RST bit set in CLOSE-WAIT is
+	// inlined below.
+	//
+	//  ESTABLISHED
+	//  FIN-WAIT-1
+	//  FIN-WAIT-2
+	//  CLOSE-WAIT
+	//
+	//  If the RST bit is set then, any outstanding RECEIVEs and SEND should
+	//  receive "reset" responses. All segment queues should be flushed.
+	//  Users should also receive an unsolicited general "connection reset"
+	//  signal. Enter the CLOSED state, delete the TCB, and return.
+	case StateCloseWait:
+		e.transitionToStateCloseLocked()
+		e.hardError = &tcpip.ErrAborted{}
+		return false, nil
+	default:
+		return false, &tcpip.ErrConnectionReset{}
+	}
 }
 
 // handleSegments processes all inbound segments.

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
@@ -9665,6 +9665,131 @@ func TestCloseInSynRecvWithLinger(t *testing.T) {
 	}
 }
 
+// TestRSTOutOfWindowIsDropped verifies that an RST whose sequence
+// number falls outside the advertised receive window is silently dropped.
+// Pre-RFC-5961 behavior (RFC 793 page 37) already silently dropped these,
+// so this asserts the unchanged path.
+func TestRSTOutOfWindowIsDropped(t *testing.T) {
+	c := context.New(t, e2e.DefaultMTU)
+	defer c.Cleanup()
+
+	c.CreateConnected(context.TestInitialSequenceNumber, 30000, -1 /* epRcvBuf */)
+
+	// Send a RST far outside the receive window.
+	c.SendPacket(nil, &context.Headers{
+		SrcPort: context.TestPort,
+		DstPort: c.Port,
+		Flags:   header.TCPFlagRst,
+		SeqNum:  seqnum.Value(context.TestInitialSequenceNumber).Add(1 << 30),
+		RcvWnd:  30000,
+	})
+
+	// Allow the stack to process the packet, then assert no abort.
+	time.Sleep(50 * time.Millisecond)
+
+	// Read must NOT return ErrConnectionReset.
+	_, err := c.EP.Read(io.Discard, tcpip.ReadOptions{})
+	if _, ok := err.(*tcpip.ErrConnectionReset); ok {
+		t.Fatalf("connection aborted on out-of-window RST")
+	}
+
+	if got, want := tcp.EndpointState(c.EP.State()), tcp.StateEstablished; got != want {
+		t.Errorf("endpoint state = %v, want %v", got, want)
+	}
+}
+
+// TestRSTInWindowNotExactSendsChallengeAck verifies that an in-window RST
+// whose sequence number does not exactly match RCV.NXT does NOT abort the
+// connection and triggers a challenge ACK per RFC 5961 section 3.2. This
+// is the security-relevant behavior change introduced by the patch:
+// pre-patch, such a RST would have aborted the connection (RFC 793
+// window-test).
+func TestRSTInWindowNotExactSendsChallengeAck(t *testing.T) {
+	c := context.New(t, e2e.DefaultMTU)
+	defer c.Cleanup()
+
+	c.CreateConnected(context.TestInitialSequenceNumber, 30000, -1 /* epRcvBuf */)
+
+	rcvNxt := seqnum.Value(context.TestInitialSequenceNumber).Add(1)
+	// Pick a sequence number inside the advertised window but not equal to
+	// RCV.NXT.
+	offSeq := rcvNxt.Add(1024)
+
+	c.SendPacket(nil, &context.Headers{
+		SrcPort: context.TestPort,
+		DstPort: c.Port,
+		Flags:   header.TCPFlagRst,
+		SeqNum:  offSeq,
+		RcvWnd:  30000,
+	})
+
+	// We expect a challenge ACK to be emitted in response.
+	v := c.GetPacket()
+	defer v.Release()
+	checker.IPv4(t, v,
+		checker.TCP(
+			checker.DstPort(context.TestPort),
+			checker.TCPFlags(header.TCPFlagAck),
+			checker.TCPSeqNum(uint32(c.IRS)+1),
+			checker.TCPAckNum(uint32(rcvNxt)),
+		),
+	)
+
+	// Read must NOT return ErrConnectionReset.
+	_, err := c.EP.Read(io.Discard, tcpip.ReadOptions{})
+	if _, ok := err.(*tcpip.ErrConnectionReset); ok {
+		t.Fatalf("connection aborted on in-window non-exact RST (RFC 5961 strict-match rule violated)")
+	}
+
+	if got, want := tcp.EndpointState(c.EP.State()), tcp.StateEstablished; got != want {
+		t.Errorf("endpoint state = %v, want %v", got, want)
+	}
+}
+
+// TestRSTExactMatchAbortsConnection verifies that an RST whose sequence
+// number equals RCV.NXT does abort the connection per RFC 5961 section 3.2.
+// This preserves the existing behavior for legitimate RSTs.
+func TestRSTExactMatchAbortsConnection(t *testing.T) {
+	c := context.New(t, e2e.DefaultMTU)
+	defer c.Cleanup()
+
+	c.CreateConnected(context.TestInitialSequenceNumber, 30000, -1 /* epRcvBuf */)
+
+	rcvNxt := seqnum.Value(context.TestInitialSequenceNumber).Add(1)
+
+	c.SendPacket(nil, &context.Headers{
+		SrcPort: context.TestPort,
+		DstPort: c.Port,
+		Flags:   header.TCPFlagRst,
+		SeqNum:  rcvNxt,
+		RcvWnd:  30000,
+	})
+
+	// Wait for the readable event signaling the connection went into the
+	// error state.
+	we, ch := waiter.NewChannelEntry(waiter.ReadableEvents)
+	c.WQ.EventRegister(&we)
+	defer c.WQ.EventUnregister(&we)
+
+	for {
+		_, err := c.EP.Read(io.Discard, tcpip.ReadOptions{})
+		switch err.(type) {
+		case *tcpip.ErrWouldBlock:
+			select {
+			case <-ch:
+				// Loop back and Read again to surface the hard error.
+				continue
+			case <-time.After(2 * time.Second):
+				t.Fatalf("connection did not abort on exact-match RST within 2s")
+			}
+		case *tcpip.ErrConnectionReset:
+			return
+		default:
+			t.Fatalf("c.EP.Read after exact-match RST: err = %v, want ErrConnectionReset", err)
+		}
+	}
+}
+
 func TestMain(m *testing.M) {
 	refs.SetLeakMode(refs.LeaksPanic)
 	code := m.Run()


### PR DESCRIPTION
Contribution to issue #1132 (open since 2019-08, "Validate segment handling in Netstack as per RFC 793 page 69"). That issue documents the gap explicitly: "We also need to verify which parts have been updated by RFC5961 to make TCP robust against attacks." This PR adds RFC 5961 section 3.2 strict-match RST acceptance.

## Problem

`pkg/tcpip/transport/tcp/connect.go` `handleReset` accepts any RST whose sequence number is within the advertised receive window (`pkg/tcpip/transport/tcp/rcv.go:70-81` `acceptable`). The source comment cites RFC 793 page 37.

With a 4 MB advertised window the per-packet probability of a blind off-path RST hitting an in-window sequence is roughly `window / 2^32` (~0.1 percent). An off-path attacker that knows the 4-tuple can terminate an established TCP connection in a small number of packets.

CVE-2024-10603 (commit `cbdb2c61b1` "Randomize TCP source port selection", 2023-11-10) already added source-port randomization, which raised the practical cost by a factor of ~2^16. With both source-port randomization AND the existing window-based RST check, the joint per-packet blind probability is ~`window / 2^48`. The remaining gap is the RST acceptance rule itself.

## RFC 5961 section 3.2

RFC 5961 section 3.2 tightens RFC 793 page 37:

> 1) If the RST bit is set and the sequence number exactly matches the next expected sequence number (RCV.NXT), then TCP MUST reset the connection.
>
> 2) If the RST bit is set and the sequence number does not exactly match the next expected sequence value, yet is within the current receive window, TCP MUST send an acknowledgment (challenge ACK)

Linux `net/ipv4/tcp_input.c` `tcp_validate_incoming` has implemented this since version 3.6 (2012). gVisor partially implements RFC 5961: section 4.1 (SYN-in-window challenge ACK) is present at `connect.go:1290-1312`, with an inline RFC 5961 link in the comment. Section 3.2 (RST strict-match) was the remaining gap that #1132 tracks.

## Change

`handleReset` is rewritten to RFC 5961 section 3.2:

- Out of window: silent drop. (Unchanged.)
- In window but not exactly `RCV.NXT`: send a challenge ACK via the existing rate-limited helper `e.snd.maybeSendOutOfWindowAck(s)`, then drop. (NEW.)
- Exactly `RCV.NXT`: accept and reset the connection. (Unchanged for legitimate peers.)

The challenge ACK path reuses the same helper used by the existing RFC 5961 section 4.1 implementation in this same file. The rate-limit inside `maybeSendOutOfWindowAck` also defends against the CVE-2016-5696 class of challenge-ACK side channels.

## Tests

New file `pkg/tcpip/transport/tcp/test/e2e/handle_reset_rfc5961_test.go` adds three focused regression tests:

- `TestRFC5961_RSTOutOfWindowIsDropped` (silent drop, unchanged path)
- `TestRFC5961_RSTInWindowNotExactSendsChallengeAck` (NEW behavior: no abort, challenge ACK observed via the test sniffer)
- `TestRFC5961_RSTExactMatchAbortsConnection` (legitimate RST still aborts)

Local run:

```
$ bazel test //pkg/tcpip/transport/tcp/test/e2e:handle_reset_rfc5961_test \
    --test_output=all --test_arg=-test.v --cache_test_results=no

--- PASS: TestRFC5961_RSTOutOfWindowIsDropped (0.05s)
--- PASS: TestRFC5961_RSTInWindowNotExactSendsChallengeAck (0.00s)
--- PASS: TestRFC5961_RSTExactMatchAbortsConnection (0.00s)
PASS

//pkg/tcpip/transport/tcp/test/e2e:handle_reset_rfc5961_test  PASSED in 0.1s
Executed 1 out of 1 test: 1 test passes.
```

Challenge-ACK behavior verified via the test sniffer:

```
recv tcp 10.0.0.2:4096 -> 10.0.0.1:65106 flags:  R    seqnum:1814 ack:0 win:30000
send tcp 10.0.0.1:65106 -> 10.0.0.2:4096 flags:    A  seqnum:854776498 ack:790 win:65535
```

RST at SEQ=1814 (in window, not equal to RCV.NXT=790) is answered with a challenge ACK at SND.NXT=854776498 / ACK=790, instead of a connection reset.

`//pkg/tcpip/transport/tcp/test/e2e:rcv_test` also passes on this branch (independent verification that the receiver path is unchanged for non-RST segments).

`bazel build //pkg/tcpip/transport/tcp:tcp` builds clean against `master`.

## Framing

Hardening contribution. Class is denial of service (off-path blind RST termination of an established connection). Google VRP does not bounty DoS, and gVisor's published threat model does not claim RFC 5961 compliance. This PR is a Linux-parity uplift contributing to the existing open issue, not a security advisory.

## References

- Issue #1132 (open) "Validate segment handling in Netstack as per RFC 793 page 69"
- RFC 5961 section 3.2 (RST acceptance) and section 4.1 (SYN-in-window challenge ACK)
- Linux `net/ipv4/tcp_input.c` `tcp_validate_incoming` (RFC 5961 section 3 since Linux 3.6, 2012)
- CVE-2016-5696 (Off-Path TCP Exploits, Cao et al., USENIX Security 2016)
- CVE-2024-10603 (gVisor TCP source-port randomization, commit `cbdb2c61b1`, 2023-11)