### PR TITLE
sentry/aio: validate nrEvents in io_setup

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_aio.go
+++ b/pkg/sentry/syscalls/linux/sys_aio.go
@@ -34,6 +34,10 @@ func IoSetup(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr
 	nrEvents := args[0].Int()
 	idAddr := args[1].Pointer()
 
+	if nrEvents <= 0 || nrEvents > 65536 {
+		return 0, nil, linuxerr.EINVAL
+	}
+
 	// Linux uses the native long as the aio ID.
 	//
 	// The context pointer _must_ be zero initially.


### PR DESCRIPTION
io_setup reads nrEvents as int32 and casts to uint32 with no validation. Negative values wrap to large unsigned values (e.g. -1 becomes 4294967295), and zero is accepted despite being invalid. Each io_submit against such a context spawns a goroutine, so an uncapped maxOutstanding allows unbounded sentry memory growth.

Linux rejects `nr_events == 0` with EINVAL and caps against `aio_max_nr` (default 65536) in `do_io_setup()`.

This adds bounds checking before the uint32 cast: reject values <= 0 and values exceeding 65536.