### PR TITLE
kernel: stop Timekeeper from waking the host while idle

### DIFF
--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1535,6 +1535,14 @@ func (k *Kernel) incRunningTasks() {
 			// their CPU usage.
 			k.cpuClockTickerRunning = true
 			k.runningTasksCond.Signal()
+
+			// The Timekeeper's updater goroutine parks together with the CPU
+			// clock ticker (see Kernel.runCPUClockTicker()), so resume it here.
+			// notifyActive also refreshes the clock parameters synchronously on
+			// this task goroutine if they have gone stale while paused, before
+			// the task can return to userspace and read the VDSO, so that it
+			// never observes stale clock data.
+			k.timekeeper.notifyActive(k.vdsoParams)
 		}
 		// This store must happen after the increment of k.cpuClock above to ensure
 		// that concurrent calls to Task.accountTaskGoroutineLeave() also observe

--- a/pkg/sentry/kernel/task_sched.go
+++ b/pkg/sentry/kernel/task_sched.go
@@ -206,6 +206,11 @@ func (k *Kernel) runCPUClockTicker() {
 			if k.runningTasks.Load() == 0 {
 				k.cpuClockTickerRunning = false
 				k.cpuClockTickerStopCond.Broadcast()
+				// Nothing can read the VDSO clock parameters while no tasks
+				// are running, so let the Timekeeper's updater goroutine park
+				// instead of waking up periodically. It is reactivated by
+				// Kernel.incRunningTasks() via Timekeeper.notifyActive().
+				k.timekeeper.markIdle()
 				k.runningTasksCond.Wait()
 				// k.cpuClockTickerRunning was set to true by our waker
 				// (Kernel.incRunningTasks()). For reasons described there, we must

--- a/pkg/sentry/kernel/timekeeper.go
+++ b/pkg/sentry/kernel/timekeeper.go
@@ -26,6 +26,23 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip"
 )
 
+// Run states of the Timekeeper's updater goroutine, held atomically in
+// Timekeeper.updaterState.
+const (
+	// updaterActive indicates that tasks are running, so the updater goroutine
+	// refreshes the clock parameters periodically.
+	updaterActive int32 = iota
+
+	// updaterIdle indicates that no tasks are running; the updater goroutine
+	// should park at its next opportunity. Set by markIdle.
+	updaterIdle
+
+	// updaterParked indicates that the updater goroutine has committed to
+	// parking and stopped refreshing. Set by the goroutine; cleared back to
+	// updaterActive by notifyActive, which refreshes on its behalf.
+	updaterParked
+)
+
 // Timekeeper manages all of the kernel clocks.
 //
 // +stateify savable
@@ -81,11 +98,33 @@ type Timekeeper struct {
 	// mu protects destruction with stop and wg.
 	mu sync.Mutex `state:"nosave"`
 
-	// stop is used to tell the update goroutine to exit.
+	// stop is closed to tell the updater goroutine to exit. It is also selected
+	// on while parked, so closing it wakes a parked goroutine.
 	stop chan struct{} `state:"nosave"`
 
 	// wg is used to indicate that the update goroutine has exited.
 	wg sync.WaitGroup `state:"nosave"`
+
+	// updaterState is the run state of the updater goroutine (one of
+	// updaterActive, updaterIdle, updaterParked). All transitions are atomic,
+	// which keeps the goroutine's "commit to park" race-free against
+	// notifyActive's "is it parked" without a lock — so markIdle never blocks.
+	updaterState atomicbitops.Int32 `state:"nosave"`
+
+	// updateMu serializes a refresh with arming the timer for the next one, so
+	// the VDSO parameter page (single writer) is never written twice at once.
+	// notifyActive refreshes only while the goroutine is parked, having armed the
+	// timer that wakes it a full interval later, so the goroutine's own refresh
+	// normally comes well after. updateMu only matters if notifyActive is
+	// descheduled between arming and refreshing past that interval, where it makes
+	// the woken goroutine wait. markIdle does not take it, so it never blocks.
+	updateMu sync.Mutex `state:"nosave"`
+
+	// timer fires when the next periodic refresh is due, and is also how the
+	// parked goroutine is woken: while parked it blocks in a select on timer.C
+	// with the timer unarmed (so it never fires); notifyActive re-arms it, and
+	// the goroutine wakes when it next fires.
+	timer *time.Timer `state:"nosave"`
 }
 
 // NewTimekeeper returns a Timekeeper that is automatically kept up-to-date.
@@ -170,6 +209,36 @@ func (t *Timekeeper) SetClocks(c sentrytime.Clocks, params *VDSOParamPage) {
 	}
 }
 
