### PR TITLE
Apply TCP keepalive sysctl options from OCI config

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -32,9 +32,11 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/pipe"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/version"
+	"gvisor.dev/gvisor/pkg/sentry/socket/netstack"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 	"gvisor.dev/gvisor/pkg/usermem"
 )
 
@@ -132,9 +134,9 @@ func (fs *filesystem) newSysNetDir(ctx context.Context, root *auth.Credentials, 
 				"tcp_fastopen":              fs.newInode(ctx, root, 0444, newStaticFile("0")),
 				"tcp_fastopen_key":          fs.newInode(ctx, root, 0444, newStaticFile("")),
 				"tcp_invalid_ratelimit":     fs.newInode(ctx, root, 0444, newStaticFile("0")),
-				"tcp_keepalive_intvl":       fs.newInode(ctx, root, 0444, newStaticFile("0")),
-				"tcp_keepalive_probes":      fs.newInode(ctx, root, 0444, newStaticFile("0")),
-				"tcp_keepalive_time":        fs.newInode(ctx, root, 0444, newStaticFile("7200")),
+				"tcp_keepalive_intvl":       fs.newInode(ctx, root, 0444, &tcpKeepaliveIntvlData{stack: stack}),
+				"tcp_keepalive_probes":      fs.newInode(ctx, root, 0444, &tcpKeepaliveProbesData{stack: stack}),
+				"tcp_keepalive_time":        fs.newInode(ctx, root, 0444, &tcpKeepaliveTimeData{stack: stack}),
 				"tcp_mtu_probing":           fs.newInode(ctx, root, 0444, newStaticFile("0")),
 				"tcp_no_metrics_save":       fs.newInode(ctx, root, 0444, newStaticFile("1")),
 				"tcp_probe_interval":        fs.newInode(ctx, root, 0444, newStaticFile("0")),
@@ -573,4 +575,79 @@ func ParseInt32Vec(ctx context.Context, src usermem.IOSequence, buf []int32) (in
 	src = src.TakeFirst(hostarch.PageSize - 1)
 
 	return usermem.CopyInt32StringsInVec(ctx, src.IO, src.Addrs, buf, src.Opts)
+}
+
+// tcpKeepaliveTimeData implements vfs.DynamicBytesSource for
+// /proc/sys/net/ipv4/tcp_keepalive_time.
+//
+// +stateify savable
+type tcpKeepaliveTimeData struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.DynamicBytesSource = (*tcpKeepaliveTimeData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (d *tcpKeepaliveTimeData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	if ns, ok := d.stack.(*netstack.Stack); ok {
+		tcpProto := tcp.ProtocolFromStack(ns.Stack)
+		idle := tcpProto.DefaultKeepaliveIdle()
+		_, err := fmt.Fprintf(buf, "%d\n", int(idle.Seconds()))
+		return err
+	}
+	// Fallback to default value if not netstack.
+	_, err := buf.WriteString("7200\n")
+	return err
+}
+
+// tcpKeepaliveIntvlData implements vfs.DynamicBytesSource for
+// /proc/sys/net/ipv4/tcp_keepalive_intvl.
+//
+// +stateify savable
+type tcpKeepaliveIntvlData struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.DynamicBytesSource = (*tcpKeepaliveIntvlData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (d *tcpKeepaliveIntvlData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	if ns, ok := d.stack.(*netstack.Stack); ok {
+		tcpProto := tcp.ProtocolFromStack(ns.Stack)
+		interval := tcpProto.DefaultKeepaliveInterval()
+		_, err := fmt.Fprintf(buf, "%d\n", int(interval.Seconds()))
+		return err
+	}
+	// Fallback to default value if not netstack.
+	_, err := buf.WriteString("75\n")
+	return err
+}
+
+// tcpKeepaliveProbesData implements vfs.DynamicBytesSource for
+// /proc/sys/net/ipv4/tcp_keepalive_probes.
+//
+// +stateify savable
+type tcpKeepaliveProbesData struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.DynamicBytesSource = (*tcpKeepaliveProbesData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (d *tcpKeepaliveProbesData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	if ns, ok := d.stack.(*netstack.Stack); ok {
+		tcpProto := tcp.ProtocolFromStack(ns.Stack)
+		count := tcpProto.DefaultKeepaliveCount()
+		_, err := fmt.Fprintf(buf, "%d\n", count)
+		return err
+	}
+	// Fallback to default value if not netstack.
+	_, err := buf.WriteString("9\n")
+	return err
 }

--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -32,9 +32,11 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/pipe"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/version"
+	"gvisor.dev/gvisor/pkg/sentry/socket/netstack"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/transport/tcp"
 	"gvisor.dev/gvisor/pkg/usermem"
 )
 
@@ -133,9 +135,9 @@ func (fs *filesystem) newSysNetDir(ctx context.Context, root *auth.Credentials, 
 				"tcp_fastopen":              fs.newInode(ctx, root, 0444, newStaticFile("0")),
 				"tcp_fastopen_key":          fs.newInode(ctx, root, 0444, newStaticFile("")),
 				"tcp_invalid_ratelimit":     fs.newInode(ctx, root, 0444, newStaticFile("0")),
-				"tcp_keepalive_intvl":       fs.newInode(ctx, root, 0444, newStaticFile("0")),
-				"tcp_keepalive_probes":      fs.newInode(ctx, root, 0444, newStaticFile("0")),
-				"tcp_keepalive_time":        fs.newInode(ctx, root, 0444, newStaticFile("7200")),
+				"tcp_keepalive_intvl":       fs.newInode(ctx, root, 0444, &tcpKeepaliveIntvlData{stack: stack}),
+				"tcp_keepalive_probes":      fs.newInode(ctx, root, 0444, &tcpKeepaliveProbesData{stack: stack}),
+				"tcp_keepalive_time":        fs.newInode(ctx, root, 0444, &tcpKeepaliveTimeData{stack: stack}),
 				"tcp_mtu_probing":           fs.newInode(ctx, root, 0444, newStaticFile("0")),
 				"tcp_no_metrics_save":       fs.newInode(ctx, root, 0444, newStaticFile("1")),
 				"tcp_probe_interval":        fs.newInode(ctx, root, 0444, newStaticFile("0")),
@@ -589,4 +591,79 @@ func ParseInt32Vec(ctx context.Context, src usermem.IOSequence, buf []int32) (in
 	src = src.TakeFirst(hostarch.PageSize - 1)
 
 	return usermem.CopyInt32StringsInVec(ctx, src.IO, src.Addrs, buf, src.Opts)
+}
+
+// tcpKeepaliveTimeData implements vfs.DynamicBytesSource for
+// /proc/sys/net/ipv4/tcp_keepalive_time.
+//
+// +stateify savable
+type tcpKeepaliveTimeData struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.DynamicBytesSource = (*tcpKeepaliveTimeData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (d *tcpKeepaliveTimeData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	if ns, ok := d.stack.(*netstack.Stack); ok {
+		tcpProto := tcp.ProtocolFromStack(ns.Stack)
+		idle := tcpProto.DefaultKeepaliveIdle()
+		_, err := fmt.Fprintf(buf, "%d\n", int(idle.Seconds()))
+		return err
+	}
+	// Fallback to default value if not netstack.
+	_, err := buf.WriteString("7200\n")
+	return err
+}
+
+// tcpKeepaliveIntvlData implements vfs.DynamicBytesSource for
+// /proc/sys/net/ipv4/tcp_keepalive_intvl.
+//
+// +stateify savable
+type tcpKeepaliveIntvlData struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.DynamicBytesSource = (*tcpKeepaliveIntvlData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (d *tcpKeepaliveIntvlData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	if ns, ok := d.stack.(*netstack.Stack); ok {
+		tcpProto := tcp.ProtocolFromStack(ns.Stack)
+		interval := tcpProto.DefaultKeepaliveInterval()
+		_, err := fmt.Fprintf(buf, "%d\n", int(interval.Seconds()))
+		return err
+	}
+	// Fallback to default value if not netstack.
+	_, err := buf.WriteString("75\n")
+	return err
+}
+
+// tcpKeepaliveProbesData implements vfs.DynamicBytesSource for
+// /proc/sys/net/ipv4/tcp_keepalive_probes.
+//
+// +stateify savable
+type tcpKeepaliveProbesData struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.DynamicBytesSource = (*tcpKeepaliveProbesData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (d *tcpKeepaliveProbesData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	if ns, ok := d.stack.(*netstack.Stack); ok {
+		tcpProto := tcp.ProtocolFromStack(ns.Stack)
+		count := tcpProto.DefaultKeepaliveCount()
+		_, err := fmt.Fprintf(buf, "%d\n", count)
+		return err
+	}
+	// Fallback to default value if not netstack.
+	_, err := buf.WriteString("9\n")
+	return err
 }

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -868,9 +868,9 @@ func newEndpoint(s *stack.Stack, protocol *protocol, netProto tcpip.NetworkProto
 		waiterQueue: waiterQueue,
 		state:       atomicbitops.FromUint32(uint32(StateInitial)),
 		keepalive: keepalive{
-			idle:     protocol.defaultKeepaliveIdle,
-			interval: protocol.defaultKeepaliveInterval,
-			count:    protocol.defaultKeepaliveCount,
+			idle:     protocol.DefaultKeepaliveIdle(),
+			interval: protocol.DefaultKeepaliveInterval(),
+			count:    protocol.DefaultKeepaliveCount(),
 		},
 		ipv4TTL:      tcpip.UseDefaultIPv4TTL,
 		ipv6HopLimit: tcpip.UseDefaultIPv6HopLimit,

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -868,9 +868,9 @@ func newEndpoint(s *stack.Stack, protocol *protocol, netProto tcpip.NetworkProto
 		waiterQueue: waiterQueue,
 		state:       atomicbitops.FromUint32(uint32(StateInitial)),
 		keepalive: keepalive{
-			idle:     DefaultKeepaliveIdle,
-			interval: DefaultKeepaliveInterval,
-			count:    DefaultKeepaliveCount,
+			idle:     protocol.defaultKeepaliveIdle,
+			interval: protocol.defaultKeepaliveInterval,
+			count:    protocol.defaultKeepaliveCount,
 		},
 		ipv4TTL:      tcpip.UseDefaultIPv4TTL,
 		ipv6HopLimit: tcpip.UseDefaultIPv6HopLimit,

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -879,9 +879,9 @@ func newEndpoint(s *stack.Stack, protocol *protocol, netProto tcpip.NetworkProto
 		waiterQueue: waiterQueue,
 		state:       atomicbitops.FromUint32(uint32(StateInitial)),
 		keepalive: keepalive{
-			idle:     DefaultKeepaliveIdle,
-			interval: DefaultKeepaliveInterval,
-			count:    DefaultKeepaliveCount,
+			idle:     protocol.DefaultKeepaliveIdle(),
+			interval: protocol.DefaultKeepaliveInterval(),
+			count:    protocol.DefaultKeepaliveCount(),
 		},
 		ipv4TTL:      tcpip.UseDefaultIPv4TTL,
 		ipv6HopLimit: tcpip.UseDefaultIPv6HopLimit,

--- a/pkg/tcpip/transport/tcp/protocol.go
+++ b/pkg/tcpip/transport/tcp/protocol.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/header/parse"
@@ -107,9 +108,9 @@ type protocol struct {
 	maxRetries                 uint32
 	synRetries                 uint8
 	dispatcher                 dispatcher
-	defaultKeepaliveIdle       time.Duration
-	defaultKeepaliveInterval   time.Duration
-	defaultKeepaliveCount      int
+	defaultKeepaliveIdle       atomicbitops.Int64
+	defaultKeepaliveInterval   atomicbitops.Int64
+	defaultKeepaliveCount      atomicbitops.Int32
 
 	// probe, if not nil, will be invoked any time an endpoint receives a
 	// TCP segment.
@@ -597,9 +598,9 @@ func newProtocol(s *stack.Stack, cc string, probe TCPProbeFunc) stack.TransportP
 		maxRTO:                     MaxRTO,
 		maxRetries:                 MaxRetries,
 		recovery:                   tcpip.TCPRACKLossDetection,
-		defaultKeepaliveIdle:       DefaultKeepaliveIdle,
-		defaultKeepaliveInterval:   DefaultKeepaliveInterval,
-		defaultKeepaliveCount:      DefaultKeepaliveCount,
+		defaultKeepaliveIdle:       atomicbitops.FromInt64(int64(DefaultKeepaliveIdle)),
+		defaultKeepaliveInterval:   atomicbitops.FromInt64(int64(DefaultKeepaliveInterval)),
+		defaultKeepaliveCount:      atomicbitops.FromInt32(int32(DefaultKeepaliveCount)),
 		seqnumSecret:               seqnumSecret,
 		tsOffsetSecret:             tsOffsetSecret,
 		probe:                      probe,
@@ -620,42 +621,30 @@ func ProtocolFromStack(s *stack.Stack) *protocol {
 
 // SetDefaultKeepaliveIdle sets the default keepalive idle time for new TCP endpoints.
 func (p *protocol) SetDefaultKeepaliveIdle(d time.Duration) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.defaultKeepaliveIdle = d
+	p.defaultKeepaliveIdle.Store(int64(d))
 }
 
 // SetDefaultKeepaliveInterval sets the default keepalive interval for new TCP endpoints.
 func (p *protocol) SetDefaultKeepaliveInterval(d time.Duration) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.defaultKeepaliveInterval = d
+	p.defaultKeepaliveInterval.Store(int64(d))
 }
 
 // SetDefaultKeepaliveCount sets the default keepalive count for new TCP endpoints.
 func (p *protocol) SetDefaultKeepaliveCount(count int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.defaultKeepaliveCount = count
+	p.defaultKeepaliveCount.Store(int32(count))
 }
 
 // DefaultKeepaliveIdle returns the default keepalive idle time.
 func (p *protocol) DefaultKeepaliveIdle() time.Duration {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.defaultKeepaliveIdle
+	return time.Duration(p.defaultKeepaliveIdle.Load())
 }
 
 // DefaultKeepaliveInterval returns the default keepalive interval.
 func (p *protocol) DefaultKeepaliveInterval() time.Duration {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.defaultKeepaliveInterval
+	return time.Duration(p.defaultKeepaliveInterval.Load())
 }
 
 // DefaultKeepaliveCount returns the default keepalive count.
 func (p *protocol) DefaultKeepaliveCount() int {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.defaultKeepaliveCount
+	return int(p.defaultKeepaliveCount.Load())
 }

--- a/pkg/tcpip/transport/tcp/protocol.go
+++ b/pkg/tcpip/transport/tcp/protocol.go
@@ -107,6 +107,9 @@ type protocol struct {
 	maxRetries                 uint32
 	synRetries                 uint8
 	dispatcher                 dispatcher
+	defaultKeepaliveIdle       time.Duration
+	defaultKeepaliveInterval   time.Duration
+	defaultKeepaliveCount      int
 
 	// probe, if not nil, will be invoked any time an endpoint receives a
 	// TCP segment.
@@ -594,6 +597,9 @@ func newProtocol(s *stack.Stack, cc string, probe TCPProbeFunc) stack.TransportP
 		maxRTO:                     MaxRTO,
 		maxRetries:                 MaxRetries,
 		recovery:                   tcpip.TCPRACKLossDetection,
+		defaultKeepaliveIdle:       DefaultKeepaliveIdle,
+		defaultKeepaliveInterval:   DefaultKeepaliveInterval,
+		defaultKeepaliveCount:      DefaultKeepaliveCount,
 		seqnumSecret:               seqnumSecret,
 		tsOffsetSecret:             tsOffsetSecret,
 		probe:                      probe,
@@ -605,4 +611,51 @@ func newProtocol(s *stack.Stack, cc string, probe TCPProbeFunc) stack.TransportP
 // protocolFromStack retrieves the tcp.protocol instance from stack s.
 func protocolFromStack(s *stack.Stack) *protocol {
 	return s.TransportProtocolInstance(ProtocolNumber).(*protocol)
+}
+
+// ProtocolFromStack retrieves the tcp.protocol instance from stack s.
+func ProtocolFromStack(s *stack.Stack) *protocol {
+	return protocolFromStack(s)
+}
+
+// SetDefaultKeepaliveIdle sets the default keepalive idle time for new TCP endpoints.
+func (p *protocol) SetDefaultKeepaliveIdle(d time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.defaultKeepaliveIdle = d
+}
+
+// SetDefaultKeepaliveInterval sets the default keepalive interval for new TCP endpoints.
+func (p *protocol) SetDefaultKeepaliveInterval(d time.Duration) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.defaultKeepaliveInterval = d
+}
+
+// SetDefaultKeepaliveCount sets the default keepalive count for new TCP endpoints.
+func (p *protocol) SetDefaultKeepaliveCount(count int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.defaultKeepaliveCount = count
+}
+
+// DefaultKeepaliveIdle returns the default keepalive idle time.
+func (p *protocol) DefaultKeepaliveIdle() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.defaultKeepaliveIdle
+}
+
+// DefaultKeepaliveInterval returns the default keepalive interval.
+func (p *protocol) DefaultKeepaliveInterval() time.Duration {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.defaultKeepaliveInterval
+}
+
+// DefaultKeepaliveCount returns the default keepalive count.
+func (p *protocol) DefaultKeepaliveCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.defaultKeepaliveCount
 }

--- a/pkg/tcpip/transport/tcp/protocol.go
+++ b/pkg/tcpip/transport/tcp/protocol.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/header/parse"
@@ -124,7 +125,10 @@ type protocol struct {
 	// +checklocks:mu
 	synRetries uint8
 
-	dispatcher dispatcher
+	dispatcher             dispatcher
+	defaultKeepaliveIdle     atomicbitops.Int64
+	defaultKeepaliveInterval atomicbitops.Int64
+	defaultKeepaliveCount    atomicbitops.Int32
 
 	// probe, if not nil, will be invoked any time an endpoint receives a
 	// TCP segment.
@@ -619,6 +623,9 @@ func newProtocol(s *stack.Stack, cc string, probe TCPProbeFunc) stack.TransportP
 		maxRTO:                     MaxRTO,
 		maxRetries:                 MaxRetries,
 		recovery:                   tcpip.TCPRACKLossDetection,
+		defaultKeepaliveIdle:       atomicbitops.FromInt64(int64(DefaultKeepaliveIdle)),
+		defaultKeepaliveInterval:   atomicbitops.FromInt64(int64(DefaultKeepaliveInterval)),
+		defaultKeepaliveCount:      atomicbitops.FromInt32(int32(DefaultKeepaliveCount)),
 		seqnumSecret:               seqnumSecret,
 		tsOffsetSecret:             tsOffsetSecret,
 		probe:                      probe,
@@ -630,4 +637,39 @@ func newProtocol(s *stack.Stack, cc string, probe TCPProbeFunc) stack.TransportP
 // protocolFromStack retrieves the tcp.protocol instance from stack s.
 func protocolFromStack(s *stack.Stack) *protocol {
 	return s.TransportProtocolInstance(ProtocolNumber).(*protocol)
+}
+
+// ProtocolFromStack retrieves the tcp.protocol instance from stack s.
+func ProtocolFromStack(s *stack.Stack) *protocol {
+	return protocolFromStack(s)
+}
+
+// SetDefaultKeepaliveIdle sets the default keepalive idle time for new TCP endpoints.
+func (p *protocol) SetDefaultKeepaliveIdle(d time.Duration) {
+	p.defaultKeepaliveIdle.Store(int64(d))
+}
+
+// SetDefaultKeepaliveInterval sets the default keepalive interval for new TCP endpoints.
+func (p *protocol) SetDefaultKeepaliveInterval(d time.Duration) {
+	p.defaultKeepaliveInterval.Store(int64(d))
+}
+
+// SetDefaultKeepaliveCount sets the default keepalive count for new TCP endpoints.
+func (p *protocol) SetDefaultKeepaliveCount(count int) {
+	p.defaultKeepaliveCount.Store(int32(count))
+}
+
+// DefaultKeepaliveIdle returns the default keepalive idle time.
+func (p *protocol) DefaultKeepaliveIdle() time.Duration {
+	return time.Duration(p.defaultKeepaliveIdle.Load())
+}
+
+// DefaultKeepaliveInterval returns the default keepalive interval.
+func (p *protocol) DefaultKeepaliveInterval() time.Duration {
+	return time.Duration(p.defaultKeepaliveInterval.Load())
+}
+
+// DefaultKeepaliveCount returns the default keepalive count.
+func (p *protocol) DefaultKeepaliveCount() int {
+	return int(p.defaultKeepaliveCount.Load())
 }

--- a/pkg/tcpip/transport/tcp/protocol_test.go
+++ b/pkg/tcpip/transport/tcp/protocol_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcp
+
+import (
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// TestDefaultKeepaliveSettings verifies that default keepalive settings
+// can be set and retrieved correctly.
+func TestDefaultKeepaliveSettings(t *testing.T) {
+	s := stack.New(stack.Options{
+		TransportProtocols: []stack.TransportProtocolFactory{NewProtocol},
+	})
+	defer s.Close()
+
+	p := protocolFromStack(s)
+
+	// Test default values
+	if got := p.DefaultKeepaliveIdle(); got != DefaultKeepaliveIdle {
+		t.Errorf("DefaultKeepaliveIdle() = %v, want %v", got, DefaultKeepaliveIdle)
+	}
+	if got := p.DefaultKeepaliveInterval(); got != DefaultKeepaliveInterval {
+		t.Errorf("DefaultKeepaliveInterval() = %v, want %v", got, DefaultKeepaliveInterval)
+	}
+	if got := p.DefaultKeepaliveCount(); got != DefaultKeepaliveCount {
+		t.Errorf("DefaultKeepaliveCount() = %v, want %v", got, DefaultKeepaliveCount)
+	}
+
+	// Test setting custom values
+	customIdle := 60 * time.Second
+	customInterval := 10 * time.Second
+	customCount := 5
+
+	p.SetDefaultKeepaliveIdle(customIdle)
+	p.SetDefaultKeepaliveInterval(customInterval)
+	p.SetDefaultKeepaliveCount(customCount)
+
+	if got := p.DefaultKeepaliveIdle(); got != customIdle {
+		t.Errorf("after Set, DefaultKeepaliveIdle() = %v, want %v", got, customIdle)
+	}
+	if got := p.DefaultKeepaliveInterval(); got != customInterval {
+		t.Errorf("after Set, DefaultKeepaliveInterval() = %v, want %v", got, customInterval)
+	}
+	if got := p.DefaultKeepaliveCount(); got != customCount {
+		t.Errorf("after Set, DefaultKeepaliveCount() = %v, want %v", got, customCount)
+	}
+}
+
+// TestNewEndpointUsesDefaultKeepalive verifies that new endpoints
+// use the protocol's default keepalive settings.
+func TestNewEndpointUsesDefaultKeepalive(t *testing.T) {
+	s := stack.New(stack.Options{
+		TransportProtocols: []stack.TransportProtocolFactory{NewProtocol},
+	})
+	defer s.Close()
+
+	p := protocolFromStack(s)
+
+	// Set custom defaults
+	customIdle := 45 * time.Second
+	customInterval := 15 * time.Second
+	customCount := 7
+
+	p.SetDefaultKeepaliveIdle(customIdle)
+	p.SetDefaultKeepaliveInterval(customInterval)
+	p.SetDefaultKeepaliveCount(customCount)
+
+	// Create a new endpoint
+	ep := newEndpoint(s, p, 0, nil)
+	defer ep.Close()
+
+	// Verify the endpoint inherited the defaults
+	if got := ep.keepalive.idle; got != customIdle {
+		t.Errorf("endpoint keepalive.idle = %v, want %v", got, customIdle)
+	}
+	if got := ep.keepalive.interval; got != customInterval {
+		t.Errorf("endpoint keepalive.interval = %v, want %v", got, customInterval)
+	}
+	if got := ep.keepalive.count; got != customCount {
+		t.Errorf("endpoint keepalive.count = %v, want %v", got, customCount)
+	}
+}

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -725,6 +725,45 @@ func New(args Args) (*Loader, error) {
 		return nil, fmt.Errorf("registering filesystems: %w", err)
 	}
 
+	// Apply network sysctl settings from OCI spec.
+	if args.Spec.Linux != nil && args.Spec.Linux.Sysctl != nil {
+		if ns, ok := l.k.RootNetworkNamespace().Stack().(*netstack.Stack); ok {
+			if val, ok := args.Spec.Linux.Sysctl["net.ipv4.tcp_keepalive_time"]; ok {
+				keepaliveTime, err := strconv.Atoi(val)
+				if err != nil {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_time=%s: %w", val, err)
+				}
+				if keepaliveTime <= 0 {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_time=%d: must be positive", keepaliveTime)
+				}
+				tcpProto := tcp.ProtocolFromStack(ns.Stack)
+				tcpProto.SetDefaultKeepaliveIdle(gtime.Duration(keepaliveTime) * gtime.Second)
+			}
+			if val, ok := args.Spec.Linux.Sysctl["net.ipv4.tcp_keepalive_intvl"]; ok {
+				keepaliveIntvl, err := strconv.Atoi(val)
+				if err != nil {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_intvl=%s: %w", val, err)
+				}
+				if keepaliveIntvl <= 0 {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_intvl=%d: must be positive", keepaliveIntvl)
+				}
+				tcpProto := tcp.ProtocolFromStack(ns.Stack)
+				tcpProto.SetDefaultKeepaliveInterval(gtime.Duration(keepaliveIntvl) * gtime.Second)
+			}
+			if val, ok := args.Spec.Linux.Sysctl["net.ipv4.tcp_keepalive_probes"]; ok {
+				keepaliveProbes, err := strconv.Atoi(val)
+				if err != nil {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_probes=%s: %w", val, err)
+				}
+				if keepaliveProbes <= 0 {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_probes=%d: must be positive", keepaliveProbes)
+				}
+				tcpProto := tcp.ProtocolFromStack(ns.Stack)
+				tcpProto.SetDefaultKeepaliveCount(keepaliveProbes)
+			}
+		}
+	}
+
 	// Turn on packet logging if enabled.
 	if args.Conf.LogPackets {
 		log.Infof("Packet logging enabled")

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -853,6 +853,45 @@ func New(args Args) (*Loader, error) {
 	}
 	args.StartupTimer.Reached("filesystems registered")
 
+	// Apply network sysctl settings from OCI spec.
+	if args.Spec.Linux != nil && args.Spec.Linux.Sysctl != nil {
+		if ns, ok := l.k.RootNetworkNamespace().Stack().(*netstack.Stack); ok {
+			if val, ok := args.Spec.Linux.Sysctl["net.ipv4.tcp_keepalive_time"]; ok {
+				keepaliveTime, err := strconv.Atoi(val)
+				if err != nil {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_time=%s: %w", val, err)
+				}
+				if keepaliveTime <= 0 {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_time=%d: must be positive", keepaliveTime)
+				}
+				tcpProto := tcp.ProtocolFromStack(ns.Stack)
+				tcpProto.SetDefaultKeepaliveIdle(gtime.Duration(keepaliveTime) * gtime.Second)
+			}
+			if val, ok := args.Spec.Linux.Sysctl["net.ipv4.tcp_keepalive_intvl"]; ok {
+				keepaliveIntvl, err := strconv.Atoi(val)
+				if err != nil {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_intvl=%s: %w", val, err)
+				}
+				if keepaliveIntvl <= 0 {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_intvl=%d: must be positive", keepaliveIntvl)
+				}
+				tcpProto := tcp.ProtocolFromStack(ns.Stack)
+				tcpProto.SetDefaultKeepaliveInterval(gtime.Duration(keepaliveIntvl) * gtime.Second)
+			}
+			if val, ok := args.Spec.Linux.Sysctl["net.ipv4.tcp_keepalive_probes"]; ok {
+				keepaliveProbes, err := strconv.Atoi(val)
+				if err != nil {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_probes=%s: %w", val, err)
+				}
+				if keepaliveProbes <= 0 {
+					return nil, fmt.Errorf("invalid net.ipv4.tcp_keepalive_probes=%d: must be positive", keepaliveProbes)
+				}
+				tcpProto := tcp.ProtocolFromStack(ns.Stack)
+				tcpProto.SetDefaultKeepaliveCount(keepaliveProbes)
+			}
+		}
+	}
+
 	// Turn on packet logging if enabled.
 	if args.Conf.LogPackets {
 		log.Infof("Packet logging enabled")


### PR DESCRIPTION
The sysctl options declared in the OCI config.json were being silently ignored for TCP keepalive settings. When a container specified net.ipv4.tcp_keepalive_time, net.ipv4.tcp_keepalive_intvl, or net.ipv4.tcp_keepalive_probes in the sysctl block, these values were never parsed or applied during container initialization.

This fix adds support for parsing these three TCP keepalive sysctl options in runsc/boot/loader.go during container boot. The values are stored as default settings in the TCP protocol struct (pkg/tcpip/transport/tcp/protocol.go) and applied to all new TCP endpoints. Additionally, the /proc/sys/net/ipv4/tcp_keepalive_* interfaces (pkg/sentry/fsimpl/proc/tasks_sys.go) now dynamically report the configured values instead of returning hardcoded defaults, ensuring both the application and visibility of sysctl settings work correctly.

The root cause was that while the OCI spec parsing was present, there was no mechanism to apply network-related sysctls to the TCP stack. The fix wires sysctl values from the OCI spec to the TCP protocol's default keepalive parameters, which are then used when creating new endpoints.

Fixes #10790
