### PR TITLE
netstack: return EADDRNOTAVAIL for SIOCGIFADDR/SIOCGIFNETMASK without IPv4

### DIFF
--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -3638,9 +3638,17 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 			if addr.Family != linux.AF_INET {
 				continue
 			}
+			// Populate ifr.ifr_addr (type sockaddr_in).
+			hostarch.ByteOrder.PutUint16(ifr.Data[0:], uint16(linux.AF_INET))
+			hostarch.ByteOrder.PutUint16(ifr.Data[2:], 0)
 			copy(ifr.Data[4:8], addr.Addr)
-			break
+			return nil
 		}
+		// Linux returns EADDRNOTAVAIL when the device has no IPv4
+		// address (Linux: net/ipv4/devinet.c:devinet_ioctl()), rather
+		// than succeeding without writing ifr, which would let the
+		// caller read back stale ifreq union data.
+		return syserr.ErrAddressNotAvailable
 
 	case linux.SIOCGIFMETRIC:
 		// Gets the metric of the device. As per netdevice(7), this
@@ -3681,8 +3689,11 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 			// Netmask is expected to be returned as a big endian
 			// value.
 			binary.BigEndian.PutUint32(ifr.Data[4:8], mask)
-			break
+			return nil
 		}
+		// Linux returns EADDRNOTAVAIL when the device has no IPv4
+		// address; see the SIOCGIFADDR case above.
+		return syserr.ErrAddressNotAvailable
 
 	case linux.SIOCETHTOOL:
 		// Stubbed out for now, Ideally we should implement the required

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -3633,6 +3633,7 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 
 	case linux.SIOCGIFADDR:
 		// Copy the IPv4 address out.
