### PR TITLE
Add NCCL/NV vendor-specific sysfs serialization and virtualization

### DIFF
--- a/pkg/sentry/fsimpl/sys/BUILD
+++ b/pkg/sentry/fsimpl/sys/BUILD
@@ -22,6 +22,7 @@ go_library(
         "dir_refs.go",
         "kcov.go",
         "pci.go",
+        "rdma.go",
         "save_restore.go",
         "sys.go",
     ],

--- a/pkg/sentry/fsimpl/sys/BUILD
+++ b/pkg/sentry/fsimpl/sys/BUILD
@@ -21,7 +21,9 @@ go_library(
     srcs = [
         "dir_refs.go",
         "kcov.go",
+        "numa.go",
         "pci.go",
+        "pci_devices.go",
         "rdma.go",
         "save_restore.go",
         "sys.go",

--- a/pkg/sentry/fsimpl/sys/numa.go
+++ b/pkg/sentry/fsimpl/sys/numa.go
@@ -1,0 +1,206 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// NUMANodeData contains the per-node sysfs attributes that NCCL reads from
+// /sys/devices/system/node/node<N>/ to build the topology XML's <cpu> blocks
+// (notably the affinity bitmap).
+type NUMANodeData struct {
+	// ID is the numeric node identifier, e.g. "0".
+	ID string `json:"id"`
+	// CPUMap is the hex bitmap from /sys/devices/system/node/nodeN/cpumap,
+	// e.g. "00000000,00000000,00ffffff,ffffffff".
+	CPUMap string `json:"cpumap"`
+	// CPUList is the range list from /sys/devices/system/node/nodeN/cpulist,
+	// e.g. "0-23,48-71".
+	CPUList string `json:"cpulist"`
+	// Distance is the space-separated NUMA distance vector from
+	// /sys/devices/system/node/nodeN/distance, e.g. "10 20".
+	Distance string `json:"distance,omitempty"`
+}
+
+// NUMAData holds all collected NUMA node attributes.
+type NUMAData struct {
+	// Nodes is sorted by numeric ID for deterministic sysfs output.
+	Nodes []NUMANodeData `json:"nodes"`
+	// Online, Possible, HasCPU, HasMemory, HasNormalMemory mirror the
+	// corresponding /sys/devices/system/node/* aggregate files. They are
+	// captured verbatim from the host so the sandbox sees the same node set
+	// as the kernel does, including any oddities like sparsely numbered nodes.
+	Online          string `json:"online,omitempty"`
+	Possible        string `json:"possible,omitempty"`
+	HasCPU          string `json:"has_cpu,omitempty"`
+	HasMemory       string `json:"has_memory,omitempty"`
+	HasNormalMemory string `json:"has_normal_memory,omitempty"`
+}
+
+// CollectNUMAData reads NUMA topology from /sys/devices/system/node/. Returns
+// nil if the host doesn't expose a node hierarchy (single-NUMA systems
+// without CONFIG_NUMA omit the tree entirely). Must be called before
+// pivot_root while host sysfs is still accessible.
+func CollectNUMAData() *NUMAData {
+	nodePath := "/sys/devices/system/node"
+	dents, err := os.ReadDir(nodePath)
+	if err != nil {
+		log.Infof("numa collect: %s not accessible: %v", nodePath, err)
+		return nil
+	}
+	data := &NUMAData{
+		Online:          readSysfsFile(path.Join(nodePath, "online")),
+		Possible:        readSysfsFile(path.Join(nodePath, "possible")),
+		HasCPU:          readSysfsFile(path.Join(nodePath, "has_cpu")),
+		HasMemory:       readSysfsFile(path.Join(nodePath, "has_memory")),
+		HasNormalMemory: readSysfsFile(path.Join(nodePath, "has_normal_memory")),
+	}
+	for _, d := range dents {
+		name := d.Name()
+		if !strings.HasPrefix(name, "node") {
+			continue
+		}
+		idStr := strings.TrimPrefix(name, "node")
+		if _, err := strconv.Atoi(idStr); err != nil {
+			continue
+		}
+		dir := path.Join(nodePath, name)
+		data.Nodes = append(data.Nodes, NUMANodeData{
+			ID:       idStr,
+			CPUMap:   readSysfsFile(path.Join(dir, "cpumap")),
+			CPUList:  readSysfsFile(path.Join(dir, "cpulist")),
+			Distance: readSysfsFile(path.Join(dir, "distance")),
+		})
+	}
+	sort.Slice(data.Nodes, func(i, j int) bool {
+		ai, _ := strconv.Atoi(data.Nodes[i].ID)
+		aj, _ := strconv.Atoi(data.Nodes[j].ID)
+		return ai < aj
+	})
+	if len(data.Nodes) == 0 {
+		log.Infof("numa collect: no node directories under %s", nodePath)
+		return nil
+	}
+	log.Infof("numa collect: collected %d node(s), online=%q", len(data.Nodes), data.Online)
+	return data
+}
+
+// NUMADataPath is the path within the chroot where serialized NUMA data is
+// stored between boot stages.
+const NUMADataPath = "/var/lib/gvisor/numa_data.json"
+
+// SerializeNUMAData writes the collected data as JSON to the given path.
+func SerializeNUMAData(data *NUMAData, filePath string) error {
+	if data == nil {
+		return nil
+	}
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return fmt.Errorf("MkdirAll %s: %w", path.Dir(filePath), err)
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("json.Marshal: %w", err)
+	}
+	return os.WriteFile(filePath, b, 0644)
+}
+
+// DeserializeNUMAData reads serialized NUMA data from the given path. Returns
+// nil if the file is absent or malformed; the sysfs tree then falls back to
+// having no /sys/devices/system/node/ subtree, which matches gVisor's
+// pre-existing behavior.
+func DeserializeNUMAData(filePath string) *NUMAData {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Infof("numa deserialize: %s: %v", filePath, err)
+		return nil
+	}
+	var data NUMAData
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Warningf("numa deserialize: unmarshal %s: %v", filePath, err)
+		return nil
+	}
+	log.Infof("numa deserialize: loaded %d node(s) from %s", len(data.Nodes), filePath)
+	return &data
+}
+
+// newNUMASysfsEntries builds the kernfs subtree to mount at
+// /sys/devices/system/node/. Returns nil if data is empty.
+//
+// Layout:
+//
+//	node/
+//	    online              -> aggregate range list
+//	    possible            -> aggregate range list
+//	    has_cpu             -> aggregate range list
+//	    has_memory          -> aggregate range list
+//	    has_normal_memory   -> aggregate range list
+//	    node<N>/
+//	        cpumap          -> hex bitmap
+//	        cpulist         -> range list
+//	        distance        -> space-separated distance vector
+func (fs *filesystem) newNUMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *NUMAData) map[string]kernfs.Inode {
+	if data == nil || len(data.Nodes) == 0 {
+		return nil
+	}
+	children := make(map[string]kernfs.Inode)
+	addAggregate := func(name, val string) {
+		if val == "" {
+			return
+		}
+		children[name] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(val))
+	}
+	addAggregate("online", data.Online)
+	addAggregate("possible", data.Possible)
+	addAggregate("has_cpu", data.HasCPU)
+	addAggregate("has_memory", data.HasMemory)
+	addAggregate("has_normal_memory", data.HasNormalMemory)
+
+	for _, n := range data.Nodes {
+		nodeChildren := make(map[string]kernfs.Inode)
+		if n.CPUMap != "" {
+			nodeChildren["cpumap"] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(n.CPUMap))
+		}
+		if n.CPUList != "" {
+			nodeChildren["cpulist"] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(n.CPUList))
+		}
+		if n.Distance != "" {
+			nodeChildren["distance"] = fs.newStaticFile(ctx, creds, defaultSysMode, ensureNewline(n.Distance))
+		}
+		children["node"+n.ID] = fs.newDir(ctx, creds, defaultSysDirMode, nodeChildren)
+	}
+	log.Infof("numa sysfs: created %d node entries", len(data.Nodes))
+	return children
+}
+
+// ensureNewline appends a trailing newline if not already present, matching
+// the kernel's sysfs convention.
+func ensureNewline(s string) string {
+	if strings.HasSuffix(s, "\n") {
+		return s
+	}
+	return s + "\n"
+}

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -90,7 +90,7 @@ func pciClassRelevant(class string) bool {
 		return true
 	case 0x0604: // PCI bridge
 		return true
-	case "0680": // NVSwitch
+	case 0x0680: // NVSwitch
 		return true
 	}
 	return false
