### PR TITLE
lisafs: bound Walk and WalkStat response payloads to maxMessageSize

### DIFF
--- a/pkg/lisafs/handlers.go
+++ b/pkg/lisafs/handlers.go
@@ -16,7 +16,6 @@ package lisafs
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"strings"
 
@@ -304,7 +303,7 @@ func WalkHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, e
 	)
 	respMetaSize := status.SizeBytes() + numInodes.SizeBytes()
 	maxPayloadSize := respMetaSize + (len(req.Path) * (*Inode)(nil).SizeBytes())
-	if maxPayloadSize > math.MaxUint32 {
+	if maxPayloadSize > int(c.maxMessageSize) {
 		// Too much to walk, can't do.
 		return 0, unix.EIO
 	}
@@ -406,7 +405,7 @@ func WalkStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint3
 	// the same as WalkStatResp's.
 	var numStats primitive.Uint16
 	maxPayloadSize := numStats.SizeBytes() + (len(req.Path) * SizeOfStatx)
-	if maxPayloadSize > math.MaxUint32 {
+	if maxPayloadSize > int(c.maxMessageSize) {
 		// Too much to walk, can't do.
 		return 0, unix.EIO
 	}


### PR DESCRIPTION
## Problem

`WalkHandler` and `WalkStatHandler` size the response payload buffer from the request-controlled `req.Path` length, and only reject it against `math.MaxUint32`:

```go
maxPayloadSize := respMetaSize + (len(req.Path) * (*Inode)(nil).SizeBytes())
if maxPayloadSize > math.MaxUint32 {
	// Too much to walk, can't do.
	return 0, unix.EIO
}
payloadBuf := comm.PayloadBuf(uint32(maxPayloadSize))
```

`comm.PayloadBuf` for the channel transport returns a slice into a window of `maxMessageSize` bytes. A `maxPayloadSize` between `maxMessageSize` and `MaxUint32` therefore indexes past that window.

## Sibling precedent

`PReadHandler`, in the same file, bounds its response payload correctly:

```go
respPayloadLen := respMetaSize + req.Count
if respPayloadLen > c.maxMessageSize {
	return 0, unix.ENOBUFS
}
payloadBuf := comm.PayloadBuf(respPayloadLen)
```

## Change

Bound `maxPayloadSize` in both Walk handlers against `c.maxMessageSize`, matching `PReadHandler`. `math` is no longer referenced in the file, so its import is dropped. Two one-line changes plus the import removal.

## Scope

Hardening. A handler panic of this shape is recovered by `Connection.handleMsg` and turned into an `EREMOTEIO` response, so the gofer does not crash, and the request is only reachable from a compromised sentry. This change removes the reliance on that recover() net and makes the two Walk handlers consistent with `PReadHandler`.

`Getdents64Handler` has a related but structurally different unbounded re-allocation; it is left for a separate change because its fix is not a one-line bound and would not belong in this minimal cleanup.
