### PR TITLE
sentry/msgqueue: fix off-by-one in negative mType receive

### DIFF
--- a/pkg/sentry/kernel/msgqueue/msgqueue.go
+++ b/pkg/sentry/kernel/msgqueue/msgqueue.go
@@ -476,7 +476,7 @@ func (q *Queue) msgOfType(mType int64, except bool) *Message {
 //
 // Precondition: caller must hold q.mu.
 func (q *Queue) msgOfTypeLessThan(mType int64) (m *Message) {
-	min := mType
+	min := mType + 1
 	for msg := q.messages.Front(); msg != nil; msg = msg.Next() {
 		if msg.Type <= mType && msg.Type < min {
 			m = msg


### PR DESCRIPTION
msgOfTypeLessThan initializes min to mType, which causes the condition `msg.Type < min` to exclude messages with type exactly equal to |mType|. For example, `msgrcv(qid, &buf, sz, -5, 0)` should match message types in [1, 5], but messages with type 5 fail the strict less-than comparison against min=5.

Linux `testmsg()` in `ipc/msg.c` uses `msg->m_type <= -msgtyp`, which includes the equal case.

This initializes min to `mType+1` so the first eligible message at the boundary is correctly matched.