### PR TITLE
fsconfig: don't require source= to be set

### DIFF
--- a/pkg/sentry/fsimpl/fsconfigfd/fsconfigfd.go
+++ b/pkg/sentry/fsimpl/fsconfigfd/fsconfigfd.go
@@ -284,9 +284,10 @@ func (fd *Fd) DoCmdCreate(ctx context.Context, vfsObj *vfs.VirtualFilesystem) er
 		return linuxerr.EBUSY
 	}
 
-	if fdContext.source == nil {
-		// Source was not specified
-		return linuxerr.EINVAL
+	// Default source to "" unless it was explicitly set
+	source := ""
+	if fdContext.source != nil {
+		source = *fdContext.source
 	}
 
 	// Check for CAP_SYS_ADMIN in the fd origin's user ns.
@@ -305,7 +306,7 @@ func (fd *Fd) DoCmdCreate(ctx context.Context, vfsObj *vfs.VirtualFilesystem) er
 	if err != nil {
 		return err
 	}
-	fs, root, err := vfsObj.NewFilesystem(ctx, creds, *fdContext.source, fdContext.fsName, opts)
+	fs, root, err := vfsObj.NewFilesystem(ctx, creds, source, fdContext.fsName, opts)
 	if err != nil {
 		// Transition into the failed state (i.e. no retries for this error)
 		fd.context = &failedContext{}

--- a/test/syscalls/linux/mount_fd.cc
+++ b/test/syscalls/linux/mount_fd.cc
@@ -216,16 +216,13 @@ TEST(FsConfigTest, FsConfigSetSourceTwice) {
 
 TEST(FsConfigTest, FsConfigCreateWithoutSource) {
   SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
-  // Note: Skipped on Linux because Linux tmpfs does not require a source.
-  // Currently, gVisor requires a source for all mounts.
-  SKIP_IF(!IsRunningOnGvisor());
 
   int fsfd = fsopen(kTmpfs, 0);
   ASSERT_THAT(fsfd, SyscallSucceeds());
   auto cleanup = Cleanup([&]() { close(fsfd); });
 
   EXPECT_THAT(fsconfig(fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0),
-              SyscallFailsWithErrno(EINVAL));
+              SyscallSucceeds());
 }
 
 TEST(FsConfigTest, FsConfigBadFilesystem) {


### PR DESCRIPTION
Linux requires this on a per-filesystem basis, and none of our filesystems require it (it's mainly used for block filesystems).

source="" is a reasonable default, and matches our mount(2) implementation as well.