### PR TITLE
Implement /proc/sys/kernel/random/uuid

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -58,6 +58,7 @@ func (fs *filesystem) newSysDir(ctx context.Context, root *auth.Credentials, k *
 			"randomize_va_space": fs.newInode(ctx, root, 0644, newStaticFile("2\n")),
 			"random": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 				"boot_id": fs.newInode(ctx, root, 0444, newStaticFile(randUUID())),
+				"uuid":    fs.newInode(ctx, root, 0444, &uuidData{}),
 			}),
 			"sem":    fs.newInode(ctx, root, 0444, newStaticFile(fmt.Sprintf("%d\t%d\t%d\t%d\n", linux.SEMMSL, linux.SEMMNS, linux.SEMOPM, linux.SEMMNI))),
 			"shmall": fs.newInode(ctx, root, 0444, ipcData(linux.SHMALL)),
@@ -195,6 +196,21 @@ func (*hostnameData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	defer utsns.DecRef(ctx)
 	buf.WriteString(utsns.HostName())
 	buf.WriteString("\n")
+	return nil
+}
+
+// uuidData implements vfs.DynamicBytesSource for /proc/sys/kernel/random/uuid.
+//
+// +stateify savable
+type uuidData struct {
+	kernfs.DynamicBytesFile
+}
+
+var _ dynamicInode = (*uuidData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (*uuidData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	buf.WriteString(randUUID())
 	return nil
 }
 

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -2719,6 +2719,16 @@ TEST(ProcSysKernelHostname, MatchesUname) {
   EXPECT_EQ(procfs_hostname, hostname);
 }
 
+TEST(ProcSysKernelRandomUuid, Exists) {
+  EXPECT_THAT(open("/proc/sys/kernel/random/uuid", O_RDONLY), SyscallSucceeds());
+}
+
+TEST(ProcSysKernelRandomUuid, DifferentEveryTime) {
+  auto uuid1 = ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/kernel/random/uuid"));
+  auto uuid2 = ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/kernel/random/uuid"));
+  EXPECT_NE(uuid1, uuid2);
+}
+
 TEST(ProcSysVmMaxmapCount, HasNumericValue) {
   const std::string val_str =
       ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/vm/max_map_count"));


### PR DESCRIPTION
For some reason, bash complains about it missing when run under machinectl.