@@ -101,14 +101,19 @@ func pciClassRelevant(class string) bool {
 // against RDMA availability — see rdmaUsablePCISlotNames for the rules on
 // which NIC PCI devices are kept in the virtual PCI tree.
 func pciClassIsNIC(class string) bool {
-	c := strings.TrimPrefix(class, "0x")
-	if len(c) < 4 {
+	c, err := strconv.ParseInt(strings.TrimSpace(class), 0, 0)
+	if err != nil {
 		return false
 	}
-	prefix := c[:4]
-	// 0200 Ethernet, 0207 InfiniBand network controller (Crusoe B200/EFA),
-	// 0c06 InfiniBand controller.
-	return prefix == "0200" || prefix == "0207" || prefix == "0c06"
+	switch c >> 8 {
+	case 0x0200: // Ethernet
+		return true
+	case 0x0207: // InfiniBand network controller (Crusoe B200/EFA)
+		return true
+	case 0x0c06: // InfiniBand controller
+		return true
+	}
+	return false
 }
 
 // rdmaUsablePCISlotNames returns the set of PCI slot names (lowercase) for

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
@@ -72,21 +73,22 @@ type PCIDevicesData struct {
 // Extend this switch when adding support for additional accelerator/NIC
 // families.
 func pciClassRelevant(class string) bool {
-	c := strings.TrimPrefix(class, "0x")
-	if len(c) < 4 {
+	c, err := strconv.ParseInt(strings.TrimSpace(class), 0, 0)
+	if err != nil {
 		return false
 	}
-	prefix := c[:4]
-	switch prefix {
-	case "0302", "0300": // GPU (3D controller, VGA)
+	// The last byte of the class string is the programming interface byte, which is too restrictive
+	// for our class matching control. We ignore it by truncating the last byte.
+	switch c >> 8 {
+	case 0x0302, 0x0300: // GPU (3D controller, VGA)
 		return true
-	case "0200": // Ethernet controller (NIC)
+	case 0x0200: // Ethernet controller (NIC)
 		return true
-	case "0c06": // InfiniBand controller
+	case 0x0c06: // InfiniBand controller
 		return true
-	case "0207": // InfiniBand network controller (e.g. Crusoe B200 RDMA NICs report 0x020700)
+	case 0x0207: // InfiniBand network controller (e.g. Crusoe B200 RDMA NICs report 0x020700)
 		return true
-	case "0604": // PCI bridge
+	case 0x0604: // PCI bridge
 		return true
 	}
 	return false
@@ -138,7 +140,11 @@ func CollectPCIDeviceData() *PCIDevicesData {
 		}
 		realPath, err := filepath.EvalSymlinks(devDir)
 		if err != nil {
-			realPath = devDir
+			// NCCL needs the resolved /sys/devices/pci... hierarchy to
+			// compute PCI distances. The flat bus path is not usable as a
+			// substitute, so skip rather than collect a broken RealPath.
+			log.Warningf("pci collect: EvalSymlinks(%s): %v; skipping", devDir, err)
+			continue
 		}
 		leaves = append(leaves, leafDev{addr: dent.Name(), realPath: realPath})
 	}

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -1,0 +1,354 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// PCIDeviceAttr contains sysfs attributes for a single PCI device,
+// including its position in the /sys/devices/pci*/ hierarchy.
+type PCIDeviceAttr struct {
+	// Address is the PCI BDF address, e.g. "0000:0f:00.0".
+	Address string `json:"address"`
+	// RealPath is the resolved sysfs path, e.g.
+	// "/sys/devices/pci0000:07/0000:07:01.0/.../0000:0f:00.0".
+	// NCCL uses this hierarchy to compute PCI distances between devices.
+	RealPath        string `json:"realpath"`
+	Class           string `json:"class"`
+	Vendor          string `json:"vendor"`
+	Device          string `json:"device"`
+	SubsystemVendor string `json:"subsystem_vendor"`
+	SubsystemDevice string `json:"subsystem_device"`
+	NumaNode        string `json:"numa_node"`
+	LocalCPUs       string `json:"local_cpus"`
+	LocalCPUList    string `json:"local_cpulist"`
+	MaxLinkSpeed    string `json:"max_link_speed"`
+	MaxLinkWidth    string `json:"max_link_width"`
+	// NCCL prefers current_link_* over max_link_* and only falls back to
+	// max when current is missing or "Unknown". Capturing both lets the
+	// virtual sysfs report the negotiated link, matching what NCCL would
+	// see on the host.
+	CurrentLinkSpeed string `json:"current_link_speed"`
+	CurrentLinkWidth string `json:"current_link_width"`
+}
+
+// PCIDevicesData holds all collected PCI device attributes.
+type PCIDevicesData struct {
+	Devices []PCIDeviceAttr `json:"devices"`
+}
+
+// pciClassRelevant returns true if the PCI class code is one that NCCL
+// needs for topology discovery.
+//
+// This allowlist is curated for NVIDIA GPU + Mellanox/InfiniBand setups. It
+// covers both InfiniBand controllers (class 0c06) and InfiniBand network
+// controllers (class 0207, reported by e.g. Crusoe B200 RDMA NICs and AWS
+// EFA). Other RDMA-capable adapters (Intel Gaudi class 1200, Broadcom
+// bnxt_re, Chelsio iWARP, etc.) are not currently surfaced to the sandbox.
+// Extend this switch when adding support for additional accelerator/NIC
+// families.
+func pciClassRelevant(class string) bool {
+	c := strings.TrimPrefix(class, "0x")
+	if len(c) < 4 {
+		return false
+	}
+	prefix := c[:4]
+	switch prefix {
+	case "0302", "0300": // GPU (3D controller, VGA)
+		return true
+	case "0200": // Ethernet controller (NIC)
+		return true
+	case "0c06": // InfiniBand controller
+		return true
+	case "0207": // InfiniBand network controller (e.g. Crusoe B200 RDMA NICs report 0x020700)
+		return true
+	case "0604": // PCI bridge
+		return true
+	}
+	return false
+}
+
+// collectDeviceAttrs reads sysfs attributes from the given directory path.
+func collectDeviceAttrs(addr, realPath, devDir string) PCIDeviceAttr {
+	return PCIDeviceAttr{
+		Address:          addr,
+		RealPath:         realPath,
+		Class:            readSysfsFile(path.Join(devDir, "class")),
+		Vendor:           readSysfsFile(path.Join(devDir, "vendor")),
+		Device:           readSysfsFile(path.Join(devDir, "device")),
+		SubsystemVendor:  readSysfsFile(path.Join(devDir, "subsystem_vendor")),
+		SubsystemDevice:  readSysfsFile(path.Join(devDir, "subsystem_device")),
+		NumaNode:         readSysfsFile(path.Join(devDir, "numa_node")),
+		LocalCPUs:        readSysfsFile(path.Join(devDir, "local_cpus")),
+		LocalCPUList:     readSysfsFile(path.Join(devDir, "local_cpulist")),
+		MaxLinkSpeed:     readSysfsFile(path.Join(devDir, "max_link_speed")),
+		MaxLinkWidth:     readSysfsFile(path.Join(devDir, "max_link_width")),
+		CurrentLinkSpeed: readSysfsFile(path.Join(devDir, "current_link_speed")),
+		CurrentLinkWidth: readSysfsFile(path.Join(devDir, "current_link_width")),
+	}
+}
+
+// CollectPCIDeviceData reads PCI device sysfs attributes for devices
+// relevant to NCCL topology discovery, including all ancestor bridge
+// devices in the PCI hierarchy. This must be called before pivot_root
+// while the host sysfs is still accessible.
+func CollectPCIDeviceData() *PCIDevicesData {
+	pciPath := "/sys/bus/pci/devices"
+	dents, err := os.ReadDir(pciPath)
+	if err != nil {
+		log.Infof("pci collect: %s not accessible: %v", pciPath, err)
+		return nil
+	}
+
+	// First pass: find relevant leaf devices and resolve their real paths.
+	type leafDev struct {
+		addr     string
+		realPath string
+	}
+	var leaves []leafDev
+	for _, dent := range dents {
+		devDir := path.Join(pciPath, dent.Name())
+		class := readSysfsFile(path.Join(devDir, "class"))
+		if class == "" || !pciClassRelevant(class) {
+			continue
+		}
+		realPath, err := filepath.EvalSymlinks(devDir)
+		if err != nil {
+			realPath = devDir
+		}
+		leaves = append(leaves, leafDev{addr: dent.Name(), realPath: realPath})
+	}
+
+	// Second pass: collect all unique paths in the ancestor chains.
+	// NCCL walks UP the /sys/devices/pci*/ hierarchy to compute PCI
+	// distances, so we need every bridge in the chain.
+	collected := make(map[string]bool)
+	data := &PCIDevicesData{}
+	for _, leaf := range leaves {
+		p := leaf.realPath
+		for p != "" && strings.Contains(p, "/pci") {
+			if collected[p] {
+				break
+			}
+			collected[p] = true
+			addr := filepath.Base(p)
+			dev := collectDeviceAttrs(addr, p, p)
+			data.Devices = append(data.Devices, dev)
+			p = filepath.Dir(p)
+		}
+	}
+
+	// Sort by path for deterministic output.
+	sort.Slice(data.Devices, func(i, j int) bool {
+		return data.Devices[i].RealPath < data.Devices[j].RealPath
+	})
+
+	log.Infof("pci collect: collected %d device(s) in hierarchy from %d leaf devices",
+		len(data.Devices), len(leaves))
+	return data
+}
+
+// PCIDevicesDataPath is the path within the chroot where serialized PCI
+// device data is stored between boot stages.
+const PCIDevicesDataPath = "/var/lib/gvisor/pci_devices_data.json"
+
+// SerializePCIDevicesData writes the collected data as JSON to the given path.
+func SerializePCIDevicesData(data *PCIDevicesData, filePath string) error {
+	if data == nil {
+		return nil
+	}
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, b, 0644)
+}
+
+// DeserializePCIDevicesData reads serialized PCI device data from the given path.
+func DeserializePCIDevicesData(filePath string) *PCIDevicesData {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Infof("pci deserialize: %s: %v", filePath, err)
+		return nil
+	}
+	var data PCIDevicesData
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Warningf("pci deserialize: unmarshal %s: %v", filePath, err)
+		return nil
+	}
+	log.Infof("pci deserialize: loaded %d device(s) from %s", len(data.Devices), filePath)
+	return &data
+}
+
+// newPCIDevicesSysfsEntries builds the virtual sysfs tree for PCI device
+// topology. It creates:
+//   - /sys/devices/pci<ROOT>/<BRIDGE>/.../<DEV>/ nested hierarchy with
+//     class, vendor, device, numa_node, local_cpulist, etc. at each level
+//   - /sys/devices/pci<ROOT>/.../<PARENT>/pci_bus/<BUS>/ directories so
+//     NCCL's "../../<DEV>" path resolution works
+//   - /sys/class/pci_bus/<BUS> symlinks into the devices hierarchy
+//   - /sys/bus/pci/devices/<ADDR> symlinks into the devices hierarchy
+//
+// NCCL discovers topology by:
+//  1. Constructing "/sys/class/pci_bus/<BUS>/../../<BUS:DEV.FN>"
+//  2. Calling realpath() which resolves through the symlink
+//  3. Walking UP the resolved path reading "class" to find bridges
+//  4. Using the hierarchy depth to compute PCI distance between devices
+func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth.Credentials, data *PCIDevicesData) (devicesSub, pciBusSub, busPCIDevicesSub map[string]kernfs.Inode, pciSlotToRelPath map[string]string) {
+	if data == nil || len(data.Devices) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	log.Infof("pci sysfs: building virtual sysfs for %d device(s)", len(data.Devices))
+
+	// Build a nested map representing the /sys/devices/ tree.
+	// Key: path relative to /sys/ (e.g., "devices/pci0000:07/0000:07:01.0")
+	// Value: map of child name -> inode
+	type dirNode struct {
+		children map[string]*dirNode
+		files    map[string]string // attribute files
+		symlinks map[string]string // child symlink name -> target
+	}
+	root := &dirNode{children: make(map[string]*dirNode), files: make(map[string]string), symlinks: make(map[string]string)}
+
+	getOrCreate := func(pathFromSys string) *dirNode {
+		parts := strings.Split(pathFromSys, "/")
+		cur := root
+		for _, part := range parts {
+			if part == "" {
+				continue
+			}
+			if cur.children[part] == nil {
+				cur.children[part] = &dirNode{
+					children: make(map[string]*dirNode),
+					files:    make(map[string]string),
+					symlinks: make(map[string]string),
+				}
+			}
+			cur = cur.children[part]
+		}
+		return cur
+	}
+
+	// pciBusEntries: bus number -> relative symlink target from /sys/class/pci_bus/<bus>
+	pciBusSymlinks := make(map[string]string)
+	// busPCIDevicesSymlinks: addr -> relative symlink target from /sys/bus/pci/devices/<addr>
+	busPCIDevicesSymlinks := make(map[string]string)
+	pciAddrToRelPath := make(map[string]string)
+
+	for _, dev := range data.Devices {
+
+		// dev.RealPath is e.g. "/sys/devices/pci0000:07/0000:07:01.0/0000:0f:00.0"
+		// Convert to relative path from /sys/
+		relPath := strings.TrimPrefix(dev.RealPath, "/sys/")
+		if relPath == dev.RealPath {
+			continue // not under /sys
+		}
+		pciAddrToRelPath[strings.ToLower(dev.Address)] = relPath
+		node := getOrCreate(relPath)
+		node.files["class"] = dev.Class
+		node.files["vendor"] = dev.Vendor
+		node.files["device"] = dev.Device
+		node.files["subsystem_vendor"] = dev.SubsystemVendor
+		node.files["subsystem_device"] = dev.SubsystemDevice
+		node.files["numa_node"] = dev.NumaNode
+		node.files["local_cpus"] = dev.LocalCPUs
+		node.files["local_cpulist"] = dev.LocalCPUList
+		node.files["max_link_speed"] = dev.MaxLinkSpeed
+		node.files["max_link_width"] = dev.MaxLinkWidth
+		node.files["current_link_speed"] = dev.CurrentLinkSpeed
+		node.files["current_link_width"] = dev.CurrentLinkWidth
+
+		// Create pci_bus entry for this device's secondary bus.
+		// The bus number is the first two hex groups of the address (domain:bus).
+		// E.g., for device "0000:0f:00.0", bus is "0000:0f".
+		addr := dev.Address
+		if len(addr) >= 7 && strings.Count(addr, ":") >= 2 {
+			bus := addr[:7] // "0000:0f"
+			// pci_bus/<bus> lives inside the PARENT device directory.
+			parentRelPath := filepath.Dir(relPath)
+			if parentRelPath != "." && parentRelPath != relPath {
+				// Create pci_bus/<bus> subdir in parent
+				pciBusNode := getOrCreate(parentRelPath + "/pci_bus/" + bus)
+				_ = pciBusNode // just ensure it exists
+
+				// Symlink: /sys/class/pci_bus/<bus> -> ../../devices/pci.../pci_bus/<bus>
+				pciBusSymlinks[bus] = "../../" + parentRelPath + "/pci_bus/" + bus
+			}
+
+			// Symlink: /sys/bus/pci/devices/<addr> -> ../../../devices/pci.../<addr>
+			busPCIDevicesSymlinks[addr] = "../../../" + relPath
+		}
+	}
+
+	// Convert the tree to kernfs inodes.
+	var buildDir func(node *dirNode) map[string]kernfs.Inode
+	buildDir = func(node *dirNode) map[string]kernfs.Inode {
+		entries := make(map[string]kernfs.Inode)
+		for name, val := range node.files {
+			if val != "" {
+				entries[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
+			}
+		}
+		for name, target := range node.symlinks {
+			entries[name] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+		}
+		for name, child := range node.children {
+			entries[name] = fs.newDir(ctx, creds, defaultSysDirMode, buildDir(child))
+		}
+		return entries
+	}
+
+	// Build /sys/devices/ subtree (pci0000:XX roots)
+	devicesSub = make(map[string]kernfs.Inode)
+	for name, child := range root.children {
+		if name == "devices" {
+			for devName, devChild := range child.children {
+				devicesSub[devName] = fs.newDir(ctx, creds, defaultSysDirMode, buildDir(devChild))
+			}
+		}
+	}
+
+	// Build /sys/class/pci_bus/ entries as symlinks
+	pciBusSub = make(map[string]kernfs.Inode)
+	for bus, target := range pciBusSymlinks {
+		pciBusSub[bus] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+	}
+
+	// Build /sys/bus/pci/devices/ entries as symlinks
+	busPCIDevicesSub = make(map[string]kernfs.Inode)
+	for addr, target := range busPCIDevicesSymlinks {
+		busPCIDevicesSub[addr] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+	}
+
+	log.Infof("pci sysfs: created %d device tree entries, %d pci_bus symlinks, %d bus/pci/devices symlinks",
+		len(devicesSub), len(pciBusSub), len(busPCIDevicesSub))
+	return devicesSub, pciBusSub, busPCIDevicesSub, pciAddrToRelPath
+}

--- a/pkg/sentry/fsimpl/sys/pci_devices.go
+++ b/pkg/sentry/fsimpl/sys/pci_devices.go
@@ -90,8 +90,72 @@ func pciClassRelevant(class string) bool {
 		return true
 	case 0x0604: // PCI bridge
 		return true
+	case "0680": // NVSwitch
+		return true
 	}
 	return false
+}
+
+// pciClassIsNIC returns true if the PCI class code is a network device
+// (Ethernet or InfiniBand controller). Used to gate NIC-class devices
+// against RDMA availability — see rdmaUsablePCISlotNames for the rules on
+// which NIC PCI devices are kept in the virtual PCI tree.
+func pciClassIsNIC(class string) bool {
+	c := strings.TrimPrefix(class, "0x")
+	if len(c) < 4 {
+		return false
+	}
+	prefix := c[:4]
+	// 0200 Ethernet, 0207 InfiniBand network controller (Crusoe B200/EFA),
+	// 0c06 InfiniBand controller.
+	return prefix == "0200" || prefix == "0207" || prefix == "0c06"
+}
+
+// rdmaUsablePCISlotNames returns the set of PCI slot names (lowercase) for
+// RDMA devices that should remain in the virtual PCI tree. A NIC-class PCI
+// device is only useful to NCCL if it backs an RDMA device the sandbox can
+// actually use; the rules differ by link layer:
+//
+//   - InfiniBand link-layer devices are driven directly through uverbs and
+//     need no netdev in the sandbox netns, so they are always kept. Their PCI
+//     entry is required so /sys/class/infiniband/<dev>/device can be a symlink
+//     into the PCI tree (NCCL realpath()s it to place the NIC near its GPU).
+//   - RoCE (Ethernet link-layer) devices are only usable once their netdev has
+//     been moved into the sandbox netns, i.e. a GID entry has a valid ndev.
+//     RoCE NICs without a moved ndev are excluded so NCCL's topology graph
+//     doesn't create dangling NET nodes ("Could not find NET with id N").
+//
+// Returns nil when rdmaData is nil (no RDMA info => no NIC filtering).
+func rdmaUsablePCISlotNames(rdmaData *RDMAData) map[string]bool {
+	if rdmaData == nil {
+		return nil
+	}
+	slots := make(map[string]bool)
+	for _, dev := range rdmaData.Devices {
+		if dev.PCISlotName == "" {
+			continue
+		}
+		keep := false
+		for _, p := range dev.Ports {
+			if p.LinkLayer == "InfiniBand" {
+				keep = true
+				break
+			}
+			for _, g := range p.GIDs {
+				if g.NetDev != "" {
+					keep = true
+					break
+				}
+			}
+			if keep {
+				break
+			}
+		}
+		if keep {
+			slots[strings.ToLower(dev.PCISlotName)] = true
+		}
+	}
+	return slots
 }
 
 // collectDeviceAttrs reads sysfs attributes from the given directory path.
@@ -227,12 +291,26 @@ func DeserializePCIDevicesData(filePath string) *PCIDevicesData {
 //  2. Calling realpath() which resolves through the symlink
 //  3. Walking UP the resolved path reading "class" to find bridges
 //  4. Using the hierarchy depth to compute PCI distance between devices
-func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth.Credentials, data *PCIDevicesData) (devicesSub, pciBusSub, busPCIDevicesSub map[string]kernfs.Inode, pciSlotToRelPath map[string]string) {
+func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth.Credentials, data *PCIDevicesData, rdmaData *RDMAData) (devicesSub, pciBusSub, busPCIDevicesSub map[string]kernfs.Inode, pciSlotToRelPath map[string]string) {
 	if data == nil || len(data.Devices) == 0 {
 		return nil, nil, nil, nil
 	}
 
-	log.Infof("pci sysfs: building virtual sysfs for %d device(s)", len(data.Devices))
+	usableNICSlots := rdmaUsablePCISlotNames(rdmaData)
+
+	kept, skipped := 0, 0
+	for _, dev := range data.Devices {
+		if pciClassIsNIC(dev.Class) {
+			addr := strings.ToLower(dev.Address)
+			if usableNICSlots != nil && !usableNICSlots[addr] {
+				skipped++
+				continue
+			}
+		}
+		kept++
+	}
+
+	log.Infof("pci sysfs: building virtual sysfs for %d device(s) (%d unusable NIC(s) skipped)", kept, skipped)
 
 	// Build a nested map representing the /sys/devices/ tree.
 	// Key: path relative to /sys/ (e.g., "devices/pci0000:07/0000:07:01.0")
@@ -270,6 +348,12 @@ func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth
 	pciAddrToRelPath := make(map[string]string)
 
 	for _, dev := range data.Devices {
+		if pciClassIsNIC(dev.Class) {
+			addr := strings.ToLower(dev.Address)
+			if usableNICSlots != nil && !usableNICSlots[addr] {
+				continue
+			}
+		}
 
 		// dev.RealPath is e.g. "/sys/devices/pci0000:07/0000:07:01.0/0000:0f:00.0"
 		// Convert to relative path from /sys/
@@ -292,6 +376,37 @@ func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth
 		node.files["current_link_speed"] = dev.CurrentLinkSpeed
 		node.files["current_link_width"] = dev.CurrentLinkWidth
 
+		if pciClassIsNIC(dev.Class) && rdmaData != nil {
+			addr := strings.ToLower(dev.Address)
+			for _, rd := range rdmaData.Devices {
+				if strings.ToLower(rd.PCISlotName) != addr {
+					continue
+				}
+				if rd.Modalias != "" {
+					node.files["modalias"] = rd.Modalias
+				}
+				uevent := ""
+				if rd.PCIDriver != "" {
+					uevent += "DRIVER=" + rd.PCIDriver + "\n"
+				}
+				if dev.Class != "" {
+					uevent += "PCI_CLASS=" + strings.TrimPrefix(dev.Class, "0x") + "\n"
+				}
+				if dev.Vendor != "" && dev.Device != "" {
+					uevent += "PCI_ID=" + strings.TrimPrefix(strings.ToUpper(dev.Vendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.Device), "0X") + "\n"
+				}
+				if dev.SubsystemVendor != "" && dev.SubsystemDevice != "" {
+					uevent += "PCI_SUBSYS_ID=" + strings.TrimPrefix(strings.ToUpper(dev.SubsystemVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.SubsystemDevice), "0X") + "\n"
+				}
+				uevent += "PCI_SLOT_NAME=" + rd.PCISlotName + "\n"
+				if rd.Modalias != "" {
+					uevent += "MODALIAS=" + rd.Modalias + "\n"
+				}
+				node.files["uevent"] = uevent
+				break
+			}
+		}
+
 		// Create pci_bus entry for this device's secondary bus.
 		// The bus number is the first two hex groups of the address (domain:bus).
 		// E.g., for device "0000:0f:00.0", bus is "0000:0f".
@@ -307,10 +422,41 @@ func (fs *filesystem) newPCIDevicesSysfsEntries(ctx context.Context, creds *auth
 
 				// Symlink: /sys/class/pci_bus/<bus> -> ../../devices/pci.../pci_bus/<bus>
 				pciBusSymlinks[bus] = "../../" + parentRelPath + "/pci_bus/" + bus
+
+				upper := strings.ToUpper(bus)
+				if upper != bus {
+					pciBusSymlinks[upper] = "../../" + parentRelPath + "/pci_bus/" + upper
+					getOrCreate(parentRelPath + "/pci_bus/" + upper)
+				}
 			}
 
 			// Symlink: /sys/bus/pci/devices/<addr> -> ../../../devices/pci.../<addr>
 			busPCIDevicesSymlinks[addr] = "../../../" + relPath
+			upper := strings.ToUpper(addr)
+			if upper != addr {
+				busPCIDevicesSymlinks[upper] = "../../../" + relPath
+			}
+		}
+	}
+
+	if rdmaData != nil {
+		for _, dev := range rdmaData.Devices {
+			if dev.IBDev == "" || dev.PCISlotName == "" {
+				continue
+			}
+			relPath, ok := pciAddrToRelPath[strings.ToLower(dev.PCISlotName)]
+			if !ok {
+				continue
+			}
+			infinibandDir := getOrCreate(relPath + "/infiniband")
+			linkDir := filepath.Join("/sys", relPath, "infiniband")
+			target := filepath.Join("/sys/class/infiniband", dev.IBDev)
+			relTarget, err := filepath.Rel(linkDir, target)
+			if err != nil {
+				log.Warningf("pci sysfs: relative symlink for %s/%s: %v", relPath, dev.IBDev, err)
+				continue
+			}
+			infinibandDir.symlinks[dev.IBDev] = relTarget
 		}
 	}
 

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
@@ -64,8 +66,8 @@ type RDMADeviceData struct {
 	Ports      []RDMAPortData `json:"ports"`
 
 	// PCI device attributes from /sys/class/infiniband/<ibdev>/device/.
-	// libibverbs reads modalias for driver matching; NCCL reads
-	// PCI_SLOT_NAME from uevent to match NICs against GPU topology.
+	// NCCL reads these (especially PCI_SLOT_NAME from uevent) to match
+	// NIC PCI bus IDs against GPU bus IDs in the topology XML.
 	PCISlotName     string `json:"pci_slot_name,omitempty"`
 	PCIDriver       string `json:"pci_driver,omitempty"`
 	PCIClass        string `json:"pci_class,omitempty"`
@@ -81,10 +83,27 @@ type RDMADeviceData struct {
 	DynMajor uint32 `json:"-"`
 }
 
+// RDMANetDeviceData contains the minimal sysfs attributes NCCL/libibverbs read
+// from /sys/class/net/<name>/ when selecting and characterizing NICs.
+type RDMANetDeviceData struct {
+	Name       string `json:"name"`
+	Type       string `json:"type,omitempty"`
+	Address    string `json:"address,omitempty"`
+	MTU        string `json:"mtu,omitempty"`
+	DevID      string `json:"dev_id,omitempty"`
+	DevPort    string `json:"dev_port,omitempty"`
+	Speed      string `json:"speed,omitempty"`
+	Duplex     string `json:"duplex,omitempty"`
+	OperState  string `json:"operstate,omitempty"`
+	DevicePath string `json:"device_path,omitempty"`
+}
+
 // RDMAData holds all collected RDMA sysfs data.
 type RDMAData struct {
-	VerbsABIVersion string           `json:"verbs_abi_version"`
-	Devices         []RDMADeviceData `json:"devices"`
+	VerbsABIVersion string              `json:"verbs_abi_version"`
+	PeerMemVersion  string              `json:"peer_mem_version,omitempty"`
+	Devices         []RDMADeviceData    `json:"devices"`
+	NetDevices      []RDMANetDeviceData `json:"net_devices,omitempty"`
 }
 
 // CollectRDMADeviceData reads the specific sysfs files that libibverbs
@@ -101,6 +120,20 @@ func CollectRDMADeviceData() *RDMAData {
 		VerbsABIVersion: readSysfsFile(path.Join(verbsPath, "abi_version")),
 	}
 
+	peerMemPaths := []string{
+		"/sys/module/nvidia_peermem/version",
+		"/sys/kernel/mm/memory_peers/nv_mem/version",
+		"/sys/kernel/mm/memory_peers/nv_mem_nc/version",
+	}
+	for _, p := range peerMemPaths {
+		if v := readSysfsFile(p); v != "" {
+			data.PeerMemVersion = v
+			log.Infof("rdma collect: nvidia_peermem version=%q (from %s)", v, p)
+			break
+		}
+	}
+
+	netDevices := make(map[string]struct{})
 	log.Infof("rdma collect: scanning %s (%d entries), verbs_abi=%q",
 		verbsPath, len(dents), data.VerbsABIVersion)
 	for _, dent := range dents {
@@ -174,6 +207,9 @@ func CollectRDMADeviceData() *RDMAData {
 							Type:   typeVal,
 							NetDev: ndevVal,
 						})
+						if ndevVal != "" {
+							netDevices[ndevVal] = struct{}{}
+						}
 					}
 				}
 				log.Infof("rdma collect:   port %s: state=%q link_layer=%q rate=%q gids=%d",
@@ -183,8 +219,36 @@ func CollectRDMADeviceData() *RDMAData {
 		}
 		data.Devices = append(data.Devices, dev)
 	}
