### PR TITLE
runsc: Auto-enable systemd cgroup handling for systemd paths

### DIFF
--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1893,15 +1893,24 @@ func (c *Container) populateStats(event *boot.EventOut) {
 
 func (c *Container) createParentCgroup(parentPath string, conf *config.Config) (cgroup.Cgroup, error) {
 	var err error
+	useSystemd := conf.SystemdCgroup
 	if conf.SystemdCgroup {
 		parentPath, err = cgroup.TransformSystemdPath(parentPath, c.ID, conf.Rootless)
 		if err != nil {
 			return nil, err
 		}
 	} else if cgroup.LikelySystemdPath(parentPath) {
-		log.Warningf("cgroup parent path is set to %q which looks like a systemd path. Please set --systemd-cgroup=true if you intend to use systemd to manage container cgroups", parentPath)
+		// Auto-enable systemd cgroup handling when a systemd path is detected.
+		// This ensures proper cgroup initialization when the shim is invoked
+		// directly with systemd paths (e.g., via Docker's --runtime flag).
+		log.Infof("Detected systemd cgroup path %q, enabling systemd cgroup handling", parentPath)
+		useSystemd = true
+		parentPath, err = cgroup.TransformSystemdPath(parentPath, c.ID, conf.Rootless)
+		if err != nil {
+			return nil, err
+		}
 	}
-	parentCgroup, err := cgroup.NewFromPath(parentPath, conf.SystemdCgroup)
+	parentCgroup, err := cgroup.NewFromPath(parentPath, useSystemd)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The containerd-shim-runsc-v1 binary failed to initialize cgroup controllers when invoked directly with systemd cgroup paths like `system.slice:docker:...`. This caused containers to fail with "no such file or directory" errors when writing to `cgroup.subtree_control`.

The root cause was in `createParentCgroup` in `runsc/container/container.go`. When a systemd-style path was detected but `SystemdCgroup` config was false, the code logged a warning but proceeded to use the path with regular cgroupv2 initialization. This failed because systemd slice paths require proper systemd dbus initialization to set up controller delegation.

This fix auto-enables systemd cgroup handling when a systemd path format is detected (containing colons in `slice:prefix:name` format). The path is properly transformed and passed to the systemd cgroup implementation, which correctly initializes the cgroup hierarchy through dbus.

Fixes #13301
