### PR TITLE
erofs: allow inline inodes that straddle a block boundary

### DIFF
--- a/pkg/erofs/erofs.go
+++ b/pkg/erofs/erofs.go
@@ -473,14 +473,20 @@ func (i *Image) Inode(nid uint64) (Inode, error) {
 
 	switch dataLayout := inode.DataLayout(); dataLayout {
 	case InodeDataLayoutFlatInline:
-		// Check that whether the file data in the last block fits into
-		// the remaining room of the metadata block.
+		// Inline data follows the inode and must fit within the block that holds
+		// it. The inode itself may straddle a block boundary, so measure the room
+		// from idataOff's offset within its block, not from blockSize-inodeSize.
+		//
+		// Linux also adds xattr_isize to inodeSize when locating the inline data.
+		// Safe to skip here because XattrCount != 0 is rejected above; revisit if
+		// EROFS xattr support is added.
+		idataOff := off + uint64(inodeSize)
 		tailSize := inode.size & (blockSize - 1)
-		if tailSize == 0 || tailSize > blockSize-uint64(inodeSize) {
+		if tailSize == 0 || (idataOff&(blockSize-1))+tailSize > blockSize {
 			log.Warningf("Inline data not found or cross block boundary at inode (nid=%v)", nid)
 			return Inode{}, linuxerr.EUCLEAN
 		}
-		inode.idataOff = off + uint64(inodeSize)
+		inode.idataOff = idataOff
 		fallthrough
 
 	case InodeDataLayoutFlatPlain:

--- a/pkg/erofs/erofs_test.go
+++ b/pkg/erofs/erofs_test.go
@@ -15,6 +15,8 @@
 package erofs
 
 import (
+	"bytes"
+	"os"
 	"testing"
 )
 
@@ -33,5 +35,68 @@ func TestOnDiskStructureSizes(t *testing.T) {
 
 	if d := new(Dirent); d.SizeBytes() != DirentSize {
 		t.Errorf("wrong dirent size: want %d, got %d", DirentSize, d.SizeBytes())
+	}
+}
+
+// TestInlineInodeStraddlingBlockBoundary checks that a FlatInline inode whose
+// extended inode straddles a block boundary (its inline tail begins in the next
+// block) is accepted, not rejected with EUCLEAN. erofs-utils >= 1.9 emits this
+// layout and the Linux kernel reads it.
+func TestInlineInodeStraddlingBlockBoundary(t *testing.T) {
+	const (
+		blockSize = 4096
+		nid       = 127  // off = nid<<InodeSlotBits = 4064: 32 bytes before block end
+		size      = 4050 // tail 4050 > blockSize-InodeExtendedSize (4032), but valid
+	)
+
+	img := make([]byte, 3*blockSize)
+
+	sb := SuperBlock{
+		Magic:         SuperBlockMagicV1,
+		BlockSizeBits: 12, // 4096
+		RootNid:       nid,
+		Blocks:        3,
+	}
+	sb.MarshalUnsafe(img[SuperBlockOffset:])
+
+	off := nid << InodeSlotBits
+	ino := InodeExtended{
+		Format: uint16(InodeLayoutExtended<<InodeLayoutBit | InodeDataLayoutFlatInline<<InodeDataLayoutBit),
+		Mode:   0x81a4, // S_IFREG | 0o644
+		Size:   size,
+		Nlink:  1,
+	}
+	ino.MarshalUnsafe(img[off:])
+
+	idataOff := off + InodeExtendedSize
+	want := make([]byte, size)
+	for i := range want {
+		want[i] = byte(i % 251)
+	}
+	copy(img[idataOff:], want)
+
+	f, err := os.CreateTemp(t.TempDir(), "erofs")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := f.Write(img); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	image, err := OpenImage(f) // takes ownership of f
+	if err != nil {
+		t.Fatalf("OpenImage: %v", err)
+	}
+	defer image.Close()
+
+	inode, err := image.Inode(nid)
+	if err != nil {
+		t.Fatalf("Inode(%d): %v", nid, err)
+	}
+	got, err := image.BytesAt(inode.idataOff, inode.size)
+	if err != nil {
+		t.Fatalf("BytesAt: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("inline data mismatch: got %d bytes, want %d", len(got), len(want))
 	}
 }


### PR DESCRIPTION
Fixes #13461.

`Image.Inode()` checked FlatInline data with `tailSize > blockSize - inodeSize`,
which assumes the inode starts at offset 0 of its block. erofs-utils >= 1.9 places
directory inodes at arbitrary offsets, so an inode can straddle a block boundary
and its inline tail legitimately begins in the next block. The Linux kernel and
`fsck.erofs` accept these images; gVisor rejected them with `EUCLEAN`.

Fix: use the kernel's actual rule — the inline data must fit within the block that
holds it: `(idataOff mod blockSize) + tailSize <= blockSize`. This only relaxes a
too-strict check; `idataOff` and all read paths are unchanged, so images that
already worked are unaffected.