+	data.NetDevices = collectRDMANetDevices(netDevices)
 	log.Infof("rdma collect: collected %d device(s)", len(data.Devices))
 	return data
+}
+
+func collectRDMANetDevices(names map[string]struct{}) []RDMANetDeviceData {
+	if len(names) == 0 {
+		return nil
+	}
+	var netDevices []RDMANetDeviceData
+	for name := range names {
+		netDir := path.Join("/sys/class/net", name)
+		devicePath, err := filepath.EvalSymlinks(path.Join(netDir, "device"))
+		if err != nil {
+			devicePath = ""
+		}
+		netDevices = append(netDevices, RDMANetDeviceData{
+			Name:       name,
+			Type:       readSysfsFile(path.Join(netDir, "type")),
+			Address:    readSysfsFile(path.Join(netDir, "address")),
+			MTU:        readSysfsFile(path.Join(netDir, "mtu")),
+			DevID:      readSysfsFile(path.Join(netDir, "dev_id")),
+			DevPort:    readSysfsFile(path.Join(netDir, "dev_port")),
+			Speed:      readSysfsFile(path.Join(netDir, "speed")),
+			Duplex:     readSysfsFile(path.Join(netDir, "duplex")),
+			OperState:  readSysfsFile(path.Join(netDir, "operstate")),
+			DevicePath: devicePath,
+		})
+	}
+	return netDevices
 }
 
 // RDMADataPath is the path within the chroot where serialized RDMA data
