### PR TITLE
tmpfs: check mount writability in SetXattrAt and RemoveXattrAt

### DIFF
--- a/pkg/sentry/fsimpl/tmpfs/filesystem.go
+++ b/pkg/sentry/fsimpl/tmpfs/filesystem.go
@@ -946,7 +946,12 @@ func (fs *filesystem) SetXattrAt(ctx context.Context, rp *vfs.ResolvingPath, opt
 		fs.mu.RUnlock()
 		return err
 	}
+	if err := rp.Mount().CheckBeginWrite(); err != nil {
+		fs.mu.RUnlock()
+		return err
+	}
 	err = d.inode.setXattr(rp.Credentials(), &opts)
+	rp.Mount().EndWrite()
 	fs.mu.RUnlock()
 	if err != nil {
 		return err
@@ -964,7 +969,12 @@ func (fs *filesystem) RemoveXattrAt(ctx context.Context, rp *vfs.ResolvingPath, 
 		fs.mu.RUnlock()
 		return err
 	}
+	if err := rp.Mount().CheckBeginWrite(); err != nil {
+		fs.mu.RUnlock()
+		return err
+	}
 	err = d.inode.removeXattr(rp.Credentials(), name)
+	rp.Mount().EndWrite()
 	fs.mu.RUnlock()
 	if err != nil {
 		return err


### PR DESCRIPTION
SetXattrAt and RemoveXattrAt in tmpfs do not check whether the mount is writable before modifying extended attributes. Every other mutating filesystem operation (SetStatAt, MkdirAt, MknodAt, RenameAt, etc.) calls rp.Mount().CheckBeginWrite() to enforce read-only mount semantics.

This adds CheckBeginWrite/EndWrite guards to both SetXattrAt and RemoveXattrAt so that xattr modifications on read-only mounts correctly return EROFS.