### PR TITLE
[WIP] Honor `type: overlay` in OCI mount entries

### DIFF
--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -430,6 +430,19 @@ type containerMounter struct {
 	// rootfsUpperTarFD is the file descriptor to the tar file containing the rootfs
 	// upper layer changes.
 	rootfsUpperTarFD *fd.FD
+
+	// overlayLayers holds the disconnected per-layer Mounts for each
+	// OCI overlay entry, keyed by the entry's destination. Layers are
+	// added as the per-layer bind mounts are processed and drained
+	// when the corresponding overlay placeholder is mounted.
+	overlayLayers map[string]*pendingOverlay
+}
+
+// pendingOverlay holds the disconnected per-layer Mounts of a single
+// OCI overlay entry until they are composed into an overlay mount.
+type pendingOverlay struct {
+	lowers []*vfs.Mount
+	upper  *vfs.Mount
 }
 
 // +checklocks:l.mu
@@ -446,6 +459,7 @@ func (l *Loader) newContainerMounter(info *containerInfo) *containerMounter {
 		containerID:       info.cid,
 		containerName:     info.containerName,
 		rootfsUpperTarFD:  info.rootfsUpperTarFD,
+		overlayLayers:     make(map[string]*pendingOverlay),
 	}
 }
 
@@ -773,8 +787,25 @@ func (c *containerMounter) mountSubmounts(ctx context.Context, spec *specs.Spec,
 		return err
 	}
 