@@ -301,7 +365,7 @@ func readSysfsFile(filePath string) string {
 
 // newRDMASysfsEntries creates /sys/class/infiniband_verbs/ and
 // /sys/class/infiniband/ directories from pre-collected device data.
-func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData) (ibVerbsDir, ibDir map[string]kernfs.Inode) {
+func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData, pciSlotToRelPath map[string]string) (ibVerbsDir, ibDir map[string]kernfs.Inode) {
 	if data == nil || len(data.Devices) == 0 {
 		log.Infof("rdma sysfs: no RDMA data, skipping sysfs construction")
 		return nil, nil
@@ -343,41 +407,28 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 		addFile(ibDevEntries, "node_guid", dev.NodeGUID)
 		addFile(ibDevEntries, "sys_image_guid", dev.SysImgGUID)
 		addFile(ibDevEntries, "fw_ver", dev.FWVer)
-		// Build the device/ subdirectory with PCI attributes.
-		// libibverbs reads modalias for driver matching; NCCL reads
-		// uevent for PCI_SLOT_NAME to match NICs against GPU topology.
-		deviceEntries := map[string]kernfs.Inode{}
-		addFile(deviceEntries, "modalias", dev.Modalias)
-		addFile(deviceEntries, "class", dev.PCIClass)
-		addFile(deviceEntries, "vendor", dev.PCIVendor)
-		addFile(deviceEntries, "device", dev.PCIDevice)
-		addFile(deviceEntries, "subsystem_vendor", dev.PCISubsysVendor)
-		addFile(deviceEntries, "subsystem_device", dev.PCISubsysDevice)
-		addFile(deviceEntries, "numa_node", dev.NUMANode)
-		addFile(deviceEntries, "local_cpulist", dev.LocalCPUList)
+		// Create the device/ entry. On real Linux this is a symlink from
+		// /sys/class/infiniband/<ibdev>/device -> /sys/devices/pci0000:XX/...
+		// NCCL calls realpath() on this to find the PCI device path and
+		// place NICs in the PCI topology tree for distance computation.
 		if dev.PCISlotName != "" {
-			uevent := ""
-			if dev.PCIDriver != "" {
-				uevent += "DRIVER=" + dev.PCIDriver + "\n"
+			if relPath, ok := pciSlotToRelPath[strings.ToLower(dev.PCISlotName)]; ok {
+				target := "../../../" + relPath
+				ibDevEntries["device"] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+				log.Infof("rdma sysfs: %s device -> %s (symlink to PCI tree)", dev.IBDev, target)
+			} else {
+				log.Warningf("rdma sysfs: %s PCI_SLOT_NAME=%s has no matching PCI device; creating device/ as directory (degraded topology)", dev.IBDev, dev.PCISlotName)
+				deviceEntries := map[string]kernfs.Inode{}
+				addFile(deviceEntries, "modalias", dev.Modalias)
+				addFile(deviceEntries, "class", dev.PCIClass)
+				addFile(deviceEntries, "vendor", dev.PCIVendor)
+				addFile(deviceEntries, "device", dev.PCIDevice)
+				addFile(deviceEntries, "subsystem_vendor", dev.PCISubsysVendor)
+				addFile(deviceEntries, "subsystem_device", dev.PCISubsysDevice)
+				addFile(deviceEntries, "numa_node", dev.NUMANode)
+				addFile(deviceEntries, "local_cpulist", dev.LocalCPUList)
+				ibDevEntries["device"] = fs.newDir(ctx, creds, defaultSysDirMode, deviceEntries)
 			}
-			if dev.PCIClass != "" {
-				uevent += "PCI_CLASS=" + strings.TrimPrefix(dev.PCIClass, "0x") + "\n"
-			}
-			if dev.PCIVendor != "" && dev.PCIDevice != "" {
-				uevent += "PCI_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCIVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCIDevice), "0X") + "\n"
-			}
-			if dev.PCISubsysVendor != "" && dev.PCISubsysDevice != "" {
-				uevent += "PCI_SUBSYS_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysDevice), "0X") + "\n"
-			}
-			uevent += "PCI_SLOT_NAME=" + dev.PCISlotName + "\n"
-			if dev.Modalias != "" {
-				uevent += "MODALIAS=" + dev.Modalias + "\n"
-			}
-			deviceEntries["uevent"] = fs.newStaticFile(ctx, creds, defaultSysMode, uevent)
-			log.Infof("rdma sysfs: %s device/uevent: PCI_SLOT_NAME=%s", dev.IBDev, dev.PCISlotName)
-		}
-		if len(deviceEntries) > 0 {
-			ibDevEntries["device"] = fs.newDir(ctx, creds, defaultSysDirMode, deviceEntries)
 		}
 		if len(dev.Ports) > 0 {
 			portsDir := map[string]kernfs.Inode{}
@@ -420,4 +471,34 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 		ibDir[dev.IBDev] = fs.newDir(ctx, creds, defaultSysDirMode, ibDevEntries)
 	}
 	return ibVerbsDir, ibDir
+}
+
+func (fs *filesystem) newRDMANetClassEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData) map[string]kernfs.Inode {
+	if data == nil || len(data.NetDevices) == 0 {
+		return nil
+	}
+	netDir := make(map[string]kernfs.Inode)
+	addFile := func(m map[string]kernfs.Inode, name, val string) {
+		if val != "" {
+			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
+		}
+	}
+	for _, dev := range data.NetDevices {
+		entries := make(map[string]kernfs.Inode)
+		addFile(entries, "type", dev.Type)
+		addFile(entries, "address", dev.Address)
+		addFile(entries, "mtu", dev.MTU)
+		addFile(entries, "dev_id", dev.DevID)
+		addFile(entries, "dev_port", dev.DevPort)
+		addFile(entries, "speed", dev.Speed)
+		addFile(entries, "duplex", dev.Duplex)
+		addFile(entries, "operstate", dev.OperState)
+		if strings.HasPrefix(dev.DevicePath, "/sys/") {
+			target := "../../../" + strings.TrimPrefix(dev.DevicePath, "/sys/")
+			entries["device"] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)
+		}
+		netDir[dev.Name] = fs.newDir(ctx, creds, defaultSysDirMode, entries)
+	}
+	log.Infof("rdma sysfs: built virtual /sys/class/net entries for %d device(s)", len(netDir))
+	return netDir
 }

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -379,6 +379,12 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
 		}
 	}
