### PR TITLE
Combine UDP broadcast socket bind tests

### DIFF
--- a/test/syscalls/linux/socket_ipv4_udp_unbound_external_networking.cc
+++ b/test/syscalls/linux/socket_ipv4_udp_unbound_external_networking.cc
@@ -23,7 +23,7 @@
 namespace gvisor {
 namespace testing {
 
-void IPv4UDPUnboundExternalNetworkingSocketTest::SetUp() {
+void IPv4UDPUnboundExternalNetworkingTestBase::SetUpInterfaces() {
 #ifdef ANDROID
   GTEST_SKIP() << "Android does not support getifaddrs in r22";
 #endif
@@ -228,12 +228,10 @@ TEST_P(IPv4UDPUnboundExternalNetworkingSocketTest,
               SyscallFailsWithErrno(EAGAIN));
 }
 
-// Verifies that a UDP broadcast can be sent and then received back on the same
-// socket that is bound to the broadcast address (255.255.255.255).
-// FIXME(b/141938460): This can be combined with the next test
-//                     (UDPBroadcastSendRecvOnSocketBoundToAny).
-TEST_P(IPv4UDPUnboundExternalNetworkingSocketTest,
-       UDPBroadcastSendRecvOnSocketBoundToBroadcast) {
+// Verifies that a UDP broadcast can be sent and then received back on the
+// same socket.
+TEST_P(IPv4UDPUnboundExternalNetworkingSocketAddressTest,
+       UDPBroadcastSendRecvOnSocketBoundToAddress) {
   auto sender = ASSERT_NO_ERRNO_AND_VALUE(NewSocket());
 
   // Enable SO_BROADCAST.
@@ -241,47 +239,8 @@ TEST_P(IPv4UDPUnboundExternalNetworkingSocketTest,
                          sizeof(kSockOptOn)),
               SyscallSucceedsWithValue(0));
 
-  // Bind the sender to the broadcast address.
-  auto src_addr = V4Broadcast();
-  ASSERT_THAT(
-      bind(sender->get(), AsSockAddr(&src_addr.addr), src_addr.addr_len),
-      SyscallSucceedsWithValue(0));
-  socklen_t src_sz = src_addr.addr_len;
-  ASSERT_THAT(getsockname(sender->get(), AsSockAddr(&src_addr.addr), &src_sz),
-              SyscallSucceedsWithValue(0));
-  EXPECT_EQ(src_sz, src_addr.addr_len);
-
-  // Send the message.
-  auto dst_addr = V4Broadcast();
-  reinterpret_cast<sockaddr_in*>(&dst_addr.addr)->sin_port =
-      reinterpret_cast<sockaddr_in*>(&src_addr.addr)->sin_port;
-  constexpr char kTestMsg[] = "hello, world";
-  EXPECT_THAT(sendto(sender->get(), kTestMsg, sizeof(kTestMsg), 0,
-                     AsSockAddr(&dst_addr.addr), dst_addr.addr_len),
-              SyscallSucceedsWithValue(sizeof(kTestMsg)));
-
-  // Verify that the message was received.
-  char buf[sizeof(kTestMsg)] = {};
-  EXPECT_THAT(RetryEINTR(recv)(sender->get(), buf, sizeof(buf), 0),
-              SyscallSucceedsWithValue(sizeof(kTestMsg)));
-  EXPECT_EQ(0, memcmp(buf, kTestMsg, sizeof(kTestMsg)));
-}
-
-// Verifies that a UDP broadcast can be sent and then received back on the same
-// socket that is bound to the ANY address (0.0.0.0).
-// FIXME(b/141938460): This can be combined with the previous test
-//                     (UDPBroadcastSendRecvOnSocketBoundToBroadcast).
-TEST_P(IPv4UDPUnboundExternalNetworkingSocketTest,
-       UDPBroadcastSendRecvOnSocketBoundToAny) {
-  auto sender = ASSERT_NO_ERRNO_AND_VALUE(NewSocket());
-
-  // Enable SO_BROADCAST.
-  ASSERT_THAT(setsockopt(sender->get(), SOL_SOCKET, SO_BROADCAST, &kSockOptOn,
-                         sizeof(kSockOptOn)),
-              SyscallSucceedsWithValue(0));
-
-  // Bind the sender to the ANY address.
-  auto src_addr = V4Any();
+  // Bind the sender to the source address.
+  auto src_addr = address();
   ASSERT_THAT(
       bind(sender->get(), AsSockAddr(&src_addr.addr), src_addr.addr_len),
       SyscallSucceedsWithValue(0));

--- a/test/syscalls/linux/socket_ipv4_udp_unbound_external_networking.h
+++ b/test/syscalls/linux/socket_ipv4_udp_unbound_external_networking.h
@@ -15,17 +15,21 @@
 #ifndef GVISOR_TEST_SYSCALLS_LINUX_SOCKET_IPV4_UDP_UNBOUND_EXTERNAL_NETWORKING_H_
 #define GVISOR_TEST_SYSCALLS_LINUX_SOCKET_IPV4_UDP_UNBOUND_EXTERNAL_NETWORKING_H_
 
+#include <cstdio>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <utility>
+
 #include "test/syscalls/linux/socket_ip_udp_unbound_external_networking.h"
 
 namespace gvisor {
 namespace testing {
 
-// Test fixture for tests that apply to unbound IPv4 UDP sockets in a sandbox
-// with external networking support.
-class IPv4UDPUnboundExternalNetworkingSocketTest
-    : public IPUDPUnboundExternalNetworkingSocketTest {
+// Base class for IPv4 UDP tests that need host interface information.
+class IPv4UDPUnboundExternalNetworkingTestBase {
  protected:
-  void SetUp() override;
+  void SetUpInterfaces();
 
   int lo_if_idx() const { return std::get<0>(lo_if_.value()); }
   int eth_if_idx() const { return std::get<0>(eth_if_.value()); }
@@ -37,6 +41,43 @@ class IPv4UDPUnboundExternalNetworkingSocketTest
 
  private:
   std::optional<std::pair<int, sockaddr_in>> lo_if_, eth_if_;
+};
+
+// Test fixture for tests that apply to unbound IPv4 UDP sockets in a sandbox
+// with external networking support.
+class IPv4UDPUnboundExternalNetworkingSocketTest
+    : public IPUDPUnboundExternalNetworkingSocketTest,
+      public IPv4UDPUnboundExternalNetworkingTestBase {
+ protected:
+  void SetUp() override { SetUpInterfaces(); }
+};
+
+using IPv4UDPUnboundExternalNetworkingSocketAddressParam =
+    std::tuple<SocketKind, TestAddress>;
+
+// Test fixture for tests that apply to unbound IPv4 UDP sockets and also need
+// an address parameter.
+class IPv4UDPUnboundExternalNetworkingSocketAddressTest
+    : public ::testing::TestWithParam<
+          IPv4UDPUnboundExternalNetworkingSocketAddressParam>,
+      public IPv4UDPUnboundExternalNetworkingTestBase {
+ protected:
+  IPv4UDPUnboundExternalNetworkingSocketAddressTest() {
+    printf("Testing with %s, %s\n", socket_kind().description.c_str(),
+           address().description.c_str());
+    fflush(stdout);
+  }
+
+  void SetUp() override { SetUpInterfaces(); }
+
+  PosixErrorOr<std::unique_ptr<FileDescriptor>> NewSocket() const {
+    return socket_kind().Create();
+  }
+
+  TestAddress address() const { return std::get<1>(GetParam()); }
+
+ private:
+  const SocketKind& socket_kind() const { return std::get<0>(GetParam()); }
 };
 
 }  // namespace testing

--- a/test/syscalls/linux/socket_ipv4_udp_unbound_external_networking_test.cc
+++ b/test/syscalls/linux/socket_ipv4_udp_unbound_external_networking_test.cc
@@ -34,6 +34,12 @@ INSTANTIATE_TEST_SUITE_P(IPv4UDPUnboundSockets,
                          IPv4UDPUnboundExternalNetworkingSocketTest,
                          ::testing::ValuesIn(GetSockets()));
 
+INSTANTIATE_TEST_SUITE_P(IPv4UDPUnboundSockets,
+                         IPv4UDPUnboundExternalNetworkingSocketAddressTest,
+                         ::testing::Combine(::testing::ValuesIn(GetSockets()),
+                                            ::testing::Values(V4Broadcast(),
+                                                              V4Any())));
+
 }  // namespace
 }  // namespace testing
 }  // namespace gvisor


### PR DESCRIPTION
Updates #1640.

This combines the two IPv4 UDP broadcast send/receive tests that only differed
by the address used to bind the sending socket.

The change:

- extracts the IPv4 external-networking interface setup into a shared base;
- adds a parameterized fixture over `(SocketKind, TestAddress)`;
- instantiates the broadcast send/receive test with `V4Broadcast()` and
  `V4Any()`.

Validation:

- `git diff --check`
- `bazel build --nobuild --macos_sdk_version=$(xcrun --show-sdk-version) -- //test/syscalls/linux:socket_ipv4_udp_unbound_external_networking_test`
- Linux execution through the gVisor build container:
  `./bazel-bin/test/syscalls/linux/socket_ipv4_udp_unbound_external_networking_test`
  passed 38/38 tests.