### PR TITLE
netstack: add ICMP echo forwarder reply API

### DIFF
--- a/pkg/tcpip/network/ipv4/icmp.go
+++ b/pkg/tcpip/network/ipv4/icmp.go
@@ -356,8 +356,19 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 		// DeliverTransportPacket so that is is only done when needed.
 		replyData := stack.PayloadSince(pkt.TransportHeader())
 		defer replyData.Release()
-		localAddressTemporary := pkt.NetworkPacketInfo.LocalAddressTemporary
+		ipHdr := iph
 		localAddressBroadcast := pkt.NetworkPacketInfo.LocalAddressBroadcast
+		localAddressTemporary := pkt.NetworkPacketInfo.LocalAddressTemporary
+		replied := false
+		reply := func() bool {
+			if replied {
+				return true
+			}
+			replied = true
+			e.sendICMPEchoReply(replyData, ipHdr, newOptions, localAddressBroadcast, localAddressTemporary)
+			return true
+		}
+		pkt.SetICMPEchoReply(reply)
 
 		// It's possible that a raw socket or per-stack default handler expects
 		// to receive this packet.
@@ -367,17 +378,17 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 		} else {
 			e.dispatcher.DeliverTransportPacket(header.ICMPv4ProtocolNumber, pkt)
 		}
+		pkt.ClearICMPEchoReply()
 		pkt = nil
 
 		// Skip the built-in ICMP echo reply if the request was consumed by a
 		// per-stack default handler. Also preserve the IPv4 behavior for
-		// temporary local addresses: the packet is delivered above, but the
-		// stack does not synthesize an echo reply for it.
+		// temporary local addresses unless the handler explicitly replied above.
 		if defaultHandlerHandled || localAddressTemporary {
 			return
 		}
 
-		e.sendICMPEchoReply(replyData, iph, newOptions, localAddressBroadcast)
+		reply()
 
 	case header.ICMPv4EchoReply:
 		received.echoReply.Increment()
@@ -421,6 +432,7 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 		case header.ICMPv4DestinationHostUnknown:
 			e.handleControl(&icmpv4DestinationHostUnknownSockError{}, pkt)
 		}
+
 	case header.ICMPv4SrcQuench:
 		received.srcQuench.Increment()
 
@@ -450,7 +462,7 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 	}
 }
 
