### PR TITLE
Implement /proc/sys/kernel/domainname

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -52,6 +52,7 @@ func (fs *filesystem) newSysDir(ctx context.Context, root *auth.Credentials, k *
 		"kernel": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 			"cap_last_cap":       fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", linux.CAP_LAST_CAP))),
 			"hostname":           fs.newInode(ctx, root, 0444, &hostnameData{}),
+			"domainname":         fs.newInode(ctx, root, 0444, &domainnameData{}),
 			"overflowgid":        fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowGID))),
 			"overflowuid":        fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\n", auth.OverflowUID))),
 			"pid_max":            fs.newInode(ctx, root, 0644, newStaticFile(fmt.Sprintf("%d\n", kernel.TasksLimit))),
@@ -195,6 +196,24 @@ func (*hostnameData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	utsns := kernel.UTSNamespaceFromContext(ctx)
 	defer utsns.DecRef(ctx)
 	buf.WriteString(utsns.HostName())
+	buf.WriteString("\n")
+	return nil
+}
+
+// domainnameData implements vfs.DynamicBytesSource for /proc/sys/kernel/domainname.
+//
+// +stateify savable
+type domainnameData struct {
+	kernfs.DynamicBytesFile
+}
+
+var _ dynamicInode = (*domainnameData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (*domainnameData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	utsns := kernel.UTSNamespaceFromContext(ctx)
+	defer utsns.DecRef(ctx)
+	buf.WriteString(utsns.DomainName())
 	buf.WriteString("\n")
 	return nil
 }

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -2719,6 +2719,19 @@ TEST(ProcSysKernelHostname, MatchesUname) {
   EXPECT_EQ(procfs_hostname, hostname);
 }
 
+TEST(ProcSysKernelDomainname, Exists) {
+  EXPECT_THAT(open("/proc/sys/kernel/domainname", O_RDONLY), SyscallSucceeds());
+}
+
+TEST(ProcSysKernelDomainname, MatchesUname) {
+  struct utsname buf;
+  EXPECT_THAT(uname(&buf), SyscallSucceeds());
+  const std::string domainname = absl::StrCat(buf.domainname, "\n");
+  auto procfs_domainname =
+      ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/kernel/domainname"));
+  EXPECT_EQ(procfs_domainname, domainname);
+}
+
 TEST(ProcSysKernelRandomUuid, Exists) {
   EXPECT_THAT(open("/proc/sys/kernel/random/uuid", O_RDONLY),
               SyscallSucceeds());


### PR DESCRIPTION
Similar implementation to /proc/sys/kernel/hostname.

Needed for systemd.