### PR TITLE
Add CLOCK_BOOTTIME coverage for clock syscalls

### DIFF
--- a/test/syscalls/linux/clock_getres.cc
+++ b/test/syscalls/linux/clock_getres.cc
@@ -15,6 +15,8 @@
 #include <sys/time.h>
 #include <time.h>
 
+#include <string>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "test/util/test_util.h"
@@ -24,12 +26,29 @@ namespace testing {
 
 namespace {
 
+class ClockGetresTest : public ::testing::TestWithParam<clockid_t> {};
+
 // clock_getres works regardless of whether or not a timespec is passed.
-TEST(ClockGetres, Timespec) {
+TEST_P(ClockGetresTest, Timespec) {
   struct timespec ts;
-  EXPECT_THAT(clock_getres(CLOCK_MONOTONIC, &ts), SyscallSucceeds());
-  EXPECT_THAT(clock_getres(CLOCK_MONOTONIC, nullptr), SyscallSucceeds());
+  EXPECT_THAT(clock_getres(GetParam(), &ts), SyscallSucceeds());
+  EXPECT_THAT(clock_getres(GetParam(), nullptr), SyscallSucceeds());
 }
+
+std::string PrintClockId(::testing::TestParamInfo<clockid_t> info) {
+  switch (info.param) {
+    case CLOCK_MONOTONIC:
+      return "CLOCK_MONOTONIC";
+    case CLOCK_BOOTTIME:
+      return "CLOCK_BOOTTIME";
+    default:
+      return std::to_string(info.param);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ClockGetres, ClockGetresTest,
+                         ::testing::Values(CLOCK_MONOTONIC, CLOCK_BOOTTIME),
+                         PrintClockId);
 
 }  // namespace
 

--- a/test/syscalls/linux/clock_nanosleep.cc
+++ b/test/syscalls/linux/clock_nanosleep.cc
@@ -150,7 +150,8 @@ TEST_P(WallClockNanosleepTest, SleepUntil) {
 }
 
 INSTANTIATE_TEST_SUITE_P(Sleepers, WallClockNanosleepTest,
-                         ::testing::Values(CLOCK_REALTIME, CLOCK_MONOTONIC));
+                         ::testing::Values(CLOCK_REALTIME, CLOCK_MONOTONIC,
+                                           CLOCK_BOOTTIME));
 
 TEST(ClockNanosleepProcessTest, SleepFiveSeconds) {
   const absl::Duration kSleepDuration = absl::Seconds(5);


### PR DESCRIPTION
## Description

Add explicit syscall test coverage for CLOCK_BOOTTIME.

- Parameterize clock_getres coverage over CLOCK_MONOTONIC and CLOCK_BOOTTIME.
- Include CLOCK_BOOTTIME in the clock_nanosleep wall-clock test matrix.

gVisor already maps CLOCK_BOOTTIME to the monotonic clock, and existing tests cover clock_gettime, VDSO clock_gettime, and timerfd behavior. This extends regression coverage to the remaining clock syscall paths that accept CLOCK_BOOTTIME.

Updates #218

## Tests

- `git diff --check`
- `bazel build --nobuild //test/syscalls/linux:clock_getres_test //test/syscalls/linux:clock_nanosleep_test`