### PR TITLE
sentry/fuse: validate NodeID in LOOKUP responses

### DIFF
--- a/pkg/sentry/fsimpl/fuse/inode.go
+++ b/pkg/sentry/fsimpl/fuse/inode.go
@@ -234,7 +234,16 @@ func (i *inode) newEntry(ctx context.Context, name string, fileType linux.FileMo
 	if err != nil {
 		return nil, err
 	}
-	if opcode != linux.FUSE_LOOKUP && ((out.Attr.Mode&linux.S_IFMT)^uint32(fileType) != 0 || out.NodeID == 0 || out.NodeID == linux.FUSE_ROOT_ID) {
+	if out.NodeID == 0 {
+		if opcode == linux.FUSE_LOOKUP {
+			return nil, linuxerr.ENOENT
+		}
+		return nil, linuxerr.EIO
+	}
+	if out.NodeID == linux.FUSE_ROOT_ID {
+		return nil, linuxerr.EIO
+	}
+	if opcode != linux.FUSE_LOOKUP && (out.Attr.Mode&linux.S_IFMT)^uint32(fileType) != 0 {
 		return nil, linuxerr.EIO
 	}
 	child, err := i.fs.newInode(ctx, out.FUSEEntryOut)


### PR DESCRIPTION
The NodeID validation (reject 0 and FUSE_ROOT_ID) in newEntry was gated behind `opcode != linux.FUSE_LOOKUP`, so LOOKUP responses from the FUSE daemon bypassed all NodeID checks. A FUSE daemon could return NodeID=0 (which means "no such entry" in the FUSE protocol) and gVisor would create a real inode with that ID, or return FUSE_ROOT_ID to alias the root inode.

This splits the validation so that NodeID checks apply to all response types. For LOOKUP with NodeID=0, returns ENOENT to match Linux `fuse_lookup_name()` behavior for negative lookups. For FUSE_ROOT_ID or NodeID=0 on non-LOOKUP opcodes, returns EIO. File type validation remains LOOKUP-exempt since LOOKUP doesn't pass an expected type.