### PR TITLE
Preserve TMPDIR for sandbox chroot setup

### DIFF
--- a/runsc/sandbox/BUILD
+++ b/runsc/sandbox/BUILD
@@ -71,6 +71,7 @@ go_test(
     name = "sandbox_test",
     size = "small",
     srcs = [
+        "env_test.go",
         "network_test.go",
     ],
     library = ":sandbox",

--- a/runsc/sandbox/BUILD
+++ b/runsc/sandbox/BUILD
@@ -72,6 +72,7 @@ go_test(
     name = "sandbox_test",
     size = "small",
     srcs = [
+        "env_test.go",
         "network_test.go",
     ],
     library = ":sandbox",

--- a/runsc/sandbox/env_test.go
+++ b/runsc/sandbox/env_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"gvisor.dev/gvisor/runsc/config"
+)
+
+func TestSandboxProcessEnvPreservesTMPDIR(t *testing.T) {
+	t.Setenv("TMPDIR", "/realtmp")
+	t.Setenv("TMP", "/wrong-tmp")
+	t.Setenv("TEMP", "/wrong-temp")
+
+	env := sandboxProcessEnv(&config.Config{})
+	if !envContains(env, "TMPDIR=/realtmp") {
+		t.Fatalf("sandboxProcessEnv() = %v, missing TMPDIR", env)
+	}
+	if envHasPrefix(env, "TMP=") {
+		t.Fatalf("sandboxProcessEnv() = %v, leaked TMP", env)
+	}
+	if envHasPrefix(env, "TEMP=") {
+		t.Fatalf("sandboxProcessEnv() = %v, leaked TEMP", env)
+	}
+}
+
+func TestSandboxProcessEnvLeavesTMPDIRUnset(t *testing.T) {
+	t.Setenv("TMPDIR", "")
+
+	env := sandboxProcessEnv(&config.Config{})
+	if envHasPrefix(env, "TMPDIR=") {
+		t.Fatalf("sandboxProcessEnv() = %v, unexpectedly set TMPDIR", env)
+	}
+}
+
+func envContains(env []string, want string) bool {
+	for _, got := range env {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func envHasPrefix(env []string, prefix string) bool {
+	for _, got := range env {
+		if strings.HasPrefix(got, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/runsc/sandbox/env_test.go
+++ b/runsc/sandbox/env_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"strings"
+	"testing"
+
+	"gvisor.dev/gvisor/runsc/config"
+)
+
+func TestSandboxProcessEnvPreservesTMPDIR(t *testing.T) {
+	t.Setenv("TMPDIR", "/realtmp")
+	t.Setenv("TMP", "/wrong-tmp")
+	t.Setenv("TEMP", "/wrong-temp")
+
+	env := sandboxProcessEnv(&config.Config{}, sandboxProcessEnvOptions{})
+	if !envContains(env, "TMPDIR=/realtmp") {
+		t.Fatalf("sandboxProcessEnv() = %v, missing TMPDIR", env)
+	}
+	if envHasPrefix(env, "TMP=") {
+		t.Fatalf("sandboxProcessEnv() = %v, leaked TMP", env)
+	}
+	if envHasPrefix(env, "TEMP=") {
+		t.Fatalf("sandboxProcessEnv() = %v, leaked TEMP", env)
+	}
+}
+
+func TestSandboxProcessEnvLeavesTMPDIRUnset(t *testing.T) {
+	t.Setenv("TMPDIR", "")
+
+	env := sandboxProcessEnv(&config.Config{}, sandboxProcessEnvOptions{})
+	if envHasPrefix(env, "TMPDIR=") {
+		t.Fatalf("sandboxProcessEnv() = %v, unexpectedly set TMPDIR", env)
+	}
+}
+
+func envContains(env []string, want string) bool {
+	for _, got := range env {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+func envHasPrefix(env []string, prefix string) bool {
+	for _, got := range env {
+		if strings.HasPrefix(got, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -870,6 +870,26 @@ func (s *Sandbox) connError(err error) error {
 	return fmt.Errorf("connecting to control server at PID %d: %v", s.Pid.Load(), err)
 }
 
+func sandboxProcessEnv(conf *config.Config) []string {
+	var env []string
+	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
+		// Setting cmd.Env = nil causes cmd to inherit the current process's env.
+		// Clear it, except for TMPDIR which must match the parent runsc process
+		// because the sandbox uses os.TempDir() to set up its chroot.
+		env = []string{}
+		if tmpDir := os.Getenv("TMPDIR"); tmpDir != "" {
+			env = append(env, "TMPDIR="+tmpDir)
+		}
+	}
+	if config.CgoEnabled {
+		// Platforms that use stub processes are not compatible with
+		// the glibc rseq, because they unmap everything from a process
+		// address space.
+		env = append(env, "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+	}
+	return env
+}
+
 // createSandboxProcess starts the sandbox as a subprocess by running the "boot"
 // command, passing in the bundle dir.
 func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyncFile *os.File) error {
@@ -960,17 +980,7 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	// All flags after this must be for the boot command
 	cmd.Args = append(cmd.Args, "boot", "--bundle="+args.BundleDir)
 
-	// Clear environment variables, unless --TESTONLY-unsafe-nonroot is set.
-	if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
-		// Setting cmd.Env = nil causes cmd to inherit the current process's env.
-		cmd.Env = []string{}
-	}
-	if config.CgoEnabled {
-		// Platforms that use stub processes are not compatible with
-		// the glibc rseq, because they unmap everything from a process
-		// address space.
-		cmd.Env = append(cmd.Env, "GLIBC_TUNABLES=glibc.pthread.rseq=0")
-	}
+	cmd.Env = sandboxProcessEnv(conf)
 
 	// If there is a gofer, sends all socket ends to the sandbox.
 	donations.DonateAndClose("io-fds", args.IOFiles...)

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -881,6 +881,37 @@ func (s *Sandbox) connError(err error) error {
 	return fmt.Errorf("connecting to control server at PID %d: %v", s.Pid.Load(), err)
 }
 
+type sandboxProcessEnvOptions struct {
+	enforceRelease bool
+	sentryUsesCgo  bool
+}
+
+func sandboxProcessEnv(conf *config.Config, opts sandboxProcessEnvOptions) []string {
+	var env []string
+	if conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
+		// --TESTONLY-unsafe-nonroot is set, so keep env.
+		env = os.Environ()
+	} else {
+		// Setting cmd.Env = nil causes cmd to inherit the current process's env.
+		// Clear it, except for TMPDIR which must match the parent runsc process
+		// because the sandbox uses os.TempDir() to set up its chroot.
+		env = []string{}
+		if tmpDir := os.Getenv("TMPDIR"); tmpDir != "" {
+			env = append(env, "TMPDIR="+tmpDir)
+		}
+	}
+	if opts.enforceRelease {
+		env = gvisorbinaries.WithEnforceRelease(env)
+	}
+	if opts.sentryUsesCgo {
+		// Platforms that use stub processes are not compatible with
+		// the glibc rseq, because they unmap everything from a process
+		// address space.
+		env = append(env, "GLIBC_TUNABLES=glibc.pthread.rseq=0")
+	}
+	return env
+}
+
 // createSandboxProcess starts the sandbox as a subprocess by running the "boot"
 // command, passing in the bundle dir.
 func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyncFile *os.File) error {
@@ -1002,22 +1033,10 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	// All flags after this must be for the boot command
 	cmd.Args = append(cmd.Args, "boot", "--bundle="+args.BundleDir)
 
-	if conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
-		// --TESTONLY-unsafe-nonroot is set, so keep env.
-		cmd.Env = os.Environ()
-	} else {
-		// Clear environment variables, unless --TESTONLY-unsafe-nonroot is set.
-		cmd.Env = []string{}
-	}
-	if bootBinPath != specutils.ExePath {
-		cmd.Env = gvisorbinaries.WithEnforceRelease(cmd.Env)
-	}
-	if sentryUsesCgo {
-		// Platforms that use stub processes are not compatible with
-		// the glibc rseq, because they unmap everything from a process
-		// address space.
-		cmd.Env = append(cmd.Env, "GLIBC_TUNABLES=glibc.pthread.rseq=0")
-	}
+	cmd.Env = sandboxProcessEnv(conf, sandboxProcessEnvOptions{
+		enforceRelease: bootBinPath != specutils.ExePath,
+		sentryUsesCgo:  sentryUsesCgo,
+	})
 
 	// If there is a gofer, sends all socket ends to the sandbox.
 	donations.DonateAndClose("io-fds", args.IOFiles...)

--- a/test/root/runsc_test.go
+++ b/test/root/runsc_test.go
@@ -152,8 +152,9 @@ func sandboxPid(pid int) (int, error) {
 	return 0, nil
 }
 
-// Tests that the sandbox process is running with no environment variables. We
-// don't want to leak any env vars from the caller to the sandbox process.
+// Tests that the sandbox process is running with no environment variables
+// except the small allowlist required for sandbox setup. We don't want to leak
+// env vars from the caller to the sandbox process.
 func TestSandboxProcessEnv(t *testing.T) {
 	ctx := context.Background()
 	d := dockerutil.MakeContainer(ctx, t)
@@ -173,6 +174,7 @@ func TestSandboxProcessEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	got = regexp.MustCompile("(^|\x00)RUNSC_START_TIME_NANOS=\\d+\x00").ReplaceAll(got, []byte("$1"))
+	got = regexp.MustCompile("(^|\x00)TMPDIR=[^\x00]*\x00").ReplaceAll(got, []byte("$1"))
 	if len(got) != 0 && string(got) != "GLIBC_TUNABLES=glibc.pthread.rseq=0\x00" {
 		t.Errorf("sandbox process's environment is not empty: got %s (%v)", string(got), got)
 	}

--- a/test/root/runsc_test.go
+++ b/test/root/runsc_test.go
@@ -152,8 +152,9 @@ func sandboxPid(pid int) (int, error) {
 	return 0, nil
 }
 
-// Tests that the sandbox process is running with no environment variables. We
-// don't want to leak any env vars from the caller to the sandbox process.
+// Tests that the sandbox process is running with no environment variables
+// except the small allowlist required for sandbox setup. We don't want to leak
+// env vars from the caller to the sandbox process.
 func TestSandboxProcessEnv(t *testing.T) {
 	ctx := context.Background()
 	d := dockerutil.MakeContainer(ctx, t)
@@ -174,6 +175,7 @@ func TestSandboxProcessEnv(t *testing.T) {
 	}
 	got = regexp.MustCompile("(^|\x00)RUNSC_START_TIME_NANOS=\\d+\x00").ReplaceAll(got, []byte("$1"))
 	got = regexp.MustCompile("(^|\x00)GVISOR_ENFORCE_RELEASE=[^\x00]*\x00").ReplaceAll(got, []byte("$1"))
+	got = regexp.MustCompile("(^|\x00)TMPDIR=[^\x00]*\x00").ReplaceAll(got, []byte("$1"))
 	if len(got) != 0 && string(got) != "GLIBC_TUNABLES=glibc.pthread.rseq=0\x00" {
 		t.Errorf("sandbox process's environment is not empty: got %s (%v)", string(got), got)
 	}


### PR DESCRIPTION
Fixes #12476.

The sandbox process clears its environment before running `boot`. That keeps the sandbox process from inheriting arbitrary caller environment variables, but it also drops `TMPDIR`, so `os.TempDir()` in the sandbox can resolve to `/tmp` even when the parent runsc process was launched with a different host temp directory such as `/realtmp`. The chroot setup then attempts to mount using the wrong path and can fail on systems where `/tmp` must not be used or is a symlink.

This change:

- centralizes sandbox process environment construction;
- keeps the existing default of clearing the sandbox environment;
- preserves only `TMPDIR` when the parent process has it set;
- keeps `TEMP`, `TMP`, and other caller variables out of the sandbox environment;
- updates the root environment test allowlist for the intentional `TMPDIR` exception.

Validation:

- `gofmt -w runsc/sandbox/sandbox.go runsc/sandbox/env_test.go test/root/runsc_test.go`
- `git diff --check`
- `bazel build --nobuild //runsc/sandbox:sandbox_test //test/root:root_test`

I also attempted `bazel test //runsc/sandbox:sandbox_test` on macOS, but this host cannot build the existing eBPF genrules because Linux headers such as `linux/types.h` are unavailable.