### PR TITLE
shim: treat non-CRI init as sandbox

### DIFF
--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -688,7 +688,7 @@ func newInit(workDir, namespace string, platform stdio.Platform, r *proc.CreateC
 	p.WorkDir = workDir
 	p.IoUID = int(options.IoUID)
 	p.IoGID = int(options.IoGID)
-	p.Sandbox = specutils.SpecContainerType(spec) == specutils.ContainerTypeSandbox
+	p.Sandbox = specutils.IsRootContainer(spec)
 	p.UserLog = utils.UserLogPath(spec)
 	p.Monitor = reaper.Default
 	return p, nil

--- a/pkg/shim/v1/runsc/service_test.go
+++ b/pkg/shim/v1/runsc/service_test.go
@@ -16,11 +16,13 @@ package runsc
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 
 	task "github.com/containerd/containerd/api/runtime/task/v2"
 	"github.com/containerd/errdefs"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"gvisor.dev/gvisor/pkg/shim/v1/proc"
 	"gvisor.dev/gvisor/pkg/shim/v1/utils"
 )
 
@@ -126,6 +128,54 @@ func TestCgroupNoUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if updated := setPodCgroup(tc.spec); updated {
 				t.Errorf("setPodCgroup(%+v), got: %v, want: false", tc.spec.Linux, updated)
+			}
+		})
+	}
+}
+
+func TestNewInitSandboxDefault(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		annotations map[string]string
+		wantSandbox bool
+	}{
+		{
+			name:        "non-cri",
+			wantSandbox: true,
+		},
+		{
+			name: "cri-sandbox",
+			annotations: map[string]string{
+				utils.ContainerTypeAnnotation: "sandbox",
+			},
+			wantSandbox: true,
+		},
+		{
+			name: "cri-container",
+			annotations: map[string]string{
+				utils.ContainerTypeAnnotation: utils.ContainerTypeContainer,
+			},
+			wantSandbox: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := t.TempDir()
+			spec := specs.Spec{
+				Version:     specs.Version,
+				Annotations: tc.annotations,
+			}
+			if err := utils.WriteSpec(bundle, &spec); err != nil {
+				t.Fatalf("WriteSpec: %v", err)
+			}
+			p, err := newInit(filepath.Join(bundle, "work"), "default", nil, &proc.CreateConfig{
+				ID:     "test",
+				Bundle: bundle,
+			}, &Options{}, "")
+			if err != nil {
+				t.Fatalf("newInit: %v", err)
+			}
+			if got := p.Sandbox; got != tc.wantSandbox {
+				t.Fatalf("p.Sandbox: got %v, want %v", got, tc.wantSandbox)
 			}
 		})
 	}


### PR DESCRIPTION
Updates #12198.

## Summary
- treat containerd shim create requests without CRI container-type annotations as sandbox/root containers
- keep annotated CRI workload containers classified as non-sandbox containers
- add regression coverage for non-CRI, CRI sandbox, and CRI container specs

## Why
Direct containerd callers such as `ctr run` and BuildKit do not set `io.kubernetes.cri.container-type`. The shim already treats missing annotations as sandbox-like in other setup paths, but `newInit` only set `p.Sandbox` for an explicit CRI sandbox annotation. That caused non-CRI root containers to skip sandbox IO setup and contributed to non-TTY hangs/no output.

## Tests
- `git diff --check`
- `bazel test //pkg/shim/v1/runsc:runsc_test --test_filter=TestNewInitSandboxDefault` (fails locally before running tests: `/usr/bin/x86_64-linux-gnu-gcc` is not present for `//vdso:vdso` on this macOS host)
- `go test ./pkg/shim/v1/runsc -run TestNewInitSandboxDefault` (fails locally before compiling tests because this repo relies on Bazel-generated packages/build constraints under plain Go tooling)