### PR TITLE
sentry/sem: reject negative values in semctl SETVAL

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_sem.go
+++ b/pkg/sentry/syscalls/linux/sys_sem.go
@@ -138,7 +138,7 @@ func Semctl(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr,
 	switch cmd {
 	case linux.SETVAL:
 		val := args[3].Int()
-		if val > math.MaxInt16 {
+		if val < 0 || val > math.MaxInt16 {
 			return 0, nil, linuxerr.ERANGE
 		}
 		return 0, nil, setVal(t, id, num, int16(val))


### PR DESCRIPTION
The SETVAL range check only validates the upper bound (> MaxInt16) before truncating the int32 argument to int16. Negative int32 values like -65536 truncate to valid int16 values (0 in this case) and bypass both the syscall check and SetVal's own `val < 0` check.

Linux checks both bounds in `semctl_setval()` in `ipc/sem.c`: `if (val > SEMVMX || val < 0) return -ERANGE;`

This adds the missing lower bound check so negative values are correctly rejected with ERANGE before the truncating cast.