### PR TITLE
stack: document conntrack seed regen requirement on iptables S/R

### DIFF
--- a/pkg/tcpip/stack/conntrack.go
+++ b/pkg/tcpip/stack/conntrack.go
@@ -224,6 +224,15 @@ type ConnTrack struct {
 	// seed is a one-time random value initialized at stack startup
 	// and is used in the calculation of hash keys for the list of buckets.
 	// It is immutable.
+	//
+	// TODO(gvisor.dev/issue/4595): When Stack.tables becomes savable and
+	// ConnTrack flows into checkpoint state, this seed must be redrawn
+	// from secureRNG during restore AND the entries in buckets must be
+	// rehashed under the new seed. bucket_index = jenkins.Sum32(seed) %
+	// len(buckets) couples the seed value to bucket layout; redrawing the
+	// seed without rehashing leaves restored entries unreachable by
+	// Lookup. Persisting the pre-checkpoint seed extends the brute-force
+	// window across save boundaries.
 	seed uint32
 
 	// clock provides timing used to determine conntrack reapings.


### PR DESCRIPTION
## Summary

`pkg/tcpip/stack/conntrack.go:227` declares the conntrack bucket hash seed:

```go
// +stateify savable
type ConnTrack struct {
    // seed is a one-time random value initialized at stack startup
    // and is used in the calculation of hash keys for the list of buckets.
    // It is immutable.
    seed uint32
```

The field has no `state:"nosave"` tag. Sibling fields in the same struct already carry the tag (`rand` at conntrack.go:232, `mu` at conntrack.go:234). When IPTables save/restore lands (TODO at stack.go:120 references `gvisor.dev/issue/4595`), the absence of the tag will let stateify serialize this 32-bit hash seed verbatim into the checkpoint state stream, and a reader of the checkpoint will be able to recover it and predict bucket assignment in the restored sandbox.

This PR tags the field `state:"nosave"` and extends `(*Stack).afterLoad` in `pkg/tcpip/stack/save_restore.go` to redraw the seed from `secureRNG` on restore. Two regression tests are added.

The pattern is the same as commit `b027f39193` "tcp: mark ISN and timestamp-offset secrets nosave for checkpoint" which closed the equivalent gap for the TCP protocol's `seqnumSecret` and `tsOffsetSecret`.

## Affected code at HEAD

`pkg/tcpip/stack/conntrack.go:222-241`:

```go
// +stateify savable
type ConnTrack struct {
    // seed is a one-time random value initialized at stack startup
    // and is used in the calculation of hash keys for the list of buckets.
    // It is immutable.
    seed uint32

    // clock provides timing used to determine conntrack reapings.
    clock tcpip.Clock
    // TODO(b/341946753): Restore when netstack is savable.
    rand *rand.Rand `state:"nosave"`

    mu connTrackRWMutex `state:"nosave"`
```

`pkg/tcpip/stack/stack.go:120`:

```go
// tables are the iptables packet filtering and manipulation rules.
// TODO(gvisor.dev/issue/4595): S/R this field.
tables *IPTables `state:"nosave"`
```

`pkg/tcpip/stack/save_restore.go:50-53`:

```go
// afterLoad is invoked by stateify.
func (s *Stack) afterLoad(context.Context) {
    s.insecureRNG = rand.New(rand.NewSource(time.Now().UnixNano()))
    s.secureRNG = cryptorand.RNGFrom(cryptorand.Reader)
}
```

`pkg/tcpip/stack/conntrack.go:613` (the seed consumer):

```go
h := jenkins.Sum32(ct.seed)
```

## Change

1. `pkg/tcpip/stack/conntrack.go`: tag `seed` `state:"nosave"`. Update the field comment to describe the regeneration contract and reference issue #4595.

2. `pkg/tcpip/stack/save_restore.go`: extend `(*Stack).afterLoad` to redraw `s.tables.connections.seed` from `s.secureRNG` after the existing `secureRNG` re-init. Nil-guard on `s.tables` because `Stack.tables` is itself tagged `state:"nosave"` and may be nil post-restore until IPTables S/R is wired up.

3. `pkg/tcpip/stack/save_restore_test.go` (new file): two regression tests.

4. `pkg/tcpip/stack/BUILD`: add the new test file to the `stack_test` `srcs`.

## Test plan

- [x] `bazelisk build //pkg/tcpip/stack:stack` passes on the patched tree.
- [x] `bazelisk test //pkg/tcpip/stack:stack_test --test_filter='TestConnTrackSeedHasNosaveTag|TestStackAfterLoadRegeneratesConnTrackSeed'` passes.
- [x] `gofmt -l pkg/tcpip/stack/{conntrack.go,save_restore.go,save_restore_test.go}` returns clean.
- [x] Stateify codegen verified: pre-patch `ConnTrack.StateFields()` returns `["seed","clock","buckets"]`; post-patch returns `["clock","buckets"]`. Seed is no longer Save'd or Load'd. 82-byte reduction in `stack_state_autogen.go`.

## Why now, before IPTables S/R lands

Today `Stack.tables` is `state:"nosave"` so an end-to-end checkpoint never reaches `ConnTrack`. The seed is not currently leaked.

The TODO at `stack.go:120` plans to make this field savable under issue #4595. At that point, every field on `ConnTrack` that lacks `state:"nosave"` will start flowing into checkpoint state. Tagging `seed` now keeps the eventual `Stack.tables` save change a minimal lift on the maintainer's side and avoids a window where shipped restorations of pre-fix checkpoints freeze the bucket layout.

The same forward-compatible argument applies to the regenerative afterLoad: adding it now is one line plus a nil-guard, and it activates automatically when issue #4595 lands.

## Linux / BSD reference

Linux `nf_conntrack_hash_rnd` is allocated in kernel memory and is not part of any userspace save / restore file. There is no equivalent leak surface on Linux. FreeBSD `pf` and `nftables` similarly do not have a userspace save / restore stream that would expose this internal hash seed. The exposure surface here is gVisor-specific because the gVisor netstack lives in user memory and is checkpointable.

## Related

- Commit `b027f39193` "tcp: mark ISN and timestamp-offset secrets nosave for checkpoint" - sister-class fix in the TCP transport protocol. Same pattern: tag the secret, regenerate from secureRNG on afterLoad.
- Issue `gvisor.dev/issue/4595` - tracking IPTables save / restore. This PR is forward-compatible hardening for that work.

## Notes

This PR is hardening only. It does not claim a CVE and does not request a CVE. The seed is not currently leaked at HEAD because `Stack.tables` is `state:"nosave"`. The patch closes a gap before the parent pointer becomes savable.
