### PR TITLE
feat(shim): add per-pod user namespace injection via annotation

### DIFF
--- a/g3doc/user_guide/containerd/configuration.md
+++ b/g3doc/user_guide/containerd/configuration.md
@@ -101,6 +101,87 @@ log_level = "debug"
 EOF
 ```
 
+## User Namespace Injection
+
+The shim can inject a Linux user namespace and uid/gid mappings into a
+sandbox container's OCI spec when the pod opts in via an annotation, so the
+workload runs in a user namespace without the caller having to set one up
+explicitly. This is useful on Kubernetes nodes whose runtime stack does not
+yet support `pod.spec.hostUsers: false` ([KEP-127][KEP-127]) for runsc; once
+that path is plumbed through, drop the annotation and use `hostUsers: false`
+instead. See [issue #13303](https://github.com/google/gvisor/issues/13303).
+
+Two gates must both be true for injection to happen:
+
+1.  The operator enables the feature in `runsc.toml` with
+    `enable_user_namespace_annotation = true`.
+2.  The pod sets `metadata.annotations["dev.gvisor.spec.user-namespace"] =
+    "true"`. Containerd propagates `dev.gvisor.*` pod annotations to the
+    sandbox OCI spec via the `pod_annotations` match list.
+
+The operator gate exists so a misconfigured pod cannot unilaterally request
+a userns on a runtime that is not provisioned for one.
+
+Application/exec containers within the same pod inherit the sandbox's user
+namespace from runsc; only the sandbox container's spec is modified. If the
+caller already declared a user namespace or uid/gid mappings (e.g. via
+`hostUsers: false`), the shim leaves the spec untouched.
+
+Each opted-in sandbox is assigned a contiguous, non-overlapping block of
+host UIDs from a per-node pool. Allocations are persisted under
+`user_namespace_state_dir` (default `/run/runsc/userns-pool`) so they
+survive shim restarts, and freed when the sandbox is deleted.
+
+Enable it in `runsc.toml`:
+
+```shell
+cat <<EOF | sudo tee /etc/containerd/runsc.toml
+enable_user_namespace_annotation = true
+user_namespace_host_uid_base = 100000
+user_namespace_host_gid_base = 100000
+# Optional, with defaults shown:
+user_namespace_range_size = 65536          # UIDs/GIDs per sandbox
+user_namespace_pool_size = 1000            # max concurrent sandboxes
+user_namespace_state_dir = "/run/runsc/userns-pool"
+EOF
+```
+
+Ensure the runtime registration in containerd's config has
+`pod_annotations = ["dev.gvisor.*"]` so the opt-in annotation reaches the
+shim:
+
+```shell
+cat <<EOF | sudo tee /etc/containerd/config.toml
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc]
+  runtime_type = "io.containerd.runsc.v1"
+  pod_annotations = ["dev.gvisor.*"]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runsc.options]
+  TypeUrl = "io.containerd.runsc.v1.options"
+  ConfigPath = "/etc/containerd/runsc.toml"
+EOF
+```
+
+A pod opts in by setting the annotation:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    dev.gvisor.spec.user-namespace: "true"
+spec:
+  runtimeClassName: gvisor
+  containers:
+    - name: app
+      image: ...
+```
+
+The host UID/GID range used by the pool must not overlap with system or
+kubelet-managed UIDs. With the defaults above the pool occupies
+`[100000, 100000 + 1000*65536)`; size accordingly for your node.
+
+[KEP-127]: https://github.com/kubernetes/enhancements/issues/127
+
 ## NVIDIA Container Runtime
 
 If you want to use

--- a/pkg/shim/v1/runsc/container.go
+++ b/pkg/shim/v1/runsc/container.go
@@ -42,6 +42,7 @@ import (
 	"gvisor.dev/gvisor/pkg/shim/v1/proc"
 	"gvisor.dev/gvisor/pkg/shim/v1/runsccmd"
 	"gvisor.dev/gvisor/pkg/shim/v1/runtimeoptions"
+	"gvisor.dev/gvisor/pkg/shim/v1/utils"
 )
 
 // CgroupMode is the cgroups mode that is being used by the container.
@@ -69,6 +70,13 @@ type Container struct {
 
 	// cgroup is the cgroups mode that is being used by the container.
 	cgroup CgroupMode
+
+	// userNS is the user-namespace allocator config that owns this
+	// container's UID/GID slot, set when newInit injected a user namespace
+	// into the spec via UserNamespaceConfig. Nil otherwise (sandbox without
+	// shim-side userns, or non-sandbox container that inherits its
+	// sandbox's userns).
+	userNS *utils.UserNamespaceConfig
 }
 
 // NewContainer returns a new runsc container
@@ -197,9 +205,19 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		FSRestoreDirect:    FSRestoreDirect,
 	}
 