+	// addHostFile serves attrs whose host values can change after collect.
+	// Requires the corresponding path to be bind-mounted into the sentry
+	// chroot (see rdmaProxyUpdateChroot).
+	addHostFile := func(m map[string]kernfs.Inode, name, hostPath string) {
+		m[name] = fs.newHostFile(ctx, creds, defaultSysMode, hostPath)
+	}
 	addFile(ibVerbsDir, "abi_version", data.VerbsABIVersion)
 
 	for _, dev := range data.Devices {
@@ -435,23 +441,24 @@ func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Crede
 			for _, port := range dev.Ports {
 				log.Infof("rdma sysfs:   port %s: state=%q link_layer=%q rate=%q",
 					port.Number, port.State, port.LinkLayer, port.Rate)
+				portBase := path.Join("/sys/class/infiniband", dev.IBDev, "ports", port.Number)
 				portEntries := map[string]kernfs.Inode{}
-				addFile(portEntries, "state", port.State)
-				addFile(portEntries, "phys_state", port.PhysState)
+				addHostFile(portEntries, "state", path.Join(portBase, "state"))
+				addHostFile(portEntries, "phys_state", path.Join(portBase, "phys_state"))
 				addFile(portEntries, "link_layer", port.LinkLayer)
-				addFile(portEntries, "rate", port.Rate)
-				addFile(portEntries, "lid", port.LID)
-				addFile(portEntries, "sm_lid", port.SMLID)
-				addFile(portEntries, "sm_sl", port.SMSL)
+				addHostFile(portEntries, "rate", path.Join(portBase, "rate"))
+				addHostFile(portEntries, "lid", path.Join(portBase, "lid"))
+				addHostFile(portEntries, "sm_lid", path.Join(portBase, "sm_lid"))
+				addHostFile(portEntries, "sm_sl", path.Join(portBase, "sm_sl"))
 				addFile(portEntries, "cap_mask", port.CapMask)
 				if len(port.GIDs) > 0 {
 					gidsEntries := map[string]kernfs.Inode{}
 					typesEntries := map[string]kernfs.Inode{}
 					ndevsEntries := map[string]kernfs.Inode{}
 					for _, gid := range port.GIDs {
-						addFile(gidsEntries, gid.Index, gid.GID)
+						addHostFile(gidsEntries, gid.Index, path.Join(portBase, "gids", gid.Index))
 						addFile(typesEntries, gid.Index, gid.Type)
-						addFile(ndevsEntries, gid.Index, gid.NetDev)
+						addHostFile(ndevsEntries, gid.Index, path.Join(portBase, "gid_attrs", "ndevs", gid.Index))
 					}
 					log.Infof("rdma sysfs:   port %s: %d gids, gidsEntries=%d typesEntries=%d ndevsEntries=%d",
 						port.Number, len(port.GIDs), len(gidsEntries), len(typesEntries), len(ndevsEntries))
@@ -483,16 +490,20 @@ func (fs *filesystem) newRDMANetClassEntries(ctx context.Context, creds *auth.Cr
 			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
 		}
 	}
+	addHostFile := func(m map[string]kernfs.Inode, name, hostPath string) {
+		m[name] = fs.newHostFile(ctx, creds, defaultSysMode, hostPath)
+	}
 	for _, dev := range data.NetDevices {
+		netBase := path.Join("/sys/class/net", dev.Name)
 		entries := make(map[string]kernfs.Inode)
 		addFile(entries, "type", dev.Type)
-		addFile(entries, "address", dev.Address)
-		addFile(entries, "mtu", dev.MTU)
+		addHostFile(entries, "address", path.Join(netBase, "address"))
+		addHostFile(entries, "mtu", path.Join(netBase, "mtu"))
 		addFile(entries, "dev_id", dev.DevID)
 		addFile(entries, "dev_port", dev.DevPort)
-		addFile(entries, "speed", dev.Speed)
-		addFile(entries, "duplex", dev.Duplex)
-		addFile(entries, "operstate", dev.OperState)
+		addHostFile(entries, "speed", path.Join(netBase, "speed"))
+		addHostFile(entries, "duplex", path.Join(netBase, "duplex"))
+		addHostFile(entries, "operstate", path.Join(netBase, "operstate"))
 		if strings.HasPrefix(dev.DevicePath, "/sys/") {
 			target := "../../../" + strings.TrimPrefix(dev.DevicePath, "/sys/")
 			entries["device"] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -1,0 +1,423 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sys
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// RDMAGIDEntry contains a single GID table entry and its RoCE type.
+type RDMAGIDEntry struct {
+	Index  string `json:"index"`
+	GID    string `json:"gid"`
+	Type   string `json:"type"`
+	NetDev string `json:"net_dev,omitempty"`
+}
+
+// RDMAPortData contains sysfs attributes for one port.
+type RDMAPortData struct {
+	Number    string         `json:"number"`
+	State     string         `json:"state"`
+	PhysState string         `json:"phys_state"`
+	LinkLayer string         `json:"link_layer"`
+	Rate      string         `json:"rate"`
+	LID       string         `json:"lid"`
+	SMLID     string         `json:"sm_lid"`
+	SMSL      string         `json:"sm_sl"`
+	CapMask   string         `json:"cap_mask"`
+	GIDs      []RDMAGIDEntry `json:"gids,omitempty"`
+}
+
+// RDMADeviceData contains sysfs data for a single RDMA uverbs device.
+type RDMADeviceData struct {
+	Name       string         `json:"name"`
+	IBDev      string         `json:"ibdev"`
+	ABIVersion string         `json:"abi_version"`
+	Dev        string         `json:"dev"`
+	NodeType   string         `json:"node_type"`
+	NodeGUID   string         `json:"node_guid"`
+	SysImgGUID string         `json:"sys_image_guid"`
+	FWVer      string         `json:"fw_ver"`
+	Modalias   string         `json:"modalias"`
+	Ports      []RDMAPortData `json:"ports"`
+
+	// PCI device attributes from /sys/class/infiniband/<ibdev>/device/.
+	// libibverbs reads modalias for driver matching; NCCL reads
+	// PCI_SLOT_NAME from uevent to match NICs against GPU topology.
+	PCISlotName     string `json:"pci_slot_name,omitempty"`
+	PCIDriver       string `json:"pci_driver,omitempty"`
+	PCIClass        string `json:"pci_class,omitempty"`
+	PCIVendor       string `json:"pci_vendor,omitempty"`
+	PCIDevice       string `json:"pci_device,omitempty"`
+	PCISubsysVendor string `json:"pci_subsys_vendor,omitempty"`
+	PCISubsysDevice string `json:"pci_subsys_device,omitempty"`
+	NUMANode        string `json:"numa_node,omitempty"`
+	LocalCPUList    string `json:"local_cpulist,omitempty"`
+
+	// DynMajor is the sentry-assigned dynamic major for this device.
+	// Set at runtime during device registration, not serialized.
+	DynMajor uint32 `json:"-"`
+}
+
+// RDMAData holds all collected RDMA sysfs data.
+type RDMAData struct {
+	VerbsABIVersion string           `json:"verbs_abi_version"`
+	Devices         []RDMADeviceData `json:"devices"`
+}
+
+// CollectRDMADeviceData reads the specific sysfs files that libibverbs
+// needs for device discovery. Only well-known paths are read — no
+// recursive traversal, no symlink following into PCI device trees.
+func CollectRDMADeviceData() *RDMAData {
+	verbsPath := "/sys/class/infiniband_verbs"
+	dents, err := os.ReadDir(verbsPath)
+	if err != nil {
+		log.Infof("rdma collect: %s not accessible: %v", verbsPath, err)
+		return nil
+	}
+	data := &RDMAData{
+		VerbsABIVersion: readSysfsFile(path.Join(verbsPath, "abi_version")),
+	}
+
+	log.Infof("rdma collect: scanning %s (%d entries), verbs_abi=%q",
+		verbsPath, len(dents), data.VerbsABIVersion)
+	for _, dent := range dents {
+		if !strings.HasPrefix(dent.Name(), "uverbs") {
+			continue
+		}
+		devDir := path.Join(verbsPath, dent.Name())
+		ibdev := readSysfsFile(path.Join(devDir, "ibdev"))
+		if ibdev == "" {
+			log.Warningf("rdma collect: %s has no ibdev, skipping", dent.Name())
+			continue
+		}
+		ibDir := path.Join("/sys/class/infiniband", ibdev)
+		deviceDir := path.Join(ibDir, "device")
+		dev := RDMADeviceData{
+			Name:            dent.Name(),
+			IBDev:           ibdev,
+			ABIVersion:      readSysfsFile(path.Join(devDir, "abi_version")),
+			Dev:             readSysfsFile(path.Join(devDir, "dev")),
+			NodeType:        readSysfsFile(path.Join(ibDir, "node_type")),
+			NodeGUID:        readSysfsFile(path.Join(ibDir, "node_guid")),
+			SysImgGUID:      readSysfsFile(path.Join(ibDir, "sys_image_guid")),
+			FWVer:           readSysfsFile(path.Join(ibDir, "fw_ver")),
+			Modalias:        readSysfsFile(path.Join(deviceDir, "modalias")),
+			PCISlotName:     parseUeventValue(path.Join(deviceDir, "uevent"), "PCI_SLOT_NAME"),
+			PCIDriver:       parseUeventValue(path.Join(deviceDir, "uevent"), "DRIVER"),
+			PCIClass:        readSysfsFile(path.Join(deviceDir, "class")),
+			PCIVendor:       readSysfsFile(path.Join(deviceDir, "vendor")),
+			PCIDevice:       readSysfsFile(path.Join(deviceDir, "device")),
+			PCISubsysVendor: readSysfsFile(path.Join(deviceDir, "subsystem_vendor")),
+			PCISubsysDevice: readSysfsFile(path.Join(deviceDir, "subsystem_device")),
+			NUMANode:        readSysfsFile(path.Join(deviceDir, "numa_node")),
+			LocalCPUList:    readSysfsFile(path.Join(deviceDir, "local_cpulist")),
+		}
+		log.Infof("rdma collect: %s → ibdev=%s dev=%s node_type=%q fw_ver=%q pci=%s numa=%s",
+			dent.Name(), ibdev, dev.Dev, dev.NodeType, dev.FWVer, dev.PCISlotName, dev.NUMANode)
+		portsPath := path.Join(ibDir, "ports")
+		portDents, err := os.ReadDir(portsPath)
+		if err == nil {
+			for _, portDent := range portDents {
+				portDir := path.Join(portsPath, portDent.Name())
+				pd := RDMAPortData{
+					Number:    portDent.Name(),
+					State:     readSysfsFile(path.Join(portDir, "state")),
+					PhysState: readSysfsFile(path.Join(portDir, "phys_state")),
+					LinkLayer: readSysfsFile(path.Join(portDir, "link_layer")),
+					Rate:      readSysfsFile(path.Join(portDir, "rate")),
+					LID:       readSysfsFile(path.Join(portDir, "lid")),
+					SMLID:     readSysfsFile(path.Join(portDir, "sm_lid")),
+					SMSL:      readSysfsFile(path.Join(portDir, "sm_sl")),
+					CapMask:   readSysfsFile(path.Join(portDir, "cap_mask")),
+				}
+				gidsPath := path.Join(portDir, "gids")
+				typesPath := path.Join(portDir, "gid_attrs", "types")
+				ndevsPath := path.Join(portDir, "gid_attrs", "ndevs")
+				gidDents, gerr := os.ReadDir(gidsPath)
+				if gerr == nil {
+					for _, gidDent := range gidDents {
+						gidVal := readSysfsFile(path.Join(gidsPath, gidDent.Name()))
+						typeVal := readSysfsFile(path.Join(typesPath, gidDent.Name()))
+						ndevVal := readSysfsFile(path.Join(ndevsPath, gidDent.Name()))
+						if gidVal == "" {
+							continue
+						}
+						if typeVal == "" && pd.LinkLayer == "Ethernet" {
+							typeVal = inferRoCEType(gidDent.Name())
+						}
+						pd.GIDs = append(pd.GIDs, RDMAGIDEntry{
+							Index:  gidDent.Name(),
+							GID:    gidVal,
+							Type:   typeVal,
+							NetDev: ndevVal,
+						})
+					}
+				}
+				log.Infof("rdma collect:   port %s: state=%q link_layer=%q rate=%q gids=%d",
+					pd.Number, pd.State, pd.LinkLayer, pd.Rate, len(pd.GIDs))
+				dev.Ports = append(dev.Ports, pd)
+			}
+		}
+		data.Devices = append(data.Devices, dev)
+	}
+	log.Infof("rdma collect: collected %d device(s)", len(data.Devices))
+	return data
+}
+
+// RDMADataPath is the path within the chroot where serialized RDMA data
+// is stored between boot stages.
+const RDMADataPath = "/var/lib/gvisor/rdma_data.json"
+
+// SerializeRDMAData writes the collected data as JSON to the given path.
+func SerializeRDMAData(data *RDMAData, filePath string) error {
+	if data == nil {
+		return nil
+	}
+	if err := os.MkdirAll(path.Dir(filePath), 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, b, 0644)
+}
+
+// DeserializeRDMAData reads serialized RDMA data from the given path.
+func DeserializeRDMAData(filePath string) *RDMAData {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Infof("rdma deserialize: %s: %v", filePath, err)
+		return nil
+	}
+	var data RDMAData
+	if err := json.Unmarshal(b, &data); err != nil {
+		log.Warningf("rdma deserialize: unmarshal %s: %v", filePath, err)
+		return nil
+	}
+	log.Infof("rdma deserialize: loaded %d device(s) from %s (verbs_abi=%q)",
+		len(data.Devices), filePath, data.VerbsABIVersion)
+	for _, d := range data.Devices {
+		log.Infof("rdma deserialize:   %s ibdev=%s dev=%s ports=%d",
+			d.Name, d.IBDev, d.Dev, len(d.Ports))
+		for _, p := range d.Ports {
+			typesWithValues := 0
+			for _, g := range p.GIDs {
+				if g.Type != "" {
+					typesWithValues++
+				}
+			}
+			log.Infof("rdma deserialize:   %s port %s: %d gids, %d with types",
+				d.IBDev, p.Number, len(p.GIDs), typesWithValues)
+		}
+	}
+	return &data
+}
+
+// extractMinor returns the minor portion from a "major:minor" dev string.
+func extractMinor(dev string) string {
+	if idx := strings.IndexByte(dev, ':'); idx >= 0 {
+		return dev[idx+1:]
+	}
+	return "0"
+}
+
+// ExtractMinorUint32 parses the minor portion from a sysfs "major:minor" dev
+// string (e.g. "231:192") and returns it as a uint32. Returns (0, false) if
+// the string is malformed.
+func ExtractMinorUint32(dev string) (uint32, bool) {
+	idx := strings.IndexByte(dev, ':')
+	if idx < 0 {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(dev[idx+1:], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(v), true
+}
+
+// inferRoCEType returns the RoCE GID type based on GID table index.
+// The sandbox's restricted sysfs mount masks gid_attrs/types/ content,
+// so we infer from the well-known mlx5 kernel assignment:
+//   - index 0: RoCE v1 (link-local MAC-derived)
+//   - index 1+: RoCE v2
+//
+// NCCL reads types from sysfs but gets actual GID addresses via ioctl.
+func inferRoCEType(gidIndex string) string {
+	if gidIndex == "0" {
+		return "IB/RoCE v1"
+	}
+	return "RoCE v2"
+}
+
+// parseUeventValue reads a uevent file and extracts the value for the given
+// KEY (matched as "KEY="). Returns empty string if the file doesn't exist or
+// has no matching line.
+func parseUeventValue(ueventPath, key string) string {
+	data, err := os.ReadFile(ueventPath)
+	if err != nil {
+		return ""
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	return ""
+}
+
+func readSysfsFile(filePath string) string {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// newRDMASysfsEntries creates /sys/class/infiniband_verbs/ and
+// /sys/class/infiniband/ directories from pre-collected device data.
+func (fs *filesystem) newRDMASysfsEntries(ctx context.Context, creds *auth.Credentials, data *RDMAData) (ibVerbsDir, ibDir map[string]kernfs.Inode) {
+	if data == nil || len(data.Devices) == 0 {
+		log.Infof("rdma sysfs: no RDMA data, skipping sysfs construction")
+		return nil, nil
+	}
+	log.Infof("rdma sysfs: building virtual sysfs for %d device(s), verbs_abi=%q",
+		len(data.Devices), data.VerbsABIVersion)
+	ibVerbsDir = map[string]kernfs.Inode{}
+	ibDir = map[string]kernfs.Inode{}
+	addFile := func(m map[string]kernfs.Inode, name, val string) {
+		if val != "" {
+			m[name] = fs.newStaticFile(ctx, creds, defaultSysMode, val+"\n")
+		}
+	}
+	addFile(ibVerbsDir, "abi_version", data.VerbsABIVersion)
+
+	for _, dev := range data.Devices {
+		verbsEntries := map[string]kernfs.Inode{}
+		addFile(verbsEntries, "ibdev", dev.IBDev)
+		addFile(verbsEntries, "abi_version", dev.ABIVersion)
+		devVal := dev.Dev
+		if dev.DynMajor != 0 {
+			minor := extractMinor(dev.Dev)
+			devVal = fmt.Sprintf("%d:%s", dev.DynMajor, minor)
+			log.Infof("rdma sysfs: %s dev=%s (patched from host %s, dynMajor=%d)",
+				dev.Name, devVal, dev.Dev, dev.DynMajor)
+		} else {
+			log.Infof("rdma sysfs: %s dev=%s (no dynMajor, using host value)", dev.Name, devVal)
+		}
+		addFile(verbsEntries, "dev", devVal)
+		ibVerbsDir[dev.Name] = fs.newDir(ctx, creds, defaultSysDirMode, verbsEntries)
+
+		if dev.IBDev == "" {
+			continue
+		}
+		log.Infof("rdma sysfs: %s → ibdev=%s node_type=%q fw_ver=%q guid=%s ports=%d",
+			dev.Name, dev.IBDev, dev.NodeType, dev.FWVer, dev.NodeGUID, len(dev.Ports))
+		ibDevEntries := map[string]kernfs.Inode{}
+		addFile(ibDevEntries, "node_type", dev.NodeType)
+		addFile(ibDevEntries, "node_guid", dev.NodeGUID)
+		addFile(ibDevEntries, "sys_image_guid", dev.SysImgGUID)
+		addFile(ibDevEntries, "fw_ver", dev.FWVer)
+		// Build the device/ subdirectory with PCI attributes.
+		// libibverbs reads modalias for driver matching; NCCL reads
+		// uevent for PCI_SLOT_NAME to match NICs against GPU topology.
+		deviceEntries := map[string]kernfs.Inode{}
+		addFile(deviceEntries, "modalias", dev.Modalias)
+		addFile(deviceEntries, "class", dev.PCIClass)
+		addFile(deviceEntries, "vendor", dev.PCIVendor)
+		addFile(deviceEntries, "device", dev.PCIDevice)
+		addFile(deviceEntries, "subsystem_vendor", dev.PCISubsysVendor)
+		addFile(deviceEntries, "subsystem_device", dev.PCISubsysDevice)
+		addFile(deviceEntries, "numa_node", dev.NUMANode)
+		addFile(deviceEntries, "local_cpulist", dev.LocalCPUList)
+		if dev.PCISlotName != "" {
+			uevent := ""
+			if dev.PCIDriver != "" {
+				uevent += "DRIVER=" + dev.PCIDriver + "\n"
+			}
+			if dev.PCIClass != "" {
+				uevent += "PCI_CLASS=" + strings.TrimPrefix(dev.PCIClass, "0x") + "\n"
+			}
+			if dev.PCIVendor != "" && dev.PCIDevice != "" {
+				uevent += "PCI_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCIVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCIDevice), "0X") + "\n"
+			}
+			if dev.PCISubsysVendor != "" && dev.PCISubsysDevice != "" {
+				uevent += "PCI_SUBSYS_ID=" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysVendor), "0X") + ":" + strings.TrimPrefix(strings.ToUpper(dev.PCISubsysDevice), "0X") + "\n"
+			}
+			uevent += "PCI_SLOT_NAME=" + dev.PCISlotName + "\n"
+			if dev.Modalias != "" {
+				uevent += "MODALIAS=" + dev.Modalias + "\n"
+			}
+			deviceEntries["uevent"] = fs.newStaticFile(ctx, creds, defaultSysMode, uevent)
+			log.Infof("rdma sysfs: %s device/uevent: PCI_SLOT_NAME=%s", dev.IBDev, dev.PCISlotName)
+		}
+		if len(deviceEntries) > 0 {
+			ibDevEntries["device"] = fs.newDir(ctx, creds, defaultSysDirMode, deviceEntries)
+		}
+		if len(dev.Ports) > 0 {
+			portsDir := map[string]kernfs.Inode{}
+			for _, port := range dev.Ports {
+				log.Infof("rdma sysfs:   port %s: state=%q link_layer=%q rate=%q",
+					port.Number, port.State, port.LinkLayer, port.Rate)
+				portEntries := map[string]kernfs.Inode{}
+				addFile(portEntries, "state", port.State)
+				addFile(portEntries, "phys_state", port.PhysState)
+				addFile(portEntries, "link_layer", port.LinkLayer)
+				addFile(portEntries, "rate", port.Rate)
+				addFile(portEntries, "lid", port.LID)
+				addFile(portEntries, "sm_lid", port.SMLID)
+				addFile(portEntries, "sm_sl", port.SMSL)
+				addFile(portEntries, "cap_mask", port.CapMask)
+				if len(port.GIDs) > 0 {
+					gidsEntries := map[string]kernfs.Inode{}
+					typesEntries := map[string]kernfs.Inode{}
+					ndevsEntries := map[string]kernfs.Inode{}
+					for _, gid := range port.GIDs {
+						addFile(gidsEntries, gid.Index, gid.GID)
+						addFile(typesEntries, gid.Index, gid.Type)
+						addFile(ndevsEntries, gid.Index, gid.NetDev)
+					}
+					log.Infof("rdma sysfs:   port %s: %d gids, gidsEntries=%d typesEntries=%d ndevsEntries=%d",
+						port.Number, len(port.GIDs), len(gidsEntries), len(typesEntries), len(ndevsEntries))
+					gidAttrsEntries := map[string]kernfs.Inode{
+						"types": fs.newDir(ctx, creds, defaultSysDirMode, typesEntries),
+					}
+					if len(ndevsEntries) > 0 {
+						gidAttrsEntries["ndevs"] = fs.newDir(ctx, creds, defaultSysDirMode, ndevsEntries)
+					}
+					portEntries["gids"] = fs.newDir(ctx, creds, defaultSysDirMode, gidsEntries)
+					portEntries["gid_attrs"] = fs.newDir(ctx, creds, defaultSysDirMode, gidAttrsEntries)
+				}
+				portsDir[port.Number] = fs.newDir(ctx, creds, defaultSysDirMode, portEntries)
+			}
+			ibDevEntries["ports"] = fs.newDir(ctx, creds, defaultSysDirMode, portsDir)
+		}
+		ibDir[dev.IBDev] = fs.newDir(ctx, creds, defaultSysDirMode, ibDevEntries)
+	}
+	return ibVerbsDir, ibDir
+}

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -170,6 +170,15 @@ func CollectRDMADeviceData() *RDMAData {
 		}
 		log.Infof("rdma collect: %s → ibdev=%s dev=%s node_type=%q fw_ver=%q pci=%s numa=%s",
 			dent.Name(), ibdev, dev.Dev, dev.NodeType, dev.FWVer, dev.PCISlotName, dev.NUMANode)
+
+		// Primary netdev discovery: kernel lists RoCE/IPoIB netdevs under
+		// the IB device's PCI node at device/net/<name>. This does not
+		// depend on GID ndevs being populated (often empty at collect time)
+		// or on the ibdev2netdev host utility.
+		for _, name := range netdevsForIBDev(ibdev) {
+			netDevices[name] = struct{}{}
+		}
+
 		portsPath := path.Join(ibDir, "ports")
 		portDents, err := os.ReadDir(portsPath)
 		if err == nil {
@@ -207,6 +216,8 @@ func CollectRDMADeviceData() *RDMAData {
 							Type:   typeVal,
 							NetDev: ndevVal,
 						})
+						// Secondary: nonempty GID ndevs (may be blank when
+						// the netdev is in another netns at collect time).
 						if ndevVal != "" {
 							netDevices[ndevVal] = struct{}{}
 						}
@@ -220,8 +231,32 @@ func CollectRDMADeviceData() *RDMAData {
 		data.Devices = append(data.Devices, dev)
 	}
 	data.NetDevices = collectRDMANetDevices(netDevices)
-	log.Infof("rdma collect: collected %d device(s)", len(data.Devices))
+	log.Infof("rdma collect: collected %d device(s), %d netdev(s)", len(data.Devices), len(data.NetDevices))
 	return data
+}
+
+// netdevsForIBDev returns netdev names bound to ibdev via
+// /sys/class/infiniband/<ibdev>/device/net/*. This is the kernel's
+// ibdev↔netdev association (what ibdev2netdev prints) without requiring
+// that host utility.
+func netdevsForIBDev(ibdev string) []string {
+	netDir := path.Join("/sys/class/infiniband", ibdev, "device", "net")
+	dents, err := os.ReadDir(netDir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, dent := range dents {
+		// Entries are directories named after the netdev (e.g. rdma0).
+		if dent.Name() == "." || dent.Name() == ".." {
+			continue
+		}
+		names = append(names, dent.Name())
+	}
+	if len(names) > 0 {
+		log.Infof("rdma collect: %s device/net → %v", ibdev, names)
+	}
+	return names
 }
 
 func collectRDMANetDevices(names map[string]struct{}) []RDMANetDeviceData {
@@ -231,6 +266,10 @@ func collectRDMANetDevices(names map[string]struct{}) []RDMANetDeviceData {
 	var netDevices []RDMANetDeviceData
 	for name := range names {
 		netDir := path.Join("/sys/class/net", name)
+		if _, err := os.Stat(netDir); err != nil {
+			log.Infof("rdma collect: netdev %s not in this netns (%v), skipping attrs", name, err)
+			continue
+		}
 		devicePath, err := filepath.EvalSymlinks(path.Join(netDir, "device"))
 		if err != nil {
 			devicePath = ""

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -60,16 +60,19 @@ type InternalData struct {
 	// accelerators.
 	EnableTPUProxyPaths bool
 	// EnableRDMAProxyPaths is whether to populate sysfs paths used by
-	// RDMA/InfiniBand libibverbs device discovery.
+	// RDMA/InfiniBand devices.
 	EnableRDMAProxyPaths bool
-	// RDMADevices contains pre-collected RDMA sysfs data for constructing
-	// virtual /sys/class/infiniband_verbs/ and /sys/class/infiniband/ trees.
+	// RDMADevices contains pre-read sysfs data for RDMA devices, collected
+	// before the sandbox chroot is entered.
 	RDMADevices *RDMAData
-	// PCIDevicesData contains pre-read PCI device topology from the host,
-	// used for NCCL PCI distance computation.
+	// PCIDevicesData contains pre-read sysfs data for PCI devices (GPUs,
+	// NICs, bridges), collected before the sandbox chroot is entered.
+	// Used by NCCL for topology discovery.
 	PCIDevicesData *PCIDevicesData
-	// NUMAData contains pre-read NUMA node layout from the host, used for
-	// NCCL CPU-affinity and distance calculations.
+	// NUMAData contains pre-read NUMA topology, collected before the sandbox
+	// chroot is entered. Used by NCCL to populate the per-NUMA-node CPU
+	// affinity bitmaps in its topology XML; without this, NCCL falls back to
+	// a single-rail layout and loses NUMA-aware ring/tree placement.
 	NUMAData *NUMAData
 	// TestSysfsPathPrefix is a prefix for the sysfs paths. It is useful for
 	// unit testing.
@@ -136,7 +139,8 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		"power_supply": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 	}
 	// systemSub holds the children of /sys/devices/system/. It's populated
-	// initially with cpu and may be extended with NUMA node entries below.
+	// here with the cpu/ subtree and then potentially extended below with
+	// the per-NUMA-node directories before being installed into devicesSub.
 	systemSub := map[string]kernfs.Inode{
 		"cpu": cpuDir(ctx, fs, creds),
 	}
@@ -144,6 +148,7 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 
 	productName := ""
 	busSub := make(map[string]kernfs.Inode)
+	moduleSub := make(map[string]kernfs.Inode)
 	kernelSub := kernelDir(ctx, fs, creds)
 	if opts.InternalData != nil {
 		idata := opts.InternalData.(*InternalData)
@@ -189,17 +194,10 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			}
 			kernelSub["iommu_groups"] = fs.newDir(ctx, creds, defaultSysDirMode, iommuGroups)
 		}
-		if idata.EnableRDMAProxyPaths {
-			ibVerbsDir, ibDir := fs.newRDMASysfsEntries(ctx, creds, idata.RDMADevices)
-			if ibVerbsDir != nil {
-				classSub["infiniband_verbs"] = fs.newDir(ctx, creds, defaultSysDirMode, ibVerbsDir)
-			}
-			if ibDir != nil {
-				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
-			}
-		}
+		var pciSlotToRelPath map[string]string
 		if idata.PCIDevicesData != nil {
-			pciDeviceTreeSub, pciBusSub, busPCIDevSub, _ := fs.newPCIDevicesSysfsEntries(ctx, creds, idata.PCIDevicesData)
+			var pciDeviceTreeSub, pciBusSub, busPCIDevSub map[string]kernfs.Inode
+			pciDeviceTreeSub, pciBusSub, busPCIDevSub, pciSlotToRelPath = fs.newPCIDevicesSysfsEntries(ctx, creds, idata.PCIDevicesData, idata.RDMADevices)
 			for name, inode := range pciDeviceTreeSub {
 				devicesSub[name] = inode
 			}
@@ -207,11 +205,6 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				classSub["pci_bus"] = fs.newDir(ctx, creds, defaultSysDirMode, pciBusSub)
 			}
 			if len(busPCIDevSub) > 0 {
-				// On GPU nodes NVProxy enables EnableTPUProxyPaths, which
-				// already populates busSub["pci"] with the TPU/GPU PCI device
-				// symlinks above. Only fall back to the serialized PCI device
-				// tree when no PCI bus directory has been set, so we don't
-				// clobber those entries.
 				if _, ok := busSub["pci"]; !ok {
 					busSub["pci"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
 						"devices": fs.newDir(ctx, creds, defaultSysDirMode, busPCIDevSub),
@@ -222,7 +215,38 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		if nodeSub := fs.newNUMASysfsEntries(ctx, creds, idata.NUMAData); nodeSub != nil {
 			systemSub["node"] = fs.newDir(ctx, creds, defaultSysDirMode, nodeSub)
 		}
+		if idata.EnableRDMAProxyPaths {
+			ibVerbsDir, ibDir := fs.newRDMASysfsEntries(ctx, creds, idata.RDMADevices, pciSlotToRelPath)
+			if ibVerbsDir != nil {
+				classSub["infiniband_verbs"] = fs.newDir(ctx, creds, defaultSysDirMode, ibVerbsDir)
+			}
+			if ibDir != nil {
+				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
+			}
+			if netDir := fs.newRDMANetClassEntries(ctx, creds, idata.RDMADevices); netDir != nil {
+				classSub["net"] = fs.newDir(ctx, creds, defaultSysDirMode, netDir)
+			}
+			if idata.RDMADevices != nil && idata.RDMADevices.PeerMemVersion != "" {
+				peerMemVer := idata.RDMADevices.PeerMemVersion + "\n"
+				moduleSub["nvidia_peermem"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+					"version": fs.newStaticFile(ctx, creds, defaultSysMode, peerMemVer),
+				})
+				if kernelSub["mm"] == nil {
+					kernelSub["mm"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+						"memory_peers": fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+							"nv_mem": fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+								"version": fs.newStaticFile(ctx, creds, defaultSysMode, peerMemVer),
+							}),
+						}),
+					})
+				}
+			}
+		}
 	}
+
+	// Install /sys/devices/system/ now that systemSub may have been extended
+	// (e.g. with the per-NUMA-node directories above).
+	devicesSub["system"] = fs.newDir(ctx, creds, defaultSysDirMode, systemSub)
 
 	if len(productName) > 0 {
 		log.Debugf("Setting product_name: %q", productName)
@@ -237,10 +261,6 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			}),
 		})
 	}
