### PR TITLE
Wrap systemd version lookup errors

### DIFF
--- a/runsc/cgroup/systemd.go
+++ b/runsc/cgroup/systemd.go
@@ -57,6 +57,10 @@ type cgroupSystemd struct {
 	dbusConn   *systemdDbus.Conn
 }
 
+type systemdManagerPropertyGetter interface {
+	GetManagerProperty(string) (string, error)
+}
+
 func newCgroupV2Systemd(cgv2 *cgroupV2) (*cgroupSystemd, error) {
 	if !isRunningSystemd() {
 		return nil, fmt.Errorf("systemd not running on host")
@@ -261,10 +265,10 @@ func isRunningSystemd() bool {
 	return systemdCheck.cache
 }
 
-func systemdVersion(conn *systemdDbus.Conn) (int, error) {
+func systemdVersion(conn systemdManagerPropertyGetter) (int, error) {
 	vStr, err := conn.GetManagerProperty("Version")
 	if err != nil {
-		return -1, errors.New("unable to get systemd version")
+		return -1, fmt.Errorf("unable to get systemd version: %w", err)
 	}
 	// vStr should be of the form:
 	// "v245.4-1.fc32", "245", "v245-1.fc32", "245-1.fc32" (without quotes).

--- a/runsc/cgroup/systemd_test.go
+++ b/runsc/cgroup/systemd_test.go
@@ -18,6 +18,7 @@ package cgroup
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
@@ -31,6 +32,15 @@ var (
 	defaultProps         = []systemdDbus.Property{}
 	mandatoryControllers = []string{"cpu", "cpuset", "io", "memory", "pids"}
 )
+
+type fakeSystemdManagerPropertyGetter struct {
+	value string
+	err   error
+}
+
+func (f fakeSystemdManagerPropertyGetter) GetManagerProperty(string) (string, error) {
+	return f.value, f.err
+}
 
 func TestIsValidSlice(t *testing.T) {
 	for _, tc := range []struct {
@@ -70,6 +80,51 @@ func TestIsValidSlice(t *testing.T) {
 			err := validSlice(tc.slice)
 			if !errors.Is(err, tc.err) {
 				t.Errorf("validSlice(%s) = %v, want %v", tc.slice, err, tc.err)
+			}
+		})
+	}
+}
+
+func TestSystemdVersionGetManagerPropertyError(t *testing.T) {
+	wantErr := errors.New("dbus timeout")
+	_, err := systemdVersion(fakeSystemdManagerPropertyGetter{err: wantErr})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("systemdVersion() error = %v, want error wrapping %v", err, wantErr)
+	}
+	if got, want := err.Error(), "unable to get systemd version: dbus timeout"; !strings.Contains(got, want) {
+		t.Fatalf("systemdVersion() error = %q, want substring %q", got, want)
+	}
+}
+
+func TestSystemdVersionParsesManagerProperty(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		want    int
+	}{
+		{
+			version: "v245.4-1.fc32",
+			want:    245,
+		},
+		{
+			version: "245",
+			want:    245,
+		},
+		{
+			version: "v245-1.fc32",
+			want:    245,
+		},
+		{
+			version: "245-1.fc32",
+			want:    245,
+		},
+	} {
+		t.Run(tc.version, func(t *testing.T) {
+			got, err := systemdVersion(fakeSystemdManagerPropertyGetter{value: tc.version})
+			if err != nil {
+				t.Fatalf("systemdVersion() failed: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("systemdVersion() = %d, want %d", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #11877.

## What
- Preserve the underlying error returned by `GetManagerProperty("Version")` when reading the systemd manager version.
- Narrow `systemdVersion` to the manager-property method it needs so the error path is unit-testable.
- Add tests for wrapped lookup errors and existing version parsing forms.

## Why
When systemd D-Bus version lookup failed, runsc returned only `unable to get systemd version`. That hides the actual D-Bus failure and makes intermittent host/load-related failures hard to diagnose. The returned error now includes and wraps the original cause.

## Testing
- `gofmt`
- `git diff --check`
- `bazel build --nobuild //runsc/cgroup:cgroup_test`

I also attempted `bazel test //runsc/cgroup:cgroup_test`. On this macOS checkout it could not run locally because the gVisor Bazel toolchain requires host setup not present here: first the default C++ headers were not found, and after adding the SDK libc++ include path the build required `/usr/bin/x86_64-linux-gnu-gcc` for the Linux vDSO genrule. Native `go test ./runsc/cgroup` is also not usable in this repo because generated packages such as `pkg/refs` are Bazel-managed.