### PR TITLE
epoll: avoid orphaned interest on EventRegister failure

### DIFF
--- a/pkg/sentry/vfs/epoll.go
+++ b/pkg/sentry/vfs/epoll.go
@@ -270,12 +270,14 @@ func (ep *EpollInstance) AddInterest(file *FileDescription, num int32, event lin
 		mask:     mask,
 		userData: event.Data,
 	}
-	ep.interest[key] = epi
 	wmask := waiter.EventMaskFromLinux(mask)
 	epi.waiter.Init(epi, wmask)
 	if err := file.EventRegister(&epi.waiter); err != nil {
 		return err
 	}
+	// Add epi to ep.interest only after EventRegister succeeds, so a failed
+	// registration does not leave an orphaned interest behind.
+	ep.interest[key] = epi
 
 	// Check if the file is already ready.
 	if m := file.Readiness(wmask) & wmask; m != 0 {


### PR DESCRIPTION
## Problem

`EpollInstance.AddInterest` inserts the new `epollInterest` into `ep.interest` before registering with the file, and adds it to `file.epolls` only after registration succeeds:

```go
ep.interest[key] = epi
wmask := waiter.EventMaskFromLinux(mask)
epi.waiter.Init(epi, wmask)
if err := file.EventRegister(&epi.waiter); err != nil {
	return err
}
...
file.epolls[epi] = struct{}{}
```

If `file.EventRegister` fails, `AddInterest` returns with `epi` in `ep.interest` but never in `file.epolls`.

The interest-removal paths rely on `ep.interest` and `file.epolls` staying in sync: `EpollInstance.Release` walks `ep.interest`, and the `FileDescription.DecRef` path walks `file.epolls`. An entry present in `ep.interest` but not `file.epolls` is orphaned, and it keeps the target `*FileDescription` reachable past its own release.

`EventRegister` fails deterministically for an unprivileged caller. For example, `epoll_ctl(EPOLL_CTL_ADD)` on an opened-but-unmounted `/dev/fuse` FD reaches `fuse.DeviceFD.EventRegister`, which returns `EPERM` when the device is not connected.

## Change

Move `ep.interest[key] = epi` to after `EventRegister` succeeds. `epi` is then added to `ep.interest` and `file.epolls` only on the success path, with no fallible call between the two inserts, so a failed registration leaves nothing behind. A short comment records the ordering requirement.

## Scope

Hardening. A bounded per-`epoll_ctl` leak plus a stale `*FileDescription` reference, reachable by an unprivileged process.