-	// Install /sys/devices/system/ now that systemSub may have been extended
-	// with NUMA node entries.
-	devicesSub["system"] = fs.newDir(ctx, creds, defaultSysDirMode, systemSub)
-
 	root := fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
 		"block": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 		"bus":   fs.newDir(ctx, creds, defaultSysDirMode, busSub),
@@ -253,7 +273,7 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		"firmware": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 		"fs":       fs.newDir(ctx, creds, defaultSysDirMode, fsDirChildren),
 		"kernel":   fs.newDir(ctx, creds, defaultSysDirMode, kernelSub),
-		"module":   fs.newDir(ctx, creds, defaultSysDirMode, nil),
+		"module":   fs.newDir(ctx, creds, defaultSysDirMode, moduleSub),
 		"power":    fs.newDir(ctx, creds, defaultSysDirMode, nil),
 	})
 	fs.root = root.(*dir)

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -65,6 +65,12 @@ type InternalData struct {
 	// RDMADevices contains pre-collected RDMA sysfs data for constructing
 	// virtual /sys/class/infiniband_verbs/ and /sys/class/infiniband/ trees.
 	RDMADevices *RDMAData
+	// PCIDevicesData contains pre-read PCI device topology from the host,
+	// used for NCCL PCI distance computation.
+	PCIDevicesData *PCIDevicesData
+	// NUMAData contains pre-read NUMA node layout from the host, used for
+	// NCCL CPU-affinity and distance calculations.
+	NUMAData *NUMAData
 	// TestSysfsPathPrefix is a prefix for the sysfs paths. It is useful for
 	// unit testing.
 	TestSysfsPathPrefix string
@@ -129,11 +135,12 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 	classSub := map[string]kernfs.Inode{
 		"power_supply": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 	}
-	devicesSub := map[string]kernfs.Inode{
-		"system": fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
-			"cpu": cpuDir(ctx, fs, creds),
-		}),
+	// systemSub holds the children of /sys/devices/system/. It's populated
+	// initially with cpu and may be extended with NUMA node entries below.
+	systemSub := map[string]kernfs.Inode{
+		"cpu": cpuDir(ctx, fs, creds),
 	}
