### PR TITLE
runsc/boot: don't pre-assign loopback addresses in application netns

### DIFF
--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -1784,12 +1784,20 @@ func (c *sandboxNetstackCreator) CreateStack() (inet.Stack, error) {
 	}
 	link := DefaultLoopbackLink
 	linkEP := ethernet.New(loopback.New())
+
 	opts := stack.NICOptions{
 		Name:               link.Name,
 		DeliverLinkPackets: true,
 	}
 
-	if err := n.createNICWithAddrs(nicID, linkEP, opts, link.Addresses); err != nil {
+	// Linux creates the loopback interface in a freshly created network
+	// namespace in the DOWN state with no addresses assigned. Match that
+	// behavior: create the "lo" NIC without any addresses. The container
+	// application is responsible for assigning the loopback address and
+	// bringing the interface up (e.g. via "ip addr add" and "ip link set lo
+	// up"), just like on Linux. The initial network namespace is configured
+	// separately in Network.CreateLinksAndRoutes with addresses assigned
+	if err := n.createNICWithAddrs(nicID, linkEP, opts, nil /* addrs */); err != nil {
 		return nil, err
 	}
 

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4676,6 +4676,8 @@ cc_binary(
     malloc = "//test/util:errno_safe_allocator",
     deps = select_gtest() + [
         ":ip_socket_test_util",
+        ":socket_netlink_route_util",
+        ":socket_netlink_util",
         "//test/util:capability_util",
         "//test/util:file_descriptor",
         "//test/util:logging",

--- a/test/syscalls/linux/network_namespace.cc
+++ b/test/syscalls/linux/network_namespace.cc
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <netinet/in.h>
 #include <sys/mount.h>
 
 #include <cerrno>
@@ -19,6 +22,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "test/syscalls/linux/ip_socket_test_util.h"
+#include "test/syscalls/linux/socket_netlink_route_util.h"
+#include "test/syscalls/linux/socket_netlink_util.h"
 #include "test/util/capability_util.h"
 #include "test/util/file_descriptor.h"
 #include "test/util/linux_capability_util.h"
@@ -44,6 +49,34 @@ TEST(NetworkNamespaceTest, LoopbackExists) {
 
     // TODO(gvisor.dev/issue/1833): Update this to test that only "lo" exists.
     ASSERT_NE(ASSERT_NO_ERRNO_AND_VALUE(GetLoopbackIndex()), 0);
+  });
+}
+
+// In a freshly created network namespace, the application must be able to
+// configure the loopback interface itself: assigning the loopback address
+// (RTM_NEWADDR) and bringing the interface up (RTM_NEWLINK with IFF_UP) both
+// succeed, just like on Linux.
+// Test for bug #13438
+TEST(NetworkNamespaceTest, LoopbackConfigurable) {
+  // TODO(b/267210840): Fix this tests for hostinet.
+  SKIP_IF(IsRunningWithHostinet());
+
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
+
+  ScopedThread t([&] {
+    ASSERT_THAT(unshare(CLONE_NEWNET), SyscallSucceedsWithValue(0));
+
+    Link lo = ASSERT_NO_ERRNO_AND_VALUE(LoopbackLink());
+
+    // Assigning the loopback address must succeed (RTM_NEWADDR).
+    FileDescriptor fd =
+        ASSERT_NO_ERRNO_AND_VALUE(NetlinkBoundSocket(NETLINK_ROUTE));
+    const struct in_addr loopback_addr = {.s_addr = htonl(INADDR_LOOPBACK)};
+    EXPECT_NO_ERRNO(LinkAddLocalAddr(fd, lo.index, AF_INET, /*prefixlen=*/8,
+                                     &loopback_addr, sizeof(loopback_addr)));
+
+    // Bringing the interface up must succeed (RTM_NEWLINK with IFF_UP).
+    EXPECT_NO_ERRNO(LinkChangeFlags(lo.index, IFF_UP, IFF_UP));
   });
 }
 


### PR DESCRIPTION
AI usage: written by Claude, reviewed by me, seems correct

Linux creates the loopback interface in a new network namespaces with no addresses assigned, but gVisor created it with 127.0.0.1, causing bubblewrap to fail when trying to add it.

This commit changes the code to not assign the address.

The other discrepancy is that the interface is up while it's down in Linux, but this should be OK since requests to change the interface to up should not fail even if it's already up; however, it would be better to change this in future work and have it also start down.
