### PR TITLE
Populate CPU statistics in `/proc/stat`

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_files.go
+++ b/pkg/sentry/fsimpl/proc/tasks_files.go
@@ -186,14 +186,47 @@ var _ dynamicInode = (*statData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
 func (*statData) Generate(ctx context.Context, buf *bytes.Buffer) error {
-	// TODO(b/37226836): We currently export only zero CPU stats. We could
-	// at least provide some aggregate stats.
-	var cpu cpuStats
-	fmt.Fprintf(buf, "cpu  %s\n", cpu)
-
 	k := kernel.KernelFromContext(ctx)
-	for c, max := uint(0), k.ApplicationCores(); c < max; c++ {
-		fmt.Fprintf(buf, "cpu%d %s\n", c, cpu)
+
+	// gVisor does not track per-CPU usage. Instead, report the kernel-wide
+	// aggregate user and system CPU time (maintained by the CPU clock ticker)
+	// and approximate idle time from uptime. This allows utilities like top(1)
+	// and htop(1) to compute non-zero CPU usage from the delta between
+	// successive reads of /proc/stat.
+	cpu := k.CPUStats()
+
+	cores := k.ApplicationCores()
+	uptime := ktime.NowFromContext(ctx).Sub(k.Timekeeper().BootTime())
+
+	userTicks := uint64(linux.ClockTFromDuration(cpu.UserTime))
+	sysTicks := uint64(linux.ClockTFromDuration(cpu.SysTime))
+
+	// Idle time is the total available CPU time (one uptime's worth per core)
+	// minus the time spent doing work.
+	var idleTicks uint64
+	if total := uint64(linux.ClockTFromDuration(uptime)) * uint64(cores); total > userTicks+sysTicks {
+		idleTicks = total - userTicks - sysTicks
+	}
+
+	fmt.Fprintf(buf, "cpu  %s\n", cpuStats{user: userTicks, system: sysTicks, idle: idleTicks})
+
+	// gVisor has no per-CPU accounting, so distribute the aggregate stats
+	// evenly across the application cores, assigning any remainder to cpu0.
+	// The per-CPU lines therefore sum back to the aggregate "cpu" line. This
+	// makes the aggregate statistic a reasonable approximation of the total CPU
+	// usage across all cores.
+	for c := uint(0); c < cores; c++ {
+		per := cpuStats{
+			user:   userTicks / uint64(cores),
+			system: sysTicks / uint64(cores),
+			idle:   idleTicks / uint64(cores),
+		}
+		if c == 0 {
+			per.user += userTicks % uint64(cores)
+			per.system += sysTicks % uint64(cores)
+			per.idle += idleTicks % uint64(cores)
+		}
+		fmt.Fprintf(buf, "cpu%d %s\n", c, per)
 	}
 
 	// The total number of interrupts is dependent on the CPUs and PCI
@@ -222,13 +255,12 @@ func (*statData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	// TODO(b/37226836): Count this.
 	fmt.Fprintf(buf, "processes 0\n")
 
-	// Number of runnable tasks.
-	// TODO(b/37226836): Count this.
-	fmt.Fprintf(buf, "procs_running 0\n")
+	// Number of runnable tasks, read directly from the kernel's running-task
+	// counter, which is maintained as tasks change scheduling state.
+	fmt.Fprintf(buf, "procs_running %d\n", k.RunningTasks())
 
-	// Number of tasks waiting on IO.
-	// TODO(b/37226836): Count this.
-	fmt.Fprintf(buf, "procs_blocked 0\n")
+	// Number of tasks in uninterruptible sleep (e.g. waiting on IO).
+	fmt.Fprintf(buf, "procs_blocked %d\n", k.BlockedTasks())
 
 	// Number of each softirq handled.
 	fmt.Fprintf(buf, "softirq 0") // total

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -211,6 +211,14 @@ type Kernel struct {
 	// further protected by runningTasksMu (see incRunningTasks).
 	runningTasks atomicbitops.Int64
 
+	// blockedTasks is the total count of tasks currently in
+	// TaskGoroutineBlockedUninterruptible, i.e. uninterruptible sleep. It is
+	// used to implement procs_blocked in /proc/stat.
+	//
+	// blockedTasks must be accessed atomically. It is not saved; on restore it
+	// is repopulated as tasks re-enter uninterruptible sleep.
+	blockedTasks atomicbitops.Int64 `state:"nosave"`
+
 	// runningTasksCond is signaled when runningTasks is incremented from 0 to 1.
 	//
 	// Invariant: runningTasksCond.L == &runningTasksMu.
@@ -242,6 +250,20 @@ type Kernel struct {
 	// does not use ktime.SyntheticClock since this clock currently does not
 	// need to support timers.
 	cpuClock atomicbitops.Int64
+
+	// userCPUClock and userSysCPUClock are kernel-wide cumulative CPU time
+	// accumulators, in nanoseconds, advanced by the CPU clock ticker as it
+	// accounts ticks to running tasks. userCPUClock mirrors the sum of all
+	// tasks' Task.appCPUClock (i.e. application/user time), while
+	// userSysCPUClock mirrors the sum of all tasks' Task.appSysCPUClock (i.e.
+	// application+sentry time). System time is the difference of the two. Like
+	// the per-task clocks, these are never decremented, so they also include
+	// the CPU time of exited tasks. They are used to implement the aggregate
+	// CPU line in /proc/stat (see Kernel.CPUStats).
+	//
+	// userCPUClock and userSysCPUClock must be accessed atomically.
+	userCPUClock    atomicbitops.Int64
+	userSysCPUClock atomicbitops.Int64
 
 	// uniqueID is used to generate unique identifiers.
 	//
@@ -1555,6 +1577,20 @@ func (k *Kernel) decRunningTasks() {
 	// there is still nothing running. This provides approximately one tick
 	// of slack in which we can switch back and forth between idle and
 	// active without an expensive transition.
+}
+
+// RunningTasks returns the number of tasks currently in
+// TaskGoroutineRunningSys or TaskGoroutineRunningApp, i.e. the number of
+// runnable tasks. It is used to implement procs_running in /proc/stat.
+func (k *Kernel) RunningTasks() int64 {
+	return k.runningTasks.Load()
+}
+
+// BlockedTasks returns the number of tasks currently in
+// TaskGoroutineBlockedUninterruptible, i.e. uninterruptible sleep. It is used
+// to implement procs_blocked in /proc/stat.
+func (k *Kernel) BlockedTasks() int64 {
+	return k.blockedTasks.Load()
 }
 
 // WaitExited blocks until all tasks in k have exited. No tasks can be created

--- a/pkg/sentry/kernel/task_sched.go
+++ b/pkg/sentry/kernel/task_sched.go
@@ -96,6 +96,10 @@ func (t *Task) accountTaskGoroutineEnter(state TaskGoroutineState) {
 		// Task is blocking/stopping.
 		t.k.decRunningTasks()
 	}
+	if state == TaskGoroutineBlockedUninterruptible {
+		// Task is entering uninterruptible sleep.
+		t.k.blockedTasks.Add(1)
+	}
 }
 
 // Preconditions:
@@ -106,6 +110,10 @@ func (t *Task) accountTaskGoroutineLeave(state TaskGoroutineState) {
 	if state != TaskGoroutineRunningApp {
 		// Task is unblocking/continuing.
 		t.k.incRunningTasks()
+	}
+	if state == TaskGoroutineBlockedUninterruptible {
+		// Task is leaving uninterruptible sleep.
+		t.k.blockedTasks.Add(-1)
 	}
 	if oldState := t.TaskGoroutineState(); oldState != state {
 		panic(fmt.Sprintf("Task goroutine switching from state %v (expected %v) to %v", oldState, state, TaskGoroutineRunningSys))
@@ -177,6 +185,22 @@ func (tg *ThreadGroup) CPUStats() usage.CPUStats {
 		UserTime:          time.Duration(appNS),
 		SysTime:           time.Duration(sysNS),
 		VoluntarySwitches: tg.yieldCount.Load(),
+	}
+}
+
+// CPUStats returns the aggregate CPU usage statistics of all tasks in the
+// kernel (including tasks that have since exited), as accumulated by the CPU
+// clock ticker. It is used to implement the aggregate "cpu" line in
+// /proc/stat.
+func (k *Kernel) CPUStats() usage.CPUStats {
+	// The CPU clock ticker advances userCPUClock before userSysCPUClock, so
+	// it's possible for the former to transiently exceed the latter.
+	userNS := k.userCPUClock.Load()
+	userSysNS := k.userSysCPUClock.Load()
+	sysNS := max(userSysNS-userNS, 0)
+	return usage.CPUStats{
+		UserTime: time.Duration(userNS),
+		SysTime:  time.Duration(sysNS),
 	}
 }
 
@@ -271,12 +295,18 @@ func (k *Kernel) runCPUClockTicker() {
 		rand.Shuffle(numIncTasks, func(i, j int) {
 			incTasks[i], incTasks[j] = incTasks[j], incTasks[i]
 		})
+		// userTickInc counts ticks accounted as application (user) time;
+		// userSysTickInc counts ticks accounted as application+sentry time.
+		// These mirror the per-task appCPUClock and appSysCPUClock increments
+		// below and feed the kernel-wide CPU time accumulators.
+		var userTickInc, userSysTickInc int64
 		for _, t := range incTasks[:numIncTasks] {
 			switch t.TaskGoroutineState() {
 			case TaskGoroutineRunningApp:
 				t.appCPUClock.Add(linux.ClockTick)
 				t.tg.appCPUClockLast.Store(t)
 				t.tg.appCPUClock.Add(linux.ClockTick)
+				userTickInc++
 				if preempt {
 					t.p.Preempt()
 				}
@@ -285,7 +315,14 @@ func (k *Kernel) runCPUClockTicker() {
 				t.appSysCPUClock.Add(linux.ClockTick)
 				t.tg.appSysCPUClockLast.Store(t)
 				t.tg.appSysCPUClock.Add(linux.ClockTick)
+				userSysTickInc++
 			}
+		}
+		if userTickInc != 0 {
+			k.userCPUClock.Add(userTickInc * linux.ClockTick.Nanoseconds())
+		}
+		if userSysTickInc != 0 {
+			k.userSysCPUClock.Add(userSysTickInc * linux.ClockTick.Nanoseconds())
 		}
 
 		// Reset storage for the next iteration.

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -1567,6 +1567,11 @@ TEST(ProcStat, Fields) {
     } else if (fields[0] == "procs_running") {
       // Single field.
       EXPECT_EQ(fields.size(), 2) << proc_stat;
+      // The task reading /proc/stat is itself running, so there must be at
+      // least one running task.
+      uint64_t running = 0;
+      EXPECT_TRUE(absl::SimpleAtoi(fields[1], &running)) << proc_stat;
+      EXPECT_GE(running, 1) << proc_stat;
     } else if (fields[0] == "procs_blocked") {
       // Single field.
       EXPECT_EQ(fields.size(), 2) << proc_stat;
@@ -1581,6 +1586,51 @@ TEST(ProcStat, Fields) {
       EXPECT_TRUE(absl::SimpleAtoi(fields[i], &val)) << proc_stat;
     }
   }
+}
+
+// Returns the total non-idle CPU time (user + nice + system, in USER_HZ ticks)
+// reported by the aggregate "cpu" line of /proc/stat.
+PosixErrorOr<uint64_t> ProcStatCpuBusyTicks() {
+  ASSIGN_OR_RETURN_ERRNO(std::string proc_stat, GetContents("/proc/stat"));
+  for (absl::string_view line : absl::StrSplit(proc_stat, '\n')) {
+    std::vector<std::string> fields =
+        absl::StrSplit(line, ' ', absl::SkipWhitespace());
+    if (fields.empty() || fields[0] != "cpu") {
+      continue;
+    }
+    // "cpu" followed by at least the user, nice, and system fields.
+    if (fields.size() < 4) {
+      return PosixError(EINVAL, "malformed aggregate cpu line in /proc/stat");
+    }
+    uint64_t user = 0, nice = 0, system = 0;
+    if (!absl::SimpleAtoi(fields[1], &user) ||
+        !absl::SimpleAtoi(fields[2], &nice) ||
+        !absl::SimpleAtoi(fields[3], &system)) {
+      return PosixError(EINVAL, "non-numeric cpu fields in /proc/stat");
+    }
+    return user + nice + system;
+  }
+  return PosixError(EINVAL, "no aggregate cpu line in /proc/stat");
+}
+
+// Regression test for the aggregate CPU statistics being hardcoded to zero
+// (b/37226836): the "cpu" line of /proc/stat must accrue CPU time as work is
+// done, so that tools like top(1) and htop(1) can compute non-zero usage.
+TEST(ProcStat, CpuTimeAccrues) {
+  uint64_t before = ASSERT_NO_ERRNO_AND_VALUE(ProcStatCpuBusyTicks());
+
+  // Burn CPU for long enough to register several USER_HZ ticks (typically
+  // 10ms each). The volatile sink prevents the loop from being optimized away.
+  const absl::Time deadline = absl::Now() + absl::Milliseconds(500);
+  volatile uint64_t sink = 0;
+  while (absl::Now() < deadline) {
+    for (int i = 0; i < 100000; i++) {
+      sink += i;
+    }
+  }
+
+  uint64_t after = ASSERT_NO_ERRNO_AND_VALUE(ProcStatCpuBusyTicks());
+  EXPECT_GT(after, before);
 }
 
 TEST(ProcLoadavg, EndsWithNewline) {


### PR DESCRIPTION
`/proc/stat` previously reported all-zero CPU stats, so tools like `top` and `htop` always showed 0% CPU usage inside a gVisor sandbox.

This change fixes the sisue by surfacing the CPU accounting gVisor already tracks:

- **`cpu` aggregate line:** sums user/system time across all thread groups and approximates idle time from uptime, giving monitoring tools meaningful deltas between samples.
- **Per-CPU lines (`cpu0`..`cpuN`):** since gVisor has no per-core accounting, the aggregate is distributed evenly across application cores (remainder assigned to `cpu0`), so the per-CPU lines sum back to the aggregate.
- **`procs_running` / `procs_blocked`:** counted from task scheduling states instead of being hardcoded to zero.

`intr`, `ctxt`, `processes`, and `softirq` remain stubbed--a global fork counter would be needed for `processes`?

Added simple nit tests covering field layout but let me know if this needs more work.

Verified end-to-end with a `runsc` build: `top` and `htop` now report live CPU usage under load.

Fixes #9967.

Assisted-by: Claude