### PR TITLE
sentry/fuse: fix FATTR_ATIME_NOW used in place of FATTR_MTIME_NOW

### DIFF
--- a/pkg/sentry/fsimpl/fuse/inode.go
+++ b/pkg/sentry/fsimpl/fuse/inode.go
@@ -404,7 +404,7 @@ func (i *inode) setAttr(ctx context.Context, fs *vfs.Filesystem, creds *auth.Cre
 		fattrMask |= linux.FATTR_ATIME_NOW
 	}
 	if opts.Stat.Mask&linux.STATX_MTIME != 0 && opts.Stat.Mtime.Nsec == linux.UTIME_NOW {
-		fattrMask |= linux.FATTR_ATIME_NOW
+		fattrMask |= linux.FATTR_MTIME_NOW
 	}
 	in := linux.FUSESetAttrIn{
 		Valid:     fattrMask,


### PR DESCRIPTION
When setAttr is called with mtime set to UTIME_NOW, the FUSE
request includes FATTR_ATIME_NOW instead of FATTR_MTIME_NOW.
This is a copy-paste from the atime block two lines above.

The FUSE daemon sees two FATTR_ATIME_NOW flags and zero
FATTR_MTIME_NOW flags, so it never applies the mtime-now
update to the file's modification time.