### PR TITLE
nftables: skip NAT rules whose family does not match the packet's family

### DIFF
--- a/pkg/tcpip/nftables/nft_nat.go
+++ b/pkg/tcpip/nftables/nft_nat.go
@@ -154,6 +154,22 @@ func (n *natOp) setupNetmap(pkt *stack.PacketBuffer, minAddr, maxAddr *tcpip.Add
 // evaluate performs NAT setup on the connection.
 // Called when the packet matches the NAT op configured.
 func (n *natOp) evaluate(regs *registerSet, pkt *stack.PacketBuffer, rule *Rule) {
+	// Skip the rule if the packet's family does not match the configured rule
+	// family. With an `inet` table the same base chain is dispatched for both
+	// IPv4 and IPv6 packets, so this mismatch is reachable in practice and
+	// must not panic inside setupNetmap. Matches the behavior of nft_nat_eval
+	// in linux/net/netfilter/nft_nat.c.
+	switch n.family {
+	case linux.NFPROTO_IPV4:
+		if pkt.NetworkProtocolNumber != header.IPv4ProtocolNumber {
+			return
+		}
+	case linux.NFPROTO_IPV6:
+		if pkt.NetworkProtocolNumber != header.IPv6ProtocolNumber {
+			return
+		}
+	}
+
 	// Just fill the data for the NAT operation.
 	changeAddress := false
 	changePort := false


### PR DESCRIPTION
# nftables: `setupNetmap` panics on family mismatch in `inet` tables (sentry crash)

## Summary

In `pkg/tcpip/nftables/nft_nat.go`, the NAT expression's address-range loop in `setupNetmap` is sized by the **packet's** network family while the address slices were sized by the **rule's** family. With an `inet` table, those two can legitimately differ — the chain is dispatched for both IPv4 and IPv6 packets but the NAT rule has one explicit `NFTA_NAT_FAMILY`. The mismatch walks `minSlice[i*4:]` past the end of a 4-byte slice and `binary.BigEndian.Uint32` panics. There is no `recover()` in the netfilter packet-processing path, so the sentry crashes.

This is a self-inflicted DoS reachable when nftables is enabled (`--TESTONLY-nftables=true`); flagging early so the fix can land before nftables flips on by default. A patch is included below.

## Affected component

- **Repository:** github.com/google/gvisor
- **HEAD verified:** `f028e6a8` (master, 2026-06-09)
- **File:** `pkg/tcpip/nftables/nft_nat.go`
- **Functions:** `setupNetmap` (line 117) called from `evaluate` (line 156)
- **Introduced in:** commit `ab3f6d46` ("nftables: Added nat expression support.", 2026-06-03)

## Trigger conditions

1. `runsc` started with `--TESTONLY-nftables=true`.
2. A sandboxed process with `CAP_NET_ADMIN` installs, in an `inet` table, a `nat`-type base chain containing a rule whose `NFTA_NAT_FAMILY` differs from the packet family that will hit the hook (the practical case: rule family `NFPROTO_IPV4` and an IPv6 packet traversing the chain, or vice versa).
3. Any packet of the mismatched family is dispatched through the hook.

The `inet` chain is attached to both `ip4InetBaseChains` and `ip6InetBaseChains` (see `nftables.go:765-768`), so step 3 is straightforward in practice.

## Code path

`pkg/tcpip/nftables/nft_nat.go`:

```go
// initNATOp accepts a rule whose family differs from the table family
// when the table family is Inet (line 230-233):
tf := tab.GetAddressFamily()
if tf != stack.Inet && tf != af {
    return ..., syserr.NewAnnotatedError(...)
}
```

```go
// getAddrRange sizes the slices by the rule's family (line 91-100):
sz := header.IPv4AddressSize
if n.family == linux.NFPROTO_IPV6 {
    sz = header.IPv6AddressSize
}
minAddr = tcpip.AddrFromSlice(regBuffer[n.sregAddrMinIdx : int(n.sregAddrMinIdx)+sz])
```

```go
// setupNetmap then sizes its loop by the packet's family (line 117-152):
addrLen = header.IPv4AddressSize
if pkt.NetworkProtocolNumber == header.IPv6ProtocolNumber {
    addrLen = header.IPv6AddressSize
}
...
minSlice := minAddr.AsSlice()       // 4-byte if rule family IPv4
words := addrLen / 4                 // 4 if pkt is IPv6
for i := 0; i < words; i++ {
    offset := i * 4
    min := binary.BigEndian.Uint32(minSlice[offset:])  // panic at i == 1
    ...
}
```

## Reproduction

Two reproductions: a standalone Go program (no gVisor build needed) and an end-to-end one (gVisor sandbox).

### Standalone (proves the loop math)

```go
package main

import (
    "encoding/binary"
    "fmt"
)

const (
    IPv4AddressSize = 4
    IPv6AddressSize = 16
)

func main() {
    // Rule loaded with NFTA_NAT_FAMILY = NFPROTO_IPV4 in an inet table.
    // getAddrRange returns 4-byte slices.
    minSlice := []byte{192, 168, 0, 1}
    maxSlice := []byte{192, 168, 0, 1}

    // Packet is IPv6 (the inet chain is attached to both families).
    addrLen := IPv6AddressSize
    manipAddrSlice := make([]byte, 16)
    newAddrBytes := make([]byte, addrLen)

    words := addrLen / 4
    for i := 0; i < words; i++ {
        offset := i * 4
        m := binary.BigEndian.Uint32(manipAddrSlice[offset:])
        _ = binary.BigEndian.Uint32(minSlice[offset:]) // panic at i == 1
        _ = binary.BigEndian.Uint32(maxSlice[offset:])
        _ = m
        binary.BigEndian.PutUint32(newAddrBytes[offset:], m)
    }
    fmt.Println("unreachable")
}
```

Output: `panic: runtime error: index out of range [3] with length 0`.

### End-to-end (live sentry panic)

Captured from a nightly runsc build (`release-20260601.0-31-gf028e6a84187-dirty`) on an Ubuntu 24.04 aarch64 host with the runsc runtime configured with `--TESTONLY-nftables=true`:

```bash
docker run --rm --runtime=runsc-nft --cap-add NET_ADMIN ubuntu:24.04 bash -c '
apt-get install -y nftables python3 >/dev/null 2>&1
nft -f - <<NFT
table inet t {
    chain postrt {
        type nat hook postrouting priority srcnat;
        snat ip to 192.168.0.1
    }
}
NFT
ip link set lo up
ip -6 addr add ::1/128 dev lo
python3 -c "import socket; s=socket.socket(socket.AF_INET6, socket.SOCK_DGRAM); s.sendto(b\"x\", (\"::1\", 7777))"
'
```

Sentry panic captured from `/var/log/runsc/*.boot.txt`:

```
panic: runtime error: index out of range [3] with length 0
gvisor.dev/gvisor/pkg/tcpip/nftables.(*natOp).setupNetmap(0x100a8c0?, ..., ..., ...)
        pkg/tcpip/nftables/nft_nat.go:141 +0x234
        pkg/tcpip/nftables/nft_nat.go:165 +0xd0
```

## Suggested fix

Skip the rule when the packet family does not match the configured rule family. This mirrors `nft_nat_eval` in `linux/net/netfilter/nft_nat.c`, which simply does nothing when the families differ.

```diff
 // evaluate performs NAT setup on the connection.
 // Called when the packet matches the NAT op configured.
 func (n *natOp) evaluate(regs *registerSet, pkt *stack.PacketBuffer, rule *Rule) {
+    // Skip the rule if the packet's family does not match the configured rule
+    // family. With an `inet` table the same base chain is dispatched for both
+    // IPv4 and IPv6 packets, so this mismatch is reachable in practice and
+    // must not panic inside setupNetmap. Matches the behavior of nft_nat_eval
+    // in linux/net/netfilter/nft_nat.c.
+    switch n.family {
+    case linux.NFPROTO_IPV4:
+        if pkt.NetworkProtocolNumber != header.IPv4ProtocolNumber {
+            return
+        }
+    case linux.NFPROTO_IPV6:
+        if pkt.NetworkProtocolNumber != header.IPv6ProtocolNumber {
+            return
+        }
+    }
+
     // Just fill the data for the NAT operation.
     changeAddress := false
     changePort := false
```

A test case in `pkg/tcpip/nftables/nftables_test.go` that exercises an `inet` table with a NAT rule of family `IPv4` plus an IPv6 packet (and vice-versa) would catch any regression.

## Critical assessment

- Bounds-checked panic, not memory corruption — Go runtime turns the over-read into a runtime panic. No info leak, no escape.
- Self-DoS class for single-container sandboxes; multi-container DoS for setups that share one sentry across containers.
- Currently behind the `TESTONLY-nftables` flag, so not in production today; worth fixing before that flag flips on.

Happy to send a PR with the diff above plus a regression test if that's the most useful path forward.
