### PR TITLE
netstack: factor ICMP echo reply helpers

### DIFF
--- a/pkg/tcpip/network/ipv4/icmp.go
+++ b/pkg/tcpip/network/ipv4/icmp.go
@@ -356,7 +356,6 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 		// DeliverTransportPacket so that is is only done when needed.
 		replyData := stack.PayloadSince(pkt.TransportHeader())
 		defer replyData.Release()
-		ipHdr := header.IPv4(pkt.NetworkHeader().Slice())
 		localAddressTemporary := pkt.NetworkPacketInfo.LocalAddressTemporary
 		localAddressBroadcast := pkt.NetworkPacketInfo.LocalAddressBroadcast
 
@@ -378,95 +377,7 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 			return
 		}
 
-		sent := e.stats.icmp.packetsSent
-		if !e.protocol.allowICMPReply(header.ICMPv4EchoReply, header.ICMPv4UnusedCode) {
-			sent.rateLimited.Increment()
-			return
-		}
-
-		// As per RFC 1122 section 3.2.1.3, when a host sends any datagram, the IP
-		// source address MUST be one of its own IP addresses (but not a broadcast
-		// or multicast address).
-		localAddr := ipHdr.DestinationAddress()
-		if localAddressBroadcast || header.IsV4MulticastAddress(localAddr) {
-			localAddr = tcpip.Address{}
-		}
-
-		r, err := e.protocol.stack.FindRoute(e.nic.ID(), localAddr, ipHdr.SourceAddress(), ProtocolNumber, false /* multicastLoop */)
-		if err != nil {
-			// If we cannot find a route to the destination, silently drop the packet.
-			return
-		}
-		defer r.Release()
-
-		outgoingEP, ok := e.protocol.getEndpointForNIC(r.NICID())
-		if !ok {
-			// The outgoing NIC went away.
-			sent.dropped.Increment()
-			return
-		}
-
-		// Because IP and ICMP are so closely intertwined, we need to handcraft our
-		// IP header to be able to follow RFC 792. The wording on page 13 is as
-		// follows:
-		//   IP Fields:
-		//   Addresses
-		//     The address of the source in an echo message will be the
-		//     destination of the echo reply message.  To form an echo reply
-		//     message, the source and destination addresses are simply reversed,
-		//     the type code changed to 0, and the checksum recomputed.
-		//
-		// This was interpreted by early implementors to mean that all options must
-		// be copied from the echo request IP header to the echo reply IP header
-		// and this behaviour is still relied upon by some applications.
-		//
-		// Create a copy of the IP header we received, options and all, and change
-		// The fields we need to alter.
-		//
-		// We need to produce the entire packet in the data segment in order to
-		// use WriteHeaderIncludedPacket(). WriteHeaderIncludedPacket sets the
-		// total length and the header checksum so we don't need to set those here.
-		//
-		// Take the base of the incoming request IP header but replace the options.
-		replyHeaderLength := uint8(header.IPv4MinimumSize + len(newOptions))
-		replyIPHdrView := buffer.NewView(int(replyHeaderLength))
-		replyIPHdrView.Write(iph[:header.IPv4MinimumSize])
-		replyIPHdrView.Write(newOptions)
-		replyIPHdr := header.IPv4(replyIPHdrView.AsSlice())
-		replyIPHdr.SetHeaderLength(replyHeaderLength)
-		replyIPHdr.SetSourceAddress(r.LocalAddress())
-		replyIPHdr.SetDestinationAddress(r.RemoteAddress())
-		replyIPHdr.SetTTL(r.DefaultTTL())
-		replyIPHdr.SetTotalLength(uint16(len(replyIPHdr) + len(replyData.AsSlice())))
-		replyIPHdr.SetChecksum(0)
-		replyIPHdr.SetChecksum(^replyIPHdr.CalculateChecksum())
-
-		replyICMPHdr := header.ICMPv4(replyData.AsSlice())
-		replyICMPHdr.SetType(header.ICMPv4EchoReply)
-		replyICMPHdr.SetChecksum(0)
-		replyICMPHdr.SetChecksum(^checksum.Checksum(replyData.AsSlice(), 0))
-
-		replyBuf := buffer.MakeWithView(replyIPHdrView)
-		replyBuf.Append(replyData.Clone())
-		replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
-			ReserveHeaderBytes: int(r.MaxHeaderLength()),
-			Payload:            replyBuf,
-		})
-		defer replyPkt.DecRef()
-		// Populate the network/transport headers in the packet buffer so the
-		// ICMP packet goes through IPTables.
-		if ok := parse.IPv4(replyPkt); !ok {
-			panic("expected to parse IPv4 header we just created")
-		}
-		if ok := parse.ICMPv4(replyPkt); !ok {
-			panic("expected to parse ICMPv4 header we just created")
-		}
-
-		if err := outgoingEP.writePacket(r, replyPkt); err != nil {
-			sent.dropped.Increment()
-			return
-		}
-		sent.echoReply.Increment()
+		e.sendICMPEchoReply(replyData, iph, newOptions, localAddressBroadcast)
 
 	case header.ICMPv4EchoReply:
 		received.echoReply.Increment()
