### PR TITLE
netstack: fix bubblewrap: add if up/down, add lo address on if up, remove ipv6 on if down

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -99,6 +99,13 @@ func (fs *filesystem) newSysNetDir(ctx context.Context, root *auth.Credentials, 
 	// network namespace of the calling process.
 	if stack := k.RootNetworkNamespace().Stack(); stack != nil {
 		contents = map[string]kernfs.Inode{
+			"ipv6": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
+				"conf": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
+					"all": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
+						"keep_addr_on_down": fs.newInode(ctx, root, 0644, &ipv6KeepAddrOnDown{stack: stack}),
+					}),
+				}),
+			}),
 			"ipv4": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 				"ip_forward":          fs.newInode(ctx, root, 0444, &ipForwarding{stack: stack}),
 				"ip_local_port_range": fs.newInode(ctx, root, 0644, &portRange{stack: stack}),
@@ -241,6 +248,45 @@ func (*uuidData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 // GetDynamicBytesPoller implements vfs.PollableDynamicBytesSource.GetDynamicBytesPoller.
 func (*domainnameData) GetDynamicBytesPoller(ctx context.Context) *vfs.DynamicBytesPoller {
 	return &kernel.KernelFromContext(ctx).DomainNamePoller
+}
+
+// ipv6KeepAddrOnDown implements vfs.WritableDynamicBytesSource for
+// /proc/sys/net/ipv6/conf/all/keep_addr_on_down.
+//
+// +stateify savable
+type ipv6KeepAddrOnDown struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.WritableDynamicBytesSource = (*ipv6KeepAddrOnDown)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (d *ipv6KeepAddrOnDown) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	val := "0\n"
+	if d.stack.IPv6KeepAddrOnDown() {
+		val = "1\n"
+	}
+	_, err := buf.WriteString(val)
+	return err
+}
+
+// Write implements vfs.WritableDynamicBytesSource.Write.
+func (d *ipv6KeepAddrOnDown) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
+	if offset != 0 {
+		// No need to handle partial writes thus far.
+		return 0, linuxerr.EINVAL
+	}
+	buf := make([]int32, 1)
+	n, err := ParseInt32Vec(ctx, src, buf)
+	if err != nil || n == 0 {
+		return 0, err
+	}
+	if err := d.stack.SetIPv6KeepAddrOnDown(buf[0] != 0); err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // tcpSackData implements vfs.WritableDynamicBytesSource for