+	devicesSub := map[string]kernfs.Inode{}
 
 	productName := ""
 	busSub := make(map[string]kernfs.Inode)
@@ -191,6 +198,30 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
 			}
 		}
+		if idata.PCIDevicesData != nil {
+			pciDeviceTreeSub, pciBusSub, busPCIDevSub, _ := fs.newPCIDevicesSysfsEntries(ctx, creds, idata.PCIDevicesData)
+			for name, inode := range pciDeviceTreeSub {
+				devicesSub[name] = inode
+			}
+			if len(pciBusSub) > 0 {
+				classSub["pci_bus"] = fs.newDir(ctx, creds, defaultSysDirMode, pciBusSub)
+			}
+			if len(busPCIDevSub) > 0 {
+				// On GPU nodes NVProxy enables EnableTPUProxyPaths, which
+				// already populates busSub["pci"] with the TPU/GPU PCI device
+				// symlinks above. Only fall back to the serialized PCI device
+				// tree when no PCI bus directory has been set, so we don't
+				// clobber those entries.
+				if _, ok := busSub["pci"]; !ok {
+					busSub["pci"] = fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
+						"devices": fs.newDir(ctx, creds, defaultSysDirMode, busPCIDevSub),
+					})
+				}
+			}
+		}
+		if nodeSub := fs.newNUMASysfsEntries(ctx, creds, idata.NUMAData); nodeSub != nil {
+			systemSub["node"] = fs.newDir(ctx, creds, defaultSysDirMode, nodeSub)
+		}
 	}
 
 	if len(productName) > 0 {
@@ -206,6 +237,10 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			}),
 		})
 	}
