### PR TITLE
systrap: don't call controlFastPath when neverEnableFastPath is set

### DIFF
--- a/pkg/sentry/platform/systrap/systrap.go
+++ b/pkg/sentry/platform/systrap/systrap.go
@@ -322,9 +322,11 @@ func New(opts platform.Options) (*Systrap, error) {
 		return nil, stubErr
 	}
 
-	latencyMonitoring.Do(func() {
-		go controlFastPath()
-	})
+	if !neverEnableFastPath {
+		latencyMonitoring.Do(func() {
+			go controlFastPath()
+		})
+	}
 
 	return &Systrap{memoryFile: mf}, nil
 }


### PR DESCRIPTION
AI usage: written by Claude, reviewed by me

The controlFastPath code seems only useful when the fast path can possibly be enabled.
