### PR TITLE
cgroupfs: drop registry entries on filesystem release

### DIFF
--- a/pkg/sentry/fsimpl/cgroupfs/cgroupfs.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cgroupfs.go
@@ -468,6 +468,14 @@ func (fs *filesystem) Release(ctx context.Context) {
 	k := kernel.KernelFromContext(ctx)
 	r := k.CgroupRegistry()
 
+	// Drop any registry entries still held by this filesystem's cgroup
+	// inodes. RmDir already calls RemoveCgroup for cgroups that were
+	// unlinked through rmdir; the remaining entries are the root cgroup
+	// and, when GetFilesystem fails after newCgroupInode, any partially
+	// initialised children. RemoveCgroup is a no-op for ids not in the
+	// map, mirroring the symmetry with AddCgroup at base.go newCgroupInode.
+	fs.removeCgroupsFromRegistryLocked(r)
+
 	if fs.hierarchyID != kernel.InvalidCgroupHierarchyID {
 		k.ReleaseCgroupHierarchy(fs.hierarchyID)
 		r.Unregister(fs.hierarchyID)
@@ -479,6 +487,30 @@ func (fs *filesystem) Release(ctx context.Context) {
 
 	fs.Filesystem.VFSFilesystem().VirtualFilesystem().PutAnonBlockDevMinor(fs.devMinor)
 	fs.Filesystem.Release(ctx)
+}
+
+// removeCgroupsFromRegistryLocked walks fs.root and removes the id of every
+// cgroupInode in the subtree from the kernel cgroup registry. RemoveCgroup is
+// a no-op for ids already removed via RmDir, so calling it for cgroups that
+// were rmdir'd before the filesystem was released is safe.
+func (fs *filesystem) removeCgroupsFromRegistryLocked(r *kernel.CgroupRegistry) {
+	if fs.root == nil {
+		return
+	}
+	rootInode, ok := fs.root.Inode().(*cgroupInode)
+	if !ok {
+		return
+	}
+	var walk func(c *cgroupInode)
+	walk = func(c *cgroupInode) {
+		r.RemoveCgroup(c.id)
+		c.dir.forEachChildDir(func(child *dir) {
+			if child.cgi != nil {
+				walk(child.cgi)
+			}
+		})
+	}
+	walk(rootInode)
 }
 
 // MountOptions implements vfs.FilesystemImpl.MountOptions.


### PR DESCRIPTION
### Summary

Follow-up to commit `26ef5174081be0b4b1f750a97e75ee6bad5d5a53` (cgroupfs: remove cgroup from CgroupRegistry on rmdir). Walk the cgroupfs dentry subtree in `(*filesystem).Release` and call `CgroupRegistry.RemoveCgroup` for every `cgroupInode.id` in the tree.

### Why

The rmdir fix covers cgroups removed via `rmdir(2)`. Two release paths still leak entries:

1. `FilesystemType.GetFilesystem` error window at `cgroupfs.go:376-398`. `newCgroupInode` at `base.go:190` calls `r.AddCgroup` for the root cgroup *before* `prepareInitialCgroup` and `r.Register` run. On either failure the code does `rootD.DecRef(ctx); fs.VFSFilesystem().DecRef(ctx)`. `Release` then runs but currently skips `ReleaseCgroupHierarchy` and `Unregister` because `fs.hierarchyID` is still `InvalidCgroupHierarchyID`. The root cgroup id stays in `CgroupRegistry.cgroups` forever. Repeated mount-failures accumulate unbounded entries that get serialized on every checkpoint, same class as the rmdir leak.

2. `prepareInitialCgroup` at `cgroupfs.go:440-447` creates intermediate cgroup directories via `newDirWithOwner`, each of which calls `AddCgroup`. If the path walk later fails, the partially created children leak.

### Approach

Add a helper `removeCgroupsFromRegistryLocked` that walks `fs.root` via the existing `dir.forEachChildDir` and calls `RemoveCgroup` for each `cgroupInode.id`. `RemoveCgroup` is documented as a no-op for ids that are not present (`cgroup.go:556-558`), so cgroups already removed by `RmDir` cost nothing. RmDir stays the primary owner of the live-cgroup case; this walk is the safety net for the release-time residue.

### Test

- `bazel test //pkg/sentry/fsimpl/cgroupfs/... //test/syscalls:cgroup_test`

### CLA

Signed via individual Google CLA on `sactransport2000@gmail.com`.
