### PR TITLE
fix: propagate SIGWINCH on window size changes

### DIFF
--- a/pkg/sentry/fsimpl/devpts/line_discipline.go
+++ b/pkg/sentry/fsimpl/devpts/line_discipline.go
@@ -232,8 +232,21 @@ func (l *lineDiscipline) windowSize(t *kernel.Task, args arch.SyscallArguments) 
 func (l *lineDiscipline) setWindowSize(t *kernel.Task, args arch.SyscallArguments) error {
 	l.sizeMu.Lock()
 	defer l.sizeMu.Unlock()
+
+	oldSize := l.size
+
 	_, err := l.size.CopyIn(t, args[2].Pointer())
-	return err
+	if err != nil {
+		return err
+	}
+
+	if oldSize != l.size {
+		if l.terminal.replicaKTTY != nil {
+			l.terminal.replicaKTTY.SignalForegroundProcessGroup(kernel.SignalInfoPriv(linux.SIGWINCH))
+		}
+	}
+
+	return nil
 }
 
 func (l *lineDiscipline) masterReadiness() waiter.EventMask {

--- a/pkg/sentry/fsimpl/devpts/master.go
+++ b/pkg/sentry/fsimpl/devpts/master.go
@@ -190,8 +190,14 @@ func (mfd *masterFileDescription) Ioctl(ctx context.Context, io usermem.IO, sysn
 		return 0, nil
 	case linux.TIOCGWINSZ:
 		return 0, mfd.t.ld.windowSize(t, args)
+
 	case linux.TIOCSWINSZ:
-		return 0, mfd.t.ld.setWindowSize(t, args)
+		err := mfd.t.ld.setWindowSize(t, args)
+		if err != nil {
+			return 0, err
+		}
+		return 0, nil
+
 	case linux.TIOCSCTTY:
 		// Make the given terminal the controlling terminal of the
 		// calling process.

--- a/pkg/sentry/fsimpl/devpts/replica.go
+++ b/pkg/sentry/fsimpl/devpts/replica.go
@@ -182,8 +182,14 @@ func (rfd *replicaFileDescription) Ioctl(ctx context.Context, io usermem.IO, sys
 		return 0, err
 	case linux.TIOCGWINSZ:
 		return 0, rfd.inode.t.ld.windowSize(t, args)
+
 	case linux.TIOCSWINSZ:
-		return 0, rfd.inode.t.ld.setWindowSize(t, args)
+		err := rfd.inode.t.ld.setWindowSize(t, args)
+		if err != nil {
+			return 0, err
+		}
+		return 0, nil
+
 	case linux.TIOCSCTTY:
 		// Make the given terminal the controlling terminal of the
 		// calling process.

--- a/pkg/sentry/fsimpl/host/tty.go
+++ b/pkg/sentry/fsimpl/host/tty.go
@@ -236,20 +236,30 @@ func (t *TTYFileDescription) Ioctl(ctx context.Context, io usermem.IO, sysno uin
 		return 0, err
 
 	case linux.TIOCSWINSZ:
-		// Args: const struct winsize *argp
-		// Set window size.
-
-		// Unlike setting the termios, any process group (even background ones) can
-		// set the winsize.
 
 		var winsize linux.Winsize
 		if _, err := winsize.CopyIn(task, args[2].Pointer()); err != nil {
 			return 0, err
 		}
-		err := ioctlSetWinsize(fd, &winsize)
-		return 0, err
 
-	// Unimplemented commands.
+		oldWinsize, _ := ioctlGetWinsize(fd)
+
+		err := ioctlSetWinsize(fd, &winsize)
+		if err != nil {
+			return 0, err
+		}
+
+		if oldWinsize.Row != winsize.Row || oldWinsize.Col != winsize.Col ||
+			oldWinsize.Xpixel != winsize.Xpixel ||
+			oldWinsize.Ypixel != winsize.Ypixel {
+			if ktty := t.TTY(); ktty != nil {
+				ktty.SignalForegroundProcessGroup(kernel.SignalInfoPriv(linux.SIGWINCH))
+			}
+		}
+
+		return 0, nil
+
+		// Unimplemented commands.
 	case linux.TIOCSETD,
 		linux.TIOCSBRK,
 		linux.TIOCCBRK,


### PR DESCRIPTION
Forward the SIGWINCH signal to the foreground process group across the
entire terminal subsystem (master, replica, and host TTY passthrough)
whenever a TIOCSWINSZ ioctl updates the window size.
Fixes : #13317 

Assisted-by: Gemini AI