### PR TITLE
sentry/iouring: return 0 instead of -1 for toSubmit=0

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_iouring.go
+++ b/pkg/sentry/syscalls/linux/sys_iouring.go
@@ -108,7 +108,7 @@ func IOUringEnter(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (ui
 
 	// If a user requested to submit zero SQEs, then we don't process any and return right away.
 	if toSubmit == 0 {
-		return uintptr(ret), nil, nil
+		return 0, nil, nil
 	}
 
 	file := t.GetFile(fd)


### PR DESCRIPTION
`io_uring_enter` with `toSubmit=0` returns `uintptr(-1)` with a nil error. The syscall dispatch writes -1 directly to RAX on the nil-error path, which userspace libc interprets as EPERM.

This is a valid and common call pattern: `io_uring_wait_cqe()` calls `io_uring_enter(fd, 0, 1, IORING_ENTER_GETEVENTS)` to wait for completions without submitting new work. Linux returns 0 for this case.

Returns 0 to indicate success when no submissions were requested.