### PR TITLE
test/syscalls: add recvfrom restart regression test

### DIFF
--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4000,8 +4000,11 @@ cc_binary(
         ":socket_non_stream_blocking_test_cases",
         ":unix_domain_socket_test_util",
         "//test/util:socket_util",
+        "//test/util:signal_util",
         "//test/util:test_main",
         "//test/util:test_util",
+        "//test/util:thread_util",
+        "@com_google_absl//absl/time",
     ],
 )
 

--- a/test/syscalls/linux/socket_unix_non_stream_blocking_local.cc
+++ b/test/syscalls/linux/socket_unix_non_stream_blocking_local.cc
@@ -12,16 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <pthread.h>
+#include <signal.h>
+#include <sys/socket.h>
+
 #include <vector>
 
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "test/syscalls/linux/socket_non_stream_blocking.h"
 #include "test/syscalls/linux/unix_domain_socket_test_util.h"
 #include "test/util/socket_util.h"
+#include "test/util/signal_util.h"
 #include "test/util/test_util.h"
+#include "test/util/thread_util.h"
 
 namespace gvisor {
 namespace testing {
 namespace {
+
+void SigUrgHandler(int) {}
 
 std::vector<SocketPairKind> GetSocketPairs() {
   return VecCat<SocketPairKind>(
@@ -36,6 +46,38 @@ std::vector<SocketPairKind> GetSocketPairs() {
 INSTANTIATE_TEST_SUITE_P(
     BlockingNonStreamUnixSockets, BlockingNonStreamSocketPairTest,
     ::testing::ValuesIn(IncludeReversals(GetSocketPairs())));
+
+// Some SOCK_SEQPACKET users probe the next packet length by calling recvfrom
+// with MSG_TRUNC | MSG_PEEK and a null, zero-length receive buffer. When a
+// signal handler is installed with SA_RESTART, Linux restarts this blocking
+// recvfrom instead of returning EINTR. Do not wrap recvfrom in RetryEINTR here:
+// the test is checking kernel restart behavior, not userspace retry behavior.
+TEST(UnixSeqpacketBlockingTest, RecvfromTruncPeekNullBufferRestarted) {
+  auto sockets = ASSERT_NO_ERRNO_AND_VALUE(
+      UnixDomainSocketPair(SOCK_SEQPACKET | SOCK_CLOEXEC).Create());
+
+  struct sigaction sa = {};
+  sa.sa_handler = SigUrgHandler;
+  sa.sa_flags = SA_RESTART;
+  sigemptyset(&sa.sa_mask);
+  auto const cleanup = ASSERT_NO_ERRNO_AND_VALUE(ScopedSigaction(SIGURG, sa));
+
+  pthread_t target = pthread_self();
+  constexpr char kPayload[] = "recvfrom-restart";
+
+  ScopedThread t([&] {
+    absl::SleepFor(absl::Milliseconds(50));
+    ASSERT_EQ(pthread_kill(target, SIGURG), 0);
+    absl::SleepFor(absl::Milliseconds(100));
+    ASSERT_THAT(RetryEINTR(send)(sockets->first_fd(), kPayload,
+                                 sizeof(kPayload), 0),
+                SyscallSucceedsWithValue(sizeof(kPayload)));
+  });
+
+  ASSERT_THAT(recvfrom(sockets->second_fd(), nullptr, 0,
+                       MSG_TRUNC | MSG_PEEK, nullptr, nullptr),
+              SyscallSucceedsWithValue(sizeof(kPayload)));
+}
 
 }  // namespace
 }  // namespace testing


### PR DESCRIPTION
This adds regression coverage for the `recvfrom` restart behavior fixed by #13212.

The test covers this syscall shape on a Unix `SOCK_SEQPACKET` socket:

```c
recvfrom(fd, nullptr, 0, MSG_TRUNC | MSG_PEEK, nullptr, nullptr)
```

Linux restarts this syscall when the blocking thread receives a signal whose handler was installed with `SA_RESTART`. The test installs a `SIGURG` handler with `SA_RESTART`, interrupts the blocked `recvfrom`, then sends one packet and expects `recvfrom` to return the packet length.

This syscall shape is relevant to runc's sync socket packet-length probe, which is the path mentioned in #13179.

Related to #13179.

Regression coverage for #13212.

**Local verification**

```bash
make test TARGETS=//test/syscalls:socket_non_stream_blocking_local_test_native \
  OPTIONS="--test_output=errors --nocache_test_results"
```

Result: **PASS**

```bash
make syscall-tests TARGETS=//test/syscalls:socket_non_stream_blocking_local_test_runsc_systrap_directfs \
  OPTIONS="--test_output=errors --nocache_test_results"
```

Result: **PASS**