-	process, err := newInit(filepath.Join(r.Bundle, "work"), ns, platform, config, &opts, st.Rootfs)
+	process, userNS, err := newInit(filepath.Join(r.Bundle, "work"), ns, platform, config, &opts, st.Rootfs)
 	if err != nil {
 		return nil, err
+	}
+	// Release the user namespace slot if anything from this point on fails.
+	// On success cu.Release() below cancels the cleanup.
+	if userNS != nil {
+		sandboxID := r.ID
+		cu.Add(func() {
+			if err := utils.ReleaseUserNamespaceSlot(userNS, sandboxID); err != nil {
+				log.L.Warningf("failed to release user namespace slot for %s: %v", sandboxID, err)
+			}
+		})
 	}
 	if err := process.Create(ctx, config); err != nil {
 		return nil, err
@@ -218,6 +236,7 @@ func NewContainer(ctx context.Context, platform stdio.Platform, r *task.CreateTa
 		task:      process,
 		cgroup:    cgroupMode,
 		processes: make(map[string]extension.Process),
+		userNS:    userNS,
 	}
 	return &c, nil
 }
@@ -312,6 +331,14 @@ func (c *Container) Delete(ctx context.Context, r *task.DeleteRequest) (extensio
 	// When ExecID is empty, it removes the init task in the container.
 	if r.ExecID != "" {
 		c.ProcessRemove(r.ExecID)
+	} else if c.userNS != nil {
+		// Sandbox init container is being deleted; release its user namespace
+		// slot. Best-effort: a leaked slot is an operator nuisance, not a
+		// correctness issue (cleared on reboot since /run is tmpfs), so log
+		// and continue.
+		if err := utils.ReleaseUserNamespaceSlot(c.userNS, c.ID); err != nil {
+			log.L.Warningf("failed to release user namespace slot for %s: %v", c.ID, err)
+		}
 	}
 	return p, nil
 }

--- a/pkg/shim/v1/runsc/options.go
+++ b/pkg/shim/v1/runsc/options.go
@@ -51,6 +51,54 @@ type Options struct {
 	// EnableHibernateServer indicates if the hibernate server should be started.
 	EnableHibernateServer bool `toml:"enable_hibernate_server" json:"enableHibernateServer"`
 
+	// EnableUserNamespaceAnnotation is the operator-side gate that allows
+	// pods to opt into shim-side user namespace injection via the pod
+	// annotation "dev.gvisor.spec.user-namespace": "true" (see
+	// utils.UserNamespaceRequestAnnotation). When true, sandbox containers
+	// whose pod annotations contain that key get a user namespace plus
+	// contiguous, non-overlapping uid/gid mappings injected into their OCI
+	// spec before runsc is invoked. Application/exec containers within the
+	// same pod inherit the sandbox's user namespace.
+	//
+	// This exists to let runsc workloads run inside a user namespace on
+	// nodes whose kubelet+containerd stack does not yet plumb pod.spec.
+	// hostUsers (KEP-127) through to runsc. When that path lands upstream,
+	// drop the annotation and use hostUsers: false on the pod spec instead.
+	// See https://github.com/google/gvisor/issues/13303.
+	//
+	// The shim respects caller-supplied user namespaces and uid/gid
+	// mappings: if the OCI spec already declares them (e.g. via
+	// hostUsers: false), the shim leaves the spec untouched and does not
+	// allocate a slot.
+	//
+	// Pods can only request the userns when this option is true, so a
+	// misconfigured workload cannot unilaterally enable it.
+	EnableUserNamespaceAnnotation bool `toml:"enable_user_namespace_annotation" json:"enableUserNamespaceAnnotation"`
+
+	// UserNamespaceHostUIDBase is the lowest host UID used by the
+	// per-node UID pool. Each sandbox that opts in receives a contiguous
+	// block of UserNamespaceRangeSize UIDs starting at
+	// UserNamespaceHostUIDBase + slot*UserNamespaceRangeSize.
+	UserNamespaceHostUIDBase uint32 `toml:"user_namespace_host_uid_base" json:"userNamespaceHostUidBase"`
+
+	// UserNamespaceHostGIDBase is the GID equivalent of
+	// UserNamespaceHostUIDBase.
+	UserNamespaceHostGIDBase uint32 `toml:"user_namespace_host_gid_base" json:"userNamespaceHostGidBase"`
+
+	// UserNamespaceRangeSize is the number of UIDs/GIDs each sandbox
+	// receives. Defaults to 65536 when the annotation gate is enabled and
+	// this field is unset.
+	UserNamespaceRangeSize uint32 `toml:"user_namespace_range_size" json:"userNamespaceRangeSize"`
+
+	// UserNamespacePoolSize is the maximum number of concurrent sandboxes
+	// that can hold non-overlapping UID/GID ranges on this node. Defaults
+	// to 1000 when the annotation gate is enabled and this field is unset.
+	UserNamespacePoolSize uint32 `toml:"user_namespace_pool_size" json:"userNamespacePoolSize"`
+
+	// UserNamespaceStateDir is the directory used to persist slot
+	// allocations across shim restarts. Defaults to /run/runsc/userns-pool.
+	UserNamespaceStateDir string `toml:"user_namespace_state_dir" json:"userNamespaceStateDir"`
+
 	// RunscConfig is a key/value map of all runsc flags.
 	RunscConfig map[string]string `toml:"runsc_config" json:"runscConfig"`
 }

--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -657,21 +657,65 @@ func getTopic(e any) string {
 	return runtime.TaskUnknownTopic
 }
 
