### PR TITLE
tcp: anchor ACK-derived time measurements to ingress time, not processing time

### DIFF
--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -663,14 +663,18 @@ func (h *handshake) transitionToStateEstablishedLocked(s *segment) {
 	// (indicated by a negative send window scale).
 	initSender(h.ep, h.iss, h.ackNum-1, h.sndWnd, h.mss, h.sndWndScale)
 
-	now := h.ep.stack.Clock().NowMonotonic()
+	// Use the final handshake ACK's ingress time (s.rcvdTime) rather than the
+	// current clock to seed the initial RTT/RTO. If the ACK was delayed inside
+	// the stack before processing, the processing-time clock would inflate the
+	// initial RTO, which then persists for several RTTs.
+	rcvd := s.rcvdTime
 
 	var rtt time.Duration
 	if h.ep.SendTSOk && s.parsedOptions.TSEcr != 0 {
-		rtt = h.ep.elapsed(now, s.parsedOptions.TSEcr)
+		rtt = h.ep.elapsed(rcvd, s.parsedOptions.TSEcr)
 	}
 	if !h.sampleRTTWithTSOnly && rtt == 0 {
-		rtt = now.Sub(h.startTime)
+		rtt = rcvd.Sub(h.startTime)
 	}
 
 	if rtt > 0 {

--- a/pkg/tcpip/transport/tcp/cubic.go
+++ b/pkg/tcpip/transport/tcp/cubic.go
@@ -79,9 +79,14 @@ func newCubicCC(s *sender) *cubicState {
 			C:    0.4,
 			// By this point, the sender has initialized it's initial sequence
 			// number.
-			EndSeq:     s.SndNxt,
-			LastRTT:    effectivelyInfinity,
-			CurrRTT:    effectivelyInfinity,
+			EndSeq:  s.SndNxt,
+			LastRTT: effectivelyInfinity,
+			CurrRTT: effectivelyInfinity,
+			// LastAck/RoundStart are seeded here from processing time, but the
+			// HyStart ACK-train comparator that reads them is gated on
+			// LastRTT < effectivelyInfinity, which only becomes true after the
+			// first beginHyStartRound re-seeds both from an ACK's ingress time.
+			// So this initial processing-time seed is never compared.
 			LastAck:    now,
 			RoundStart: now,
 		},
@@ -122,12 +127,19 @@ func (c *cubicState) enterCongestionAvoidance() {
 // here.
 //
 // +checklocks:c.s.ep.mu
-func (c *cubicState) updateHyStart(rtt time.Duration) {
+func (c *cubicState) updateHyStart(rtt time.Duration, ackTime tcpip.MonotonicTime) {
 	if rtt < 0 {
 		// negative indicates unknown
 		return
 	}
-	now := c.s.ep.stack.Clock().NowMonotonic()
+	// Use the ACK's ingress time (ackTime) rather than the current clock for
+	// HyStart's ACK-train timing. The ACK-train detector compares inter-ACK
+	// spacing against ackDelta (2ms) and the round duration against LastRTT/2;
+	// if ACKs are delayed and processed in a burst inside the stack (e.g.
+	// queued while the application held the endpoint lock during a Write), the
+	// processing clock would make distinct ACKs appear to arrive together,
+	// distorting both comparisons and potentially exiting slow start early.
+	now := ackTime
 	if c.EndSeq.LessThan(c.s.SndUna) {
 		c.beginHyStartRound(now)
 	}
@@ -197,9 +209,9 @@ func (c *cubicState) updateSlowStart(packetsAcked int) int {
 // Refer: https://tools.ietf.org/html/rfc8312#section-4
 //
 // +checklocks:c.s.ep.mu
-func (c *cubicState) Update(packetsAcked int, rtt time.Duration) {
+func (c *cubicState) Update(packetsAcked int, rtt time.Duration, ackTime tcpip.MonotonicTime) {
 	if c.s.Ssthresh == InitialSsthresh && c.s.SndCwnd < c.s.Ssthresh {
-		c.updateHyStart(rtt)
+		c.updateHyStart(rtt, ackTime)
 	}
 	if c.s.SndCwnd < c.s.Ssthresh {
 		packetsAcked = c.updateSlowStart(packetsAcked)

--- a/pkg/tcpip/transport/tcp/cubic_test.go
+++ b/pkg/tcpip/transport/tcp/cubic_test.go
@@ -61,7 +61,7 @@ func TestHyStartAckTrainOK(t *testing.T) {
 	d0 := 4 * time.Millisecond
 	uut.s.ep.mu.Lock()
 	defer uut.s.ep.mu.Unlock()
-	uut.updateHyStart(d0)
+	uut.updateHyStart(d0, fClock.NowMonotonic())
 	if uut.CurrRTT != d0 {
 		t.Fatal()
 	}
@@ -76,7 +76,7 @@ func TestHyStartAckTrainOK(t *testing.T) {
 	r1ExpectedStart := fClock.NowMonotonic()
 
 	d1 := 5 * time.Millisecond
-	uut.updateHyStart(d1)
+	uut.updateHyStart(d1, fClock.NowMonotonic())
 	if uut.LastRTT != d0 {
 		t.Fatal()
 	}
@@ -92,7 +92,7 @@ func TestHyStartAckTrainOK(t *testing.T) {
 	// times.
 	for range 2 {
 		fClock.Advance(time.Millisecond)
-		uut.updateHyStart(d1)
+		uut.updateHyStart(d1, fClock.NowMonotonic())
 		if snd.Ssthresh != InitialSsthresh {
 			t.Fatal("HyStart should not be triggered")
 		}
@@ -103,7 +103,7 @@ func TestHyStartAckTrainOK(t *testing.T) {
 
 	// 3 ms---triggers HyStart setting Ssthresh
 	fClock.Advance(time.Millisecond)
-	uut.updateHyStart(d1)
+	uut.updateHyStart(d1, fClock.NowMonotonic())
 	if snd.Ssthresh == InitialSsthresh {
 		t.Fatal("HyStart SHOULD be triggered")
 	}
@@ -145,7 +145,7 @@ func TestHyStartAckTrainTooSpread(t *testing.T) {
 	d0 := 4 * time.Millisecond
 	uut.s.ep.mu.Lock()
 	defer uut.s.ep.mu.Unlock()
-	uut.updateHyStart(d0)
+	uut.updateHyStart(d0, fClock.NowMonotonic())
 	if uut.CurrRTT != d0 {
 		t.Fatal()
 	}
@@ -160,7 +160,7 @@ func TestHyStartAckTrainTooSpread(t *testing.T) {
 	r1ExpectedStart := fClock.NowMonotonic()
 
 	d1 := 5 * time.Millisecond
-	uut.updateHyStart(d1)
+	uut.updateHyStart(d1, fClock.NowMonotonic())
 	if uut.LastRTT != d0 {
 		t.Fatal()
 	}
@@ -173,7 +173,7 @@ func TestHyStartAckTrainTooSpread(t *testing.T) {
 
 	// HyStart will ignore ACKs spaced more than 2ms apart
 	fClock.Advance(3 * time.Millisecond)
-	uut.updateHyStart(d1)
+	uut.updateHyStart(d1, fClock.NowMonotonic())
 	if snd.Ssthresh != InitialSsthresh {
 		t.Fatal("HyStart should not be triggered")
 	}
@@ -212,7 +212,7 @@ func TestHyStartDelayOK(t *testing.T) {
 	d0 := 4 * time.Millisecond
 	uut.s.ep.mu.Lock()
 	defer uut.s.ep.mu.Unlock()
-	uut.updateHyStart(d0)
+	uut.updateHyStart(d0, fClock.NowMonotonic())
 
 	// Move SndNext and SndUna to advance to a new round.
 	snd.SndNxt = snd.SndNxt.Add(2000)
@@ -223,7 +223,7 @@ func TestHyStartDelayOK(t *testing.T) {
 
 	// Delay detection requires at least nRTTSample measurements.
 	for i := uint(1); i < nRTTSample; i++ {
-		uut.updateHyStart(d1)
+		uut.updateHyStart(d1, fClock.NowMonotonic())
 		if uut.SampleCount != i {
 			t.Fatal()
 		}
@@ -231,7 +231,7 @@ func TestHyStartDelayOK(t *testing.T) {
 	if snd.Ssthresh != InitialSsthresh {
 		t.Fatal("triggered with fewer than nRTTSample measurements")
 	}
-	uut.updateHyStart(d1)
+	uut.updateHyStart(d1, fClock.NowMonotonic())
 	if snd.Ssthresh == InitialSsthresh {
 		t.Fatal("didn't trigger SS exit")
 	}
@@ -267,7 +267,7 @@ func TestHyStartDelay_BelowThresh(t *testing.T) {
 	d0 := 4 * time.Millisecond
 	uut.s.ep.mu.Lock()
 	defer uut.s.ep.mu.Unlock()
-	uut.updateHyStart(d0)
+	uut.updateHyStart(d0, fClock.NowMonotonic())
 
 	// Move SndNext and SndUna to advance to a new round.
 	snd.SndNxt = snd.SndNxt.Add(2000)
@@ -278,7 +278,7 @@ func TestHyStartDelay_BelowThresh(t *testing.T) {
 
 	// Delay detection requires at least nRTTSample measurements.
 	for i := uint(1); i < nRTTSample; i++ {
-		uut.updateHyStart(d1)
+		uut.updateHyStart(d1, fClock.NowMonotonic())
 		if uut.SampleCount != i {
 			t.Fatal()
 		}
@@ -286,8 +286,105 @@ func TestHyStartDelay_BelowThresh(t *testing.T) {
 	if snd.Ssthresh != InitialSsthresh {
 		t.Fatal("triggered with fewer than nRTTSample measurements")
 	}
-	uut.updateHyStart(d1 - time.Millisecond)
+	uut.updateHyStart(d1 - time.Millisecond, fClock.NowMonotonic())
 	if snd.Ssthresh != InitialSsthresh {
 		t.Fatal("triggered with a measurement under threshold")
+	}
+}
+
+// TestHyStartAckTrainUsesIngressTime verifies that HyStart's ACK-train detector
+// uses each ACK's ingress time (the ackTime argument) rather than the time the
+// ACK was processed. This is a regression test for the gvisor#9707/#9778 family:
+// if ACKs are delayed inside the stack and processed in a burst (so their
+// processing-clock timestamps cluster within ackDelta), measuring against
+// processing time would make widely-spaced ACKs look like a tight "train" and
+// could trip a premature exit from slow start, capping cwnd on a high-BDP path.
+//
+// Here the processing clock (fClock) is held essentially still across the ACKs
+// (simulating a burst drained after a lock release) while the ackTime arguments
+// reflect the ACKs' true arrival, spaced > ackDelta (2ms) apart. With the fix,
+// the ACK-train detector ignores them (they are not a train) and HyStart does
+// not fire. With the bug (processing-time), they would look like a train and
+// fire.
+func TestHyStartAckTrainUsesIngressTime(t *testing.T) {
+	fClock := faketime.NewManualClock()
+	stackOpts := stack.Options{
+		TransportProtocols: []stack.TransportProtocolFactory{NewProtocol},
+		Clock:              fClock,
+	}
+	s := stack.New(stackOpts)
+	ep := &Endpoint{
+		stack: s,
+		cc:    tcpip.CongestionControlOption("cubic"),
+	}
+	iss := seqnum.Value(0)
+	snd := &sender{
+		ep: ep,
+		TCPSenderState: TCPSenderState{
+			SndUna:   iss + 1,
+			SndNxt:   iss + 1,
+			Ssthresh: InitialSsthresh,
+		},
+	}
+	snd.ep.mu.Lock()
+	uut := newCubicCC(snd)
+	snd.ep.mu.Unlock()
+	snd.cc = uut
+
+	uut.s.ep.mu.Lock()
+	defer uut.s.ep.mu.Unlock()
+
+	// This mirrors TestHyStartAckTrainOK, which establishes a round and then
+	// shows that ACKs spaced 1ms apart (< ackDelta) trigger HyStart once the
+	// round has lasted > LastRTT/2. The only difference here: the PROCESSING
+	// clock is frozen during the burst (modeling ACKs drained together after a
+	// stack-internal delay), and the ACKs' true arrival times — supplied via
+	// ackTime — are spaced 3ms apart (> ackDelta), i.e. NOT a real train.
+	//
+	// With the fix (ackTime is used) the detector sees 3ms spacing and never
+	// fires. Without the fix (processing clock is used) the frozen clock makes
+	// every burst ACK look simultaneous (spacing 0 < ackDelta) while the round
+	// has aged past LastRTT/2, so HyStart fires spuriously.
+	d0 := 4 * time.Millisecond
+	uut.updateHyStart(d0, fClock.NowMonotonic())
+
+	// Begin the round under test (LastRTT = d0 = 4ms; RoundStart = 4ms).
+	snd.SndNxt = snd.SndNxt.Add(2000)
+	snd.SndUna = snd.SndUna.Add(1000)
+	fClock.Advance(d0)
+	roundStart := fClock.NowMonotonic() // t = 4ms
+	uut.updateHyStart(5*time.Millisecond, roundStart)
+
+	// Keep the train "warm": process two more ACKs ~1ms apart so LastAck tracks
+	// recent processing time. This is the normal in-round state right before a
+	// stack-internal delay/burst occurs.
+	fClock.Advance(time.Millisecond) // t = 5ms
+	uut.updateHyStart(5*time.Millisecond, fClock.NowMonotonic())
+	fClock.Advance(time.Millisecond) // t = 6ms; LastAck now 6ms
+	uut.updateHyStart(5*time.Millisecond, fClock.NowMonotonic())
+
+	// Now the burst: the processing clock jumps forward (the ACKs were delayed
+	// inside the stack) and is then frozen while several ACKs are drained
+	// together. Their TRUE arrival times, supplied via ackTime, are spaced 3ms
+	// apart (> ackDelta), so they are NOT a real train.
+	//
+	//   - Fix (ackTime): inter-ACK spacing seen as 3ms >= ackDelta, and after
+	//     the first ACK LastAck advances to the (spread) arrival time, so the
+	//     train branch is never taken -> HyStart does not fire.
+	//   - Bug (processing clock): the frozen processing time is within ackDelta
+	//     of the previous LastAck, and after the first burst ACK LastAck = that
+	//     frozen time, so every subsequent ACK has spacing 0 < ackDelta while
+	//     now - RoundStart (>> 2ms) exceeds LastRTT/2 -> HyStart fires.
+	fClock.Advance(time.Millisecond) // t = 7ms: within ackDelta of LastAck(6ms) and
+	// 3ms past RoundStart(4ms) > LastRTT/2(2ms); frozen below for the burst.
+	arrival := fClock.NowMonotonic()
+	for i := 0; i < 4; i++ {
+		arrival = arrival.Add(3 * time.Millisecond) // true arrivals 3ms apart
+		uut.updateHyStart(5*time.Millisecond, arrival)
+		if snd.Ssthresh != InitialSsthresh {
+			t.Fatalf("HyStart ACK-train fired on ACKs whose true arrivals are 3ms apart "+
+				"(> ackDelta); it measured clustered processing time instead of ingress "+
+				"time (iteration %d)", i)
+		}
 	}
 }

--- a/pkg/tcpip/transport/tcp/rack.go
+++ b/pkg/tcpip/transport/tcp/rack.go
@@ -78,7 +78,15 @@ func (rc *rackControl) init(snd *sender, iss seqnum.Value) {
 // update will update the RACK related fields when an ACK has been received.
 // See: https://tools.ietf.org/html/draft-ietf-tcpm-rack-09#section-6.2
 func (rc *rackControl) update(seg *segment, ackSeg *segment) {
-	rtt := rc.snd.ep.stack.Clock().NowMonotonic().Sub(seg.xmitTime)
+	// Compute the RTT sample against the time the ACK was received at ingress
+	// (ackSeg.rcvdTime), not the current clock. The two differ when the ACK was
+	// delayed inside the stack before being processed (e.g. it sat in the
+	// endpoint's segment queue while the application held the endpoint lock
+	// during a Write that synchronously flushed a window). Using the processing
+	// time would inflate the RTT by that internal delay, corrupting RACK.RTT,
+	// RACK.minRTT and the reorder window, and causing spurious loss detection.
+	// detectLoss already uses ackSeg.rcvdTime; this keeps update consistent.
+	rtt := ackSeg.rcvdTime.Sub(seg.xmitTime)
 
 	// If the ACK is for a retransmitted packet, do not update if it is a
 	// spurious inference which is determined by below checks:
@@ -400,7 +408,17 @@ func (rc *rackControl) reorderTimerExpired() tcpip.Error {
 		return nil
 	}
 
-	numLost := rc.detectLoss(rc.snd.ep.stack.Clock().NowMonotonic())
+	// Evaluate loss as of the time the reorder timer was scheduled to fire (its
+	// target), not the current clock. The timer is armed for the instant a
+	// segment's reorder window elapses, but the timer callback itself can run
+	// arbitrarily late under load (the processor goroutine is busy, or the
+	// endpoint lock is held while a Write flushes a window). Using the
+	// (possibly much later) processing time would make timeRemaining strongly
+	// negative and mark not-yet-lost segments as lost, triggering spurious
+	// retransmits and recovery on a path with little or no real loss
+	// (gvisor#9707/#9778). detectLoss arms the timer from rcvdTime-derived
+	// values, so evaluating it at the timer target keeps the two consistent.
+	numLost := rc.detectLoss(rc.snd.reorderTimer.target)
 	if numLost == 0 {
 		return nil
 	}

--- a/pkg/tcpip/transport/tcp/rcv.go
+++ b/pkg/tcpip/transport/tcp/rcv.go
@@ -317,9 +317,12 @@ func (r *receiver) consumeSegment(s *segment, segSeq seqnum.Value, segLen seqnum
 	return true
 }
 
-// updateRTT updates the receiver RTT measurement based on the sequence number
-// of the received segment.
-func (r *receiver) updateRTT() {
+// updateRTT estimates a receiver-side RTT for receive-buffer autotuning, based
+// on the sequence number of the received segment. rcvdTime is the ingress
+// timestamp of the segment that triggered this measurement; it is used instead
+// of the current clock so that an internal processing delay does not inflate the
+// estimate (which would size the receive buffer too large).
+func (r *receiver) updateRTT(rcvdTime tcpip.MonotonicTime) {
 	// From: https://public.lanl.gov/radiant/pubs/drs/sc2001-poster.pdf
 	//
 	// A system that is only transmitting acknowledgements can still
@@ -329,7 +332,7 @@ func (r *receiver) updateRTT() {
 	r.ep.rcvQueueMu.Lock()
 	if r.ep.RcvAutoParams.RTTMeasureTime == (tcpip.MonotonicTime{}) {
 		// New measurement.
-		r.ep.RcvAutoParams.RTTMeasureTime = r.ep.stack.Clock().NowMonotonic()
+		r.ep.RcvAutoParams.RTTMeasureTime = rcvdTime
 		r.ep.RcvAutoParams.RTTMeasureSeqNumber = r.RcvNxt.Add(r.rcvWnd)
 		r.ep.rcvQueueMu.Unlock()
 		return
@@ -338,14 +341,14 @@ func (r *receiver) updateRTT() {
 		r.ep.rcvQueueMu.Unlock()
 		return
 	}
-	rtt := r.ep.stack.Clock().NowMonotonic().Sub(r.ep.RcvAutoParams.RTTMeasureTime)
+	rtt := rcvdTime.Sub(r.ep.RcvAutoParams.RTTMeasureTime)
 	// We only store the minimum observed RTT here as this is only used in
 	// absence of a SRTT available from either timestamps or a sender
 	// measurement of RTT.
 	if r.ep.RcvAutoParams.RTT == 0 || rtt < r.ep.RcvAutoParams.RTT {
 		r.ep.RcvAutoParams.RTT = rtt
 	}
-	r.ep.RcvAutoParams.RTTMeasureTime = r.ep.stack.Clock().NowMonotonic()
+	r.ep.RcvAutoParams.RTTMeasureTime = rcvdTime
 	r.ep.RcvAutoParams.RTTMeasureSeqNumber = r.RcvNxt.Add(r.rcvWnd)
 	r.ep.rcvQueueMu.Unlock()
 }
@@ -470,8 +473,10 @@ func (r *receiver) handleRcvdSegment(s *segment) (drop bool, err tcpip.Error) {
 		}
 	}
 
-	// Store the time of the last ack.
-	r.lastRcvdAckTime = r.ep.stack.Clock().NowMonotonic()
+	// Store the time of the last ack. Use the segment's ingress time rather than
+	// the current clock so a segment delayed inside the stack before processing
+	// records when it actually arrived (consumed by the user-timeout check).
+	r.lastRcvdAckTime = s.rcvdTime
 
 	// Defer segment processing if it can't be consumed now.
 	if !r.consumeSegment(s, segSeq, segLen) {
@@ -514,7 +519,7 @@ func (r *receiver) handleRcvdSegment(s *segment) (drop bool, err tcpip.Error) {
 	// Since we consumed a segment update the receiver's RTT estimate
 	// if required.
 	if segLen > 0 {
-		r.updateRTT()
+		r.updateRTT(s.rcvdTime)
 	}
 
 	// By consuming the current segment, we may have filled a gap in the

--- a/pkg/tcpip/transport/tcp/reno.go
+++ b/pkg/tcpip/transport/tcp/reno.go
@@ -16,6 +16,8 @@ package tcp
 
 import (
 	"time"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
 )
 
 // renoState stores the variables related to TCP New Reno congestion
@@ -81,7 +83,7 @@ func (r *renoState) reduceSlowStartThreshold() {
 // Update implements congestionControl.Update.
 //
 // +checklocks:r.s.ep.mu
-func (r *renoState) Update(packetsAcked int, _ time.Duration) {
+func (r *renoState) Update(packetsAcked int, _ time.Duration, _ tcpip.MonotonicTime) {
 	if r.s.SndCwnd < r.s.Ssthresh {
 		packetsAcked = r.updateSlowStart(packetsAcked)
 		if packetsAcked == 0 {

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -74,8 +74,11 @@ type congestionControl interface {
 	// Update is invoked when processing inbound acks. It's passed the
 	// number of packet's that were acked by the most recent cumulative
 	// acknowledgement.  rtt is the round-trip time, or is set to unknownRTT
-	// (above) to indicate the time is unknown.
-	Update(packetsAcked int, rtt time.Duration)
+	// (above) to indicate the time is unknown. ackTime is the time the
+	// processed ACK arrived at the stack (its ingress timestamp), used for
+	// arrival-anchored timing such as CUBIC HyStart's ACK-train detection so
+	// that an ACK delayed inside the stack does not distort it.
+	Update(packetsAcked int, rtt time.Duration, ackTime tcpip.MonotonicTime)
 
 	// PostRecovery is invoked when the sender is exiting a fast retransmit/
 	// recovery phase. This provides congestion control algorithms a way
@@ -426,6 +429,13 @@ func (s *sender) sendAck() {
 //
 // +checklocks:s.ep.mu
 func (s *sender) updateRTO(rtt time.Duration) {
+	// A negative RTT sample is nonsensical and would skew SRTT/RTTVar (and thus
+	// RTO). RTT samples are now anchored to a segment's ingress time, which is
+	// monotonic and never after the corresponding send time, so this should not
+	// occur; guard defensively rather than corrupt the estimator.
+	if rtt < 0 {
+		return
+	}
 	s.rtt.Lock()
 	if !s.rtt.TCPRTTState.SRTTInited {
 		s.rtt.TCPRTTState.RTTVar = rtt / 2
@@ -1513,9 +1523,13 @@ func (s *sender) inRecovery() bool {
 func (s *sender) handleRcvdSegment(rcvdSeg *segment) {
 	bestRTT := unknownRTT
 
-	// Check if we can extract an RTT measurement from this ack.
+	// Check if we can extract an RTT measurement from this ack. Measure against
+	// the ACK's ingress time (rcvdSeg.rcvdTime), not the current clock: if the
+	// ACK was delayed inside the stack before being processed (e.g. queued while
+	// the application held the endpoint lock during a Write), using the
+	// processing time would inflate the RTT sample and thus SRTT/RTO.
 	if !rcvdSeg.parsedOptions.TS && s.RTTMeasureSeqNum.LessThan(rcvdSeg.ackNumber) {
-		bestRTT = s.ep.stack.Clock().NowMonotonic().Sub(s.RTTMeasureTime)
+		bestRTT = rcvdSeg.rcvdTime.Sub(s.RTTMeasureTime)
 		s.updateRTO(bestRTT)
 		s.RTTMeasureSeqNum = s.SndNxt
 	}
@@ -1618,7 +1632,10 @@ func (s *sender) handleRcvdSegment(rcvdSeg *segment) {
 		//    some new data, i.e., only if it advances the left edge of
 		//    the send window.
 		if s.ep.SendTSOk && rcvdSeg.parsedOptions.TSEcr != 0 {
-			tsRTT := s.ep.elapsed(s.ep.stack.Clock().NowMonotonic(), rcvdSeg.parsedOptions.TSEcr)
+			// Compute elapsed time from the ACK's ingress time, not the current
+			// clock, so an ACK delayed inside the stack before processing does
+			// not inflate the timestamp-based RTT sample (and thus SRTT/RTO).
+			tsRTT := s.ep.elapsed(rcvdSeg.rcvdTime, rcvdSeg.parsedOptions.TSEcr)
 			s.updateRTO(tsRTT)
 			// Following Linux, prefer RTT computed from ACKs to TSEcr because,
 			// "broken middle-boxes or peers may corrupt TS-ECR fields"
@@ -1698,7 +1715,7 @@ func (s *sender) handleRcvdSegment(rcvdSeg *segment) {
 		// If we are not in fast recovery then update the congestion
 		// window based on the number of acknowledged packets.
 		if !s.FastRecovery.Active {
-			s.cc.Update(originalOutstanding-s.Outstanding, bestRTT)
+			s.cc.Update(originalOutstanding-s.Outstanding, bestRTT, rcvdSeg.rcvdTime)
 			if s.FastRecovery.Last.LessThan(s.SndUna) {
 				s.state = tcpip.Open
 				// Update RACK when we are exiting fast or RTO

--- a/pkg/tcpip/transport/tcp/test/e2e/BUILD
+++ b/pkg/tcpip/transport/tcp/test/e2e/BUILD
@@ -144,6 +144,22 @@ go_test(
 )
 
 go_test(
+    name = "tcp_acktiming_test",
+    size = "small",
+    srcs = ["tcp_acktiming_test.go"],
+    deps = [
+        ":e2e",
+        "//pkg/refs",
+        "//pkg/tcpip",
+        "//pkg/tcpip/faketime",
+        "//pkg/tcpip/header",
+        "//pkg/tcpip/seqnum",
+        "//pkg/tcpip/transport/tcp",
+        "//pkg/tcpip/transport/tcp/testing/context",
+    ],
+)
+
+go_test(
     name = "tcp_sack_test",
     size = "small",
     srcs = ["tcp_sack_test.go"],

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_acktiming_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_acktiming_test.go
@@ -1,0 +1,226 @@
+// Copyright 2024 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tcp_acktiming_test verifies that TCP RTT measurements are anchored to
+// the time an ACK arrived at the stack (its ingress timestamp, segment.rcvdTime)
+// rather than the time the stack got around to processing it.
+//
+// These are regression tests for the gvisor#9707 / gvisor#9778 family: when the
+// sending endpoint is busy (e.g. the application holds the endpoint lock during
+// a Write that synchronously flushes a window of segments, paying real
+// per-packet cost such as WireGuard encryption), inbound ACKs sit unprocessed in
+// the endpoint's segment queue. If an RTT is measured against the processing-time
+// clock instead of the ACK's ingress time, it is inflated by that internal
+// delay. For RACK this corrupts RACK.RTT/minRTT and the reorder window and
+// triggers spurious loss detection; for the main-path RTT it inflates SRTT/RTO.
+package tcp_acktiming_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/refs"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/faketime"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/seqnum"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp/test/e2e"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp/testing/context"
+)
+
+const (
+	maxPayload = 10
+	mtu        = header.TCPMinimumSize + header.IPv4MinimumSize + 40 + maxPayload
+)
+
+func TestMain(m *testing.M) {
+	refs.SetLeakMode(refs.NoLeakChecking)
+	m.Run()
+}
+
+// agedACKResult holds the sender state captured by the probe when the aged ACK
+// was processed.
+type agedACKResult struct {
+	rackRTT time.Duration
+	srtt    time.Duration
+	rto     time.Duration
+}
+
+// runAgedACK establishes a connection, sends one segment, and then processes its
+// ACK after an internal processing delay of processHold (created by holding the
+// endpoint lock via StopWork while virtual time advances). The ACK genuinely
+// arrives trueRTT after transmission. useTS selects whether the connection
+// negotiates TCP timestamps (which selects the timestamp vs non-timestamp RTT
+// path in the sender). It returns the sender RTT state observed when the aged
+// ACK is processed.
+func runAgedACK(t *testing.T, useTS bool, trueRTT, processHold time.Duration) agedACKResult {
+	t.Helper()
+
+	clock := faketime.NewManualClock()
+
+	stateCh := make(chan tcp.TCPEndpointState, 256)
+	probe := func(state *tcp.TCPEndpointState) {
+		// Non-blocking: never stall the stack's processing goroutine.
+		select {
+		case stateCh <- *state:
+		default:
+		}
+	}
+
+	c := context.NewWithOpts(t, context.Options{
+		EnableV4: true,
+		EnableV6: true,
+		MTU:      mtu,
+		Clock:    clock,
+		Probe:    probe,
+	})
+	defer c.Cleanup()
+
+	e2e.SetStackSACKPermitted(t, c, true)
+	// Always negotiate timestamps so we can choose, per test, whether the
+	// injected ACK carries a TSEcr (which selects the timestamp RTT path,
+	// snd.go) or not (the non-timestamp path). rep is the peer (link) side.
+	rep := e2e.CreateConnectedWithSACKAndTS(c)
+
+	tcpEP, ok := c.EP.(interface {
+		StopWork()
+		ResumeWork()
+	})
+	if !ok {
+		t.Fatalf("endpoint %T does not expose StopWork/ResumeWork", c.EP)
+	}
+
+	data := make([]byte, maxPayload)
+	for i := range data {
+		data[i] = byte(i)
+	}
+
+	// Send one segment and read it off the link, capturing the data segment's
+	// TSVal so the ACK below can echo it back as TSEcr (selecting the timestamp
+	// RTT path).
+	var r bytes.Reader
+	r.Reset(data)
+	if _, err := c.EP.Write(&r, tcpip.WriteOptions{}); err != nil {
+		t.Fatalf("Write failed: %s", err)
+	}
+	dataPkt := c.GetPacket()
+	dataTCP := header.TCP(header.IPv4(dataPkt.AsSlice()).Payload())
+	dataTSVal := dataTCP.ParsedOptions().TSVal
+	dataPkt.Release()
+	if useTS && dataTSVal == 0 {
+		t.Fatal("data segment carried no TSVal; cannot exercise the timestamp RTT path")
+	}
+
+	// The ACK genuinely arrives one RTT after transmission.
+	clock.Advance(trueRTT)
+
+	// Drain probe samples produced so far so we observe the post-ACK state.
+	for len(stateCh) > 0 {
+		<-stateCh
+	}
+
+	// Create the internal processing delay: hold the endpoint lock so the
+	// injected ACK cannot be processed, advance virtual time while it sits in
+	// the segment queue, then release the lock so it is processed against the
+	// advanced clock. With the fix, the RTT is computed from the ACK's ingress
+	// time (rcvdTime) and is not inflated.
+	//
+	// NB: StopWork takes the endpoint lock directly; it models the processing
+	// delay (segment stamped at SendAck time, processed after the clock
+	// advanced), not the exact LockUser/UnlockUser handoff of the real bug.
+	rep.NextSeqNum = seqnum.Value(context.TestInitialSequenceNumber).Add(1)
+	rep.AckNum = c.IRS.Add(1 + seqnum.Size(len(data)))
+	rep.Flags = header.TCPFlagAck
+	tcpEP.StopWork()
+	if useTS {
+		// Echo the data segment's TSVal as TSEcr so the sender takes the
+		// timestamp RTT path (s.ep.elapsed(rcvdSeg.rcvdTime, TSEcr)).
+		rep.RecentTS = dataTSVal
+		rep.SendPacketWithTS(nil, rep.TSVal+1)
+	} else {
+		c.SendAck(seqnum.Value(context.TestInitialSequenceNumber).Add(1), len(data))
+	}
+	// Keep processHold below the (3s test) RTO so no retransmit timer fires
+	// while we hold the lock.
+	clock.Advance(processHold)
+	tcpEP.ResumeWork()
+
+	// Wait for the probe to report the state after the aged ACK is processed.
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case st := <-stateCh:
+			// The ACK acknowledges our one segment, advancing SndUna. Once that
+			// has happened the RTT state reflects this ACK.
+			if st.Sender.RTTState.SRTT != 0 {
+				return agedACKResult{
+					rackRTT: st.Sender.RACKState.RTT,
+					srtt:    st.Sender.RTTState.SRTT,
+					rto:     st.Sender.RTO,
+				}
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for the aged ACK to be processed")
+		}
+	}
+}
+
+// TestRACKRTTNotInflatedByProcessingDelay covers rackControl.update (RACK RTT).
+func TestRACKRTTNotInflatedByProcessingDelay(t *testing.T) {
+	const (
+		trueRTT     = 50 * time.Millisecond
+		processHold = 250 * time.Millisecond
+	)
+	got := runAgedACK(t, true /* useTS */, trueRTT, processHold)
+	t.Logf("true RTT=%v hold=%v: RACK RTT=%v SRTT=%v", trueRTT, processHold, got.rackRTT, got.srtt)
+	if got.rackRTT > trueRTT+processHold/2 {
+		t.Errorf("RACK RTT inflated by internal processing delay: got %v, want <= %v; "+
+			"RTT measured against processing time instead of the ACK's ingress time (rcvdTime)",
+			got.rackRTT, trueRTT+processHold/2)
+	}
+}
+
+// TestSRTTNotInflatedByProcessingDelayTS covers the timestamp-based main-path
+// RTT in sender.handleRcvdSegment.
+func TestSRTTNotInflatedByProcessingDelayTS(t *testing.T) {
+	const (
+		trueRTT     = 50 * time.Millisecond
+		processHold = 250 * time.Millisecond
+	)
+	got := runAgedACK(t, true /* useTS */, trueRTT, processHold)
+	t.Logf("true RTT=%v hold=%v: SRTT=%v RTO=%v", trueRTT, processHold, got.srtt, got.rto)
+	// SRTT is the first sample here (smoothed estimator seeded by this RTT), so
+	// an inflated sample shows up close to trueRTT+processHold.
+	if got.srtt > trueRTT+processHold/2 {
+		t.Errorf("SRTT inflated by internal processing delay (TS path): got %v, want <= %v",
+			got.srtt, trueRTT+processHold/2)
+	}
+}
+
+// TestSRTTNotInflatedByProcessingDelayNoTS covers the non-timestamp main-path
+// RTT in sender.handleRcvdSegment.
+func TestSRTTNotInflatedByProcessingDelayNoTS(t *testing.T) {
+	const (
+		trueRTT     = 50 * time.Millisecond
+		processHold = 250 * time.Millisecond
+	)
+	got := runAgedACK(t, false /* useTS */, trueRTT, processHold)
+	t.Logf("true RTT=%v hold=%v: SRTT=%v RTO=%v", trueRTT, processHold, got.srtt, got.rto)
+	if got.srtt > trueRTT+processHold/2 {
+		t.Errorf("SRTT inflated by internal processing delay (non-TS path): got %v, want <= %v",
+			got.srtt, trueRTT+processHold/2)
+	}
+}


### PR DESCRIPTION
Several TCP measurements that are causally anchored to the arrival of an inbound ACK were computed using the wall clock at the moment the segment was *processed* (ep.stack.Clock().NowMonotonic()) rather than the time the segment *arrived* at the stack (segment.rcvdTime, stamped in newIncomingSegment before the segment is queued).

These differ when an inbound ACK is delayed inside the stack before being processed. In particular, a busy sender holds the endpoint lock while Write synchronously flushes a window of segments (each paying real per-packet cost such as encryption and a tun write), so inbound ACKs sit unprocessed in the endpoint's segment queue. Measuring against processing time then inflates the result by that internal delay, corrupting:

  - RACK.RTT / RACK.minRTT and the reorder window (rackControl.update), which can trigger spurious loss detection and hold cwnd abnormally low on a path with little or no real loss;
  - the connection's SRTT/RTO via the timestamp and non-timestamp RTT samples in sender.handleRcvdSegment;
  - the initial RTO seeded at handshake completion (handshake.transitionToStateEstablishedLocked);
  - the receiver's RTT estimate used for receive-buffer autotuning (receiver.updateRTT), and lastRcvdAckTime;
  - CUBIC HyStart's ACK-train detection (now.Sub(LastAck)/now.Sub(RoundStart)), where a burst of ACKs drained together after an internal delay can look like a tight train and exit slow start prematurely.

This is the long-standing root cause behind reports of RACK performing poorly under load (spurious retransmissions, reduced congestion window). detectLoss already used the segment's rcvdTime; this change makes the rest of the ACK-anchored time measurements consistent with it, and threads the ACK ingress time through congestionControl.Update so CUBIC HyStart's ACK-train timing uses it too. updateRTO also gains a defensive guard against a negative RTT sample.

Anchoring RTT to ingress time is more in line with RFC 6298 ("measure the elapsed time between sending a data octet ... and receiving the acknowledgment") and RFC 8985, and matches Linux, which samples RTT at receive (softirq) time.

Note: CUBIC's congestion-event epoch timestamps (c.T in getCwnd and the loss/ recovery handlers) are intentionally left on processing time; they are event markers, not arrival-anchored estimators, and Linux uses processing time there as well.

Adds tcp_acktiming_test.go, which uses a manual clock and the StopWork hook to hold the endpoint lock while an ACK ages in the queue, asserting the RACK RTT and SRTT are not inflated by the internal delay; the timestamp and non-timestamp RTT paths are each exercised. Adds a CUBIC HyStart regression test that drives a "burst" of ACKs whose ingress times are spaced beyond ackDelta while the processing clock is frozen, asserting HyStart does not fire. Both fail without the corresponding fix and pass with it.

Fixes #9778
Updates tailscale/tailscale#9707