### PR TITLE
Make /proc/sys/kernel/hostname and /proc/sys/kernel/domainname pollable

### DIFF
--- a/pkg/sentry/fsimpl/kernfs/BUILD
+++ b/pkg/sentry/fsimpl/kernfs/BUILD
@@ -148,6 +148,7 @@ go_library(
         "//pkg/sync",
         "//pkg/sync/locking",
         "//pkg/usermem",
+        "//pkg/waiter",
     ],
 )
 

--- a/pkg/sentry/fsimpl/kernfs/dynamic_bytes_file.go
+++ b/pkg/sentry/fsimpl/kernfs/dynamic_bytes_file.go
@@ -18,11 +18,13 @@ import (
 	"fmt"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/pkg/usermem"
+	"gvisor.dev/gvisor/pkg/waiter"
 )
 
 // DataSourceProvider represents a dynamic data source provider for DynamicBytesFile.
@@ -77,10 +79,25 @@ func (f *DynamicBytesFile) Open(ctx context.Context, rp *vfs.ResolvingPath, d *D
 	if err != nil {
 		return nil, err
 	}
+
+	if src, ok := data.(vfs.PollableDynamicBytesSource); ok {
+		if poller := src.GetDynamicBytesPoller(ctx); poller != nil {
+			// Pollable fd
+			fd := &PollableDynamicBytesFD{}
+			if err := fd.Init(rp.Mount(), d, data, &f.locks, opts.Flags, rp.Credentials(), poller); err != nil {
+				return nil, err
+			}
+
+			return &fd.vfsfd, nil
+		}
+	}
+
+	// Non-pollable fd
 	fd := &DynamicBytesFD{}
 	if err := fd.Init(rp.Mount(), d, data, &f.locks, opts.Flags, rp.Credentials()); err != nil {
 		return nil, err
 	}
+
 	return &fd.vfsfd, nil
 }
 
