### PR TITLE
netstack: let ICMP echo handlers consume requests

### DIFF
--- a/pkg/tcpip/network/ipv4/icmp.go
+++ b/pkg/tcpip/network/ipv4/icmp.go
@@ -360,14 +360,21 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 		localAddressTemporary := pkt.NetworkPacketInfo.LocalAddressTemporary
 		localAddressBroadcast := pkt.NetworkPacketInfo.LocalAddressBroadcast
 
-		// It's possible that a raw socket or custom defaultHandler expects to
-		// receive this packet.
-		e.dispatcher.DeliverTransportPacket(header.ICMPv4ProtocolNumber, pkt)
+		// It's possible that a raw socket or per-stack default handler expects
+		// to receive this packet.
+		defaultHandlerHandled := false
+		if dispatcher, ok := e.dispatcher.(stack.TransportDispatcherWithDefaultHandlerResult); ok {
+			_, defaultHandlerHandled = dispatcher.DeliverTransportPacketWithDefaultHandlerResult(header.ICMPv4ProtocolNumber, pkt)
+		} else {
+			e.dispatcher.DeliverTransportPacket(header.ICMPv4ProtocolNumber, pkt)
+		}
 		pkt = nil
 
-		// Skip direct ICMP echo reply if the packet was received with a temporary
-		// address, allowing custom handlers to take over.
-		if localAddressTemporary {
+		// Skip the built-in ICMP echo reply if the request was consumed by a
+		// per-stack default handler. Also preserve the IPv4 behavior for
+		// temporary local addresses: the packet is delivered above, but the
+		// stack does not synthesize an echo reply for it.
+		if defaultHandlerHandled || localAddressTemporary {
 			return
 		}
 

--- a/pkg/tcpip/network/ipv4/ipv4_test.go
+++ b/pkg/tcpip/network/ipv4/ipv4_test.go
@@ -3886,6 +3886,319 @@ func TestCloseLocking(t *testing.T) {
 	}()
 }
 
