### PR TITLE
getsockopt(2): only copy out data up to optLen bytes

### DIFF
--- a/pkg/sentry/socket/netlink/socket.go
+++ b/pkg/sentry/socket/netlink/socket.go
@@ -516,29 +516,20 @@ func (s *Socket) Shutdown(t *kernel.Task, how int) *syserr.Error {
 }
 
 // GetSockOpt implements socket.Socket.GetSockOpt.
-func (s *Socket) GetSockOpt(t *kernel.Task, level int, name int, outPtr hostarch.Addr, outLen int) (marshal.Marshallable, *syserr.Error) {
+func (s *Socket) GetSockOpt(t *kernel.Task, level int, name int, outPtr hostarch.Addr, _ int) (marshal.Marshallable, *syserr.Error) {
 	switch level {
 	case linux.SOL_SOCKET:
 		switch name {
 		case linux.SO_SNDBUF:
-			if outLen < sizeOfInt32 {
-				return nil, syserr.ErrInvalidArgument
-			}
 			s.mu.Lock()
 			defer s.mu.Unlock()
 			return primitive.AllocateInt32(int32(s.sendBufferSize)), nil
 
 		case linux.SO_RCVBUF:
-			if outLen < sizeOfInt32 {
-				return nil, syserr.ErrInvalidArgument
-			}
 			// We don't have limit on receiving size.
 			return primitive.AllocateInt32(math.MaxInt32), nil
 
 		case linux.SO_PASSCRED:
-			if outLen < sizeOfInt32 {
-				return nil, syserr.ErrInvalidArgument
-			}
 			var passcred primitive.Int32
 			if s.Passcred() {
 				passcred = 1
@@ -546,25 +537,16 @@ func (s *Socket) GetSockOpt(t *kernel.Task, level int, name int, outPtr hostarch
 			return &passcred, nil
 
 		case linux.SO_SNDTIMEO:
-			if outLen < linux.SizeOfTimeval {
-				return nil, syserr.ErrInvalidArgument
-			}
 			sendTimeout := linux.NsecToTimeval(s.SendTimeout())
 			return &sendTimeout, nil
 
 		case linux.SO_RCVTIMEO:
-			if outLen < linux.SizeOfTimeval {
-				return nil, syserr.ErrInvalidArgument
-			}
 			recvTimeout := linux.NsecToTimeval(s.RecvTimeout())
 			return &recvTimeout, nil
 		}
 	case linux.SOL_NETLINK:
 		switch name {
 		case linux.NETLINK_LIST_MEMBERSHIPS:
-			if outLen < sizeOfInt32 {
-				return nil, syserr.ErrInvalidArgument
-			}
 			return primitive.AllocateUint64(s.groups.Load()), nil
 
 		case linux.NETLINK_BROADCAST_ERROR,

--- a/pkg/sentry/syscalls/linux/sys_socket.go
+++ b/pkg/sentry/syscalls/linux/sys_socket.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
@@ -479,8 +480,9 @@ func GetSockOpt(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uint
 		return 0, nil, err
 	}
 
-	if v != nil {
-		if _, err := v.CopyOut(t, optValAddr); err != nil {
+	if optLen != 0 {
+		n := min(int(optLen), v.SizeBytes())
+		if _, err := v.CopyOutN(t, optValAddr, n); err != nil {
 			return 0, nil, err
 		}
 	}

--- a/test/syscalls/linux/socket_netlink_route.cc
+++ b/test/syscalls/linux/socket_netlink_route.cc
@@ -119,6 +119,99 @@ INSTANTIATE_TEST_SUITE_P(
                         absl::StrFormat("NETLINK_ROUTE (%d)", NETLINK_ROUTE)),
         std::make_tuple(SO_PASSCRED, IsEqual(0), "0")));
 
+PosixErrorOr<FileDescriptor> netlinkRouteSocketInLinkGroup() {
+  ASSIGN_OR_RETURN_ERRNO(FileDescriptor fd, NetlinkBoundSocket(NETLINK_ROUTE));
+  const unsigned int group = RTNLGRP_LINK;
+  RETURN_ERROR_IF_SYSCALL_FAIL(setsockopt(
+      fd.get(), SOL_NETLINK, NETLINK_ADD_MEMBERSHIP, &group, sizeof(group)));
+  return fd;
+}
+
+// NETLINK_LIST_MEMBERSHIPS returns the output length when optval is not
+// specified.
+TEST(NetlinkRouteTest, ListMembershipsSizeProbe) {
+  SKIP_IF(IsRunningWithHostinet());
+
+  FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(netlinkRouteSocketInLinkGroup());
+
+  socklen_t len = 0;
+  EXPECT_THAT(getsockopt(fd.get(), SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS,
+                         nullptr, &len),
+              SyscallSucceeds());
+  EXPECT_GT(len, 0);
+}
+
+// A buffer larger than the value succeeds; optlen is updated to the actual
+// size, which fits within the provided buffer.
+TEST(NetlinkRouteTest, ListMembershipsLargeBuffer) {
+  SKIP_IF(IsRunningWithHostinet());
+
+  FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(netlinkRouteSocketInLinkGroup());
+
+  // Fetch the real length
+  socklen_t len = 0;
+  EXPECT_THAT(getsockopt(fd.get(), SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS,
+                         nullptr, &len),
+              SyscallSucceeds());
+  EXPECT_GT(len, 0);
+
+  // And make a buffer larger than that
+  socklen_t new_len = len + 10;
+  std::vector<char> buf(new_len, 0);
+
+  EXPECT_THAT(getsockopt(fd.get(), SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS,
+                         buf.data(), &new_len),
+              SyscallSucceeds());
+  EXPECT_EQ(len, new_len);
+
+  // First len elements were set (some may be zero, so all we can do is test
+  // that they're not *all* 0).
+  EXPECT_FALSE(
+      std::all_of(buf.begin(), buf.end() - 10, [](char c) { return c == 0; }));
+  // Last 10 elements were not touched
+  EXPECT_TRUE(
+      std::all_of(buf.begin() + len, buf.end(), [](char c) { return c == 0; }));
+}
+
+// A buffer smaller than the value is truncated to optlen bytes, but optlen is
+// still updated to the full size.
+TEST(NetlinkRouteTest, ListMembershipsTruncated) {
+  SKIP_IF(IsRunningWithHostinet());
+
+  FileDescriptor fd =
+      ASSERT_NO_ERRNO_AND_VALUE(netlinkRouteSocketInLinkGroup());
+
+  // Fetch the real length
+  socklen_t len = 0;
+  EXPECT_THAT(getsockopt(fd.get(), SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS,
+                         nullptr, &len),
+              SyscallSucceeds());
+
+  // Make a smaller buffer
+  ASSERT_GE(len, 2);
+  socklen_t new_len = len / 2;
+  std::vector<char> buf(new_len, 0);
+
+  int ret = getsockopt(fd.get(), SOL_NETLINK, NETLINK_LIST_MEMBERSHIPS,
+                       buf.data(), &new_len);
+  const bool was_efault = Value(ret, SyscallFailsWithErrno(EFAULT));
+
+  // Strangely, this EFAULTs on native, but only on our testing infrastructure.
+  // Seems like something is intercepting the getsockopt() call. Skip it for
+  // now.
+  SKIP_IF(was_efault && !IsRunningOnGvisor());
+
+  EXPECT_THAT(ret, SyscallSucceeds());
+
+  EXPECT_EQ(new_len, len);
+  // First len / 2 elements were set (some may be zero, so all we can do is test
+  // that they're not *all* 0).
+  EXPECT_FALSE(!buf.empty() && std::all_of(buf.begin(), buf.end(),
+                                           [](char c) { return c == 0; }));
+}
+
 // Validates the responses to RTM_GETLINK + NLM_F_DUMP.
 void CheckGetLinkResponse(const struct nlmsghdr* hdr, int seq, int port) {
   EXPECT_THAT(hdr->nlmsg_type, AnyOf(Eq(RTM_NEWLINK), Eq(NLMSG_DONE)));


### PR DESCRIPTION
This frees implementations of getsockopt to no longer return EINVAL when userspace specifies a buffer smaller than the output. Some callers, such as resolved, pass a null buffer to probe the output size before passing a real buffer to getsockopt. This allows those callers to succeed.

This commit also removes EINVAL returns from netlink route sockets related to the userspace-provided size to allow this pattern.

Finally, replacing CopyOut() with CopyOutN() makes getsockopt more robust to socket implementations such as hostinet/ that forget to check optLen before returning a non-zero-sized object, which previously would cause memory corruption in userspace the userspace-provided buffer was too small.