-func (e *endpoint) sendICMPEchoReply(replyData *buffer.View, ipHdr header.IPv4, newOptions header.IPv4Options, localAddressBroadcast bool) {
+func (e *endpoint) sendICMPEchoReply(replyData *buffer.View, ipHdr header.IPv4, newOptions header.IPv4Options, localAddressBroadcast, localAddressTemporary bool) {
 	sent := e.stats.icmp.packetsSent
 	if !e.protocol.allowICMPReply(header.ICMPv4EchoReply, header.ICMPv4UnusedCode) {
 		sent.rateLimited.Increment()
@@ -461,7 +473,11 @@ func (e *endpoint) sendICMPEchoReply(replyData *buffer.View, ipHdr header.IPv4, 
 	// source address MUST be one of its own IP addresses (but not a broadcast
 	// or multicast address).
 	localAddr := ipHdr.DestinationAddress()
+	replySourceAddr := localAddr
 	if localAddressBroadcast || header.IsV4MulticastAddress(localAddr) {
+		localAddr = tcpip.Address{}
+		replySourceAddr = tcpip.Address{}
+	} else if localAddressTemporary {
 		localAddr = tcpip.Address{}
 	}
 
@@ -507,7 +523,10 @@ func (e *endpoint) sendICMPEchoReply(replyData *buffer.View, ipHdr header.IPv4, 
 	replyIPHdrView.Write(newOptions)
 	replyIPHdr := header.IPv4(replyIPHdrView.AsSlice())
 	replyIPHdr.SetHeaderLength(replyHeaderLength)
-	replyIPHdr.SetSourceAddress(r.LocalAddress())
+	if replySourceAddr.BitLen() == 0 {
+		replySourceAddr = r.LocalAddress()
+	}
+	replyIPHdr.SetSourceAddress(replySourceAddr)
 	replyIPHdr.SetDestinationAddress(r.RemoteAddress())
 	replyIPHdr.SetTTL(r.DefaultTTL())
 	replyIPHdr.SetTotalLength(uint16(len(replyIPHdr) + len(replyData.AsSlice())))

--- a/pkg/tcpip/network/ipv4/ipv4_test.go
+++ b/pkg/tcpip/network/ipv4/ipv4_test.go
@@ -3947,9 +3947,11 @@ func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
 
 			const ident = 1234
 			handlerCalled := false
+			var handlerPkt *stack.PacketBuffer
 			if test.installHandler {
 				s.SetTransportProtocolHandler(icmp.ProtocolNumber4, func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
 					handlerCalled = true
+					handlerPkt = pkt
 					if got := id.LocalPort; got != ident {
 						t.Errorf("got id.LocalPort = %d, want = %d", got, ident)
 					}
@@ -3997,6 +3999,14 @@ func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
 			if got, want := handlerCalled, test.wantHandlerCalled; got != want {
 				t.Fatalf("got handlerCalled = %t, want = %t", got, want)
 			}
+			if test.installHandler {
+				if handlerPkt == nil {
+					t.Fatalf("handler did not save packet")
+				}
+				if stack.ReplyICMPEcho(handlerPkt) {
+					t.Fatalf("got stack.ReplyICMPEcho(handlerPkt) after handler returned = true, want = false")
+				}
+			}
 
 			p := e.Read()
 			if !test.wantReply {
@@ -4019,6 +4029,296 @@ func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
 					checker.ICMPv4Type(header.ICMPv4EchoReply),
 					checker.ICMPv4Code(header.ICMPv4UnusedCode)))
 		})
+	}
+}
+
+func TestICMPEchoForwarderReply(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.1").To4()),
+			PrefixLen: 24,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.2").To4()),
+			PrefixLen: 24,
+		},
+	}
+
+	clock := faketime.NewManualClock()
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{arp.NewProtocol, ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+		Clock:              clock,
+	})
+	defer func() {
+		s.Close()
+		s.Wait()
+		refs.DoRepeatedLeakCheck()
+	}()
+
+	const ident = 1234
+	forwarderCalled := false
+	var request *icmp.ForwarderRequest
+	var requestPkt *stack.PacketBuffer
+	f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
+		request = r
+		forwarderCalled = true
+		requestPkt = r.PacketBuffer()
+		if got := r.ID().LocalPort; got != ident {
+			t.Errorf("got r.ID().LocalPort = %d, want = %d", got, ident)
+		}
+		if !r.Reply() {
+			t.Errorf("got r.Reply() = false, want = true")
+		}
+		if !r.Reply() {
+			t.Errorf("got second r.Reply() = false, want = true")
+		}
+		clone := r.PacketBuffer().Clone()
+		defer clone.DecRef()
+		if stack.ReplyICMPEcho(clone) {
+			t.Errorf("got stack.ReplyICMPEcho(clone) = true, want = false")
+		}
+		return false
+	})
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber4, f.HandlePacket)
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	totalLength := header.IPv4MinimumSize + header.ICMPv4MinimumSize
+	hdr := prependable.New(totalLength)
+	icmpH := header.ICMPv4(hdr.Prepend(header.ICMPv4MinimumSize))
+	icmpH.SetIdent(ident)
+	icmpH.SetType(header.ICMPv4Echo)
+	icmpH.SetCode(header.ICMPv4UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(^checksum.Checksum(icmpH, 0))
+	ip := header.IPv4(hdr.Prepend(header.IPv4MinimumSize))
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(totalLength),
+		Protocol:    uint8(icmp.ProtocolNumber4),
+		TTL:         ipv4.DefaultTTL,
+		SrcAddr:     remoteAddr.AddressWithPrefix.Address,
+		DstAddr:     localAddr.AddressWithPrefix.Address,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(header.IPv4ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	clock.RunImmediatelyScheduledJobs()
+
+	if !forwarderCalled {
+		t.Fatalf("forwarder was not called")
+	}
+	if request == nil {
+		t.Fatalf("request was not saved")
+	}
+	if request.Reply() {
+		t.Fatalf("got request.Reply() after handler returned = true, want = false")
+	}
+	if stack.ReplyICMPEcho(requestPkt) {
+		t.Fatalf("got stack.ReplyICMPEcho(requestPkt) after handler returned = true, want = false")
+	}
+	p := e.Read()
+	if p == nil {
+		t.Fatalf("expected ICMP echo reply")
+	}
+	defer p.DecRef()
+	payload := stack.PayloadSince(p.NetworkHeader())
+	defer payload.Release()
+	checker.IPv4(t, payload,
+		checker.SrcAddr(localAddr.AddressWithPrefix.Address),
+		checker.DstAddr(remoteAddr.AddressWithPrefix.Address),
+		checker.ICMPv4(
+			checker.ICMPv4Type(header.ICMPv4EchoReply),
+			checker.ICMPv4Code(header.ICMPv4UnusedCode)))
+	if p := e.Read(); p != nil {
+		p.DecRef()
+		t.Fatalf("got unexpected second ICMP echo reply")
+	}
+}
+
+func TestICMPEchoForwarderConsumesWithoutReply(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.1").To4()),
+			PrefixLen: 24,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.2").To4()),
+			PrefixLen: 24,
+		},
+	}
+
+	clock := faketime.NewManualClock()
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{arp.NewProtocol, ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+		Clock:              clock,
+	})
+	defer func() {
+		s.Close()
+		s.Wait()
+		refs.DoRepeatedLeakCheck()
+	}()
+
+	forwarderCalled := false
+	var requestPkt *stack.PacketBuffer
+	f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
+		forwarderCalled = true
+		requestPkt = r.PacketBuffer()
+		return true
+	})
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber4, f.HandlePacket)
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	totalLength := header.IPv4MinimumSize + header.ICMPv4MinimumSize
+	hdr := prependable.New(totalLength)
+	icmpH := header.ICMPv4(hdr.Prepend(header.ICMPv4MinimumSize))
+	icmpH.SetType(header.ICMPv4Echo)
+	icmpH.SetCode(header.ICMPv4UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(^checksum.Checksum(icmpH, 0))
+	ip := header.IPv4(hdr.Prepend(header.IPv4MinimumSize))
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(totalLength),
+		Protocol:    uint8(icmp.ProtocolNumber4),
+		TTL:         ipv4.DefaultTTL,
+		SrcAddr:     remoteAddr.AddressWithPrefix.Address,
+		DstAddr:     localAddr.AddressWithPrefix.Address,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(header.IPv4ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	clock.RunImmediatelyScheduledJobs()
+
+	if !forwarderCalled {
+		t.Fatalf("forwarder was not called")
+	}
+	if stack.ReplyICMPEcho(requestPkt) {
+		t.Fatalf("got stack.ReplyICMPEcho(requestPkt) after handler returned = true, want = false")
+	}
+	if p := e.Read(); p != nil {
+		p.DecRef()
+		t.Fatalf("got unexpected ICMP echo reply")
+	}
+}
+
+func TestICMPForwarderReplyNonEchoRequest(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.1").To4()),
+			PrefixLen: 24,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.2").To4()),
+			PrefixLen: 24,
+		},
+	}
+
+	clock := faketime.NewManualClock()
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{arp.NewProtocol, ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+		Clock:              clock,
+	})
+	defer func() {
+		s.Close()
+		s.Wait()
+		refs.DoRepeatedLeakCheck()
+	}()
+
+	forwarderCalled := false
+	f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
+		forwarderCalled = true
+		if r.Reply() {
+			t.Errorf("got r.Reply() = true for non-Echo-Request packet, want false")
+		}
+		return true
+	})
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber4, f.HandlePacket)
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	totalLength := header.IPv4MinimumSize + header.ICMPv4MinimumSize
+	hdr := prependable.New(totalLength)
+	icmpH := header.ICMPv4(hdr.Prepend(header.ICMPv4MinimumSize))
+	icmpH.SetType(header.ICMPv4EchoReply)
+	icmpH.SetCode(header.ICMPv4UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(^checksum.Checksum(icmpH, 0))
+	ip := header.IPv4(hdr.Prepend(header.IPv4MinimumSize))
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(totalLength),
+		Protocol:    uint8(icmp.ProtocolNumber4),
+		TTL:         ipv4.DefaultTTL,
+		SrcAddr:     remoteAddr.AddressWithPrefix.Address,
+		DstAddr:     localAddr.AddressWithPrefix.Address,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+	echoReplyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(header.IPv4ProtocolNumber, echoReplyPkt)
+	echoReplyPkt.DecRef()
+	clock.RunImmediatelyScheduledJobs()
+
+	if !forwarderCalled {
+		t.Fatalf("forwarder was not called")
+	}
+	if p := e.Read(); p != nil {
+		p.DecRef()
+		t.Fatalf("got unexpected ICMP echo reply")
 	}
 }
 