+func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
+	var (
+		localAddr = tcpip.ProtocolAddress{
+			Protocol: ipv4.ProtocolNumber,
+			AddressWithPrefix: tcpip.AddressWithPrefix{
+				Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.1").To4()),
+				PrefixLen: 24,
+			},
+		}
+		remoteAddr = tcpip.ProtocolAddress{
+			Protocol: ipv4.ProtocolNumber,
+			AddressWithPrefix: tcpip.AddressWithPrefix{
+				Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.2").To4()),
+				PrefixLen: 24,
+			},
+		}
+	)
+
+	tests := []struct {
+		name              string
+		installHandler    bool
+		handled           bool
+		wantHandlerCalled bool
+		wantReply         bool
+	}{
+		{
+			name:      "no default handler",
+			wantReply: true,
+		},
+		{
+			name:              "default handler handled",
+			installHandler:    true,
+			handled:           true,
+			wantHandlerCalled: true,
+			wantReply:         false,
+		},
+		{
+			name:              "default handler not handled",
+			installHandler:    true,
+			handled:           false,
+			wantHandlerCalled: true,
+			wantReply:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clock := faketime.NewManualClock()
+			s := stack.New(stack.Options{
+				NetworkProtocols:   []stack.NetworkProtocolFactory{arp.NewProtocol, ipv4.NewProtocol},
+				TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+				Clock:              clock,
+			})
+			defer func() {
+				s.Close()
+				s.Wait()
+				refs.DoRepeatedLeakCheck()
+			}()
+
+			const ident = 1234
+			handlerCalled := false
+			if test.installHandler {
+				s.SetTransportProtocolHandler(icmp.ProtocolNumber4, func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
+					handlerCalled = true
+					if got := id.LocalPort; got != ident {
+						t.Errorf("got id.LocalPort = %d, want = %d", got, ident)
+					}
+					return test.handled
+				})
+			}
+
+			e := channel.New(1, defaultMTU, "")
+			defer e.Close()
+			if err := s.CreateNIC(nicID, e); err != nil {
+				t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+			}
+			if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+				t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+			}
+			s.SetRouteTable([]tcpip.Route{{
+				Destination: localAddr.AddressWithPrefix.Subnet(),
+				NIC:         nicID,
+			}})
+
+			totalLength := header.IPv4MinimumSize + header.ICMPv4MinimumSize
+			hdr := prependable.New(totalLength)
+			icmpH := header.ICMPv4(hdr.Prepend(header.ICMPv4MinimumSize))
+			icmpH.SetIdent(ident)
+			icmpH.SetType(header.ICMPv4Echo)
+			icmpH.SetCode(header.ICMPv4UnusedCode)
+			icmpH.SetChecksum(0)
+			icmpH.SetChecksum(^checksum.Checksum(icmpH, 0))
+			ip := header.IPv4(hdr.Prepend(header.IPv4MinimumSize))
+			ip.Encode(&header.IPv4Fields{
+				TotalLength: uint16(totalLength),
+				Protocol:    uint8(icmp.ProtocolNumber4),
+				TTL:         ipv4.DefaultTTL,
+				SrcAddr:     remoteAddr.AddressWithPrefix.Address,
+				DstAddr:     localAddr.AddressWithPrefix.Address,
+			})
+			ip.SetChecksum(^ip.CalculateChecksum())
+			echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+				Payload: buffer.MakeWithData(hdr.View()),
+			})
+			e.InjectInbound(header.IPv4ProtocolNumber, echoPkt)
+			echoPkt.DecRef()
+			clock.RunImmediatelyScheduledJobs()
+
+			if got, want := handlerCalled, test.wantHandlerCalled; got != want {
+				t.Fatalf("got handlerCalled = %t, want = %t", got, want)
+			}
+
+			p := e.Read()
+			if !test.wantReply {
+				if p != nil {
+					p.DecRef()
+					t.Fatalf("got unexpected ICMP echo reply")
+				}
+				return
+			}
+			if p == nil {
+				t.Fatalf("expected ICMP echo reply")
+			}
+			defer p.DecRef()
+			payload := stack.PayloadSince(p.NetworkHeader())
+			defer payload.Release()
+			checker.IPv4(t, payload,
+				checker.SrcAddr(localAddr.AddressWithPrefix.Address),
+				checker.DstAddr(remoteAddr.AddressWithPrefix.Address),
+				checker.ICMPv4(
+					checker.ICMPv4Type(header.ICMPv4EchoReply),
+					checker.ICMPv4Code(header.ICMPv4UnusedCode)))
+		})
+	}
+}
+
+func TestICMPEchoRegisteredEndpointDoesNotSuppressReply(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.1").To4()),
+			PrefixLen: 24,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.2").To4()),
+			PrefixLen: 24,
+		},
+	}
+
+	clock := faketime.NewManualClock()
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{arp.NewProtocol, ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+		Clock:              clock,
+	})
+	defer func() {
+		s.Close()
+		s.Wait()
+		refs.DoRepeatedLeakCheck()
+	}()
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	const ident = 1234
+	var wq waiter.Queue
+	ep, err := s.NewEndpoint(icmp.ProtocolNumber4, ipv4.ProtocolNumber, &wq)
+	if err != nil {
+		t.Fatalf("s.NewEndpoint(%d, %d, _) = %s", icmp.ProtocolNumber4, ipv4.ProtocolNumber, err)
+	}
+	defer ep.Close()
+	if err := ep.Bind(tcpip.FullAddress{Addr: localAddr.AddressWithPrefix.Address, Port: ident}); err != nil {
+		t.Fatalf("ep.Bind(...) = %s", err)
+	}
+
+	handlerCalled := false
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber4, func(stack.TransportEndpointID, *stack.PacketBuffer) bool {
+		handlerCalled = true
+		return true
+	})
+
+	totalLength := header.IPv4MinimumSize + header.ICMPv4MinimumSize
+	hdr := prependable.New(totalLength)
+	icmpH := header.ICMPv4(hdr.Prepend(header.ICMPv4MinimumSize))
+	icmpH.SetIdent(ident)
+	icmpH.SetType(header.ICMPv4Echo)
+	icmpH.SetCode(header.ICMPv4UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(^checksum.Checksum(icmpH, 0))
+	ip := header.IPv4(hdr.Prepend(header.IPv4MinimumSize))
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(totalLength),
+		Protocol:    uint8(icmp.ProtocolNumber4),
+		TTL:         ipv4.DefaultTTL,
+		SrcAddr:     remoteAddr.AddressWithPrefix.Address,
+		DstAddr:     localAddr.AddressWithPrefix.Address,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(header.IPv4ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	clock.RunImmediatelyScheduledJobs()
+
+	if handlerCalled {
+		t.Fatalf("default handler was unexpectedly called")
+	}
+
+	p := e.Read()
+	if p == nil {
+		t.Fatalf("expected ICMP echo reply")
+	}
+	defer p.DecRef()
+	payload := stack.PayloadSince(p.NetworkHeader())
+	defer payload.Release()
+	checker.IPv4(t, payload,
+		checker.SrcAddr(localAddr.AddressWithPrefix.Address),
+		checker.DstAddr(remoteAddr.AddressWithPrefix.Address),
+		checker.ICMPv4(
+			checker.ICMPv4Type(header.ICMPv4EchoReply),
+			checker.ICMPv4Code(header.ICMPv4UnusedCode)))
+}
+
+func TestICMPEchoTemporaryAddressSuppressesReply(t *testing.T) {
+	assignedAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.1").To4()),
+			PrefixLen: 24,
+		},
+	}
+	temporaryAddr := tcpip.AddrFromSlice(net.ParseIP("192.168.0.99").To4())
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.2").To4()),
+			PrefixLen: 24,
+		},
+	}
+
+	clock := faketime.NewManualClock()
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{arp.NewProtocol, ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+		Clock:              clock,
+	})
+	defer func() {
+		s.Close()
+		s.Wait()
+		refs.DoRepeatedLeakCheck()
+	}()
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, assignedAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, assignedAddr, err)
+	}
+	if err := s.SetPromiscuousMode(nicID, true); err != nil {
+		t.Fatalf("s.SetPromiscuousMode(%d, true): %s", nicID, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: assignedAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	const ident = 1234
+	totalLength := header.IPv4MinimumSize + header.ICMPv4MinimumSize
+	hdr := prependable.New(totalLength)
+	icmpH := header.ICMPv4(hdr.Prepend(header.ICMPv4MinimumSize))
+	icmpH.SetIdent(ident)
+	icmpH.SetType(header.ICMPv4Echo)
+	icmpH.SetCode(header.ICMPv4UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(^checksum.Checksum(icmpH, 0))
+	ip := header.IPv4(hdr.Prepend(header.IPv4MinimumSize))
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(totalLength),
+		Protocol:    uint8(icmp.ProtocolNumber4),
+		TTL:         ipv4.DefaultTTL,
+		SrcAddr:     remoteAddr.AddressWithPrefix.Address,
+		DstAddr:     temporaryAddr,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(header.IPv4ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	clock.RunImmediatelyScheduledJobs()
+
+	if p := e.Read(); p != nil {
+		p.DecRef()
+		t.Fatalf("got unexpected ICMP echo reply")
+	}
+}
+
 func TestIcmpRateLimit(t *testing.T) {
 	var (
 		host1IPv4Addr = tcpip.ProtocolAddress{

--- a/pkg/tcpip/network/ipv6/icmp.go
+++ b/pkg/tcpip/network/ipv6/icmp.go
@@ -654,6 +654,27 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer, hasFragmentHeader bool, r
 
 	case header.ICMPv6EchoRequest:
 		received.echoRequest.Increment()
+		replyPayload := pkt.Data().ToBuffer()
+		replyHeader := make([]byte, header.ICMPv6EchoMinimumSize)
+		copy(replyHeader, h[:header.ICMPv6EchoMinimumSize])
+
+		// It's possible that a raw socket or per-stack default handler expects
+		// to receive this packet.
+		defaultHandlerHandled := false
+		if dispatcher, ok := e.dispatcher.(stack.TransportDispatcherWithDefaultHandlerResult); ok {
+			_, defaultHandlerHandled = dispatcher.DeliverTransportPacketWithDefaultHandlerResult(header.ICMPv6ProtocolNumber, pkt)
+		} else {
+			e.dispatcher.DeliverTransportPacket(header.ICMPv6ProtocolNumber, pkt)
+		}
+		pkt = nil
+
+		// Skip the built-in ICMP echo reply if the request was consumed by a
+		// per-stack default handler.
+		if defaultHandlerHandled {
+			replyPayload.Release()
+			return
+		}
+
 		// As per RFC 4291 section 2.7, multicast addresses must not be used as
 		// source addresses in IPv6 packets.
 		localAddr := dstAddr
@@ -664,23 +685,25 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer, hasFragmentHeader bool, r
 		r, err := e.protocol.stack.FindRoute(e.nic.ID(), localAddr, srcAddr, ProtocolNumber, false /* multicastLoop */)
 		if err != nil {
 			// If we cannot find a route to the destination, silently drop the packet.
+			replyPayload.Release()
 			return
 		}
 		defer r.Release()
 
 		if !e.protocol.allowICMPReply(header.ICMPv6EchoReply) {
 			sent.rateLimited.Increment()
+			replyPayload.Release()
 			return
 		}
 
 		replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 			ReserveHeaderBytes: int(r.MaxHeaderLength()) + header.ICMPv6EchoMinimumSize,
-			Payload:            pkt.Data().ToBuffer(),
+			Payload:            replyPayload,
 		})
 		defer replyPkt.DecRef()
 		icmp := header.ICMPv6(replyPkt.TransportHeader().Push(header.ICMPv6EchoMinimumSize))
 		replyPkt.TransportProtocolNumber = header.ICMPv6ProtocolNumber
-		copy(icmp, h)
+		copy(icmp, replyHeader)
 		icmp.SetType(header.ICMPv6EchoReply)
 		replyData := replyPkt.Data()
 		icmp.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{

--- a/pkg/tcpip/network/ipv6/icmp_test.go
+++ b/pkg/tcpip/network/ipv6/icmp_test.go
@@ -229,6 +229,233 @@ func (c *testContext) cleanup() {
 	refs.DoRepeatedLeakCheck()
 }
 
+func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
+	var (
+		localAddr = tcpip.ProtocolAddress{
+			Protocol: ProtocolNumber,
+			AddressWithPrefix: tcpip.AddressWithPrefix{
+				Address:   tcpip.AddrFromSlice(net.ParseIP("a::1").To16()),
+				PrefixLen: 64,
+			},
+		}
+		remoteAddr = tcpip.ProtocolAddress{
+			Protocol: ProtocolNumber,
+			AddressWithPrefix: tcpip.AddressWithPrefix{
+				Address:   tcpip.AddrFromSlice(net.ParseIP("a::2").To16()),
+				PrefixLen: 64,
+			},
+		}
+	)
+
+	tests := []struct {
+		name              string
+		installHandler    bool
+		handled           bool
+		wantHandlerCalled bool
+		wantReply         bool
+	}{
+		{
+			name:      "no default handler",
+			wantReply: true,
+		},
+		{
+			name:              "default handler handled",
+			installHandler:    true,
+			handled:           true,
+			wantHandlerCalled: true,
+			wantReply:         false,
+		},
+		{
+			name:              "default handler not handled",
+			installHandler:    true,
+			handled:           false,
+			wantHandlerCalled: true,
+			wantReply:         true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := newTestContext()
+			defer c.cleanup()
+			s := c.s
+
+			const ident = 1234
+			handlerCalled := false
+			if test.installHandler {
+				s.SetTransportProtocolHandler(icmp.ProtocolNumber6, func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
+					handlerCalled = true
+					if got := id.LocalPort; got != ident {
+						t.Errorf("got id.LocalPort = %d, want = %d", got, ident)
+					}
+					return test.handled
+				})
+			}
+
+			e := channel.New(1, defaultMTU, "")
+			defer e.Close()
+			if err := s.CreateNIC(nicID, e); err != nil {
+				t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+			}
+			if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+				t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+			}
+			s.SetRouteTable([]tcpip.Route{{
+				Destination: localAddr.AddressWithPrefix.Subnet(),
+				NIC:         nicID,
+			}})
+
+			totalLen := header.IPv6MinimumSize + header.ICMPv6MinimumSize
+			hdr := prependable.New(totalLen)
+			icmpH := header.ICMPv6(hdr.Prepend(header.ICMPv6MinimumSize))
+			icmpH.SetIdent(ident)
+			icmpH.SetType(header.ICMPv6EchoRequest)
+			icmpH.SetCode(header.ICMPv6UnusedCode)
+			icmpH.SetChecksum(0)
+			icmpH.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{
+				Header: icmpH,
+				Src:    remoteAddr.AddressWithPrefix.Address,
+				Dst:    localAddr.AddressWithPrefix.Address,
+			}))
+			ip := header.IPv6(hdr.Prepend(header.IPv6MinimumSize))
+			ip.Encode(&header.IPv6Fields{
+				PayloadLength:     header.ICMPv6MinimumSize,
+				TransportProtocol: icmp.ProtocolNumber6,
+				HopLimit:          DefaultTTL,
+				SrcAddr:           remoteAddr.AddressWithPrefix.Address,
+				DstAddr:           localAddr.AddressWithPrefix.Address,
+			})
+			echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+				Payload: buffer.MakeWithData(hdr.View()),
+			})
+			e.InjectInbound(ProtocolNumber, echoPkt)
+			echoPkt.DecRef()
+			c.clock.RunImmediatelyScheduledJobs()
+
+			if got, want := handlerCalled, test.wantHandlerCalled; got != want {
+				t.Fatalf("got handlerCalled = %t, want = %t", got, want)
+			}
+
+			p := e.Read()
+			if !test.wantReply {
+				if p != nil {
+					p.DecRef()
+					t.Fatalf("got unexpected ICMP echo reply")
+				}
+				return
+			}
+			if p == nil {
+				t.Fatalf("expected ICMP echo reply")
+			}
+			defer p.DecRef()
+			payload := stack.PayloadSince(p.NetworkHeader())
+			defer payload.Release()
+			checker.IPv6(t, payload,
+				checker.SrcAddr(localAddr.AddressWithPrefix.Address),
+				checker.DstAddr(remoteAddr.AddressWithPrefix.Address),
+				checker.ICMPv6(
+					checker.ICMPv6Type(header.ICMPv6EchoReply),
+					checker.ICMPv6Code(header.ICMPv6UnusedCode)))
+		})
+	}
+}
+
+func TestICMPEchoRegisteredEndpointDoesNotSuppressReply(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::1").To16()),
+			PrefixLen: 64,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::2").To16()),
+			PrefixLen: 64,
+		},
+	}
+
+	c := newTestContext()
+	defer c.cleanup()
+	s := c.s
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	const ident = 1234
+	var wq waiter.Queue
+	ep, err := s.NewEndpoint(icmp.ProtocolNumber6, ProtocolNumber, &wq)
+	if err != nil {
+		t.Fatalf("s.NewEndpoint(%d, %d, _) = %s", icmp.ProtocolNumber6, ProtocolNumber, err)
+	}
+	defer ep.Close()
+	if err := ep.Bind(tcpip.FullAddress{Addr: localAddr.AddressWithPrefix.Address, Port: ident}); err != nil {
+		t.Fatalf("ep.Bind(...) = %s", err)
+	}
+
+	handlerCalled := false
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber6, func(stack.TransportEndpointID, *stack.PacketBuffer) bool {
+		handlerCalled = true
+		return true
+	})
+
+	totalLen := header.IPv6MinimumSize + header.ICMPv6MinimumSize
+	hdr := prependable.New(totalLen)
+	icmpH := header.ICMPv6(hdr.Prepend(header.ICMPv6MinimumSize))
+	icmpH.SetIdent(ident)
+	icmpH.SetType(header.ICMPv6EchoRequest)
+	icmpH.SetCode(header.ICMPv6UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{
+		Header: icmpH,
+		Src:    remoteAddr.AddressWithPrefix.Address,
+		Dst:    localAddr.AddressWithPrefix.Address,
+	}))
+	ip := header.IPv6(hdr.Prepend(header.IPv6MinimumSize))
+	ip.Encode(&header.IPv6Fields{
+		PayloadLength:     header.ICMPv6MinimumSize,
+		TransportProtocol: icmp.ProtocolNumber6,
+		HopLimit:          DefaultTTL,
+		SrcAddr:           remoteAddr.AddressWithPrefix.Address,
+		DstAddr:           localAddr.AddressWithPrefix.Address,
+	})
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	c.clock.RunImmediatelyScheduledJobs()
+
+	if handlerCalled {
+		t.Fatalf("default handler was unexpectedly called")
+	}
+
+	p := e.Read()
+	if p == nil {
+		t.Fatalf("expected ICMP echo reply")
+	}
+	defer p.DecRef()
+	payload := stack.PayloadSince(p.NetworkHeader())
+	defer payload.Release()
+	checker.IPv6(t, payload,
+		checker.SrcAddr(localAddr.AddressWithPrefix.Address),
+		checker.DstAddr(remoteAddr.AddressWithPrefix.Address),
+		checker.ICMPv6(
+			checker.ICMPv6Type(header.ICMPv6EchoReply),
+			checker.ICMPv6Code(header.ICMPv6UnusedCode)))
+}
+
 func TestICMPCounts(t *testing.T) {
 	c := newTestContext()
 	defer c.cleanup()

--- a/pkg/tcpip/stack/nic.go
+++ b/pkg/tcpip/stack/nic.go
@@ -841,23 +841,34 @@ func (n *nic) DeliverLinkPacket(protocol tcpip.NetworkProtocolNumber, pkt *Packe
 // DeliverTransportPacket delivers the packets to the appropriate transport
 // protocol endpoint.
 func (n *nic) DeliverTransportPacket(protocol tcpip.TransportProtocolNumber, pkt *PacketBuffer) TransportPacketDisposition {
+	res, _ := n.deliverTransportPacket(protocol, pkt)
+	return res
+}
+
+// DeliverTransportPacketWithDefaultHandlerResult implements
+// TransportDispatcherWithDefaultHandlerResult.DeliverTransportPacketWithDefaultHandlerResult.
+func (n *nic) DeliverTransportPacketWithDefaultHandlerResult(protocol tcpip.TransportProtocolNumber, pkt *PacketBuffer) (TransportPacketDisposition, bool) {
+	return n.deliverTransportPacket(protocol, pkt)
+}
+
+func (n *nic) deliverTransportPacket(protocol tcpip.TransportProtocolNumber, pkt *PacketBuffer) (TransportPacketDisposition, bool) {
 	state, ok := n.stack.transportProtocols[protocol]
 	if !ok {
 		n.stats.unknownL4ProtocolRcvdPacketCounts.Increment(uint64(protocol))
-		return TransportPacketProtocolUnreachable
+		return TransportPacketProtocolUnreachable, false
 	}
 
 	transProto := state.proto
 
 	if len(pkt.TransportHeader().Slice()) == 0 {
 		n.stats.malformedL4RcvdPackets.Increment()
-		return TransportPacketHandled
+		return TransportPacketHandled, false
 	}
 
 	srcPort, dstPort, err := transProto.ParsePorts(pkt.TransportHeader().Slice())
 	if err != nil {
 		n.stats.malformedL4RcvdPackets.Increment()
-		return TransportPacketHandled
+		return TransportPacketHandled, false
 	}
 
 	netProto, ok := n.stack.networkProtocols[pkt.NetworkProtocolNumber]
@@ -873,13 +884,13 @@ func (n *nic) DeliverTransportPacket(protocol tcpip.TransportProtocolNumber, pkt
 		RemoteAddress: src,
 	}
 	if n.stack.demux.deliverPacket(protocol, pkt, id) {
-		return TransportPacketHandled
+		return TransportPacketHandled, false
 	}
 
 	// Try to deliver to per-stack default handler.
 	if state.defaultHandler != nil {
 		if state.defaultHandler(id, pkt) {
-			return TransportPacketHandled
+			return TransportPacketHandled, true
 		}
 	}
 
@@ -889,11 +900,11 @@ func (n *nic) DeliverTransportPacket(protocol tcpip.TransportProtocolNumber, pkt
 	switch res := transProto.HandleUnknownDestinationPacket(id, pkt); res {
 	case UnknownDestinationPacketMalformed:
 		n.stats.malformedL4RcvdPackets.Increment()
-		return TransportPacketHandled
+		return TransportPacketHandled, false
 	case UnknownDestinationPacketUnhandled:
-		return TransportPacketDestinationPortUnreachable
+		return TransportPacketDestinationPortUnreachable, false
 	case UnknownDestinationPacketHandled:
-		return TransportPacketHandled
+		return TransportPacketHandled, false
 	default:
 		panic(fmt.Sprintf("unrecognized result from HandleUnknownDestinationPacket = %d", res))
 	}

--- a/pkg/tcpip/stack/registration.go
+++ b/pkg/tcpip/stack/registration.go
@@ -365,6 +365,21 @@ type TransportDispatcher interface {
 	DeliverRawPacket(tcpip.TransportProtocolNumber, *PacketBuffer)
 }
 
+// TransportDispatcherWithDefaultHandlerResult extends TransportDispatcher with
+// default-handler-specific delivery metadata.
+type TransportDispatcherWithDefaultHandlerResult interface {
+	TransportDispatcher
+
+	// DeliverTransportPacketWithDefaultHandlerResult delivers packets to the
+	// appropriate transport protocol endpoint and reports whether the packet was
+	// specifically handled by the per-stack default transport protocol handler.
+	//
+	// pkt.NetworkHeader must be set before calling this method.
+	//
+	// DeliverTransportPacketWithDefaultHandlerResult may modify the packet.
+	DeliverTransportPacketWithDefaultHandlerResult(tcpip.TransportProtocolNumber, *PacketBuffer) (TransportPacketDisposition, bool)
+}
+
 // PacketLooping specifies where an outbound packet should be sent.
 type PacketLooping byte
 


### PR DESCRIPTION
## Overview

This change makes ICMP Echo Request handling follow the usual `SetTransportProtocolHandler` default-handler contract: **if an ICMP default handler returns true, the stack treats the request as consumed and does not also synthesize a built-in Echo Reply**.

The default behavior is preserved when there is **no ICMP default handler**, or when the handler returns `false`.

The intended scope is small:

* preserve the IPv4 `LocalAddressTemporary` behavior from #11609
* add the same `Echo Request` default-handler contract for IPv6
* leave `ICMPv6 NDP` and other ICMP control paths unchanged

Related discussion:

* [#8657 comment from @kevinGC](https://github.com/google/gvisor/issues/8657#issuecomment-1600061847)
* [#11609 comment from @ericpauley](https://github.com/google/gvisor/pull/11609#issuecomment-2917389850)
* [#11609 comment from @dyhkwong](https://github.com/google/gvisor/pull/11609#issuecomment-3009685102)

## Context

TCP and UDP default handlers already have a clear ownership signal:

```text
defaultHandler returns true
        |
        v
packet is handled by the embedder
protocol fallback does not continue
```

`ICMP Echo` is different today because `Echo Request`s are intercepted by IPv4/IPv6 network endpoints before the built-in reply is generated.

That makes it possible for an embedder to receive an `Echo Request` and still get a second reply from netstack.

The earlier discussion started in [#8657](https://github.com/google/gvisor/issues/8657), where @fredwangwang reported that `ICMP Echo` could still be answered by the stack even when an ICMP handler was installed with `SetTransportProtocolHandler`. @deepcode2019 noted the same need, and [@kevinGC suggested](https://github.com/google/gvisor/issues/8657#issuecomment-1600061847) that a tested PR would be welcome.

[#11609](https://github.com/google/gvisor/pull/11609) took a narrow first step for IPv4 promiscuous-mode temporary addresses. After it merged, [@ericpauley pointed out](https://github.com/google/gvisor/pull/11609#issuecomment-2917389850) that restoring the old behavior could require reimplementing ICMP in a custom handler, and [@dyhkwong noted](https://github.com/google/gvisor/pull/11609#issuecomment-3009685102) the remaining IPv4/IPv6 inconsistency.

This change addresses that follow-up without widening the behavior change beyond **Echo Request default-handler ownership**.

The compatibility-sensitive case is `runsc`. It registers ICMP as a normal transport protocol, but does not install an ICMP default handler for this path:

[`runsc/boot/loader.go`](https://github.com/Amaindex/gvisor/blob/8b0e1620109a51f06306a0f2643d61fa8f1d5631/runsc/boot/loader.go#L1702-L1721)

```go
transProtos := []stack.TransportProtocolFactory{
    tcp.NewProtocol,
    udp.NewProtocol,
    icmp.NewProtocol4,
    icmp.NewProtocol6,
}
```

So the **no-default-handler path** remains the ordinary built-in `Echo Reply` path.

## Why This Matters

The main beneficiary is not ICMP itself, but embedders that use netstack inside **user-space tunneling** or **virtual-networking** software.

Several widely used downstream or adjacent projects use netstack, or downstream forks of it, in this role, including Tailscale's userspace networking, wireguard-go's netstack TUN backend, sing-box/mihomo-style TUN stacks, and tun2socks.

For those programs, an `Echo Reply` is often a **policy decision**:

```text
Echo Request
  -> should this address be reachable through the tunnel?
  -> should the request be forwarded to a remote peer?
  -> should the reply reflect tunnel reachability, latency, filtering, or policy?
```

If netstack synthesizes a local `Echo Reply` after the embedder has consumed the request, **unreachable or policy-blocked addresses can appear reachable**.

After this change, ICMP default handlers can return `true` and take responsibility for Echo behavior. That lets tunneling software return replies that reflect its own forwarding policy and the current state of the tunnel.

## Flow

Current behavior:

```text
IPv4 Echo Request
  -> network/ipv4 ICMP handler
  -> DeliverTransportPacket(ICMPv4, pkt)
  -> if LocalAddressTemporary: stop
  -> built-in Echo Reply

IPv6 Echo Request
  -> network/ipv6 ICMP handler
  -> built-in Echo Reply
```

New behavior:

```text
ICMP Echo Request
  -> network ICMP handler
  -> deliver to ICMP endpoint/defaultHandler
       |-- defaultHandler returned true  -> stop
       `-- otherwise                     -> continue built-in handling

built-in handling
  -> (IPv4 only: if LocalAddressTemporary -> stop)
  -> synthesize Echo Reply
```

The asymmetry above is intentional: the new default-handler ownership rule is shared by IPv4 and IPv6, while `LocalAddressTemporary` is a pre-existing IPv4 compatibility guard from #11609.

## Implementation

Relevant code points:

* [`SetTransportProtocolHandler`](https://github.com/Amaindex/gvisor/blob/8b0e1620109a51f06306a0f2643d61fa8f1d5631/pkg/tcpip/stack/stack.go#L530-L539) stores a per-stack default handler.
* [`TransportDispatcherWithDefaultHandlerResult`](https://github.com/Amaindex/gvisor/blob/8b0e1620109a51f06306a0f2643d61fa8f1d5631/pkg/tcpip/stack/registration.go#L368-L380) carries the narrower ownership signal.
* [`DeliverTransportPacketWithDefaultHandlerResult`](https://github.com/Amaindex/gvisor/blob/8b0e1620109a51f06306a0f2643d61fa8f1d5631/pkg/tcpip/stack/nic.go#L848-L854) shares the NIC transport delivery path.
* [`defaultHandler` result propagation](https://github.com/Amaindex/gvisor/blob/8b0e1620109a51f06306a0f2643d61fa8f1d5631/pkg/tcpip/stack/nic.go#L886-L895) reports true only when the default handler consumed the packet.
* [`network/ipv4/icmp.go`](https://github.com/Amaindex/gvisor/blob/8b0e1620109a51f06306a0f2643d61fa8f1d5631/pkg/tcpip/network/ipv4/icmp.go#L363-L377) uses that signal while preserving `LocalAddressTemporary`.
* [`network/ipv6/icmp.go`](https://github.com/Amaindex/gvisor/blob/8b0e1620109a51f06306a0f2643d61fa8f1d5631/pkg/tcpip/network/ipv6/icmp.go#L655-L674) delivers Echo Requests through the ICMP endpoint/default-handler path before deciding whether to synthesize the built-in reply.

`TransportPacketHandled` is too broad for this decision:

```text
TransportPacketHandled
  |-- registered endpoint matched
  |-- defaultHandler returned true
  |-- unknown-destination handler consumed it
  `-- malformed packet was swallowed
```

Only one branch should suppress the built-in Echo Reply:

```text
defaultHandler returned true
```

This change therefore adds a narrow dispatcher extension:

```go
type TransportDispatcherWithDefaultHandlerResult interface {
    TransportDispatcher

    DeliverTransportPacketWithDefaultHandlerResult(
        tcpip.TransportProtocolNumber,
        *PacketBuffer,
    ) (TransportPacketDisposition, bool)
}
```

The second result is `true` only when the per-stack `defaultHandler` returned `true`:

```go
if n.stack.demux.deliverPacket(protocol, pkt, id) {
    return TransportPacketHandled, false
}

if state.defaultHandler != nil {
    if state.defaultHandler(id, pkt) {
        return TransportPacketHandled, true
    }
}
```

This keeps **endpoint visibility** separate from **default-handler ownership**.

For IPv6, the built-in reply path now saves the data needed for the reply before transport delivery, because `DeliverTransportPacket` may modify the `PacketBuffer`:

```go
replyPayload := pkt.Data().ToBuffer()
replyHeader := make([]byte, header.ICMPv6EchoMinimumSize)
copy(replyHeader, h[:header.ICMPv6EchoMinimumSize])
```

This also makes IPv6 Echo Requests observable through the same registered-endpoint/default-handler delivery path used by IPv4. A registered ICMP endpoint does not suppress the built-in reply; only a per-stack default handler returning `true` does.

## Compatibility

**Default runsc/netstack behavior should remain unchanged.**

This change separates two decisions:

```text
defaultHandler returned true
  -> new shared IPv4/IPv6 ownership rule

IPv4 LocalAddressTemporary
  -> existing #11609 guard, preserved as-is
```

Behavior matrix:

```text
no ICMP default handler        -> built-in Echo Reply
default handler returns false  -> built-in Echo Reply
default handler returns true   -> consumed by handler; no built-in Echo Reply
IPv4 LocalAddressTemporary     -> preserve #11609; no built-in Echo Reply
```

ICMPv6 scope:

```text
changed:    Echo Request
unchanged:  NDP, Packet Too Big, Destination Unreachable, Time Exceeded, other control paths
```

I am not trying to make IPv6 mirror the IPv4 `LocalAddressTemporary` path in this change. That would be a separate behavior change. Here, IPv6 gains the Echo Request endpoint/default-handler delivery path and the default-handler ownership rule.

`LocalAddressTemporary` remains useful as an IPv4 signal for embedders that already need to distinguish promiscuous-mode temporary local delivery from ordinary local delivery.

## Follow-ups

I plan to keep the remaining work split into smaller follow-ups.

If this direction looks acceptable, I can follow up promptly with the mechanical helper extraction first. The `ICMP Forwarder` API can then be discussed on top of that smaller refactor, so the public API shape does not have to be decided in this change.

First, factor the built-in IPv4/IPv6 `Echo Reply` construction into an internal helper while preserving route lookup, rate limiting, stats, checksums, IPv4 options, IPv6 traffic class handling, and output hooks.

Then add an `ICMP Forwarder` API, analogous to the TCP/UDP forwarders:

```go
f := icmp.NewForwarder(s, func(r *icmp.ForwarderRequest) bool {
    if shouldHandleByTunnel(r) {
        return handleByTunnel(r)
    }
    return r.Reply()
})

s.SetTransportProtocolHandler(icmp.ProtocolNumber4, f.HandlePacket)
s.SetTransportProtocolHandler(icmp.ProtocolNumber6, f.HandlePacket)
```

The goal of `ForwarderRequest.Reply()` is to let embedders explicitly delegate `Echo Reply` generation back to the stack, without copying netstack's reply construction logic downstream. That should also provide a cleaner way to restore the old "let netstack reply" behavior when a custom handler decides not to own a particular Echo Request.

## Tests

The new tests cover the behavior matrix directly.

IPv4:

```text
TestICMPEchoDefaultHandlerControlsReply
  no default handler             -> built-in Echo Reply is preserved
  default handler returns false  -> built-in Echo Reply is preserved
  default handler returns true   -> no built-in Echo Reply

TestICMPEchoRegisteredEndpointDoesNotSuppressReply
  registered endpoint is matched -> default handler is not called
                                  -> built-in Echo Reply is preserved

TestICMPEchoTemporaryAddressSuppressesReply
  promiscuous temporary address  -> built-in Echo Reply is suppressed
```

IPv6:

```text
TestICMPEchoDefaultHandlerControlsReply
  no default handler             -> built-in Echo Reply is preserved
  default handler returns false  -> built-in Echo Reply is preserved
  default handler returns true   -> no built-in Echo Reply

TestICMPEchoRegisteredEndpointDoesNotSuppressReply
  registered endpoint is matched -> default handler is not called
                                  -> built-in Echo Reply is preserved
```

Commands:

```shell
make test TARGETS=//pkg/tcpip/network/ipv4:ipv4_test OPTIONS=--test_filter=TestICMPEcho
make test TARGETS=//pkg/tcpip/network/ipv6:ipv6_test OPTIONS=--test_filter=TestICMPEcho
make test TARGETS=//pkg/tcpip/network/ipv4:ipv4_test OPTIONS=--test_filter=TestIcmpRateLimit
make test TARGETS=//pkg/tcpip/network/ipv6:ipv6_test OPTIONS=--test_filter=TestNeighborSolicitationResponse
make test TARGETS="//pkg/tcpip/network/ipv4:ipv4_test //pkg/tcpip/network/ipv6:ipv6_test"
make test TARGETS=//pkg/tcpip/stack:stack_test
```

All of the commands above pass in my fork branch, `netstack-icmp-echo-default-handler`.

## Review Context

While preparing the change, I discussed the direction with several downstream/heavy netstack users to validate the embedding use case and compatibility expectations.

I also used AI-assisted review as an additional pass to look for missing edge cases. The technical argument here is still based on the source links, behavior matrix, and tests above.

Fixes #8657.