### PR TITLE
Add minimal plumbing to serialize sysfs information for ib_write_bw

### DIFF
--- a/pkg/sentry/fsimpl/sys/BUILD
+++ b/pkg/sentry/fsimpl/sys/BUILD
@@ -22,6 +22,7 @@ go_library(
         "dir_refs.go",
         "kcov.go",
         "pci.go",
+        "rdma.go",
         "save_restore.go",
         "sys.go",
     ],

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -1,0 +1,423 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// RDMAGIDEntry contains a single GID table entry and its RoCE type.
+type RDMAGIDEntry struct {
+	Index  string `json:"index"`
+	GID    string `json:"gid"`
+	Type   string `json:"type"`
+	NetDev string `json:"net_dev,omitempty"`
+}
+
+// RDMAPortData contains sysfs attributes for one port.
+type RDMAPortData struct {
+	Number    string         `json:"number"`
+	State     string         `json:"state"`
+	PhysState string         `json:"phys_state"`
+	LinkLayer string         `json:"link_layer"`
+	Rate      string         `json:"rate"`
+	LID       string         `json:"lid"`
+	SMLID     string         `json:"sm_lid"`
+	SMSL      string         `json:"sm_sl"`
+	CapMask   string         `json:"cap_mask"`
+	GIDs      []RDMAGIDEntry `json:"gids,omitempty"`
+}
+
+// RDMADeviceData contains sysfs data for a single RDMA uverbs device.
+type RDMADeviceData struct {
+	Name       string         `json:"name"`
+	IBDev      string         `json:"ibdev"`
+	ABIVersion string         `json:"abi_version"`
+	Dev        string         `json:"dev"`
+	NodeType   string         `json:"node_type"`
+	NodeGUID   string         `json:"node_guid"`
+	SysImgGUID string         `json:"sys_image_guid"`
+	FWVer      string         `json:"fw_ver"`
+	Modalias   string         `json:"modalias"`
+	Ports      []RDMAPortData `json:"ports"`
+
+	// PCI device attributes from /sys/class/infiniband/<ibdev>/device/.
+	// libibverbs reads modalias for driver matching; NCCL reads
+	// PCI_SLOT_NAME from uevent to match NICs against GPU topology.
+	PCISlotName     string `json:"pci_slot_name,omitempty"`
+	PCIDriver       string `json:"pci_driver,omitempty"`
+	PCIClass        string `json:"pci_class,omitempty"`
+	PCIVendor       string `json:"pci_vendor,omitempty"`
+	PCIDevice       string `json:"pci_device,omitempty"`
+	PCISubsysVendor string `json:"pci_subsys_vendor,omitempty"`
+	PCISubsysDevice string `json:"pci_subsys_device,omitempty"`
+	NUMANode        string `json:"numa_node,omitempty"`
+	LocalCPUList    string `json:"local_cpulist,omitempty"`
+
+	// DynMajor is the sentry-assigned dynamic major for this device.
+	// Set at runtime during device registration, not serialized.
+	DynMajor uint32 `json:"-"`
+}
+
+// RDMAData holds all collected RDMA sysfs data.
+type RDMAData struct {
+	VerbsABIVersion string           `json:"verbs_abi_version"`
+	Devices         []RDMADeviceData `json:"devices"`
+}
+
+// CollectRDMADeviceData reads the specific sysfs files that libibverbs
+// needs for device discovery. Only well-known paths are read — no
+// recursive traversal, no symlink following into PCI device trees.
+func CollectRDMADeviceData() *RDMAData {
+	verbsPath := "/sys/class/infiniband_verbs"
+	dents, err := os.ReadDir(verbsPath)
+	if err != nil {
+		log.Infof("rdma collect: %s not accessible: %v", verbsPath, err)
+		return nil
+	}
+	data := &RDMAData{
+		VerbsABIVersion: readSysfsFile(path.Join(verbsPath, "abi_version")),
+	}
+
+	log.Infof("rdma collect: scanning %s (%d entries), verbs_abi=%q",
+		verbsPath, len(dents), data.VerbsABIVersion)
+	for _, dent := range dents {
+		if !strings.HasPrefix(dent.Name(), "uverbs") {
+			continue
+		}
+		devDir := path.Join(verbsPath, dent.Name())
+		ibdev := readSysfsFile(path.Join(devDir, "ibdev"))
+		if ibdev == "" {
+			log.Warningf("rdma collect: %s has no ibdev, skipping", dent.Name())
+			continue
+		}
+		ibDir := path.Join("/sys/class/infiniband", ibdev)
+		deviceDir := path.Join(ibDir, "device")
+		dev := RDMADeviceData{
+			Name:            dent.Name(),
+			IBDev:           ibdev,
+			ABIVersion:      readSysfsFile(path.Join(devDir, "abi_version")),
+			Dev:             readSysfsFile(path.Join(devDir, "dev")),
+			NodeType:        readSysfsFile(path.Join(ibDir, "node_type")),
+			NodeGUID:        readSysfsFile(path.Join(ibDir, "node_guid")),
+			SysImgGUID:      readSysfsFile(path.Join(ibDir, "sys_image_guid")),
+			FWVer:           readSysfsFile(path.Join(ibDir, "fw_ver")),
+			Modalias:        readSysfsFile(path.Join(deviceDir, "modalias")),
+			PCISlotName:     parseUeventValue(path.Join(deviceDir, "uevent"), "PCI_SLOT_NAME"),
+			PCIDriver:       parseUeventValue(path.Join(deviceDir, "uevent"), "DRIVER"),
+			PCIClass:        readSysfsFile(path.Join(deviceDir, "class")),
+			PCIVendor:       readSysfsFile(path.Join(deviceDir, "vendor")),
+			PCIDevice:       readSysfsFile(path.Join(deviceDir, "device")),
+			PCISubsysVendor: readSysfsFile(path.Join(deviceDir, "subsystem_vendor")),
+			PCISubsysDevice: readSysfsFile(path.Join(deviceDir, "subsystem_device")),
+			NUMANode:        readSysfsFile(path.Join(deviceDir, "numa_node")),
+			LocalCPUList:    readSysfsFile(path.Join(deviceDir, "local_cpulist")),
+		}
+		log.Infof("rdma collect: %s → ibdev=%s dev=%s node_type=%q fw_ver=%q pci=%s numa=%s",
+			dent.Name(), ibdev, dev.Dev, dev.NodeType, dev.FWVer, dev.PCISlotName, dev.NUMANode)
+		portsPath := path.Join(ibDir, "ports")
+		portDents, err := os.ReadDir(portsPath)
+		if err == nil {
+			for _, portDent := range portDents {
+				portDir := path.Join(portsPath, portDent.Name())
+				pd := RDMAPortData{
+					Number:    portDent.Name(),
+					State:     readSysfsFile(path.Join(portDir, "state")),
+					PhysState: readSysfsFile(path.Join(portDir, "phys_state")),
+					LinkLayer: readSysfsFile(path.Join(portDir, "link_layer")),
+					Rate:      readSysfsFile(path.Join(portDir, "rate")),
+					LID:       readSysfsFile(path.Join(portDir, "lid")),
+					SMLID:     readSysfsFile(path.Join(portDir, "sm_lid")),
+					SMSL:      readSysfsFile(path.Join(portDir, "sm_sl")),
+					CapMask:   readSysfsFile(path.Join(portDir, "cap_mask")),
+				}
+				gidsPath := path.Join(portDir, "gids")
+				typesPath := path.Join(portDir, "gid_attrs", "types")
+				ndevsPath := path.Join(portDir, "gid_attrs", "ndevs")
+				gidDents, gerr := os.ReadDir(gidsPath)
+				if gerr == nil {
+					for _, gidDent := range gidDents {
+						gidVal := readSysfsFile(path.Join(gidsPath, gidDent.Name()))
+						typeVal := readSysfsFile(path.Join(typesPath, gidDent.Name()))
+						ndevVal := readSysfsFile(path.Join(ndevsPath, gidDent.Name()))
+						if gidVal == "" {
+							continue
+						}
+						if typeVal == "" && pd.LinkLayer == "Ethernet" {
+							typeVal = inferRoCEType(gidDent.Name())
+						}
+						pd.GIDs = append(pd.GIDs, RDMAGIDEntry{
+							Index:  gidDent.Name(),
+							GID:    gidVal,
+							Type:   typeVal,
+							NetDev: ndevVal,
+						})
+					}
+				}
+				log.Infof("rdma collect:   port %s: state=%q link_layer=%q rate=%q gids=%d",
+					pd.Number, pd.State, pd.LinkLayer, pd.Rate, len(pd.GIDs))
+				dev.Ports = append(dev.Ports, pd)
+			}
+		}
+		data.Devices = append(data.Devices, dev)
+	}
+	log.Infof("rdma collect: collected %d device(s)", len(data.Devices))
+	return data
+}
+
+// RDMADataPath is the path within the chroot where serialized RDMA data
+// is stored between boot stages.
+const RDMADataPath = "/var/lib/gvisor/rdma_data.json"
+
+// SerializeRDMAData writes the collected data as JSON to the given path.
+func SerializeRDMAData(data *RDMAData, filePath string) error {
+	if data == nil {
+		return nil
+	}
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, b, 0644)
+}
+
+// DeserializeRDMAData reads serialized RDMA data from the given path.
+func DeserializeRDMAData(filePath string) *RDMAData {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Infof("rdma deserialize: %s: %v", filePath, err)
+		return nil
+	}
+	var data RDMAData
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Warningf("rdma deserialize: unmarshal %s: %v", filePath, err)
+		return nil
+	}
+	log.Infof("rdma deserialize: loaded %d device(s) from %s (verbs_abi=%q)",
+		len(data.Devices), filePath, data.VerbsABIVersion)
+	for _, d := range data.Devices {
+		log.Infof("rdma deserialize:   %s ibdev=%s dev=%s ports=%d",
+			d.Name, d.IBDev, d.Dev, len(d.Ports))
+		for _, p := range d.Ports {
+			typesWithValues := 0
+			for _, g := range p.GIDs {
+				if g.Type != "" {
+					typesWithValues++
+				}
+			}
+			log.Infof("rdma deserialize:   %s port %s: %d gids, %d with types",
+				d.IBDev, p.Number, len(p.GIDs), typesWithValues)
+		}
+	}
+	return &data
+}
+
+// extractMinor returns the minor portion from a "major:minor" dev string.
+func extractMinor(dev string) string {
+	if idx := strings.IndexByte(dev, ':'); idx >= 0 {
+		return dev[idx+1:]
+	}
+	return "0"
+}
+
+// ExtractMinorUint32 parses the minor portion from a sysfs "major:minor" dev
+// string (e.g. "231:192") and returns it as a uint32. Returns (0, false) if
+// the string is malformed.
+func ExtractMinorUint32(dev string) (uint32, bool) {
+	idx := strings.IndexByte(dev, ':')
+	if idx < 0 {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(dev[idx+1:], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(v), true
+}
+
+// inferRoCEType returns the RoCE GID type based on GID table index.
+// The sandbox's restricted sysfs mount masks gid_attrs/types/ content,
+// so we infer from the well-known mlx5 kernel assignment:
+//   - index 0: RoCE v1 (link-local MAC-derived)
+//   - index 1+: RoCE v2
+//
+// NCCL reads types from sysfs but gets actual GID addresses via ioctl.
+func inferRoCEType(gidIndex string) string {
+	if gidIndex == "0" {
+		return "IB/RoCE v1"
+	}
+	return "RoCE v2"
+}
+
+// parseUeventValue reads a uevent file and extracts the value for the given
+// KEY (matched as "KEY="). Returns empty string if the file doesn't exist or
+// has no matching line.
+func parseUeventValue(ueventPath, key string) string {
+	data, err := os.ReadFile(ueventPath)
+	if err != nil {
+		return ""
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
+}
+
+func readSysfsFile(filePath string) string {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// newRDMASysfsEntries creates /sys/class/infiniband_verbs/ and
+// /sys/class/infiniband/ directories from pre-collected device data.
+func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData) (ibVerbsDir, ibDir map[string]kernfs.Inode) {
+	if data == nil || len(data.Devices) == 0 {
+		log.Infof("rdma sysfs: no RDMA data, skipping sysfs construction")
+		return nil, nil
+	}
+	log.Infof("rdma sysfs: building virtual sysfs for %d device(s), verbs_abi=%q",
+		len(data.Devices), data.VerbsABIVersion)
+	ibVerbsDir = map[string]kernfs.Inode{}
+	ibDir = map[string]kernfs.Inode{}
+	addFile := func(m map[string]kernfs.Inode, name, val string) {
+		if val != "" {
+			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
+		}
+	}
+	addFile(ibVerbsDir, "abi_version", data.VerbsABIVersion)
+
+	for _, dev := range data.Devices {
+		verbsEntries := map[string]kernfs.Inode{}
+		addFile(verbsEntries, "ibdev", dev.IBDev)
+		addFile(verbsEntries, "abi_version", dev.ABIVersion)
+		devVal := dev.Dev
+		if dev.DynMajor != 0 {
+			minor := extractMinor(dev.Dev)
+			devVal = fmt.Sprintf("%d:%s", dev.DynMajor, minor)
+			log.Infof("rdma sysfs: %s dev=%s (patched from host %s, dynMajor=%d)",
+				dev.Name, devVal, dev.Dev, dev.DynMajor)
+		} else {
+			log.Infof("rdma sysfs: %s dev=%s (no dynMajor, using host value)", dev.Name, devVal)
+		}
+		addFile(verbsEntries, "dev", devVal)
+		ibVerbsDir[dev.Name] = fs.newDir(ctx, creds, defaultSysDirMode, verbsEntries)
+
+		if dev.IBDev == "" {
+			continue
+		}
+		log.Infof("rdma sysfs: %s → ibdev=%s node_type=%q fw_ver=%q guid=%s ports=%d",
+			dev.Name, dev.IBDev, dev.NodeType, dev.FWVer, dev.NodeGUID, len(dev.Ports))
+		ibDevEntries := map[string]kernfs.Inode{}
+		addFile(ibDevEntries, "node_type", dev.NodeType)
+		addFile(ibDevEntries, "node_guid", dev.NodeGUID)
+		addFile(ibDevEntries, "sys_image_guid", dev.SysImgGUID)
+		addFile(ibDevEntries, "fw_ver", dev.FWVer)
+		// Build the device/ subdirectory with PCI attributes.
+		// libibverbs reads modalias for driver matching; NCCL reads
+		// uevent for PCI_SLOT_NAME to match NICs against GPU topology.
+		deviceEntries := map[string]kernfs.Inode{}
+		addFile(deviceEntries, "modalias", dev.Modalias)
+		addFile(deviceEntries, "class", dev.PCIClass)
+		addFile(deviceEntries, "vendor", dev.PCIVendor)
+		addFile(deviceEntries, "device", dev.PCIDevice)
+		addFile(deviceEntries, "subsystem_vendor", dev.PCISubsysVendor)
+		addFile(deviceEntries, "subsystem_device", dev.PCISubsysDevice)
+		addFile(deviceEntries, "numa_node", dev.NUMANode)
+		addFile(deviceEntries, "local_cpulist", dev.LocalCPUList)
+		if dev.PCISlotName != "" {
+			uevent := ""
+			if dev.PCIDriver != "" {
+				uevent += "DRIVER=" + dev.PCIDriver + "\n"
+			}
+			if dev.PCIClass != "" {
+				uevent += "PCI_CLASS=" + strings.TrimPrefix(dev.PCIClass, "0x") + "\n"
+			}
+			if dev.PCIVendor != "" && dev.PCIDevice != "" {
+				uevent += "PCI_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCIVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCIDevice), "0X") + "\n"
+			}
+			if dev.PCISubsysVendor != "" && dev.PCISubsysDevice != "" {
+				uevent += "PCI_SUBSYS_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysDevice), "0X") + "\n"
+			}
+			uevent += "PCI_SLOT_NAME=" + dev.PCISlotName + "\n"
+			if dev.Modalias != "" {
+				uevent += "MODALIAS=" + dev.Modalias + "\n"
+			}
+			deviceEntries["uevent"] = fs.newStaticFile(ctx, creds, defaultSysMode, uevent)
+			log.Infof("rdma sysfs: %s device/uevent: PCI_SLOT_NAME=%s", dev.IBDev, dev.PCISlotName)
+		}
+		if len(deviceEntries) > 0 {
+			ibDevEntries["device"] = fs.newDir(ctx, creds, defaultSysDirMode, deviceEntries)
+		}
+		if len(dev.Ports) > 0 {
+			portsDir := map[string]kernfs.Inode{}
+			for _, port := range dev.Ports {
+				log.Infof("rdma sysfs:   port %s: state=%q link_layer=%q rate=%q",
+					port.Number, port.State, port.LinkLayer, port.Rate)
+				portEntries := map[string]kernfs.Inode{}
+				addFile(portEntries, "state", port.State)
+				addFile(portEntries, "phys_state", port.PhysState)
+				addFile(portEntries, "link_layer", port.LinkLayer)
+				addFile(portEntries, "rate", port.Rate)
+				addFile(portEntries, "lid", port.LID)
+				addFile(portEntries, "sm_lid", port.SMLID)
+				addFile(portEntries, "sm_sl", port.SMSL)
+				addFile(portEntries, "cap_mask", port.CapMask)
+				if len(port.GIDs) > 0 {
+					gidsEntries := map[string]kernfs.Inode{}
+					typesEntries := map[string]kernfs.Inode{}
+					ndevsEntries := map[string]kernfs.Inode{}
+					for _, gid := range port.GIDs {
+						addFile(gidsEntries, gid.Index, gid.GID)
+						addFile(typesEntries, gid.Index, gid.Type)
+						addFile(ndevsEntries, gid.Index, gid.NetDev)
+					}
+					log.Infof("rdma sysfs:   port %s: %d gids, gidsEntries=%d typesEntries=%d ndevsEntries=%d",
+						port.Number, len(port.GIDs), len(gidsEntries), len(typesEntries), len(ndevsEntries))
+					gidAttrsEntries := map[string]kernfs.Inode{
+						"types": fs.newDir(ctx, creds, defaultSysDirMode, typesEntries),
+					}
+					if len(ndevsEntries) > 0 {
+						gidAttrsEntries["ndevs"] = fs.newDir(ctx, creds, defaultSysDirMode, ndevsEntries)
+					}
+					portEntries["gids"] = fs.newDir(ctx, creds, defaultSysDirMode, gidsEntries)
+					portEntries["gid_attrs"] = fs.newDir(ctx, creds, defaultSysDirMode, gidAttrsEntries)
+				}
+				portsDir[port.Number] = fs.newDir(ctx, creds, defaultSysDirMode, portEntries)
+			}
+			ibDevEntries["ports"] = fs.newDir(ctx, creds, defaultSysDirMode, portsDir)
+		}
+		ibDir[dev.IBDev] = fs.newDir(ctx, creds, defaultSysDirMode, ibDevEntries)
+	}
+	return ibVerbsDir, ibDir
+}

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -59,6 +59,12 @@ type InternalData struct {
 	// EnableTPUProxyPaths is whether to populate sysfs paths used by hardware
 	// accelerators.
 	EnableTPUProxyPaths bool
+	// EnableRDMAProxyPaths is whether to populate sysfs paths used by
+	// RDMA/InfiniBand libibverbs device discovery.
+	EnableRDMAProxyPaths bool
+	// RDMADevices contains pre-collected RDMA sysfs data for constructing
+	// virtual /sys/class/infiniband_verbs/ and /sys/class/infiniband/ trees.
+	RDMADevices *RDMAData
 	// TestSysfsPathPrefix is a prefix for the sysfs paths. It is useful for
 	// unit testing.
 	TestSysfsPathPrefix string
@@ -175,6 +181,15 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				return nil, nil, err
 			}
 			kernelSub["iommu_groups"] = fs.newDir(ctx, creds, defaultSysDirMode, iommuGroups)
+		}
+		if idata.EnableRDMAProxyPaths {
+			ibVerbsDir, ibDir := fs.newRDMASysfsEntries(ctx, creds, idata.RDMADevices)
+			if ibVerbsDir != nil {
+				classSub["infiniband_verbs"] = fs.newDir(ctx, creds, defaultSysDirMode, ibVerbsDir)
+			}
+			if ibDir != nil {
+				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
+			}
 		}
 	}
 

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -45,6 +45,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/fdimport"
 	cgroup2fs "gvisor.dev/gvisor/pkg/sentry/fsimpl/cgroup2fs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/host"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/user"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
@@ -246,6 +247,9 @@ type Loader struct {
 	// productName is the value to show in
 	// /sys/devices/virtual/dmi/id/product_name.
 	productName string
+
+	// rdmaDevices contains pre-collected sysfs data for RDMA devices.
+	rdmaDevices *sys.RDMAData
 
 	// cpuQuota and cpuPeriod are the raw host CFS settings that should be
 	// exposed through sandbox cgroupfs.
@@ -449,6 +453,9 @@ type Args struct {
 	// RootfsUpperTarFD is the file descriptor to the tar file containing the rootfs
 	// upper layer changes.
 	RootfsUpperTarFD int
+
+	// RDMADevices contains pre-collected sysfs data for RDMA devices.
+	RDMADevices *sys.RDMAData
 }
 
 // HostTHP holds host transparent hugepage settings.
@@ -532,6 +539,7 @@ func New(args Args) (*Loader, error) {
 		sharedMounts:          make(map[string]*vfs.Mount),
 		stopProfiling:         stopProfiling,
 		productName:           args.ProductName,
+		rdmaDevices:           args.RDMADevices,
 		cpuQuota:              args.CPUQuota,
 		cpuPeriod:             args.CPUPeriod,
 		hostTHP:               args.HostTHP,

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -921,7 +921,7 @@ func (c *containerMounter) getPathMode(ctx context.Context, creds *auth.Credenti
 }
 
 func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) (*vfs.Mount, error) {
-	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
 	if err != nil {
 		return nil, fmt.Errorf("mountOptions failed: %w", err)
 	}
@@ -984,7 +984,7 @@ func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, 
 
 // getMountNameAndOptions retrieves the fsName, opts, and useOverlay values
 // used for mounts.
-func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore) (string, *vfs.MountOptions, error) {
+func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaDevices *sys.RDMAData) (string, *vfs.MountOptions, error) {
 	fsName := m.mount.Type
 	var (
 		mopts        = m.mount.Options
@@ -1004,7 +1004,11 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 		internalData = newProcInternalData(conf, spec)
 
 	case sys.Name:
-		sysData := &sys.InternalData{EnableTPUProxyPaths: specutils.TPUProxyEnabled(spec, conf)}
+		sysData := &sys.InternalData{
+			EnableTPUProxyPaths:  specutils.TPUProxyEnabled(spec, conf),
+			EnableRDMAProxyPaths: conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec),
+			RDMADevices:          rdmaDevices,
+		}
 		if len(productName) > 0 {
 			sysData.ProductName = productName
 		}
@@ -1385,7 +1389,7 @@ func (c *containerMounter) mountSharedMaster(ctx context.Context, spec *specs.Sp
 	// Mount the master using the options from the hint (mount annotations).
 	origOpts := mntInfo.mount.Options
 	mntInfo.mount.Options = mntInfo.hint.Mount.Options
-	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
 	mntInfo.mount.Options = origOpts
 	if err != nil {
 		return nil, err

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -100,6 +100,7 @@ go_library(
         "//pkg/sentry/control",
         "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/devices/tpuproxy",
+        "//pkg/sentry/fsimpl/sys",
         "//pkg/sentry/hostmm",
         "//pkg/sentry/kernel",
         "//pkg/sentry/kernel/auth",

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -38,6 +38,7 @@ import (
 	"gvisor.dev/gvisor/pkg/prometheus"
 	"gvisor.dev/gvisor/pkg/ring0"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/pkg/sentry/hostmm"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
 	"gvisor.dev/gvisor/pkg/sentry/syscalls/linux"
@@ -581,6 +582,12 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 	linux.SetAFSSyscallPanic(conf.TestOnlyAFSSyscallPanic)
 
+	// Read RDMA device data serialized by stage 1 (rdmaProxyUpdateChroot).
+	var rdmaDevices *sys.RDMAData
+	if conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec) {
+		rdmaDevices = sys.DeserializeRDMAData(sys.RDMADataPath)
+	}
+
 	// Create the loader.
 	bootArgs := boot.Args{
 		ID:                  f.Arg(0),
@@ -619,6 +626,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		FSRestoreFDs:             b.fsRestoreFDs.GetFDs(),
 		FSRestoreCheckpointGofer: b.fsRestoreCheckpointGofer,
 		RootfsUpperTarFD:         b.rootfsUpperTarFD,
+		RDMADevices:              rdmaDevices,
 	}
 	l, err := boot.New(bootArgs)
 	if err != nil {

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -27,6 +27,7 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/specutils"
 )
@@ -148,6 +149,10 @@ func setUpChroot(spec *specs.Spec, conf *config.Config) error {
 		return fmt.Errorf("error configuring chroot for TPU devices: %w", err)
 	}
 
+	if err := rdmaProxyUpdateChroot(chroot, spec, conf); err != nil {
+		return fmt.Errorf("error configuring chroot for RDMA devices: %w", err)
+	}
+
 	if err := specutils.SafeMount("", chroot, "", unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_BIND, "", "/proc"); err != nil {
 		return fmt.Errorf("error remounting chroot in read-only: %v", err)
 	}
@@ -212,4 +217,27 @@ func tpuProxyUpdateChroot(hostRoot, chroot string, spec *specs.Spec, conf *confi
 		}
 	}
 	return err
+}
+
+func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
+	if !conf.RDMAProxy || !specutils.HasRDMADevicesInSpec(spec) {
+		return nil
+	}
+	// Collect RDMA device data from the real host sysfs (accessible now,
+	// before pivot_root) and serialize it as JSON into the chroot. Stage 2
+	// deserializes this instead of trying to read sysfs — avoids all the
+	// symlink resolution and depth-limiting complexity of copying sysfs
+	// trees. The RoCE netdev backing each ibdev should have already been
+	// moved into the sandbox netns by MoveRDMANetdevsIntoSandbox; the GID
+	// sysfs entries we read here therefore include the kernel's normal
+	// IPv4-mapped RoCE v2 entries.
+	data := sys.CollectRDMADeviceData()
+	if data == nil {
+		return nil
+	}
+	jsonPath := filepath.Join(chroot, sys.RDMADataPath)
+	if err := sys.SerializeRDMAData(data, jsonPath); err != nil {
+		return fmt.Errorf("serializing RDMA data: %w", err)
+	}
+	return nil
 }

--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -506,6 +506,13 @@ func ShouldExposeTpuDevice(path string) bool {
 	return valid || ShouldExposeVFIODevice(path)
 }
 
+// ShouldExposeRDMADevice returns true if path refers to an RDMA uverbs device.
+//
+// Precondition: rdmaproxy is enabled.
+func ShouldExposeRDMADevice(path string) bool {
+	return strings.HasPrefix(path, "/dev/infiniband/uverbs")
+}
+
 // SetupDev mounts devices from the OCI spec into the gofer's /dev directory.
 func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) error {
 	if err := os.MkdirAll(filepath.Join(root, "dev"), 0777); err != nil {
@@ -517,9 +524,11 @@ func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) erro
 	}
 	nvproxyEnabled := specutils.NVProxyEnabled(spec, conf)
 	tpuproxyEnabled := specutils.TPUProxyEnabled(spec, conf)
+	rdmaproxyEnabled := conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec)
 	for _, dev := range spec.Linux.Devices {
 		shouldMount := (nvproxyEnabled && ShouldExposeNvidiaDevice(dev.Path)) ||
-			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path))
+			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path)) ||
+			(rdmaproxyEnabled && ShouldExposeRDMADevice(dev.Path))
 		if !shouldMount {
 			continue
 		}

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -367,6 +367,9 @@ type Config struct {
 	// TPUProxy enables support for TPUs.
 	TPUProxy bool `flag:"tpuproxy"`
 
+	// RDMAProxy enables support for RDMA device passthrough.
+	RDMAProxy bool `flag:"rdmaproxy"`
+
 	// TestOnlyAllowRunAsCurrentUserWithoutChroot should only be used in
 	// tests. It allows runsc to start the sandbox process as the current
 	// user, and without chrooting the sandbox process. This can be

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -180,6 +180,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("nvproxy-allow-unsupported-driver", false, "allow nvproxy to be initialized with an unsupported driver version.")
 	flagSet.String("nvproxy-allowed-driver-capabilities", "utility,compute", "Comma separated list of NVIDIA driver capabilities that are allowed to be requested by the container. If 'all' is specified here, it is resolved to all driver capabilities supported in nvproxy. If 'all' is requested by the container, it is resolved to this list.")
 	flagSet.Bool("tpuproxy", false, "LEGACY: enable support for TPU devices. TPU support gets automatically enabled if TPU devices are present in the OCI spec.")
+	flagSet.Bool("rdmaproxy", false, "EXPERIMENTAL: enable support for RDMA device passthrough.")
 
 	// Test flags, not to be used outside tests, ever.
 	flagSet.Bool("TESTONLY-unsafe-nonroot", false, "TEST ONLY; do not ever use! This skips many security measures that isolate the host from the sandbox.")

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1333,7 +1333,7 @@ func (c *Container) waitForStopped() error {
 // shouldCreateDeviceGofer indicates whether a device gofer connection should
 // be created.
 func shouldCreateDeviceGofer(spec *specs.Spec, conf *config.Config) bool {
-	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf)
+	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf) || (conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec))
 }
 
 // shouldSpawnGofer indicates whether the gofer process should be spawned.

