### PR TITLE
(recreated so bot doesn't ask for a CLA for Claude)

### DIFF
--- a/pkg/sentry/platform/systrap/lib_arm64.s
+++ b/pkg/sentry/platform/systrap/lib_arm64.s
@@ -24,3 +24,9 @@ TEXT ·cputicks(SB),NOSPLIT,$0-8
 	WORD	$0xd53be040     //MRS	CNTVCT_EL0, R0
 	MOVD	R0, ret+0(FP)
 	RET
+
+TEXT ·getCNTFRQ(SB),NOSPLIT,$0-8
+	// Get the virtual counter frequency.
+	WORD	$0xd53be000     //MRS	CNTFRQ_EL0, R0
+	MOVD	R0, ret+0(FP)
+	RET

--- a/pkg/sentry/platform/systrap/shared_context.go
+++ b/pkg/sentry/platform/systrap/shared_context.go
@@ -296,18 +296,54 @@ type fastPathDispatcher struct {
 var dispatcher fastPathDispatcher
 
 const (
-	// deepSleepTimeout is the timeout after which both stub threads and the
-	// dispatcher consider whether to stop polling. They need to have elapsed
-	// this timeout twice in a row in order to stop, so the actual timeout
-	// can be considered to be (deepSleepTimeout*2). Falling asleep after two
-	// shorter timeouts instead of one long timeout is done in order to
-	// mitigate the effects of rdtsc inaccuracies.
+	// deepSleepTimeoutNS is the wall-clock duration after which both stub
+	// threads and the dispatcher consider whether to stop polling. They need to
+	// have elapsed this timeout twice in a row in order to stop, so the actual
+	// timeout can be considered to be (deepSleepTimeoutNS*2). Falling asleep
+	// after two shorter timeouts instead of one long timeout is done in order to
+	// mitigate the effects of cputicks() inaccuracies.
 	//
-	// The value is 20µs for 2GHz CPU. 40µs matches the sentry<->stub
+	// 20µs deep sleep means 40µs round trip, which matches the sentry<->stub
 	// round trip in the pure deep sleep case.
-	deepSleepTimeout = uint64(40000)
-	handshakeTimeout = uint64(1000)
+	deepSleepTimeoutNS = uint64(20000)
+
+	// handshakeTimeoutNS is the wall-clock duration after which the dispatcher
+	// kicks a stub thread that hasn't acknowledged a context yet.
+	handshakeTimeoutNS = uint64(500)
 )
+
+// deepSleepTimeout and handshakeTimeout are the deepSleepTimeoutNS and
+// handshakeTimeoutNS durations expressed in cputicks() units (the values
+// returned by the architecture's cycle counter: RDTSC on amd64, CNTVCT_EL0 on
+// arm64).
+//
+// They are zero until initSleepTimeouts() computes them, which happens before
+// any stub thread is created.
+//
+// The conversion is per-architecture because cputicks() advances at a
+// platform-specific fixed rate, unrelated to the CPU clock and not an
+// instruction/cycle counter: a ~GHz reference rate for the invariant TSC on
+// amd64, and CNTFRQ_EL0 for CNTVCT_EL0 on arm64, which varies widely across
+// parts -- from tens of MHz up to ~1GHz on newer cores. A single fixed tick
+// count therefore cannot express the same duration across platforms.
+var (
+	deepSleepTimeout uint64
+	handshakeTimeout uint64
+)
+
+// initSleepTimeouts converts deepSleepTimeoutNS and handshakeTimeoutNS from
+// wall-clock durations into cputicks() units using the measured frequency of
+// the cputicks() counter. It must be called once before any stub thread is
+// created.
+func initSleepTimeouts() {
+	// cputicksFreq() always returns a non-zero, arch-appropriate frequency:
+	// there is no meaningful cross-platform default, so each architecture is
+	// responsible for its own fallback.
+	freq := cputicksFreq()
+	const nsPerSec = uint64(1000000000)
+	deepSleepTimeout = max(1, freq*deepSleepTimeoutNS/nsPerSec)
+	handshakeTimeout = max(1, freq*handshakeTimeoutNS/nsPerSec)
+}
 
 // loop is processing contexts in the queue. Only one instance of it can be
 // running, because it has exclusive access to the list.

--- a/pkg/sentry/platform/systrap/systrap.go
+++ b/pkg/sentry/platform/systrap/systrap.go
@@ -298,6 +298,11 @@ func New(opts platform.Options) (*Systrap, error) {
 		// Don't use sentry and stub fast paths if here is just one cpu.
 		neverEnableFastPath = min(runtime.NumCPU(), runtime.GOMAXPROCS(0)) == 1
 
+		// Convert the spin/deep-sleep timeouts into cputicks() units for
+		// the current architecture. Must happen before stubInit(), which
+		// copies deepSleepTimeout into the stub.
+		initSleepTimeouts()
+
 		// Initialize the stub.
 		stubInit()
 

--- a/pkg/sentry/platform/systrap/systrap_amd64.go
+++ b/pkg/sentry/platform/systrap/systrap_amd64.go
@@ -22,6 +22,17 @@ func stackPointer(r *arch.Registers) uintptr {
 	return uintptr(r.Rsp)
 }
 
+// nominalTSCFreq is the assumed frequency in Hz of the x86 TSC read by
+// cputicks(). The TSC is invariant (it ticks at a fixed reference rate
+// independent of the core clock), but its exact frequency is not cheaply
+// discoverable, so cputicksFreq() assumes this nominal ~2GHz.
+const nominalTSCFreq = 2 * 1000 * 1000 * 1000
+
+// cputicksFreq returns the frequency in Hz of the counter read by cputicks().
+func cputicksFreq() uint64 {
+	return nominalTSCFreq
+}
+
 // x86 use the fs_base register to store the TLS pointer which can be
 // get/set in "func (t *thread) get/setRegs(regs *arch.Registers)".
 // So both of the get/setTLS() operations are noop here.

--- a/pkg/sentry/platform/systrap/systrap_arm64.go
+++ b/pkg/sentry/platform/systrap/systrap_arm64.go
@@ -19,6 +19,31 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 )
 
+// getCNTFRQ returns the frequency (in Hz) of the system counter read by
+// cputicks(), as reported by CNTFRQ_EL0.
+func getCNTFRQ() int64
+
+// typicalCNTFRQ is a fallback system counter frequency (24MHz, a common
+// reference-crystal value) used only if CNTFRQ_EL0 reads back as zero. The
+// architecture requires firmware to program CNTFRQ_EL0, so real hardware always
+// reports a non-zero value; this only guards against a misconfigured board.
+// Actual frequencies vary widely -- from tens of MHz up to ~1GHz on newer
+// cores -- so this is a best-effort guess, not a value that fits all hardware.
+const typicalCNTFRQ = 24 * 1000 * 1000
+
+// cputicksFreq returns the frequency in Hz of the counter read by cputicks().
+// On arm64 cputicks() reads CNTVCT_EL0, whose frequency is reported exactly by
+// CNTFRQ_EL0, so no calibration is needed. It always returns a non-zero value:
+// the sleep-timeout conversion needs a frequency, and there is no sane
+// cross-platform default (the counter rate is platform-specific and ranges from
+// tens of MHz to ~GHz), so the fallback must be arch-specific.
+func cputicksFreq() uint64 {
+	if freq := getCNTFRQ(); freq > 0 {
+		return uint64(freq)
+	}
+	return typicalCNTFRQ
+}
+
 func stackPointer(r *arch.Registers) uintptr {
 	return uintptr(r.Sp)
 }


### PR DESCRIPTION
AI usage: this description written by me, code and commit messages written by Claude with guidance and review, I'm reasonably sure it should be correct

Currently timeouts are expressed assuming that cputicks() ticks at 2 GHz. However, on ARM64 before ARMv8.6 it usually ticks at 16-50 MHz resulting in completely wrong timeouts.

This pull request fixes it by making the frequency per-platform and getting it from CNTVCT_EL0; amd64 is unchanged.

While this is an improvement over the current status and is within 2-3x of the correct values, I think further changes are desirable.

In particular, there needs to be a decision on whether the timeouts should be a constant amount of time or a constant amount of clock cycles.

If time is chosen, then the amd64 code should be fixed to not assume a 2GHz rdtsc, but figure out the actual frequency.

If cycles is chosen, then the arm64 code should be fixed to determine the CPU frequency and adjust accordingly and the general code should be fixed to rescale to use cycles instead of nanoseconds.

I didn't do either since this is the minimal fix and it's a 2-3x approximation anyway, and I'm not sure which is the one we want since I'm not familiar with the rationale for the choice of the timeouts.
