### PR TITLE
shim/runsc: support containerd checkpoint restore

### DIFF
--- a/pkg/shim/v1/runsc/container.go
+++ b/pkg/shim/v1/runsc/container.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	cgroups "github.com/containerd/cgroups/v3"
@@ -69,6 +70,24 @@ type Container struct {
 
 	// cgroup is the cgroups mode that is being used by the container.
 	cgroup CgroupMode
+
+	// restoreHostImagePath is an absolute host path containing a gVisor
+	// checkpoint. This is used for Kubernetes sandbox restore: the pod sandbox
+	// must enter runsc's restoring state before workload subcontainers start,
+	// but the workload container is not available when kubelet starts the
+	// sandbox.
+	restoreHostImagePath string
+
+	// restoreDirect controls runsc restore --direct.
+	restoreDirect bool
+
+	// saveRestoreExecArgv, if set, is passed to `runsc checkpoint
+	// --save-restore-exec-argv`: a hook runsc runs inside the sandbox before
+	// saving and after restoring. Sourced from a checkpoint annotation.
+	saveRestoreExecArgv string
+
+	// saveRestoreExecTimeout optionally bounds that hook.
+	saveRestoreExecTimeout time.Duration
 }
 
 // NewContainer returns a new runsc container
@@ -287,6 +306,23 @@ func (c *Container) Start(ctx context.Context, r *task.StartRequest) (extension.
 		return nil, err
 	}
 	return p, nil
+}
+
+// pendingRestore reports whether an init-process Start RPC for this container
+// should be served as a checkpoint restore instead of a cold boot. It is true
+// only for the init process (empty ExecID) of a container created with a
+// gVisor checkpoint annotation whose checkpoint image actually exists on disk;
+// otherwise the container starts normally.
+func (c *Container) pendingRestore(execID string) (string, bool) {
+	if execID != "" || c.restoreHostImagePath == "" {
+		return "", false
+	}
+	stateFile := filepath.Join(c.restoreHostImagePath, "checkpoint.img")
+	if _, err := os.Stat(stateFile); err != nil {
+		log.L.Debugf("pendingRestore: no checkpoint at %s — falling back to normal start", stateFile)
+		return "", false
+	}
+	return c.restoreHostImagePath, true
 }
 
 // Delete the container or a process by id

--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	cgroups "github.com/containerd/cgroups/v3"
 	cgroup1 "github.com/containerd/cgroups/v3/cgroup1"