@@ -177,4 +194,56 @@ func (fd *DynamicBytesFD) Stat(ctx context.Context, opts vfs.StatOptions) (linux
 func (fd *DynamicBytesFD) SetStat(context.Context, vfs.SetStatOptions) error {
 	// DynamicBytesFiles are immutable.
 	return linuxerr.EPERM
+}
+
+// PollableDynamicBytesFD represents a DynamicBytesFD that can be monitored
+// for changes using select, poll, or epoll.
+//
+// +stateify savable
+type PollableDynamicBytesFD struct {
+	DynamicBytesFD
+
+	poller       *vfs.DynamicBytesPoller
+	pollSnapshot atomicbitops.Uint64
+}
+
+// Init initializes a PollableDynamicBytesFD.
+func (fd *PollableDynamicBytesFD) Init(m *vfs.Mount, d *Dentry, data vfs.DynamicBytesSource, locks *vfs.FileLocks, flags uint32, creds *auth.Credentials, poller *vfs.DynamicBytesPoller) error {
+	fd.LockFD.Init(locks)
+	if err := fd.vfsfd.Init(fd, flags, creds, m, d.VFSDentry(),
+		&vfs.FileDescriptionOptions{DenySpliceIn: true}); err != nil {
+		return err
+	}
+	fd.inode = d.inode
+	fd.DynamicBytesFileDescriptionImpl.Init(&fd.vfsfd, data)
+	fd.poller = poller
+	fd.pollSnapshot.Store(poller.Seq())
+	return nil
+}
+
+// Epollable implements FileDescriptionImpl.Epollable.
+func (fd *PollableDynamicBytesFD) Epollable() bool {
+	return true
+}
+
+// Readiness implements waiter.Waitable.Readiness.
+func (fd *PollableDynamicBytesFD) Readiness(mask waiter.EventMask) waiter.EventMask {
+	cur := fd.poller.Seq()
+	events := waiter.ReadableEvents | waiter.WritableEvents
+	if cur != fd.pollSnapshot.Load() {
+		fd.pollSnapshot.Store(cur)
+		events = waiter.ReadableEvents | vfs.DynamicBytesPollEvents
+	}
+	return events & mask
+}
+
+// EventRegister implements waiter.Waitable.EventRegister.
+func (fd *PollableDynamicBytesFD) EventRegister(e *waiter.Entry) error {
+	fd.poller.EventRegister(e)
+	return nil
+}
+
+// EventUnregister implements waiter.Waitable.EventUnregister.
+func (fd *PollableDynamicBytesFD) EventUnregister(e *waiter.Entry) {
+	fd.poller.EventUnregister(e)
 }

--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -200,6 +200,11 @@ func (*hostnameData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	return nil
 }
 
+// GetDynamicBytesPoller implements vfs.PollableDynamicBytesSource.GetDynamicBytesPoller.
+func (*hostnameData) GetDynamicBytesPoller(ctx context.Context) *vfs.DynamicBytesPoller {
+	return &kernel.KernelFromContext(ctx).HostNamePoller
+}
+
 // domainnameData implements vfs.DynamicBytesSource for /proc/sys/kernel/domainname.
 //
 // +stateify savable
@@ -231,6 +236,11 @@ var _ dynamicInode = (*uuidData)(nil)
 func (*uuidData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	buf.WriteString(randUUID())
 	return nil
+}
+
+// GetDynamicBytesPoller implements vfs.PollableDynamicBytesSource.GetDynamicBytesPoller.
+func (*domainnameData) GetDynamicBytesPoller(ctx context.Context) *vfs.DynamicBytesPoller {
+	return &kernel.KernelFromContext(ctx).DomainNamePoller
 }
 
 // tcpSackData implements vfs.WritableDynamicBytesSource for

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -440,6 +440,14 @@ type Kernel struct {
 	// protected by fsSaveMu.
 	fsSaveMu      fsSaveMutex  `state:"nosave"`
 	fsSaveWaiters []chan error `state:"nosave"`
+
+	// HostNamePoller is notified when the system hostname changes in *any*
+	// UTS namespace.
+	HostNamePoller vfs.DynamicBytesPoller
+
+	// DomainNamePoller is notified when the system domainname changes in *any*
+	// UTS namespace.
+	DomainNamePoller vfs.DynamicBytesPoller
 }
 
 // InitKernelArgs holds arguments to Init.

--- a/pkg/sentry/kernel/uts_namespace.go
+++ b/pkg/sentry/kernel/uts_namespace.go
@@ -78,11 +78,13 @@ func (u *UTSNamespace) HostName() string {
 }
 
 // SetHostName sets the host name of this UTS namespace.
-func (u *UTSNamespace) SetHostName(host string) {
+func (u *UTSNamespace) SetHostName(ctx context.Context, host string) {
 	u.mu.Lock()
-	defer u.mu.Unlock()
 	u.hostName = host
 	u.hostNameChanged = true
+	u.mu.Unlock()
+
+	KernelFromContext(ctx).HostNamePoller.Notify()
 }
 
 // DomainName returns the domain name of this UTS namespace.
@@ -93,11 +95,13 @@ func (u *UTSNamespace) DomainName() string {
 }
 
 // SetDomainName sets the domain name of this UTS namespace.
-func (u *UTSNamespace) SetDomainName(domain string) {
+func (u *UTSNamespace) SetDomainName(ctx context.Context, domain string) {
 	u.mu.Lock()
-	defer u.mu.Unlock()
 	u.domainName = domain
 	u.domainNameChanged = true
+	u.mu.Unlock()
+
+	KernelFromContext(ctx).DomainNamePoller.Notify()
 }
 
 // UserNamespace returns the user namespace associated with this UTS namespace.

--- a/pkg/sentry/syscalls/linux/sys_utsname.go
+++ b/pkg/sentry/syscalls/linux/sys_utsname.go
@@ -68,7 +68,7 @@ func Setdomainname(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (u
 		return 0, nil, err
 	}
 
-	utsns.SetDomainName(string(name))
+	utsns.SetDomainName(t, string(name))
 	return 0, nil, nil
 }
 
@@ -90,6 +90,6 @@ func Sethostname(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uin
 		return 0, nil, err
 	}
 
-	utsns.SetHostName(string(name))
+	utsns.SetHostName(t, string(name))
 	return 0, nil, nil
 }

--- a/pkg/sentry/vfs/file_description_impl_util.go
+++ b/pkg/sentry/vfs/file_description_impl_util.go
@@ -239,6 +239,47 @@ func (DentryMetadataFileDescriptionImpl) SetStat(ctx context.Context, opts SetSt
 	panic("illegal call to DentryMetadataFileDescriptionImpl.SetStat")
 }
 
+// DynamicBytesPollEvents represents the poll events that are triggered
+// when a dynamic bytes file is updated.
+const DynamicBytesPollEvents = waiter.EventPri | waiter.EventErr
+
+// DynamicBytesPoller represents a handle to notify a dynamic bytes file when
+// its data has been updated.
+//
+// +stateify savable
+type DynamicBytesPoller struct {
+	// queue is notified when the data has been updated
+	queue waiter.Queue
+
+	// seq is a counter that increases monotonically when
+	// the dynamic bytes file data is updated
+	seq atomicbitops.Uint64
+}
+
+// Notify is called to indicate that the data in the dynamic bytes file
+// should be reported to userspace as having changed.
+func (p *DynamicBytesPoller) Notify() {
+	p.seq.Add(1)
+	p.queue.Notify(waiter.ReadableEvents | DynamicBytesPollEvents)
+}
+
+// EventRegister passes through a waiter to the DynamicBytesPoller's
+// underlying queue.
+func (p *DynamicBytesPoller) EventRegister(e *waiter.Entry) {
+	p.queue.EventRegister(e)
+}
+
+// EventUnregister passes through a waiter unregistration to the
+// DynamicBytesPoller's underlying queue.
+func (p *DynamicBytesPoller) EventUnregister(e *waiter.Entry) {
+	p.queue.EventUnregister(e)
+}
+
+// Seq returns the current sequence number for the poller.
+func (p *DynamicBytesPoller) Seq() uint64 {
+	return p.seq.Load()
+}
+
 // DynamicBytesSource represents a data source for a
 // DynamicBytesFileDescriptionImpl.
 //
@@ -246,6 +287,13 @@ func (DentryMetadataFileDescriptionImpl) SetStat(ctx context.Context, opts SetSt
 type DynamicBytesSource interface {
 	// Generate writes the file's contents to buf.
 	Generate(ctx context.Context, buf *bytes.Buffer) error
+}
+
+// PollableDynamicBytesSource represents a data source for
+// a DynamicBytesFileDescriptionImpl that supports polling.
+type PollableDynamicBytesSource interface {
+	DynamicBytesSource
+	GetDynamicBytesPoller(ctx context.Context) *DynamicBytesPoller
 }
 
 // StaticData implements DynamicBytesSource over a static string.

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -2056,6 +2056,7 @@ cc_binary(
     deps = select_gtest() + [
         "//test/util:capability_util",
         "//test/util:cleanup",
+        "//test/util:epoll_util",
         "//test/util:eventfd_util",
         "//test/util:file_descriptor",
         "//test/util:fs_util",

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/epoll.h>
 #include <sys/mman.h>
 #include <sys/prctl.h>
 #include <sys/ptrace.h>
@@ -68,6 +69,7 @@
 #include "absl/time/time.h"
 #include "test/util/capability_util.h"
 #include "test/util/cleanup.h"
+#include "test/util/epoll_util.h"
 #include "test/util/eventfd_util.h"
 #include "test/util/file_descriptor.h"
 #include "test/util/fs_util.h"
@@ -2769,6 +2771,57 @@ TEST(ProcSysKernelHostname, MatchesUname) {
   EXPECT_EQ(procfs_hostname, hostname);
 }
 
+// Ensure that epoll triggers EPOLLERR when the hostname changes.
+TEST(ProcSysKernelHostname, EpollNotifiesOnChange) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  const FileDescriptor fd = ASSERT_NO_ERRNO_AND_VALUE(
+      Open("/proc/sys/kernel/hostname", O_RDONLY));
+  const FileDescriptor epfd = ASSERT_NO_ERRNO_AND_VALUE(NewEpollFD());
+  ASSERT_NO_ERRNO(RegisterEpollFD(epfd.get(), fd.get(), 0, 0));
+
+  constexpr char kNew[] = "epoll-hostname-test";
+  ASSERT_THAT(sethostname(kNew, sizeof(kNew) - 1), SyscallSucceeds());
+
+  struct epoll_event ev;
+  EXPECT_THAT(RetryEINTR(epoll_wait)(epfd.get(), &ev, 1, 5000),
+              SyscallSucceedsWithValue(1));
+  EXPECT_TRUE(ev.events & EPOLLERR);
+}
+
+// Same epoll test as above, but ensure that it works across multiple
+// FDs and does not re-trigger.
+TEST(ProcSysKernelHostname, EpollLatchesAndWakesAllSubscribers) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  const FileDescriptor fd1 = ASSERT_NO_ERRNO_AND_VALUE(
+      Open("/proc/sys/kernel/hostname", O_RDONLY));
+  const FileDescriptor fd2 = ASSERT_NO_ERRNO_AND_VALUE(
+      Open("/proc/sys/kernel/hostname", O_RDONLY));
+  const FileDescriptor epfd1 = ASSERT_NO_ERRNO_AND_VALUE(NewEpollFD());
+  const FileDescriptor epfd2 = ASSERT_NO_ERRNO_AND_VALUE(NewEpollFD());
+  ASSERT_NO_ERRNO(RegisterEpollFD(epfd1.get(), fd1.get(), 0, 0));
+  ASSERT_NO_ERRNO(RegisterEpollFD(epfd2.get(), fd2.get(), 0, 0));
+
+  constexpr char kNew[] = "epoll-latch-test";
+  ASSERT_THAT(sethostname(kNew, sizeof(kNew) - 1), SyscallSucceeds());
+
+  // Both subscribers wake on the single write.
+  struct epoll_event ev;
+  EXPECT_THAT(RetryEINTR(epoll_wait)(epfd1.get(), &ev, 1, 5000),
+              SyscallSucceedsWithValue(1));
+  EXPECT_TRUE(ev.events & EPOLLERR);
+  EXPECT_THAT(RetryEINTR(epoll_wait)(epfd2.get(), &ev, 1, 5000),
+              SyscallSucceedsWithValue(1));
+  EXPECT_TRUE(ev.events & EPOLLERR);
+
+  // No further write: neither subscriber refires.
+  EXPECT_THAT(RetryEINTR(epoll_wait)(epfd1.get(), &ev, 1, 100),
+              SyscallSucceedsWithValue(0));
+  EXPECT_THAT(RetryEINTR(epoll_wait)(epfd2.get(), &ev, 1, 100),
+              SyscallSucceedsWithValue(0));
+}
+
 TEST(ProcSysKernelDomainname, Exists) {
   EXPECT_THAT(open("/proc/sys/kernel/domainname", O_RDONLY), SyscallSucceeds());
 }
@@ -2780,6 +2833,23 @@ TEST(ProcSysKernelDomainname, MatchesUname) {
   auto procfs_domainname =
       ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/kernel/domainname"));
   EXPECT_EQ(procfs_domainname, domainname);
+}
+
+TEST(ProcSysKernelDomainname, EpollNotifiesOnChange) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  const FileDescriptor fd = ASSERT_NO_ERRNO_AND_VALUE(
+      Open("/proc/sys/kernel/domainname", O_RDONLY));
+  const FileDescriptor epfd = ASSERT_NO_ERRNO_AND_VALUE(NewEpollFD());
+  ASSERT_NO_ERRNO(RegisterEpollFD(epfd.get(), fd.get(), 0, 0));
+
+  constexpr char kNew[] = "epoll-domainname-test";
+  ASSERT_THAT(setdomainname(kNew, sizeof(kNew) - 1), SyscallSucceeds());
+
+  struct epoll_event ev;
+  EXPECT_THAT(RetryEINTR(epoll_wait)(epfd.get(), &ev, 1, 5000),
+              SyscallSucceedsWithValue(1));
+  EXPECT_TRUE(ev.events & EPOLLERR);
 }
 
 TEST(ProcSysKernelRandomUuid, Exists) {


### PR DESCRIPTION
Adds the infrastructure for a DynamicBytesFile to become pollable (perhaps with select, poll, or epoll). Simply arrange for a DynamicBytesPoller to be notified whenever the relevant file is updated and implement PollableDynamicBytesSource on the DynamicBytesSource.

EPOLLPRI and EPOLLERR are triggered for these files, which seems to match Linux's implementation for /proc/sys files.

The first two files to support this are hostname and domainname in /proc/sys/kernel. This is used by systemd-journald to monitor for hostname changes.