### PR TITLE
Fix setdomainname(2)

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_utsname.go
+++ b/pkg/sentry/syscalls/linux/sys_utsname.go
@@ -63,12 +63,12 @@ func Setdomainname(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (u
 		return 0, nil, linuxerr.EINVAL
 	}
 
-	name, err := t.CopyInString(nameAddr, int(size))
-	if err != nil {
+	name := make([]byte, size)
+	if _, err := t.CopyInBytes(nameAddr, name); err != nil {
 		return 0, nil, err
 	}
 
-	utsns.SetDomainName(name)
+	utsns.SetDomainName(string(name))
 	return 0, nil, nil
 }
 

--- a/test/syscalls/linux/uname.cc
+++ b/test/syscalls/linux/uname.cc
@@ -54,6 +54,19 @@ TEST(UnameTest, SetNames) {
   EXPECT_THAT(gethostname(hostname, sizeof(hostname)), SyscallSucceeds());
   EXPECT_EQ(absl::string_view(hostname), "0123456789");
 
+  char domainname[65];
+  ASSERT_THAT(setdomainname("abcdefghij", 3), SyscallSucceeds());
+  EXPECT_THAT(getdomainname(domainname, sizeof(domainname)), SyscallSucceeds());
+  EXPECT_EQ(absl::string_view(domainname), "abc");
+
+  ASSERT_THAT(setdomainname("abcdefghij\0xxx", 11), SyscallSucceeds());
+  EXPECT_THAT(getdomainname(domainname, sizeof(domainname)), SyscallSucceeds());
+  EXPECT_EQ(absl::string_view(domainname), "abcdefghij");
+
+  ASSERT_THAT(setdomainname("abcdefghij\0xxx", 12), SyscallSucceeds());
+  EXPECT_THAT(getdomainname(domainname, sizeof(domainname)), SyscallSucceeds());
+  EXPECT_EQ(absl::string_view(domainname), "abcdefghij");
+
   constexpr char kHostname[] = "wubbalubba";
   ASSERT_THAT(sethostname(kHostname, sizeof(kHostname)), SyscallSucceeds());
 
@@ -70,7 +83,6 @@ TEST(UnameTest, SetNames) {
   EXPECT_THAT(gethostname(hostname, sizeof(hostname)), SyscallSucceeds());
   EXPECT_EQ(absl::string_view(hostname), kHostname);
 
-  char domainname[65];
   EXPECT_THAT(getdomainname(domainname, sizeof(domainname)), SyscallSucceeds());
   EXPECT_EQ(absl::string_view(domainname), kDomainname);
 }


### PR DESCRIPTION
The arg to setdomainname isn't a string, it's a byte array with a specified length.

This fix was previously applied to sethostname(2), but not setdomainname(2).