### PR TITLE
tcpip/ipv6: use isEnabled() in disableLocked() to match ipv4 sibling

### DIFF
--- a/pkg/tcpip/network/ipv6/ipv6.go
+++ b/pkg/tcpip/network/ipv6/ipv6.go
@@ -672,7 +672,7 @@ func (e *endpoint) Disable() {
 }
 
 func (e *endpoint) disableLocked() {
-	if !e.Enabled() {
+	if !e.isEnabled() {
 		return
 	}
 


### PR DESCRIPTION
### Summary

Swap `e.Enabled()` for `e.isEnabled()` in `(*endpoint).disableLocked()` at `pkg/tcpip/network/ipv6/ipv6.go`. The IPv4 sibling at `pkg/tcpip/network/ipv4/ipv4.go:363` already uses `e.isEnabled()`.

### Why

`e.Enabled()` returns `e.nic.Enabled() && e.isEnabled()`. If the NIC has been disabled but the endpoint's own `isEnabled()` is still set, the current code early-returns from `disableLocked` and skips the full per-protocol teardown: `ndp.stopSolicitingRouters`, `ndp.cleanupState`, MLD `softLeaveAll`, DAD stop, the all-nodes multicast leave, and `setEnabled(false)`. After the early-return, `e.isEnabled()` still reports true. A subsequent `endpoint.Close()` calls `disableLocked` again, hits the same early-return, then runs `addressableEndpointState.Cleanup` while NDP state and any still-armed SLAAC, RS, or DAD timer remain alive against the wiped address state.

IPv4 at `ipv4.go:363` uses `e.isEnabled()` and runs the local teardown regardless of the NIC's state. The 2020 commit 53a95ad0df that introduced the `e.Enabled()` form was about gating packet-sending paths during shutdown; the disable path itself should not be one of those gated sites.

### Test

- `bazel test //pkg/tcpip/network/ipv6/... //pkg/tcpip/tests/integration/...`

The intent of the original 2020 commit (gating packet-sending paths during shutdown) is preserved at the packet sites that still call `e.Enabled()`; only `disableLocked` is changed to match IPv4.

### CLA

Signed via individual Google CLA on `sactransport2000@gmail.com`.