+// update samples the backing clocks and writes the new parameters to the VDSO
+// parameter page.
+//
+// Preconditions: updateMu must be held (the VDSO parameter page has a single
+// writer; see updateMu).
+func (t *Timekeeper) update(params *VDSOParamPage) {
+	// Call Update within a Write block to prevent the VDSO from using the old
+	// params between Update and Write.
+	if err := params.Write(func() vdsoParams {
+		monotonicParams, monotonicOk, realtimeParams, realtimeOk := t.clocks.Update()
+
+		var p vdsoParams
+		if monotonicOk {
+			p.monotonicReady = 1
+			p.monotonicBaseCycles = int64(monotonicParams.BaseCycles)
+			p.monotonicBaseRef = int64(monotonicParams.BaseRef) + t.monotonicOffset
+			p.monotonicFrequency = monotonicParams.Frequency
+		}
+		if realtimeOk {
+			p.realtimeReady = 1
+			p.realtimeBaseCycles = int64(realtimeParams.BaseCycles)
+			p.realtimeBaseRef = int64(realtimeParams.BaseRef)
+			p.realtimeFrequency = realtimeParams.Frequency
+		}
+		return p
+	}); err != nil {
+		log.Warningf("Unable to update VDSO parameter page: %v", err)
+	}
+}
+
 // startUpdater starts an update goroutine that keeps the clocks updated.
 //
 // mu must be held.
@@ -179,6 +248,7 @@ func (t *Timekeeper) startUpdater(params *VDSOParamPage) {
 		return
 	}
 	t.stop = make(chan struct{})
+	t.updaterState.Store(updaterActive)
 
 	// Keep the clocks up to date.
 	//
