### PR TITLE
fsimpl/overlay: strip security.capability on copy-up

### DIFF
--- a/pkg/sentry/fsimpl/overlay/copy_up.go
+++ b/pkg/sentry/fsimpl/overlay/copy_up.go
@@ -407,8 +407,12 @@ func (d *dentry) copyXattrsLocked(ctx context.Context) error {
 	// A lower-layer file may carry file capabilities (e.g. cap_net_raw on
 	// /usr/bin/ping); retaining them on the upper layer allows an
 	// unprivileged in-container process to gain those capabilities via exec
-	// after triggering copy-up. This mirrors Linux's ovl_copy_up_data()
-	// calling security_inode_killpriv().
+	// after triggering copy-up. Linux handles this via write ordering:
+	// copy_up.c copies data after xattrs so that the subsequent VFS-level
+	// write triggers cap_inode_killpriv automatically (copy_up.c ~L1029).
+	// gVisor does not have that implicit hook on SetXattrAt, so we strip
+	// security.capability explicitly here. See also PR #13072 which closes
+	// the analogous gap on the SetStat path in tmpfs.
 	if err := vfsObj.RemoveXattrAt(ctx, d.fs.creds, upperPop, linux.XATTR_SECURITY_CAPABILITY); err != nil {
 		if !linuxerr.Equals(linuxerr.ENODATA, err) && !linuxerr.Equals(linuxerr.EOPNOTSUPP, err) {
 			ctx.Infof("failed to remove security.capability on copy-up: %v", err)

--- a/pkg/sentry/fsimpl/overlay/copy_up.go
+++ b/pkg/sentry/fsimpl/overlay/copy_up.go
@@ -403,6 +403,18 @@ func (d *dentry) copyXattrsLocked(ctx context.Context) error {
 			return err
 		}
 	}
+	// Strip security.capability from the upper layer after copy-up.
+	// A lower-layer file may carry file capabilities (e.g. cap_net_raw on
+	// /usr/bin/ping); retaining them on the upper layer allows an
+	// unprivileged in-container process to gain those capabilities via exec
+	// after triggering copy-up. This mirrors Linux's ovl_copy_up_data()
+	// calling security_inode_killpriv().
+	if err := vfsObj.RemoveXattrAt(ctx, d.fs.creds, upperPop, linux.XATTR_SECURITY_CAPABILITY); err != nil {
+		if !linuxerr.Equals(linuxerr.ENODATA, err) && !linuxerr.Equals(linuxerr.EOPNOTSUPP, err) {
+			ctx.Infof("failed to remove security.capability on copy-up: %v", err)
+			return err
+		}
+	}
 	return nil
 }
 

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -2590,6 +2590,100 @@ TEST(MountTest, OverlayfsSgidBitIsCopiedUp) {
   }
 }
 
