### PR TITLE
vfs: check umounted in CloneTreeToAnonNS

### DIFF
--- a/pkg/sentry/vfs/namespace.go
+++ b/pkg/sentry/vfs/namespace.go
@@ -257,6 +257,13 @@ func (vfs *VirtualFilesystem) CloneTreeToAnonNS(
 	// MS_UNBINDABLE mounts should be rejected here.
 
 	fsName := fromMnt.Filesystem().FilesystemType().Name()
+	// fromMnt must not have been detached from its mount tree (e.g. via
+	// umount(MNT_DETACH)). Note that fromMnt.ns is not cleared on detach,
+	// only fromMnt.umounted is set, so this must be checked independently
+	// of the namespace-membership check below.
+	if fromMnt.umounted {
+		return nil, linuxerr.EINVAL
+	}
 	// fromMnt must be either:
 	// - In the same mount ns as the current task
 	// - In an appropriate anonymous mount namespace

--- a/test/syscalls/linux/mount_fd.cc
+++ b/test/syscalls/linux/mount_fd.cc
@@ -730,6 +730,35 @@ TEST(OpenTreeTest, OpenTreeCloneNonRecursiveOnAttached) {
               SyscallFailsWithErrno(ENOENT));
 }
 
+TEST(OpenTreeTest, OpenTreeCloneFailsOnDetachedMount) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // Create a detached tmpfs mount fd via fsopen/fsmount (no path attachment).
+  int fsfd = fsopen(kTmpfs, 0);
+  ASSERT_THAT(fsfd, SyscallSucceeds());
+  auto cleanup_fs = Cleanup([&]() { close(fsfd); });
+  ASSERT_THAT(fsconfig(fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0),
+              SyscallSucceeds());
+  int mntfd = fsmount(fsfd, 0, 0);
+  ASSERT_THAT(mntfd, SyscallSucceeds());
+  auto cleanup_mnt = Cleanup([&]() { close(mntfd); });
+
+  // Attach the mount to a path and then detach it via MNT_DETACH while
+  // keeping the mount fd alive.
+  const TempPath dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  ASSERT_THAT(
+      move_mount(mntfd, "", AT_FDCWD, dir.path().c_str(),
+                 MOVE_MOUNT_F_EMPTY_PATH),
+      SyscallSucceeds());
+  ASSERT_THAT(umount2(dir.path().c_str(), MNT_DETACH), SyscallSucceeds());
+
+  // open_tree(OPEN_TREE_CLONE) on a mount that has already been detached via
+  // MNT_DETACH must fail with EINVAL, matching Linux. Regression test for
+  // CloneTreeToAnonNS() not checking Mount.umounted (gvisor.dev/issue/13481).
+  EXPECT_THAT(open_tree(mntfd, "", AT_EMPTY_PATH | OPEN_TREE_CLONE),
+              SyscallFailsWithErrno(EINVAL));
+}
+
 TEST(OpenTreeTest, OpenTreeCloneNonRecursiveOnDetached) {
   SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
 


### PR DESCRIPTION
CloneTreeToAnonNS validated namespace membership but did not check Mount.umounted. After umount2(MNT_DETACH), a mount's .umounted flag is set but .ns is not cleared until the last reference is dropped, so a detached-but-referenced mount passed the existing check and could be cloned via open_tree(OPEN_TREE_CLONE), then re-attached via move_mount(2) -- reversing the detach.

This mirrors the fix in 6a112c60a257dadac59962e0bc9e9b5aee70b5b6 for BindAt, ConnectMountAt, MoveMountAt, and propagateMount.

Fixes #13481