@@ -537,6 +448,98 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 	default:
 		received.invalid.Increment()
 	}
+}
+
+func (e *endpoint) sendICMPEchoReply(replyData *buffer.View, ipHdr header.IPv4, newOptions header.IPv4Options, localAddressBroadcast bool) {
+	sent := e.stats.icmp.packetsSent
+	if !e.protocol.allowICMPReply(header.ICMPv4EchoReply, header.ICMPv4UnusedCode) {
+		sent.rateLimited.Increment()
+		return
+	}
+
+	// As per RFC 1122 section 3.2.1.3, when a host sends any datagram, the IP
+	// source address MUST be one of its own IP addresses (but not a broadcast
+	// or multicast address).
+	localAddr := ipHdr.DestinationAddress()
+	if localAddressBroadcast || header.IsV4MulticastAddress(localAddr) {
+		localAddr = tcpip.Address{}
+	}
+
+	r, err := e.protocol.stack.FindRoute(e.nic.ID(), localAddr, ipHdr.SourceAddress(), ProtocolNumber, false /* multicastLoop */)
+	if err != nil {
+		// If we cannot find a route to the destination, silently drop the packet.
+		return
+	}
+	defer r.Release()
+
+	outgoingEP, ok := e.protocol.getEndpointForNIC(r.NICID())
+	if !ok {
+		// The outgoing NIC went away.
+		sent.dropped.Increment()
+		return
+	}
+
+	// Because IP and ICMP are so closely intertwined, we need to handcraft our
+	// IP header to be able to follow RFC 792. The wording on page 13 is as
+	// follows:
+	//   IP Fields:
+	//   Addresses
+	//     The address of the source in an echo message will be the
+	//     destination of the echo reply message.  To form an echo reply
+	//     message, the source and destination addresses are simply reversed,
+	//     the type code changed to 0, and the checksum recomputed.
+	//
+	// This was interpreted by early implementors to mean that all options must
+	// be copied from the echo request IP header to the echo reply IP header
+	// and this behaviour is still relied upon by some applications.
+	//
+	// Create a copy of the IP header we received, options and all, and change
+	// The fields we need to alter.
+	//
+	// We need to produce the entire packet in the data segment in order to
+	// use WriteHeaderIncludedPacket(). WriteHeaderIncludedPacket sets the
+	// total length and the header checksum so we don't need to set those here.
+	//
+	// Take the base of the incoming request IP header but replace the options.
+	replyHeaderLength := uint8(header.IPv4MinimumSize + len(newOptions))
+	replyIPHdrView := buffer.NewView(int(replyHeaderLength))
+	replyIPHdrView.Write(ipHdr[:header.IPv4MinimumSize])
+	replyIPHdrView.Write(newOptions)
+	replyIPHdr := header.IPv4(replyIPHdrView.AsSlice())
+	replyIPHdr.SetHeaderLength(replyHeaderLength)
+	replyIPHdr.SetSourceAddress(r.LocalAddress())
+	replyIPHdr.SetDestinationAddress(r.RemoteAddress())
+	replyIPHdr.SetTTL(r.DefaultTTL())
+	replyIPHdr.SetTotalLength(uint16(len(replyIPHdr) + len(replyData.AsSlice())))
+	replyIPHdr.SetChecksum(0)
+	replyIPHdr.SetChecksum(^replyIPHdr.CalculateChecksum())
+
+	replyICMPHdr := header.ICMPv4(replyData.AsSlice())
+	replyICMPHdr.SetType(header.ICMPv4EchoReply)
+	replyICMPHdr.SetChecksum(0)
+	replyICMPHdr.SetChecksum(^checksum.Checksum(replyData.AsSlice(), 0))
+
+	replyBuf := buffer.MakeWithView(replyIPHdrView)
+	replyBuf.Append(replyData.Clone())
+	replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		ReserveHeaderBytes: int(r.MaxHeaderLength()),
+		Payload:            replyBuf,
+	})
+	defer replyPkt.DecRef()
+	// Populate the network/transport headers in the packet buffer so the
+	// ICMP packet goes through IPTables.
+	if ok := parse.IPv4(replyPkt); !ok {
+		panic("expected to parse IPv4 header we just created")
+	}
+	if ok := parse.ICMPv4(replyPkt); !ok {
+		panic("expected to parse ICMPv4 header we just created")
+	}
+
+	if err := outgoingEP.writePacket(r, replyPkt); err != nil {
+		sent.dropped.Increment()
+		return
+	}
+	sent.echoReply.Increment()
 }
 
 // ======= ICMP Error packet generation =========

