### PR TITLE
overlay: tolerate non-must-copy xattr failures during copy-up

### DIFF
--- a/pkg/sentry/fsimpl/overlay/copy_up.go
+++ b/pkg/sentry/fsimpl/overlay/copy_up.go
@@ -16,6 +16,7 @@ package overlay
 
 import (
 	"fmt"
+	"strings"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
@@ -367,6 +368,14 @@ func (d *dentry) copyUpMaybeSyntheticMountpointLocked(ctx context.Context, forSy
 	return nil
 }
 
+// mustCopyXattr returns true if a copy-up failure on the given xattr must
+// abort the copy-up. Mirrors Linux's fs/overlayfs/util.c:ovl_must_copy_xattr.
+func mustCopyXattr(name string) bool {
+	return name == "system.posix_acl_access" ||
+		name == "system.posix_acl_default" ||
+		strings.HasPrefix(name, linux.XATTR_USER_PREFIX)
+}
+
 // copyXattrsLocked copies a subset of lower's extended attributes to upper.
 // Attributes that configure an overlay in the lower are not copied up.
 //
@@ -394,12 +403,26 @@ func (d *dentry) copyXattrsLocked(ctx context.Context) error {
 
 		value, err := vfsObj.GetXattrAt(ctx, d.fs.creds, lowerPop, &vfs.GetXattrOptions{Name: name, Size: 0})
 		if err != nil {
-			ctx.Infof("failed to copy up xattrs because GetXattrAt failed: %v", err)
+			// Match Linux's ovl_copy_xattr: tolerate per-xattr failures
+			// unless the xattr is must-copy. EPERM covers e.g. trusted.*
+			// without CAP_SYS_ADMIN; ENODATA covers an xattr that
+			// disappears between ListXattrAt and GetXattrAt.
+			if !mustCopyXattr(name) && (linuxerr.Equals(linuxerr.EOPNOTSUPP, err) ||
+				linuxerr.Equals(linuxerr.EPERM, err) ||
+				linuxerr.Equals(linuxerr.ENODATA, err)) {
+				ctx.Debugf("skipping copy-up of xattr %q: GetXattrAt: %v", name, err)
+				continue
+			}
+			ctx.Infof("failed to copy up xattrs because GetXattrAt(%q) failed: %v", name, err)
 			return err
 		}
 
 		if err := vfsObj.SetXattrAt(ctx, d.fs.creds, upperPop, &vfs.SetXattrOptions{Name: name, Value: value}); err != nil {
-			ctx.Infof("failed to copy up xattrs because SetXattrAt failed: %v", err)
+			if !mustCopyXattr(name) && linuxerr.Equals(linuxerr.EOPNOTSUPP, err) {
+				ctx.Debugf("skipping copy-up of xattr %q: SetXattrAt: %v", name, err)
+				continue
+			}
+			ctx.Infof("failed to copy up xattrs because SetXattrAt(%q) failed: %v", name, err)
 			return err
 		}
 	}

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -2590,6 +2590,159 @@ TEST(MountTest, OverlayfsSgidBitIsCopiedUp) {
   }
 }
 
