### PR TITLE
tmpfs: ignore noswap option

### DIFF
--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -353,6 +353,8 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 
 		printedOpts = append(printedOpts, fmt.Sprintf("gid=%s", gidStr))
 	}
+	// Accept, but ignore, noswap
+	delete(mopts, "noswap")
 
 	if len(mopts) != 0 {
 		ctx.Warningf("tmpfs.FilesystemType.GetFilesystem: unknown options: %v", mopts)


### PR DESCRIPTION
On Linux, tmpfs's "noswap" option specifies whether tmpfs blocks can be swapped out.

Since the concept of swap doesn't make sense on gVisor, we can accept and ignore this flag rather than EINVALing.