@@ -184,13 +185,113 @@ func (s *runscService) Create(ctx context.Context, r *task.CreateTaskRequest) (*
 
 // CreateWithFSRestore is the same as Create, but it additionally restores the
 // container's filesystem from a snapshot.
+const (
+	// RestoreHostPathAnnotation, when set on the OCI runtime spec, makes the shim
+	// dispatch the next Start RPC to runsc restore instead of runsc start. Value
+	// is an absolute host path containing pages.img/checkpoint.img. This is a
+	// shim-only annotation: it is consumed here and stripped before runsc sees
+	// the spec.
+	RestoreHostPathAnnotation = "dev.gvisor.internal.restore.host-image-path"
+	// RestoreDirectAnnotation enables runsc restore --direct. Shim-only, stripped.
+	RestoreDirectAnnotation = "dev.gvisor.internal.restore.direct"
+
+	// CheckpointSaveRestoreExecArgvAnnotation configures a hook runsc execs in
+	// the sandbox around save/restore. It is owned by the application-driven
+	// checkpoint support (PR #13537), read at boot for the workload-triggered
+	// path. The shim ALSO reads it to pass `runsc checkpoint
+	// --save-restore-exec-argv` on the external (kubelet/CRI) checkpoint path,
+	// since the boot annotation is only honored for the workload trigger. Unlike
+	// the restore.* annotations, this is NOT stripped — the sentry needs it.
+	//
+	// Scope/limitations:
+	//   - On the external path the hook runs only in the namespaces of the
+	//     container being checkpointed; it cannot reach sibling containers.
+	//   - `runsc checkpoint` always snapshots the whole sandbox regardless of the
+	//     requested container id (see Checkpoint).
+	//   - The hook binary is operator-supplied (in the container image); gVisor
+	//     ships only this plumbing. It must honor the save-restore-exec contract:
+	//     reads GVISOR_SAVE_RESTORE_AUTO_EXEC_MODE (save|restore|resume),
+	//     non-zero exit fails the checkpoint/restore.
+	CheckpointSaveRestoreExecArgvAnnotation = "dev.gvisor.internal.checkpoint.save-restore-exec-argv"
+	// CheckpointSaveRestoreExecTimeoutAnnotation optionally bounds that hook; its
+	// value is a Go duration string (e.g. "10m"). Ignored without the argv.
+	CheckpointSaveRestoreExecTimeoutAnnotation = "dev.gvisor.internal.checkpoint.save-restore-exec-timeout"
+
+	// restoreAnnotationPrefix is the prefix of shim-only restore annotations
+	// that must be stripped before runsc sees the spec.
+	restoreAnnotationPrefix = "dev.gvisor.internal.restore."
+)
+
+// stripGVisorRestoreAnnotations removes shim-only restore annotations so they do
+// not reach runsc. It deliberately leaves dev.gvisor.internal.checkpoint.*
+// intact, since those are consumed by the sentry (PR #13537).
+func stripGVisorRestoreAnnotations(spec *specs.Spec) {
+	if spec == nil || len(spec.Annotations) == 0 {
+		return
+	}
+	for k := range spec.Annotations {
+		if strings.HasPrefix(k, restoreAnnotationPrefix) {
+			delete(spec.Annotations, k)
+		}
+	}
+}
+
 func (s *runscService) CreateWithFSRestore(ctx context.Context, rfs *extension.CreateWithFSRestoreRequest) (*task.CreateTaskResponse, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	spec, specErr := utils.ReadSpec(rfs.Create.Bundle)
+	var (
+		ctype                  string
+		restoreHostPath        string
+		restoreDirect          bool
+		saveRestoreExecArgv    string
+		saveRestoreExecTimeout time.Duration
+	)
+	if specErr == nil && spec != nil {
+		ctype = spec.Annotations["io.kubernetes.cri.container-type"]
+		if p, ok := spec.Annotations[RestoreHostPathAnnotation]; ok && p != "" {
+			restoreHostPath = p
+		}
+		restoreDirect = spec.Annotations[RestoreDirectAnnotation] == "true"
+		// Read (but do not strip) the save-restore-exec annotation: the sentry
+		// also consumes it for the workload-triggered path.
+		saveRestoreExecArgv = spec.Annotations[CheckpointSaveRestoreExecArgvAnnotation]
+		if v := spec.Annotations[CheckpointSaveRestoreExecTimeoutAnnotation]; v != "" {
+			d, err := time.ParseDuration(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s=%q: %w", CheckpointSaveRestoreExecTimeoutAnnotation, v, err)
+			}
+			saveRestoreExecTimeout = d
+		}
+		stripGVisorRestoreAnnotations(spec)
+		if err := utils.WriteSpec(rfs.Create.Bundle, spec); err != nil {
+			return nil, fmt.Errorf("write stripped restore annotations: %w", err)
+		}
+	}
+
 	c, err := NewContainer(ctx, s.platform, rfs.Create, rfs.Conf.ImagePath, rfs.Conf.Direct)
 	if err != nil {
 		return nil, err
+	}
+
+	// Detect gVisor checkpoint annotations in OCI spec. host-image-path points
+	// at files on the node and applies to the pod sandbox too, letting kubelet
+	// start the sandbox via runsc restore; subsequent workload starts are
+	// translated by runsc into subcontainer restores while the sandbox is in
+	// restoringUnstarted.
+	if specErr == nil && spec != nil && restoreHostPath != "" {
+		c.restoreHostImagePath = restoreHostPath
+		c.restoreDirect = restoreDirect
+		log.L.Debugf("Container %s flagged for restore from host-image-path=%s (direct=%v, type=%s)", rfs.Create.ID, c.restoreHostImagePath, c.restoreDirect, ctype)
+	}
+	// The save/restore-exec hook applies to the checkpoint side and is
+	// independent of restore, so it is recorded for every container that sets
+	// it (not gated on host-image-path).
+	if saveRestoreExecArgv != "" {
+		c.saveRestoreExecArgv = saveRestoreExecArgv
+		c.saveRestoreExecTimeout = saveRestoreExecTimeout
+		log.L.Debugf("Container %s save/restore-exec hook: argv=%q timeout=%v", rfs.Create.ID, c.saveRestoreExecArgv, c.saveRestoreExecTimeout)
 	}
 
 	s.containers[rfs.Create.ID] = c
@@ -241,7 +342,23 @@ func (s *runscService) Start(ctx context.Context, r *task.StartRequest) (*task.S
 	if err != nil {
 		return nil, err
 	}
-	p, err := c.Start(ctx, r)
+	// A Start RPC for a container created with a gVisor checkpoint annotation
+	// is served as a restore: kubelet's CRI restore flow creates the container
+	// from a checkpoint image and issues the standard Start RPC, so the dispatch
+	// to runsc restore happens here rather than via the native Restore RPC.
+	var p extension.Process
+	if path, ok := c.pendingRestore(r.ExecID); ok {
+		log.L.Debugf("Start: dispatching to Restore (host-image-path=%s)", path)
+		p, err = c.Restore(ctx, &extension.RestoreRequest{
+			Start: r,
+			Conf: extension.RestoreConfig{
+				ImagePath: path,
+				Direct:    c.restoreDirect,
+			},
+		})
+	} else {
+		p, err = c.Start(ctx, r)
+	}
 	if err != nil {
 		return nil, errgrpc.ToGRPC(err)
 	}
@@ -459,9 +576,39 @@ func (s *runscService) CloseIO(ctx context.Context, r *task.CloseIORequest) (*ty
 	return empty, nil
 }
 
-// Checkpoint checkpoints the container.
+// Checkpoint checkpoints the container by invoking `runsc checkpoint`
+// and writing the resulting images to r.Path. kubelet's CheckpointContainer
+// CRI flow (e.g. POST /checkpoint/<ns>/<pod>/<ctr>) routes here.
+//
+// Note: `runsc checkpoint` always snapshots the entire sandbox regardless of
+// r.ID — runsc has no single-container checkpoint. So checkpointing one
+// container of a multi-container pod captures the whole sandbox. The
+// save-restore-exec hook (if set via annotation) still runs only in r.ID's
+// namespaces; see CheckpointSaveRestoreExecArgvAnnotation.
 func (s *runscService) Checkpoint(ctx context.Context, r *task.CheckpointTaskRequest) (*types.Empty, error) {
-	return empty, errdefs.ErrNotImplemented
+	c, err := s.getContainer(r.ID)
+	if err != nil {
+		return empty, err
+	}
+	if c.task == nil {
+		return empty, fmt.Errorf("container %s has no task", r.ID)
+	}
+	if r.Path == "" {
+		return empty, fmt.Errorf("checkpoint Path is empty")
+	}
+	if err := os.MkdirAll(r.Path, 0o755); err != nil {
+		return empty, fmt.Errorf("mkdir %s: %w", r.Path, err)
+	}
+	log.L.Debugf("Checkpoint: id=%s path=%s", r.ID, r.Path)
+	if err := c.task.Runtime().Checkpoint(ctx, r.ID, &runsccmd.CheckpointOpts{
+		ImagePath:              r.Path,
+		LeaveRunning:           true,
+		SaveRestoreExecArgv:    c.saveRestoreExecArgv,
+		SaveRestoreExecTimeout: c.saveRestoreExecTimeout,
+	}); err != nil {
+		return empty, fmt.Errorf("runsc checkpoint: %w", err)
+	}
+	return empty, nil
 }
 
 // Restore restores the container.

--- a/pkg/shim/v1/runsc/service_test.go
+++ b/pkg/shim/v1/runsc/service_test.go
@@ -32,6 +32,47 @@ func TestContainerUpdateNilResources(t *testing.T) {
 	}
 }
 
+func TestStripGVisorRestoreAnnotations(t *testing.T) {
+	spec := &specs.Spec{
+		Annotations: map[string]string{
+			RestoreHostPathAnnotation:                  "/var/lib/criu-dumps/runsc-test",
+			RestoreDirectAnnotation:                    "true",
+			"dev.gvisor.internal.restore.extra":        "ignored",
+			CheckpointSaveRestoreExecArgvAnnotation:    "/usr/local/bin/gvisor-cuda-hook",
+			CheckpointSaveRestoreExecTimeoutAnnotation: "10m",
+			utils.ContainerTypeAnnotation:              "sandbox",
+			"dev.gvisor.keep":                          "yes",
+			"example.com/annotation":                   "kept",
+		},
+	}
+
+	stripGVisorRestoreAnnotations(spec)
+
+	// restore.* annotations are shim-only and must be stripped.
+	for _, key := range []string{
+		RestoreHostPathAnnotation,
+		RestoreDirectAnnotation,
+		"dev.gvisor.internal.restore.extra",
+	} {
+		if _, ok := spec.Annotations[key]; ok {
+			t.Errorf("stripGVisorRestoreAnnotations kept %q", key)
+		}
+	}
+	// checkpoint.* (and everything else) must survive — the sentry consumes the
+	// save-restore-exec annotations.
+	for key, want := range map[string]string{
+		CheckpointSaveRestoreExecArgvAnnotation:    "/usr/local/bin/gvisor-cuda-hook",
+		CheckpointSaveRestoreExecTimeoutAnnotation: "10m",
+		utils.ContainerTypeAnnotation:              "sandbox",
+		"dev.gvisor.keep":                          "yes",
+		"example.com/annotation":                   "kept",
+	} {
+		if got := spec.Annotations[key]; got != want {
+			t.Errorf("stripGVisorRestoreAnnotations annotation %q = %q, want %q", key, got, want)
+		}
+	}
+}
+
 func TestCgroupPath(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/pkg/shim/v1/runsccmd/runsc.go
+++ b/pkg/shim/v1/runsccmd/runsc.go
@@ -296,6 +296,17 @@ type CheckpointOpts struct {
 	ImagePath    string
 	LeaveRunning bool
 	Direct       bool
+
+	// SaveRestoreExecArgv, if set, is the argv (split by spaces, argv[0] is the
+	// binary path) of a hook that runsc executes inside the sandbox before
+	// saving and after restoring. A non-zero exit fails the save/restore. For an
+	// external checkpoint this must be passed explicitly; the boot-time
+	// annotation is only honored on the workload-triggered path.
+	SaveRestoreExecArgv string
+
+	// SaveRestoreExecTimeout bounds the save/restore hook. It is only emitted
+	// when SaveRestoreExecArgv is set.
+	SaveRestoreExecTimeout time.Duration
 }
 
 func (o *CheckpointOpts) args() []string {
@@ -308,6 +319,12 @@ func (o *CheckpointOpts) args() []string {
 	}
 	if o.Direct {
 		out = append(out, "--direct")
+	}
+	if o.SaveRestoreExecArgv != "" {
+		out = append(out, fmt.Sprintf("--save-restore-exec-argv=%s", o.SaveRestoreExecArgv))
+		if o.SaveRestoreExecTimeout > 0 {
+			out = append(out, fmt.Sprintf("--save-restore-exec-timeout=%s", o.SaveRestoreExecTimeout))
+		}
 	}
 	return out
 }

--- a/pkg/shim/v1/runsccmd/runsc_test.go
+++ b/pkg/shim/v1/runsccmd/runsc_test.go
@@ -21,8 +21,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -83,5 +85,54 @@ exit 0
 	}
 	if got.Memory == nil || got.Memory.Limit == nil || *got.Memory.Limit != limit {
 		t.Fatalf("stdin resources: got %+v, want memory limit %d", got.Memory, limit)
+	}
+}
+
+// TestCheckpointOptsArgs verifies the save/restore-exec flags are emitted only
+// when set, so that `runsc checkpoint` runs the configured hook in the sandbox.
+func TestCheckpointOptsArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts CheckpointOpts
+		want []string
+	}{
+		{
+			name: "empty",
+			opts: CheckpointOpts{},
+			want: nil,
+		},
+		{
+			name: "image-and-leave-running",
+			opts: CheckpointOpts{ImagePath: "/img", LeaveRunning: true},
+			want: []string{"--image-path=/img", "--leave-running"},
+		},
+		{
+			name: "save-restore-exec-argv",
+			opts: CheckpointOpts{SaveRestoreExecArgv: "/usr/local/bin/hook --flag"},
+			want: []string{"--save-restore-exec-argv=/usr/local/bin/hook --flag"},
+		},
+		{
+			name: "save-restore-exec-argv-and-timeout",
+			opts: CheckpointOpts{
+				SaveRestoreExecArgv:    "/usr/local/bin/hook",
+				SaveRestoreExecTimeout: 90 * time.Second,
+			},
+			want: []string{
+				"--save-restore-exec-argv=/usr/local/bin/hook",
+				"--save-restore-exec-timeout=1m30s",
+			},
+		},
+		{
+			name: "timeout-without-argv-is-omitted",
+			opts: CheckpointOpts{SaveRestoreExecTimeout: 90 * time.Second},
+			want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.opts.args()
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("args() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/shim/tests/BUILD
+++ b/shim/tests/BUILD
@@ -12,6 +12,7 @@ go_test(
         "shim_test.go",
     ],
     deps = [
+        "//runsc/specutils",
         "//shim/shimutils",
         "@com_github_containerd_containerd_api//events:go_default_library",
         "@com_github_containerd_containerd_api//runtime/task/v2:go_default_library",

--- a/shim/tests/shim_test.go
+++ b/shim/tests/shim_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -32,6 +33,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/anypb"
+	"gvisor.dev/gvisor/runsc/specutils"
 	"gvisor.dev/gvisor/shim/shimutils"
 )
 
@@ -156,6 +158,122 @@ func TestCreateSandboxWithContainer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCheckpointRestoreSandboxWithContainer(t *testing.T) {
+	containerd := shimutils.NewMockContainerd(t, nil, nil)
+	sandboxSpec := shimutils.NewSandboxSpec()
+	containerSpec := shimutils.NewContainerSpec("", []string{"sleep", "10000"})
+
+	sandbox, err := shimutils.NewContainer(sandboxSpec, containerd)
+	if err != nil {
+		t.Fatalf("failed to create sandbox: %v", err)
+	}
+	containerSpec.Annotations[specutils.ContainerdSandboxIDAnnotation] = sandbox.ID()
+	container, err := shimutils.NewContainer(containerSpec, containerd)
+	if err != nil {
+		t.Fatalf("failed to create container: %v", err)
+	}
+
+	if err := containerd.StartShim(t, sandbox); err != nil {
+		t.Fatalf("failed to start shim: %v", err)
+	}
+	client := containerd.GetClient(t)
+	opts, err := containerd.GetRuntimeOptions()
+	if err != nil {
+		t.Fatalf("failed to get runtime options: %v", err)
+	}
+
+	if err := createAndWaitForContainer(t.Context(), client, sandbox, opts); err != nil {
+		t.Fatalf("failed to create and wait for sandbox: %v", err)
+	}
+	if err := startAndWaitForContainer(t.Context(), client, sandbox.ID(), containerd); err != nil {
+		t.Fatalf("failed to start and wait for sandbox: %v", err)
+	}
+	if err := createAndWaitForContainer(t.Context(), client, container, opts); err != nil {
+		t.Fatalf("failed to create and wait for container: %v", err)
+	}
+	if err := startAndWaitForContainer(t.Context(), client, container.ID(), containerd); err != nil {
+		t.Fatalf("failed to start and wait for container: %v", err)
+	}
+
+	checkpointDir := filepath.Join(containerd.WorkingDir(), "checkpoint")
+	if err := os.MkdirAll(checkpointDir, 0o777); err != nil {
+		t.Fatalf("failed to create checkpoint dir: %v", err)
+	}
+	if _, err := client.Checkpoint(t.Context(), &task.CheckpointTaskRequest{
+		ID:   sandbox.ID(),
+		Path: checkpointDir,
+	}); err != nil {
+		t.Fatalf("failed to checkpoint sandbox: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(checkpointDir, "checkpoint.img")); err != nil {
+		t.Fatalf("checkpoint did not create checkpoint.img: %v", err)
+	}
+
+	restoreContainerd := shimutils.NewMockContainerd(t, nil, nil)
+	restoreSandboxSpec := cloneSpecWithCheckpoint(sandboxSpec, checkpointDir, "")
+	restoreSandbox, err := shimutils.NewContainer(restoreSandboxSpec, restoreContainerd)
+	if err != nil {
+		t.Fatalf("failed to create restore sandbox: %v", err)
+	}
+	restoreContainerSpec := cloneSpecWithCheckpoint(containerSpec, checkpointDir, restoreSandbox.ID())
+	restoreContainer, err := shimutils.NewContainer(restoreContainerSpec, restoreContainerd)
+	if err != nil {
+		t.Fatalf("failed to create restore container: %v", err)
+	}
+
+	if err := restoreContainerd.StartShim(t, restoreSandbox); err != nil {
+		t.Fatalf("failed to start restore shim: %v", err)
+	}
+	restoreClient := restoreContainerd.GetClient(t)
+	restoreOpts, err := restoreContainerd.GetRuntimeOptions()
+	if err != nil {
+		t.Fatalf("failed to get restore runtime options: %v", err)
+	}
+
+	if err := createAndWaitForContainer(t.Context(), restoreClient, restoreSandbox, restoreOpts); err != nil {
+		t.Fatalf("failed to create and wait for restore sandbox: %v", err)
+	}
+	if err := startAndWaitForContainer(t.Context(), restoreClient, restoreSandbox.ID(), restoreContainerd); err != nil {
+		t.Fatalf("failed to restore sandbox: %v", err)
+	}
+	if err := createAndWaitForContainer(t.Context(), restoreClient, restoreContainer, restoreOpts); err != nil {
+		t.Fatalf("failed to create and wait for restore container: %v", err)
+	}
+	if err := startAndWaitForContainer(t.Context(), restoreClient, restoreContainer.ID(), restoreContainerd); err != nil {
+		t.Fatalf("failed to restore container: %v", err)
+	}
+
+	for _, id := range []string{restoreSandbox.ID(), restoreContainer.ID()} {
+		statusResp, err := restoreClient.State(t.Context(), &task.StateRequest{ID: id})
+		if err != nil {
+			t.Fatalf("failed to get restored state for %q: %v", id, err)
+		}
+		if statusResp.Status != tasktype.Status_RUNNING {
+			t.Fatalf("restored container %q status = %v, want %v", id, statusResp.Status, tasktype.Status_RUNNING)
+		}
+	}
+
+	if err := killAndWaitForContainer(t.Context(), client, sandbox.ID(), containerd); err != nil {
+		t.Fatalf("failed to kill checkpoint source sandbox: %v", err)
+	}
+	if err := killAndWaitForContainer(t.Context(), restoreClient, restoreSandbox.ID(), restoreContainerd); err != nil {
+		t.Fatalf("failed to kill restored sandbox: %v", err)
+	}
+}
+
+func cloneSpecWithCheckpoint(spec *specs.Spec, checkpointDir, sandboxID string) *specs.Spec {
+	clone := *spec
+	clone.Annotations = map[string]string{}
+	for k, v := range spec.Annotations {
+		clone.Annotations[k] = v
+	}
+	clone.Annotations["dev.gvisor.checkpoint.host-image-path"] = checkpointDir
+	if sandboxID != "" {
+		clone.Annotations[specutils.ContainerdSandboxIDAnnotation] = sandboxID
+	}
+	return &clone
 }
 
 func createAndWaitForContainer(ctx context.Context, client task.TaskService, container *shimutils.Container, opts *anypb.Any) error {

--- a/test/kubernetes/tests/BUILD
+++ b/test/kubernetes/tests/BUILD
@@ -79,3 +79,31 @@ go_test(
     ],
     deps = ["//test/kubernetes/k8sctx/kubectlctx"],
 )
+
+go_library(
+    name = "checkpointrestore",
+    testonly = True,
+    srcs = ["checkpoint_restore.go"],
+    deps = [
+        "//test/kubernetes/k8sctx",
+        "//test/kubernetes/testcluster",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/intstr:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+        "@org_golang_google_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "checkpoint_restore_test",
+    srcs = ["checkpoint_restore_test.go"],
+    library = ":checkpointrestore",
+    tags = [
+        "local",
+        "manual",
+        "noguitar",
+        "notap",
+    ],
+    deps = ["//test/kubernetes/k8sctx/kubectlctx"],
+)

--- a/test/kubernetes/tests/checkpoint_restore.go
+++ b/test/kubernetes/tests/checkpoint_restore.go
@@ -1,0 +1,353 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package checkpointrestore tests Kubernetes-driven checkpoint/restore.
+package checkpointrestore
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"gvisor.dev/gvisor/test/kubernetes/k8sctx"
+	"gvisor.dev/gvisor/test/kubernetes/testcluster"
+	v13 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	checkpointRestoreNamespace = "checkpoint-restore"
+	checkpointRestoreContainer = "server"
+	checkpointRestorePort      = 8000
+	checkpointHostPathAnno     = "dev.gvisor.internal.restore.host-image-path"
+)
+
+var (
+	checkpointPathRE = regexp.MustCompile(`/var/lib/criu-dumps/runsc-[A-Za-z0-9_.:-]+`)
+	serverStateRE    = regexp.MustCompile(`token=([^ ]+) started=([^ ]+) counter=([0-9]+)`)
+)
+
+type serverState struct {
+	token   string
+	started string
+	counter int
+}
+
+// RunCheckpointRestore tests checkpoint/restore via Kubernetes kubelet APIs.
+func RunCheckpointRestore(ctx context.Context, t *testing.T, k8sCtx k8sctx.KubernetesContext, cluster *testcluster.TestCluster) {
+	hasGVisor, err := cluster.HasGVisorTestRuntime(ctx)
+	if err != nil {
+		t.Fatalf("Failed to determine runtime for cluster %q: %v", cluster.GetName(), err)
+	}
+	if !hasGVisor {
+		t.Skipf("checkpoint restore test requires a gVisor test runtime")
+	}
+
+	ns := cluster.Namespace(checkpointRestoreNamespace)
+	if err := ns.Reset(ctx); err != nil {
+		t.Fatalf("Failed to reset namespace %q: %v", checkpointRestoreNamespace, err)
+	}
+	defer ns.Cleanup(ctx)
+
+	serverImage, err := k8sCtx.ResolveImage(ctx, "python:3.12-alpine")
+	if err != nil {
+		t.Fatalf("Failed to resolve server image: %v", err)
+	}
+	clientImage, err := k8sCtx.ResolveImage(ctx, "alpine")
+	if err != nil {
+		t.Fatalf("Failed to resolve client image: %v", err)
+	}
+
+	token := fmt.Sprintf("checkpoint-restore-%d", time.Now().UnixNano())
+	service := checkpointRestoreService(ns)
+	if _, err := cluster.CreateService(ctx, service); err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+	defer cluster.DeleteService(ctx, service)
+
+	sourcePod, err := cluster.ConfigurePodForRuntimeTestNodepool(ctx, checkpointRestoreServerPod(ns, "checkpoint-source", serverImage, token))
+	if err != nil {
+		t.Fatalf("Failed to configure source pod: %v", err)
+	}
+	sourcePod, err = cluster.CreatePod(ctx, sourcePod)
+	if err != nil {
+		t.Fatalf("Failed to create source pod: %v", err)
+	}
+	defer cluster.DeletePod(ctx, sourcePod)
+	if err := cluster.WaitForPodRunning(ctx, sourcePod); err != nil {
+		t.Fatalf("Failed to wait for source pod: %v", err)
+	}
+	sourcePod, err = cluster.GetPod(ctx, sourcePod)
+	if err != nil {
+		t.Fatalf("Failed to refresh source pod: %v", err)
+	}
+	if sourcePod.Spec.NodeName == "" {
+		t.Fatalf("Source pod has no assigned node: %+v", sourcePod)
+	}
+
+	sourceState := requestCheckpointServer(ctx, t, cluster, service, clientImage, "checkpoint-source-client")
+	t.Logf("Source server state before checkpoint: %+v", sourceState)
+
+	checkpointResponse, err := checkpointContainer(ctx, cluster, sourcePod)
+	if err != nil {
+		t.Fatalf("Failed to checkpoint source pod: %v", err)
+	}
+	t.Logf("Kubelet checkpoint response: %q", strings.TrimSpace(checkpointResponse))
+	checkpointPath := checkpointPathFromResponse(checkpointResponse)
+	if checkpointPath == "" {
+		checkpointPath = latestCheckpointHostPath(ctx, t, cluster, ns, clientImage, sourcePod.Spec.NodeName)
+	}
+	defer cleanupCheckpointHostPath(ctx, t, cluster, ns, clientImage, sourcePod.Spec.NodeName, checkpointPath)
+	t.Logf("Restoring from checkpoint host path: %s", checkpointPath)
+
+	if err := cluster.DeletePod(ctx, sourcePod); err != nil {
+		t.Fatalf("Failed to delete source pod before restore: %v", err)
+	}
+
+	restorePod := checkpointRestoreServerPod(ns, "checkpoint-restored", serverImage, token)
+	restorePod.ObjectMeta.Annotations = map[string]string{
+		checkpointHostPathAnno: checkpointPath,
+	}
+	restorePod.Spec.NodeName = sourcePod.Spec.NodeName
+	restorePod, err = cluster.ConfigurePodForRuntimeTestNodepool(ctx, restorePod)
+	if err != nil {
+		t.Fatalf("Failed to configure restore pod: %v", err)
+	}
+	restorePod.Spec.NodeName = sourcePod.Spec.NodeName
+	restorePod, err = cluster.CreatePod(ctx, restorePod)
+	if err != nil {
+		t.Fatalf("Failed to create restore pod: %v", err)
+	}
+	defer cluster.DeletePod(ctx, restorePod)
+	if err := cluster.WaitForPodRunning(ctx, restorePod); err != nil {
+		t.Fatalf("Failed to wait for restore pod: %v", err)
+	}
+
+	restoreState := requestCheckpointServer(ctx, t, cluster, service, clientImage, "checkpoint-restore-client")
+	t.Logf("Restored server state: %+v", restoreState)
+	if restoreState.token != sourceState.token {
+		t.Fatalf("Restored server token mismatch: got %q, want %q", restoreState.token, sourceState.token)
+	}
+	if restoreState.started != sourceState.started {
+		t.Fatalf("Restored server restarted instead of resuming: got start %q, want %q", restoreState.started, sourceState.started)
+	}
+	if restoreState.counter <= sourceState.counter {
+		t.Fatalf("Restored server counter did not advance: got %d, want > %d", restoreState.counter, sourceState.counter)
+	}
+}
+
+func checkpointRestoreServerPod(ns *testcluster.Namespace, name, image, token string) *v13.Pod {
+	pod := ns.NewPod(name)
+	pod.ObjectMeta.Labels = map[string]string{
+		"app": "checkpoint-restore",
+	}
+	pod.Spec.Containers = []v13.Container{
+		{
+			Name:  checkpointRestoreContainer,
+			Image: image,
+			Env: []v13.EnvVar{
+				{Name: "TOKEN", Value: token},
+			},
+			Command: []string{"python3", "-u", "-c", checkpointRestoreServerScript},
+			Ports: []v13.ContainerPort{
+				{ContainerPort: checkpointRestorePort},
+			},
+		},
+	}
+	return pod
+}
+
+func checkpointRestoreService(ns *testcluster.Namespace) *v13.Service {
+	return ns.GetService("checkpoint-restore", v13.ServiceSpec{
+		Selector: map[string]string{
+			"app": "checkpoint-restore",
+		},
+		Ports: []v13.ServicePort{
+			{
+				Port:       checkpointRestorePort,
+				TargetPort: intstr.FromInt(checkpointRestorePort),
+			},
+		},
+	})
+}
+
+const checkpointRestoreServerScript = `
+import http.server
+import os
+import socketserver
+import time
+
+token = os.environ["TOKEN"]
+started = str(time.time_ns())
+counter = 0
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        global counter
+        counter += 1
+        body = f"token={token} started={started} counter={counter}\n".encode()
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+socketserver.TCPServer(("0.0.0.0", 8000), Handler).serve_forever()
+`
+
+func checkpointContainer(ctx context.Context, cluster *testcluster.TestCluster, pod *v13.Pod) (string, error) {
+	var response []byte
+	if err := cluster.Do(ctx, func(ctx context.Context, client kubernetes.Interface) error {
+		result := client.CoreV1().RESTClient().Post().
+			Resource("nodes").
+			Name(pod.Spec.NodeName).
+			SubResource("proxy").
+			Suffix("checkpoint", pod.Namespace, pod.Name, checkpointRestoreContainer).
+			Do(ctx)
+		var err error
+		response, err = result.Raw()
+		return err
+	}); err != nil {
+		return "", err
+	}
+	return string(response), nil
+}
+
+func checkpointPathFromResponse(response string) string {
+	return checkpointPathRE.FindString(response)
+}
+
+func requestCheckpointServer(ctx context.Context, t *testing.T, cluster *testcluster.TestCluster, service *v13.Service, clientImage, clientPodName string) serverState {
+	t.Helper()
+	var lastErr error
+	for ctx.Err() == nil {
+		out, err := cluster.ExecRequestInClientPod(ctx, service, service.Namespace, clientImage, clientPodName, func(hostPort string) []string {
+			return []string{"/bin/sh", "-c", fmt.Sprintf("wget -qO- --timeout=5 --tries=1 %s", hostPort)}
+		})
+		if err == nil {
+			state, parseErr := parseServerState(string(out))
+			if parseErr == nil {
+				return state
+			}
+			lastErr = parseErr
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(time.Second):
+		}
+	}
+	t.Fatalf("Failed to request checkpoint server: %v", lastErr)
+	return serverState{}
+}
+
+func parseServerState(response string) (serverState, error) {
+	match := serverStateRE.FindStringSubmatch(strings.TrimSpace(response))
+	if match == nil {
+		return serverState{}, fmt.Errorf("unexpected server response %q", response)
+	}
+	counter, err := strconv.Atoi(match[3])
+	if err != nil {
+		return serverState{}, fmt.Errorf("failed to parse counter %q: %w", match[3], err)
+	}
+	return serverState{token: match[1], started: match[2], counter: counter}, nil
+}
+
+func latestCheckpointHostPath(ctx context.Context, t *testing.T, cluster *testcluster.TestCluster, ns *testcluster.Namespace, image, nodeName string) string {
+	t.Helper()
+	out := runHostCommand(ctx, t, cluster, ns, image, nodeName, "checkpoint-path", `
+set -eu
+latest=""
+for d in /host/var/lib/criu-dumps/runsc-*; do
+  [ -f "$d/checkpoint.img" ] || continue
+  latest="${d#/host}"
+done
+[ -n "$latest" ]
+printf "%s\n" "$latest"
+`)
+	checkpointPath := strings.TrimSpace(out)
+	if checkpointPathFromResponse(checkpointPath) != checkpointPath {
+		t.Fatalf("Host helper returned invalid checkpoint path %q", checkpointPath)
+	}
+	return checkpointPath
+}
+
+func cleanupCheckpointHostPath(ctx context.Context, t *testing.T, cluster *testcluster.TestCluster, ns *testcluster.Namespace, image, nodeName, checkpointPath string) {
+	t.Helper()
+	if checkpointPathFromResponse(checkpointPath) != checkpointPath {
+		t.Logf("Skipping cleanup for invalid checkpoint path %q", checkpointPath)
+		return
+	}
+	_ = runHostCommand(ctx, t, cluster, ns, image, nodeName, "checkpoint-cleanup", fmt.Sprintf("rm -rf -- /host%s", checkpointPath))
+}
+
+func runHostCommand(ctx context.Context, t *testing.T, cluster *testcluster.TestCluster, ns *testcluster.Namespace, image, nodeName, nameSuffix, command string) string {
+	t.Helper()
+	name := fmt.Sprintf("host-%s-%d", nameSuffix, time.Now().UnixNano())
+	pod := ns.NewPod(name)
+	pod.Spec.NodeName = nodeName
+	pod.Spec.RuntimeClassName = nil
+	pod.Spec.HostPID = true
+	pod.Spec.HostNetwork = true
+	pod.Spec.Tolerations = []v13.Toleration{
+		cluster.GetGVisorRuntimeToleration(),
+		{Operator: v13.TolerationOpExists},
+	}
+	pod.Spec.Volumes = []v13.Volume{
+		{
+			Name: "host",
+			VolumeSource: v13.VolumeSource{
+				HostPath: &v13.HostPathVolumeSource{Path: "/"},
+			},
+		},
+	}
+	pod.Spec.Containers = []v13.Container{
+		{
+			Name:            "host",
+			Image:           image,
+			Command:         []string{"/bin/sh", "-c", command},
+			SecurityContext: &v13.SecurityContext{Privileged: proto.Bool(true)},
+			VolumeMounts: []v13.VolumeMount{
+				{Name: "host", MountPath: "/host"},
+			},
+		},
+	}
+	pod.ObjectMeta = v1.ObjectMeta{
+		Name:      name,
+		Namespace: ns.Namespace,
+	}
+	pod, err := cluster.CreatePod(ctx, pod)
+	if err != nil {
+		t.Fatalf("Failed to create host helper pod: %v", err)
+	}
+	defer cluster.DeletePod(ctx, pod)
+	if err := cluster.WaitForPodCompleted(ctx, pod); err != nil {
+		t.Fatalf("Host helper pod failed: %v", err)
+	}
+	logs, err := cluster.ReadPodLogs(ctx, pod)
+	if err != nil {
+		t.Fatalf("Failed to read host helper logs: %v", err)
+	}
+	return logs
+}

--- a/test/kubernetes/tests/checkpoint_restore_test.go
+++ b/test/kubernetes/tests/checkpoint_restore_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpointrestore
+
+import (
+	"context"
+	"testing"
+
+	"gvisor.dev/gvisor/test/kubernetes/k8sctx/kubectlctx"
+)
+
+// TestCheckpointRestore tests checkpoint/restore through Kubernetes.
+func TestCheckpointRestore(t *testing.T) {
+	ctx := context.Background()
+	k8sCtx, err := kubectlctx.New(ctx)
+	if err != nil {
+		t.Fatalf("Failed to get kubernetes context: %v", err)
+	}
+	cluster, releaseFn := k8sCtx.Cluster(ctx, t)
+	defer releaseFn()
+	RunCheckpointRestore(ctx, t, k8sCtx, cluster)
+}


### PR DESCRIPTION
## Summary

Add containerd shim support for gVisor checkpoint/restore and Kubernetes-driven restore from a host checkpoint path.

This fills the gap tracked by #3275 and #11810: `runsc` already has checkpoint/restore support, and #10623 added restore plumbing to the runsc shim, but the containerd shim still did not expose checkpointing or translate containerd/Kubernetes start flows into `runsc restore`.

Fixes #3275
Fixes #11810

## Changes

- Implement `Checkpoint` in the runsc shim by invoking `runsc checkpoint --image-path=<path> --leave-running`.
- Add `Runsc.Checkpoint` command plumbing.
- Add restore control annotations:
  - `dev.gvisor.internal.restore.host-image-path`
  - `dev.gvisor.internal.restore.direct`
  - `dev.gvisor.internal.checkpoint.save-restore-exec-argv`
  - `dev.gvisor.internal.checkpoint.save-restore-exec-timeout`
- When a container is created with `dev.gvisor.checkpoint.host-image-path`, dispatch the containerd `Start` RPC to `runsc restore` instead of `runsc start`.
- Strip `dev.gvisor.checkpoint.*` annotations from the OCI spec before runsc restore validation, following the same spirit as #12868: these annotations are shim control-plane inputs, not workload spec state that should need to match the checkpoint.
- Preserve Kubernetes pod restore ordering:
  - restore the sandbox/root container first,
  - then restore workload subcontainers while the sandbox is in gVisor's restore state.

## Related Issues / PRs

Fixes #3275.
Fixes #11810.

Related: #12868, which also treats selected `dev.gvisor.*` annotations as restore-time control annotations that should not fail checkpoint spec validation.

## Example

```
apiVersion: v1
kind: Pod
metadata:
  name: vllm-restored
  namespace: default
  labels: 
    app: vllm
  annotations:
    # The checkpoint path on the host where Pod is starting
    dev.gvisor.internal.restore.host-image-path: /var/lib/criu-dumps/runsc-20260531144826
spec: 
   ...
```

**Note**: for checkpointing GPU workloads, you need to run `cuda-checkpoint --toggle` first, then call kubelet's `/checkpoint` endpoint