### PR TITLE
fsconfig: silently accept FSCONFIG_CMD_RECONFIGURE

### DIFF
--- a/pkg/sentry/fsimpl/fsconfigfd/fsconfigfd.go
+++ b/pkg/sentry/fsimpl/fsconfigfd/fsconfigfd.go
@@ -183,16 +183,21 @@ type awaitingMountContext struct {
 	// Note that the filesystem-specific options have already been processed by
 	// FSCONFIG_CMD_CREATE, so only the mount-specific options are relevant here.
 	opts *vfs.MountOptions
+
+	// The credentials of the process that mounted the filesystem.
+	creds *auth.Credentials
 }
 
 func (awaitingMountContext) isFSContext() {}
 
-// doneContext represents a filesystem configuration context after fsmount(2) has been called.
-// TODO(b/513024543): this should be removed once reconfiguration support is added.
-type doneContext struct {
+// reconfParamsContext represents a filesystem configuration context after fsmount(2) has
+// been called.
+type reconfParamsContext struct {
+	// The credentials of the process that mounted the filesystem.
+	creds *auth.Credentials
 }
 
-func (doneContext) isFSContext() {}
+func (reconfParamsContext) isFSContext() {}
 
 // failedContext represents a filesystem configuration context after an operation has failed
 // and left an unrecoverable state.
@@ -241,31 +246,41 @@ func (fd *Fd) SetParam(key string, param FSParameter) error {
 	fd.contextMu.Lock()
 	defer fd.contextMu.Unlock()
 
-	fdContext, ok := fd.context.(*createParamsContext)
-	if !ok {
+	switch fdContext := fd.context.(type) {
+	case *createParamsContext:
+		// Filesystem has not been created yet
+
+		if key == "source" {
+			// source= is handled separately
+			source, ok := param.Value.(FSValueString)
+			if !ok {
+				// source= must be a string
+				return linuxerr.EINVAL
+			}
+			if fdContext.source != nil {
+				// source= can only be set once
+				return linuxerr.EINVAL
+			}
+			src := string(source)
+			fdContext.source = &src
+		} else if clearFlag, ok := clearFlags[key]; ok {
+			delete(fdContext.params, clearFlag)
+		} else {
+			// TODO(b/513024543): refactor filesystems to parse options at fsconfig() time
+			// rather than at mount time
+			fdContext.params[key] = param
+		}
+	case *reconfParamsContext:
+		// Filesystem has already been created: reconfiguration mode
+		if key == "source" {
+			// Cannot reconfigure source
+			return linuxerr.EINVAL
+		}
+
+		// TODO(gvisor.dev/issues/13450): properly support reconfiguration on underlying filesystems.
+	default:
 		// Filesystem context is in the wrong state to add a param
 		return linuxerr.EBUSY
-	}
-
-	if key == "source" {
-		// source= is handled separately
-		source, ok := param.Value.(FSValueString)
-		if !ok {
-			// source= must be a string
-			return linuxerr.EINVAL
-		}
-		if fdContext.source != nil {
-			// source= can only be set once
-			return linuxerr.EINVAL
-		}
-		src := string(source)
-		fdContext.source = &src
-	} else if clearFlag, ok := clearFlags[key]; ok {
-		delete(fdContext.params, clearFlag)
-	} else {
-		// TODO(b/513024543): refactor filesystems to parse options at fsconfig() time
-		// rather than at mount time
-		fdContext.params[key] = param
 	}
 
 	return nil
@@ -318,7 +333,32 @@ func (fd *Fd) DoCmdCreate(ctx context.Context, vfsObj *vfs.VirtualFilesystem) er
 		filesystem: fs,
 		root:       root,
 		opts:       opts,
+		creds:      creds,
 	}
+
+	return nil
+}
+
+// DoCmdReconfigure reconfigures the underlying filesystem with the parameters queued
+// up by fsconfig(2), including permission checks.
+// Currently a no-op.
+func (fd *Fd) DoCmdReconfigure(ctx context.Context, vfsObj *vfs.VirtualFilesystem) error {
+	fd.contextMu.Lock()
+	defer fd.contextMu.Unlock()
+
+	fdContext, ok := fd.context.(*reconfParamsContext)
+	if !ok {
+		// Filesystem context is in the wrong state to reconfigure the fs
+		return linuxerr.EBUSY
+	}
+
+	// Check for CAP_SYS_ADMIN in the fd origin's user ns.
+	creds := fdContext.creds
+	if !creds.HasSelfCapability(linux.CAP_SYS_ADMIN) {
+		return linuxerr.EPERM
+	}
+
+	// TODO(gvisor.dev/issues/13450): properly support reconfiguration on underlying filesystems.
 
 	return nil
 }
@@ -347,8 +387,10 @@ func (fd *Fd) GetFilesystem() (*vfs.Filesystem, *vfs.Dentry, *vfs.MountOptions, 
 	root := fdContext.root
 	opts := fdContext.opts
 
-	// Transition into doneContext
-	fd.context = &doneContext{}
+	// Transition into reconfParamsContext
+	fd.context = &reconfParamsContext{
+		creds: fdContext.creds,
+	}
 
 	return fs, root, opts, nil
 }

--- a/pkg/sentry/syscalls/linux/sys_mount_fd.go
+++ b/pkg/sentry/syscalls/linux/sys_mount_fd.go
@@ -144,18 +144,25 @@ func FSConfig(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintpt
 		return 0, nil, err
 	}
 
-	if cmd == linux.FSCONFIG_CMD_CREATE {
+	vfsObj := t.Kernel().VFS()
+	switch cmd {
+	case linux.FSCONFIG_CMD_CREATE:
 		// FSCONFIG_CMD_CREATE: create a detached mount
 
 		// CAP_SYS_ADMIN check performed in fsfd.DoCmdCreate().
-		vfsObj := t.Kernel().VFS()
 		err := fsfd.DoCmdCreate(t, vfsObj)
 		return 0, nil, err
+	case linux.FSCONFIG_CMD_RECONFIGURE:
+		// FSCONFIG_CMD_RECONFIGURE: reconfigure the underlying filesystem
+
+		// CAP_SYS_ADMIN check performed in fsfd.DoCmdReconfigure().
+		err := fsfd.DoCmdReconfigure(t, vfsObj)
+		return 0, nil, err
+	default:
+		return 0, nil, linuxerr.EINVAL
 	}
 
-	// TODO(b/513024543): support FSCONFIG_CMD_CREATE_EXCL and FSCONFIG_CMD_RECONFIGURE
-
-	return 0, nil, linuxerr.EINVAL
+	// TODO(b/513024543): support FSCONFIG_CMD_CREATE_EXCL
 }
 
 var fsmountValidAttrFlags = uint32(linux.MOUNT_ATTR_RDONLY | linux.MOUNT_ATTR_NOSUID | linux.MOUNT_ATTR_NODEV | linux.MOUNT_ATTR_NOEXEC | linux.MOUNT_ATTR__ATIME)

--- a/test/syscalls/linux/mount_fd.cc
+++ b/test/syscalls/linux/mount_fd.cc
@@ -273,7 +273,7 @@ TEST(FsConfigTest, FsConfigCreateTwice) {
 TEST(FsConfigTest, FsConfigUnsupportedCmds) {
   SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
   // Note: Skipped on Linux because gVisor currently does not support
-  // FSCONFIG_CMD_CREATE_EXCL or FSCONFIG_CMD_RECONFIGURE (returns EINVAL).
+  // FSCONFIG_CMD_CREATE_EXCL (returns EINVAL).
   SKIP_IF(!IsRunningOnGvisor());
 
   int fsfd = fsopen(kTmpfs, 0);
@@ -282,8 +282,38 @@ TEST(FsConfigTest, FsConfigUnsupportedCmds) {
 
   EXPECT_THAT(fsconfig(fsfd, FSCONFIG_CMD_CREATE_EXCL, NULL, NULL, 0),
               SyscallFailsWithErrno(EINVAL));
+}
+
+TEST(FsConfigTest, FsConfigReconfigureSucceeds) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  int fsfd = fsopen(kTmpfs, 0);
+  ASSERT_THAT(fsfd, SyscallSucceeds());
+  auto cleanup_fs = Cleanup([&]() { close(fsfd); });
+
+  EXPECT_THAT(fsconfig(fsfd, FSCONFIG_SET_STRING, "source", "my_source", 0),
+              SyscallSucceeds());
+  EXPECT_THAT(fsconfig(fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0),
+              SyscallSucceeds());
+
+  int mntfd =
+      fsmount(fsfd, FSMOUNT_CLOEXEC, 0);
+  ASSERT_THAT(mntfd, SyscallSucceeds());
+  auto cleanup_mnt = Cleanup([&]() { close(mntfd); });
+
+  EXPECT_THAT(fsconfig(fsfd, FSCONFIG_SET_FLAG, "ro", NULL, 0),
+              SyscallSucceeds());
+  EXPECT_THAT(fsconfig(fsfd, FSCONFIG_SET_STRING, "nr_inodes", "12345", 0),
+              SyscallSucceeds());
   EXPECT_THAT(fsconfig(fsfd, FSCONFIG_CMD_RECONFIGURE, NULL, NULL, 0),
-              SyscallFailsWithErrno(EINVAL));
+              SyscallSucceeds());
+
+	// TODO(gvisor.dev/issues/13450): once reconfiguration is properly supported
+  // on underlying filesystems, this test should be updated.
+  struct statfs st;
+  ASSERT_THAT(fstatfs(mntfd, &st), SyscallSucceeds());
+  EXPECT_NE(st.f_files, 12345);
+  EXPECT_NE(st.f_flags & ST_RDONLY, ST_RDONLY);
 }
 
 TEST(FsConfigTest, FsConfigUnsupportedTypes) {


### PR DESCRIPTION
systemd uses this for some trivial options (ro, noswap).

I had originally wanted a proper implementation, but as far as I can tell we have no logic to pass through reconfiguration data to underlying filesystems, so properly supporting this will be a big change.

RemountAt(), used by MS_REMOUNT, claims to pass data to the underlying fs, but it doesn't seem to do so. It only sets per-mount options, which are not applicable to FSCONFIG_CMD_RECONFIGURE.

For now, this behavior matches MS_REMOUNT.