### PR TITLE
stack: remove unused ReceiveBufferSizeOption type

### DIFF
--- a/pkg/tcpip/stack/stack_options.go
+++ b/pkg/tcpip/stack/stack_options.go
@@ -37,14 +37,6 @@ const (
 	defaultTCPInvalidRateLimit = 500 * time.Millisecond
 )
 
-// ReceiveBufferSizeOption is used by stack.(Stack*).Option/SetOption to
-// get/set the default, min and max receive buffer sizes.
-type ReceiveBufferSizeOption struct {
-	Min     int
-	Default int
-	Max     int
-}
-
 // TCPInvalidRateLimitOption is used by stack.(Stack*).Option/SetOption to get/set
 // stack.tcpInvalidRateLimit.
 type TCPInvalidRateLimitOption time.Duration


### PR DESCRIPTION
The `stack.ReceiveBufferSizeOption` type defined in pkg/tcpip/stack/stack_options.go is unused throughout the codebase. The `SetOption` and `Option` methods on Stack use `tcpip.ReceiveBufferSizeOption` and `tcpip.SendBufferSizeOption` from pkg/tcpip/tcpip.go instead. The stack package never defined a corresponding `SendBufferSizeOption`, confirming these types were superseded by the tcpip package equivalents.

This change removes the unused type definition to clean up dead code.

Fixes #13409
