### PR TITLE
Add changelog to runsc Debian package

### DIFF
--- a/debian/BUILD
+++ b/debian/BUILD
@@ -32,12 +32,71 @@ pkg_tar(
     package_dir = "/usr/bin",
 )
 
+genrule(
+    name = "debian-changelog",
+    srcs = [version],
+    outs = ["changelog"],
+    cmd = """
+version="$$(cat $(location %s))"
+: "$${version:=0.0.0}"
+release_date="$$(printf '%%s' "$$version" | sed -n 's/^\\([0-9]\\{4\\}\\)\\([0-9]\\{2\\}\\)\\([0-9]\\{2\\}\\).*/\\1-\\2-\\3/p')"
+changelog_date=""
+if [ -n "$$release_date" ]; then
+  linux_date="$$(date -u -d "$$release_date" '+%%a, %%d %%b %%Y 00:00:00 +0000' 2>/dev/null || true)"
+  darwin_date="$$(date -u -j -f '%%Y-%%m-%%d' "$$release_date" '+%%a, %%d %%b %%Y 00:00:00 +0000' 2>/dev/null || true)"
+  changelog_date="$${linux_date:-$$darwin_date}"
+fi
+if [ -z "$$changelog_date" ]; then
+  changelog_date="Thu, 01 Jan 1970 00:00:00 +0000"
+fi
+cat >"$@" <<EOF
+runsc ($${version}) release; urgency=medium
+
+  * gVisor runsc release. See https://github.com/google/gvisor/releases
+    for release notes.
+
+ -- The gVisor Authors <gvisor-dev@googlegroups.com>  $${changelog_date}
+EOF
+""" % version,
+)
+
+genrule(
+    name = "changelog-debian-gz",
+    srcs = [":debian-changelog"],
+    outs = ["changelog.Debian.gz"],
+    cmd = "gzip -n -c $(location :debian-changelog) >$@",
+)
+
+pkg_tar(
+    name = "debian-doc",
+    srcs = [":changelog-debian-gz"],
+    mode = "0644",
+    package_dir = "/usr/share/doc/runsc",
+)
+
+sh_test(
+    name = "changelog_test",
+    size = "small",
+    srcs = ["changelog_test.sh"],
+    args = [
+        "$(location :debian-changelog)",
+        "$(location :changelog-debian-gz)",
+        "$(location :debian-doc)",
+    ],
+    data = [
+        ":changelog-debian-gz",
+        ":debian-changelog",
+        ":debian-doc",
+    ],
+)
+
 pkg_tar(
     name = "debian-data",
     extension = "tar.gz",
     deps = [
         ":debian-bin",
         ":debian-gvisor-bin",
+        ":debian-doc",
         "//shim:config",
     ],
 )
@@ -48,6 +107,7 @@ pkg_deb(
         amd64 = "amd64",
         arm64 = "arm64",
     ),
+    changelog = ":debian-changelog",
     conffiles = [
         "/etc/containerd/runsc.toml",
     ],

--- a/debian/changelog_test.sh
+++ b/debian/changelog_test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Copyright 2026 The gVisor Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+changelog="$1"
+compressed_changelog="$2"
+doc_tar="$3"
+
+grep -Eq '^runsc \([0-9][^)]*\) release; urgency=medium$' "${changelog}"
+grep -q 'https://github.com/google/gvisor/releases' "${changelog}"
+gzip -dc "${compressed_changelog}" | cmp - "${changelog}"
+tar -tf "${doc_tar}" | grep -qx 'usr/share/doc/runsc/changelog.Debian.gz'


### PR DESCRIPTION
Fixes #11372.

The runsc deb package did not ship a Debian changelog, so tools such as apt-listchanges can report that the changelog is unavailable for runsc releases.

This change:

- generates a Debian-format changelog from the stamped package version;
- packages the gzipped changelog at `/usr/share/doc/runsc/changelog.Debian.gz`;
- passes the same changelog to `pkg_deb`;
- adds a small packaging test for the generated content and package path.

Validation:

- `bazel test //debian:changelog_test`
- `bazel build //debian:debian-changelog //debian:changelog-debian-gz //debian:debian-doc`
- `git diff --check`
- Attempted `bazel build //debian:debian` and `bazel build --config=x86_64 //debian:debian` on macOS; both fail before packaging because eBPF generation needs Linux headers (`linux/types.h` / `linux/bpf.h`) unavailable on this host.