### PR TITLE
SO_PEERCRED: snapshot peer pid instead of looking up upon getsockopt()

### DIFF
--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -331,6 +331,31 @@ func (ns *PIDNamespace) IDOfThreadGroup(tg *ThreadGroup) ThreadID {
 	return id
 }
 
+// PIDNamespacedIDs returns a snapshot mapping each PID namespace in which tg's
+// leader is visible (tg's PID namespace and every ancestor) to tg's ID (PID)
+// in that namespace.
+//
+// The returned map is intended to be indexed by a PID namespace to which the
+// caller holds a reference. Because the returned map does not hold references
+// on its own, the other keys in the map *MUST NOT* be dereferenced.
+//
+// tg must be visible in its own PID namespace.
+func (tg *ThreadGroup) PIDNamespacedIDs() map[*PIDNamespace]ThreadID {
+	tg.pidns.owner.mu.RLock()
+	defer tg.pidns.owner.mu.RUnlock()
+	ids := make(map[*PIDNamespace]ThreadID)
+	for ns := tg.pidns; ns != nil; ns = ns.parent {
+		id, ok := ns.tgids[tg]
+		if !ok {
+			// If tg is visible in its own pid ns, it must be visible in all ancestors
+			// as per the pid ns invariant.
+			panic("thread group not visible in its own or an ancestor PID namespace")
+		}
+		ids[ns] = id
+	}
+	return ids
+}
+
 // Tasks returns a snapshot of the tasks in ns.
 func (ns *PIDNamespace) Tasks() []*Task {
 	return ns.TasksAppend(nil)

--- a/pkg/sentry/socket/control/control.go
+++ b/pkg/sentry/socket/control/control.go
@@ -17,6 +17,7 @@
 package control
 
 import (
+	"maps"
 	"math"
 	"time"
 
@@ -47,7 +48,12 @@ type SCMCredentials interface {
 //
 // +stateify savable
 type scmCredentials struct {
-	t    *kernel.Task
+	// Add any new fields here to scmCredentials.Equals().
+
+	// pids snapshots the peer's PID in every PID namespace in which it is
+	// visible, captured when the credentials were created.
+	pids map[*kernel.PIDNamespace]kernel.ThreadID
+
 	kuid auth.KUID
 	kgid auth.KGID
 }
@@ -64,16 +70,17 @@ func NewSCMCredentials(t *kernel.Task, cred linux.ControlMessageCredentials) (SC
 	if err != nil {
 		return nil, err
 	}
-	if kernel.ThreadID(cred.PID) != t.ThreadGroup().ID() && !t.HasCapabilityIn(linux.CAP_SYS_ADMIN, t.PIDNamespace().UserNamespace()) {
+	tg := t.ThreadGroup()
+	if kernel.ThreadID(cred.PID) != tg.ID() && !t.HasCapabilityIn(linux.CAP_SYS_ADMIN, t.PIDNamespace().UserNamespace()) {
 		return nil, linuxerr.EPERM
 	}
-	return &scmCredentials{t, kuid, kgid}, nil
+	return &scmCredentials{tg.PIDNamespacedIDs(), kuid, kgid}, nil
 }
 
 // Equals implements transport.CredentialsControlMessage.Equals.
 func (c *scmCredentials) Equals(oc transport.CredentialsControlMessage) bool {
-	if oc, _ := oc.(*scmCredentials); oc != nil && *c == *oc {
-		return true
+	if oc, _ := oc.(*scmCredentials); oc != nil {
+		return c.kuid == oc.kuid && c.kgid == oc.kgid && maps.Equal(c.pids, oc.pids)
 	}
 	return false
 }
@@ -159,7 +166,11 @@ func (c *scmCredentials) Credentials(t *kernel.Task) (kernel.ThreadID, auth.UID,
 	// of SCM_CREDENTIALS in unix(7)), they are translated into the
 	// corresponding values as per the receiving process's user and group ID
 	// mappings." - user_namespaces(7)
-	pid := t.PIDNamespace().IDOfTask(c.t)
+	//
+	// If t.PIDNamespace() is not present in c.pids, that means the peer
+	// is not visible to the caller's PID namespace. In this case, returning
+	// 0 is appropriate.
+	pid := c.pids[t.PIDNamespace()]
 	uid := c.kuid.In(t.UserNamespace()).OrOverflow()
 	gid := c.kgid.In(t.UserNamespace()).OrOverflow()
 
@@ -633,7 +644,7 @@ func MakeCreds(t *kernel.Task) SCMCredentials {
 		return nil
 	}
 	tcred := t.Credentials()
-	return &scmCredentials{t, tcred.EffectiveKUID, tcred.EffectiveKGID}
+	return &scmCredentials{t.ThreadGroup().PIDNamespacedIDs(), tcred.EffectiveKUID, tcred.EffectiveKGID}
 }
 
 // New creates default control messages if needed.

--- a/test/syscalls/linux/socket_unix_peercred.cc
+++ b/test/syscalls/linux/socket_unix_peercred.cc
@@ -14,14 +14,19 @@
 
 #include "test/syscalls/linux/socket_unix_peercred.h"
 
+#include <sched.h>
+#include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "test/util/linux_capability_util.h"
 #include "test/util/logging.h"
+#include "test/util/memory_util.h"
 #include "test/util/multiprocess_util.h"
 #include "test/util/posix_error.h"
 #include "test/util/save_util.h"
@@ -187,6 +192,164 @@ TEST_P(UnixSocketPeerCredTest, AfterConnectServerPeerCred) {
   // Wait for the client to exit.
   int status;
   ASSERT_GE(waitpid(pid, &status, 0), 0);
+}
+
+// SO_PEERCRED must keep reporting the PID captured at connection time even
+// after the peer has exited and been reaped.
+TEST_P(UnixSocketPeerCredTest, PeerCredSurvivesPeerExit) {
+  if (GetParam().type != SOCK_STREAM) {
+    GTEST_SKIP() << "Test requires SOCK_STREAM";
+  }
+  // Pipe used to tell the client when to exit (after we have accepted).
+  int pipe_fd[2];
+  ASSERT_THAT(pipe(pipe_fd), SyscallSucceeds());
+
+  auto addr = ASSERT_NO_ERRNO_AND_VALUE(UniqueUnixAddr(true, AF_UNIX));
+  auto server_socket =
+      ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_UNIX, SOCK_STREAM, 0));
+  ASSERT_THAT(bind(server_socket.get(), AsSockAddr(&addr), sizeof(addr)),
+              SyscallSucceeds());
+  ASSERT_THAT(listen(server_socket.get(), 5), SyscallSucceeds());
+
+  const auto client = [&] {
+    TEST_PCHECK_MSG(close(pipe_fd[1]) == 0, "close failed");
+    auto client_socket = Socket(AF_UNIX, SOCK_STREAM, 0);
+    TEST_PCHECK_MSG(client_socket.ok(), "client socket failed");
+    auto client_soc = client_socket.ValueOrDie().get();
+    TEST_PCHECK_MSG(connect(client_soc, AsSockAddr(&addr), sizeof(addr)) == 0,
+                    "connect failed");
+    // Wait for the parent to accept and signal us before exiting.
+    char ok = 0;
+    TEST_PCHECK_MSG(read(pipe_fd[0], &ok, sizeof(ok)) == sizeof(ok),
+                    "read failed");
+  };
+  pid_t pid = fork();
+  if (pid == 0) {
+    client();
+    _exit(0);
+  }
+  ASSERT_GT(pid, 0);
+  ASSERT_THAT(close(pipe_fd[0]), SyscallSucceeds());
+
+  // Accept the connection while the client is still alive.
+  auto accepted_socket =
+      ASSERT_NO_ERRNO_AND_VALUE(Accept(server_socket.get(), nullptr, nullptr));
+
+  // Tell the client to exit and reap it, so the connecting task is fully gone
+  // before we read its credentials.
+  char ok = 1;
+  ASSERT_THAT(write(pipe_fd[1], &ok, sizeof(ok)),
+              SyscallSucceedsWithValue(sizeof(ok)));
+  ASSERT_THAT(close(pipe_fd[1]), SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "child exited abnormally: status=" << status;
+
+  // The peer is dead and reaped, but SO_PEERCRED must still report its original
+  // PID rather than 0.
+  struct ucred serverPeerCred;
+  socklen_t len = sizeof(serverPeerCred);
+  ASSERT_THAT(getsockopt(accepted_socket.get(), SOL_SOCKET, SO_PEERCRED,
+                         &serverPeerCred, &len),
+              SyscallSucceeds());
+  AssertCredSetTo(serverPeerCred, pid, getuid(), getgid());
+}
+
+// Arguments passed to peerCredNSConnectChild, which runs in a separate (cloned)
+// process in its own PID namespace.
+struct PeerCredNSChildArgs {
+  struct sockaddr_un addr;
+  // pipe_w is written with the child's PID as seen in its own (new) PID
+  // namespace, signalling the parent that the connection is established.
+  int pipe_w;
+};
+
+// peerCredNSConnectChild is the entry point of a process cloned into a new PID
+// namespace (so getpid() returns 1). It connects to addr, reports its
+// in-namespace PID, then blocks until the parent closes the connection.
+int peerCredNSConnectChild(void* arg) {
+  auto* a = static_cast<PeerCredNSChildArgs*>(arg);
+  int s = socket(AF_UNIX, SOCK_STREAM, 0);
+  TEST_PCHECK_MSG(s >= 0, "child socket failed");
+  TEST_PCHECK_MSG(connect(s, AsSockAddr(&a->addr), sizeof(a->addr)) == 0,
+                  "child connect failed");
+  pid_t in_ns_pid = getpid();  // 1 in the new PID namespace.
+  TEST_PCHECK_MSG(
+      write(a->pipe_w, &in_ns_pid, sizeof(in_ns_pid)) == sizeof(in_ns_pid),
+      "child write failed");
+  // Stay alive until the parent has read our credentials and closes the
+  // accepted socket, which we observe as EOF.
+  char c;
+  while (read(s, &c, sizeof(c)) > 0) {
+  }
+  _exit(0);
+}
+
+// SO_PEERCRED must report the peer's PID translated into the reader's PID
+// namespace. The peer connects from a child PID namespace, so the reader in the
+// ancestor (root) namespace must see the peer's root-namespace PID, not its
+// in-namespace PID (which is 1).
+TEST_P(UnixSocketPeerCredTest, PeerCredAcrossPIDNamespace) {
+  if (GetParam().type != SOCK_STREAM) {
+    GTEST_SKIP() << "Test requires SOCK_STREAM";
+  }
+  // Creating a PID namespace requires CAP_SYS_ADMIN.
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto addr = ASSERT_NO_ERRNO_AND_VALUE(UniqueUnixAddr(true, AF_UNIX));
+  auto server_socket =
+      ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_UNIX, SOCK_STREAM, 0));
+  ASSERT_THAT(bind(server_socket.get(), AsSockAddr(&addr), sizeof(addr)),
+              SyscallSucceeds());
+  ASSERT_THAT(listen(server_socket.get(), 5), SyscallSucceeds());
+
+  int sync_pipe[2];
+  ASSERT_THAT(pipe(sync_pipe), SyscallSucceeds());
+
+  PeerCredNSChildArgs args = {
+      .addr = addr,
+      .pipe_w = sync_pipe[1],
+  };
+
+  // Clone a child into a new PID namespace.
+  constexpr int kStackSize = 4096;
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      Mmap(nullptr, kStackSize, PROT_READ | PROT_WRITE,
+           MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0));
+  pid_t child_pid = clone(peerCredNSConnectChild,
+                          reinterpret_cast<char*>(stack.ptr()) + stack.len(),
+                          CLONE_NEWPID | SIGCHLD, &args);
+  ASSERT_THAT(child_pid, SyscallSucceeds());
+  ASSERT_THAT(close(sync_pipe[1]), SyscallSucceeds());
+
+  // Read the child's in-namespace PID, confirming it is PID 1 of a new
+  // namespace (and that the connection is established).
+  pid_t child_in_ns_pid = 0;
+  ASSERT_THAT(read(sync_pipe[0], &child_in_ns_pid, sizeof(child_in_ns_pid)),
+              SyscallSucceedsWithValue(sizeof(child_in_ns_pid)));
+  EXPECT_EQ(child_in_ns_pid, 1);
+
+  {
+    auto accepted_socket = ASSERT_NO_ERRNO_AND_VALUE(
+        Accept(server_socket.get(), nullptr, nullptr));
+    struct ucred peerCreds;
+    socklen_t len = sizeof(peerCreds);
+    ASSERT_THAT(getsockopt(accepted_socket.get(), SOL_SOCKET, SO_PEERCRED,
+                           &peerCreds, &len),
+                SyscallSucceeds());
+    // The PID must be the peer's PID in *our* namespace.
+    EXPECT_EQ(peerCreds.pid, child_pid);
+    EXPECT_EQ(peerCreds.uid, getuid());
+    EXPECT_EQ(peerCreds.gid, getgid());
+    // accepted_socket closes here, releasing the child from its blocking read.
+  }
+
+  int status;
+  ASSERT_THAT(waitpid(child_pid, &status, 0),
+              SyscallSucceedsWithValue(child_pid));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "child exited abnormally: status=" << status;
 }
 
 }  // namespace


### PR DESCRIPTION
Previously, scmCredentials stored a *kernel.Task, from which the peer pid could be looked up when getsockopt() was called with SO_PEERCRED. However, if the peer had since died, the lookup would fail and the returned pid would be 0.

Instead, we should store a snapshot of the *pid*, not the Task pointer. The lookup should happen at open time, not at getsockopt() time.

This does mean that the returned pid may be stale, but this happens on Linux too, so userspace should know to avoid racy behavior with the returned PID.

Other things changed:
- Since the cred is a PID, not a TID, use the task group ID instead of task ID
- Add a test for SO_PEERCRED across a different PID namespace