### PR TITLE
systrap: Add --systrap-disable-fast-path option to disable the fast path

### DIFF
--- a/pkg/sentry/platform/platform.go
+++ b/pkg/sentry/platform/platform.go
@@ -584,6 +584,9 @@ type Options struct {
 	// syscalls invocations sites at runtime.
 	DisableSyscallPatching bool
 
+	// DisableFastPath, if true, completely disables the Systrap fast path.
+	DisableFastPath bool
+
 	// ApplicationCores is used by KVM to determine the correct amount of
 	// vCPUs to create.
 	ApplicationCores int

--- a/pkg/sentry/platform/systrap/systrap.go
+++ b/pkg/sentry/platform/systrap/systrap.go
@@ -295,8 +295,9 @@ func New(opts platform.Options) (*Systrap, error) {
 		// Configure address space parameters for the current host's
 		// VA width. Must be called before any Context64 is created.
 		configureSystrapAddressSpace()
-		// Don't use sentry and stub fast paths if here is just one cpu.
-		neverEnableFastPath = min(runtime.NumCPU(), runtime.GOMAXPROCS(0)) == 1
+		// Don't use sentry and stub fast paths if here is just one cpu,
+		// or if the fast path has been explicitly disabled.
+		neverEnableFastPath = opts.DisableFastPath || min(runtime.NumCPU(), runtime.GOMAXPROCS(0)) == 1
 
 		// Initialize the stub.
 		stubInit()

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -915,6 +915,7 @@ func createPlatform(conf *config.Config, numCPU int, deviceFile *fd.FD) (platfor
 	return p.New(platform.Options{
 		DeviceFile:             deviceFile,
 		DisableSyscallPatching: platformName == "systrap" && conf.SystrapDisableSyscallPatching,
+		DisableFastPath:        platformName == "systrap" && conf.SystrapDisableFastPath,
 		ApplicationCores:       numCPU,
 		UseCPUNums:             platformName == "kvm" && conf.UseCPUNums,
 	})

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -419,6 +419,9 @@ type Config struct {
 	// SystrapDisableSyscallPatching disables syscall patching in Systrap.
 	SystrapDisableSyscallPatching bool `flag:"systrap-disable-syscall-patching"`
 
+	// SystrapDisableFastPath disables the Systrap fast path entirely.
+	SystrapDisableFastPath bool `flag:"systrap-disable-fast-path"`
+
 	// Nftables enables support for nftables to be used instead of iptables.
 	Nftables bool `flag:"TESTONLY-nftables"`
 

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -118,6 +118,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Var(HostSettingsCheck.Ptr(), "host-settings", "how to handle non-optimal host kernel settings: check (default, advisory-only), ignore (do not check), adjust (best-effort auto-adjustment), or enforce (auto-adjustment must succeed).")
 	flagSet.Var(RestoreSpecValidationEnforce.Ptr(), "restore-spec-validation", "how to handle spec validation during restore.")
 	flagSet.Bool("systrap-disable-syscall-patching", false, "disables syscall patching when using the Systrap platform. May be necessary to use in case the workload uses the GS register, or uses ptrace within gVisor. Has significant performance implications and is only recommended when the sandbox is known to run otherwise-incompatible workloads. Only relevant for x86.")
+	flagSet.Bool("systrap-disable-fast-path", false, "unconditionally disables the Systrap fast path.")
 	flagSet.Bool("allow-suid", false, "allows ID elevation when executing binaries with the SUID/SGID bits set. The OCI --no-new-privileges flag continues to prevent ID elevation even when this flag is true.")
 	flagSet.Bool("kvm-use-cpu-nums", false, "on KVM use vCPU numbers as CPU numbers in the sentry. This is necessary to support features like rseq.")
 	flagSet.Bool("allow-rootfs-tar-annotation", false, "allows the rootfs tar annotation to be set.")


### PR DESCRIPTION
AI usage: written by Claude, reviewed by me, seems trivially correct

The fast path can increase CPU usage, so add a command line option that allows to unconditionally disable it

Asked for in #13361 
