### PR TITLE
Handle permission denied errors when reading mmap_min_addr

### DIFF
--- a/pkg/sentry/platform/mmap_min_addr.go
+++ b/pkg/sentry/platform/mmap_min_addr.go
@@ -15,6 +15,7 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -25,6 +26,10 @@ import (
 
 // systemMMapMinAddrSource is the source file.
 const systemMMapMinAddrSource = "/proc/sys/vm/mmap_min_addr"
+
+// defaultMMapMinAddr is used when the system file cannot be read.
+// 65536 (64KB) is the most common default on modern Linux systems.
+const defaultMMapMinAddr = 65536
 
 // systemMMapMinAddr is the system's minimum map address.
 var systemMMapMinAddr uint64
@@ -49,6 +54,12 @@ func init() {
 	// Open the source file.
 	b, err := os.ReadFile(systemMMapMinAddrSource)
 	if err != nil {
+		// If the file is inaccessible (e.g., permission denied in restricted
+		// environments like Termux/Android), use a sensible default.
+		if errors.Is(err, os.ErrPermission) || errors.Is(err, os.ErrNotExist) {
+			systemMMapMinAddr = defaultMMapMinAddr
+			return
+		}
 		panic(fmt.Sprintf("couldn't open %s: %v", systemMMapMinAddrSource, err))
 	}
 


### PR DESCRIPTION
The platform initialization code in `pkg/sentry/platform/mmap_min_addr.go` unconditionally panicked when unable to read `/proc/sys/vm/mmap_min_addr`, which occurs in restricted environments like Termux on Android where the file exists but is not readable by unprivileged processes.

The fix handles permission denied and file-not-found errors gracefully by falling back to a default value of 65536 (64KB), which is the standard default on most modern Linux systems. Other unexpected errors still panic as before to maintain robustness on properly configured systems.

This change allows runsc to run in restricted environments without compromising behavior on standard Linux systems where the file is readable.

resolves https://github.com/google/gvisor/issues/12544

Fixes #12544