### PR TITLE
netstack: log the correct field in the unsupported ifi_flags warning

### DIFF
--- a/pkg/sentry/socket/netstack/stack.go
+++ b/pkg/sentry/socket/netstack/stack.go
@@ -227,7 +227,7 @@ func (s *Stack) SetInterface(ctx context.Context, msg *nlmsg.Message) *syserr.Er
 			return syserr.ErrInvalidArgument
 		}
 		if ifinfomsg.Flags & ^uint32(linux.IFF_UP) != 0 {
-			ctx.Warningf("Unsupported ifi_flags: %x", ifinfomsg.Change)
+			ctx.Warningf("Unsupported ifi_flags: %x", ifinfomsg.Flags)
 			return syserr.ErrInvalidArgument
 		}
 		// Netstack interfaces are always up.


### PR DESCRIPTION
AI usage: found and wrote by Claude, obviously correct (if one looks at a few more context lines)

The warning for unsupported ifi_flags printed ifinfomsg.Change instead of ifinfomsg.Flags. Print the field actually being validated.
