### PR TITLE
netstack/ipv4: suppress ICMP echo replies to broadcast/multicast

### DIFF
--- a/pkg/tcpip/network/ipv4/icmp.go
+++ b/pkg/tcpip/network/ipv4/icmp.go
@@ -373,7 +373,10 @@ func (e *endpoint) handleICMP(pkt *stack.PacketBuffer) {
 		// per-stack default handler. Also preserve the IPv4 behavior for
 		// temporary local addresses: the packet is delivered above, but the
 		// stack does not synthesize an echo reply for it.
-		if defaultHandlerHandled || localAddressTemporary {
+		//
+		// Do not reply to echo requests sent to broadcast or multicast
+		// addresses, matching Linux's default icmp_echo_ignore_broadcasts=1.
+		if defaultHandlerHandled || localAddressTemporary || localAddressBroadcast || header.IsV4MulticastAddress(iph.DestinationAddress()) {
 			return
 		}
 


### PR DESCRIPTION
ICMP echo requests addressed to broadcast or multicast addresses receive a reply, which enables Smurf-style amplification attacks. Linux defaults to suppressing these replies via `net.ipv4.icmp_echo_ignore_broadcasts=1`.

The broadcast flag was already tracked (`localAddressBroadcast`) and used for source address selection inside `sendICMPEchoReply`, but the reply was still generated and sent. This adds a check to suppress the reply entirely when the destination is a broadcast or multicast address, matching Linux's default behavior.