### PR TITLE
test/syscalls: fix DataTransferStressTest.BigDataTransfer port exhaustion

### DIFF
--- a/test/syscalls/linux/socket_generic_stress.cc
+++ b/test/syscalls/linux/socket_generic_stress.cc
@@ -193,6 +193,30 @@ INSTANTIATE_TEST_SUITE_P(
 using DataTransferStressTest = SocketPairTest;
 
 TEST_P(DataTransferStressTest, BigDataTransfer) {
+  // ConnectStressTest / PersistentListenerConnectStressTest narrow the
+  // ephemeral port range to ~50 ports via MaybeLimitEphemeralPorts() so they
+  // can exercise port-exhaustion behavior. That range is process-global, so
+  // when one of them runs before this test in the same shard the small pool is
+  // left full of TIME-WAIT 4-tuples and bind(port=0) fails with EADDRINUSE
+  // that no amount of SO_REUSEADDR / brief sleep can rescue. Widen the pool
+  // back to a large range for this test.
+  const char kRangeFile[] = "/proc/sys/net/ipv4/ip_local_port_range";
+  if (!access(kRangeFile, W_OK)) {
+    FileDescriptor fd =
+        ASSERT_NO_ERRNO_AND_VALUE(Open(kRangeFile, O_WRONLY | O_TRUNC));
+    const char full_range[] = "16000 65535";
+    const int n = write(fd.get(), full_range, sizeof(full_range) - 1);
+    // As root, access()/open() succeed even when the file is read-only (e.g.
+    // the host's port range under hostinet), so write() may still fail with
+    // EACCES. Tolerate that and skip widening rather than failing the test,
+    // mirroring MaybeLimitEphemeralPorts().
+    if (n < 0) {
+      ASSERT_THAT(n, SyscallFailsWithErrno(EACCES));
+    } else {
+      ASSERT_THAT(n, SyscallSucceedsWithValue(sizeof(full_range) - 1));
+    }
+  }
+
   const std::unique_ptr<SocketPair> sockets =
       ASSERT_NO_ERRNO_AND_VALUE(NewSocketPair());
   int client_fd = sockets->first_fd();
@@ -253,9 +277,20 @@ TEST_P(DataTransferStressTest, BigDataTransfer) {
 
 INSTANTIATE_TEST_SUITE_P(
     AllConnectedSockets, DataTransferStressTest,
-    ::testing::Values(IPv6TCPAcceptBindPersistentListenerSocketPair(0),
-                      IPv4TCPAcceptBindPersistentListenerSocketPair(0),
-                      DualStackTCPAcceptBindPersistentListenerSocketPair(0)));
+    // SO_REUSEADDR is applied to the returned connect/accept sockets (see
+    // SetSockOpt), purely to mirror the PersistentListenerConnectStressTest
+    // instantiation above. Note it does NOT reach the shared persistent
+    // listener, which is created and bound inside the creator before any
+    // setsockopt runs; the actual fix for the listener bind() that would
+    // otherwise fail with EADDRINUSE is the port-range widening at the top of
+    // BigDataTransfer.
+    ::testing::Values(SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &kSockOptOn)(
+                          IPv6TCPAcceptBindPersistentListenerSocketPair(0)),
+                      SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &kSockOptOn)(
+                          IPv4TCPAcceptBindPersistentListenerSocketPair(0)),
+                      SetSockOpt(SOL_SOCKET, SO_REUSEADDR, &kSockOptOn)(
+                          DualStackTCPAcceptBindPersistentListenerSocketPair(
+                              0))));
 
 }  // namespace testing
 }  // namespace gvisor

--- a/test/util/socket_util.cc
+++ b/test/util/socket_util.cc
@@ -463,21 +463,35 @@ Creator<SocketPair> TCPAcceptBindPersistentListenerSocketPairCreator(
     }
 
     // Bind the listener once, but create a new connect/accept pair each
-    // time.
+    // time. On bind/listen failure (e.g. EADDRINUSE because a prior test in
+    // the same shard left connections in TIME-WAIT against the small
+    // ephemeral pool) propagate the error and close the listener so the
+    // caller can retry; otherwise the cached (unbound) listener would
+    // poison every subsequent invocation.
     if (domain == AF_INET) {
       if (!addr4->has_value()) {
-        addr4->emplace(
-            TCPBindAndListen<sockaddr_in>(listener->value(), dual_stack)
-                .ValueOrDie());
+        PosixErrorOr<sockaddr_in> bound =
+            TCPBindAndListen<sockaddr_in>(listener->value(), dual_stack);
+        if (!bound.ok()) {
+          close(listener->value());
+          listener->reset();
+          return bound.error();
+        }
+        addr4->emplace(bound.ValueOrDie());
       }
       return CreateTCPConnectAcceptSocketPair(listener->value(),
                                               std::move(connected), type,
                                               dual_stack, addr4->value());
     }
     if (!addr6->has_value()) {
-      addr6->emplace(
-          TCPBindAndListen<sockaddr_in6>(listener->value(), dual_stack)
-              .ValueOrDie());
+      PosixErrorOr<sockaddr_in6> bound =
+          TCPBindAndListen<sockaddr_in6>(listener->value(), dual_stack);
+      if (!bound.ok()) {
+        close(listener->value());
+        listener->reset();
+        return bound.error();
+      }
+      addr6->emplace(bound.ValueOrDie());
     }
     return CreateTCPConnectAcceptSocketPair(listener->value(),
                                             std::move(connected), type,


### PR DESCRIPTION
socket_stress_test shard 1 deterministically failed when PersistentListenerConnectStressTest and DataTransferStressTest landed in the same shard (kvm platform, netstack): the connect-stress tests shrink the ephemeral pool to ~50 ports via MaybeLimitEphemeralPorts() and fill it with TIME-WAIT 4-tuples, so the persistent listener's bind(port=0) for BigDataTransfer fails with EADDRINUSE. Worse, that bind ran through.ValueOrDie() and aborted the whole binary instead of failing gracefully.

  * socket_generic_stress.cc: widen the ephemeral range back to the full 16-bit space at the top of BigDataTransfer (tolerating EACCES when the /proc file is read-only, e.g. hostinet as root). SO_REUSEADDR is added to the instantiations only for parity with PersistentListenerConnectStressTest; it applies to the connect/accept pair, not the shared listener.

  * socket_util.cc: TCPAcceptBindPersistentListenerSocketPairCreator now propagates the bind/listen PosixError and resets the unbound cached listener so a retry doesn't reuse a poisoned fd, instead of TEST_CHECK aborting.

Validated: socket_stress_test_runsc_kvm passes 24 runs (runs_per_test=3 x 8 shards), previously failed 1/8 every time.