+// Copy-up of a lower with an xattr that the upper-layer filesystem cannot
+// accept (e.g. security.selinux on a tmpfs upper) must skip the xattr rather
+// than abort the whole copy-up, matching Linux's ovl_copy_xattr semantics for
+// non-must-copy xattrs. Regression test for the interaction with the
+// "gofer: Add full xattr support" change, which started exposing security.*
+// xattrs from real host filesystems to overlay copy-up.
+TEST(MountTest, OverlayfsCopyUpSkipsUnsupportedSecurityXattr) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  bool in_overlayfs = ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(base_dir.path()));
+  if (in_overlayfs) {
+    ASSERT_THAT(
+        mount("tmpfs", base_dir.path().c_str(), "tmpfs", 0, "mode=1777"),
+        SyscallSucceeds());
+  }
+  auto tmpfs_cleanup = Cleanup([&base_dir, &in_overlayfs] {
+    if (in_overlayfs) {
+      ASSERT_THAT(umount2(base_dir.path().c_str(), MNT_DETACH),
+                  SyscallSucceeds());
+    }
+  });
+
+  auto lower =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  std::string lower_subdir = JoinPath(lower.path(), "subdir");
+  ASSERT_THAT(mkdir(lower_subdir.c_str(), 0755), SyscallSucceeds());
+
+  // Set an unwritable-on-upper xattr. If the underlying filesystem does
+  // not support security.* at all, the regression can't be triggered.
+  const char kSelinuxLabel[] = "system_u:object_r:container_ro_file_t:s0";
+  if (setxattr(lower_subdir.c_str(), "security.selinux", kSelinuxLabel,
+               sizeof(kSelinuxLabel) - 1, 0) < 0) {
+    SKIP_IF(errno == EOPNOTSUPP || errno == ENOTSUP);
+    ASSERT_NO_ERRNO(PosixError(errno, "setxattr security.selinux"));
+  }
+
+  // Also set a must-copy xattr (user.*) so we can verify that the fix is
+  // selective rather than skipping all xattrs.
+  ASSERT_THAT(setxattr(lower_subdir.c_str(), "user.test_marker", "x", 1, 0),
+              SyscallSucceeds());
+
+  auto upper =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto work = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto merged =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  std::string opts = "lowerdir=" + lower.path() + ",upperdir=" + upper.path() +
+                     ",workdir=" + work.path();
+  ASSERT_THAT(
+      mount("overlay", merged.path().c_str(), "overlay", 0, opts.c_str()),
+      SyscallSucceeds());
+  auto overlayfs_cleanup =
+      Cleanup([&merged] { umount2(merged.path().c_str(), MNT_DETACH); });
+
+  // mkdir through merged triggers copy-up of subdir. On unpatched code,
+  // copy-up aborts with EOPNOTSUPP and mkdir fails. The patched code
+  // skips the security.selinux xattr and the mkdir succeeds.
+  std::string merged_child = JoinPath(merged.path(), "subdir", "child");
+  ASSERT_THAT(mkdir(merged_child.c_str(), 0755), SyscallSucceeds());
+
+  // Confirm copy-up actually happened (not a fast-path no-op).
+  std::string upper_subdir = JoinPath(upper.path(), "subdir");
+  struct stat st;
+  ASSERT_THAT(stat(upper_subdir.c_str(), &st), SyscallSucceeds());
+
+  // The must-copy user.* xattr should be present on the upper copy.
+  char marker_buf[2] = {};
+  EXPECT_THAT(
+      getxattr(upper_subdir.c_str(), "user.test_marker", marker_buf, 1),
+      SyscallSucceeds());
+
+  // The skipped security.selinux xattr must not have been copied.
+  char selinux_buf[64] = {};
+  EXPECT_THAT(getxattr(upper_subdir.c_str(), "security.selinux", selinux_buf,
+                       sizeof(selinux_buf)),
+              SyscallFailsWithErrno(ENODATA));
+}
+
+// Must-copy xattrs (POSIX ACLs, user.*) must NOT be silently skipped during
+// copy-up — if the upper layer rejects them, the whole copy-up must abort.
+// Guards against the fix being too permissive.
+TEST(MountTest, OverlayfsCopyUpFailsForMustCopyXattr) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  bool in_overlayfs = ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(base_dir.path()));
+  if (in_overlayfs) {
+    ASSERT_THAT(
+        mount("tmpfs", base_dir.path().c_str(), "tmpfs", 0, "mode=1777"),
+        SyscallSucceeds());
+  }
+  auto tmpfs_cleanup = Cleanup([&base_dir, &in_overlayfs] {
+    if (in_overlayfs) {
+      ASSERT_THAT(umount2(base_dir.path().c_str(), MNT_DETACH),
+                  SyscallSucceeds());
+    }
+  });
+
+  // Minimal valid POSIX ACL on-disk format (struct posix_acl_xattr_header +
+  // 3 entries): version=2, then USER_OBJ/GROUP_OBJ/OTHER all rwx with id=-1.
+  static constexpr unsigned char kPosixAclDefault[] = {
+      0x02, 0x00, 0x00, 0x00,
+      0x01, 0x00, 0x07, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+      0x04, 0x00, 0x07, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+      0x20, 0x00, 0x07, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+  };
+
+  // Probe whether the upper-layer filesystem accepts POSIX ACLs. If it
+  // does, we can't exercise the must-copy failure path.
+  auto probe_dir =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  if (setxattr(probe_dir.path().c_str(), "system.posix_acl_default",
+               kPosixAclDefault, sizeof(kPosixAclDefault), 0) == 0) {
+    GTEST_SKIP() << "upper filesystem accepts POSIX ACLs; cannot test "
+                    "must-copy failure";
+  }
+  SKIP_IF(errno != EOPNOTSUPP && errno != ENOTSUP);
+
+  auto lower =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  std::string lower_subdir = JoinPath(lower.path(), "subdir");
+  ASSERT_THAT(mkdir(lower_subdir.c_str(), 0755), SyscallSucceeds());
+
+  // The lower-layer filesystem must accept the must-copy xattr in the
+  // first place; if not, the must-copy failure path can't trigger.
+  if (setxattr(lower_subdir.c_str(), "system.posix_acl_default",
+               kPosixAclDefault, sizeof(kPosixAclDefault), 0) < 0) {
+    SKIP_IF(errno == EOPNOTSUPP || errno == ENOTSUP);
+    ASSERT_NO_ERRNO(PosixError(errno, "setxattr system.posix_acl_default"));
+  }
+
+  auto upper =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto work = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto merged =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  std::string opts = "lowerdir=" + lower.path() + ",upperdir=" + upper.path() +
+                     ",workdir=" + work.path();
+  ASSERT_THAT(
+      mount("overlay", merged.path().c_str(), "overlay", 0, opts.c_str()),
+      SyscallSucceeds());
+  auto overlayfs_cleanup =
+      Cleanup([&merged] { umount2(merged.path().c_str(), MNT_DETACH); });
+
+  // mkdir triggers copy-up of subdir. The must-copy POSIX ACL xattr
+  // cannot be set on the upper (probed above), so copy-up must abort
+  // and mkdir must fail with EOPNOTSUPP.
+  std::string merged_child = JoinPath(merged.path(), "subdir", "child");
+  EXPECT_THAT(mkdir(merged_child.c_str(), 0755),
+              SyscallFailsWithErrno(EOPNOTSUPP));
+}
+
 // Renaming a directory on an overlay inside a user namespace requires
 // user.overlay.* xattrs to mark the directory opaque.
 TEST(MountTest, OverlayfsDirectoryRenameInUserNamespace) {


### PR DESCRIPTION
## Summary

Fixes `mkdir`, `open(O_CREAT)`, and similar operations failing with `EOPNOTSUPP` inside the sandbox when the lower-layer filesystem exposes a non-must-copy `security.*` xattr (e.g. `security.selinux` on a container rootfs labeled by Docker/containerd on an SELinux-enabled host).

`copyXattrsLocked` in `pkg/sentry/fsimpl/overlay/copy_up.go` iterates lower-layer xattrs and copies each to upper. Until [4e559c2af](https://github.com/google/gvisor/commit/4e559c2af) ("gofer: Add full xattr support"), the gofer's `ListXattrAt` was a stub returning `EOPNOTSUPP`, so the loop's function-level early-return short-circuited it and copy-up never saw real host xattrs. After 4e559c2af, the gofer calls `unix.Flistxattr` on the host file, so copy-up now sees names like `security.selinux`. The VFS permission check (`pkg/sentry/vfs/permissions.go:317-324`) rejects writes to `security.*` other than `security.capability` with `EOPNOTSUPP`, and the previous unconditional `return err` in the loop propagated that error all the way out to userspace. The "should not regress" claim in 4e559c2af's commit message considered `GetXattrAt` for `user.overlay.opaque` lookups, not the new `ListXattrAt` exposing arbitrary host xattrs to copy-up.

This change matches Linux's `fs/overlayfs/copy_up.c:ovl_copy_xattr`, which tolerates per-xattr failures unless the xattr is in `ovl_must_copy_xattr` (POSIX ACLs and `user.*`). For SELinux specifically, Linux relies on the LSM to re-label the upper file independently rather than copying the xattr verbatim — gVisor's tmpfs upper has no SELinux LSM, so the xattr is simply absent on upper, which matches Linux behavior with SELinux disabled.

## Repro

Triggered by any host filesystem that exposes a `security.*` xattr (other than `security.capability`) on the lower layer. SELinux labeling of container rootfs files is the common in-the-wild trigger — every file under a containerd-managed bundle on Amazon Linux 2023 carries `security.selinux="system_u:object_r:container_ro_file_t:s0"`. Observed sentry log and strace excerpt:

```
copy_up.go:402] [1:1] failed to copy up xattrs because SetXattrAt failed:
                       operation not supported on transport endpoint
strace.go:602]  [1:1] node X mkdir(/app/sandbox-data/workspace, 0o777) = -1 errno=95
```

The user-visible symptom is `mkdir(2)` (or any operation that triggers copy-up of the parent) returning `EOPNOTSUPP`, after which the in-sandbox process typically exits because it can't create its workspace.

## Test

Two regression tests in `test/syscalls/linux/mount.cc`:

- `OverlayfsCopyUpSkipsUnsupportedSecurityXattr` — sets `security.selinux` and `user.test_marker` on a lower directory, mounts overlay with a tmpfs upper, triggers copy-up via `mkdir` on a child path, and asserts that `mkdir` succeeds, the must-copy `user.test_marker` was copied to upper, and the skipped `security.selinux` was not. Without the fix, `mkdir` fails with `EOPNOTSUPP`.
- `OverlayfsCopyUpFailsForMustCopyXattr` — guards the must-copy boundary. Sets `system.posix_acl_default` on a lower directory and triggers copy-up against an upper that rejects POSIX ACLs (probed at setup time). Asserts copy-up still aborts as before, so the fix isn't blanket-permissive.

Verified with:
- `bazel test //test/syscalls:mount_test_runsc_systrap --test_filter="*OverlayfsCopyUp*"`
- `bazel test //test/syscalls:mount_test_runsc_ptrace --test_filter="*OverlayfsCopyUp*"`
- `bazel test //pkg/sentry/fsimpl/overlay:overlay_test`

Assisted-by: Claude Opus 4.7