### PR TITLE
netstack/udp: preserve checksum=0 during NAT rewriting

### DIFF
--- a/pkg/tcpip/header/udp.go
+++ b/pkg/tcpip/header/udp.go
@@ -134,6 +134,10 @@ func (b UDP) Encode(u *UDPFields) {
 
 // SetSourcePortWithChecksumUpdate implements ChecksummableTransport.
 func (b UDP) SetSourcePortWithChecksumUpdate(new uint16) {
+	if b.Checksum() == 0 {
+		b.SetSourcePort(new)
+		return
+	}
 	old := b.SourcePort()
 	b.SetSourcePort(new)
 	b.SetChecksum(^checksumUpdate2ByteAlignedUint16(^b.Checksum(), old, new))
@@ -141,6 +145,10 @@ func (b UDP) SetSourcePortWithChecksumUpdate(new uint16) {
 
 // SetDestinationPortWithChecksumUpdate implements ChecksummableTransport.
 func (b UDP) SetDestinationPortWithChecksumUpdate(new uint16) {
+	if b.Checksum() == 0 {
+		b.SetDestinationPort(new)
+		return
+	}
 	old := b.DestinationPort()
 	b.SetDestinationPort(new)
 	b.SetChecksum(^checksumUpdate2ByteAlignedUint16(^b.Checksum(), old, new))
@@ -148,6 +156,9 @@ func (b UDP) SetDestinationPortWithChecksumUpdate(new uint16) {
 
 // UpdateChecksumPseudoHeaderAddress implements ChecksummableTransport.
 func (b UDP) UpdateChecksumPseudoHeaderAddress(old, new tcpip.Address, fullChecksum bool) {
+	if b.Checksum() == 0 {
+		return
+	}
 	xsum := b.Checksum()
 	if fullChecksum {
 		xsum = ^xsum


### PR DESCRIPTION
Per RFC 768, a UDP checksum of 0 means "no checksum computed" and is valid for IPv4 UDP. When a checksum-disabled UDP packet undergoes NAT, the incremental checksum update functions operate on the zero value, producing a non-zero but arithmetically incorrect checksum. The receiver then validates the non-zero checksum, finds it invalid, and drops the packet silently.

This adds an early return to all three UDP checksum update functions (SetSourcePortWithChecksumUpdate, SetDestinationPortWithChecksumUpdate, UpdateChecksumPseudoHeaderAddress) to preserve the zero checksum when the original checksum is 0. The port/address fields are still updated; only the checksum computation is skipped. This does not affect TCP, which has mandatory checksums.