### PR TITLE
tmpfs: account for long symlink targets when restoring from tar

### DIFF
--- a/pkg/sentry/fsimpl/tmpfs/BUILD
+++ b/pkg/sentry/fsimpl/tmpfs/BUILD
@@ -162,6 +162,7 @@ go_test(
         "pipe_test.go",
         "regular_file_test.go",
         "stat_test.go",
+        "tar_test.go",
         "tmpfs_test.go",
     ],
     library = ":tmpfs",

--- a/pkg/sentry/fsimpl/tmpfs/tar.go
+++ b/pkg/sentry/fsimpl/tmpfs/tar.go
@@ -255,6 +255,16 @@ func (fs *filesystem) symlinkFromTar(hdr *tar.Header, pathToInode map[string]*in
 	if !ok {
 		return fmt.Errorf("%v is not a directory", dir)
 	}
+	// Linux allocates a page to store symlink targets that have length larger
+	// than shortSymlinkLen. Mirror SymlinkAt's accounting so creation and
+	// teardown stay balanced; otherwise (*inode).decRef's matching
+	// unaccountPages(1) underflows fs.pagesUsed and panics on teardown.
+	// See mm/shmem.c:shmem_symlink().
+	if len(hdr.Linkname) >= shortSymlinkLen {
+		if !fs.accountPages(1) {
+			return fmt.Errorf("tmpfs: insufficient space to account for symlink target %q", hdr.Name)
+		}
+	}
 	child := fs.newDentry(fs.newSymlink(auth.KUID(hdr.Uid), auth.KGID(hdr.Gid), 0777, hdr.Linkname, parentDir))
 	child.inode.mtime.Store(hdr.ModTime.UnixNano())
 	child.inode.setXattrsFromPAXRecords(hdr)

--- a/pkg/sentry/fsimpl/tmpfs/tar_test.go
+++ b/pkg/sentry/fsimpl/tmpfs/tar_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tmpfs
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/sentry/contexttest"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+)
+
+// TestSourceTarLongSymlinkRelease is a regression test for a bug where
+// symlinkFromTar did not call fs.accountPages(1) for symlinks whose target
+// length is >= shortSymlinkLen, while (*inode).decRef unconditionally calls
+// fs.unaccountPages(1) on teardown for such symlinks. The asymmetry
+// underflowed fs.pagesUsed and panicked filesystem.unaccountPages on
+// mount-namespace teardown.
+func TestSourceTarLongSymlinkRelease(t *testing.T) {
+	ctx := contexttest.Context(t)
+	creds := auth.CredentialsFromContext(ctx)
+
+	// Symlink target of length shortSymlinkLen (128) triggers the long-symlink
+	// accounting path.
+	longTarget := strings.Repeat("a", shortSymlinkLen)
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "./",
+		Typeflag: tar.TypeDir,
+		Mode:     0755,
+	}); err != nil {
+		t.Fatalf("tar.WriteHeader(dir): %v", err)
+	}
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "./longlink",
+		Typeflag: tar.TypeSymlink,
+		Linkname: longTarget,
+		Mode:     0777,
+	}); err != nil {
+		t.Fatalf("tar.WriteHeader(symlink): %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar.Writer.Close: %v", err)
+	}
+
+	vfsObj := &vfs.VirtualFilesystem{}
+	if err := vfsObj.Init(ctx); err != nil {
+		t.Fatalf("VFS init: %v", err)
+	}
+	vfsObj.MustRegisterFilesystemType("tmpfs", FilesystemType{}, &vfs.RegisterFilesystemTypeOptions{
+		AllowUserMount: true,
+	})
+
+	mntns, err := vfsObj.NewMountNamespace(ctx, creds, "", "tmpfs", &vfs.MountOptions{
+		GetFilesystemOptions: vfs.GetFilesystemOptions{
+			InternalData: FilesystemOpts{
+				SourceTar: io.NopCloser(&buf),
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewMountNamespace: %v", err)
+	}
+
+	// Drop the only reference to trigger filesystem teardown. Without the fix,
+	// releaseChildrenLocked -> inode.decRef -> fs.unaccountPages(1) underflows
+	// fs.pagesUsed and panics here.
+	mntns.DecRef(ctx)
+}


### PR DESCRIPTION
## Summary

Fixes a sentry panic on overlay teardown when the `dev.gvisor.tar.rootfs.upper` archive contains long-target symlinks.

`symlinkFromTar` (in `pkg/sentry/fsimpl/tmpfs/tar.go`) creates symlink inodes without calling `accountPages(1)` for long targets, while the corresponding `unaccountPages(1)` in `(*inode).decRef` fires unconditionally on teardown. The asymmetry underflows `fs.pagesUsed` and panics:

    panic: Deallocating more pages than allocated: fs.pagesUsed = 0, pagesDec = 1

The `SymlinkAt` path at `filesystem.go:799-814` already handles this:

```go
if len(target) >= shortSymlinkLen {
    if !fs.accountPages(1) {
        return linuxerr.ENOSPC
    }
}
```

This PR mirrors that call in `symlinkFromTar`.

## Repro

Triggered by any tar applied via `tmpfsOpts.SourceTar` that contains symlinks with target length ≥ 128 bytes (`shortSymlinkLen`). pnpm-style `node_modules/.pnpm/<pkg>@<version>_<hash>/...` paths routinely exceed this threshold; in one observed archive, 181 of 1,003 symlinks had targets ≥ 128 bytes (max 176). Mounting such a tmpfs and dropping the mount-namespace reference deterministically panics on teardown.

Captured from the new regression test with the fix reverted:

```
panic: Deallocating more pages than allocated: fs.pagesUsed = 0, pagesDec = 1 [recovered, repanicked]

goroutine 36 [running]:
panic(...)
        GOROOT/src/runtime/panic.go:783
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.(*filesystem).unaccountPages(...)
        pkg/sentry/fsimpl/tmpfs/filesystem.go:1064
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.(*inode).decLinksLocked.(*inode).decRef.func1()
        pkg/sentry/fsimpl/tmpfs/tmpfs.go:646
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.(*inodeRefs).DecRef(...)
        pkg/sentry/fsimpl/tmpfs/inode_refs.go:133
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.(*inode).decRef(...)
        pkg/sentry/fsimpl/tmpfs/tmpfs.go:640
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.(*inode).decLinksLocked(...)
        pkg/sentry/fsimpl/tmpfs/tmpfs.go:627
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.(*dentry).releaseChildrenLocked(...)
        pkg/sentry/fsimpl/tmpfs/tmpfs.go:429
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.(*filesystem).Release(...)
        pkg/sentry/fsimpl/tmpfs/tmpfs.go:394
gvisor.dev/gvisor/pkg/sentry/vfs.(*Filesystem).DecRef.func1()
        pkg/sentry/vfs/filesystem.go:83
gvisor.dev/gvisor/pkg/sentry/vfs.(*Mount).destroy(...)
        pkg/sentry/vfs/mount.go:1005
gvisor.dev/gvisor/pkg/sentry/vfs.(*MountNamespace).Destroy(...)
        pkg/sentry/vfs/namespace.go:205
gvisor.dev/gvisor/pkg/sentry/vfs.(*MountNamespace).DecRef(...)
        pkg/sentry/vfs/namespace.go:225
gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs.TestSourceTarLongSymlinkRelease(...)
        pkg/sentry/fsimpl/tmpfs/tar_test.go:85
```

## Test

Added a regression test (`TestSourceTarLongSymlinkRelease` in `pkg/sentry/fsimpl/tmpfs/tar_test.go`) that builds an in-memory tar with a long-target symlink, mounts a tmpfs from it via `SourceTar`, and verifies release does not panic. Without the fix, the test reproduces the panic above.

Verified with:
- `bazel test //pkg/sentry/fsimpl/tmpfs:tmpfs_test`
- `bazel build //runsc`

Assisted-by: Claude Opus 4.7