### PR TITLE
sentry/shm: check ownership before shmctl IPC_RMID

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_shm.go
+++ b/pkg/sentry/syscalls/linux/sys_shm.go
@@ -19,6 +19,7 @@ import (
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/ipc"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/shm"
 )
@@ -145,6 +146,10 @@ func Shmctl(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr,
 		return 0, nil, err
 
 	case linux.IPC_RMID:
+		creds := auth.CredentialsFromContext(t)
+		if !segment.Object().CheckOwnership(creds) {
+			return 0, nil, linuxerr.EPERM
+		}
 		segment.MarkDestroyed(t)
 		return 0, nil, nil
 


### PR DESCRIPTION
shmctl(IPC_RMID) does not verify that the caller is the creator, owner, or has CAP_SYS_ADMIN before destroying the segment. Any process that can reference the segment ID can destroy it.

The semaphore equivalent (semctl IPC_RMID) correctly checks ownership via ipc.Registry.Remove -> Object.CheckOwnership. The shmctl IPC_SET path also checks ownership through Shm.Set -> Object.Set -> Object.CheckOwnership.

From shmctl(2): "IPC_RMID: Mark the segment to be destroyed. The segment will actually be destroyed only after the last process detaches it. The caller must be the owner or creator of the segment, or be privileged."

This adds an ownership check before marking the segment for destruction, matching the semantics of both the man page and the existing semctl IPC_RMID implementation.