### PR TITLE
Implement /proc/sys/user/max_user_namespaces

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -88,6 +88,9 @@ func (fs *filesystem) newSysDir(ctx context.Context, root *auth.Credentials, k *
 			"overcommit_memory": fs.newInode(ctx, root, 0444, newStaticFile("0\n")),
 		}),
 		"net": fs.newSysNetDir(ctx, root, k),
+		"user": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
+			"max_user_namespaces": fs.newInode(ctx, root, 0644, &maxUserNamespacesData{}),
+		}),
 	})
 }
 
@@ -241,6 +244,42 @@ func (*uuidData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 // GetDynamicBytesPoller implements vfs.PollableDynamicBytesSource.GetDynamicBytesPoller.
 func (*domainnameData) GetDynamicBytesPoller(ctx context.Context) *vfs.DynamicBytesPoller {
 	return &kernel.KernelFromContext(ctx).DomainNamePoller
+}
+
+// maxUserNamespacesData implements vfs.WritableDynamicBytesSource for
+// /proc/sys/user/max_user_namespaces, the caller's own user namespace limit.
+//
+// +stateify savable
+type maxUserNamespacesData struct {
+	kernfs.DynamicBytesFile
+}
+
+var _ vfs.WritableDynamicBytesSource = (*maxUserNamespacesData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (*maxUserNamespacesData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	userns := auth.CredentialsFromContext(ctx).UserNamespace
+	_, err := fmt.Fprintf(buf, "%d\n", userns.MaxUserNamespaces())
+	return err
+}
+
+// Write implements vfs.WritableDynamicBytesSource.Write.
+func (*maxUserNamespacesData) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
+	if offset != 0 {
+		// Ignore partial writes.
+		return 0, linuxerr.EINVAL
+	}
+	var buf [1]int32
+	n, err := ParseInt32Vec(ctx, src, buf[:])
+	if err != nil || n == 0 {
+		return 0, err
+	}
+	// The limit is a non-negative count.
+	if buf[0] < 0 {
+		return 0, linuxerr.EINVAL
+	}
+	auth.CredentialsFromContext(ctx).UserNamespace.SetMaxUserNamespaces(buf[0])
+	return n, nil
 }
 
 // tcpSackData implements vfs.WritableDynamicBytesSource for

--- a/pkg/sentry/kernel/auth/user_namespace.go
+++ b/pkg/sentry/kernel/auth/user_namespace.go
@@ -62,6 +62,15 @@ type UserNamespace struct {
 	// setgroupsAllowed mirrors USERNS_SETGROUPS_ALLOWED in Linux. Protected by mu.
 	setgroupsAllowed bool
 
+	// maxUserNamespaces is this namespace's /proc/sys/user/max_user_namespaces:
+	// the most descendant user namespaces that may be charged to it. Protected
+	// by mu.
+	maxUserNamespaces int32
+
+	// numUserNamespaces is the number of descendant user namespaces currently
+	// charged to this namespace. Protected by mu.
+	numUserNamespaces int32
+
 	// inode is the nsfs inode associated with this namespace. This is stored as
 	// refs.TryRefCounter instead of *nsfs.Inode because nsfs imports auth.
 	inode refs.TryRefCounter
@@ -75,6 +84,7 @@ type UserNamespace struct {
 func NewRootUserNamespace() *UserNamespace {
 	var ns UserNamespace
 	ns.setgroupsAllowed = true
+	ns.maxUserNamespaces = defaultMaxUserNamespaces
 	// """
 	// The initial user namespace has no parent namespace, but, for
 	// consistency, the kernel provides dummy user and group ID mapping files
@@ -109,8 +119,29 @@ func (ns *UserNamespace) Type() string {
 	return "user"
 }
 
-// Destroy implements vfs.Namespace.Destroy.
-func (ns *UserNamespace) Destroy(ctx context.Context) {}
+// Destroy implements vfs.Namespace.Destroy. Called when ns's nsfs inode
+// refcount reaches zero, it releases ns's charge on its ancestors.
+func (ns *UserNamespace) Destroy(ctx context.Context) {
+	for anc := ns.parent; anc != nil; anc = anc.parent {
+		anc.mu.Lock()
+		anc.numUserNamespaces--
+		anc.mu.Unlock()
+	}
+}
+
+// MaxUserNamespaces returns ns's max_user_namespaces limit.
+func (ns *UserNamespace) MaxUserNamespaces() int32 {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	return ns.maxUserNamespaces
+}
+
+// SetMaxUserNamespaces sets ns's max_user_namespaces limit.
+func (ns *UserNamespace) SetMaxUserNamespaces(max int32) {
+	ns.mu.Lock()
+	defer ns.mu.Unlock()
+	ns.maxUserNamespaces = max
+}
 
 // UserNamespace implements vfs.Namespace.UserNamespace.
 func (ns *UserNamespace) UserNamespace() *UserNamespace {
@@ -158,6 +189,10 @@ func (ns *UserNamespace) DecRef(ctx context.Context) {
 // namespaces." - user_namespaces(7)
 const maxUserNamespaceDepth = 32
 
+// defaultMaxUserNamespaces is a new namespace's max_user_namespaces: effectively
+// unlimited until lowered through /proc/sys/user/max_user_namespaces.
+const defaultMaxUserNamespaces = math.MaxInt32
+
 func (ns *UserNamespace) depth() int {
 	var i int
 	for ns != nil {
@@ -190,15 +225,53 @@ func (c *Credentials) NewChildUserNamespace() (*UserNamespace, error) {
 	c.UserNamespace.mu.Lock()
 	parentSetgroupsAllowed := c.UserNamespace.setgroupsAllowed
 	c.UserNamespace.mu.Unlock()
+	// Charge the new namespace to the creating namespace and its ancestors;
+	// ENOSPC if any has hit its max_user_namespaces.
+	if err := c.UserNamespace.chargeChild(); err != nil {
+		return nil, err
+	}
 	return &UserNamespace{
-		parent:           c.UserNamespace,
-		owner:            c.EffectiveKUID,
-		parentHadSetfcap: c.HasSelfCapability(linux.CAP_SETFCAP),
-		setgroupsAllowed: parentSetgroupsAllowed,
+		parent:            c.UserNamespace,
+		owner:             c.EffectiveKUID,
+		parentHadSetfcap:  c.HasSelfCapability(linux.CAP_SETFCAP),
+		setgroupsAllowed:  parentSetgroupsAllowed,
+		maxUserNamespaces: defaultMaxUserNamespaces,
 		// "When a user namespace is created, it starts without a mapping of
 		// user IDs (group IDs) to the parent user namespace." -
 		// user_namespaces(7)
 	}, nil
+}
+
+// chargeChild increments the descendant count of ns and each ancestor for a
+// new child namespace. If any would exceed its max_user_namespaces, it rolls
+// back and returns ENOSPC. Locks each mu alone, descendant-to-ancestor per the
+// lock order on mu.
+func (ns *UserNamespace) chargeChild() error {
+	var charged []*UserNamespace
+	for cur := ns; cur != nil; cur = cur.parent {
+		cur.mu.Lock()
+		// Check before incrementing so the count never exceeds the limit (and
+		// so it cannot overflow, since the limit is at most math.MaxInt32).
+		if cur.numUserNamespaces >= cur.maxUserNamespaces {
+			cur.mu.Unlock()
+			unchargeChain(charged)
+			return linuxerr.ENOSPC
+		}
+		cur.numUserNamespaces++
+		charged = append(charged, cur)
+		cur.mu.Unlock()
+	}
+	return nil
+}
+
+// unchargeChain decrements the descendant count of each namespace in chain. It
+// undoes a partial or complete chargeChild.
+func unchargeChain(chain []*UserNamespace) {
+	for _, ns := range chain {
+		ns.mu.Lock()
+		ns.numUserNamespaces--
+		ns.mu.Unlock()
+	}
 }
 
 // SetgroupsAllowed returns ns's USERNS_SETGROUPS_ALLOWED bit.

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -2865,6 +2865,179 @@ TEST(ProcSysKernelRandomUuid, DifferentEveryTime) {
   EXPECT_NE(uuid1, uuid2);
 }
 
+TEST(ProcSysUserMaxUserNamespaces, Exists) {
+  EXPECT_THAT(open("/proc/sys/user/max_user_namespaces", O_RDONLY),
+              SyscallSucceeds());
+}
+
+TEST(ProcSysUserMaxUserNamespaces, HasNumericValue) {
+  const std::string val_str = ASSERT_NO_ERRNO_AND_VALUE(
+      GetContents("/proc/sys/user/max_user_namespaces"));
+  int64_t val;
+  EXPECT_TRUE(absl::SimpleAtoi(val_str, &val))
+      << "/proc/sys/user/max_user_namespaces does not contain a numeric value: "
+      << val_str;
+  // The default permits creating user namespaces.
+  EXPECT_GT(val, 0);
+}
+
+// Writing the limit in a fresh user namespace reads back unchanged.
+TEST(ProcSysUserMaxUserNamespaces, WriteUpdatesValue) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  EXPECT_THAT(InForkedProcess([] {
+                // Throwaway namespace: we hold full caps here, so may write it.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                MaybeSave();
+
+                int wfd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                TEST_PCHECK(wfd >= 0);
+                TEST_PCHECK(write(wfd, "42", 2) == 2);
+                TEST_PCHECK(close(wfd) == 0);
+
+                int rfd = open("/proc/sys/user/max_user_namespaces", O_RDONLY);
+                TEST_PCHECK(rfd >= 0);
+                char buf[32] = {};
+                TEST_PCHECK(read(rfd, buf, sizeof(buf) - 1) >= 2);
+                TEST_PCHECK(close(rfd) == 0);
+                // Compare bytes directly to stay async-signal-safe.
+                TEST_PCHECK(buf[0] == '4' && buf[1] == '2');
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
+// A negative limit is rejected.
+TEST(ProcSysUserMaxUserNamespaces, RejectsNegativeValue) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  EXPECT_THAT(InForkedProcess([] {
+                // Throwaway namespace so the host's value is left untouched.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                MaybeSave();
+
+                int fd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                TEST_PCHECK(fd >= 0);
+                TEST_CHECK_ERRNO(write(fd, "-1", 2), EINVAL);
+                TEST_PCHECK(close(fd) == 0);
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
+// With the limit at zero, creating a nested user namespace must fail.
+TEST(ProcSysUserMaxUserNamespaces, LimitBlocksNestedUserNamespace) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  // An unmapped namespace returns EPERM before the limit is checked, so map it
+  // first; mapping from the parent (not /proc/self) keeps teardown clean.
+  char ubuf[32], gbuf[32];
+  snprintf(ubuf, sizeof(ubuf), "0 %u 1", getuid());
+  snprintf(gbuf, sizeof(gbuf), "0 %u 1", getgid());
+  const std::string uid_map = ubuf;
+  const std::string gid_map = gbuf;
+
+  EXPECT_THAT(InForkedProcess([&uid_map, &gid_map] {
+                int ready[2], go[2];
+                TEST_PCHECK(pipe(ready) == 0);
+                TEST_PCHECK(pipe(go) == 0);
+                pid_t child = fork();
+                TEST_PCHECK(child >= 0);
+                if (child == 0) {
+                  TEST_PCHECK(close(ready[0]) == 0);
+                  TEST_PCHECK(close(go[1]) == 0);
+                  TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                  TEST_PCHECK(close(ready[1]) == 0);  // namespace created
+                  char x;
+                  RetryEINTR(read)(go[0], &x, 1);  // wait until mapped
+
+                  // Forbid descendants, then the next unshare must be ENOSPC.
+                  int fd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                  TEST_PCHECK(fd >= 0);
+                  TEST_PCHECK(write(fd, "0", 1) == 1);
+                  TEST_PCHECK(close(fd) == 0);
+                  TEST_CHECK_ERRNO(unshare(CLONE_NEWUSER), ENOSPC);
+                  _exit(0);
+                }
+                TEST_PCHECK(close(ready[1]) == 0);
+                TEST_PCHECK(close(go[0]) == 0);
+                char c;
+                TEST_PCHECK(RetryEINTR(read)(ready[0], &c, 1) == 0);
+
+                // Map the child's namespace (uid_map, then setgroups, gid_map).
+                auto write_file = [](const char* path, const char* data,
+                                     size_t len) {
+                  int fd = open(path, O_WRONLY);
+                  TEST_PCHECK(fd >= 0);
+                  TEST_PCHECK(write(fd, data, len) ==
+                              static_cast<ssize_t>(len));
+                  TEST_PCHECK(close(fd) == 0);
+                };
+                char path[64];
+                snprintf(path, sizeof(path), "/proc/%d/uid_map", child);
+                write_file(path, uid_map.c_str(), uid_map.size());
+                snprintf(path, sizeof(path), "/proc/%d/setgroups", child);
+                write_file(path, "deny", 4);
+                snprintf(path, sizeof(path), "/proc/%d/gid_map", child);
+                write_file(path, gid_map.c_str(), gid_map.size());
+
+                TEST_PCHECK(close(go[1]) == 0);  // release child
+                int status;
+                TEST_PCHECK(RetryEINTR(waitpid)(child, &status, 0) == child);
+                TEST_PCHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
+// A parent namespace with a limit of one still blocks a grandchild namespace:
+// each new namespace is charged to its ancestors, so the child uses up the
+// parent's single-namespace budget even though the child's own limit is the
+// default. This is the case bubblewrap exercises.
+TEST(ProcSysUserMaxUserNamespaces, RecursiveLimitBlocksGrandchild) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  // Each namespace is mapped before nesting deeper, otherwise the next unshare
+  // returns EPERM from an unmapped namespace before the limit is checked.
+  char ubuf[32], gbuf[32];
+  snprintf(ubuf, sizeof(ubuf), "0 %u 1", getuid());
+  snprintf(gbuf, sizeof(gbuf), "0 %u 1", getgid());
+  const std::string uid_map = ubuf;
+  const std::string gid_map = gbuf;
+
+  EXPECT_THAT(InForkedProcess([&uid_map, &gid_map] {
+                auto self_map = [](const char* name, const char* data,
+                                   size_t len) {
+                  char path[64];
+                  snprintf(path, sizeof(path), "/proc/self/%s", name);
+                  int fd = open(path, O_WRONLY);
+                  TEST_PCHECK(fd >= 0);
+                  TEST_PCHECK(write(fd, data, len) ==
+                              static_cast<ssize_t>(len));
+                  TEST_PCHECK(close(fd) == 0);
+                };
+
+                // Parent namespace A, mapped, allowing exactly one descendant.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                self_map("uid_map", uid_map.c_str(), uid_map.size());
+                self_map("setgroups", "deny", 4);
+                self_map("gid_map", gid_map.c_str(), gid_map.size());
+                int fd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                TEST_PCHECK(fd >= 0);
+                TEST_PCHECK(write(fd, "1", 1) == 1);
+                TEST_PCHECK(close(fd) == 0);
+
+                // Child namespace B succeeds and consumes A's budget. The mapped
+                // uid is now 0, so map it to itself.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                self_map("uid_map", "0 0 1", 5);
+                self_map("setgroups", "deny", 4);
+                self_map("gid_map", "0 0 1", 5);
+
+                // The grandchild is still charged to A, whose budget is gone, so
+                // the unshare must fail with ENOSPC rather than succeeding.
+                TEST_CHECK_ERRNO(unshare(CLONE_NEWUSER), ENOSPC);
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
 TEST(ProcSysVmMaxmapCount, HasNumericValue) {
   const std::string val_str =
       ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/vm/max_map_count"));

--- a/test/syscalls/linux/proc.cc
+++ b/test/syscalls/linux/proc.cc
@@ -2879,6 +2879,179 @@ TEST(ProcSysKernelRandomUuid, DifferentEveryTime) {
   EXPECT_NE(uuid1, uuid2);
 }
 
+TEST(ProcSysUserMaxUserNamespaces, Exists) {
+  EXPECT_THAT(open("/proc/sys/user/max_user_namespaces", O_RDONLY),
+              SyscallSucceeds());
+}
+
+TEST(ProcSysUserMaxUserNamespaces, HasNumericValue) {
+  const std::string val_str = ASSERT_NO_ERRNO_AND_VALUE(
+      GetContents("/proc/sys/user/max_user_namespaces"));
+  int64_t val;
+  EXPECT_TRUE(absl::SimpleAtoi(val_str, &val))
+      << "/proc/sys/user/max_user_namespaces does not contain a numeric value: "
+      << val_str;
+  // The default permits creating user namespaces.
+  EXPECT_GT(val, 0);
+}
+
+// Writing the limit in a fresh user namespace reads back unchanged.
+TEST(ProcSysUserMaxUserNamespaces, WriteUpdatesValue) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  EXPECT_THAT(InForkedProcess([] {
+                // Throwaway namespace: we hold full caps here, so may write it.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                MaybeSave();
+
+                int wfd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                TEST_PCHECK(wfd >= 0);
+                TEST_PCHECK(write(wfd, "42", 2) == 2);
+                TEST_PCHECK(close(wfd) == 0);
+
+                int rfd = open("/proc/sys/user/max_user_namespaces", O_RDONLY);
+                TEST_PCHECK(rfd >= 0);
+                char buf[32] = {};
+                TEST_PCHECK(read(rfd, buf, sizeof(buf) - 1) >= 2);
+                TEST_PCHECK(close(rfd) == 0);
+                // Compare bytes directly to stay async-signal-safe.
+                TEST_PCHECK(buf[0] == '4' && buf[1] == '2');
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
+// A negative limit is rejected.
+TEST(ProcSysUserMaxUserNamespaces, RejectsNegativeValue) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  EXPECT_THAT(InForkedProcess([] {
+                // Throwaway namespace so the host's value is left untouched.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                MaybeSave();
+
+                int fd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                TEST_PCHECK(fd >= 0);
+                TEST_CHECK_ERRNO(write(fd, "-1", 2), EINVAL);
+                TEST_PCHECK(close(fd) == 0);
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
+// With the limit at zero, creating a nested user namespace must fail.
+TEST(ProcSysUserMaxUserNamespaces, LimitBlocksNestedUserNamespace) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  // An unmapped namespace returns EPERM before the limit is checked, so map it
+  // first; mapping from the parent (not /proc/self) keeps teardown clean.
+  char ubuf[32], gbuf[32];
+  snprintf(ubuf, sizeof(ubuf), "0 %u 1", getuid());
+  snprintf(gbuf, sizeof(gbuf), "0 %u 1", getgid());
+  const std::string uid_map = ubuf;
+  const std::string gid_map = gbuf;
+
+  EXPECT_THAT(InForkedProcess([&uid_map, &gid_map] {
+                int ready[2], go[2];
+                TEST_PCHECK(pipe(ready) == 0);
+                TEST_PCHECK(pipe(go) == 0);
+                pid_t child = fork();
+                TEST_PCHECK(child >= 0);
+                if (child == 0) {
+                  TEST_PCHECK(close(ready[0]) == 0);
+                  TEST_PCHECK(close(go[1]) == 0);
+                  TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                  TEST_PCHECK(close(ready[1]) == 0);  // namespace created
+                  char x;
+                  RetryEINTR(read)(go[0], &x, 1);  // wait until mapped
+
+                  // Forbid descendants, then the next unshare must be ENOSPC.
+                  int fd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                  TEST_PCHECK(fd >= 0);
+                  TEST_PCHECK(write(fd, "0", 1) == 1);
+                  TEST_PCHECK(close(fd) == 0);
+                  TEST_CHECK_ERRNO(unshare(CLONE_NEWUSER), ENOSPC);
+                  _exit(0);
+                }
+                TEST_PCHECK(close(ready[1]) == 0);
+                TEST_PCHECK(close(go[0]) == 0);
+                char c;
+                TEST_PCHECK(RetryEINTR(read)(ready[0], &c, 1) == 0);
+
+                // Map the child's namespace (uid_map, then setgroups, gid_map).
+                auto write_file = [](const char* path, const char* data,
+                                     size_t len) {
+                  int fd = open(path, O_WRONLY);
+                  TEST_PCHECK(fd >= 0);
+                  TEST_PCHECK(write(fd, data, len) ==
+                              static_cast<ssize_t>(len));
+                  TEST_PCHECK(close(fd) == 0);
+                };
+                char path[64];
+                snprintf(path, sizeof(path), "/proc/%d/uid_map", child);
+                write_file(path, uid_map.c_str(), uid_map.size());
+                snprintf(path, sizeof(path), "/proc/%d/setgroups", child);
+                write_file(path, "deny", 4);
+                snprintf(path, sizeof(path), "/proc/%d/gid_map", child);
+                write_file(path, gid_map.c_str(), gid_map.size());
+
+                TEST_PCHECK(close(go[1]) == 0);  // release child
+                int status;
+                TEST_PCHECK(RetryEINTR(waitpid)(child, &status, 0) == child);
+                TEST_PCHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
+// A parent namespace with a limit of one still blocks a grandchild namespace:
+// each new namespace is charged to its ancestors, so the child uses up the
+// parent's single-namespace budget even though the child's own limit is the
+// default. This is the case bubblewrap exercises.
+TEST(ProcSysUserMaxUserNamespaces, RecursiveLimitBlocksGrandchild) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(CanCreateUserNamespace()));
+
+  // Each namespace is mapped before nesting deeper, otherwise the next unshare
+  // returns EPERM from an unmapped namespace before the limit is checked.
+  char ubuf[32], gbuf[32];
+  snprintf(ubuf, sizeof(ubuf), "0 %u 1", getuid());
+  snprintf(gbuf, sizeof(gbuf), "0 %u 1", getgid());
+  const std::string uid_map = ubuf;
+  const std::string gid_map = gbuf;
+
+  EXPECT_THAT(InForkedProcess([&uid_map, &gid_map] {
+                auto self_map = [](const char* name, const char* data,
+                                   size_t len) {
+                  char path[64];
+                  snprintf(path, sizeof(path), "/proc/self/%s", name);
+                  int fd = open(path, O_WRONLY);
+                  TEST_PCHECK(fd >= 0);
+                  TEST_PCHECK(write(fd, data, len) ==
+                              static_cast<ssize_t>(len));
+                  TEST_PCHECK(close(fd) == 0);
+                };
+
+                // Parent namespace A, mapped, allowing exactly one descendant.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                self_map("uid_map", uid_map.c_str(), uid_map.size());
+                self_map("setgroups", "deny", 4);
+                self_map("gid_map", gid_map.c_str(), gid_map.size());
+                int fd = open("/proc/sys/user/max_user_namespaces", O_WRONLY);
+                TEST_PCHECK(fd >= 0);
+                TEST_PCHECK(write(fd, "1", 1) == 1);
+                TEST_PCHECK(close(fd) == 0);
+
+                // Child namespace B succeeds and consumes A's budget. The mapped
+                // uid is now 0, so map it to itself.
+                TEST_PCHECK(unshare(CLONE_NEWUSER) == 0);
+                self_map("uid_map", "0 0 1", 5);
+                self_map("setgroups", "deny", 4);
+                self_map("gid_map", "0 0 1", 5);
+
+                // The grandchild is still charged to A, whose budget is gone, so
+                // the unshare must fail with ENOSPC rather than succeeding.
+                TEST_CHECK_ERRNO(unshare(CLONE_NEWUSER), ENOSPC);
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
 TEST(ProcSysVmMaxmapCount, HasNumericValue) {
   const std::string val_str =
       ASSERT_NO_ERRNO_AND_VALUE(GetContents("/proc/sys/vm/max_map_count"));


### PR DESCRIPTION
Fixes #11210.

This adds `/proc/sys/user/max_user_namespaces` and actually enforces it, rather than just exposing a readable value. The motivation is bubblewrap's `--disable-userns` (which flatpak enables by default): it writes a low limit to this file and then expects a following `unshare(CLONE_NEWUSER)` to fail. As discussed on the issue, a read-only value isn't enough — the limit has to be enforced.

Each user namespace now tracks its limit plus a count of the descendant user namespaces charged to it. Creating a namespace charges the creating namespace and every ancestor up to the root; if any of them is already at its limit, creation fails with `ENOSPC` and the partial accounting is rolled back. (The nesting-depth limit keeps returning `EUSERS` as before.) The count is released when the namespace's nsfs inode is dropped, so it's held for exactly the namespace's lifetime. The file reads and writes the caller's own namespace limit and rejects negative values.

There's a unit test covering the charging, rollback and release logic, and a syscall test for the file itself. I also ran it end-to-end against a `runsc` built from this branch to reproduce the bubblewrap sequence — logs in a comment below.

cc @EtiennePerot
