### PR TITLE
runsc: skip no-op CDI disable-device-node-modification hook under nvproxy

### DIFF
--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -206,19 +206,25 @@ func SetupRootFS(spec *specs.Spec, conf *config.Config, mountConfs []specutils.G
 
 	if rootfsConf.ShouldUseLisafs() {
 		if spec.Hooks != nil && len(spec.Hooks.CreateContainer) > 0 {
-			state := specs.State{
-				Version: specs.Version,
-				ID:      containerID,
-				Status:  specs.StateCreating,
-				// The sandbox pid is not easily available at this point. We'll set
-				// it to -1 for now. A future improvement could plumb this value
-				// through to the gofer if it becomes necessary.
-				Pid:         -1,
-				Bundle:      bundleDir,
-				Annotations: spec.Annotations,
+			hooks := spec.Hooks.CreateContainer
+			if specutils.NVProxyEnabled(spec, conf) {
+				hooks = filterNVProxyNoOpHooks(hooks)
 			}
-			if err := specutils.ExecuteHooks(spec.Hooks.CreateContainer, state); err != nil {
-				util.Fatalf("error executing CreateContainer hooks: %v", err)
+			if len(hooks) > 0 {
+				state := specs.State{
+					Version: specs.Version,
+					ID:      containerID,
+					Status:  specs.StateCreating,
+					// The sandbox pid is not easily available at this point. We'll set
+					// it to -1 for now. A future improvement could plumb this value
+					// through to the gofer if it becomes necessary.
+					Pid:         -1,
+					Bundle:      bundleDir,
+					Annotations: spec.Annotations,
+				}
+				if err := specutils.ExecuteHooks(hooks, state); err != nil {
+					util.Fatalf("error executing CreateContainer hooks: %v", err)
+				}
 			}
 		}
 
@@ -367,6 +373,55 @@ func SetupMounts(conf *config.Config, mounts []specs.Mount, root, procPath strin
 		}
 	}
 	return nil
+}
+
+// isNvidiaDisableDeviceNodeModificationHook reports whether h is the NVIDIA
+// CDI createContainer hook "nvidia-ctk hook disable-device-node-modification",
+// emitted by NVIDIA's k8s-device-plugin and `nvidia-ctk cdi generate`.
+//
+// The hook bind-mounts a modified /proc/driver/nvidia/params (with
+// ModifyDeviceFiles set to 0) over the container's procfs so that in-container
+// libnvidia-ml does not try to recreate /dev/nvidiaN device nodes. Under
+// nvproxy, this hook is a no-op for two reasons:
+//
+//  1. nvproxy mediates all NVIDIA device access and the sentry owns /dev, so
+//     in-container libnvidia-ml cannot create new device files regardless of
+//     what /proc/driver/nvidia/params says.
+//  2. gVisor already exposes /proc/driver/nvidia/params inside the sandbox
+//     with ModifyDeviceFiles forced to 0; see
+//     pkg/sentry/devices/nvproxy/nvproxy.go's procDriverNvidiaParams setup,
+//     which is consistent with libnvidia-container's
+//     src/nvc_mount.c:mount_procfs().
+//
+// In addition, executing this hook is fatal during sandbox setup: the hook
+// opens <containerRootFs>/proc/driver/nvidia/params, but procfs is not
+// mounted into containerRootFs at hook time (the sentry serves /proc
+// itself later), so the open(2) fails with ENOENT and aborts container
+// creation.
+func isNvidiaDisableDeviceNodeModificationHook(h specs.Hook) bool {
+	if !strings.HasSuffix(h.Path, "nvidia-ctk") {
+		return false
+	}
+	// nvidia-ctk hook disable-device-node-modification [...]
+	return len(h.Args) >= 3 && h.Args[1] == "hook" && h.Args[2] == "disable-device-node-modification"
+}
+
+// filterNVProxyNoOpHooks returns hooks with any CDI createContainer hooks
+// that are no-ops under nvproxy removed. Currently this matches only
+// "nvidia-ctk hook disable-device-node-modification"; see
+// isNvidiaDisableDeviceNodeModificationHook for the rationale.
+//
+// Caller must ensure nvproxy is enabled before invoking this.
+func filterNVProxyNoOpHooks(hooks []specs.Hook) []specs.Hook {
+	out := make([]specs.Hook, 0, len(hooks))
+	for _, h := range hooks {
+		if isNvidiaDisableDeviceNodeModificationHook(h) {
+			log.Infof("Skipping CDI createContainer hook %v under nvproxy: no-op (sentry forces ModifyDeviceFiles=0 in /proc/driver/nvidia/params)", h.Args)
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
 }
 
 // ShouldExposeNvidiaDevice returns true if path refers to an Nvidia device

--- a/runsc/cmd/sandboxsetup/gofer_mount_test.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount_test.go
@@ -15,7 +15,10 @@
 package sandboxsetup
 
 import (
+	"reflect"
 	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func TestShouldExposeNvidiaDevice(t *testing.T) {
@@ -62,6 +65,105 @@ func TestShouldExposeVFIODevice(t *testing.T) {
 			got := ShouldExposeVFIODevice(tst.path)
 			if got != tst.want {
 				t.Errorf("ShouldExposeVFIODevice(%q) = %v, want %v", tst.path, got, tst.want)
+			}
+		})
+	}
+}
+
+func TestIsNvidiaDisableDeviceNodeModificationHook(t *testing.T) {
+	tests := []struct {
+		name string
+		hook specs.Hook
+		want bool
+	}{
+		{
+			name: "match: absolute nvidia-ctk path",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "disable-device-node-modification"}},
+			want: true,
+		},
+		{
+			name: "match: bare nvidia-ctk path",
+			hook: specs.Hook{Path: "nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "disable-device-node-modification"}},
+			want: true,
+		},
+		{
+			name: "match: extra args after subcommand",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "disable-device-node-modification", "--container-spec", "/some/path"}},
+			want: true,
+		},
+		{
+			name: "no match: different subcommand",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "create-symlinks"}},
+			want: false,
+		},
+		{
+			name: "no match: enable-cuda-compat",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "enable-cuda-compat"}},
+			want: false,
+		},
+		{
+			name: "no match: not nvidia-ctk",
+			hook: specs.Hook{Path: "/usr/bin/some-other-hook", Args: []string{"some-other-hook", "hook", "disable-device-node-modification"}},
+			want: false,
+		},
+		{
+			name: "no match: args too short",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook"}},
+			want: false,
+		},
+		{
+			name: "no match: no args",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk"},
+			want: false,
+		},
+		{
+			name: "no match: middle arg is not 'hook'",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "cdi", "disable-device-node-modification"}},
+			want: false,
+		},
+		{
+			// Locks the suffix semantics: nvidia-ctk-foo does not end in
+			// "nvidia-ctk", so it is not matched.
+			name: "no match: path with nvidia-ctk prefix but extra suffix",
+			hook: specs.Hook{Path: "/usr/bin/nvidia-ctk-foo", Args: []string{"nvidia-ctk-foo", "hook", "disable-device-node-modification"}},
+			want: false,
+		},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got := isNvidiaDisableDeviceNodeModificationHook(tst.hook)
+			if got != tst.want {
+				t.Errorf("isNvidiaDisableDeviceNodeModificationHook(%+v) = %v, want %v", tst.hook, got, tst.want)
+			}
+		})
+	}
+}
+
+func TestFilterNVProxyNoOpHooks(t *testing.T) {
+	create := specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "create-symlinks", "--link", "libcuda.so.1::/usr/lib/x86_64-linux-gnu/libcuda.so"}}
+	cuda := specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "enable-cuda-compat", "--host-driver-version=580.159.04"}}
+	ldcache := specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "update-ldcache", "--folder", "/usr/lib/x86_64-linux-gnu"}}
+	disable := specs.Hook{Path: "/usr/bin/nvidia-ctk", Args: []string{"nvidia-ctk", "hook", "disable-device-node-modification"}}
+	other := specs.Hook{Path: "/usr/bin/some-other-hook", Args: []string{"some-other-hook"}}
+
+	tests := []struct {
+		name  string
+		hooks []specs.Hook
+		want  []specs.Hook
+	}{
+		{name: "nil", hooks: nil, want: []specs.Hook{}},
+		{name: "empty", hooks: []specs.Hook{}, want: []specs.Hook{}},
+		{name: "only the no-op hook", hooks: []specs.Hook{disable}, want: []specs.Hook{}},
+		{name: "no no-op hook", hooks: []specs.Hook{create, cuda, ldcache}, want: []specs.Hook{create, cuda, ldcache}},
+		{name: "four NVIDIA hooks, no-op last", hooks: []specs.Hook{create, cuda, ldcache, disable}, want: []specs.Hook{create, cuda, ldcache}},
+		{name: "four NVIDIA hooks, no-op first", hooks: []specs.Hook{disable, create, cuda, ldcache}, want: []specs.Hook{create, cuda, ldcache}},
+		{name: "no-op interleaved with non-nvidia", hooks: []specs.Hook{other, disable, create}, want: []specs.Hook{other, create}},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got := filterNVProxyNoOpHooks(tst.hooks)
+			if !reflect.DeepEqual(got, tst.want) {
+				t.Errorf("filterNVProxyNoOpHooks(%v) = %v, want %v", tst.hooks, got, tst.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #13283. Alternative approach to #13284, per @ayushr2's suggestion on that PR.

## What this does

NVIDIA's `k8s-device-plugin` and `nvidia-ctk cdi generate` emit a CDI `createContainer` hook `nvidia-ctk hook disable-device-node-modification` that bind-mounts a modified `/proc/driver/nvidia/params` (with `ModifyDeviceFiles=0`) over the container's procfs, so in-container `libnvidia-ml` does not try to recreate `/dev/nvidiaN` device files.

Under `nvproxy` this hook is a no-op for two reasons:

1. `nvproxy` mediates all NVIDIA device access and the sentry owns `/dev`, so in-container `libnvidia-ml` cannot create new device files regardless of what `/proc/driver/nvidia/params` says.
2. gVisor already exposes `/proc/driver/nvidia/params` inside the sandbox with `ModifyDeviceFiles` forced to 0; see [`pkg/sentry/devices/nvproxy/nvproxy.go`](https://github.com/google/gvisor/blob/cd64409bb9b0ccaaccb46d47ff01ab3f98dd12a0/pkg/sentry/devices/nvproxy/nvproxy.go#L82-L84), consistent with `libnvidia-container`'s `src/nvc_mount.c:mount_procfs()`.

In addition, executing the hook is currently fatal during sandbox setup because the hook opens `<containerRootFs>/proc/driver/nvidia/params`, but procfs is not mounted into containerRootFs at hook time (the sentry serves `/proc` itself later), so the `open(2)` fails with `ENOENT` and aborts container creation:

```
hooks.go:63] Executing hook nvidia-ctk hook disable-device-node-modification
util.go:107] FATAL ERROR: error executing CreateContainer hooks
stderr: failed to mount modified params file: open o_path procfd:
  open /run/containerd/.../rootfs/proc/driver/nvidia/params:
  no such file or directory
```

This change filters that hook out of `spec.Hooks.CreateContainer` before invoking `specutils.ExecuteHooks`, when `nvproxy` is enabled. The filter is targeted at the specific argv shape (`nvidia-ctk hook disable-device-node-modification`) and is a no-op for any other hook.

## Sequence

```
gofer setup (containerRootFs)
  SetupMounts          → libcuda / library bind-mounts
  SetupDev             → /dev/nvidia* cdevs
  ExecuteHooks         ← NEW: drop disable-device-node-modification before calling
                          ExecuteHooks; the other three NVIDIA hooks
                          (create-symlinks, enable-cuda-compat, update-ldcache)
                          continue to execute
bind-mount containerRootFs → goferRootFs (existing behavior)
pivot_root into goferRootFs
sentry boots; serves its own /proc with ModifyDeviceFiles=0
```

## Why this instead of #13284

@ayushr2 pointed out on #13284 that the hook's only semantic effect is something `nvproxy` already does. Skipping is therefore functionally equivalent to making the hook succeed (as #13284 does by bind-mounting host `/proc/driver/nvidia` into containerRootFs), and is simpler:

| Aspect | #13284 (bind-mount) | This PR (skip) |
| --- | --- | --- |
| Container surface | Adds a read-only bind mount of host `/proc/driver/nvidia` into per-container rootfs (sentry then shadows `/proc` again, so the hook's write is overwritten anyway) | None added |
| Code | New `SetupNvidiaProcDriver` + `os.MkdirAll` + bind mount + EROFS handling | Single filter function next to `ExecuteHooks` |
| Behavior on EROFS rootfs | Fatal on `MkdirAll` | Unchanged from today |
| Generalization | Generalizes to any future hook that wants procfs at hook time | Targeted; address future cases when they arise |

## Tests

* `TestIsNvidiaDisableDeviceNodeModificationHook` covers the predicate (matches the specific `nvidia-ctk hook disable-device-node-modification` argv shape, rejects other subcommands, other binaries, short argv, and `nvidia-ctk`-prefix-but-not-suffix paths).
* `TestFilterNVProxyNoOpHooks` covers the filter behavior (nil/empty input, only-no-op input, no no-op present, no-op in various positions, interleaved with non-NVIDIA hooks).
* The integration call site is `SetupRootFS`'s existing `if rootfsConf.ShouldUseLisafs()` block where it already calls `specutils.ExecuteHooks`; the filter is applied right before that call, gated on `specutils.NVProxyEnabled(spec, conf)`. The other GPU integration tests exercise the same path and continue to apply.

## Verified end-to-end

Tested on a Tesla T4 host (Ubuntu 24.04, kernel 6.17, containerd 2.2.2, kubelet 1.35, `k8s-device-plugin` v0.17.0 in `DEVICE_LIST_STRATEGY=cdi-cri`, `runsc release-20260520.0` with this change applied as a one-off patch to a sandbox node). Before this change, the gofer log shows the `FATAL ERROR` above. With this change applied, the gofer logs three successful hook executions (`create-symlinks`, `enable-cuda-compat`, `update-ldcache`) and skips `disable-device-node-modification`, the sandbox starts, and a PyTorch CUDA pod reports `cuda available: True` end to end.

## Risks

* **No host-filesystem exposure added**: the previous approach bind-mounted host `/proc/driver/nvidia` into containerRootFs; this PR adds no new mounts.
* **No-op when nvproxy is disabled**: filter is gated on `specutils.NVProxyEnabled(spec, conf)`.
* **No-op for any other hook**: predicate matches only the specific `nvidia-ctk hook disable-device-node-modification` argv shape.
* **Behavior change when the hook would have failed**: under `nvproxy`, hook now silently skipped rather than aborting; the sandbox starts. Under `nvproxy`, this is functionally equivalent to the hook succeeding because the sentry overrides `/proc/driver/nvidia/params` anyway.