--- a/pkg/tcpip/network/ipv6/icmp.go
+++ b/pkg/tcpip/network/ipv6/icmp.go
@@ -675,57 +675,7 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer, hasFragmentHeader bool, r
 			return
 		}
 
-		// As per RFC 4291 section 2.7, multicast addresses must not be used as
-		// source addresses in IPv6 packets.
-		localAddr := dstAddr
-		if header.IsV6MulticastAddress(dstAddr) {
-			localAddr = tcpip.Address{}
-		}
-
-		r, err := e.protocol.stack.FindRoute(e.nic.ID(), localAddr, srcAddr, ProtocolNumber, false /* multicastLoop */)
-		if err != nil {
-			// If we cannot find a route to the destination, silently drop the packet.
-			replyPayload.Release()
-			return
-		}
-		defer r.Release()
-
-		if !e.protocol.allowICMPReply(header.ICMPv6EchoReply) {
-			sent.rateLimited.Increment()
-			replyPayload.Release()
-			return
-		}
-
-		replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
-			ReserveHeaderBytes: int(r.MaxHeaderLength()) + header.ICMPv6EchoMinimumSize,
-			Payload:            replyPayload,
-		})
-		defer replyPkt.DecRef()
-		icmp := header.ICMPv6(replyPkt.TransportHeader().Push(header.ICMPv6EchoMinimumSize))
-		replyPkt.TransportProtocolNumber = header.ICMPv6ProtocolNumber
-		copy(icmp, replyHeader)
-		icmp.SetType(header.ICMPv6EchoReply)
-		replyData := replyPkt.Data()
-		icmp.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{
-			Header:      icmp,
-			Src:         r.LocalAddress(),
-			Dst:         r.RemoteAddress(),
-			PayloadCsum: replyData.Checksum(),
-			PayloadLen:  replyData.Size(),
-		}))
-		replyTClass, _ := iph.TOS()
-		if err := r.WritePacket(stack.NetworkHeaderParams{
-			Protocol: header.ICMPv6ProtocolNumber,
-			TTL:      r.DefaultTTL(),
-			// Even though RFC 4443 does not mention anything about it, Linux uses the
-			// TrafficClass of the received echo request when replying.
-			// https://github.com/torvalds/linux/blob/0280e3c58f9/net/ipv6/icmp.c#L797
-			TOS: replyTClass,
-		}, replyPkt); err != nil {
-			sent.dropped.Increment()
-			return
-		}
-		sent.echoReply.Increment()
+		e.sendICMPEchoReply(replyPayload, replyHeader, srcAddr, dstAddr, iph)
 
 	case header.ICMPv6EchoReply:
 		received.echoReply.Increment()
@@ -919,6 +869,62 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer, hasFragmentHeader bool, r
 	default:
 		received.unrecognized.Increment()
 	}
+}
+
+func (e *endpoint) sendICMPEchoReply(replyPayload buffer.Buffer, replyHeader []byte, srcAddr, dstAddr tcpip.Address, ipHdr header.IPv6) {
+	sent := e.stats.icmp.packetsSent
+
+	// As per RFC 4291 section 2.7, multicast addresses must not be used as
+	// source addresses in IPv6 packets.
+	localAddr := dstAddr
+	if header.IsV6MulticastAddress(dstAddr) {
+		localAddr = tcpip.Address{}
+	}
+
+	r, err := e.protocol.stack.FindRoute(e.nic.ID(), localAddr, srcAddr, ProtocolNumber, false /* multicastLoop */)
+	if err != nil {
+		// If we cannot find a route to the destination, silently drop the packet.
+		replyPayload.Release()
+		return
+	}
+	defer r.Release()
+
+	if !e.protocol.allowICMPReply(header.ICMPv6EchoReply) {
+		sent.rateLimited.Increment()
+		replyPayload.Release()
+		return
+	}
+
+	replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		ReserveHeaderBytes: int(r.MaxHeaderLength()) + header.ICMPv6EchoMinimumSize,
+		Payload:            replyPayload,
+	})
+	defer replyPkt.DecRef()
+	icmp := header.ICMPv6(replyPkt.TransportHeader().Push(header.ICMPv6EchoMinimumSize))
+	replyPkt.TransportProtocolNumber = header.ICMPv6ProtocolNumber
+	copy(icmp, replyHeader)
+	icmp.SetType(header.ICMPv6EchoReply)
+	replyData := replyPkt.Data()
+	icmp.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{
+		Header:      icmp,
+		Src:         r.LocalAddress(),
+		Dst:         r.RemoteAddress(),
+		PayloadCsum: replyData.Checksum(),
+		PayloadLen:  replyData.Size(),
+	}))
+	replyTClass, _ := ipHdr.TOS()
+	if err := r.WritePacket(stack.NetworkHeaderParams{
+		Protocol: header.ICMPv6ProtocolNumber,
+		TTL:      r.DefaultTTL(),
+		// Even though RFC 4443 does not mention anything about it, Linux uses the
+		// TrafficClass of the received echo request when replying.
+		// https://github.com/torvalds/linux/blob/0280e3c58f9/net/ipv6/icmp.c#L797
+		TOS: replyTClass,
+	}, replyPkt); err != nil {
+		sent.dropped.Increment()
+		return
+	}
+	sent.echoReply.Increment()
 }
 
 // LinkAddressProtocol implements stack.LinkAddressResolver.