--- a/pkg/sentry/inet/inet.go
+++ b/pkg/sentry/inet/inet.go
@@ -58,6 +58,13 @@ type Stack interface {
 	// SupportsIPv6 returns true if the stack supports IPv6 connectivity.
 	SupportsIPv6() bool
 
+	// IPv6KeepAddrOnDown returns true if IPv6 should keep permanent, non-local
+	// addresses when an interface goes down.
+	IPv6KeepAddrOnDown() bool
+
+	// SetIPv6KeepAddrOnDown changes IPv6 keep_addr_on_down behavior.
+	SetIPv6KeepAddrOnDown(bool) error
+
 	// TCPReceiveBufferSize returns TCP receive buffer size settings.
 	TCPReceiveBufferSize() (TCPBufferSize, error)
 

--- a/pkg/sentry/inet/test_stack.go
+++ b/pkg/sentry/inet/test_stack.go
@@ -32,15 +32,16 @@ var _ Stack = (*TestStack)(nil)
 
 // TestStack is a dummy implementation of Stack for tests.
 type TestStack struct {
-	InterfacesMap     map[int32]Interface
-	InterfaceAddrsMap map[int32][]InterfaceAddr
-	RouteList         []Route
-	SupportsIPv6Flag  bool
-	TCPRecvBufSize    TCPBufferSize
-	TCPSendBufSize    TCPBufferSize
-	TCPSACKFlag       bool
-	Recovery          TCPLossRecovery
-	IPForwarding      bool
+	InterfacesMap          map[int32]Interface
+	InterfaceAddrsMap      map[int32][]InterfaceAddr
+	RouteList              []Route
+	SupportsIPv6Flag       bool
+	TCPRecvBufSize         TCPBufferSize
+	TCPSendBufSize         TCPBufferSize
+	TCPSACKFlag            bool
+	Recovery               TCPLossRecovery
+	IPForwarding           bool
+	IPv6KeepAddrOnDownFlag bool
 }
 
 // NewTestStack returns a TestStack with no network interfaces. The value of
@@ -112,6 +113,17 @@ func (s *TestStack) RemoveInterfaceAddr(idx int32, addr InterfaceAddr) error {
 // SupportsIPv6 implements Stack.
 func (s *TestStack) SupportsIPv6() bool {
 	return s.SupportsIPv6Flag
+}
+
+// IPv6KeepAddrOnDown implements Stack.
+func (s *TestStack) IPv6KeepAddrOnDown() bool {
+	return s.IPv6KeepAddrOnDownFlag
+}
+
+// SetIPv6KeepAddrOnDown implements Stack.
+func (s *TestStack) SetIPv6KeepAddrOnDown(enabled bool) error {
+	s.IPv6KeepAddrOnDownFlag = enabled
+	return nil
 }
 
 // TCPReceiveBufferSize implements Stack.

--- a/pkg/sentry/socket/hostinet/stack.go
+++ b/pkg/sentry/socket/hostinet/stack.go
@@ -60,6 +60,7 @@ type Stack struct {
 	netSNMPFile    *os.File
 	// allowedSocketTypes is the list of allowed socket types
 	allowedSocketTypes []AllowedSocketType
+	ipv6KeepAddrOnDown bool
 }
 
 // Destroy implements inet.Stack.Destroy.
@@ -110,6 +111,18 @@ func (s *Stack) Configure(allowRawSockets bool) error {
 		log.Warningf("Failed to open /proc/net/snmp: %v", err)
 	} else {
 		s.netSNMPFile = f
+	}
+
+	// keep_addr_on_down is >0 when enabled, and 0 (system default) or <0 when
+	// disabled.
+	if contents, err := os.ReadFile("/proc/sys/net/ipv6/conf/all/keep_addr_on_down"); err == nil {
+		if ipv6KeepAddrOnDown, err := strconv.Atoi(strings.TrimSpace(string(contents))); err == nil {
+			s.ipv6KeepAddrOnDown = ipv6KeepAddrOnDown > 0
+		} else {
+			log.Warningf("Failed to parse IPv6 keep_addr_on_down, setting to false")
+		}
+	} else {
+		log.Warningf("Failed to read IPv6 keep_addr_on_down, setting to false")
 	}
 
 	s.allowedSocketTypes = AllowedSocketTypes
@@ -246,6 +259,16 @@ func (*Stack) RemoveInterfaceAddr(idx int32, addr inet.InterfaceAddr) error {
 // SupportsIPv6 implements inet.Stack.SupportsIPv6.
 func (s *Stack) SupportsIPv6() bool {
 	return s.supportsIPv6
+}
+
+// IPv6KeepAddrOnDown implements inet.Stack.IPv6KeepAddrOnDown.
+func (s *Stack) IPv6KeepAddrOnDown() bool {
+	return s.ipv6KeepAddrOnDown
+}
+
+// SetIPv6KeepAddrOnDown implements inet.Stack.SetIPv6KeepAddrOnDown.
+func (*Stack) SetIPv6KeepAddrOnDown(bool) error {
+	return linuxerr.EACCES
 }
 
 // TCPReceiveBufferSize implements inet.Stack.TCPReceiveBufferSize.

--- a/pkg/sentry/socket/netstack/BUILD
+++ b/pkg/sentry/socket/netstack/BUILD
@@ -35,6 +35,7 @@ go_library(
         ":events_go_proto",
         "//pkg/abi/linux",
         "//pkg/abi/linux/errno",
+        "//pkg/atomicbitops",
         "//pkg/context",
         "//pkg/errors/linuxerr",
         "//pkg/eventchannel",

--- a/pkg/sentry/socket/netstack/stack.go
+++ b/pkg/sentry/socket/netstack/stack.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/log"
@@ -54,6 +55,9 @@ type Stack struct {
 	// id is a unique identifier for this stack, it is currently only
 	// used for a deterministic lock ordering.
 	id uint64
+
+	// ipv6KeepAddrOnDown backs /proc/sys/net/ipv6/conf/all/keep_addr_on_down.
+	ipv6KeepAddrOnDown atomicbitops.Bool
 }
 
 // NewStack creates a new netstack.Stack which wraps the given tcpip.Stack.
@@ -221,6 +225,9 @@ func (s *Stack) SetInterface(ctx context.Context, msg *nlmsg.Message) *syserr.Er
 	if flags&(linux.NLM_F_EXCL|linux.NLM_F_REPLACE) != 0 {
 		return syserr.ErrExists
 	}
+	// setUp tracks a requested administrative up/down state change (IFF_UP).
+	// It is nil when the message does not change IFF_UP.
+	var setUp *bool
 	if ifinfomsg.Flags != 0 || ifinfomsg.Change != 0 {
 		if ifinfomsg.Change & ^uint32(linux.IFF_UP) != 0 {
 			ctx.Warningf("Unsupported ifi_change flags: %x", ifinfomsg.Change)
@@ -230,7 +237,10 @@ func (s *Stack) SetInterface(ctx context.Context, msg *nlmsg.Message) *syserr.Er
 			ctx.Warningf("Unsupported ifi_flags: %x", ifinfomsg.Flags)
 			return syserr.ErrInvalidArgument
 		}
-		// Netstack interfaces are always up.
+		if ifinfomsg.Change&uint32(linux.IFF_UP) != 0 {
+			up := ifinfomsg.Flags&uint32(linux.IFF_UP) != 0
+			setUp = &up
+		}
 	}
 
 	dstNs, err := s.lockSrcAndDst(ctx, attrs)
@@ -238,7 +248,7 @@ func (s *Stack) SetInterface(ctx context.Context, msg *nlmsg.Message) *syserr.Er
 		return err
 	}
 	defer s.unlockSrcAndDst(ctx, dstNs)
-	return s.setLinkLocked(ctx, tcpip.NICID(ifinfomsg.Index), attrs, dstNs)
+	return s.setLinkLocked(ctx, tcpip.NICID(ifinfomsg.Index), attrs, dstNs, setUp)
 }
 
 // If the linkAttrs map contains IFLA_NET_NS_FD, locks the source and
@@ -320,7 +330,10 @@ func (s *Stack) unlockSrcAndDst(ctx context.Context, ns *inet.Namespace) {
 
 // precondition: s.linkLock is held. If dstNs is not nil, dstNs.Stack.linkMu is
 // also held.
-func (s *Stack) setLinkLocked(ctx context.Context, id tcpip.NICID, linkAttrs map[uint16]nlmsg.BytesView, dstNs *inet.Namespace) *syserr.Error {
+//
+// setUp, when non-nil, requests an administrative up (true) or down (false)
+// state change for the interface (IFF_UP).
+func (s *Stack) setLinkLocked(ctx context.Context, id tcpip.NICID, linkAttrs map[uint16]nlmsg.BytesView, dstNs *inet.Namespace, setUp *bool) *syserr.Error {
 	src := s
 	changed := false
 	nicInfo, ok := src.Stack.SingleNICInfo(id)
@@ -358,19 +371,9 @@ func (s *Stack) setLinkLocked(ctx context.Context, id tcpip.NICID, linkAttrs map
 	for t, v := range linkAttrs {
 		switch t {
 		case linux.IFLA_MASTER:
-			master, ok := v.Uint32()
-			if !ok {
-				return syserr.ErrInvalidArgument
-			}
-			if mid, ok := src.Stack.GetNICCoordinatorID(id); ok && mid == tcpip.NICID(master) {
-				continue
-			}
-			if master != 0 {
-				if err := src.Stack.SetNICCoordinator(id, tcpip.NICID(master)); err != nil {
-					return syserr.TranslateNetstackError(err)
-				}
-				changed = true
-			}
+			// Enslavement is applied after the up/down change below, to match
+			// Linux's do_setlink, which calls do_set_master after
+			// dev_change_flags.
 		case linux.IFLA_ADDRESS:
 			if len(v) != tcpip.LinkAddressSize {
 				return syserr.ErrInvalidArgument
@@ -408,10 +411,128 @@ func (s *Stack) setLinkLocked(ctx context.Context, id tcpip.NICID, linkAttrs map
 		}
 	}
 
+	// Apply the administrative up/down change after the attribute changes
+	// above. Skip it, like the attribute changes do, when the interface is
+	// already in the requested state: Linux performs no work and sends no
+	// notification for a no-op flag change.
+	if setUp != nil && *setUp != nicInfo.Flags.Up {
+		if *setUp {
+			if err := src.Stack.EnableNIC(id); err != nil {
+				return syserr.TranslateNetstackError(err)
+			}
+			// Like Linux, assign the default loopback addresses when the
+			// loopback interface is brought up.
+			if nicInfo.Flags.Loopback {
+				if err := src.addLoopbackAddrs(id); err != nil {
+					return err
+				}
+			}
+		} else {
+			// Snapshot addresses before disabling the NIC, since IPv6 address
+			// enumeration hides addresses while disabled.
+			addrs := src.Stack.AllAddressInfo()[id]
+			if err := src.Stack.DisableNIC(id); err != nil {
+				return syserr.TranslateNetstackError(err)
+			}
+			src.removeIPv6Addrs(id, addrs)
+		}
+		changed = true
+	}
+
+	// Apply enslavement (IFLA_MASTER) after the up/down change, matching
+	// Linux's do_setlink ordering.
+	if v, ok := linkAttrs[linux.IFLA_MASTER]; ok {
+		master, ok := v.Uint32()
+		if !ok {
+			return syserr.ErrInvalidArgument
+		}
+		if master != 0 {
+			if mid, ok := src.Stack.GetNICCoordinatorID(id); !ok || mid != tcpip.NICID(master) {
+				if err := src.Stack.SetNICCoordinator(id, tcpip.NICID(master)); err != nil {
+					return syserr.TranslateNetstackError(err)
+				}
+				changed = true
+			}
+		}
+	}
+
 	if changed {
 		src.sendChangeEvent(ctx, id)
 	}
 	return nil
+}
+
+// loopbackAddrs are the addresses Linux automatically assigns to a loopback
+// interface when it is brought up: 127.0.0.1/8 and ::1/128. They mirror
+// boot.DefaultLoopbackLink, which configures the loopback interface of the
+// initial network namespace.
+var loopbackAddrs = []tcpip.ProtocolAddress{
+	{
+		Protocol: ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   tcpip.AddrFrom4([4]byte{127, 0, 0, 1}),
+			PrefixLen: 8,
+		},
+	},
+	{
+		Protocol: ipv6.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{
+			Address:   header.IPv6Loopback,
+			PrefixLen: header.IPv6AddressSize * 8,
+		},
+	},
+}
+
+// addLoopbackAddrs assigns the default loopback addresses to the loopback
+// interface id. Like the Linux kernel, netstack does this when the loopback
+// interface is brought up rather than when it is created, so a freshly created
+// network namespace starts with an unconfigured loopback interface. Each address
+// is added through addInterfaceAddr, so its connected route is installed too,
+// just as for any other address.
+//
+// An address that is already assigned (ErrDuplicateAddress) is left as it is.
+func (s *Stack) addLoopbackAddrs(id tcpip.NICID) *syserr.Error {
+	for _, pa := range loopbackAddrs {
+		if pa.Protocol == ipv6.ProtocolNumber && !s.SupportsIPv6() {
+			continue
+		}
+		if err := s.addInterfaceAddr(id, pa); err != nil && err != syserr.ErrDuplicateAddress {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeIPv6Addrs removes IPv6 addresses from interface id when it is brought
+// down, matching Linux's keep_addr_on_down behavior.
+func (s *Stack) removeIPv6Addrs(id tcpip.NICID, addrs []stack.ProtocolAddressInfo) {
+	keepAddrOnDown := s.IPv6KeepAddrOnDown()
+	for _, addr := range addrs {
+		if !shouldRemoveIPv6AddrOnDown(addr, keepAddrOnDown) {
+			continue
+		}
+		protocolAddress := tcpip.ProtocolAddress{
+			Protocol:          addr.Protocol,
+			AddressWithPrefix: addr.AddressWithPrefix,
+		}
+		if err := s.removeInterfaceAddr(id, protocolAddress); err != nil && err != syserr.ErrBadLocalAddress {
+			log.Warningf("Failed to remove IPv6 address %s from NIC %d on interface down: %s", protocolAddress.AddressWithPrefix, id, err)
+		}
+	}
+}
+
+func shouldRemoveIPv6AddrOnDown(addr stack.ProtocolAddressInfo, keepAddrOnDown bool) bool {
+	if addr.Protocol != ipv6.ProtocolNumber {
+		return false
+	}
+	if !keepAddrOnDown {
+		return true
+	}
+	return !addr.Permanent || ipv6AddrIsLocal(addr.AddressWithPrefix.Address)
+}
+
+func ipv6AddrIsLocal(addr tcpip.Address) bool {
+	return header.IsV6LinkLocalUnicastAddress(addr) || header.IsV6LoopbackAddress(addr)
 }
 
 const defaultMTU = 1500
@@ -483,7 +604,7 @@ func (s *Stack) newVeth(ctx context.Context, linkAttrs map[uint16]nlmsg.BytesVie
 		s.unlockSrcAndDst(ctx, dstNs)
 		return syserr.TranslateNetstackError(err)
 	}
-	if err := s.setLinkLocked(ctx, id, linkAttrs, dstNs); err != nil {
+	if err := s.setLinkLocked(ctx, id, linkAttrs, dstNs, nil /* setUp */); err != nil {
 		s.unlockSrcAndDst(ctx, dstNs)
 		peerEP.Close()
 		return err
@@ -507,7 +628,7 @@ func (s *Stack) newVeth(ctx context.Context, linkAttrs map[uint16]nlmsg.BytesVie
 		return syserr.TranslateNetstackError(err)
 	}
 	if peerLinkAttrs != nil {
-		if err := peerStack.setLinkLocked(ctx, peerID, peerLinkAttrs, peerDstNs); err != nil {
+		if err := peerStack.setLinkLocked(ctx, peerID, peerLinkAttrs, peerDstNs, nil /* setUp */); err != nil {
 			peerStack.Stack.RemoveNIC(peerID)
 			peerEP.Close()
 			return err
@@ -537,7 +658,7 @@ func (s *Stack) newBridge(ctx context.Context, linkAttrs map[uint16]nlmsg.BytesV
 	if err != nil {
 		return syserr.TranslateNetstackError(err)
 	}
-	if err := s.setLinkLocked(ctx, id, linkAttrs, dstNs); err != nil {
+	if err := s.setLinkLocked(ctx, id, linkAttrs, dstNs, nil /* setUp */); err != nil {
 		return err
 	}
 
@@ -655,11 +776,17 @@ func (s *Stack) AddInterfaceAddr(idx int32, addr inet.InterfaceAddr) error {
 	if err != nil {
 		return err
 	}
+	if err := s.addInterfaceAddr(tcpip.NICID(idx), protocolAddress); err != nil {
+		return err.ToError()
+	}
+	return nil
+}
 
-	// Attach address to interface.
-	nicID := tcpip.NICID(idx)
+// addInterfaceAddr attaches protocolAddress to the NIC and, like the Linux
+// kernel, adds the connected route for its subnet if it does not already exist.
+func (s *Stack) addInterfaceAddr(nicID tcpip.NICID, protocolAddress tcpip.ProtocolAddress) *syserr.Error {
 	if err := s.Stack.AddProtocolAddress(nicID, protocolAddress, stack.AddressProperties{}); err != nil {
-		return syserr.TranslateNetstackError(err).ToError()
+		return syserr.TranslateNetstackError(err)
 	}
 
 	// Add route for local network if it doesn't exist already.
@@ -687,11 +814,18 @@ func (s *Stack) RemoveInterfaceAddr(idx int32, addr inet.InterfaceAddr) error {
 	if err != nil {
 		return err
 	}
+	if err := s.removeInterfaceAddr(tcpip.NICID(idx), protocolAddress); err != nil {
+		return err.ToError()
+	}
+	return nil
+}
 
+// removeInterfaceAddr removes protocolAddress from nicID and removes the
+// connected route for its subnet.
+func (s *Stack) removeInterfaceAddr(nicID tcpip.NICID, protocolAddress tcpip.ProtocolAddress) *syserr.Error {
 	// Remove addresses matching the address and prefix.
-	nicID := tcpip.NICID(idx)
 	if err := s.Stack.RemoveAddress(nicID, protocolAddress.AddressWithPrefix.Address); err != nil {
-		return syserr.TranslateNetstackError(err).ToError()
+		return syserr.TranslateNetstackError(err)
 	}
 
 	// Remove the corresponding local network route if it exists.
@@ -704,6 +838,17 @@ func (s *Stack) RemoveInterfaceAddr(idx int32, addr inet.InterfaceAddr) error {
 		return rt.Equal(localRoute)
 	})
 
+	return nil
+}
+
+// IPv6KeepAddrOnDown implements inet.Stack.IPv6KeepAddrOnDown.
+func (s *Stack) IPv6KeepAddrOnDown() bool {
+	return s.ipv6KeepAddrOnDown.Load()
+}
+
+// SetIPv6KeepAddrOnDown implements inet.Stack.SetIPv6KeepAddrOnDown.
+func (s *Stack) SetIPv6KeepAddrOnDown(enabled bool) error {
+	s.ipv6KeepAddrOnDown.Store(enabled)
 	return nil
 }
 

--- a/pkg/tcpip/network/ipv4/ipv4.go
+++ b/pkg/tcpip/network/ipv4/ipv4.go
@@ -1577,6 +1577,13 @@ func (e *endpoint) PermanentAddresses() []tcpip.AddressWithPrefix {
 	return e.addressableEndpointState.PermanentAddresses()
 }
 
+// AddressInfos implements stack.AddressableEndpoint.
+func (e *endpoint) AddressInfos() []stack.AddressInfo {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.addressableEndpointState.AddressInfos()
+}
+
 // JoinGroup implements stack.GroupAddressableEndpoint.
 func (e *endpoint) JoinGroup(addr tcpip.Address) tcpip.Error {
 	e.mu.Lock()

--- a/pkg/tcpip/network/ipv6/ipv6.go
+++ b/pkg/tcpip/network/ipv6/ipv6.go
@@ -2297,6 +2297,13 @@ func (e *endpoint) PermanentAddresses() []tcpip.AddressWithPrefix {
 	return e.mu.addressableEndpointState.PermanentAddresses()
 }
 
+// AddressInfos implements stack.AddressableEndpoint.
+func (e *endpoint) AddressInfos() []stack.AddressInfo {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.mu.addressableEndpointState.AddressInfos()
+}
+
 // JoinGroup implements stack.GroupAddressableEndpoint.
 func (e *endpoint) JoinGroup(addr tcpip.Address) tcpip.Error {
 	e.mu.Lock()

--- a/pkg/tcpip/stack/addressable_endpoint_state.go
+++ b/pkg/tcpip/stack/addressable_endpoint_state.go
@@ -719,6 +719,32 @@ func (a *AddressableEndpointState) PermanentAddresses() []tcpip.AddressWithPrefi
 	return addrs
 }
 
+// AddressInfos implements AddressableEndpoint.
+func (a *AddressableEndpointState) AddressInfos() []AddressInfo {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	var infos []AddressInfo
+	for _, ep := range a.endpoints {
+		switch kind := ep.GetKind(); kind {
+		case Permanent, PermanentTentative:
+		case Temporary, PermanentExpired:
+			continue
+		default:
+			panic(fmt.Sprintf("address %s has unknown kind %d", ep.AddressWithPrefix(), kind))
+		}
+
+		lifetimes := ep.Lifetimes()
+		validUntil := lifetimes.ValidUntil
+		infos = append(infos, AddressInfo{
+			AddressWithPrefix: ep.AddressWithPrefix(),
+			Permanent:         !ep.Temporary() && (validUntil == (tcpip.MonotonicTime{}) || validUntil == tcpip.MonotonicTimeInfinite()),
+		})
+	}
+
+	return infos
+}
+
 // Cleanup forcefully leaves all groups and removes all permanent addresses.
 func (a *AddressableEndpointState) Cleanup() {
 	a.mu.Lock()

--- a/pkg/tcpip/stack/nic.go
+++ b/pkg/tcpip/stack/nic.go
@@ -568,6 +568,25 @@ func (n *nic) allPermanentAddresses() []tcpip.ProtocolAddress {
 	return addrs
 }
 
+func (n *nic) allAddressInfo() []ProtocolAddressInfo {
+	var infos []ProtocolAddressInfo
+	for p, ep := range n.networkEndpoints {
+		addressableEndpoint, ok := ep.(AddressableEndpoint)
+		if !ok {
+			continue
+		}
+
+		for _, info := range addressableEndpoint.AddressInfos() {
+			infos = append(infos, ProtocolAddressInfo{
+				Protocol:          p,
+				AddressWithPrefix: info.AddressWithPrefix,
+				Permanent:         info.Permanent,
+			})
+		}
+	}
+	return infos
+}
+
 // primaryAddresses returns the primary addresses associated with this NIC.
 func (n *nic) primaryAddresses() []tcpip.ProtocolAddress {
 	var addrs []tcpip.ProtocolAddress

--- a/pkg/tcpip/stack/registration.go
+++ b/pkg/tcpip/stack/registration.go
@@ -526,6 +526,27 @@ type AddressProperties struct {
 	Disp      AddressDispatcher
 }
 
+// AddressInfo contains information about an address assigned to an
+// AddressableEndpoint.
+type AddressInfo struct {
+	AddressWithPrefix tcpip.AddressWithPrefix
+
+	// Permanent is true if the address is configured with an infinite valid
+	// lifetime and is not a temporary (RFC 4941) address.
+	Permanent bool
+}
+
+// ProtocolAddressInfo contains information about a protocol address assigned to
+// a NIC.
+type ProtocolAddressInfo struct {
+	Protocol tcpip.NetworkProtocolNumber
+	tcpip.AddressWithPrefix
+
+	// Permanent is true if the address is configured with an infinite valid
+	// lifetime and is not a temporary (RFC 4941) address.
+	Permanent bool
+}
+
 // AddressAssignmentState is an address' assignment state.
 type AddressAssignmentState int
 
@@ -782,6 +803,10 @@ type AddressableEndpoint interface {
 
 	// PermanentAddresses returns all the permanent addresses.
 	PermanentAddresses() []tcpip.AddressWithPrefix
+
+	// AddressInfos returns all configured address endpoints, including tentative
+	// endpoints, but excluding expired endpoints and one-off temporary endpoints.
+	AddressInfos() []AddressInfo
 }
 
 // NDPEndpoint is a network endpoint that supports NDP.

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -1227,7 +1227,7 @@ func forwardingValue(forwardingFn forwardingFn, proto tcpip.NetworkProtocolNumbe
 // precondition: s.mu is held.
 func (s *Stack) nicInfo(nic *nic, id tcpip.NICID) *NICInfo {
 	flags := NICStateFlags{
-		Up:          true, // Netstack interfaces are always up.
+		Up:          nic.Enabled(),
 		Running:     nic.Enabled(),
 		Promiscuous: nic.Promiscuous(),
 		Loopback:    nic.IsLoopback(),
@@ -1357,6 +1357,18 @@ func (s *Stack) AllAddresses() map[tcpip.NICID][]tcpip.ProtocolAddress {
 	nics := make(map[tcpip.NICID][]tcpip.ProtocolAddress)
 	for id, nic := range s.nics {
 		nics[id] = nic.allPermanentAddresses()
+	}
+	return nics
+}
+
+// AllAddressInfo returns a map of NICIDs to their protocol address information.
+func (s *Stack) AllAddressInfo() map[tcpip.NICID][]ProtocolAddressInfo {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	nics := make(map[tcpip.NICID][]ProtocolAddressInfo)
+	for id, nic := range s.nics {
+		nics[id] = nic.allAddressInfo()
 	}
 	return nics
 }

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -1845,12 +1845,20 @@ func (c *sandboxNetstackCreator) CreateStack() (inet.Stack, error) {
 	}
 	link := DefaultLoopbackLink
 	linkEP := ethernet.New(loopback.New())
+
+	// Like Linux, create the loopback interface of a freshly created network
+	// namespace administratively DOWN and with no addresses. The application
+	// brings it up with RTM_NEWLINK (IFF_UP), at which point netstack assigns the
+	// default loopback addresses, just as the Linux kernel does. The initial
+	// network namespace is configured separately in Network.CreateLinksAndRoutes
+	// and keeps its addresses and UP state.
 	opts := stack.NICOptions{
 		Name:               link.Name,
 		DeliverLinkPackets: true,
+		Disabled:           true,
 	}
 
-	if err := n.createNICWithAddrs(nicID, linkEP, opts, link.Addresses); err != nil {
+	if err := n.createNICWithAddrs(nicID, linkEP, opts, nil /* addrs */); err != nil {
 		return nil, err
 	}
 

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4704,11 +4704,13 @@ cc_binary(
     malloc = "//test/util:errno_safe_allocator",
     deps = select_gtest() + [
         ":ip_socket_test_util",
+        ":socket_netlink_route_util",
         "//test/util:capability_util",
         "//test/util:file_descriptor",
         "//test/util:logging",
         "//test/util:multiprocess_util",
         "//test/util:posix_error",
+        "//test/util:socket_util",
         "//test/util:temp_path",
         "//test/util:test_main",
         "//test/util:test_util",

--- a/test/syscalls/linux/network_namespace.cc
+++ b/test/syscalls/linux/network_namespace.cc
@@ -12,19 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <fcntl.h>
 #include <sys/mount.h>
+#include <unistd.h>
 
 #include <cerrno>
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "test/syscalls/linux/ip_socket_test_util.h"
+#include "test/syscalls/linux/socket_netlink_route_util.h"
 #include "test/util/capability_util.h"
 #include "test/util/file_descriptor.h"
 #include "test/util/linux_capability_util.h"
 #include "test/util/logging.h"
 #include "test/util/multiprocess_util.h"
 #include "test/util/posix_error.h"
+#include "test/util/socket_util.h"
 #include "test/util/temp_path.h"
 #include "test/util/test_util.h"
 #include "test/util/thread_util.h"
@@ -44,6 +48,205 @@ TEST(NetworkNamespaceTest, LoopbackExists) {
 
     // TODO(gvisor.dev/issue/1833): Update this to test that only "lo" exists.
     ASSERT_NE(ASSERT_NO_ERRNO_AND_VALUE(GetLoopbackIndex()), 0);
+  });
+}
+
+// Like Linux, a newly created network namespace starts with its loopback
+// interface administratively DOWN. The application is responsible for bringing
+// it up, after which it reports IFF_UP.
+TEST(NetworkNamespaceTest, LoopbackStartsDown) {
+  // TODO(b/267210840): Fix this tests for hostinet.
+  SKIP_IF(IsRunningWithHostinet());
+
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
+
+  ScopedThread t([&] {
+    ASSERT_THAT(unshare(CLONE_NEWNET), SyscallSucceedsWithValue(0));
+
+    Link lo = ASSERT_NO_ERRNO_AND_VALUE(LoopbackLink());
+    EXPECT_EQ(lo.flags & IFF_UP, 0u)
+        << "loopback should start down in a new network namespace";
+
+    // The application can bring it up, just like on Linux.
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, IFF_UP, IFF_UP));
+
+    lo = ASSERT_NO_ERRNO_AND_VALUE(LoopbackLink());
+    EXPECT_NE(lo.flags & IFF_UP, 0u)
+        << "loopback should be up after bringing it up";
+  });
+}
+
+// Like Linux, the loopback interface of a new network namespace starts with no
+// addresses; the kernel assigns 127.0.0.1/8 and ::1/128 when it is brought up.
+TEST(NetworkNamespaceTest, LoopbackAddressesAddedOnUp) {
+  // TODO(b/267210840): Fix this tests for hostinet.
+  SKIP_IF(IsRunningWithHostinet());
+
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
+
+  ScopedThread t([&] {
+    ASSERT_THAT(unshare(CLONE_NEWNET), SyscallSucceedsWithValue(0));
+
+    struct sockaddr_in addr4 = {};
+    addr4.sin_family = AF_INET;
+    addr4.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    struct sockaddr_in6 addr6 = {};
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_addr = in6addr_loopback;
+
+    // Before the loopback interface is brought up it has no addresses, so
+    // binding to a loopback address fails.
+    {
+      FileDescriptor s4 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s4.get(), AsSockAddr(&addr4), sizeof(addr4)),
+                  SyscallFailsWithErrno(EADDRNOTAVAIL));
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&addr6), sizeof(addr6)),
+                  SyscallFailsWithErrno(EADDRNOTAVAIL));
+    }
+
+    Link lo = ASSERT_NO_ERRNO_AND_VALUE(LoopbackLink());
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, IFF_UP, IFF_UP));
+
+    // Bringing it up assigns the default loopback addresses, just like Linux, so
+    // binding to them now succeeds.
+    {
+      FileDescriptor s4 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s4.get(), AsSockAddr(&addr4), sizeof(addr4)),
+                  SyscallSucceeds());
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&addr6), sizeof(addr6)),
+                  SyscallSucceeds());
+    }
+
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, 0, IFF_UP));
+
+    // Linux removes IPv6 local addresses when an interface goes down, so ::1 is
+    // no longer bindable. IPv4 loopback addresses remain assigned.
+    {
+      FileDescriptor s4 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s4.get(), AsSockAddr(&addr4), sizeof(addr4)),
+                  SyscallSucceeds());
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&addr6), sizeof(addr6)),
+                  SyscallFailsWithErrno(EADDRNOTAVAIL));
+    }
+
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, IFF_UP, IFF_UP));
+
+    // Bringing loopback up again recreates ::1.
+    {
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&addr6), sizeof(addr6)),
+                  SyscallSucceeds());
+    }
+  });
+}
+
+// Like Linux, IPv6 addresses are flushed when an interface goes down. When
+// net/ipv6/conf/all/keep_addr_on_down is enabled, permanent global addresses
+// instead survive a down/up cycle.
+TEST(NetworkNamespaceTest, IPv6KeepAddrOnDown) {
+  // TODO(b/267210840): Fix this tests for hostinet.
+  SKIP_IF(IsRunningWithHostinet());
+
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
+
+  ScopedThread t([&] {
+    ASSERT_THAT(unshare(CLONE_NEWNET), SyscallSucceedsWithValue(0));
+
+    FileDescriptor nlsk =
+        ASSERT_NO_ERRNO_AND_VALUE(NetlinkBoundSocket(NETLINK_ROUTE));
+
+    Link lo = ASSERT_NO_ERRNO_AND_VALUE(LoopbackLink());
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, IFF_UP, IFF_UP));
+
+    // A permanent global IPv6 address (2001:db8::1) assigned to loopback. It is
+    // neither link-local nor loopback, so keep_addr_on_down applies to it.
+    struct in6_addr global = {};
+    global.s6_addr[0] = 0x20;
+    global.s6_addr[1] = 0x01;
+    global.s6_addr[2] = 0x0d;
+    global.s6_addr[3] = 0xb8;
+    global.s6_addr[15] = 0x01;
+
+    struct sockaddr_in6 addr6 = {};
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_addr = global;
+
+    // keep_addr_on_down defaults to off: bringing the interface down flushes
+    // the global address, and bringing it back up does not restore it.
+    ASSERT_NO_ERRNO(LinkAddLocalAddr(nlsk, lo.index, AF_INET6,
+                                     /*prefixlen=*/128, &global,
+                                     sizeof(global)));
+    {
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&addr6), sizeof(addr6)),
+                  SyscallSucceeds());
+    }
+
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, 0, IFF_UP));
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, IFF_UP, IFF_UP));
+
+    {
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&addr6), sizeof(addr6)),
+                  SyscallFailsWithErrno(EADDRNOTAVAIL));
+    }
+
+    // Enable keep_addr_on_down and re-assign the global address.
+    {
+      const FileDescriptor fd = ASSERT_NO_ERRNO_AND_VALUE(
+          Open("/proc/sys/net/ipv6/conf/all/keep_addr_on_down", O_WRONLY));
+      constexpr char kEnable[] = "1";
+      ASSERT_THAT(write(fd.get(), kEnable, sizeof(kEnable) - 1),
+                  SyscallSucceedsWithValue(sizeof(kEnable) - 1));
+    }
+
+    ASSERT_NO_ERRNO(LinkAddLocalAddr(nlsk, lo.index, AF_INET6,
+                                     /*prefixlen=*/128, &global,
+                                     sizeof(global)));
+
+    struct sockaddr_in6 loaddr6 = {};
+    loaddr6.sin6_family = AF_INET6;
+    loaddr6.sin6_addr = in6addr_loopback;
+
+    // Like Linux, keep_addr_on_down does not apply to IPv6 loopback or
+    // link-local addresses: ::1 is still removed when the interface goes down.
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, 0, IFF_UP));
+    {
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&loaddr6), sizeof(loaddr6)),
+                  SyscallFailsWithErrno(EADDRNOTAVAIL));
+    }
+
+    ASSERT_NO_ERRNO(LinkChangeFlags(lo.index, IFF_UP, IFF_UP));
+
+    // Bringing the interface back up recreates ::1, and the permanent global
+    // address survived the down/up cycle because keep_addr_on_down is enabled.
+    {
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&loaddr6), sizeof(loaddr6)),
+                  SyscallSucceeds());
+    }
+    {
+      FileDescriptor s6 =
+          ASSERT_NO_ERRNO_AND_VALUE(Socket(AF_INET6, SOCK_STREAM, 0));
+      EXPECT_THAT(bind(s6.get(), AsSockAddr(&addr6), sizeof(addr6)),
+                  SyscallSucceeds());
+    }
   });
 }
 

