### PR TITLE
runsc: gofer aborts for EROFS/non-lisafs rootfs in chroot mode

### DIFF
--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -172,30 +172,34 @@ func SetupRootFS(spec *specs.Spec, conf *config.Config, mountConfs []specutils.G
 	}
 
 	rootfsConf := mountConfs[0]
-	if !rootfsConf.ShouldUseLisafs() {
+	if rootfsConf.ShouldUseLisafs() {
+		// Some CDI createContainer hooks pivot_root(2) into spec.Root.Path.
+		// pivot_root(2) requires the target to be a mount point, so we must
+		// self-bind-mount spec.Root.Path here. runc does this step unconditionally
+		// in libcontainer/rootfs_linux.go:prepareRoot().
+		if err := unix.Mount(containerRootFs, containerRootFs, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+			return fmt.Errorf("self-bind-mounting rootfs %q: %w", containerRootFs, err)
+		}
+
+		// Ensure the containerRootFs is set to the RootfsPropagation that the user
+		// requested. Mounts added under SetupMounts inherit the propagation flags of
+		// the root.
+		flags := uint32(unix.MS_SLAVE | unix.MS_REC)
+		if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
+			flags = specutils.PropOptionsToFlags([]string{spec.Linux.RootfsPropagation})
+		}
+		if err := unix.Mount("", containerRootFs, "", uintptr(flags), ""); err != nil {
+			return fmt.Errorf("mounting root (%q) with flags: %#x, err: %v", containerRootFs, flags, err)
+		}
+	} else {
 		// When not using gofer mount for rootfs, spec.Root.Path may not be set or
 		// may not be a writable directory. So set up the container rootfs directly
 		// in /proc/fs/root, which is a writable directory.
+		//
+		// The self-bind-mount and propagation change above are skipped here: they
+		// are only needed for lisafs rootfs, and /proc/fs/root is not a mount point
+		// on the MS_UNBINDABLE /proc/fs tmpfs, so both would fail with EINVAL.
 		containerRootFs = goferRootFs
-	}
-
-	// Some CDI createContainer hooks pivot_root(2) into spec.Root.Path.
-	// pivot_root(2) requires the target to be a mount point, so we must
-	// self-bind-mount spec.Root.Path here. runc does this step unconditionally
-	// in libcontainer/rootfs_linux.go:prepareRoot().
-	if err := unix.Mount(containerRootFs, containerRootFs, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
-		return fmt.Errorf("self-bind-mounting rootfs %q: %w", containerRootFs, err)
-	}
-
-	// Ensure the containerRootFs is set to the RootfsPropagation that the user
-	// requested. Mounts added under SetupMounts inherit the propagation flags of
-	// the root.
-	flags := uint32(unix.MS_SLAVE | unix.MS_REC)
-	if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
-		flags = specutils.PropOptionsToFlags([]string{spec.Linux.RootfsPropagation})
-	}
-	if err := unix.Mount("", containerRootFs, "", uintptr(flags), ""); err != nil {
-		return fmt.Errorf("mounting root (%q) with flags: %#x, err: %v", containerRootFs, flags, err)
 	}
 
 	// Replace the current spec, with the clean spec with symlinks resolved.


### PR DESCRIPTION
A container with an EROFS rootfs fails to boot — the gofer aborts during rootfs setup:
Error setting up root FS: self-bind-mounting rootfs "/proc/fs/root": invalid argument ... waiting for sandbox to start: EOF

Regression from #11901, which made the rootfs self-bind-mount unconditional. For a
non-lisafs rootfs, `containerRootFs` is `/proc/fs/root`, which sits on the
`MS_UNBINDABLE` `/proc/fs` tmpfs, so the bind returns `EINVAL`. The self-bind is
only needed for CDI `createContainer` hooks, which already run only in the
`ShouldUseLisafs()` branch.

### Fix
Gate the self-bind-mount + propagation on `ShouldUseLisafs()` (its placement
before #11901). No-op for lisafs; restores EROFS-rootfs boot.

### Test
Adds `TestRootfsEROFSChroot` (EROFS rootfs + lisafs submount, real chroot, root-only):
fails on master, passes with this change. The existing `container_test` can't catch
this because `TestConfig` forces `TestOnlyAllowRunAsCurrentUserWithoutChroot=true`,
skipping the chroot path.

### Related
Related to #13238 (same #11901 self-bind), but a distinct trigger/root cause not
fixed by a7d0e52f; still reproduces on master.

Fixes #13529