@@ -4197,6 +4497,107 @@ func TestICMPEchoTemporaryAddressSuppressesReply(t *testing.T) {
 		p.DecRef()
 		t.Fatalf("got unexpected ICMP echo reply")
 	}
+}
+
+func TestICMPEchoForwarderReplyOverridesTemporaryAddressSuppression(t *testing.T) {
+	assignedAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.1").To4()),
+			PrefixLen: 24,
+		},
+	}
+	temporaryAddr := tcpip.AddrFromSlice(net.ParseIP("192.168.0.99").To4())
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("192.168.0.2").To4()),
+			PrefixLen: 24,
+		},
+	}
+
+	clock := faketime.NewManualClock()
+	s := stack.New(stack.Options{
+		NetworkProtocols:   []stack.NetworkProtocolFactory{arp.NewProtocol, ipv4.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+		Clock:              clock,
+	})
+	defer func() {
+		s.Close()
+		s.Wait()
+		refs.DoRepeatedLeakCheck()
+	}()
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, assignedAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, assignedAddr, err)
+	}
+	if err := s.SetPromiscuousMode(nicID, true); err != nil {
+		t.Fatalf("s.SetPromiscuousMode(%d, true): %s", nicID, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: assignedAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	const ident = 1234
+	forwarderCalled := false
+	f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
+		forwarderCalled = true
+		if got := r.ID().LocalPort; got != ident {
+			t.Errorf("got r.ID().LocalPort = %d, want = %d", got, ident)
+		}
+		if !r.PacketInfo().LocalAddressTemporary {
+			t.Errorf("got r.PacketInfo().LocalAddressTemporary = false, want = true")
+		}
+		return r.Reply()
+	})
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber4, f.HandlePacket)
+
+	totalLength := header.IPv4MinimumSize + header.ICMPv4MinimumSize
+	hdr := prependable.New(totalLength)
+	icmpH := header.ICMPv4(hdr.Prepend(header.ICMPv4MinimumSize))
+	icmpH.SetIdent(ident)
+	icmpH.SetType(header.ICMPv4Echo)
+	icmpH.SetCode(header.ICMPv4UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(^checksum.Checksum(icmpH, 0))
+	ip := header.IPv4(hdr.Prepend(header.IPv4MinimumSize))
+	ip.Encode(&header.IPv4Fields{
+		TotalLength: uint16(totalLength),
+		Protocol:    uint8(icmp.ProtocolNumber4),
+		TTL:         ipv4.DefaultTTL,
+		SrcAddr:     remoteAddr.AddressWithPrefix.Address,
+		DstAddr:     temporaryAddr,
+	})
+	ip.SetChecksum(^ip.CalculateChecksum())
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(header.IPv4ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	clock.RunImmediatelyScheduledJobs()
+
+	if !forwarderCalled {
+		t.Fatalf("forwarder was not called")
+	}
+	p := e.Read()
+	if p == nil {
+		t.Fatalf("expected ICMP echo reply")
+	}
+	defer p.DecRef()
+	payload := stack.PayloadSince(p.NetworkHeader())
+	defer payload.Release()
+	checker.IPv4(t, payload,
+		checker.SrcAddr(temporaryAddr),
+		checker.DstAddr(remoteAddr.AddressWithPrefix.Address),
+		checker.ICMPv4(
+			checker.ICMPv4Type(header.ICMPv4EchoReply),
+			checker.ICMPv4Code(header.ICMPv4UnusedCode)))
 }
 
 func TestIcmpRateLimit(t *testing.T) {

--- a/pkg/tcpip/network/ipv6/icmp.go
+++ b/pkg/tcpip/network/ipv6/icmp.go
@@ -655,8 +655,26 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer, hasFragmentHeader bool, r
 	case header.ICMPv6EchoRequest:
 		received.echoRequest.Increment()
 		replyPayload := pkt.Data().ToBuffer()
+		replyPayloadConsumed := false
+		defer func() {
+			if !replyPayloadConsumed {
+				replyPayload.Release()
+			}
+		}()
 		replyHeader := make([]byte, header.ICMPv6EchoMinimumSize)
 		copy(replyHeader, h[:header.ICMPv6EchoMinimumSize])
+		replied := false
+		reply := func() bool {
+			if replied {
+				return true
+			}
+			replied = true
+			if e.sendICMPEchoReply(replyPayload, replyHeader, srcAddr, dstAddr, iph) {
+				replyPayloadConsumed = true
+			}
+			return true
+		}
+		pkt.SetICMPEchoReply(reply)
 
 		// It's possible that a raw socket or per-stack default handler expects
 		// to receive this packet.
@@ -666,16 +684,16 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer, hasFragmentHeader bool, r
 		} else {
 			e.dispatcher.DeliverTransportPacket(header.ICMPv6ProtocolNumber, pkt)
 		}
+		pkt.ClearICMPEchoReply()
 		pkt = nil
 
 		// Skip the built-in ICMP echo reply if the request was consumed by a
 		// per-stack default handler.
 		if defaultHandlerHandled {
-			replyPayload.Release()
 			return
 		}
 
-		e.sendICMPEchoReply(replyPayload, replyHeader, srcAddr, dstAddr, iph)
+		reply()
 
 	case header.ICMPv6EchoReply:
 		received.echoReply.Increment()
@@ -871,7 +889,7 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer, hasFragmentHeader bool, r
 	}
 }
 
