### PR TITLE
runsc: stop leaking host DMI product name to containers

### DIFF
--- a/runsc/cmd/boot.go
+++ b/runsc/cmd/boot.go
@@ -318,13 +318,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 	// Do these before chroot takes effect, otherwise we can't read /proc and /sys.
 	if len(b.productName) == 0 {
-		if product, err := os.ReadFile("/sys/devices/virtual/dmi/id/product_name"); err != nil {
-			log.Warningf("Not setting product_name: %v", err)
-		} else {
-			b.productName = strings.TrimSpace(string(product))
-			log.Infof("Setting product_name: %q", b.productName)
-			argOverride["product-name"] = b.productName
-		}
+		b.productName = "gVisor"
 	}
 	if conf.AppHugePages {
 		if len(b.hostTHP.ShmemEnabled) == 0 {


### PR DESCRIPTION
When --product-name is not explicitly set, boot.go reads /sys/devices/virtual/dmi/id/product_name from the host and serves it verbatim to sandboxed processes via sysfs. This reveals the host platform identity to any containerized process (e.g. "Google Compute Engine", "HVM domU", or bare-metal model names like "PowerEdge R750").

This uses a static default ("gVisor") instead of reading the host value. Operators who need the real product name can still pass it explicitly via --product-name.