### PR TITLE
iouringfs: release MemoryFile allocations on error paths in New

### DIFF
--- a/pkg/sentry/fsimpl/iouringfs/BUILD
+++ b/pkg/sentry/fsimpl/iouringfs/BUILD
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//pkg/abi/linux",
         "//pkg/atomicbitops",
+        "//pkg/cleanup",
         "//pkg/context",
         "//pkg/errors/linuxerr",
         "//pkg/hostarch",

--- a/pkg/sentry/fsimpl/iouringfs/iouringfs.go
+++ b/pkg/sentry/fsimpl/iouringfs/iouringfs.go
@@ -168,6 +168,12 @@ func New(ctx context.Context, vfsObj *vfs.VirtualFilesystem, entries uint32, par
 		return nil, err
 	}
 
+	// Transfer cleanup ownership to the FileDescription: vfsfd.DecRef ->
+	// Release will DecRef both MemoryFile allocations and also release the
+	// mount/dentry refs and writer counter that Init took (O_RDWR mode).
+	cu.Release()
+	cu = cleanup.Make(func() { iouringfd.vfsfd.DecRef(ctx) })
+
 	params.SqEntries = numSqEntries
 	params.CqEntries = numCqEntries
 

--- a/pkg/sentry/fsimpl/iouringfs/iouringfs.go
+++ b/pkg/sentry/fsimpl/iouringfs/iouringfs.go
@@ -28,6 +28,7 @@ import (
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/atomicbitops"
+	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
@@ -130,6 +131,11 @@ func New(ctx context.Context, vfsObj *vfs.VirtualFilesystem, entries uint32, par
 		return nil, linuxerr.ENOMEM
 	}
 
+	// On any error below, release the MemoryFile allocations; the success
+	// path transfers ownership to FileDescription.Release.
+	cu := cleanup.Make(func() { mf.DecRef(rbfr) })
+	defer cu.Clean()
+
 	// Allocate enough space to store the given number of submission queue entries.
 	sqEntriesSize := uint64(numSqEntries * uint32((*linux.IOUringSqe)(nil).SizeBytes()))
 	sqEntriesSize = uint64(hostarch.Addr(sqEntriesSize).MustRoundUp())
@@ -137,6 +143,7 @@ func New(ctx context.Context, vfsObj *vfs.VirtualFilesystem, entries uint32, par
 	if err != nil {
 		return nil, linuxerr.ENOMEM
 	}
+	cu.Add(func() { mf.DecRef(sqefr) })
 
 	iouringfd := &FileDescription{
 		mf: mf,
@@ -210,6 +217,7 @@ func New(ctx context.Context, vfsObj *vfs.VirtualFilesystem, entries uint32, par
 		return nil, err
 	}
 
+	cu.Release()
 	return &iouringfd.vfsfd, nil
 }
 


### PR DESCRIPTION
## Problem

`iouringfs.New` allocates two `MemoryFile` ranges and then runs several fallible steps. Each error path returns without releasing the allocations:

- `mf.Allocate(sqEntriesSize, ...)` failing leaks `rbfr` (the first allocation).
- `iouringfd.vfsfd.Init(...)` failing leaks `rbfr` and `sqefr`.
- the two `CacheLineRoundUp` overflow checks (`EOVERFLOW`) leak both.
- `iouringfd.mapSharedBuffers()` failing leaks both.
- `iouringfd.ioRingsBuf.view(...)` and `.writeback(...)` failing leak both.

`mf.Allocate` returns a refcounted `MemoryFile` range. The success path transfers ownership to `FileDescription.Release`:

```go
func (fd *FileDescription) Release(ctx context.Context) {
	fd.mf.DecRef(fd.rbmf.fr)
	fd.mf.DecRef(fd.sqemf.fr)
}
```

`Release` runs only once the `FileDescription` is installed and later released. On any error path in `New` the `FileDescription` is never returned, so `Release` never runs and the allocations leak. `New` is reachable from `io_uring_setup(2)`.

## Change

Wrap the two allocations in a `cleanup.Cleanup`: register `mf.DecRef(rbfr)` after the first allocation, `mf.DecRef(sqefr)` after the second, `defer cu.Clean()`, and `cu.Release()` on the success path. The cleanup performs exactly the two `DecRef` calls that `Release` does, so it is the correct teardown for every error path, including those after `mapSharedBuffers` (`Release` itself does no extra unmapping). This is the `cleanup.Cleanup` pattern already used across `pkg/sentry/fsimpl`.

## Scope

Hardening. Resource leak confined to the error paths of `New`; triggering it requires the allocation or a later step to fail.