+	// Install /sys/devices/system/ now that systemSub may have been extended
+	// with NUMA node entries.
+	devicesSub["system"] = fs.newDir(ctx, creds, defaultSysDirMode, systemSub)
+
 	root := fs.newDir(ctx, creds, defaultSysDirMode, map[string]kernfs.Inode{
 		"block": fs.newDir(ctx, creds, defaultSysDirMode, nil),
 		"bus":   fs.newDir(ctx, creds, defaultSysDirMode, busSub),

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -59,6 +59,12 @@ type InternalData struct {
 	// EnableTPUProxyPaths is whether to populate sysfs paths used by hardware
 	// accelerators.
 	EnableTPUProxyPaths bool
+	// EnableRDMAProxyPaths is whether to populate sysfs paths used by
+	// RDMA/InfiniBand libibverbs device discovery.
+	EnableRDMAProxyPaths bool
+	// RDMADevices contains pre-collected RDMA sysfs data for constructing
+	// virtual /sys/class/infiniband_verbs/ and /sys/class/infiniband/ trees.
+	RDMADevices *RDMAData
 	// TestSysfsPathPrefix is a prefix for the sysfs paths. It is useful for
 	// unit testing.
 	TestSysfsPathPrefix string
@@ -175,6 +181,15 @@ func (fsType FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 				return nil, nil, err
 			}
 			kernelSub["iommu_groups"] = fs.newDir(ctx, creds, defaultSysDirMode, iommuGroups)
+		}
+		if idata.EnableRDMAProxyPaths {
+			ibVerbsDir, ibDir := fs.newRDMASysfsEntries(ctx, creds, idata.RDMADevices)
+			if ibVerbsDir != nil {
+				classSub["infiniband_verbs"] = fs.newDir(ctx, creds, defaultSysDirMode, ibVerbsDir)
+			}
+			if ibDir != nil {
+				classSub["infiniband"] = fs.newDir(ctx, creds, defaultSysDirMode, ibDir)
+			}
 		}
 	}
 

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -45,6 +45,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/fdimport"
 	cgroup2fs "gvisor.dev/gvisor/pkg/sentry/fsimpl/cgroup2fs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/host"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/user"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
@@ -246,6 +247,9 @@ type Loader struct {
 	// productName is the value to show in
 	// /sys/devices/virtual/dmi/id/product_name.
 	productName string
+
+	// rdmaDevices contains pre-collected sysfs data for RDMA devices.
+	rdmaDevices *sys.RDMAData
 
 	// cpuQuota and cpuPeriod are the raw host CFS settings that should be
 	// exposed through sandbox cgroupfs.
@@ -449,6 +453,9 @@ type Args struct {
 	// RootfsUpperTarFD is the file descriptor to the tar file containing the rootfs
 	// upper layer changes.
 	RootfsUpperTarFD int
+
+	// RDMADevices contains pre-collected sysfs data for RDMA devices.
+	RDMADevices *sys.RDMAData
 }
 
 // HostTHP holds host transparent hugepage settings.
@@ -532,6 +539,7 @@ func New(args Args) (*Loader, error) {
 		sharedMounts:          make(map[string]*vfs.Mount),
 		stopProfiling:         stopProfiling,
 		productName:           args.ProductName,
+		rdmaDevices:           args.RDMADevices,
 		cpuQuota:              args.CPUQuota,
 		cpuPeriod:             args.CPUPeriod,
 		hostTHP:               args.HostTHP,

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -251,6 +251,12 @@ type Loader struct {
 	// rdmaDevices contains pre-collected sysfs data for RDMA devices.
 	rdmaDevices *sys.RDMAData
 
+	// pciDevicesData contains pre-collected PCI topology from the host.
+	pciDevicesData *sys.PCIDevicesData
+
+	// numaData contains pre-collected NUMA node layout from the host.
+	numaData *sys.NUMAData
+
 	// cpuQuota and cpuPeriod are the raw host CFS settings that should be
 	// exposed through sandbox cgroupfs.
 	cpuQuota  int64
@@ -456,6 +462,10 @@ type Args struct {
 
 	// RDMADevices contains pre-collected sysfs data for RDMA devices.
 	RDMADevices *sys.RDMAData
+	// PCIDevicesData contains pre-collected PCI topology from the host.
+	PCIDevicesData *sys.PCIDevicesData
+	// NUMAData contains pre-collected NUMA node layout from the host.
+	NUMAData *sys.NUMAData
 }
 
 // HostTHP holds host transparent hugepage settings.
@@ -540,6 +550,8 @@ func New(args Args) (*Loader, error) {
 		stopProfiling:         stopProfiling,
 		productName:           args.ProductName,
 		rdmaDevices:           args.RDMADevices,
+		pciDevicesData:        args.PCIDevicesData,
+		numaData:              args.NUMAData,
 		cpuQuota:              args.CPUQuota,
 		cpuPeriod:             args.CPUPeriod,
 		hostTHP:               args.HostTHP,

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -921,7 +921,7 @@ func (c *containerMounter) getPathMode(ctx context.Context, creds *auth.Credenti
 }
 
 func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) (*vfs.Mount, error) {
-	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
 	if err != nil {
 		return nil, fmt.Errorf("mountOptions failed: %w", err)
 	}
@@ -984,7 +984,7 @@ func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, 
 
 // getMountNameAndOptions retrieves the fsName, opts, and useOverlay values
 // used for mounts.
-func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore) (string, *vfs.MountOptions, error) {
+func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaDevices *sys.RDMAData) (string, *vfs.MountOptions, error) {
 	fsName := m.mount.Type
 	var (
 		mopts        = m.mount.Options
@@ -1004,7 +1004,11 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 		internalData = newProcInternalData(conf, spec)
 
 	case sys.Name:
-		sysData := &sys.InternalData{EnableTPUProxyPaths: specutils.TPUProxyEnabled(spec, conf)}
+		sysData := &sys.InternalData{
+			EnableTPUProxyPaths:  specutils.TPUProxyEnabled(spec, conf),
+			EnableRDMAProxyPaths: conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec),
+			RDMADevices:          rdmaDevices,
+		}
 		if len(productName) > 0 {
 			sysData.ProductName = productName
 		}
@@ -1385,7 +1389,7 @@ func (c *containerMounter) mountSharedMaster(ctx context.Context, spec *specs.Sp
 	// Mount the master using the options from the hint (mount annotations).
 	origOpts := mntInfo.mount.Options
 	mntInfo.mount.Options = mntInfo.hint.Mount.Options
-	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
 	mntInfo.mount.Options = origOpts
 	if err != nil {
 		return nil, err

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -921,7 +921,7 @@ func (c *containerMounter) getPathMode(ctx context.Context, creds *auth.Credenti
 }
 
 func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) (*vfs.Mount, error) {
-	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices, c.l.pciDevicesData, c.l.numaData)
 	if err != nil {
 		return nil, fmt.Errorf("mountOptions failed: %w", err)
 	}
@@ -984,7 +984,7 @@ func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, 
 
 // getMountNameAndOptions retrieves the fsName, opts, and useOverlay values
 // used for mounts.
-func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaDevices *sys.RDMAData) (string, *vfs.MountOptions, error) {
+func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaDevices *sys.RDMAData, pciDevicesData *sys.PCIDevicesData, numaData *sys.NUMAData) (string, *vfs.MountOptions, error) {
 	fsName := m.mount.Type
 	var (
 		mopts        = m.mount.Options
@@ -1008,6 +1008,8 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 			EnableTPUProxyPaths:  specutils.TPUProxyEnabled(spec, conf),
 			EnableRDMAProxyPaths: conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec),
 			RDMADevices:          rdmaDevices,
+			PCIDevicesData:       pciDevicesData,
+			NUMAData:             numaData,
 		}
 		if len(productName) > 0 {
 			sysData.ProductName = productName
@@ -1389,7 +1391,7 @@ func (c *containerMounter) mountSharedMaster(ctx context.Context, spec *specs.Sp
 	// Mount the master using the options from the hint (mount annotations).
 	origOpts := mntInfo.mount.Options
 	mntInfo.mount.Options = mntInfo.hint.Mount.Options
-	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices)
+	fsName, opts, err := getMountNameAndOptions(spec, conf, mntInfo, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaDevices, c.l.pciDevicesData, c.l.numaData)
 	mntInfo.mount.Options = origOpts
 	if err != nil {
 		return nil, err

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -100,6 +100,7 @@ go_library(
         "//pkg/sentry/control",
         "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/devices/tpuproxy",
+        "//pkg/sentry/fsimpl/sys",
         "//pkg/sentry/hostmm",
         "//pkg/sentry/kernel",
         "//pkg/sentry/kernel/auth",

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -38,6 +38,7 @@ import (
 	"gvisor.dev/gvisor/pkg/prometheus"
 	"gvisor.dev/gvisor/pkg/ring0"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/pkg/sentry/hostmm"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
 	"gvisor.dev/gvisor/pkg/sentry/syscalls/linux"
@@ -581,6 +582,12 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 	linux.SetAFSSyscallPanic(conf.TestOnlyAFSSyscallPanic)
 
+	// Read RDMA device data serialized by stage 1 (rdmaProxyUpdateChroot).
+	var rdmaDevices *sys.RDMAData
+	if conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec) {
+		rdmaDevices = sys.DeserializeRDMAData(sys.RDMADataPath)
+	}
+
 	// Create the loader.
 	bootArgs := boot.Args{
 		ID:                  f.Arg(0),
@@ -619,6 +626,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		FSRestoreFDs:             b.fsRestoreFDs.GetFDs(),
 		FSRestoreCheckpointGofer: b.fsRestoreCheckpointGofer,
 		RootfsUpperTarFD:         b.rootfsUpperTarFD,
+		RDMADevices:              rdmaDevices,
 	}
 	l, err := boot.New(bootArgs)
 	if err != nil {

--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -588,6 +588,10 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		rdmaDevices = sys.DeserializeRDMAData(sys.RDMADataPath)
 	}
 
+	// Read PCI/NUMA topology data serialized by stage 1.
+	pciDevicesData := sys.DeserializePCIDevicesData(sys.PCIDevicesDataPath)
+	numaData := sys.DeserializeNUMAData(sys.NUMADataPath)
+
 	// Create the loader.
 	bootArgs := boot.Args{
 		ID:                  f.Arg(0),
@@ -627,6 +631,8 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		FSRestoreCheckpointGofer: b.fsRestoreCheckpointGofer,
 		RootfsUpperTarFD:         b.rootfsUpperTarFD,
 		RDMADevices:              rdmaDevices,
+		PCIDevicesData:           pciDevicesData,
+		NUMAData:                 numaData,
 	}
 	l, err := boot.New(bootArgs)
 	if err != nil {

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -252,9 +252,9 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 
 	const bindFlags = unix.MS_BIND | unix.MS_RDONLY
 
-	// Only bind-mount RDMA-backed netdevs discovered via GID ndevs — not
-	// all of /sys/class/net, which would expose unrelated host interfaces
-	// (and confuse --network=sandbox / hostinet modes).
+	// Only bind-mount RDMA-backed netdevs from CollectRDMADeviceData
+	// (primarily /sys/class/infiniband/<ibdev>/device/net/*) — not all of
+	// /sys/class/net, which would expose unrelated host interfaces.
 	seenNetDev := make(map[string]struct{})
 	for _, netDev := range data.NetDevices {
 		if netDev.Name == "" {

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -27,6 +27,7 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/runsc/cmd/sandboxsetup"
 	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/specutils"
 )
@@ -148,6 +149,10 @@ func setUpChroot(spec *specs.Spec, conf *config.Config) error {
 		return fmt.Errorf("error configuring chroot for TPU devices: %w", err)
 	}
 
+	if err := rdmaProxyUpdateChroot(chroot, spec, conf); err != nil {
+		return fmt.Errorf("error configuring chroot for RDMA devices: %w", err)
+	}
+
 	if err := specutils.SafeMount("", chroot, "", unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_BIND, "", "/proc"); err != nil {
 		return fmt.Errorf("error remounting chroot in read-only: %v", err)
 	}
@@ -212,4 +217,27 @@ func tpuProxyUpdateChroot(hostRoot, chroot string, spec *specs.Spec, conf *confi
 		}
 	}
 	return err
+}
+
+func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
+	if !conf.RDMAProxy || !specutils.HasRDMADevicesInSpec(spec) {
+		return nil
+	}
+	// Collect RDMA device data from the real host sysfs (accessible now,
+	// before pivot_root) and serialize it as JSON into the chroot. Stage 2
+	// deserializes this instead of trying to read sysfs — avoids all the
+	// symlink resolution and depth-limiting complexity of copying sysfs
+	// trees. The RoCE netdev backing each ibdev should have already been
+	// moved into the sandbox netns by MoveRDMANetdevsIntoSandbox; the GID
+	// sysfs entries we read here therefore include the kernel's normal
+	// IPv4-mapped RoCE v2 entries.
+	data := sys.CollectRDMADeviceData()
+	if data == nil {
+		return nil
+	}
+	jsonPath := filepath.Join(chroot, sys.RDMADataPath)
+	if err := sys.SerializeRDMAData(data, jsonPath); err != nil {
+		return fmt.Errorf("serializing RDMA data: %w", err)
+	}
+	return nil
 }

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -233,11 +233,13 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 	}
 	// Collect RDMA device data from the real host sysfs (accessible now,
 	// before pivot_root) and serialize it as JSON into the chroot. Stage 2
-	// deserializes this instead of trying to read sysfs — avoids all the
-	// symlink resolution and depth-limiting complexity of copying sysfs
-	// trees. The RoCE netdev backing each ibdev should have already been
-	// moved into the sandbox netns by MoveRDMANetdevsIntoSandbox; the GID
-	// sysfs entries we read here therefore include the kernel's normal
+	// deserializes this for mostly-static attrs. Dynamic port/netdev attrs
+	// are served via hostFile and need the bind mounts below so those
+	// paths remain openable after pivot_root.
+	//
+	// The RoCE netdev backing each ibdev should have already been moved
+	// into the sandbox netns by MoveRDMANetdevsIntoSandbox; the GID sysfs
+	// entries we read here therefore include the kernel's normal
 	// IPv4-mapped RoCE v2 entries.
 	data := sys.CollectRDMADeviceData()
 	if data == nil {
@@ -246,6 +248,49 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 	jsonPath := filepath.Join(chroot, sys.RDMADataPath)
 	if err := sys.SerializeRDMAData(data, jsonPath); err != nil {
 		return fmt.Errorf("serializing RDMA data: %w", err)
+	}
+
+	const bindFlags = unix.MS_BIND | unix.MS_RDONLY
+
+	// Only bind-mount RDMA-backed netdevs discovered via GID ndevs — not
+	// all of /sys/class/net, which would expose unrelated host interfaces
+	// (and confuse --network=sandbox / hostinet modes).
+	seenNetDev := make(map[string]struct{})
+	for _, netDev := range data.NetDevices {
+		if netDev.Name == "" {
+			continue
+		}
+		if _, ok := seenNetDev[netDev.Name]; ok {
+			continue
+		}
+		seenNetDev[netDev.Name] = struct{}{}
+		netPath := path.Join("/sys/class/net", netDev.Name)
+		if _, err := os.Stat(netPath); err != nil {
+			log.Infof("rdma chroot: %s not present, skipping bind mount: %v", netPath, err)
+			continue
+		}
+		if err := mountInChroot(chroot, netPath, netPath, "bind", bindFlags); err != nil {
+			return fmt.Errorf("error mounting %q in chroot: %w", netPath, err)
+		}
+	}
+
+	seenIBDev := make(map[string]struct{})
+	for _, dev := range data.Devices {
+		if dev.IBDev == "" {
+			continue
+		}
+		if _, ok := seenIBDev[dev.IBDev]; ok {
+			continue
+		}
+		seenIBDev[dev.IBDev] = struct{}{}
+		portsPath := path.Join("/sys/class/infiniband", dev.IBDev, "ports")
+		if _, err := os.Stat(portsPath); err != nil {
+			log.Infof("rdma chroot: %s not present, skipping bind mount: %v", portsPath, err)
+			continue
+		}
+		if err := mountInChroot(chroot, portsPath, portsPath, "bind", bindFlags); err != nil {
+			return fmt.Errorf("error mounting %q in chroot: %w", portsPath, err)
+		}
 	}
 	return nil
 }

--- a/runsc/cmd/chroot.go
+++ b/runsc/cmd/chroot.go
@@ -153,6 +153,14 @@ func setUpChroot(spec *specs.Spec, conf *config.Config) error {
 		return fmt.Errorf("error configuring chroot for RDMA devices: %w", err)
 	}
 
+	if err := pciDevicesUpdateChroot(chroot, spec, conf); err != nil {
+		return fmt.Errorf("error configuring chroot for PCI topology: %w", err)
+	}
+
+	if err := numaUpdateChroot(chroot, spec, conf); err != nil {
+		return fmt.Errorf("error configuring chroot for NUMA topology: %w", err)
+	}
+
 	if err := specutils.SafeMount("", chroot, "", unix.MS_REMOUNT|unix.MS_RDONLY|unix.MS_BIND, "", "/proc"); err != nil {
 		return fmt.Errorf("error remounting chroot in read-only: %v", err)
 	}
@@ -238,6 +246,36 @@ func rdmaProxyUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config)
 	jsonPath := filepath.Join(chroot, sys.RDMADataPath)
 	if err := sys.SerializeRDMAData(data, jsonPath); err != nil {
 		return fmt.Errorf("serializing RDMA data: %w", err)
+	}
+	return nil
+}
+
+func pciDevicesUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
+	if !conf.NVProxy && !specutils.HasRDMADevicesInSpec(spec) {
+		return nil
+	}
+	data := sys.CollectPCIDeviceData()
+	if data == nil {
+		return nil
+	}
+	jsonPath := filepath.Join(chroot, sys.PCIDevicesDataPath)
+	if err := sys.SerializePCIDevicesData(data, jsonPath); err != nil {
+		return fmt.Errorf("serializing PCI devices data: %w", err)
+	}
+	return nil
+}
+
+func numaUpdateChroot(chroot string, spec *specs.Spec, conf *config.Config) error {
+	if !conf.NVProxy && !specutils.HasRDMADevicesInSpec(spec) {
+		return nil
+	}
+	data := sys.CollectNUMAData()
+	if data == nil {
+		return nil
+	}
+	jsonPath := filepath.Join(chroot, sys.NUMADataPath)
+	if err := sys.SerializeNUMAData(data, jsonPath); err != nil {
+		return fmt.Errorf("serializing NUMA data: %w", err)
 	}
 	return nil
 }

--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -506,6 +506,13 @@ func ShouldExposeTpuDevice(path string) bool {
 	return valid || ShouldExposeVFIODevice(path)
 }
 
+// ShouldExposeRDMADevice returns true if path refers to an RDMA uverbs device.
+//
+// Precondition: rdmaproxy is enabled.
+func ShouldExposeRDMADevice(path string) bool {
+	return strings.HasPrefix(path, "/dev/infiniband/uverbs")
+}
+
 // SetupDev mounts devices from the OCI spec into the gofer's /dev directory.
 func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) error {
 	if err := os.MkdirAll(filepath.Join(root, "dev"), 0777); err != nil {
@@ -517,9 +524,11 @@ func SetupDev(spec *specs.Spec, conf *config.Config, root, procPath string) erro
 	}
 	nvproxyEnabled := specutils.NVProxyEnabled(spec, conf)
 	tpuproxyEnabled := specutils.TPUProxyEnabled(spec, conf)
+	rdmaproxyEnabled := conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec)
 	for _, dev := range spec.Linux.Devices {
 		shouldMount := (nvproxyEnabled && ShouldExposeNvidiaDevice(dev.Path)) ||
-			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path))
+			(tpuproxyEnabled && ShouldExposeTpuDevice(dev.Path)) ||
+			(rdmaproxyEnabled && ShouldExposeRDMADevice(dev.Path))
 		if !shouldMount {
 			continue
 		}

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -367,6 +367,9 @@ type Config struct {
 	// TPUProxy enables support for TPUs.
 	TPUProxy bool `flag:"tpuproxy"`
 
+	// RDMAProxy enables support for RDMA device passthrough.
+	RDMAProxy bool `flag:"rdmaproxy"`
+
 	// TestOnlyAllowRunAsCurrentUserWithoutChroot should only be used in
 	// tests. It allows runsc to start the sandbox process as the current
 	// user, and without chrooting the sandbox process. This can be

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -180,6 +180,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("nvproxy-allow-unsupported-driver", false, "allow nvproxy to be initialized with an unsupported driver version.")
 	flagSet.String("nvproxy-allowed-driver-capabilities", "utility,compute", "Comma separated list of NVIDIA driver capabilities that are allowed to be requested by the container. If 'all' is specified here, it is resolved to all driver capabilities supported in nvproxy. If 'all' is requested by the container, it is resolved to this list.")
 	flagSet.Bool("tpuproxy", false, "LEGACY: enable support for TPU devices. TPU support gets automatically enabled if TPU devices are present in the OCI spec.")
+	flagSet.Bool("rdmaproxy", false, "EXPERIMENTAL: enable support for RDMA device passthrough.")
 
 	// Test flags, not to be used outside tests, ever.
 	flagSet.Bool("TESTONLY-unsafe-nonroot", false, "TEST ONLY; do not ever use! This skips many security measures that isolate the host from the sandbox.")

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1333,7 +1333,7 @@ func (c *Container) waitForStopped() error {
 // shouldCreateDeviceGofer indicates whether a device gofer connection should
 // be created.
 func shouldCreateDeviceGofer(spec *specs.Spec, conf *config.Config) bool {
-	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf)
+	return specutils.GPUFunctionalityRequested(spec, conf) || specutils.TPUFunctionalityRequested(spec, conf) || (conf.RDMAProxy && specutils.HasRDMADevicesInSpec(spec))
 }
 
 // shouldSpawnGofer indicates whether the gofer process should be spawned.

--- a/runsc/specutils/BUILD
+++ b/runsc/specutils/BUILD
@@ -14,6 +14,7 @@ go_library(
         "hooks.go",
         "namespace.go",
         "nvidia.go",
+        "rdma.go",
         "restore.go",
         "specutils.go",
     ],

--- a/runsc/specutils/rdma.go
+++ b/runsc/specutils/rdma.go
@@ -1,0 +1,42 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package specutils
+
+import (
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// HasRDMADevicesInSpec returns true if the OCI spec lists at least one
+// /dev/infiniband/uverbs* device. Used to gate sysfs RDMA topology
+// serialization at chroot time, so PCI/RDMA/NUMA snapshot data is only
+// collected when the container actually requests RDMA devices.
+//
+// This intentionally does NOT consult the runtime rdmaproxy enable flag
+// (which lives in the rdmaproxy package, downstream of this PR) — sysfs
+// data collection is harmless without rdmaproxy and shipping serialize
+// alone should not require rdmaproxy.
+func HasRDMADevicesInSpec(spec *specs.Spec) bool {
+	if spec.Linux == nil {
+		return false
+	}
+	for _, dev := range spec.Linux.Devices {
+		if strings.HasPrefix(dev.Path, "/dev/infiniband/uverbs") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Stacks on #13312 and based on #13114. Adds necessary GPU/NIC/NVSwitch topology information for NVIDIA NCCL discovery in [GDRDMA](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://developer.nvidia.com/gpudirect&ved=2ahUKEwjEi_qSm9-UAxUpkYkEHW6jMhsQFnoECBoQAQ&usg=AOvVaw1ntntQ1TNOhVJE40xJi24c).

<img width="1164" height="179" alt="image" src="https://github.com/user-attachments/assets/1afc6b84-3ca1-405d-8d36-1084d5a33512" />
<img width="614" height="265" alt="image" src="https://github.com/user-attachments/assets/7fd5223d-f86f-4858-b02b-5d4e0df2ee42" />

Files modified:
- `pkg/sentry/fsimpl/sys/pci_devices.go`: add `0680` and `0207 ` class for NVSwitch. Make NIC-filtering IB-aware. Add InfiniBand symlinks in PCI tree. 
- `pkg/sentry/fsimpl/sys/rdma.go`: Add `/sys/module/nvidia_peermem/version` for NCCL to check if GDRDMA is available.  Collect InfiniBand netdevs as symlink into PCI tree. Add `/sys/class/net/` entries.
- `pkg/sentry/fsimpl/sys/sys.go`: build PCI sysfs tree before RDMA devices to resolve symlinks from RDMA -> PCI. Collect all previously serialized information and reconstruct in chroot virtual sysfs tree. 