-func (e *endpoint) sendICMPEchoReply(replyPayload buffer.Buffer, replyHeader []byte, srcAddr, dstAddr tcpip.Address, ipHdr header.IPv6) {
+func (e *endpoint) sendICMPEchoReply(replyPayload buffer.Buffer, replyHeader []byte, srcAddr, dstAddr tcpip.Address, ipHdr header.IPv6) bool {
 	sent := e.stats.icmp.packetsSent
 
 	// As per RFC 4291 section 2.7, multicast addresses must not be used as
@@ -884,15 +902,13 @@ func (e *endpoint) sendICMPEchoReply(replyPayload buffer.Buffer, replyHeader []b
 	r, err := e.protocol.stack.FindRoute(e.nic.ID(), localAddr, srcAddr, ProtocolNumber, false /* multicastLoop */)
 	if err != nil {
 		// If we cannot find a route to the destination, silently drop the packet.
-		replyPayload.Release()
-		return
+		return false
 	}
 	defer r.Release()
 
 	if !e.protocol.allowICMPReply(header.ICMPv6EchoReply) {
 		sent.rateLimited.Increment()
-		replyPayload.Release()
-		return
+		return false
 	}
 
 	replyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
@@ -922,9 +938,10 @@ func (e *endpoint) sendICMPEchoReply(replyPayload buffer.Buffer, replyHeader []b
 		TOS: replyTClass,
 	}, replyPkt); err != nil {
 		sent.dropped.Increment()
-		return
+		return true
 	}
 	sent.echoReply.Increment()
+	return true
 }
 
 // LinkAddressProtocol implements stack.LinkAddressResolver.

--- a/pkg/tcpip/network/ipv6/icmp_test.go
+++ b/pkg/tcpip/network/ipv6/icmp_test.go
@@ -282,9 +282,11 @@ func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
 
 			const ident = 1234
 			handlerCalled := false
+			var handlerPkt *stack.PacketBuffer
 			if test.installHandler {
 				s.SetTransportProtocolHandler(icmp.ProtocolNumber6, func(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
 					handlerCalled = true
+					handlerPkt = pkt
 					if got := id.LocalPort; got != ident {
 						t.Errorf("got id.LocalPort = %d, want = %d", got, ident)
 					}
@@ -335,6 +337,14 @@ func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
 			if got, want := handlerCalled, test.wantHandlerCalled; got != want {
 				t.Fatalf("got handlerCalled = %t, want = %t", got, want)
 			}
+			if test.installHandler {
+				if handlerPkt == nil {
+					t.Fatalf("handler did not save packet")
+				}
+				if stack.ReplyICMPEcho(handlerPkt) {
+					t.Fatalf("got stack.ReplyICMPEcho(handlerPkt) after handler returned = true, want = false")
+				}
+			}
 
 			p := e.Read()
 			if !test.wantReply {
@@ -357,6 +367,281 @@ func TestICMPEchoDefaultHandlerControlsReply(t *testing.T) {
 					checker.ICMPv6Type(header.ICMPv6EchoReply),
 					checker.ICMPv6Code(header.ICMPv6UnusedCode)))
 		})
+	}
+}
+
+func TestICMPEchoForwarderReply(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::1").To16()),
+			PrefixLen: 64,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::2").To16()),
+			PrefixLen: 64,
+		},
+	}
+
+	c := newTestContext()
+	defer c.cleanup()
+	s := c.s
+
+	const ident = 1234
+	forwarderCalled := false
+	var request *icmp.ForwarderRequest
+	var requestPkt *stack.PacketBuffer
+	f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
+		request = r
+		forwarderCalled = true
+		requestPkt = r.PacketBuffer()
+		if got := r.ID().LocalPort; got != ident {
+			t.Errorf("got r.ID().LocalPort = %d, want = %d", got, ident)
+		}
+		if !r.Reply() {
+			t.Errorf("got r.Reply() = false, want = true")
+		}
+		if !r.Reply() {
+			t.Errorf("got second r.Reply() = false, want = true")
+		}
+		clone := r.PacketBuffer().Clone()
+		defer clone.DecRef()
+		if stack.ReplyICMPEcho(clone) {
+			t.Errorf("got stack.ReplyICMPEcho(clone) = true, want = false")
+		}
+		return false
+	})
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber6, f.HandlePacket)
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	totalLen := header.IPv6MinimumSize + header.ICMPv6MinimumSize
+	hdr := prependable.New(totalLen)
+	icmpH := header.ICMPv6(hdr.Prepend(header.ICMPv6MinimumSize))
+	icmpH.SetIdent(ident)
+	icmpH.SetType(header.ICMPv6EchoRequest)
+	icmpH.SetCode(header.ICMPv6UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{
+		Header: icmpH,
+		Src:    remoteAddr.AddressWithPrefix.Address,
+		Dst:    localAddr.AddressWithPrefix.Address,
+	}))
+	ip := header.IPv6(hdr.Prepend(header.IPv6MinimumSize))
+	ip.Encode(&header.IPv6Fields{
+		PayloadLength:     header.ICMPv6MinimumSize,
+		TransportProtocol: icmp.ProtocolNumber6,
+		HopLimit:          DefaultTTL,
+		SrcAddr:           remoteAddr.AddressWithPrefix.Address,
+		DstAddr:           localAddr.AddressWithPrefix.Address,
+	})
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	c.clock.RunImmediatelyScheduledJobs()
+
+	if !forwarderCalled {
+		t.Fatalf("forwarder was not called")
+	}
+	if request == nil {
+		t.Fatalf("request was not saved")
+	}
+	if request.Reply() {
+		t.Fatalf("got request.Reply() after handler returned = true, want = false")
+	}
+	if stack.ReplyICMPEcho(requestPkt) {
+		t.Fatalf("got stack.ReplyICMPEcho(requestPkt) after handler returned = true, want = false")
+	}
+	p := e.Read()
+	if p == nil {
+		t.Fatalf("expected ICMP echo reply")
+	}
+	defer p.DecRef()
+	payload := stack.PayloadSince(p.NetworkHeader())
+	defer payload.Release()
+	checker.IPv6(t, payload,
+		checker.SrcAddr(localAddr.AddressWithPrefix.Address),
+		checker.DstAddr(remoteAddr.AddressWithPrefix.Address),
+		checker.ICMPv6(
+			checker.ICMPv6Type(header.ICMPv6EchoReply),
+			checker.ICMPv6Code(header.ICMPv6UnusedCode)))
+	if p := e.Read(); p != nil {
+		p.DecRef()
+		t.Fatalf("got unexpected second ICMP echo reply")
+	}
+}
+
+func TestICMPEchoForwarderConsumesWithoutReply(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::1").To16()),
+			PrefixLen: 64,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::2").To16()),
+			PrefixLen: 64,
+		},
+	}
+
+	c := newTestContext()
+	defer c.cleanup()
+	s := c.s
+
+	forwarderCalled := false
+	var requestPkt *stack.PacketBuffer
+	f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
+		forwarderCalled = true
+		requestPkt = r.PacketBuffer()
+		return true
+	})
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber6, f.HandlePacket)
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	totalLen := header.IPv6MinimumSize + header.ICMPv6MinimumSize
+	hdr := prependable.New(totalLen)
+	icmpH := header.ICMPv6(hdr.Prepend(header.ICMPv6MinimumSize))
+	icmpH.SetType(header.ICMPv6EchoRequest)
+	icmpH.SetCode(header.ICMPv6UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{
+		Header: icmpH,
+		Src:    remoteAddr.AddressWithPrefix.Address,
+		Dst:    localAddr.AddressWithPrefix.Address,
+	}))
+	ip := header.IPv6(hdr.Prepend(header.IPv6MinimumSize))
+	ip.Encode(&header.IPv6Fields{
+		PayloadLength:     header.ICMPv6MinimumSize,
+		TransportProtocol: icmp.ProtocolNumber6,
+		HopLimit:          DefaultTTL,
+		SrcAddr:           remoteAddr.AddressWithPrefix.Address,
+		DstAddr:           localAddr.AddressWithPrefix.Address,
+	})
+	echoPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(ProtocolNumber, echoPkt)
+	echoPkt.DecRef()
+	c.clock.RunImmediatelyScheduledJobs()
+
+	if !forwarderCalled {
+		t.Fatalf("forwarder was not called")
+	}
+	if stack.ReplyICMPEcho(requestPkt) {
+		t.Fatalf("got stack.ReplyICMPEcho(requestPkt) after handler returned = true, want = false")
+	}
+	if p := e.Read(); p != nil {
+		p.DecRef()
+		t.Fatalf("got unexpected ICMP echo reply")
+	}
+}
+
+func TestICMPForwarderReplyNonEchoRequest(t *testing.T) {
+	localAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::1").To16()),
+			PrefixLen: 64,
+		},
+	}
+	remoteAddr := tcpip.ProtocolAddress{
+		Protocol: ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFromSlice(net.ParseIP("a::2").To16()),
+			PrefixLen: 64,
+		},
+	}
+
+	c := newTestContext()
+	defer c.cleanup()
+	s := c.s
+
+	forwarderCalled := false
+	f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
+		forwarderCalled = true
+		if r.Reply() {
+			t.Errorf("got r.Reply() = true for non-Echo-Request packet, want false")
+		}
+		return true
+	})
+	s.SetTransportProtocolHandler(icmp.ProtocolNumber6, f.HandlePacket)
+
+	e := channel.New(1, defaultMTU, "")
+	defer e.Close()
+	if err := s.CreateNIC(nicID, e); err != nil {
+		t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+	}
+	if err := s.AddProtocolAddress(nicID, localAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, localAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{{
+		Destination: localAddr.AddressWithPrefix.Subnet(),
+		NIC:         nicID,
+	}})
+
+	totalLen := header.IPv6MinimumSize + header.ICMPv6MinimumSize
+	hdr := prependable.New(totalLen)
+	icmpH := header.ICMPv6(hdr.Prepend(header.ICMPv6MinimumSize))
+	icmpH.SetType(header.ICMPv6EchoReply)
+	icmpH.SetCode(header.ICMPv6UnusedCode)
+	icmpH.SetChecksum(0)
+	icmpH.SetChecksum(header.ICMPv6Checksum(header.ICMPv6ChecksumParams{
+		Header: icmpH,
+		Src:    remoteAddr.AddressWithPrefix.Address,
+		Dst:    localAddr.AddressWithPrefix.Address,
+	}))
+	ip := header.IPv6(hdr.Prepend(header.IPv6MinimumSize))
+	ip.Encode(&header.IPv6Fields{
+		PayloadLength:     header.ICMPv6MinimumSize,
+		TransportProtocol: icmp.ProtocolNumber6,
+		HopLimit:          DefaultTTL,
+		SrcAddr:           remoteAddr.AddressWithPrefix.Address,
+		DstAddr:           localAddr.AddressWithPrefix.Address,
+	})
+	echoReplyPkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+		Payload: buffer.MakeWithData(hdr.View()),
+	})
+	e.InjectInbound(ProtocolNumber, echoReplyPkt)
+	echoReplyPkt.DecRef()
+	c.clock.RunImmediatelyScheduledJobs()
+
+	if !forwarderCalled {
+		t.Fatalf("forwarder was not called")
+	}
+	if p := e.Read(); p != nil {
+		p.DecRef()
+		t.Fatalf("got unexpected ICMP echo reply")
 	}
 }
 

