### PR TITLE
sentry/overlay: use fs.creds for upper layer rename

### DIFF
--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -1275,7 +1275,7 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 		Start: oldParent.upperVD,
 		Path:  fspath.Parse(oldName),
 	}
-	if err := vfsObj.RenameAt(ctx, creds, &oldpop, &newpop, &opts); err != nil {
+	if err := vfsObj.RenameAt(ctx, fs.creds, &oldpop, &newpop, &opts); err != nil {
 		vfsObj.AbortRenameDentry(&renamed.vfsd, replacedVFSD)
 		cleanupRecreateWhiteouts()
 		return err


### PR DESCRIPTION
RenameAt passes the caller's credentials (rp.Credentials()) to the
upper layer VFS rename, while all other upper layer mutations
(CreateWhiteout, SetXattrAt, UnlinkAt, copy-up) consistently use
the overlay creator's credentials (fs.creds).

Linux overlayfs uses override_creds() with the mounter's credentials
for all upper layer operations including rename.

Use fs.creds to match both the Linux behavior and the pattern used
by every other upper layer operation in this file.