+	// Process per-layer overlay binds first so that placeholder
+	// overlay mounts always find their layers, regardless of the
+	// destination-length ordering applied in prepareMounts.
 	for i := range mounts {
 		submount := &mounts[i]
+		parent := specutils.OverlayParentFromOptions(submount.mount.Options)
+		if parent == "" {
+			continue
+		}
+		if err := c.collectOverlayLayer(ctx, spec, conf, creds, submount, parent); err != nil {
+			return fmt.Errorf("collect overlay layer %q: %w", submount.mount.Source, err)
+		}
+	}
+
+	for i := range mounts {
+		submount := &mounts[i]
+		if specutils.OverlayParentFromOptions(submount.mount.Options) != "" {
+			continue
+		}
 		log.Debugf("Mounting %q to %q, type: %s, options: %s", submount.mount.Source, submount.mount.Destination, submount.mount.Type, submount.mount.Options)
 		var (
 			mnt *vfs.Mount
@@ -794,6 +825,11 @@ func (c *containerMounter) mountSubmounts(ctx context.Context, spec *specs.Spec,
 			// Mount all the cgroups controllers.
 			if err := c.mountCgroupSubmounts(ctx, spec, conf, mns, creds, submount); err != nil {
 				return fmt.Errorf("mount cgroup %q: %w", submount.mount.Destination, err)
+			}
+		} else if specutils.IsOverlayComposed(submount.mount.Options) {
+			mnt, err = c.mountComposedOverlay(ctx, conf, creds, mns, submount)
+			if err != nil {
+				return fmt.Errorf("mount submount %q: %w", submount.mount.Destination, err)
 			}
 		} else {
 			mnt, err = c.mountSubmount(ctx, spec, conf, mns, creds, submount)
@@ -948,6 +984,134 @@ func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, 
 
 	log.Infof("Mounted %q to %q type: %s, internal-options: %q",
 		mount.Source, mount.Destination, mount.Type, opts.GetFilesystemOptions.Data)
+	return mnt, nil
+}
+
+// collectOverlayLayer materializes a per-layer bind mount as a
+// disconnected gofer-served Mount and records it under the parent
+// overlay's destination. The mount is not attached to the workload's
+// namespace; mountComposedOverlay consumes it later.
+func (c *containerMounter) collectOverlayLayer(ctx context.Context, spec *specs.Spec, conf *config.Config, creds *auth.Credentials, submount *mountInfo, parent string) error {
+	role := specutils.OverlayRoleFromOptions(submount.mount.Options)
+	if role != specutils.GvisorOverlayLowerRole && role != specutils.GvisorOverlayUpperRole {
+		return fmt.Errorf("overlay layer %q (parent %q) has invalid %s value %q", submount.mount.Source, parent, specutils.GvisorOverlayRoleOpt, role)
+	}
+	pending := c.overlayLayers[parent]
+	if pending == nil {
+		pending = &pendingOverlay{}
+		c.overlayLayers[parent] = pending
+	}
+	if role == specutils.GvisorOverlayUpperRole && pending.upper != nil {
+		return fmt.Errorf("overlay at %q: multiple upper layers declared", parent)
+	}
+	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore)
+	if err != nil {
+		return fmt.Errorf("mountOptions for overlay layer %q (parent %q): %w", submount.mount.Source, parent, err)
+	}
+	if len(fsName) == 0 {
+		return fmt.Errorf("overlay layer %q (parent %q) has unsupported filesystem type %q", submount.mount.Source, parent, submount.mount.Type)
+	}
+	mnt, err := c.l.k.VFS().MountDisconnected(ctx, creds, "", fsName, opts)
+	if err != nil {
+		return fmt.Errorf("disconnected mount for overlay layer %q (parent %q): %w", submount.mount.Source, parent, err)
+	}
+	// The Mount's reference is owned by overlayLayers until
+	// mountComposedOverlay consumes it.
+	if role == specutils.GvisorOverlayLowerRole {
+		pending.lowers = append(pending.lowers, mnt)
+	} else {
+		pending.upper = mnt
+	}
+	log.Debugf("Collected overlay layer at %q for parent %q (role=%s)", submount.mount.Source, parent, role)
+	return nil
+}
+
+// mountComposedOverlay assembles the per-layer Mounts collected for
+// submount.mount.Destination into an overlay mount and attaches it at
+// the destination. If no upper layer was declared the upper is an
+// in-sentry tmpfs, giving an ephemeral writable view; otherwise the
+// upper is the gofer-served Mount the OCI spec requested.
+func (c *containerMounter) mountComposedOverlay(ctx context.Context, conf *config.Config, creds *auth.Credentials, mns *vfs.MountNamespace, submount *mountInfo) (*vfs.Mount, error) {
+	dst := submount.mount.Destination
+	pending, ok := c.overlayLayers[dst]
+	if !ok {
+		return nil, fmt.Errorf("composed overlay at %q has no collected layers", dst)
+	}
+	delete(c.overlayLayers, dst)
+	if len(pending.lowers) == 0 {
+		return nil, fmt.Errorf("composed overlay at %q has no lower layers", dst)
+	}
+
+	// Build FilesystemOptions from the collected layers. With no
+	// declared upper, mount an in-sentry tmpfs to serve as the
+	// writable upper layer.
+	overlayOpts := overlay.FilesystemOptions{}
+	for _, lower := range pending.lowers {
+		overlayOpts.LowerRoots = append(overlayOpts.LowerRoots, vfs.MakeVirtualDentry(lower, lower.Root()))
+	}
+	var upper *vfs.Mount
+	if pending.upper != nil {
+		upper = pending.upper
+	} else {
+		tmpfsOpts := &vfs.MountOptions{
+			GetFilesystemOptions: vfs.GetFilesystemOptions{InternalMount: true},
+		}
+		var err error
+		upper, err = c.l.k.VFS().MountDisconnected(ctx, creds, "", tmpfs.Name, tmpfsOpts)
+		if err != nil {
+			for _, l := range pending.lowers {
+				l.DecRef(ctx)
+			}
+			return nil, fmt.Errorf("composing overlay at %q: tmpfs upper: %w", dst, err)
+		}
+	}
+	overlayOpts.UpperRoot = vfs.MakeVirtualDentry(upper, upper.Root())
+
+	mountOpts := &vfs.MountOptions{
+		GetFilesystemOptions: vfs.GetFilesystemOptions{
+			InternalMount: true,
+			InternalData:  overlayOpts,
+		},
+	}
+
+	mnt, err := c.l.k.VFS().MountDisconnected(ctx, creds, "", overlay.Name, mountOpts)
+	// overlay.GetFilesystem takes its own references on LowerRoots and
+	// UpperRoot; drop the per-layer Mount references regardless of
+	// success.
+	for _, l := range pending.lowers {
+		l.DecRef(ctx)
+	}
+	upper.DecRef(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("composing overlay at %q: %w", dst, err)
+	}
+	defer mnt.DecRef(ctx)
+
+	root := mns.Root(ctx)
+	defer root.DecRef(ctx)
+	target := &vfs.PathOperation{
+		Root:               root,
+		Start:              root,
+		Path:               fspath.Parse(dst),
+		FollowFinalSymlink: true,
+	}
+	vd := vfs.MakeVirtualDentry(mnt, mnt.Root())
+	rootPath := &vfs.PathOperation{Root: vd, Start: vd}
+	rootMode, err := c.getPathMode(ctx, creds, rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("composed overlay at %q: stat root: %w", dst, err)
+	}
+	if err := c.makeMountPoint(ctx, creds, mns, dst, rootMode); err != nil {
+		return nil, fmt.Errorf("composed overlay at %q: mountpoint: %w", dst, err)
+	}
+	if err := c.l.k.VFS().ConnectMountAt(ctx, creds, mnt, target); err != nil {
+		return nil, fmt.Errorf("composed overlay at %q: attach: %w", dst, err)
+	}
+	upperKind := "gofer"
+	if pending.upper == nil {
+		upperKind = "tmpfs(ephemeral)"
+	}
+	log.Infof("Mounted composed overlay at %q (lowers=%d, upper=%s)", dst, len(pending.lowers), upperKind)
 	return mnt, nil
 }
 

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1103,6 +1103,13 @@ func (c *Container) initGoferConfs(ovlConf config.Overlay2, mountHints *boot.Pod
 		if specutils.IsReadonlyMount(c.Spec.Mounts[i].Options) {
 			overlayMedium = config.NoOverlay
 		}
+		// Per-layer bind mounts of an OCI overlay are gofer-served like
+		// any other bind, but must not be wrapped in their own overlayfs
+		// — they are layered together by the mount composer.
+		if specutils.OverlayParentFromOptions(c.Spec.Mounts[i].Options) != "" {
+			overlayMedium = config.NoOverlay
+			overlaySize = ""
+		}
 		if hint := mountHints.FindMount(c.Spec.Mounts[i].Source); hint != nil && hint.IsSandboxLocal() {
 			// Note that we want overlayMedium=self even if this is a read-only mount so that
 			// the shared mount is created correctly. Future containers may mount this writably.

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -170,6 +170,9 @@ func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
 			return err
 		}
 	}
+	if err := NormalizeOverlayMounts(spec); err != nil {
+		return err
+	}
 	for _, m := range spec.Mounts {
 		if err := validateMount(&m); err != nil {
 			return err
@@ -564,6 +567,176 @@ func MaybeConvertToBindMount(m *specs.Mount) {
 			return
 		}
 	}
+}
+
+// Synthetic mount options that link the per-layer bind mounts a
+// `type: overlay` entry is decomposed into back to the overlay
+// placeholder they belong to.
+const (
+	// GvisorOverlayParentOpt prefixes the destination of the overlay
+	// mount this layer is part of.
+	GvisorOverlayParentOpt = "x-gvisor-overlay-parent="
+
+	// GvisorOverlayRoleOpt prefixes the layer's role within the
+	// parent overlay (GvisorOverlayLowerRole or GvisorOverlayUpperRole).
+	GvisorOverlayRoleOpt = "x-gvisor-overlay-role="
+
+	// GvisorOverlayLowerRole identifies a lower layer.
+	GvisorOverlayLowerRole = "lower"
+
+	// GvisorOverlayUpperRole identifies the upper (writable) layer.
+	GvisorOverlayUpperRole = "upper"
+
+	// GvisorOverlayComposedOpt marks the placeholder mount whose
+	// destination is the OCI overlay's destination. The mount composer
+	// treats it as the signal to assemble the previously-collected
+	// layers into a single overlay.
+	GvisorOverlayComposedOpt = "x-gvisor-overlay-composed"
+
+	// gvisorOverlayLayerDestPrefix is the destination path used for
+	// synthetic per-layer bind mounts. The path never appears in the
+	// workload's view; the prefix exists because validateMount
+	// requires an absolute destination string.
+	gvisorOverlayLayerDestPrefix = "/.gvisor-overlay-layer/"
+)
+
+// NormalizeOverlayMounts rewrites each `type: overlay` entry in
+// spec.Mounts into a sequence of synthetic per-layer bind mounts
+// followed by an overlay placeholder. The mount composer in
+// runsc/boot/vfs.go reads the binds as disconnected gofer-served
+// Mounts and then assembles them into a single overlay at the
+// placeholder's destination.
+//
+// For an input mount of the form
+//
+//	{destination: D, type: overlay,
+//	 options: ["lowerdir=A:B:...", "upperdir=U", "workdir=W"]}
+//
+// the normalized output is one bind mount per lowerdir entry (each
+// tagged with GvisorOverlayParentOpt=D and
+// GvisorOverlayRoleOpt=lower), an optional bind mount for upperdir
+// (tagged GvisorOverlayRoleOpt=upper), and a placeholder
+// {destination: D, type: overlay} tagged with
+// GvisorOverlayComposedOpt. The workdir option is parsed for
+// compatibility with kernel overlayfs syntax and discarded; gVisor's
+// overlay implementation manages its own scratch state.
+//
+// When upperdir is omitted the placeholder is composed with an
+// in-sentry tmpfs upper layer, giving an ephemeral writable view that
+// is preserved across checkpoint/restore and discarded on container
+// teardown.
+//
+// Synthetic binds intentionally omit the "ro" option: lower layers
+// are made immutable through overlay.FilesystemOptions.LowerRoots
+// rather than through mount-flag propagation, and a "ro" flag on the
+// bind would interact poorly with the upper layer's writability.
+func NormalizeOverlayMounts(spec *specs.Spec) error {
+	if len(spec.Mounts) == 0 {
+		return nil
+	}
+	var expanded []specs.Mount
+	var layerCounter int
+	for i := range spec.Mounts {
+		m := &spec.Mounts[i]
+		if m.Type != "overlay" {
+			expanded = append(expanded, *m)
+			continue
+		}
+		var lowerDirs []string
+		var upperDir string
+		var keep []string
+		for _, o := range m.Options {
+			switch {
+			case strings.HasPrefix(o, "lowerdir="):
+				for _, d := range strings.Split(strings.TrimPrefix(o, "lowerdir="), ":") {
+					if d != "" {
+						lowerDirs = append(lowerDirs, d)
+					}
+				}
+			case strings.HasPrefix(o, "upperdir="):
+				upperDir = strings.TrimPrefix(o, "upperdir=")
+			case strings.HasPrefix(o, "workdir="):
+				// Compatible-parsed and discarded; gVisor's overlay
+				// manages scratch state internally.
+			default:
+				keep = append(keep, o)
+			}
+		}
+		if len(lowerDirs) == 0 {
+			return fmt.Errorf("overlay mount at %q: missing lowerdir= option", m.Destination)
+		}
+		parentDest := m.Destination
+		for _, lower := range lowerDirs {
+			expanded = append(expanded, specs.Mount{
+				Destination: fmt.Sprintf("%s%d", gvisorOverlayLayerDestPrefix, layerCounter),
+				Type:        "bind",
+				Source:      lower,
+				Options: []string{
+					"bind",
+					GvisorOverlayParentOpt + parentDest,
+					GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+				},
+			})
+			layerCounter++
+		}
+		if upperDir != "" {
+			expanded = append(expanded, specs.Mount{
+				Destination: fmt.Sprintf("%s%d", gvisorOverlayLayerDestPrefix, layerCounter),
+				Type:        "bind",
+				Source:      upperDir,
+				Options: []string{
+					"bind",
+					GvisorOverlayParentOpt + parentDest,
+					GvisorOverlayRoleOpt + GvisorOverlayUpperRole,
+				},
+			})
+			layerCounter++
+		}
+		expanded = append(expanded, specs.Mount{
+			Destination: parentDest,
+			Type:        "overlay",
+			Source:      m.Source,
+			Options:     append(keep, GvisorOverlayComposedOpt),
+		})
+	}
+	spec.Mounts = expanded
+	return nil
+}
+
+// OverlayParentFromOptions returns the destination of the parent
+// overlay mount that opts belongs to, or "" if opts is not a
+// NormalizeOverlayMounts-emitted synthetic bind.
+func OverlayParentFromOptions(opts []string) string {
+	for _, o := range opts {
+		if strings.HasPrefix(o, GvisorOverlayParentOpt) {
+			return strings.TrimPrefix(o, GvisorOverlayParentOpt)
+		}
+	}
+	return ""
+}
+
+// OverlayRoleFromOptions returns the layer role (GvisorOverlayLowerRole
+// or GvisorOverlayUpperRole) of a synthetic bind emitted by
+// NormalizeOverlayMounts, or "" if opts has none.
+func OverlayRoleFromOptions(opts []string) string {
+	for _, o := range opts {
+		if strings.HasPrefix(o, GvisorOverlayRoleOpt) {
+			return strings.TrimPrefix(o, GvisorOverlayRoleOpt)
+		}
+	}
+	return ""
+}
+
+// IsOverlayComposed reports whether opts contains GvisorOverlayComposedOpt,
+// i.e. whether this mount is the placeholder a `type: overlay` entry
+// was rewritten to by NormalizeOverlayMounts.
+func IsOverlayComposed(opts []string) bool {
+	for _, o := range opts {
+		if o == GvisorOverlayComposedOpt {
+			return true
+		}
+	}
+	return false
 }
 
 // WaitForReady waits for a process to become ready. The process is ready when

--- a/runsc/specutils/specutils_test.go
+++ b/runsc/specutils/specutils_test.go
@@ -17,6 +17,7 @@ package specutils
 import (
 	"fmt"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -752,5 +753,340 @@ func TestContainerName(t *testing.T) {
 				t.Errorf("ContainerName() got: %v, want: %v", got, tc.want)
 			}
 		})
