### PR TITLE
runsc/cgroup: set swap for precreated cgroups

### DIFF
--- a/runsc/cgroup/cgroup_v2.go
+++ b/runsc/cgroup/cgroup_v2.go
@@ -142,6 +142,13 @@ func (c *cgroupV2) Install(res *specs.LinuxResources) error {
 		if err := c.Update(res); err != nil {
 			return err
 		}
+	} else {
+		// Kubernetes can pre-create the pod cgroup and pass the swap limit
+		// through the OCI spec. Preserve the existing resource ownership
+		// contract for pre-created cgroups, but still honor memory.swap.max.
+		if err := setMemorySwap(res, c.MakePath("")); err != nil {
+			return err
+		}
 	}
 
 	clean.Release()
@@ -594,29 +601,8 @@ func (*memory2) set(spec *specs.LinuxResources, path string) error {
 		return nil
 	}
 
-	if spec.Memory.Swap != nil {
-		// in cgroup v2, we set memory and swap separately, but the spec specifies
-		// Swap field as memory+swap, so we need memory limit here to be set in
-		// order to get the correct swap value.
-		if spec.Memory.Limit == nil {
-			return errors.New("cgroup: Memory.Swap is set without Memory.Limit")
-		}
-
-		swap, err := convertMemorySwapToCgroupV2Value(*spec.Memory.Swap, *spec.Memory.Limit)
-		if err != nil {
-			return err
-		}
-		swapStr := numToStr(swap)
-		// memory and memorySwap set to the same value -- disable swap
-		if swapStr == "" && swap == 0 && *spec.Memory.Swap > 0 {
-			swapStr = "0"
-		}
-		// never write empty string to `memory.swap.max`, it means set to 0.
-		if swapStr != "" {
-			if err := setValue(path, "memory.swap.max", swapStr); err != nil {
-				return err
-			}
-		}
+	if err := setMemorySwap(spec, path); err != nil {
+		return err
 	}
 
 	if spec.Memory.Limit != nil {
@@ -635,6 +621,35 @@ func (*memory2) set(spec *specs.LinuxResources, path string) error {
 		}
 	}
 
+	return nil
+}
+
+func setMemorySwap(spec *specs.LinuxResources, path string) error {
+	if spec == nil || spec.Memory == nil || spec.Memory.Swap == nil {
+		return nil
+	}
+
+	// In cgroup v2, memory and swap are set separately, but the OCI spec's Swap
+	// field is memory+swap, so the memory limit is needed to derive swap.max.
+	if spec.Memory.Limit == nil {
+		return errors.New("cgroup: Memory.Swap is set without Memory.Limit")
+	}
+
+	swap, err := convertMemorySwapToCgroupV2Value(*spec.Memory.Swap, *spec.Memory.Limit)
+	if err != nil {
+		return err
+	}
+	swapStr := numToStr(swap)
+	// memory and memorySwap set to the same value -- disable swap
+	if swapStr == "" && swap == 0 && *spec.Memory.Swap > 0 {
+		swapStr = "0"
+	}
+	// never write empty string to `memory.swap.max`, it means set to 0.
+	if swapStr != "" {
+		if err := setValue(path, "memory.swap.max", swapStr); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/runsc/cgroup/cgroup_v2_test.go
+++ b/runsc/cgroup/cgroup_v2_test.go
@@ -416,6 +416,58 @@ func TestConvertMemorySwapToCgroupV2Value(t *testing.T) {
 	}
 }
 
+func TestInstallPrecreatedCgroupV2SetsMemorySwap(t *testing.T) {
+	dir, err := os.MkdirTemp(testutil.TmpDir(), "cgroup")
+	if err != nil {
+		t.Fatalf("error creating temporary directory: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	cg := &cgroupV2{
+		Mountpoint:  dir,
+		Path:        "kubepods-pod",
+		Controllers: mandatoryControllers,
+	}
+	cgPath := filepath.Join(cg.Mountpoint, cg.Path)
+	if err := os.MkdirAll(cgPath, 0o777); err != nil {
+		t.Fatalf("os.MkdirAll(): %v", err)
+	}
+	for name, value := range map[string]string{
+		"memory.max":      "max",
+		"memory.swap.max": "max",
+	} {
+		if err := os.WriteFile(filepath.Join(cgPath, name), []byte(value), 0o666); err != nil {
+			t.Fatalf("os.WriteFile(%q): %v", name, err)
+		}
+	}
+
+	resources := &specs.LinuxResources{
+		Memory: &specs.LinuxMemory{
+			Limit: int64Ptr(1024),
+			Swap:  int64Ptr(1280),
+		},
+	}
+	if err := cg.Install(resources); err != nil {
+		t.Fatalf("Install(): %v", err)
+	}
+
+	gotSwap, err := os.ReadFile(filepath.Join(cgPath, "memory.swap.max"))
+	if err != nil {
+		t.Fatalf("ReadFile(memory.swap.max): %v", err)
+	}
+	if string(gotSwap) != "256" {
+		t.Errorf("memory.swap.max = %q, want %q", string(gotSwap), "256")
+	}
+
+	gotMemory, err := os.ReadFile(filepath.Join(cgPath, "memory.max"))
+	if err != nil {
+		t.Fatalf("ReadFile(memory.max): %v", err)
+	}
+	if string(gotMemory) != "max" {
+		t.Errorf("memory.max = %q, want %q", string(gotMemory), "max")
+	}
+}
+
 func TestParseCPUQuotaAndPeriod(t *testing.T) {
 	cases := []struct {
 		quota     string


### PR DESCRIPTION
## Summary
- honor OCI `LinuxResources.Memory.Swap` for cgroup v2 paths that were pre-created by the caller
- keep the existing pre-created-cgroup ownership behavior for other resource knobs, so runsc does not overwrite pod CPU or memory limits it does not own
- add a regression test that verifies `memory.swap.max` is updated while `memory.max` stays untouched

Fixes #13267

## Testing
- `git diff --check`
- `bazel test //runsc/cgroup:cgroup_test` (fails before running tests on this macOS host because `/usr/bin/x86_64-linux-gnu-gcc` is not installed for the `//vdso:vdso` genrule)
