### PR TITLE
tcp: transition to FIN_WAIT1 when FIN is queued

### DIFF
--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -2586,9 +2586,18 @@ func (e *Endpoint) shutdownLocked(flags tcpip.ShutdownFlags) tcpip.Error {
 				return nil
 			}
 
-			// Queue fin segment.
+			// Queue FIN and transition to the closing state immediately,
+			// matching Linux tcp_close_state(): the FIN may be queued but
+			// not yet transmitted when the write queue is blocked.
 			s := newOutgoingSegment(e.TransportEndpointInfo.ID, e.stack.Clock(), buffer.Buffer{})
 			e.snd.writeList.PushBack(s)
+			e.updateConnDirectionState(connDirectionStateSndClosed)
+			switch e.EndpointState() {
+			case StateCloseWait:
+				e.setEndpointState(StateLastAck)
+			default:
+				e.setEndpointState(StateFinWait1)
+			}
 			// Mark endpoint as closed.
 			e.sndQueueInfo.SndClosed = true
 			e.sndQueueInfo.sndQueueMu.Unlock()

--- a/pkg/tcpip/transport/tcp/rcv.go
+++ b/pkg/tcpip/transport/tcp/rcv.go
@@ -262,7 +262,7 @@ func (r *receiver) consumeSegment(s *segment, segSeq seqnum.Value, segLen seqnum
 		case StateEstablished:
 			r.ep.setEndpointState(StateCloseWait)
 		case StateFinWait1:
-			if s.flags.Contains(header.TCPFlagAck) && s.ackNumber == r.ep.snd.SndNxt {
+			if s.flags.Contains(header.TCPFlagAck) && r.ep.snd.finSent && s.ackNumber == r.ep.snd.SndNxt {
 				// FIN-ACK, transition to TIME-WAIT.
 				r.ep.setEndpointState(StateTimeWait)
 			} else {
@@ -296,8 +296,9 @@ func (r *receiver) consumeSegment(s *segment, segSeq seqnum.Value, segLen seqnum
 	}
 
 	// Handle ACK (not FIN-ACK, which we handled above) during one of the
-	// shutdown states.
-	if s.flags.Contains(header.TCPFlagAck) && s.ackNumber == r.ep.snd.SndNxt {
+	// shutdown states. These completions require that our FIN was sent;
+	// without finSent a data ACK would be mistaken for a FIN ACK.
+	if s.flags.Contains(header.TCPFlagAck) && r.ep.snd.finSent && s.ackNumber == r.ep.snd.SndNxt {
 		switch r.ep.EndpointState() {
 		case StateFinWait1:
 			r.ep.setEndpointState(StateFinWait2)

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -104,6 +104,11 @@ type sender struct {
 
 	ep *Endpoint
 
+	// finSent is set when the FIN segment is actually transmitted.
+	// The endpoint may be in FIN_WAIT1/LAST_ACK while the FIN is still
+	// queued behind blocked data; finSent guards closing ACK completions.
+	finSent bool
+
 	// lr is the loss recovery algorithm used by the sender.
 	lr lossRecovery
 
@@ -894,15 +899,9 @@ func (s *sender) maybeSendSegment(seg *segment, limit int, end seqnum.Value) (se
 		}
 		seg.flags = header.TCPFlagAck | header.TCPFlagFin
 		segEnd = seg.sequenceNumber.Add(1)
-		// Update the state to reflect that we have now
-		// queued a FIN.
-		s.ep.updateConnDirectionState(connDirectionStateSndClosed)
-		switch s.ep.EndpointState() {
-		case StateCloseWait:
-			s.ep.setEndpointState(StateLastAck)
-		default:
-			s.ep.setEndpointState(StateFinWait1)
-		}
+		// FIN is now being transmitted; mark it so the receiver can tell
+		// a data-only ACK apart from one that acknowledges our FIN.
+		s.finSent = true
 	} else {
 		// We're sending a non-FIN segment.
 		if seg.flags&header.TCPFlagFin != 0 {

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
@@ -9790,6 +9790,87 @@ func TestRSTExactMatchAbortsConnection(t *testing.T) {
 	}
 }
 
+// TestCloseWithPendingDataCwndFull verifies that close() keeps the
+// connection on the graceful FIN path even when the current congestion
+// window is full and the queued FIN cannot be transmitted immediately.
+func TestCloseWithPendingDataCwndFull(t *testing.T) {
+	c := context.New(t, e2e.DefaultMTU)
+	defer c.Cleanup()
+
+	c.CreateConnected(context.TestInitialSequenceNumber, 30000, -1 /* epRcvBuf */)
+
+	// Write enough segments to fill the congestion window before ACK'ing
+	// any of them.
+	view := make([]byte, 10)
+	var r bytes.Reader
+	for i := tcp.InitialCwnd; i > 0; i-- {
+		r.Reset(view)
+		if _, err := c.EP.Write(&r, tcpip.WriteOptions{}); err != nil {
+			t.Fatalf("Write failed: %s", err)
+		}
+	}
+
+	next := uint32(c.IRS) + 1
+	iss := seqnum.Value(context.TestInitialSequenceNumber).Add(1)
+	for i := tcp.InitialCwnd; i > 0; i-- {
+		v := c.GetPacket()
+		defer v.Release()
+		checker.IPv4(t, v,
+			checker.PayloadLen(len(view)+header.TCPMinimumSize),
+			checker.TCP(
+				checker.DstPort(context.TestPort),
+				checker.TCPSeqNum(next),
+				checker.TCPAckNum(uint32(iss)),
+				checker.TCPFlagsMatch(header.TCPFlagAck, ^header.TCPFlagPsh),
+			),
+		)
+		next += uint32(len(view))
+	}
+
+	// Close the endpoint. The write queue is still full, so no FIN can be
+	// sent yet; the endpoint should remain on the graceful close path.
+	c.EP.Close()
+
+	v := c.GetPacket()
+	defer v.Release()
+	checker.IPv4(t, v,
+		checker.PayloadLen(len(view)+header.TCPMinimumSize),
+		checker.TCP(
+			checker.DstPort(context.TestPort),
+			checker.TCPSeqNum(uint32(c.IRS)+1),
+			checker.TCPAckNum(uint32(iss)),
+			checker.TCPFlagsMatch(header.TCPFlagAck, ^header.TCPFlagPsh),
+		),
+	)
+
+	if got, want := tcp.EndpointState(c.EP.State()), tcp.StateFinWait1; got != want {
+		t.Errorf("unexpected endpoint state: want %s, got %s", want, got)
+	}
+
+	// ACK the queued data; once congestion window allows it, the FIN should
+	// be transmitted instead of sending a reset.
+	c.SendPacket(nil, &context.Headers{
+		SrcPort: context.TestPort,
+		DstPort: c.Port,
+		Flags:   header.TCPFlagAck,
+		SeqNum:  iss,
+		AckNum:  seqnum.Value(next),
+		RcvWnd:  30000,
+	})
+
+	v = c.GetPacket()
+	defer v.Release()
+	checker.IPv4(t, v,
+		checker.PayloadLen(header.TCPMinimumSize),
+		checker.TCP(
+			checker.DstPort(context.TestPort),
+			checker.TCPSeqNum(next),
+			checker.TCPAckNum(uint32(iss)),
+			checker.TCPFlags(header.TCPFlagAck|header.TCPFlagFin),
+		),
+	)
+}
+
 func TestMain(m *testing.M) {
 	refs.SetLeakMode(refs.LeaksPanic)
 	code := m.Run()


### PR DESCRIPTION
Fix #13393

gVisor performs the close-state transition (ESTABLISHED -> FIN_WAIT1, CLOSE_WAIT -> LAST_ACK) in the sender, at the moment the FIN segment is actually transmitted. Because the FIN is queued as a separate segment behind any pending data, a full send window keeps it from ever being sent: the transition never happens and the endpoint stays in ESTABLISHED forever, so a peer that actively closes the connection (e.g. a slow consumer hit by a write deadline) is never observed as closed.

Linux instead transitions at enqueue time: tcp_close_state() moves the socket to FIN_WAIT1 before tcp_send_fin(), and the FIN may remain queued until the window opens.

Move the transition out of the sender and into shutdownLocked(), performed the moment the FIN is enqueued. The queued FIN still flushes normally once the window opens (no data loss), and the connection advances through the closing state machine even when the FIN cannot be sent yet.