### PR TITLE
netstack/ipv4: drop TTL=1 packets instead of forwarding with TTL=0

### DIFF
--- a/pkg/tcpip/network/ipv4/ipv4.go
+++ b/pkg/tcpip/network/ipv4/ipv4.go
@@ -854,16 +854,11 @@ func (e *endpoint) forwardUnicastPacket(pkt *stack.PacketBuffer) ip.ForwardingEr
 	}
 
 	ttl := h.TTL()
-	if ttl == 0 {
-		// As per RFC 792 page 6, Time Exceeded Message,
-		//
-		//  If the gateway processing a datagram finds the time to live field
-		//  is zero it must discard the datagram.  The gateway may also notify
-		//  the source host via the time exceeded message.
-		//
-		// We return the original error rather than the result of returning
-		// the ICMP packet because the original error is more relevant to
-		// the caller.
+	if ttl <= 1 {
+		// As per RFC 791 page 30 and RFC 792 page 6, a gateway must
+		// discard a datagram whose TTL reaches zero after decrementing.
+		// Check before decrement: TTL=0 is already expired, TTL=1 will
+		// reach zero after the mandatory decrement.
 		_ = e.protocol.returnError(&icmpReasonTTLExceeded{}, pkt, false /* deliveredLocally */)
 		return &ip.ErrTTLExceeded{}
 	}


### PR DESCRIPTION
The TTL check in forwardUnicastPacket uses `ttl == 0`, so packets arriving with TTL=1 pass the check, get decremented to TTL=0 in forwardPacketWithRoute, and are forwarded with a zero TTL. There is no post-decrement TTL check.

Linux `ip_forward()` checks `ip_hdr(skb)->ttl <= 1` before forwarding, which correctly drops TTL=1 packets and sends ICMP Time Exceeded.

This changes the pre-decrement check from `ttl == 0` to `ttl <= 1` so that packets that would reach zero after the mandatory decrement are dropped with an ICMP Time Exceeded response.