@@ -186,45 +256,86 @@ func (t *Timekeeper) startUpdater(params *VDSOParamPage) {
 	// timer, so it may run at a *slightly* different rate from the
 	// application CLOCK_MONOTONIC. That is fine, as we only need to update
 	// at approximately this rate.
-	timer := time.NewTicker(sentrytime.ApproxUpdateInterval)
+	//
+	// To avoid waking up the host periodically when nothing can read the
+	// clock, the updater parks itself while no tasks are running (see
+	// markIdle): while parked it leaves the timer unarmed, so the select below
+	// blocks with no host timer pending. notifyActive re-arms the timer when a
+	// task becomes runnable, which both wakes this select and schedules the next
+	// tick, and refreshes the params synchronously so the resuming task never
+	// observes stale data.
+	t.timer = time.NewTimer(sentrytime.ApproxUpdateInterval)
 	t.wg.Add(1)
 	go func() { // S/R-SAFE: stopped during save.
 		defer t.wg.Done()
+		defer t.timer.Stop()
 		for {
-			// Start with an update immediately, so the clocks are
-			// ready ASAP.
-
-			// Call Update within a Write block to prevent the VDSO
-			// from using the old params between Update and
-			// Write.
-			if err := params.Write(func() vdsoParams {
-				monotonicParams, monotonicOk, realtimeParams, realtimeOk := t.clocks.Update()
-
-				var p vdsoParams
-				if monotonicOk {
-					p.monotonicReady = 1
-					p.monotonicBaseCycles = int64(monotonicParams.BaseCycles)
-					p.monotonicBaseRef = int64(monotonicParams.BaseRef) + t.monotonicOffset
-					p.monotonicFrequency = monotonicParams.Frequency
-				}
-				if realtimeOk {
-					p.realtimeReady = 1
-					p.realtimeBaseCycles = int64(realtimeParams.BaseCycles)
-					p.realtimeBaseRef = int64(realtimeParams.BaseRef)
-					p.realtimeFrequency = realtimeParams.Frequency
-				}
-				return p
-			}); err != nil {
-				log.Warningf("Unable to update VDSO parameter page: %v", err)
+			// If our CAS fails, a task is running (state is active): arm the timer
+			// for the next tick before refreshing, so the cadence is anchored to
+			// now rather than pushed out by the refresh (or a preemption during
+			// it). The first iteration makes the clocks ready ASAP.
+			//
+			// If the CAS succeeds, no task is running, so nothing can read the
+			// params: we park by leaving the timer unarmed (it was drained by the
+			// previous iteration's receive), and the select below blocks until
+			// notifyActive re-arms it. No host timer is armed while parked.
+			if !t.updaterState.CompareAndSwap(updaterIdle, updaterParked) {
+				t.updateMu.Lock()
+				t.timer.Reset(sentrytime.ApproxUpdateInterval)
+				t.update(params)
+				t.updateMu.Unlock()
 			}
 
+			// Wait for the next tick (or, if parked, until notifyActive arms the
+			// timer), draining timer.C so the next park starts unarmed.
 			select {
-			case <-timer.C:
+			case <-t.timer.C:
 			case <-t.stop:
 				return
 			}
 		}
 	}()
+}
+
+// notifyActive ensures the clock parameters are up to date and wakes the
+// updater goroutine if it is parked.
+//
+// It must be called when a task becomes runnable after the sentry has been
+// idle, on the task goroutine and before the task can read the clock, so that
+// the task never observes stale clock parameters (which may have drifted while
+// idle, since updates were paused). params must be the same VDSOParamPage that
+// was passed to SetClocks.
+func (t *Timekeeper) notifyActive(params *VDSOParamPage) {
+	// Mark the updater active and learn its previous state. The atomic swap is
+	// race-free against the goroutine committing to park: either it set parked
+	// before this swap (we observe updaterParked and refresh on its behalf), or
+	// its CAS(idle -> parked) loses to this swap and it refreshes itself.
+	if t.updaterState.Swap(updaterActive) != updaterParked {
+		// The updater is still cycling, so the parameters are at most one update
+		// interval old already — the same freshness the periodic updater provides
+		// — and it will keep refreshing on its own. Nothing to do, and we avoid
+		// an update on what may be a frequent wakeup path.
+		return
+	}
+
+	// The updater was parked: updates were paused and the parameters may have
+	// drifted. Under updateMu, arm the timer — which schedules the next tick and,
+	// one interval out, wakes the parked goroutine — then refresh synchronously,
+	// on this task goroutine, before it can read the clock. The goroutine wakes an
+	// interval from now, so it normally won't contend for updateMu; the lock only
+	// matters if we're descheduled here past that interval, when it serializes the
+	// goroutine's refresh after ours rather than letting them write concurrently.
+	t.updateMu.Lock()
+	t.timer.Reset(sentrytime.ApproxUpdateInterval)
+	t.update(params)
+	t.updateMu.Unlock()
+}
+
+// markIdle indicates that no tasks are running, allowing the updater goroutine
+// to park rather than continue updating clock parameters that nothing can read.
+// The updater is reactivated by notifyActive.
+func (t *Timekeeper) markIdle() {
+	t.updaterState.CompareAndSwap(updaterActive, updaterIdle)
 }
 
 // stopUpdater stops the update goroutine, blocking until it exits.
@@ -236,6 +347,8 @@ func (t *Timekeeper) stopUpdater() {
 		return
 	}
 
+	// Closing stop tells the goroutine to exit and wakes it if it is parked,
+	// since the park and tick selects both wait on stop.
 	close(t.stop)
 	t.wg.Wait()
 	t.stop = nil


### PR DESCRIPTION
AI usage: code written by Claude, with extensive guidance and lots of back-and-forth to end up with the simplest possible code. I believe it's correct, provided that starting and stopping the timekeeper at that place (same as the existing CPU clock ticker) is indeed correct.

Current gVisor timekeeper unconditionally wakes up every second to update the vDSO clock parameters. This change makes it so that this doesn't happen when nothing is running, making sure that when tasks become running again, the vDSO is updated synchronously before we run them.
