### PR TITLE
sentry/kernel: implement SECCOMP_RET_KILL_PROCESS

### DIFF
--- a/pkg/sentry/kernel/seccomp.go
+++ b/pkg/sentry/kernel/seccomp.go
@@ -132,6 +132,10 @@ func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip h
 		// system call. The exit status of the task will be SIGSYS, not
 		// SIGKILL."
 
+	case linux.SECCOMP_RET_KILL_PROCESS:
+		// "Results in the entire process exiting immediately without
+		// executing the system call."
+
 	default:
 		// consistent with Linux
 		return linux.SECCOMP_RET_KILL_THREAD

--- a/pkg/sentry/kernel/task_syscall.go
+++ b/pkg/sentry/kernel/task_syscall.go
@@ -246,6 +246,10 @@ func (t *Task) doSyscall() taskRunState {
 			t.Debugf("Syscall %d: killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
 			return (*runExit)(nil)
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("Syscall %d: process killed by seccomp", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
 		case linux.SECCOMP_RET_TRACE:
 			t.Debugf("Syscall %d: stopping for PTRACE_EVENT_SECCOMP", sysno)
 			return (*runSyscallAfterPtraceEventSeccomp)(nil)
@@ -402,6 +406,10 @@ func (t *Task) doVsyscall(addr hostarch.Addr, sysno uintptr) taskRunState {
 		case linux.SECCOMP_RET_KILL_THREAD:
 			t.Debugf("vsyscall %d: killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("vsyscall %d: process killed by seccomp", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
 			return (*runExit)(nil)
 		default:
 			panic(fmt.Sprintf("Unknown seccomp result %d", r))


### PR DESCRIPTION
The seccomp filter evaluation in checkSeccompSyscall handles SECCOMP_RET_KILL_THREAD but falls through to the default case for SECCOMP_RET_KILL_PROCESS, which treats it as SECCOMP_RET_KILL_THREAD. This means SECCOMP_RET_KILL_PROCESS only terminates the offending thread (via PrepareExit) instead of the entire thread group (via PrepareGroupExit).

Linux distinguishes the two actions clearly: SECCOMP_RET_KILL_THREAD sends SIGSYS to the thread, while SECCOMP_RET_KILL_PROCESS calls do_group_exit() to terminate all threads in the process. The task_syscall.go handling is also updated to call PrepareGroupExit with SIGSYS for the KILL_PROCESS case.