### PR TITLE
Add NVIDIA MPS support to nvproxy

### DIFF
--- a/pkg/abi/nvgpu/classes.go
+++ b/pkg/abi/nvgpu/classes.go
@@ -71,6 +71,7 @@ const (
 	NV50_THIRD_PARTY_P2P             = 0x0000503c
 	NV50_MEMORY_VIRTUAL              = 0x000050a0
 	GT200_DEBUGGER                   = 0x000083de
+	MPS_COMPUTE                      = 0x0000900e
 	FERMI_TWOD_A                     = 0x0000902d
 	FERMI_CONTEXT_SHARE_A            = 0x00009067
 	GF100_DISP_SW                    = 0x00009072

--- a/pkg/abi/nvgpu/ctrl.go
+++ b/pkg/abi/nvgpu/ctrl.go
@@ -382,9 +382,10 @@ type RmapiParamNvU32List struct {
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl0080/ctrl0080gr.h:
 const (
-	NV0080_CTRL_CMD_GR_GET_CAPS    = 0x801102
-	NV0080_CTRL_CMD_GR_GET_INFO    = 0x801104
-	NV0080_CTRL_CMD_GR_GET_CAPS_V2 = 0x801109
+	NV0080_CTRL_CMD_GR_GET_CAPS               = 0x801102
+	NV0080_CTRL_CMD_GR_GET_INFO               = 0x801104
+	NV0080_CTRL_CMD_GR_SET_TPC_PARTITION_MODE = 0x801108
+	NV0080_CTRL_CMD_GR_GET_CAPS_V2            = 0x801109
 )
 
 // NV0080_CTRL_GET_CAPS_PARAMS is used to represent the following:

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -370,6 +370,7 @@ func Init() {
 					nvgpu.NV0080_CTRL_CMD_GPU_GET_CLASSLIST:                                ctrlHandler(ctrlGetNvU32List, compUtil),
 					nvgpu.NV0080_CTRL_CMD_GR_GET_CAPS:                                      ctrlHandler(ctrlDevGetCaps, nvconf.CapGraphics),
 					nvgpu.NV0080_CTRL_CMD_GR_GET_CAPS_V2:                                   ctrlHandler(rmControlSimple, nvconf.CapGraphics|nvconf.CapVideo),
+					nvgpu.NV0080_CTRL_CMD_GR_SET_TPC_PARTITION_MODE:                        ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV0080_CTRL_CMD_GR_GET_INFO:                                      ctrlHandler(ctrlIoctlHasInfoList[nvgpu.NvxxxCtrlXxxGetInfoParams], nvconf.CapGraphics),
 					nvgpu.NV0080_CTRL_CMD_FB_GET_CAPS:                                      ctrlHandler(ctrlDevGetCaps, nvconf.CapGraphics),
 					nvgpu.NV0080_CTRL_CMD_FIFO_GET_CAPS:                                    ctrlHandler(ctrlDevGetCaps, nvconf.CapGraphics),
@@ -420,6 +421,7 @@ func Init() {
 					nvgpu.GF100_PROFILER:             allocHandler(rmAllocNoParams, nvconf.CapProfiling),
 					nvgpu.MAXWELL_PROFILER_DEVICE:    allocHandler(rmAllocSimple[nvgpu.NVB2CC_ALLOC_PARAMETERS], nvconf.CapProfiling),
 					nvgpu.NV_COUNTER_COLLECTION_UNIT: allocHandler(rmAllocNoParams, nvconf.CapProfiling),
+					nvgpu.MPS_COMPUTE:                allocHandler(rmAllocNoParams, compUtil),
 					nvgpu.GT200_DEBUGGER:             allocHandler(rmAllocSMDebuggerSession, compUtil),
 					nvgpu.FERMI_TWOD_A:               allocHandler(rmAllocSimple[nvgpu.NV_GR_ALLOCATION_PARAMETERS], nvconf.CapGraphics),
 					nvgpu.FERMI_CONTEXT_SHARE_A:      allocHandler(rmAllocContextShare, compUtil),
@@ -682,6 +684,7 @@ func Init() {
 							nvgpu.NV0080_CTRL_CMD_GPU_GET_CLASSLIST:                                ioctlInfoWithStructName("NV0080_CTRL_CMD_GPU_GET_CLASSLIST", nvgpu.RmapiParamNvU32List{}, "NV0080_CTRL_GPU_GET_CLASSLIST_PARAMS"),
 							nvgpu.NV0080_CTRL_CMD_GR_GET_CAPS:                                      ioctlInfoWithStructName("NV0080_CTRL_CMD_GR_GET_CAPS", nvgpu.NV0080_CTRL_GET_CAPS_PARAMS{}, "NV0080_CTRL_GR_GET_CAPS_PARAMS"),
 							nvgpu.NV0080_CTRL_CMD_GR_GET_CAPS_V2:                                   simpleIoctlInfo("NV0080_CTRL_CMD_GR_GET_CAPS_V2", "NV0080_CTRL_GR_GET_CAPS_V2_PARAMS"),
+							nvgpu.NV0080_CTRL_CMD_GR_SET_TPC_PARTITION_MODE:                        simpleIoctlInfo("NV0080_CTRL_CMD_GR_SET_TPC_PARTITION_MODE", "NV0080_CTRL_GR_TPC_PARTITION_MODE_PARAMS"),
 							nvgpu.NV0080_CTRL_CMD_GR_GET_INFO:                                      ioctlInfoWithStructName("NV0080_CTRL_CMD_GR_GET_INFO", nvgpu.NvxxxCtrlXxxGetInfoParams{}, "NV0080_CTRL_GR_GET_INFO_PARAMS"),
 							nvgpu.NV0080_CTRL_CMD_FB_GET_CAPS:                                      ioctlInfoWithStructName("NV0080_CTRL_CMD_FB_GET_CAPS", nvgpu.NV0080_CTRL_GET_CAPS_PARAMS{}, "NV0080_CTRL_FB_GET_CAPS_PARAMS"),
 							nvgpu.NV0080_CTRL_CMD_FIFO_GET_CAPS:                                    ioctlInfoWithStructName("NV0080_CTRL_CMD_FIFO_GET_CAPS", nvgpu.NV0080_CTRL_GET_CAPS_PARAMS{}, "NV0080_CTRL_FIFO_GET_CAPS_PARAMS"),
@@ -733,6 +736,7 @@ func Init() {
 							nvgpu.GF100_PROFILER:             simpleIoctlInfo("GF100_PROFILER"), // No params
 							nvgpu.MAXWELL_PROFILER_DEVICE:    ioctlInfo("MAXWELL_PROFILER_DEVICE", nvgpu.NVB2CC_ALLOC_PARAMETERS{}),
 							nvgpu.NV_COUNTER_COLLECTION_UNIT: simpleIoctlInfo("NV_COUNTER_COLLECTION_UNIT"), // No params
+							nvgpu.MPS_COMPUTE:                simpleIoctlInfo("MPS_COMPUTE"),                // No params
 							nvgpu.FERMI_TWOD_A:               ioctlInfo("FERMI_TWOD_A", nvgpu.NV_GR_ALLOCATION_PARAMETERS{}),
 							nvgpu.FERMI_CONTEXT_SHARE_A:      ioctlInfo("FERMI_CONTEXT_SHARE_A", nvgpu.NV_CTXSHARE_ALLOCATION_PARAMETERS{}),
 							nvgpu.GF100_DISP_SW:              ioctlInfo("GF100_DISP_SW", nvgpu.NV9072_ALLOCATION_PARAMETERS{}),


### PR DESCRIPTION
Adds the two missing `ioctls` required to run [MPS (Multi-Process Service)](https://docs.nvidia.com/deploy/mps/latest/index.html):

- **`MPS_COMPUTE`** (`0x900e`) allocation class — the per-client MPS object that the MPS server allocates root client
- **`NV0080_CTRL_CMD_GR_SET_TPC_PARTITION_MODE`** (`0x801108`) control command, with its `NV0080_CTRL_GR_TPC_PARTITION_MODE_PARAMS` struct — used by the MPS server to set TPC partitioning (e.g. the "Active Thread Percentage" provisioning).

MPS is used by certain applications to manage GPU concurrency inside containers.