+		found := false
 		for _, addr := range stk.InterfaceAddrs()[index] {
 			// This ioctl is only compatible with AF_INET addresses.
 			if addr.Family != linux.AF_INET {
@@ -3642,13 +3643,16 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 			hostarch.ByteOrder.PutUint16(ifr.Data[0:], uint16(linux.AF_INET))
 			hostarch.ByteOrder.PutUint16(ifr.Data[2:], 0)
 			copy(ifr.Data[4:8], addr.Addr)
-			return nil
+			found = true
+			break
 		}
-		// Linux returns EADDRNOTAVAIL when the device has no IPv4
-		// address (Linux: net/ipv4/devinet.c:devinet_ioctl()), rather
-		// than succeeding without writing ifr, which would let the
-		// caller read back stale ifreq union data.
-		return syserr.ErrAddressNotAvailable
+		if !found {
+			// Linux returns EADDRNOTAVAIL when the device has no IPv4
+			// address (Linux: net/ipv4/devinet.c:devinet_ioctl()), rather
+			// than succeeding without writing ifr, which would let the
+			// caller read back stale ifreq union data.
+			return syserr.ErrAddressNotAvailable
+		}
 
 	case linux.SIOCGIFMETRIC:
 		// Gets the metric of the device. As per netdevice(7), this
@@ -3677,6 +3681,7 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 
 	case linux.SIOCGIFNETMASK:
 		// Gets the network mask of a device.
+		found := false
 		for _, addr := range stk.InterfaceAddrs()[index] {
 			// This ioctl is only compatible with AF_INET addresses.
 			if addr.Family != linux.AF_INET {
@@ -3689,11 +3694,14 @@ func interfaceIoctl(ctx context.Context, _ usermem.IO, arg int, ifr *linux.IFReq
 			// Netmask is expected to be returned as a big endian
 			// value.
 			binary.BigEndian.PutUint32(ifr.Data[4:8], mask)
-			return nil
+			found = true
+			break
 		}
-		// Linux returns EADDRNOTAVAIL when the device has no IPv4
-		// address; see the SIOCGIFADDR case above.
-		return syserr.ErrAddressNotAvailable
+		if !found {
+			// Linux returns EADDRNOTAVAIL when the device has no IPv4
+			// address; see the SIOCGIFADDR case above.
+			return syserr.ErrAddressNotAvailable
+		}
 
 	case linux.SIOCETHTOOL:
 		// Stubbed out for now, Ideally we should implement the required

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4117,6 +4117,7 @@ cc_binary(
     malloc = "//test/util:errno_safe_allocator",
     deps = select_gtest() + [
         ":socket_netlink_util",
+        "//test/util:capability_util",
         "//test/util:file_descriptor",
         "//test/util:socket_util",
         "//test/util:test_main",

--- a/test/syscalls/linux/socket_netdevice.cc
+++ b/test/syscalls/linux/socket_netdevice.cc
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fcntl.h>
 #include <linux/ethtool.h>
+#include <linux/if_tun.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <linux/sockios.h>
+#include <netinet/in.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
+#include <cstring>
+
 #include "gtest/gtest.h"
 #include "test/syscalls/linux/socket_netlink_util.h"
+#include "test/util/capability_util.h"
+#include "test/util/linux_capability_util.h"
 #include "test/util/file_descriptor.h"
 #include "test/util/socket_util.h"
 #include "test/util/test_util.h"
@@ -56,6 +63,45 @@ TEST(NetdeviceTest, Loopback) {
   EXPECT_EQ(ifr.ifr_hwaddr.sa_data[3], 0);
   EXPECT_EQ(ifr.ifr_hwaddr.sa_data[4], 0);
   EXPECT_EQ(ifr.ifr_hwaddr.sa_data[5], 0);
+}
+
+TEST(NetdeviceTest, InterfaceAddr) {
+  FileDescriptor sock =
+      ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_DGRAM, 0));
+
+  // Loopback always has 127.0.0.1 assigned, and Linux returns it as a
+  // sockaddr_in with the family filled in.
+  struct ifreq ifr = {};
+  snprintf(ifr.ifr_name, IFNAMSIZ, "lo");
+  ASSERT_THAT(ioctl(sock.get(), SIOCGIFADDR, &ifr), SyscallSucceeds());
+  struct sockaddr_in* sin =
+      reinterpret_cast<struct sockaddr_in*>(&ifr.ifr_addr);
+  EXPECT_EQ(sin->sin_family, AF_INET);
+  EXPECT_EQ(ntohl(sin->sin_addr.s_addr), INADDR_LOOPBACK);
+}
+
+TEST(NetdeviceTest, InterfaceAddrIoctlsNoIPv4Addr) {
+  // SIOCGIFADDR and SIOCGIFNETMASK fail with EADDRNOTAVAIL on an interface
+  // that has no IPv4 address assigned, rather than returning success without
+  // writing ifr, which would let callers read back stale ifreq data.
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
+
+  // Create a tun interface, which starts out with no addresses assigned.
+  FileDescriptor tun =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/net/tun", O_RDWR));
+  struct ifreq tun_ifr = {};
+  tun_ifr.ifr_flags = IFF_TUN;
+  strncpy(tun_ifr.ifr_name, "tun_noaddr", IFNAMSIZ);
+  ASSERT_THAT(ioctl(tun.get(), TUNSETIFF, &tun_ifr), SyscallSucceeds());
+
+  FileDescriptor sock =
+      ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_DGRAM, 0));
+  struct ifreq ifr = {};
+  strncpy(ifr.ifr_name, "tun_noaddr", IFNAMSIZ);
+  EXPECT_THAT(ioctl(sock.get(), SIOCGIFADDR, &ifr),
+              SyscallFailsWithErrno(EADDRNOTAVAIL));
+  EXPECT_THAT(ioctl(sock.get(), SIOCGIFNETMASK, &ifr),
+              SyscallFailsWithErrno(EADDRNOTAVAIL));
 }
 
 TEST(NetdeviceTest, Netmask) {


### PR DESCRIPTION
Fixes #13431

## Root cause

In `interfaceIoctl` (pkg/sentry/socket/netstack/netstack.go), the `SIOCGIFADDR` and `SIOCGIFNETMASK` cases loop over interface addresses looking for AF_INET. When the interface has no IPv4 address (for example an IPv6-only interface), the loop finds nothing and the function returns success without writing the ifreq. The caller then reads back whatever was previously in the ifreq union, which is how ifconfig ends up displaying a fabricated IPv4 address built from stale bytes (in the issue's strace, remnants of the preceding SIOCGIFMTU call).

Linux returns EADDRNOTAVAIL for both ioctls in this case (net/ipv4/devinet.c:devinet_ioctl, the `ifa == NULL` path shared by the SIOCGIF* address ioctls).

## Changes

- `SIOCGIFADDR` and `SIOCGIFNETMASK` now return EADDRNOTAVAIL when the interface has no IPv4 address.
- The `SIOCGIFADDR` success path now also populates `sa_family` (AF_INET) and the port bytes; previously only the 4 address bytes were written, while Linux fills in the full sockaddr_in. The `SIOCGIFNETMASK` success path already did this.
- New syscall tests: `NetdeviceTest.InterfaceAddr` (loopback, family + address) and `NetdeviceTest.InterfaceAddrIoctlsNoIPv4Addr` (TUN device with no addresses, expects EADDRNOTAVAIL for both ioctls; gated on CAP_NET_ADMIN).

## Verification

Probe calling SIOCGIFMTU, then SIOCGIFADDR and SIOCGIFNETMASK with the ifreq poisoned with 0xAA bytes:

| case | native Linux (6.x) | runsc before | runsc after |
|---|---|---|---|
| GIFADDR, IPv6-only interface | EADDRNOTAVAIL | success, poison bytes returned | EADDRNOTAVAIL |
| GIFNETMASK, IPv6-only interface | EADDRNOTAVAIL | success, poison bytes returned | EADDRNOTAVAIL |
| GIFADDR, interface with IPv4 | `02000000` + addr | poison family bytes + addr | `02000000` + addr (matches Linux) |
| GIFNETMASK, interface with IPv4 | family + mask | family + mask | family + mask |

The IPv6-only scenario was reproduced with runsc under Docker on an IPv6-only network (`docker network create --ipv6 --ipv4=false`), matching the issue's EKS setup. A standalone mirror of the new test cases passes on native Linux and patched runsc, and fails on stock runsc with exactly the three asserted behaviors.

Authored with the help of an AI assistant, per AGENTS.md the ABI change was verified against Linux kernel behavior as described above.