--- a/pkg/tcpip/stack/packet_buffer.go
+++ b/pkg/tcpip/stack/packet_buffer.go
@@ -172,6 +172,10 @@ type PacketBuffer struct {
 	// Mark is the mark value of this packet.
 	Mark uint32
 
+	// icmpEchoReply replies to an ICMP Echo Request using the stack's built-in
+	// Echo Reply path.
+	icmpEchoReply *icmpEchoReplyHook `state:"nosave"`
+
 	tuple *tuple
 
 	// onRelease is a function to be run when the packet buffer is no longer
@@ -407,6 +411,71 @@ func (pk *PacketBuffer) Clone() *PacketBuffer {
 	newPk.tuple = pk.tuple
 	newPk.InitRefs()
 	return newPk
+}
+
+type icmpEchoReplyHook struct {
+	mu      sync.Mutex
+	active  bool
+	replied bool
+	reply   func() bool
+}
+
+// SetICMPEchoReply sets the built-in ICMP Echo Reply hook for an ICMP Echo
+// Request packet. SetICMPEchoReply is a cross-package bridge for ICMP network
+// endpoint reply paths; ICMP forwarder users should call the forwarder
+// request's Reply method instead.
+func (pk *PacketBuffer) SetICMPEchoReply(reply func() bool) {
+	pk.icmpEchoReply = &icmpEchoReplyHook{
+		active: true,
+		reply:  reply,
+	}
+}
+
+// ClearICMPEchoReply clears the built-in ICMP Echo Reply hook. It is paired
+// with SetICMPEchoReply by ICMP network endpoint reply paths.
+func (pk *PacketBuffer) ClearICMPEchoReply() {
+	if hook := pk.icmpEchoReply; hook != nil {
+		hook.deactivate()
+	}
+	pk.icmpEchoReply = nil
+}
+
+// ReplyICMPEcho asks the stack to synthesize its built-in ICMP Echo Reply for
+// pkt. ReplyICMPEcho is a cross-package bridge for the ICMP forwarder; ICMP
+// forwarder users should call the forwarder request's Reply method instead.
+// ReplyICMPEcho is idempotent and returns false if pkt has no active built-in
+// reply path. A true return value does not guarantee that the reply packet was
+// delivered.
+func ReplyICMPEcho(pkt *PacketBuffer) bool {
+	if pkt == nil {
+		return false
+	}
+	if hook := pkt.icmpEchoReply; hook != nil {
+		return hook.replyOnce()
+	}
+	return false
+}
+
+func (h *icmpEchoReplyHook) replyOnce() bool {
+	h.mu.Lock()
+	if !h.active {
+		h.mu.Unlock()
+		return false
+	}
+	if h.replied {
+		h.mu.Unlock()
+		return true
+	}
+	h.replied = true
+	reply := h.reply
+	h.mu.Unlock()
+	return reply()
+}
+
+func (h *icmpEchoReplyHook) deactivate() {
+	h.mu.Lock()
+	h.active = false
+	h.mu.Unlock()
 }
 
 // ReserveHeaderBytes prepends reserved space for headers at the front

--- a/pkg/tcpip/transport/icmp/BUILD
+++ b/pkg/tcpip/transport/icmp/BUILD
@@ -23,6 +23,7 @@ go_library(
     srcs = [
         "endpoint.go",
         "endpoint_state.go",
+        "forwarder.go",
         "icmp_packet_list.go",
         "protocol.go",
     ],

--- a/pkg/tcpip/transport/icmp/forwarder.go
+++ b/pkg/tcpip/transport/icmp/forwarder.go
@@ -1,0 +1,92 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package icmp
+
+import "gvisor.dev/gvisor/pkg/tcpip/stack"
+
+// ForwarderHandler handles incoming ICMP packets. Returning true marks the
+// packet as handled, returning false marks the packet as unhandled.
+type ForwarderHandler func(*ForwarderRequest) (handled bool)
+
+// Forwarder allows clients to decide what to do with ICMP packets delivered to
+// the per-stack default handler.
+//
+// The canonical way of using it is to pass the Forwarder.HandlePacket function
+// to stack.SetTransportProtocolHandler.
+type Forwarder struct {
+	handler ForwarderHandler
+}
+
+// NewForwarder allocates and initializes a new forwarder.
+func NewForwarder(handler ForwarderHandler) *Forwarder {
+	return &Forwarder{
+		handler: handler,
+	}
+}
+
+// HandlePacket handles ICMP packets.
+//
+// This function is expected to be passed as an argument to the
+// stack.SetTransportProtocolHandler function.
+func (f *Forwarder) HandlePacket(id stack.TransportEndpointID, pkt *stack.PacketBuffer) bool {
+	req := &ForwarderRequest{
+		id:  id,
+		pkt: pkt,
+	}
+	handled := f.handler(req)
+	if req.pkt != nil {
+		req.pkt.ClearICMPEchoReply()
+	}
+	req.pkt = nil
+	return handled
+}
+
+// ForwarderRequest represents an ICMP request received by the forwarder and
+// passed to the client. ForwarderRequest is only valid for the duration of the
+// ForwarderHandler call; callers must not save it and call Reply after the
+// handler returns.
+type ForwarderRequest struct {
+	id  stack.TransportEndpointID
+	pkt *stack.PacketBuffer
+}
+
+// ID returns the addresses and ICMP identifier associated with the request.
+func (r *ForwarderRequest) ID() stack.TransportEndpointID {
+	return r.id
+}
+
+// PacketBuffer returns the packet associated with the request. The packet is
+// only valid for the duration of the ForwarderHandler call and must not be
+// saved to call Reply after the handler returns.
+func (r *ForwarderRequest) PacketBuffer() *stack.PacketBuffer {
+	return r.pkt
+}
+
+// PacketInfo returns network-layer information associated with the request.
+func (r *ForwarderRequest) PacketInfo() stack.NetworkPacketInfo {
+	if r.pkt == nil {
+		return stack.NetworkPacketInfo{}
+	}
+	return r.pkt.NetworkPacketInfo
+}
+
+// Reply asks netstack to synthesize its built-in ICMP Echo Reply for the
+// request. Reply is only valid for the duration of the ForwarderHandler call.
+// Reply is idempotent and returns false if the packet is not an ICMP Echo
+// Request with an active built-in reply path. A true return value does not
+// guarantee that the reply packet was delivered.
+func (r *ForwarderRequest) Reply() bool {
+	return stack.ReplyICMPEcho(r.pkt)
+}


### PR DESCRIPTION
## Overview

This is the next ICMP Echo follow-up after #13189 and #13281.

It adds an `icmp.Forwarder` adapter for ICMP packets delivered through `stack.SetTransportProtocolHandler`, and lets the handler explicitly delegate ICMP Echo Reply generation back to netstack with `ForwarderRequest.Reply()`.

The goal is to let embedders handle ICMP Echo Requests without reimplementing the built-in reply construction logic downstream.

## Behavior

The default behavior remains conservative:

```text
no ICMP default handler                   -> built-in Echo Reply is preserved
default handler returns false, no Reply() -> built-in Echo Reply is preserved
default handler returns true, no Reply()  -> no built-in Echo Reply
registered ICMP endpoint                  -> default handler is not called; built-in Echo Reply is preserved
IPv4 LocalAddressTemporary                -> built-in Echo Reply is still suppressed unless the handler explicitly calls Reply()
```

The new explicit delegation path is:

```go
f := icmp.NewForwarder(func(r *icmp.ForwarderRequest) bool {
    if shouldHandleByTunnel(r) {
        return handleByTunnel(r)
    }
    return r.Reply()
})

s.SetTransportProtocolHandler(icmp.ProtocolNumber4, f.HandlePacket)
s.SetTransportProtocolHandler(icmp.ProtocolNumber6, f.HandlePacket)
```

`Reply()` is idempotent. If a handler calls `Reply()` and then returns `false`, netstack does not synthesize a second built-in Echo Reply on the fallback path. A successful `Reply()` return means the built-in reply path was available and accepted for this request; it is not a packet-delivery guarantee.

## API Semantics

This API keeps the existing `SetTransportProtocolHandler` ownership contract:

```text
handler returns true   -> the handler consumed the packet
handler returns false  -> the handler did not consume the packet; protocol fallback may continue
```

`ForwarderRequest.Reply()` is a separate explicit action. It asks netstack to synthesize the built-in Echo Reply for this request, without changing what the handler's return value means.

That gives handlers two independent decisions:

```text
return true without Reply()   -> consume/drop/forward the Echo Request; no built-in reply
return false without Reply()  -> do not consume it; preserve the current fallback behavior
Reply(); return true          -> explicitly send the built-in reply and consume the request
Reply(); return false         -> explicitly send the built-in reply, then allow fallback to continue without sending a duplicate reply
```

I kept the final API as `bool + Reply()` because it fits the existing default-handler contract and keeps the user-facing surface small. An action enum could model this, but it would need to combine two distinct decisions: whether the handler consumed the packet, and whether it asked netstack to send the built-in Echo Reply. Keeping `Reply()` as an explicit request method avoids redefining `SetTransportProtocolHandler` semantics for ICMP.

## LocalAddressTemporary

This change keeps the no-handler IPv4 `LocalAddressTemporary` behavior from #11609 and #13189: temporary local addresses do not automatically trigger a built-in Echo Reply.

The new capability is explicit delegation. If the ICMP default handler sees `r.PacketInfo().LocalAddressTemporary` and decides that netstack should still generate the Echo Reply, it can call `r.Reply()`. In that path, the reply uses the original Echo Request destination address as the reply source, and the reply path can find a route without requiring that temporary address to be registered as the route local address.

That addresses the large-address-space embedder case discussed in #13189 without changing the conservative default for tunnel/proxy handlers that intentionally consume Echo Requests.

This does not add an IPv6 `Temporary()`-based Echo Reply suppression rule.

## Implementation Notes

The user-facing adapter is intentionally small:

* `icmp.NewForwarder(handler)` constructs a handler adapter.
* `Forwarder.HandlePacket` can be passed to `stack.SetTransportProtocolHandler`.
* `ForwarderRequest.ID()` exposes the parsed ICMP identifier through `stack.TransportEndpointID`.
* `ForwarderRequest.PacketBuffer()` exposes the packet for the duration of the handler call.
* `ForwarderRequest.PacketInfo()` exposes network-layer metadata such as `LocalAddressTemporary`.
* `ForwarderRequest.Reply()` delegates to the built-in Echo Reply path.

The actual Echo Reply construction remains in the IPv4/IPv6 network endpoint layer. `transport/icmp` does not duplicate route lookup, source address selection, rate limiting, stats, checksum handling, IPv4 options, IPv6 traffic class, or output hooks.

The per-packet reply hook is not the intended embedder-facing API. Embedders should use `ForwarderRequest.Reply()`; the exported `PacketBuffer` hook helpers are a cross-package bridge that lets the network endpoint path expose its built-in reply operation to the ICMP forwarder without moving protocol-specific reply construction into `transport/icmp`.

The hook is deliberately scoped to packet delivery:

* `PacketBuffer` stores a private transient hook object.
* `NetworkPacketInfo` remains metadata-only.
* `ForwarderRequest` is invalidated after the handler returns.
* `PacketBuffer.Clone()` does not copy the reply hook.
* The IPv4/IPv6 ICMP paths clear the hook after transport delivery.

This keeps the hook from escaping past the temporary reply buffers prepared by the network endpoint.

## Tests

The added tests cover:

* IPv4 and IPv6 `Reply()` delegation.
* `Reply()` idempotence when a handler returns `false` after replying.
* `Forwarder` consuming an Echo Request without `Reply()`.
* `Reply()` returning `false` for non-Echo-Request packets.
* saved request / saved `PacketBuffer` invalidation after handler return.
* cloned `PacketBuffer` not inheriting the reply hook.
* IPv4 temporary-address default suppression and explicit `Reply()` override.

```shell
go run github.com/bazelbuild/bazelisk@latest test --nocache_test_results \
  //pkg/tcpip/network/ipv4:ipv4_test \
  //pkg/tcpip/network/ipv6:ipv6_test \
  //pkg/tcpip/network/ipv6:ipv6_x_test \
  //pkg/tcpip/transport/icmp:icmp_x_test \
  //pkg/tcpip/transport/icmp:icmp_nogo \
  //pkg/tcpip/stack:stack_test \
  //pkg/tcpip/stack:stack_x_test \
  //pkg/tcpip/stack:stack_nogo
```

## Related

* #13189
* #13281