### PR TITLE
sentry/kernel: add CLONE_NEWNS to namespace capability check in Clone

### DIFF
--- a/pkg/sentry/kernel/task_clone.go
+++ b/pkg/sentry/kernel/task_clone.go
@@ -148,7 +148,7 @@ func (t *Task) Clone(args *linux.CloneArgs) (ThreadID, *SyscallControl, error) {
 	cu.Add(func() {
 		userns.DecRef(t)
 	})
-	if args.Flags&(linux.CLONE_NEWPID|linux.CLONE_NEWNET|linux.CLONE_NEWUTS|linux.CLONE_NEWIPC) != 0 && !creds.HasCapabilityIn(linux.CAP_SYS_ADMIN, userns) {
+	if args.Flags&(linux.CLONE_NEWPID|linux.CLONE_NEWNET|linux.CLONE_NEWUTS|linux.CLONE_NEWIPC|linux.CLONE_NEWNS) != 0 && !creds.HasCapabilityIn(linux.CAP_SYS_ADMIN, userns) {
 		return 0, nil, linuxerr.EPERM
 	}
 


### PR DESCRIPTION
The capability check for namespace-creating clone flags covers CLONE_NEWPID, CLONE_NEWNET, CLONE_NEWUTS, and CLONE_NEWIPC, but omits CLONE_NEWNS. The corresponding check in unshare (line 894) correctly includes all five flags, including CLONE_NEWNS.

Linux requires CAP_SYS_ADMIN in the user namespace for CLONE_NEWNS (see fork.c and namespace.c). Without this check, an unprivileged process can create a new mount namespace without the required capability.

This adds CLONE_NEWNS to the clone capability check bitmask to match the unshare path.