--- a/runsc/specutils/BUILD
+++ b/runsc/specutils/BUILD
@@ -14,6 +14,7 @@ go_library(
         "hooks.go",
         "namespace.go",
         "nvidia.go",
+        "rdma.go",
         "restore.go",
         "specutils.go",
     ],

--- a/runsc/specutils/rdma.go
+++ b/runsc/specutils/rdma.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specutils
+
+import (
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// HasRDMADevicesInSpec returns true if the OCI spec lists at least one
+// /dev/infiniband/uverbs* device. Used to gate sysfs RDMA topology
+// serialization at chroot time, so PCI/RDMA/NUMA snapshot data is only
+// collected when the container actually requests RDMA devices.
+//
+// This intentionally does NOT consult the runtime rdmaproxy enable flag
+// (which lives in the rdmaproxy package, downstream of this PR) — sysfs
+// data collection is harmless without rdmaproxy and shipping serialize
+// alone should not require rdmaproxy.
+func HasRDMADevicesInSpec(spec *specs.Spec) bool {
+	if spec.Linux == nil {
+		return false
+	}
+	for _, dev := range spec.Linux.Devices {
+		if strings.HasPrefix(dev.Path, "/dev/infiniband/uverbs") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Based on #13114, this PR provides the minimal devices + sysfs information necessary to get ib_write_bw working between two gVisor containers (relies on later rdmaproxy PRs): 

<img width="1013" height="463" alt="Screenshot 2026-05-27 at 12 21 09 PM" src="https://github.com/user-attachments/assets/e66520c8-526e-4267-9885-105d26d5ffb1" />

The serialized JSON fields per device contain basic device identity information like `name`, `abi_version`, `node_type`, `node_guid`, `dev`, `ibdev`, `fw_ver`, and `sys_image_guid`. Modalias provides the PCI information that libibverbs uses to match a device to a user space driver plugin (e.g. `mlx5`). PCI attributes about the NIC device include `pci_slot_name`, `pci_driver`, `pci_class`, `pci_vendor`, `pci_device`, `pci_subsys_vendor`, and `pci_subsys_device`. `numa_node` and `local_cpulist` detail which NUMA node and CPUs the NIC is closest to. Finally, the `ports` array includes various per-port information.  

`verbs_abi_version` tells libibverbs which version of the kernel uverbs API is supported. This file lives globally in `sys/class/infiniband_verbs/abi_version`. 

Files added:
- `pkg/sentry/fsimpl/sys/rdma.go` contain the RDMA-specific data-types, host sysfs collection, and interface for serialization -> deserialization -> reconstruction of virtual sysfs tree. 
- `runsc/specutils/rdma.go` gates the entire serialization process on the presence of `/dev/infiniband/uverbs*` in the OCI spec.

Files modified: 
- `runsc/cmd/chroot.go` executes collection of RDMA information from sysfs before `pivot_root`. Data is serialized to `/var/lib/gvisor/rdma_data.json` inside the chroot. 
- `runsc/cmd/boot.go` deserializes the collected data from `/var/lib/gvisor/rdma_data.json` and is passed into the boot args `RDMADevices`.
- `runsc/boot/loader.go` stores the `RDMADevices` args on the `Loader` struct.
- `runsc/boot/vfs.go` passes `rdmaDevices` into `sys.InternalData`.
- `pkg/sentry/fsimpl/sys/sys.go` reads `sys.InternalData` and calls `rdma.go` to build the `/sys/class/infiniband_verbs/` and `/sys/class/infiniband/` trees.
- `runsc/container/container.go` tells the gofer to create RDMA devices when the OCI spec lists uverbs devices.
- `runsc/cmd/sandboxsetup/gofer_mount.go` adds `ShouldExposeRDMADevice` to the gofer's device filer for bind-mounting the uverbs device nodes when `/dev/infiniband/uverbs*` is included in the OCI spec. 