### PR TITLE
runsc/cgroup: clarify systemd cgroupfs path errors

### DIFF
--- a/g3doc/user_guide/containerd/configuration.md
+++ b/g3doc/user_guide/containerd/configuration.md
@@ -50,6 +50,27 @@ When you are done, restart containerd to pick up the changes.
 sudo systemctl restart containerd
 ```
 
+### systemd cgroups
+
+If you set `systemd-cgroup = "true"` under `[runsc_config]`, containerd must
+pass cgroup paths in systemd `slice:prefix:name` form. Do not enable this flag
+when the OCI spec contains cgroupfs paths such as
+`/kubepods/burstable/pod<uid>/<container-id>`; in that case runsc should use
+the default cgroupfs driver so it joins the same cgroup hierarchy where kubelet
+applies resource limits.
+
+After creating a pod with CPU or memory limits, verify that the sandbox process
+is in the limited host cgroup:
+
+```shell
+PID=$(sudo crictl inspectp <sandbox-id> | jq -r .info.pid)
+CGROUP=/sys/fs/cgroup$(awk -F'::' '{print $2}' /proc/$PID/cgroup)
+cat "$CGROUP/cpu.max"
+```
+
+For a pod with a CPU limit, `cpu.max` should show a quota and period instead of
+`max 100000`.
+
 ## Debug
 
 When `shim_debug` is enabled in `/etc/containerd/config.toml`, containerd will

--- a/g3doc/user_guide/systemd.md
+++ b/g3doc/user_guide/systemd.md
@@ -18,6 +18,11 @@ runtime spec in the following way:
 1.  If `Linux.CgroupsPath` is set, it is expected to be in the form
     `[slice]:[prefix]:[name]`.
 
+    `--systemd-cgroup` does not accept cgroupfs paths such as
+    `/kubepods/burstable/pod<uid>/<container-id>`. If a container manager
+    provides cgroupfs paths, leave `--systemd-cgroup` disabled so runsc joins
+    the same cgroupfs tree where the manager applies pod limits.
+
     Here `slice` is a systemd slice under which the container is placed. If
     empty, it defaults to `system.slice`, except when cgroup v2 is used and
     rootless container is created, in which case it defaults to `user.slice`.
@@ -40,6 +45,20 @@ runtime spec in the following way:
 As described above, a unit will be created as a systemd scope. For a scope,
 runsc specifies its parent slice via a *Slice=* systemd property, and also sets
 *Delegate=true*.
+
+For Kubernetes through containerd, verify that kubelet and containerd pass
+systemd-style cgroup paths before enabling `--systemd-cgroup`. After creating a
+gVisor pod, inspect the sandbox process cgroup:
+
+```shell
+PID=$(sudo crictl inspectp <sandbox-id> | jq -r .info.pid)
+sudo cat /proc/$PID/cgroup
+```
+
+The cgroup path should be in the same subtree where kubelet writes resource
+limits. On cgroup v2 systems, compare that path with the host `cpu.max` file;
+it should contain the expected quota and period, not `max 100000`, when a CPU
+limit is configured.
 
 ### Resource limits
 

--- a/runsc/cgroup/cgroup.go
+++ b/runsc/cgroup/cgroup.go
@@ -377,6 +377,12 @@ func TransformSystemdPath(path, cid string, rootless bool) (string, error) {
 	}
 	parts := strings.SplitN(path, ":", 4)
 	if len(parts) != 3 {
+		if filepath.IsAbs(path) {
+			return "", fmt.Errorf("--systemd-cgroup requires cgroupsPath to use "+
+				"\"slice:prefix:name\" form, got cgroupfs path %q; leave "+
+				"--systemd-cgroup disabled when the container manager passes "+
+				"cgroupfs paths", path)
+		}
 		return "", fmt.Errorf("invalid systemd path: %q", path)
 	}
 	slice, prefix, name := parts[0], parts[1], parts[2]

--- a/runsc/cgroup/cgroup_test.go
+++ b/runsc/cgroup/cgroup_test.go
@@ -720,6 +720,22 @@ func TestPids(t *testing.T) {
 	}
 }
 
+func TestTransformSystemdPathRejectsCgroupfsPath(t *testing.T) {
+	_, err := TransformSystemdPath("/kubepods/burstable/pod123/container456", "container456", false)
+	if err == nil {
+		t.Fatalf("TransformSystemdPath succeeded for cgroupfs path")
+	}
+	for _, want := range []string{
+		"--systemd-cgroup requires cgroupsPath",
+		"slice:prefix:name",
+		"leave --systemd-cgroup disabled",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("TransformSystemdPath error %q does not contain %q", err, want)
+		}
+	}
+}
+
 func TestLoadPaths(t *testing.T) {
 	for _, tc := range []struct {
 		name      string


### PR DESCRIPTION
Updates #13258.

## Summary
- return a more specific error when --systemd-cgroup is used with a cgroupfs-style cgroupsPath
- document that containerd must pass systemd slice:prefix:name paths before enabling systemd-cgroup
- add a verification step for Kubernetes/containerd users to confirm the sandbox is in the limited cgroup

## Tests
- `git diff --check`
- `go test ./runsc/cgroup -run TestTransformSystemdPathRejectsCgroupfsPath` (fails locally before compiling tests: pkg/refs has both refs and refs_template packages under plain Go tooling)
- `bazel test //runsc/cgroup:cgroup_test --test_filter=TestTransformSystemdPathRejectsCgroupfsPath` (fails locally before running tests: /usr/bin/x86_64-linux-gnu-gcc is not present for //vdso:vdso on this macOS host)