### PR TITLE
sentry/mmap: bound mincore allocation to fixed batch size

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_mmap.go
+++ b/pkg/sentry/syscalls/linux/sys_mmap.go
@@ -15,8 +15,6 @@
 package linux
 
 import (
-	"bytes"
-
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
@@ -257,9 +255,23 @@ func Mincore(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr
 	if mapped != uint64(la) {
 		return 0, nil, linuxerr.ENOMEM
 	}
-	resident := bytes.Repeat([]byte{1}, int(mapped/hostarch.PageSize))
-	_, err := t.CopyOutBytes(vec, resident)
-	return 0, nil, err
+	total := int(mapped / hostarch.PageSize)
+	const batchSize = 4096
+	var buf [batchSize]byte
+	for i := range buf {
+		buf[i] = 1
+	}
+	for written := 0; written < total; {
+		n := total - written
+		if n > batchSize {
+			n = batchSize
+		}
+		if _, err := t.CopyOutBytes(vec+hostarch.Addr(written), buf[:n]); err != nil {
+			return 0, nil, err
+		}
+		written += n
+	}
+	return 0, nil, nil
 }
 
 // Msync implements Linux syscall msync(2).


### PR DESCRIPTION
mincore allocates a Go heap buffer proportional to the queried address range using bytes.Repeat. A single large anonymous mmap (e.g. 1TB, which is trivial to create) followed by mincore causes the sentry to allocate ~256MB in a single allocation, enabling denial of service against all containers sharing the sandbox.

Linux mincore processes pages in batches of PAGE_SIZE, writing one page of residency info at a time without allocating the entire result in kernel memory.

This replaces the single allocation with a fixed 4096-byte stack buffer that is written out in batches via CopyOutBytes. The total amount of data written is unchanged, but peak sentry heap usage for a mincore call is now bounded at 4KB regardless of the queried range.