### PR TITLE
sentry/mm: use actual mappable offset in mremap overflow check

### DIFF
--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -548,12 +548,13 @@ func (mm *MemoryManager) MRemap(ctx context.Context, oldAddr hostarch.Addr, oldS
 	}
 
 	if vma := vseg.ValuePtr(); vma.mappable != nil {
+		off := vseg.mappableOffsetAt(oldAR.Start)
 		// Check that offset+length does not overflow.
-		if vma.off+uint64(newAR.Length()) < vma.off {
+		if off+uint64(newAR.Length()) < off {
 			return 0, linuxerr.EINVAL
 		}
 		// Inform the Mappable, if any, of the new mapping.
-		if err := vma.mappable.CopyMapping(ctx, mm, oldAR, newAR, vseg.mappableOffsetAt(oldAR.Start), vma.canWriteMappableLocked()); err != nil {
+		if err := vma.mappable.CopyMapping(ctx, mm, oldAR, newAR, off, vma.canWriteMappableLocked()); err != nil {
 			return 0, err
 		}
 	}


### PR DESCRIPTION
The overflow check in MRemap validates `vma.off + newAR.Length()`, but the offset passed to `CopyMapping` is `mappableOffsetAt(oldAR.Start)`, which equals `vma.off + (oldAR.Start - vseg.Start())`. When the mremap region starts partway into the VMA, the actual offset is larger than `vma.off`, so the check can pass while the real offset overflows.

This computes the actual offset first, then uses it for both the overflow check and the CopyMapping call.