### PR TITLE
feat: Add CRI-O compatibility for containerd-shim-runsc-v1

### DIFF
--- a/g3doc/user_guide/containerd/BUILD
+++ b/g3doc/user_guide/containerd/BUILD
@@ -16,6 +16,15 @@ doc(
 )
 
 doc(
+    name = "crio",
+    src = "crio.md",
+    category = "User Guide",
+    permalink = "/docs/user_guide/containerd/crio/",
+    subcategory = "Containerd",
+    weight = "20",
+)
+
+doc(
     name = "configuration",
     src = "configuration.md",
     category = "User Guide",

--- a/g3doc/user_guide/containerd/crio.md
+++ b/g3doc/user_guide/containerd/crio.md
@@ -1,0 +1,173 @@
+# CRI-O Quick Start
+
+This document describes how to use `containerd-shim-runsc-v1` with
+[CRI-O](https://cri-o.io/) as the container runtime interface.
+
+> **Note**: CRI-O is not officially supported and is not covered by gVisor's
+> integration tests. The configuration below is provided on a best-effort basis
+> and may break as either project evolves. For a fully supported setup, use
+> [containerd](/docs/user_guide/containerd/quick_start/).
+
+## Requirements
+
+-   **runsc** and **containerd-shim-runsc-v1**: See the
+    [installation guide](/docs/user_guide/install/).
+-   **CRI-O**: See the [CRI-O installation guide](https://github.com/cri-o/cri-o/blob/main/install.md).
+    **Minimal version supported: v1.37.**
+-   **CNI plugins**: Required for pod networking. Install via your distribution
+    package manager (e.g. `containernetworking-plugins` on Fedora,
+    `containernetworking-plugins` on Ubuntu/Debian).
+
+## Configure the shim
+
+Create `/etc/containerd/runsc.toml` with the following content:
+
+```toml
+binary_name = "/usr/local/bin/runsc"
+
+# grouping must be true so that sub-containers (app containers) attach to the
+# sandbox shim started for the pause container, rather than starting their own.
+grouping = true
+
+[runsc_config]
+  debug-log = "/var/log/runsc/%ID%.log"
+```
+
+-   `binary_name`: path to the `runsc` binary. This is distinct from the shim
+    binary path configured in CRI-O below.
+-   `grouping = true`: required for Kubernetes-style pod semantics. Without it,
+    each container launches an independent shim that cannot find the sandbox,
+    causing container start failures.
+-   `[runsc_config]`: additional `runsc` runtime flags. The defaults are
+    recommended for most environments; `debug-log` is optional and useful for
+    troubleshooting. To select a non-default platform (e.g. KVM), see
+    [Changing Platforms](/docs/user_guide/platforms/).
+
+## Configure CRI-O
+
+Create a drop-in configuration file `/etc/crio/crio.conf.d/99-gvisor.conf`:
+
+```toml
+[crio.runtime]
+selinux = false
+
+# runtime_type = "vm" instructs CRI-O to create a pause (infra) container for
+# the sandbox. gVisor requires this container to exist before app containers
+# are started. Without it, CRI-O skips sandbox creation and the pod fails.
+[crio.runtime.runtimes.runsc]
+runtime_path        = "/usr/local/bin/containerd-shim-runsc-v1"
+runtime_config_path = "/etc/containerd/runsc.toml"
+runtime_type        = "vm"
+runtime_root        = "/run/runsc"
+```
+
+-   `selinux = false`: required when running gVisor. gVisor manages its own
+    isolation and does not support SELinux labels on its containers; leaving
+    SELinux enabled causes container creation to fail.
+-   `runtime_type = "vm"`: the key setting. It tells CRI-O that this runtime
+    uses the VM shim model, which ensures the pause container (sandbox) is
+    created before any app containers are started.
+-   `runtime_path`: path to `containerd-shim-runsc-v1`, which must follow the
+    `containerd-shim-<name>-v1` naming convention.
+-   `runtime_config_path`: path to the shim configuration file created above.
+-   `runtime_root`: directory where runsc stores sandbox state.
+
+### CNI plugin path
+
+CRI-O's default CNI plugin search path may not match your distribution. If pods
+fail to start with a CNI error, configure the path explicitly:
+
+```toml
+# Fedora / RHEL (containernetworking-plugins installs to /usr/libexec/cni/)
+[crio.network]
+plugin_dirs = ["/usr/libexec/cni/", "/opt/cni/bin/"]
+```
+
+```toml
+# Ubuntu / Debian (plugins typically install to /opt/cni/bin/)
+[crio.network]
+plugin_dirs = ["/opt/cni/bin/"]
+```
+
+## Restart CRI-O
+
+```shell
+sudo systemctl restart crio
+```
+
+## Usage
+
+You can run gVisor sandboxes through CRI-O using [crictl].
+
+[crictl]: https://github.com/kubernetes-sigs/cri-tools/blob/master/docs/crictl.md
+
+### Configure crictl
+
+```shell
+cat <<EOF | sudo tee /etc/crictl.yaml
+runtime-endpoint: unix:///var/run/crio/crio.sock
+EOF
+```
+
+### Create a sandbox
+
+```shell
+cat <<EOF | tee sandbox.json
+{
+    "metadata": {
+        "name": "nginx-sandbox",
+        "namespace": "default",
+        "attempt": 1,
+        "uid": "hdishd83djaidwnduwk28bcsb"
+    },
+    "linux": {},
+    "log_directory": "/tmp"
+}
+EOF
+
+SANDBOX_ID=$(sudo crictl runp --runtime runsc sandbox.json)
+```
+
+### Run a container in the sandbox
+
+```shell
+cat <<EOF | tee container.json
+{
+  "metadata": { "name": "nginx" },
+  "image": { "image": "nginx" },
+  "log_path": "nginx.0.log",
+  "linux": {}
+}
+EOF
+
+CONTAINER_ID=$(sudo crictl create ${SANDBOX_ID} container.json sandbox.json)
+sudo crictl start ${CONTAINER_ID}
+```
+
+### Verify the runtime
+
+```shell
+sudo crictl exec ${CONTAINER_ID} dmesg | grep -i gvisor
+```
+
+### Set up the Kubernetes RuntimeClass
+
+```shell
+cat <<EOF | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: runsc
+EOF
+```
+
+## Debug
+
+See the [debugging guide](/docs/user_guide/debugging/) for general guidance.
+Shim logs are written to the path specified by `debug-log` in `runsc.toml`. CRI-O
+daemon logs are available via:
+
+```shell
+sudo journalctl -u crio
+```

--- a/pkg/shim/v1/BUILD
+++ b/pkg/shim/v1/BUILD
@@ -49,6 +49,7 @@ go_test(
     ],
     library = ":v1",
     deps = [
+        "//runsc/specutils",
         "@com_github_containerd_containerd_api//runtime/task/v2:go_default_library",
         "@com_github_containerd_containerd_v2//core/events:go_default_library",
         "@com_github_containerd_containerd_v2//pkg/shim:go_default_library",

--- a/pkg/shim/v1/manager.go
+++ b/pkg/shim/v1/manager.go
@@ -91,6 +91,21 @@ func (m manager) Name() string {
 	return m.name
 }
 
+// resolveGrouping determines the grouping key from the OCI spec annotations.
+// It checks the containerd annotation first, then falls back to the CRI-O
+// annotation. If neither is found, it returns the container ID unchanged.
+func resolveGrouping(id string, annotations map[string]string) string {
+	if groupID, ok := annotations[kubernetesGroupAnnotation]; ok {
+		log.L.Debugf("group label found %v: %v", kubernetesGroupAnnotation, groupID)
+		return groupID
+	}
+	if groupID, ok := annotations[specutils.CRIOSandboxIDAnnotation]; ok {
+		log.L.Debugf("group label found %v: %v", specutils.CRIOSandboxIDAnnotation, groupID)
+		return groupID
+	}
+	return id
+}
+
 // Start implements shim.Manager.Start.
 func (m *manager) Start(ctx context.Context, id string, opts shim.StartOpts) (shim.BootstrapParams, error) {
 	grouping := id
@@ -107,10 +122,7 @@ func (m *manager) Start(ctx context.Context, id string, opts shim.StartOpts) (sh
 			return shim.BootstrapParams{}, err
 		}
 		configFile.Close()
-		if groupID, ok := readSpec.Annotations[kubernetesGroupAnnotation]; ok {
-			log.L.Debugf("group label found %v: %v", kubernetesGroupAnnotation, groupID)
-			grouping = groupID
-		}
+		grouping = resolveGrouping(id, readSpec.Annotations)
 	}
 
 	cmd, err := newCommand(ctx, id, opts.Address, opts.Debug)

--- a/pkg/shim/v1/manager_test.go
+++ b/pkg/shim/v1/manager_test.go
@@ -17,12 +17,67 @@ package v1
 import (
 	"bytes"
 	"context"
+	"testing"
 
 	typeurl "github.com/containerd/typeurl/v2"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
 
-	"testing"
+	"gvisor.dev/gvisor/runsc/specutils"
 )
+
+// TestResolveGrouping verifies that resolveGrouping correctly extracts the
+// sandbox ID from both containerd and CRI-O annotations.
+func TestResolveGrouping(t *testing.T) {
+	const containerID = "test-container-id"
+	const sandboxID = "test-sandbox-id"
+
+	for _, tc := range []struct {
+		name        string
+		annotations map[string]string
+		want        string
+	}{
+		{
+			name:        "containerd annotation",
+			annotations: map[string]string{kubernetesGroupAnnotation: sandboxID},
+			want:        sandboxID,
+		},
+		{
+			name:        "crio annotation",
+			annotations: map[string]string{specutils.CRIOSandboxIDAnnotation: sandboxID},
+			want:        sandboxID,
+		},
+		{
+			name: "containerd takes precedence over crio",
+			annotations: map[string]string{
+				kubernetesGroupAnnotation:            "containerd-sandbox",
+				specutils.CRIOSandboxIDAnnotation:    "crio-sandbox",
+			},
+			want: "containerd-sandbox",
+		},
+		{
+			name:        "no annotation returns container ID",
+			annotations: map[string]string{},
+			want:        containerID,
+		},
+		{
+			name:        "nil annotations returns container ID",
+			annotations: nil,
+			want:        containerID,
+		},
+		{
+			name:        "unrelated annotations returns container ID",
+			annotations: map[string]string{"io.kubernetes.cri-o.ContainerType": "container"},
+			want:        containerID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveGrouping(containerID, tc.annotations)
+			if got != tc.want {
+				t.Errorf("resolveGrouping(%q, %v) = %q, want %q", containerID, tc.annotations, got, tc.want)
+			}
+		})
+	}
+}
 
 // TestManagerInfo verifies that the Info() call returns the expected information
 // about the runtime.

--- a/pkg/shim/v1/runsc/BUILD
+++ b/pkg/shim/v1/runsc/BUILD
@@ -76,6 +76,7 @@ go_test(
     deps = [
         "//pkg/shim/v1/utils",
         "@com_github_containerd_cgroups_v3//cgroup2:go_default_library",
+        "@com_github_containerd_containerd_api//events:go_default_library",
         "@com_github_containerd_containerd_api//runtime/task/v2:go_default_library",
         "@com_github_containerd_containerd_v2//core/events:go_default_library",
         "@com_github_containerd_containerd_v2//core/runtime:go_default_library",

--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -651,10 +651,20 @@ func (s *runscService) getContainerPids(ctx context.Context, c *Container) ([]ui
 }
 
 func (s *runscService) forward(ctx context.Context, publisher shim.Publisher) {
+	// An empty TTRPC_ADDRESS means no containerd event sink is configured, so
+	// the publisher can never connect and publish errors are expected and
+	// non-fatal. This is how CRI-O launches the shim, but the check is not
+	// CRI-O specific: any caller that omits TTRPC_ADDRESS gets the same lenient
+	// handling. When TTRPC_ADDRESS is set (e.g. under containerd) a publish
+	// failure is unexpected and remains fatal.
+	isEmptyTTRPCAddress := os.Getenv("TTRPC_ADDRESS") == ""
 	for e := range s.events {
-		err := publisher.Publish(ctx, getTopic(e), e)
-		if err != nil {
-			// Should not happen.
+		if err := publisher.Publish(ctx, getTopic(e), e); err != nil {
+			if isEmptyTTRPCAddress {
+				log.L.Warningf("Failed to post event (no containerd event sink): %v", err)
+				continue
+			}
+			// Should not happen when an event sink is configured.
 			panic(fmt.Errorf("post event: %w", err))
 		}
 	}

--- a/pkg/shim/v1/runsc/service_test.go
+++ b/pkg/shim/v1/runsc/service_test.go
@@ -15,14 +15,85 @@
 package runsc
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
+	apievents "github.com/containerd/containerd/api/events"
 	task "github.com/containerd/containerd/api/runtime/task/v2"
+	coreevents "github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/errdefs"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"gvisor.dev/gvisor/pkg/shim/v1/utils"
 )
+
+// errorPublisher is a publisher that always returns an error.
+type errorPublisher struct{}
+
+func (p *errorPublisher) Publish(_ context.Context, _ string, _ coreevents.Event) error {
+	return fmt.Errorf("dial unix: missing address")
+}
+
+func (p *errorPublisher) Close() error { return nil }
+
+// TestForwardDoesNotPanicOnPublishError verifies that the event forward
+// function logs errors instead of panicking when the publisher fails and no
+// event sink is configured (empty TTRPC_ADDRESS). This is how the shim runs
+// under CRI-O, where publish errors are expected and non-fatal.
+func TestForwardDoesNotPanicOnPublishError(t *testing.T) {
+	// Empty TTRPC_ADDRESS means no event sink is configured (as under CRI-O).
+	t.Setenv("TTRPC_ADDRESS", "")
+
+	s := &runscService{
+		events: make(chan any, 2),
+	}
+	s.events <- &apievents.TaskCreate{ContainerID: "test"}
+	s.events <- &apievents.TaskExit{ContainerID: "test"}
+	close(s.events)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.forward(context.Background(), &errorPublisher{})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("forward did not complete within timeout")
+	}
+}
+
+// TestForwardPanicsOnPublishErrorUnderContainerd verifies that, when a
+// containerd event sink is configured (TTRPC_ADDRESS set), a publish failure
+// remains fatal (panics) as it did before CRI-O support was added. This keeps
+// the non-fatal behavior scoped to the CRI-O case only.
+func TestForwardPanicsOnPublishErrorUnderContainerd(t *testing.T) {
+	t.Setenv("TTRPC_ADDRESS", "/run/containerd/containerd.sock.ttrpc")
+
+	s := &runscService{
+		events: make(chan any, 1),
+	}
+	s.events <- &apievents.TaskCreate{ContainerID: "test"}
+	close(s.events)
+
+	panicked := make(chan any, 1)
+	go func() {
+		defer func() { panicked <- recover() }()
+		s.forward(context.Background(), &errorPublisher{})
+	}()
+
+	select {
+	case r := <-panicked:
+		if r == nil {
+			t.Fatal("forward did not panic on publish error under containerd")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("forward did not complete within timeout")
+	}
+}
 
 func TestContainerUpdateNilResources(t *testing.T) {
 	c := &Container{}

--- a/website/BUILD
+++ b/website/BUILD
@@ -178,6 +178,7 @@ docs(
         "//g3doc/user_guide:tpu",
         "//g3doc/user_guide/containerd:configuration",
         "//g3doc/user_guide/containerd:containerd_11",
+        "//g3doc/user_guide/containerd:crio",
         "//g3doc/user_guide/containerd:quick_start",
         "//g3doc/user_guide/quick_start:docker",
         "//g3doc/user_guide/quick_start:kubernetes",


### PR DESCRIPTION
This update addresses two critical issues preventing containerd-shim-runsc-v1 from functioning with CRI-O when runtime_type=vm is configured. First, it resolves a shim grouping failure by adding support for CRI-O’s sandbox annotation (io.kubernetes.cri-o.SandboxID), ensuring sub-containers correctly identify their parent sandbox instead of spawning independent, non-functional shims. Second, it fixes a stability issue where the shim would panic due to missing containerd event addresses; these fatal panics have been replaced with non-fatal warning logs. Finally, to ensure successful deployment, a new quick-start guide has been added to g3doc/user_guide/containerd/ detailing the required configuration to complement the companion fix in https://github.com/cri-o/cri-o/pull/9974

Fixes: https://github.com/google/gvisor/issues/10313