### PR TITLE
netstack: rebuild dispatcher queue on restore instead of persisting it

### DIFF
--- a/pkg/tcpip/transport/tcp/dispatcher.go
+++ b/pkg/tcpip/transport/tcp/dispatcher.go
@@ -36,7 +36,7 @@ import (
 // +stateify savable
 type epQueue struct {
 	mu   epQueueMutex `state:"nosave"`
-	list endpointList
+	list endpointList `state:"nosave"`
 }
 
 // enqueue adds e to the queue if the endpoint is not already on the queue.

--- a/pkg/tcpip/transport/tcp/endpoint_state.go
+++ b/pkg/tcpip/transport/tcp/endpoint_state.go
@@ -277,6 +277,7 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 			e.snd.corkTimer.enable(MinRTO)
 		}
 		e.mu.Unlock()
+		e.requeueOnRestore()
 		connectedLoading.Done()
 	case epState == StateListen:
 		tcpip.AsyncLoading.Add(1)
@@ -290,6 +291,7 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 			rcvWnd := seqnum.Size(e.receiveBufferAvailable())
 			e.listenCtx = newListenContext(e.stack, e.protocol, e, rcvWnd, e.ops.GetV6Only(), e.NetProto)
 			e.UnlockUser()
+			e.requeueOnRestore()
 			listenLoading.Done()
 			tcpip.AsyncLoading.Done()
 		}()
@@ -337,6 +339,7 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 			connectingLoading.Done()
 			tcpip.AsyncLoading.Done()
 			e.mu.Unlock()
+			e.requeueOnRestore()
 		}()
 	case epState == StateBound:
 		tcpip.AsyncLoading.Add(1)
@@ -362,4 +365,13 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 // Resume implements tcpip.ResumableEndpoint.Resume.
 func (e *Endpoint) Resume() {
 	e.segmentQueue.thaw()
+}
+
+// requeueOnRestore re-adds the endpoint to its processor's run-queue if it has
+// queued segments. The run-queue is not saved across checkpoint/restore.
+func (e *Endpoint) requeueOnRestore() {
+	if e.segmentQueue.empty() || e.isOwnedByUser() {
+		return
+	}
+	e.protocol.dispatcher.selectProcessor(e.TransportEndpointInfo.ID).queueEndpoint(e)
 }


### PR DESCRIPTION
epQueue was being serialized incorrectly. The beforeSave hook also mangles any persisted list. Instead of trying to persist the queue correctly we instead rebuild the queue from Endpoint structs.

A listening socket stops accepting connections after checkpoint/restore taken
under load. The per-processor run-queue (epQueue.list) is an intrusive list
whose element links and membership flag are state:"nosave" while the header is
saved, so a non-empty run-queue restores inconsistent and the first dequeue
severs it, stranding every endpoint on that processor -- including the listener.

This fixes the reproduction in the script in the issue.

Fixes: #13554
Assisted-by: Claude