### PR TITLE
tools/bazeldefs: clarify CI platform comment

### DIFF
--- a/tools/bazeldefs/platforms.bzl
+++ b/tools/bazeldefs/platforms.bzl
@@ -43,3 +43,5 @@ platform_capabilities = {
 
 default_platform = "systrap"
 save_restore_platforms = ["systrap"]
+
+# Clarifies that this file is shared by CI platform definitions.


### PR DESCRIPTION
Small comment-only clarification in Bazel platform definitions.