### PR TITLE
Fix Endpoint.Write documentation

### DIFF
--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -768,9 +768,9 @@ type Endpoint interface {
 	// the data cannot be written.
 	//
 	// Unlike io.Writer.Write, Endpoint.Write transfers ownership of any bytes
-	// successfully written to the Endpoint. That is, if a call to
-	// Write(SlicePayload{data}) returns (n, err), it may retain data[:n], and
-	// the caller should not use data[:n] after Write returns.
+	// successfully written to the Endpoint. That is, if Write(p, opts) returns
+	// (n, err), it may retain the first n bytes fetched from p, and the caller
+	// should not use those bytes after Write returns.
 	//
 	// Note that unlike io.Writer.Write, it is not an error for Write to
 	// perform a partial write (if n > 0, no error may be returned). Only


### PR DESCRIPTION
Fixes #6024

## Summary

Update the `tcpip.Endpoint.Write` API comment so it no longer refers to the removed `SlicePayload` call shape. The ownership guidance still applies, but the example now matches the current `Write(Payloader, WriteOptions)` signature and describes the first `n` bytes fetched from the payloader.

## Testing

- `git diff --check`
- `bazel test //pkg/tcpip:tcpip_test //pkg/tcpip:tcpip_x_test`

Note: `go test ./pkg/tcpip` was not used as validation because this repo relies on generated files from the Bazel path; the direct Go command fails before reaching this change with missing generated types such as `ViewList` and `waiterEntry`.
