### PR TITLE
sentry/kernel: fix saved set-user-ID update in SetREUID/SetREGID

### DIFF
--- a/pkg/sentry/kernel/task_identity.go
+++ b/pkg/sentry/kernel/task_identity.go
@@ -117,7 +117,7 @@ func (t *Task) SetREUID(r, e auth.UID) error {
 	// ID is set to a value not equal to the previous real user ID, the saved
 	// set-user-ID will be set to the new effective user ID."
 	newS := creds.SavedKUID
-	if r.Ok() || (e.Ok() && newE != creds.EffectiveKUID) {
+	if r.Ok() || (e.Ok() && newE != creds.RealKUID) {
 		newS = newE
 	}
 	t.setKUIDsUnchecked(newR, newE, newS)
@@ -277,7 +277,7 @@ func (t *Task) SetREGID(r, e auth.GID) error {
 		}
 	}
 	newS := creds.SavedKGID
-	if r.Ok() || (e.Ok() && newE != creds.EffectiveKGID) {
+	if r.Ok() || (e.Ok() && newE != creds.RealKGID) {
 		newS = newE
 	}
 	t.setKGIDsUnchecked(newR, newE, newS)


### PR DESCRIPTION
SetREUID and SetREGID update the saved set-user-ID/GID when the new effective UID/GID differs from the previous saved set-user-ID/GID. However, the comparand used is the effective (not real) UID/GID. POSIX (setreuid(2)) specifies that the saved set-user-ID is set to the new effective UID if the real UID was changed, or if the effective UID is set to a value not equal to the (previous) real UID. The current code compares against the effective UID, which means the saved set-user-ID is not updated when it should be.

The sibling function SetRESUID correctly uses `creds.RealKUID` as the comparand at line 181. This change aligns SetREUID and SetREGID with both the POSIX specification and the existing SetRESUID/SetRESGID implementations.