-func newInit(workDir, namespace string, platform stdio.Platform, r *proc.CreateConfig, options *Options, rootfs string) (*proc.Init, error) {
+func newInit(workDir, namespace string, platform stdio.Platform, r *proc.CreateConfig, options *Options, rootfs string) (*proc.Init, *utils.UserNamespaceConfig, error) {
 	spec, err := utils.ReadSpec(r.Bundle)
 	if err != nil {
-		return nil, fmt.Errorf("read oci spec: %w", err)
+		return nil, nil, fmt.Errorf("read oci spec: %w", err)
 	}
 
 	updated, err := utils.UpdateVolumeAnnotations(spec)
 	if err != nil {
-		return nil, fmt.Errorf("update volume annotations: %w", err)
+		return nil, nil, fmt.Errorf("update volume annotations: %w", err)
 	}
 	updated = setPodCgroup(spec) || updated
 
+	// Shim-side user namespace injection.
+	//
+	// Two gates must both be true: the runtime operator opted in via
+	// enable_user_namespace_annotation, AND the pod's metadata.annotations
+	// requested it via "dev.gvisor.spec.user-namespace": "true". The
+	// operator gate exists so a misconfigured workload cannot unilaterally
+	// enable a userns when the runtime is not configured to support one.
+	//
+	// Only applied to sandbox containers; application/exec containers within
+	// the pod inherit the sandbox's user namespace from runsc. The caller's
+	// pre-existing user namespace or uid/gid mappings (e.g. from kubelet's
+	// pod.spec.hostUsers: false plumbing) take precedence: InjectUserNamespace
+	// returns updated=false in that case and we drop the slot we just claimed.
+	var userNS *utils.UserNamespaceConfig
+	if options.EnableUserNamespaceAnnotation && utils.IsSandbox(spec) && utils.HasUserNamespaceRequest(spec) {
+		userNS = &utils.UserNamespaceConfig{
+			HostUIDBase: options.UserNamespaceHostUIDBase,
+			HostGIDBase: options.UserNamespaceHostGIDBase,
+			RangeSize:   options.UserNamespaceRangeSize,
+			PoolSize:    options.UserNamespacePoolSize,
+			StateDir:    options.UserNamespaceStateDir,
+		}
+		slot, err := utils.AllocateUserNamespaceSlot(userNS, r.ID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("allocate user namespace slot: %w", err)
+		}
+		injected, err := utils.InjectUserNamespace(spec, userNS, slot)
+		if err != nil {
+			_ = utils.ReleaseUserNamespaceSlot(userNS, r.ID)
+			return nil, nil, fmt.Errorf("inject user namespace: %w", err)
+		}
+		if injected {
+			updated = true
+		} else {
+			// Caller already configured a user namespace; release the slot
+			// we claimed and let the caller's spec stand.
+			_ = utils.ReleaseUserNamespaceSlot(userNS, r.ID)
+			userNS = nil
+		}
+	}
+
 	if updated {
 		if err := utils.WriteSpec(r.Bundle, spec); err != nil {
-			return nil, err
+			if userNS != nil {
+				_ = utils.ReleaseUserNamespaceSlot(userNS, r.ID)
+			}
+			return nil, nil, err
 		}
 	}
 
@@ -691,7 +735,7 @@ func newInit(workDir, namespace string, platform stdio.Platform, r *proc.CreateC
 	p.Sandbox = specutils.SpecContainerType(spec) == specutils.ContainerTypeSandbox
 	p.UserLog = utils.UserLogPath(spec)
 	p.Monitor = reaper.Default
-	return p, nil
+	return p, userNS, nil
 }
 
 // setPodCgroup searches for the pod cgroup path inside the container's cgroup

--- a/pkg/shim/v1/utils/BUILD
+++ b/pkg/shim/v1/utils/BUILD
@@ -9,6 +9,7 @@ go_library(
     name = "utils",
     srcs = [
         "annotations.go",
+        "userns.go",
         "utils.go",
         "volumes.go",
     ],
@@ -25,7 +26,10 @@ go_library(
 go_test(
     name = "utils_test",
     size = "small",
-    srcs = ["volumes_test.go"],
+    srcs = [
+        "userns_test.go",
+        "volumes_test.go",
+    ],
     library = ":utils",
     deps = [
         "@com_github_mohae_deepcopy//:go_default_library",

--- a/pkg/shim/v1/utils/userns.go
+++ b/pkg/shim/v1/utils/userns.go
@@ -1,0 +1,282 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// UserNamespaceConfig configures shim-side injection of a Linux user namespace
+// into the OCI spec for sandbox containers. It is consulted when the shim's
+// runtime options enable enable_user_namespace_annotation (see
+// pkg/shim/v1/runsc/options.go) AND the sandbox's pod annotations contain
+// UserNamespaceRequestAnnotation = "true". The operator-side gate exists so a
+// pod cannot unilaterally request a userns when the runtime is not configured
+// for one.
+//
+// This path exists so runsc workloads can run inside a user namespace on
+// Kubernetes nodes whose runtime stack does not yet support pod.spec.hostUsers
+// (KEP-127). Once kubelet+containerd plumb user namespaces to runsc directly,
+// drop the annotation and use hostUsers: false instead.
+// See https://github.com/google/gvisor/issues/13303.
+type UserNamespaceConfig struct {
+	// HostUIDBase is the lowest host UID used by the pool. Each sandbox is
+	// assigned a contiguous block of size RangeSize starting at
+	// HostUIDBase + slot*RangeSize.
+	HostUIDBase uint32
+
+	// HostGIDBase mirrors HostUIDBase for GIDs.
+	HostGIDBase uint32
+
+	// RangeSize is the number of UIDs/GIDs each sandbox receives. Defaults to
+	// 65536, which is large enough to host typical multi-UID images.
+	RangeSize uint32
+
+	// PoolSize is the maximum number of concurrent sandboxes that can hold
+	// non-overlapping ID ranges on this node. Defaults to 1000.
+	PoolSize uint32
+
+	// StateDir is the directory used to persist slot allocations across
+	// shim restarts. Defaults to /run/runsc/userns-pool. Cleared on reboot
+	// (since /run is tmpfs on systemd hosts), which is the desired behavior:
+	// no sandboxes can survive a reboot, so all slots are free.
+	StateDir string
+}
+
+// UserNamespaceRequestAnnotation is the pod-level annotation that opts the
+// sandbox into shim-side user namespace injection. Set to "true" on a pod's
+// metadata.annotations to request a userns. Containerd propagates this to
+// the sandbox OCI spec via the runtime's pod_annotations match list (see the
+// existing pod_annotations = ["dev.gvisor.*"] entry in the runtime config).
+//
+// This is a stopgap signal until kubelet/containerd plumb pod.spec.hostUsers
+// (KEP-127) through to runsc; see https://github.com/google/gvisor/issues/13303.
+const UserNamespaceRequestAnnotation = "dev.gvisor.spec.user-namespace"
+
+// UserNamespaceSlotAnnotation records the allocated slot on the sandbox spec
+// for diagnostics and for runtime introspection. The value is a decimal
+// string of the slot index (0..PoolSize).
+const UserNamespaceSlotAnnotation = "dev.gvisor.shim.userns.slot"
+
+// HasUserNamespaceRequest returns true if spec.Annotations contains the opt-in
+// annotation and its value is "true".
+func HasUserNamespaceRequest(spec *specs.Spec) bool {
+	if spec == nil || spec.Annotations == nil {
+		return false
+	}
+	return spec.Annotations[UserNamespaceRequestAnnotation] == "true"
+}
+
+const (
+	defaultUserNamespaceRangeSize = 65536
+	defaultUserNamespacePoolSize  = 1000
+	defaultUserNamespaceStateDir  = "/run/runsc/userns-pool"
+
+	// sandboxIDFile holds the sandbox ID owning a slot directory. Written
+	// after the slot directory is atomically created so concurrent shim
+	// invocations cannot race past mkdir into a partially-claimed slot.
+	sandboxIDFile = "sandbox-id"
+)
+
+// errPoolExhausted is returned when no free slot is available. Operators
+// should bump UserNamespaceConfig.PoolSize.
+var errPoolExhausted = errors.New("user namespace pool exhausted")
+
+// validate fills in defaults and rejects misconfiguration. Callers should
+// invoke c.validate before using any other method on UserNamespaceConfig.
+func (c *UserNamespaceConfig) validate() error {
+	if c.HostUIDBase == 0 || c.HostGIDBase == 0 {
+		return fmt.Errorf("user_namespace_host_uid_base and user_namespace_host_gid_base must be set to non-zero values when force_user_namespace is enabled")
+	}
+	if c.RangeSize == 0 {
+		c.RangeSize = defaultUserNamespaceRangeSize
+	}
+	if c.PoolSize == 0 {
+		c.PoolSize = defaultUserNamespacePoolSize
+	}
+	if c.StateDir == "" {
+		c.StateDir = defaultUserNamespaceStateDir
+	}
+	// Reject configurations that would map any sandbox UID outside uint32.
+	maxBlocks := uint64(c.PoolSize) * uint64(c.RangeSize)
+	if uint64(c.HostUIDBase)+maxBlocks > uint64(^uint32(0)) {
+		return fmt.Errorf("user namespace pool overflows uint32 host UID space: host_uid_base=%d + pool_size*range_size=%d", c.HostUIDBase, maxBlocks)
+	}
+	if uint64(c.HostGIDBase)+maxBlocks > uint64(^uint32(0)) {
+		return fmt.Errorf("user namespace pool overflows uint32 host GID space: host_gid_base=%d + pool_size*range_size=%d", c.HostGIDBase, maxBlocks)
+	}
+	return nil
+}
+
+// AllocateUserNamespaceSlot atomically reserves an unused slot in [0, PoolSize)
+// for sandboxID, persisting the assignment under c.StateDir so it survives
+// shim restarts. If sandboxID already holds a slot the existing slot is
+// returned (idempotent). Returns errPoolExhausted if all slots are taken.
+//
+// The allocator uses os.Mkdir as the synchronization primitive: on Linux the
+// kernel guarantees mkdir(2) is atomic with respect to other mkdir(2) and
+// rmdir(2) callers, so two shim invocations racing on the same slot will see
+// exactly one mkdir succeed.
+func AllocateUserNamespaceSlot(c *UserNamespaceConfig, sandboxID string) (uint32, error) {
+	if err := c.validate(); err != nil {
+		return 0, err
+	}
+	if sandboxID == "" {
+		return 0, fmt.Errorf("sandboxID is required")
+	}
+	if err := os.MkdirAll(c.StateDir, 0700); err != nil {
+		return 0, fmt.Errorf("create userns state dir %q: %w", c.StateDir, err)
+	}
+
+	// Idempotency: if sandboxID already owns a slot, reuse it. This handles
+	// retries by containerd as well as shim restarts that reissue Create.
+	if slot, ok, err := findExistingSlot(c, sandboxID); err != nil {
+		return 0, err
+	} else if ok {
+		return slot, nil
+	}
+
+	for i := uint32(0); i < c.PoolSize; i++ {
+		dir := slotPath(c, i)
+		if err := os.Mkdir(dir, 0700); err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return 0, fmt.Errorf("claim slot %d (%s): %w", i, dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, sandboxIDFile), []byte(sandboxID), 0600); err != nil {
+			// Best-effort cleanup. If the rmdir fails too, the slot leaks
+			// until reboot (or manual operator intervention) -- safer than
+			// returning a slot we couldn't tag with the owning sandbox.
+			_ = os.RemoveAll(dir)
+			return 0, fmt.Errorf("record sandbox owner for slot %d: %w", i, err)
+		}
+		return i, nil
+	}
+	return 0, fmt.Errorf("%w: pool_size=%d", errPoolExhausted, c.PoolSize)
+}
+
+// ReleaseUserNamespaceSlot frees the slot owned by sandboxID, if any. It is
+// safe to call on a sandbox that never claimed a slot or whose slot was
+// already removed; in those cases it returns nil.
+func ReleaseUserNamespaceSlot(c *UserNamespaceConfig, sandboxID string) error {
+	if err := c.validate(); err != nil {
+		return err
+	}
+	if sandboxID == "" {
+		return fmt.Errorf("sandboxID is required")
+	}
+	slot, ok, err := findExistingSlot(c, sandboxID)
+	if err != nil || !ok {
+		return err
+	}
+	return os.RemoveAll(slotPath(c, slot))
+}
+
+// findExistingSlot scans c.StateDir for a slot whose sandbox-id file matches
+// sandboxID. The caller-visible state dir is small (PoolSize entries, default
+// 1000) so a linear scan is acceptable.
+func findExistingSlot(c *UserNamespaceConfig, sandboxID string) (uint32, bool, error) {
+	entries, err := os.ReadDir(c.StateDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("scan userns state dir %q: %w", c.StateDir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		slot, err := strconv.ParseUint(e.Name(), 10, 32)
+		if err != nil {
+			continue
+		}
+		idFile := filepath.Join(c.StateDir, e.Name(), sandboxIDFile)
+		data, err := os.ReadFile(idFile)
+		if err != nil {
+			// A directory with no sandbox-id file is a partial claim from a
+			// shim that crashed between mkdir and WriteFile. Skip it; the
+			// next allocator pass will eventually overwrite it via mkdir
+			// returning EEXIST. Manual operator cleanup may be needed if it
+			// persists indefinitely.
+			continue
+		}
+		if string(data) == sandboxID {
+			return uint32(slot), true, nil
+		}
+	}
+	return 0, false, nil
+}
+
+func slotPath(c *UserNamespaceConfig, slot uint32) string {
+	return filepath.Join(c.StateDir, strconv.FormatUint(uint64(slot), 10))
+}
+
+// InjectUserNamespace mutates spec to add a Linux user namespace and the
+// uid/gid mappings derived from c and slot. It is a no-op (returns false)
+// when the spec already declares a user namespace or already contains
+// uid/gid mappings, so caller-provided configuration (e.g. kubelet's
+// hostUsers: false plumbing) wins.
+//
+// The shim must call InjectUserNamespace only on sandbox containers
+// (utils.IsSandbox(spec) == true). Application/exec containers within the
+// same pod inherit the sandbox's user namespace and must not have separate
+// mappings; the runsc binary uses the sandbox's mappings for all
+// containers in the pod.
+func InjectUserNamespace(spec *specs.Spec, c *UserNamespaceConfig, slot uint32) (bool, error) {
+	if err := c.validate(); err != nil {
+		return false, err
+	}
+	if slot >= c.PoolSize {
+		return false, fmt.Errorf("slot %d out of range [0, %d)", slot, c.PoolSize)
+	}
+	if spec.Linux == nil {
+		spec.Linux = &specs.Linux{}
+	}
+	for _, ns := range spec.Linux.Namespaces {
+		if ns.Type == specs.UserNamespace {
+			return false, nil
+		}
+	}
+	if len(spec.Linux.UIDMappings) > 0 || len(spec.Linux.GIDMappings) > 0 {
+		return false, nil
+	}
+
+	hostUID := c.HostUIDBase + slot*c.RangeSize
+	hostGID := c.HostGIDBase + slot*c.RangeSize
+
+	spec.Linux.Namespaces = append(spec.Linux.Namespaces, specs.LinuxNamespace{
+		Type: specs.UserNamespace,
+	})
+	spec.Linux.UIDMappings = []specs.LinuxIDMapping{
+		{ContainerID: 0, HostID: hostUID, Size: c.RangeSize},
+	}
+	spec.Linux.GIDMappings = []specs.LinuxIDMapping{
+		{ContainerID: 0, HostID: hostGID, Size: c.RangeSize},
+	}
+
+	if spec.Annotations == nil {
+		spec.Annotations = make(map[string]string)
+	}
+	spec.Annotations[UserNamespaceSlotAnnotation] = strconv.FormatUint(uint64(slot), 10)
+	return true, nil
+}

--- a/pkg/shim/v1/utils/userns_test.go
+++ b/pkg/shim/v1/utils/userns_test.go
@@ -1,0 +1,293 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func newTestUserNSConfig(t *testing.T) *UserNamespaceConfig {
+	t.Helper()
+	return &UserNamespaceConfig{
+		HostUIDBase: 100000,
+		HostGIDBase: 100000,
+		RangeSize:   65536,
+		PoolSize:    8,
+		StateDir:    filepath.Join(t.TempDir(), "userns-pool"),
+	}
+}
+
+func TestUserNamespaceConfigValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*UserNamespaceConfig)
+		wantErr bool
+	}{
+		{
+			name:   "defaults populated",
+			mutate: func(c *UserNamespaceConfig) {},
+		},
+		{
+			name:    "missing host uid base",
+			mutate:  func(c *UserNamespaceConfig) { c.HostUIDBase = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "missing host gid base",
+			mutate:  func(c *UserNamespaceConfig) { c.HostGIDBase = 0 },
+			wantErr: true,
+		},
+		{
+			name: "uint32 overflow",
+			mutate: func(c *UserNamespaceConfig) {
+				c.HostUIDBase = ^uint32(0) - 1
+				c.RangeSize = 65536
+				c.PoolSize = 1000
+			},
+			wantErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestUserNSConfig(t)
+			tc.mutate(c)
+			err := c.validate()
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validate() err=%v wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAllocateUserNamespaceSlotUnique(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	const want = 5
+	got := make(map[uint32]string)
+	for i := 0; i < want; i++ {
+		id := "sandbox-" + string(rune('a'+i))
+		slot, err := AllocateUserNamespaceSlot(c, id)
+		if err != nil {
+			t.Fatalf("AllocateUserNamespaceSlot(%q): %v", id, err)
+		}
+		if existing, ok := got[slot]; ok {
+			t.Fatalf("slot %d allocated to %q and %q", slot, existing, id)
+		}
+		got[slot] = id
+	}
+	if len(got) != want {
+		t.Fatalf("got %d unique slots, want %d", len(got), want)
+	}
+}
+
+func TestAllocateUserNamespaceSlotIdempotent(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	const id = "sandbox-A"
+	first, err := AllocateUserNamespaceSlot(c, id)
+	if err != nil {
+		t.Fatalf("first AllocateUserNamespaceSlot: %v", err)
+	}
+	second, err := AllocateUserNamespaceSlot(c, id)
+	if err != nil {
+		t.Fatalf("second AllocateUserNamespaceSlot: %v", err)
+	}
+	if first != second {
+		t.Errorf("idempotency: first=%d second=%d, want equal", first, second)
+	}
+}
+
+func TestAllocateUserNamespaceSlotPoolExhausted(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	for i := uint32(0); i < c.PoolSize; i++ {
+		if _, err := AllocateUserNamespaceSlot(c, "filler-"+string(rune('a'+i))); err != nil {
+			t.Fatalf("filler %d: %v", i, err)
+		}
+	}
+	_, err := AllocateUserNamespaceSlot(c, "overflow")
+	if !errors.Is(err, errPoolExhausted) {
+		t.Errorf("got %v, want errPoolExhausted", err)
+	}
+}
+
+func TestReleaseUserNamespaceSlotFreesSlot(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	const id = "sandbox-A"
+	first, err := AllocateUserNamespaceSlot(c, id)
+	if err != nil {
+		t.Fatalf("AllocateUserNamespaceSlot: %v", err)
+	}
+	if err := ReleaseUserNamespaceSlot(c, id); err != nil {
+		t.Fatalf("ReleaseUserNamespaceSlot: %v", err)
+	}
+	// After release, a different sandbox should be able to claim the slot
+	// (or any other free slot) without error.
+	again, err := AllocateUserNamespaceSlot(c, "sandbox-B")
+	if err != nil {
+		t.Fatalf("re-allocate: %v", err)
+	}
+	if again != first {
+		t.Logf("re-allocated slot %d (originally %d); both are valid outcomes", again, first)
+	}
+	// Releasing an unknown sandbox is a no-op (no error).
+	if err := ReleaseUserNamespaceSlot(c, "never-allocated"); err != nil {
+		t.Errorf("release unknown: got %v, want nil", err)
+	}
+}
+
+func TestAllocateUserNamespaceSlotConcurrent(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	c.PoolSize = 64
+	const goroutines = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	slots := make([]uint32, goroutines)
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			slots[i], errs[i] = AllocateUserNamespaceSlot(c, "concurrent-"+string(rune('a'+i)))
+		}()
+	}
+	wg.Wait()
+
+	seen := make(map[uint32]int, goroutines)
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: %v", i, err)
+			continue
+		}
+		if prev, ok := seen[slots[i]]; ok {
+			t.Errorf("slot %d collided: goroutines %d and %d", slots[i], prev, i)
+		}
+		seen[slots[i]] = i
+	}
+}
+
+func TestInjectUserNamespaceMutatesSpec(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	if err := c.validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	spec := &specs.Spec{}
+	const slot = 3
+
+	updated, err := InjectUserNamespace(spec, c, slot)
+	if err != nil {
+		t.Fatalf("InjectUserNamespace: %v", err)
+	}
+	if !updated {
+		t.Fatal("expected spec to be modified")
+	}
+	if spec.Linux == nil {
+		t.Fatal("spec.Linux is nil after injection")
+	}
+	foundUserns := false
+	for _, ns := range spec.Linux.Namespaces {
+		if ns.Type == specs.UserNamespace {
+			foundUserns = true
+		}
+	}
+	if !foundUserns {
+		t.Error("spec.Linux.Namespaces missing user namespace entry")
+	}
+	wantUID := c.HostUIDBase + slot*c.RangeSize
+	if got := spec.Linux.UIDMappings; len(got) != 1 || got[0].HostID != wantUID || got[0].Size != c.RangeSize || got[0].ContainerID != 0 {
+		t.Errorf("UIDMappings = %+v, want one entry [container=0 host=%d size=%d]", got, wantUID, c.RangeSize)
+	}
+	wantGID := c.HostGIDBase + slot*c.RangeSize
+	if got := spec.Linux.GIDMappings; len(got) != 1 || got[0].HostID != wantGID || got[0].Size != c.RangeSize || got[0].ContainerID != 0 {
+		t.Errorf("GIDMappings = %+v, want one entry [container=0 host=%d size=%d]", got, wantGID, c.RangeSize)
+	}
+	if got := spec.Annotations[UserNamespaceSlotAnnotation]; got != "3" {
+		t.Errorf("slot annotation = %q, want %q", got, "3")
+	}
+}
+
+func TestInjectUserNamespaceRespectsCallerMappings(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	if err := c.validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+
+	// Caller already supplied uidMappings (e.g. kubelet KEP-127 plumbing).
+	spec := &specs.Spec{
+		Linux: &specs.Linux{
+			Namespaces: []specs.LinuxNamespace{{Type: specs.UserNamespace}},
+			UIDMappings: []specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 50000, Size: 1024},
+			},
+			GIDMappings: []specs.LinuxIDMapping{
+				{ContainerID: 0, HostID: 50000, Size: 1024},
+			},
+		},
+	}
+	updated, err := InjectUserNamespace(spec, c, 0)
+	if err != nil {
+		t.Fatalf("InjectUserNamespace: %v", err)
+	}
+	if updated {
+		t.Error("expected no-op when caller supplied mappings, got modification")
+	}
+	if len(spec.Linux.UIDMappings) != 1 || spec.Linux.UIDMappings[0].HostID != 50000 {
+		t.Errorf("caller mappings overwritten: %+v", spec.Linux.UIDMappings)
+	}
+}
+
+func TestInjectUserNamespaceRejectsOutOfRangeSlot(t *testing.T) {
+	c := newTestUserNSConfig(t)
+	spec := &specs.Spec{}
+	if _, err := InjectUserNamespace(spec, c, c.PoolSize); err == nil {
+		t.Error("expected error for slot == PoolSize, got nil")
+	}
+}
+
+func TestHasUserNamespaceRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec *specs.Spec
+		want bool
+	}{
+		{name: "nil spec", spec: nil},
+		{name: "no annotations", spec: &specs.Spec{}},
+		{
+			name: "annotation absent",
+			spec: &specs.Spec{Annotations: map[string]string{"unrelated": "true"}},
+		},
+		{
+			name: "annotation false",
+			spec: &specs.Spec{Annotations: map[string]string{UserNamespaceRequestAnnotation: "false"}},
+		},
+		{
+			name: "annotation truthy non-true value (must be exact)",
+			spec: &specs.Spec{Annotations: map[string]string{UserNamespaceRequestAnnotation: "1"}},
+		},
+		{
+			name: "annotation true",
+			spec: &specs.Spec{Annotations: map[string]string{UserNamespaceRequestAnnotation: "true"}},
+			want: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasUserNamespaceRequest(tc.spec); got != tc.want {
+				t.Errorf("HasUserNamespaceRequest = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `enable_user_namespace_annotation` option to `containerd-shim-runsc-v1`. When the runtime opts in and a pod sets `dev.gvisor.spec.user-namespace: "true"` in its `metadata.annotations`, the shim injects a Linux user namespace and a contiguous, non-overlapping uid/gid block into the sandbox container's OCI spec before invoking runsc. Application/exec containers in the same pod inherit the sandbox's user namespace from runsc.

The injection is a no-op when the caller already declared a user namespace or uid/gid mappings, so kubelet's `pod.spec.hostUsers: false` plumbing (KEP-127) takes precedence when it lands for runsc.

Refs: #13303.

## Why

Per #13303, `runtimeClassName: gvisor` workloads cannot opt into user namespaces via `pod.spec.hostUsers: false` today because:

1. containerd's `introspectRuntimeFeatures` (`internal/cri/server/service.go`) hardcodes `r.Type == plugins.RuntimeRuncV2`, so the runsc shim's `manager.Info()` features are never consulted.
2. Even if (1) were lifted, `supportsCRIUserns` requires `Linux.MountExtensions.IDMap.Enabled = true`, which `runsc/specutils/specutils.go` returns `false` for since runsc does not implement OCI `mount.idmap`.

This patch sidesteps both issues at the runtime layer with a per-pod opt-in: a pod annotation tells the shim to mutate the sandbox's OCI spec the same way kubelet would, without requiring kubelet/CRI cooperation. A separate operator-side gate ensures a misconfigured workload cannot unilaterally request a userns on a runtime that is not provisioned for one.

This is intended as a **stopgap**, not a long-term replacement for KEP-127. When the upstream path lands, operators set `enable_user_namespace_annotation = false` and pods drop the annotation in favor of `hostUsers: false`. The change is forward-compatible: the shim respects caller-supplied mappings and yields without allocating a slot.

## How

- New shim options in `pkg/shim/v1/runsc/options.go`: `enable_user_namespace_annotation`, `user_namespace_host_uid_base`, `user_namespace_host_gid_base`, `user_namespace_range_size` (default 65536), `user_namespace_pool_size` (default 1000), `user_namespace_state_dir` (default `/run/runsc/userns-pool`).
- New `pkg/shim/v1/utils/userns.go`: `UserNamespaceConfig`, `UserNamespaceRequestAnnotation` (`dev.gvisor.spec.user-namespace`), `HasUserNamespaceRequest`, `AllocateUserNamespaceSlot`, `ReleaseUserNamespaceSlot`, `InjectUserNamespace`. Uses `os.Mkdir` as the per-slot synchronization primitive (kernel-atomic), so concurrent shim invocations don't collide. State persisted under `user_namespace_state_dir` so allocations survive shim restarts; cleared on reboot via tmpfs.
- `pkg/shim/v1/runsc/service.go:newInit` registers a third spec mutator alongside the existing `UpdateVolumeAnnotations` / `setPodCgroup` chain. Only runs for sandbox containers (`utils.IsSandbox(spec)`) AND when both gates are satisfied; app containers inherit.
- `pkg/shim/v1/runsc/container.go`: `Container.userNS` field threads the allocator config through to `Container.Delete`, which releases the slot when the init task is torn down. Failure paths in `NewContainer` register a `cleanup.Add` hook so a partially-created sandbox releases its slot.
- Doc: new "User Namespace Injection" section in `g3doc/user_guide/containerd/configuration.md` linking back to #13303.

Per-sandbox UID range is `host_uid_base + slot * range_size`, where `slot` is allocated from `[0, pool_size)`. With defaults, the pool occupies `[100000, 100000 + 1000*65536)`.

## Pod-side UX

```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    dev.gvisor.spec.user-namespace: "true"
spec:
  runtimeClassName: gvisor   # no new RuntimeClass required
  containers:
    - name: app
      image: ...
```

## Test Plan

Unit tests in `pkg/shim/v1/utils/userns_test.go`:

- `TestUserNamespaceConfigValidate` -- defaults populated, missing UID/GID base fails, uint32 overflow fails.
- `TestAllocateUserNamespaceSlotUnique` -- 5 sandboxes get 5 distinct slots.
- `TestAllocateUserNamespaceSlotIdempotent` -- same sandbox-id returns same slot.
- `TestAllocateUserNamespaceSlotPoolExhausted` -- fills pool, returns `errPoolExhausted`.
- `TestReleaseUserNamespaceSlotFreesSlot` -- release then re-allocate works; releasing unknown sandbox is a no-op.
- `TestAllocateUserNamespaceSlotConcurrent` -- 20 goroutines, 64-slot pool, no collisions.
- `TestInjectUserNamespaceMutatesSpec` -- spec gets userns + correct mappings + slot annotation.
- `TestInjectUserNamespaceRespectsCallerMappings` -- caller-supplied uid/gid mappings preserved (no-op).
- `TestInjectUserNamespaceRejectsOutOfRangeSlot` -- slot >= PoolSize fails.
- `TestHasUserNamespaceRequest` -- annotation absent / "false" / "1" / "true" / nil-spec / nil-annotations.

End-to-end validated against `kubernetes 1.35.2`, `containerd 2.2.2`, runsc release-20260520.0 by enabling `enable_user_namespace_annotation = true` on the runsc runtime, applying a pod with the opt-in annotation, and confirming that `cat /proc/self/uid_map` shows a non-zero, per-pod-unique host UID range.

## Open Questions for Maintainers

1. Is this an acceptable shape for a stopgap, or would you prefer to wait for KEP-127 / CRI feature plumbing? Happy to abandon this in favor of an upstream containerd PR that lifts the runc-only restriction in `introspectRuntimeFeatures`, plus whatever is needed gVisor-side to satisfy `supportsCRIUserns`.
2. The allocator lives in the shim. An alternative is to require operators to pre-allocate ranges in `/etc/subuid`/`/etc/subgid` and have the shim consume them. The current design is more self-contained but does its own bookkeeping. Would maintainers prefer the subuid path?
3. Naming conventions: `dev.gvisor.spec.user-namespace` (matches the existing `dev.gvisor.spec.mount.{name}` pattern) and `enable_user_namespace_annotation` (snake_case to match other shim TOML options). Alternatives welcome.

Happy to iterate or split into smaller commits.