+	}
+}
+func TestNormalizeOverlayMounts(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		in        []specs.Mount
+		want      []specs.Mount
+		wantError string
+	}{
+		{
+			name: "no overlay entries are unchanged",
+			in: []specs.Mount{
+				{Destination: "/proc", Type: "proc", Source: "proc"},
+				{Destination: "/data", Type: "bind", Source: "/host/data", Options: []string{"bind"}},
+			},
+			want: []specs.Mount{
+				{Destination: "/proc", Type: "proc", Source: "proc"},
+				{Destination: "/data", Type: "bind", Source: "/host/data", Options: []string{"bind"}},
+			},
+		},
+		{
+			name: "single lower no upper",
+			in: []specs.Mount{
+				{
+					Destination: "/var/log",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{"lowerdir=/host/lower"},
+				},
+			},
+			want: []specs.Mount{
+				{
+					Destination: "/.gvisor-overlay-layer/0",
+					Type:        "bind",
+					Source:      "/host/lower",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/var/log",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/var/log",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{GvisorOverlayComposedOpt},
+				},
+			},
+		},
+		{
+			name: "single lower with upper and workdir",
+			in: []specs.Mount{
+				{
+					Destination: "/var/log",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options: []string{
+						"lowerdir=/host/lower",
+						"upperdir=/host/upper",
+						"workdir=/host/work",
+					},
+				},
+			},
+			want: []specs.Mount{
+				{
+					Destination: "/.gvisor-overlay-layer/0",
+					Type:        "bind",
+					Source:      "/host/lower",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/var/log",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/.gvisor-overlay-layer/1",
+					Type:        "bind",
+					Source:      "/host/upper",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/var/log",
+						GvisorOverlayRoleOpt + GvisorOverlayUpperRole,
+					},
+				},
+				{
+					Destination: "/var/log",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{GvisorOverlayComposedOpt},
+				},
+			},
+		},
+		{
+			name: "multi-lowerdir is split on colons",
+			in: []specs.Mount{
+				{
+					Destination: "/stack",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{"lowerdir=/host/a:/host/b:/host/c"},
+				},
+			},
+			want: []specs.Mount{
+				{
+					Destination: "/.gvisor-overlay-layer/0",
+					Type:        "bind",
+					Source:      "/host/a",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/stack",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/.gvisor-overlay-layer/1",
+					Type:        "bind",
+					Source:      "/host/b",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/stack",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/.gvisor-overlay-layer/2",
+					Type:        "bind",
+					Source:      "/host/c",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/stack",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/stack",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{GvisorOverlayComposedOpt},
+				},
+			},
+		},
+		{
+			name: "non-layer options are preserved on the placeholder",
+			in: []specs.Mount{
+				{
+					Destination: "/x",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options: []string{
+						"lowerdir=/host/l",
+						"nosuid",
+						"nodev",
+					},
+				},
+			},
+			want: []specs.Mount{
+				{
+					Destination: "/.gvisor-overlay-layer/0",
+					Type:        "bind",
+					Source:      "/host/l",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/x",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/x",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{"nosuid", "nodev", GvisorOverlayComposedOpt},
+				},
+			},
+		},
+		{
+			name: "layer counter does not reset between overlay entries",
+			in: []specs.Mount{
+				{
+					Destination: "/first",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{"lowerdir=/host/l1"},
+				},
+				{
+					Destination: "/second",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{"lowerdir=/host/l2"},
+				},
+			},
+			want: []specs.Mount{
+				{
+					Destination: "/.gvisor-overlay-layer/0",
+					Type:        "bind",
+					Source:      "/host/l1",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/first",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/first",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{GvisorOverlayComposedOpt},
+				},
+				{
+					Destination: "/.gvisor-overlay-layer/1",
+					Type:        "bind",
+					Source:      "/host/l2",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/second",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/second",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{GvisorOverlayComposedOpt},
+				},
+			},
+		},
+		{
+			name: "missing lowerdir is rejected",
+			in: []specs.Mount{
+				{
+					Destination: "/x",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{"upperdir=/host/upper"},
+				},
+			},
+			wantError: "missing lowerdir",
+		},
+		{
+			name: "empty lowerdir entries are dropped before counting",
+			in: []specs.Mount{
+				{
+					Destination: "/x",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{"lowerdir=:/host/l::"},
+				},
+			},
+			want: []specs.Mount{
+				{
+					Destination: "/.gvisor-overlay-layer/0",
+					Type:        "bind",
+					Source:      "/host/l",
+					Options: []string{
+						"bind",
+						GvisorOverlayParentOpt + "/x",
+						GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+					},
+				},
+				{
+					Destination: "/x",
+					Type:        "overlay",
+					Source:      "overlay",
+					Options:     []string{GvisorOverlayComposedOpt},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &specs.Spec{Mounts: append([]specs.Mount(nil), tc.in...)}
+			err := NormalizeOverlayMounts(spec)
+			if tc.wantError != "" {
+				if err == nil {
+					t.Fatalf("NormalizeOverlayMounts returned nil error, want one containing %q", tc.wantError)
+				}
+				if !strings.Contains(err.Error(), tc.wantError) {
+					t.Fatalf("NormalizeOverlayMounts error = %q, want one containing %q", err.Error(), tc.wantError)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeOverlayMounts returned unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(spec.Mounts, tc.want) {
+				t.Errorf("NormalizeOverlayMounts spec.Mounts mismatch\ngot:  %#v\nwant: %#v", spec.Mounts, tc.want)
+			}
+		})
+	}
+}
+
+func TestOverlayOptionAccessors(t *testing.T) {
+	const dest = "/var/log"
+	upper := []string{
+		"bind",
+		GvisorOverlayParentOpt + dest,
+		GvisorOverlayRoleOpt + GvisorOverlayUpperRole,
+	}
+	lower := []string{
+		"bind",
+		GvisorOverlayParentOpt + dest,
+		GvisorOverlayRoleOpt + GvisorOverlayLowerRole,
+	}
+	composed := []string{GvisorOverlayComposedOpt}
+	plain := []string{"bind", "ro"}
+
+	if got := OverlayParentFromOptions(upper); got != dest {
+		t.Errorf("OverlayParentFromOptions(upper) = %q, want %q", got, dest)
+	}
+	if got := OverlayParentFromOptions(lower); got != dest {
+		t.Errorf("OverlayParentFromOptions(lower) = %q, want %q", got, dest)
+	}
+	if got := OverlayParentFromOptions(plain); got != "" {
+		t.Errorf("OverlayParentFromOptions(plain) = %q, want %q", got, "")
+	}
+	if got := OverlayParentFromOptions(composed); got != "" {
+		t.Errorf("OverlayParentFromOptions(composed) = %q, want %q", got, "")
+	}
+
+	if got := OverlayRoleFromOptions(upper); got != GvisorOverlayUpperRole {
+		t.Errorf("OverlayRoleFromOptions(upper) = %q, want %q", got, GvisorOverlayUpperRole)
+	}
+	if got := OverlayRoleFromOptions(lower); got != GvisorOverlayLowerRole {
+		t.Errorf("OverlayRoleFromOptions(lower) = %q, want %q", got, GvisorOverlayLowerRole)
+	}
+	if got := OverlayRoleFromOptions(plain); got != "" {
+		t.Errorf("OverlayRoleFromOptions(plain) = %q, want %q", got, "")
+	}
+
+	if !IsOverlayComposed(composed) {
+		t.Errorf("IsOverlayComposed(composed) = false, want true")
+	}
+	if IsOverlayComposed(upper) {
+		t.Errorf("IsOverlayComposed(upper) = true, want false")
+	}
+	if IsOverlayComposed(plain) {
+		t.Errorf("IsOverlayComposed(plain) = true, want false")
 	}
 }


### PR DESCRIPTION
runsc currently dispatches OCI mount entries on m.Type in getMountNameAndOptions and silently drops anything outside its switch. `type: overlay` falls into the default branch, logs `ignoring unknown filesystem type "overlay"`, and the mount has no effect.

Decompose each `type: overlay` entry, during ValidateSpec, into one synthetic bind mount per `lowerdir=` path (split on `:`), an optional synthetic bind for `upperdir=`, and a placeholder mount at the original destination. The synthetic binds are tagged with marker options that identify the parent overlay's destination and the layer's role (lower or upper); the placeholder carries a third marker identifying it as the composed overlay.

In the boot path, the mount composer in runsc/boot/vfs.go runs a pre-pass that materializes each per-layer bind as a disconnected gofer-served Mount (skipping its attachment to the workload namespace) and records it under the parent overlay's destination. prepareMounts sorts mounts by destination length, so without the pre-pass the placeholder would be processed before its layers. The composer then mounts an overlay at each placeholder's destination using the collected layers as overlay.FilesystemOptions.LowerRoots and UpperRoot.

When `upperdir=` is omitted, the placeholder is composed with an in-sentry tmpfs upper, giving an ephemeral writable view that is preserved across checkpoint/restore and discarded on container teardown. When `upperdir=` is supplied, the upper is a gofer-served Mount and writes persist to the host directory. Multi-lowerdir (`lowerdir=A:B:C`) stacks the lowers in declared order. The `workdir=` option is parsed for compatibility with the kernel overlayfs syntax and discarded; the gVisor overlay implementation manages its own scratch state.

Verified by mounting three OCI overlay entries in a single container: single-lower with no upper, single-lower with a host upperdir, and two-lower stacked. /proc/self/mountinfo reports `/destination rw - overlay none rw` for each. Reads of files unique to one lower resolve to that lower; reads of files present in multiple lowers resolve to the topmost. Writes go to the configured upper (in-sentry tmpfs for the first and third entries, the host upperdir for the second); host lowerdirs are not modified. A runsc checkpoint + restore cycle preserves the tmpfs upper layer's contents.

Refs [#4768](https://github.com/google/gvisor/issues/4768)

Assisted-by: Claude Code