### PR DESCRIPTION
## Overview

This is a mechanical follow-up to the previous ICMP Echo handler PR, #13189.[^pr1]

It factors the built-in IPv4 and IPv6 ICMP Echo Reply construction paths into private endpoint helpers, without changing the Echo Request handling semantics.

The immediate goal is to make the existing built-in reply path reusable by a follow-up ICMP handler API, while keeping this PR limited to a behavior-preserving refactor.

No public API is added in this change, and `LocalAddressTemporary` behavior is unchanged.

## Behavior

This PR should preserve the current behavior matrix:

```text
no ICMP default handler        -> built-in Echo Reply is preserved
default handler returns false  -> built-in Echo Reply is preserved
default handler returns true   -> no built-in Echo Reply
registered ICMP endpoint       -> default handler is not called; built-in Echo Reply is preserved
IPv4 LocalAddressTemporary     -> built-in Echo Reply is still suppressed
```

The only code movement is the built-in reply construction itself:

* IPv4 Echo Reply construction moves to a private IPv4 endpoint helper.
* IPv6 Echo Reply construction moves to a private IPv6 endpoint helper.

The call sites still make the same decisions before invoking those helpers.

## Why and Follow-up Direction

For the next PR, I would like to continue with the same handler action direction.

The follow-up API should preserve the distinction between explicit handler actions and the no-explicit-action path:

```text
explicitly suppress the built-in Echo Reply
explicitly send/delegate to the built-in Echo Reply path
take no explicit action and preserve the current behavior matrix
```

That should address the large-address-space embedder case raised in the previous discussion[^pr1] without requiring downstreams to reimplement ICMP Echo Reply construction, while still preserving explicit ownership for tunnel/proxy handlers that intentionally consume Echo Requests.

This refactor is the small mechanical step needed before that API. The built-in reply path should stay in the network endpoint layer because it depends on protocol-specific details such as route lookup, source address selection, rate limiting, stats, checksums, IPv4 options, IPv6 traffic class, and output hooks. The follow-up API should delegate to this path rather than copying those details into `transport/icmp`.

One possible API shape could be along these lines:

```go
f := icmp.NewForwarder(s, func(r *icmp.ForwarderRequest) icmp.ForwarderAction {
    if shouldHandleByTunnel(r) {
        return icmp.ForwarderActionSuppress
    }
    return r.Reply()
})

s.SetTransportProtocolHandler(icmp.ProtocolNumber4, f.HandlePacket)
s.SetTransportProtocolHandler(icmp.ProtocolNumber6, f.HandlePacket)
```

or an equivalent API where the handler can explicitly request the built-in reply path.

The important part is that explicit suppress/reply decisions remain distinguishable from the no-explicit-action path, and that `Reply()` / `SendReply` delegates to the existing network-layer helper rather than duplicating that protocol-specific reply logic in `transport/icmp`.

The follow-up should align the ICMPv4 and ICMPv6 handler action surface while preserving the current default behavior matrix.

Does that action-style direction still look right for the follow-up?

## Tests

```shell
make test TARGETS=//pkg/tcpip/network/ipv4:ipv4_test OPTIONS=--test_filter=TestICMPEcho
make test TARGETS=//pkg/tcpip/network/ipv6:ipv6_test OPTIONS=--test_filter=TestICMPEcho
make test TARGETS=//pkg/tcpip/network/ipv4:ipv4_test OPTIONS=--test_filter=TestIcmpRateLimit
make test TARGETS=//pkg/tcpip/network/ipv6:ipv6_test OPTIONS=--test_filter=TestNeighborSolicitationResponse
make test TARGETS="//pkg/tcpip/network/ipv4:ipv4_test //pkg/tcpip/network/ipv6:ipv6_test"
make test TARGETS=//pkg/tcpip/stack:stack_test
```

[^pr1]: #13189