--- a/test/syscalls/linux/proc_net.cc
+++ b/test/syscalls/linux/proc_net.cc
@@ -40,6 +40,8 @@ namespace {
 
 constexpr const char kProcNet[] = "/proc/net";
 constexpr const char kIpForward[] = "/proc/sys/net/ipv4/ip_forward";
+constexpr const char kIPv6KeepAddrOnDown[] =
+    "/proc/sys/net/ipv6/conf/all/keep_addr_on_down";
 constexpr const char kRangeFile[] = "/proc/sys/net/ipv4/ip_local_port_range";
 
 TEST(ProcNetSymlinkTarget, FileMode) {
@@ -583,6 +585,34 @@ TEST(ProcSysNetIpv4Recovery, CanReadAndWrite) {
 
 TEST(ProcSysNetIpv4IpForward, Exists) {
   auto fd = ASSERT_NO_ERRNO_AND_VALUE(Open(kIpForward, O_RDONLY));
+}
+
+TEST(ProcSysNetIpv6KeepAddrOnDown, Exists) {
+  auto fd = ASSERT_NO_ERRNO_AND_VALUE(Open(kIPv6KeepAddrOnDown, O_RDONLY));
+}
+
+TEST(ProcSysNetIpv6KeepAddrOnDown, CanReadAndWrite) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability((CAP_NET_ADMIN))) ||
+          IsRunningWithHostinet());
+
+  auto const fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open(kIPv6KeepAddrOnDown, O_RDWR));
+
+  char buf;
+  EXPECT_THAT(PreadFd(fd.get(), &buf, sizeof(buf), 0),
+              SyscallSucceedsWithValue(sizeof(buf)));
+
+  EXPECT_TRUE(buf == '0' || buf == '1')
+      << "unexpected keep_addr_on_down: " << buf;
+
+  char to_write = (buf == '1') ? '0' : '1';
+  EXPECT_THAT(PwriteFd(fd.get(), &to_write, sizeof(to_write), 0),
+              SyscallSucceedsWithValue(sizeof(to_write)));
+
+  buf = 0;
+  EXPECT_THAT(PreadFd(fd.get(), &buf, sizeof(buf), 0),
+              SyscallSucceedsWithValue(sizeof(buf)));
+  EXPECT_EQ(buf, to_write);
 }
 
 TEST(ProcSysNetIpv4IpForward, DefaultValueEqZero) {


### PR DESCRIPTION
AI usage: written by Claude with guidance: I think it's fine in general, but I suspect it might need adjustments since I'm not really familiar with the codebase and I reviewed it but not in a very in-depth way

This pull requests adds support for pulling interfaces up and down, and aligns the address addition semantics to Linux ones: create loopback with no addresses and add them on up if not already present, and remove IPv6 addresses on down unless keep_addr_on_down sysctl is set and they are not local/loopback.

The motivation is to make bwrap --unshare-net work (currently fails because gVisor starts loopback with 127.0.0.1 assigned and bwrap tries to add it without ignoring errors) and thus Claude Code and Codex with sandbox configurations that partially or fully deny network access.

I can squash the commits if approved, but it seems better to keep them separate for review.

Commit 1: adds support to set interfaces up/down. This is necessary so that we can add loopback addresses on up like Linux does and also aligns behavior in network namespaces to the Linux one of starting with loopback down, and generally provides support for ip link set <dev> up/down

Commit 2: extract helper to prepare for next commit

Commit 3: start loopback down with no addresses and add them on up if they are not present. This is the motivation of the PR, and makes bubblewrap --unshare-net work.

Commit 4: this removes IPv6 addresses on interface down, to align with Linux behavior (mysteriously, by default IPv6 addresses are removed but not IPv4 ones...)

Commit 5: adds support for the IPv6 "keep_addr_on_down" sysctl to not remove IPv6 addresses (except linklocal and loopback addresses). This is optional, but since the default Linux IPv6 stack behavior is kind of absurd (why would one automatically remove addresses on down, especially given IPv4 doesn't...), and previously gVisor didn't do this, this sysctl allows to restore saner behavior. It only supports the all/ version since gVisor currently has no per-netdev sysctls. This is probably the commit that is most likely to need refactoring to adjust to gVisor conventions.