+// security.capability must be stripped from the upper layer after copy-up so
+// that an unprivileged container process cannot gain file capabilities by
+// exec-ing a copied-up binary (e.g. /usr/bin/ping carrying cap_net_raw).
+//
+// Copy-up is triggered via utimensat (a metadata-only operation) so that the
+// write path's incidental KillPriv does not mask a missing explicit strip in
+// copyXattrsLocked. Native Linux 6.x does not strip security.capability on
+// utimensat copy-up (only on write), so this test is gVisor-only: gVisor is
+// intentionally stricter to provide a stronger container isolation guarantee.
+TEST(MountTest, OverlayfsSecurityCapabilityStrippedOnCopyUp) {
+  SKIP_IF(!IsRunningOnGvisor());
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETFCAP)));
+
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  // Overlayfs cannot be used as the upper layer for another overlayfs mount.
+  // If the test is already running inside overlayfs, mount a tmpfs base first.
+  bool in_overlayfs = ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(base_dir.path()));
+  if (in_overlayfs) {
+    ASSERT_THAT(
+        mount("tmpfs", base_dir.path().c_str(), "tmpfs", 0, "mode=1777"),
+        SyscallSucceeds());
+  }
+  auto tmpfs_cleanup = Cleanup([&base_dir, &in_overlayfs] {
+    if (in_overlayfs) {
+      ASSERT_THAT(umount2(base_dir.path().c_str(), MNT_DETACH),
+                  SyscallSucceeds());
+    }
+  });
+
+  // Create a regular file in the lower layer and attach a VFS2 file-capability
+  // record (cap_net_raw, as carried by /usr/bin/ping in container images).
+  auto lower =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  std::string lower_file = lower.path() + "/testbin";
+  ASSERT_NO_ERRNO(CreateWithContents(lower_file, "data", 0755));
+
+  struct {
+    uint32_t magic_etc;
+    uint32_t permitted_lo;
+    uint32_t inheritable_lo;
+    uint32_t permitted_hi;
+    uint32_t inheritable_hi;
+  } cap_data = {};
+  cap_data.magic_etc = VFS_CAP_REVISION_2 | VFS_CAP_FLAGS_EFFECTIVE;
+  cap_data.permitted_lo = (1u << CAP_NET_RAW);
+  ASSERT_THAT(
+      setxattr(lower_file.c_str(), "security.capability", &cap_data,
+               sizeof(cap_data), 0),
+      SyscallSucceeds());
+
+  // Mount the overlay.
+  auto upper =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto work = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  auto merged =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDirIn(base_dir.path()));
+  std::string opts = "lowerdir=" + lower.path() + ",upperdir=" + upper.path() +
+                     ",workdir=" + work.path();
+  ASSERT_THAT(
+      mount("overlay", merged.path().c_str(), "overlay", 0, opts.c_str()),
+      SyscallSucceeds());
+  auto overlayfs_cleanup =
+      Cleanup([&merged] { umount2(merged.path().c_str(), MNT_DETACH); });
+
+  std::string merged_file = merged.path() + "/testbin";
+  std::string upper_file = upper.path() + "/testbin";
+  char buf[sizeof(cap_data)] = {};
+
+  // Before copy-up the capability is visible through the overlay.
+  ASSERT_THAT(
+      getxattr(merged_file.c_str(), "security.capability", buf, sizeof(buf)),
+      SyscallSucceedsWithValue(sizeof(cap_data)));
+
+  // Trigger copy-up via utimensat (metadata-only; does not go through the
+  // write path, so KillPriv from the write path is not involved).
+  ASSERT_THAT(utimensat(AT_FDCWD, merged_file.c_str(), nullptr, 0),
+              SyscallSucceeds());
+
+  // Confirm the file was actually copied up to the upper layer.
+  struct stat st;
+  ASSERT_THAT(stat(upper_file.c_str(), &st), SyscallSucceeds());
+
+  // security.capability must be absent from the upper layer after copy-up.
+  EXPECT_THAT(
+      getxattr(upper_file.c_str(), "security.capability", buf, sizeof(buf)),
+      SyscallFailsWithErrno(ENODATA));
+
+  // And must also be absent through the merged (overlay) view.
+  EXPECT_THAT(
+      getxattr(merged_file.c_str(), "security.capability", buf, sizeof(buf)),
+      SyscallFailsWithErrno(ENODATA));
+}
+
 // Renaming a directory on an overlay inside a user namespace requires
 // user.overlay.* xattrs to mark the directory opaque.
 TEST(MountTest, OverlayfsDirectoryRenameInUserNamespace) {


### PR DESCRIPTION
## Problem

A file on a lower overlay layer may carry file capabilities in the`security.capability` xattr (e.g. `cap_net_raw` on `/usr/bin/ping` in standard container images such as `debian:bookworm` and `ubuntu:22.04`). When a write operation triggers copy-up, `copyXattrsLocked()` copies all non-overlay xattrs to the upper layer, including `security.capability`.

A process inside the container can then exec the copied-up file and acquire those capabilities, bypassing the container's intended privilege boundary. A typical pattern: a uid=0 init container or sidecar triggers copy-up of a distro binary (e.g. `touch /usr/bin/ping`); the application workload running as an unprivileged uid then execs that binary and gains the file capability (e.g. `CAP_NET_RAW`) via the preserved `security.capability` xattr on the upper layer.

The overlay filesystem is the default rootfs for gVisor runsc (`defaultOverlay2` has `rootMount: true` in `runsc/config/config.go`), so all default container workloads are affected.

## Fix

Call `RemoveXattrAt("security.capability")` on the upper layer immediately after the xattr copy loop in `copyXattrsLocked()`,
tolerating `ENODATA` (xattr was never present) and `EOPNOTSUPP` (upper fs does not support xattrs).

Linux handles this through write ordering: `copy_up.c` intentionally copies data **after** xattrs so that the subsequent VFS-level write triggers `cap_inode_killpriv` automatically (see `copy_up.c` ~L1029:
*"Copy up data first and then xattrs. Writing data after xattrs will remove security.capability xattr automatically."*). gVisor's
`copyXattrsLocked()` calls `SetXattrAt` directly on the upper layer without a subsequent data write through the same path, so that automatic stripping does not apply here — explicit removal is therefore required.

## Why other paths are safe

- **`setXattrLocked`** (write path): requires `CAP_SETFCAP` to set `security.capability`, enforced by `FixupVfsCapDataOnSet` in the capability layer. Unprivileged container processes cannot re-add it.
- **`LinkAt` / `RenameAt`**: both call `copyUpLocked()` before the operation, so the strip already happened.

## Reference

- Linux ordering mechanism: `copy_up.c` ~L1029 (data after xattrs → automatic `cap_inode_killpriv`)
- CVE-2021-3493: Ubuntu overlayfs privilege escalation (same root cause)
- PR #13072 closes the `SetStat` path in tmpfs (`tmpfs.go:878`, `regular_file.go:596`). This patch closes the distinct copy-up gap in the overlay package, which goes through `SetXattrAt` and is not reached by #13072's `KillPriv` call.