### PR TITLE
Allow writing to special files on read-only mounts.

### DIFF
--- a/pkg/abi/linux/file.go
+++ b/pkg/abi/linux/file.go
@@ -416,6 +416,19 @@ func (m FileMode) IsDir() bool {
 	return m.FileType() == S_IFDIR
 }
 
+// IsSpecialFile returns true if m is the mode of a "special file": a character
+// or block device, FIFO, or socket.
+//
+// Analogous to include/linux/fs.h:special_file().
+func (m FileMode) IsSpecialFile() bool {
+	switch m.FileType() {
+	case ModeCharacterDevice, ModeBlockDevice, ModeNamedPipe, ModeSocket:
+		return true
+	default:
+		return false
+	}
+}
+
 // String returns a string representation of m.
 func (m FileMode) String() string {
 	var s []string

--- a/pkg/sentry/devices/memdev/full.go
+++ b/pkg/sentry/devices/memdev/full.go
@@ -34,6 +34,7 @@ func (fullDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, op
 	fd := &fullFD{}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/devices/memdev/null.go
+++ b/pkg/sentry/devices/memdev/null.go
@@ -40,6 +40,7 @@ func NewNullFD(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opts vfs.O
 	fd := &nullFD{}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/devices/memdev/random.go
+++ b/pkg/sentry/devices/memdev/random.go
@@ -39,6 +39,7 @@ func (randomDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, 
 	fd := &randomFD{}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/devices/memdev/zero.go
+++ b/pkg/sentry/devices/memdev/zero.go
@@ -36,6 +36,7 @@ func (zeroDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, op
 	fd := &zeroFD{}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/devices/nvproxy/frontend.go
+++ b/pkg/sentry/devices/nvproxy/frontend.go
@@ -69,6 +69,7 @@ func (dev *frontendDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.D
 	}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		unix.Close(int(fd.hostFD))
 		return nil, err

--- a/pkg/sentry/devices/nvproxy/open_only.go
+++ b/pkg/sentry/devices/nvproxy/open_only.go
@@ -43,6 +43,7 @@ func (dev *openOnlyDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.D
 	}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		unix.Close(int(fd.hostFD))
 		return nil, err

--- a/pkg/sentry/devices/nvproxy/uvm.go
+++ b/pkg/sentry/devices/nvproxy/uvm.go
@@ -52,6 +52,7 @@ func (dev *uvmDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry
 	}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		unix.Close(int(fd.hostFD))
 		return nil, err

--- a/pkg/sentry/devices/tpuproxy/accel/accel.go
+++ b/pkg/sentry/devices/tpuproxy/accel/accel.go
@@ -67,6 +67,7 @@ func (dev *accelDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dent
 	}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		unix.Close(hostFD)
 		return nil, err

--- a/pkg/sentry/devices/tpuproxy/vfio/tpu_fd.go
+++ b/pkg/sentry/devices/tpuproxy/vfio/tpu_fd.go
@@ -196,6 +196,7 @@ func (fd *tpuFD) getPciDeviceFd(t *kernel.Task, arg hostarch.Addr) (uintptr, fun
 	defer vd.DecRef(t)
 	if err := pciDevFD.vfsfd.Init(pciDevFD, linux.O_RDWR, t.Credentials(), vd.Mount(), vd.Dentry(), &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return 0, cleanup, err
 	}

--- a/pkg/sentry/devices/tpuproxy/vfio/vfio.go
+++ b/pkg/sentry/devices/tpuproxy/vfio/vfio.go
@@ -76,6 +76,7 @@ func (dev *tpuDevice) Open(ctx context.Context, mnt *vfs.Mount, d *vfs.Dentry, o
 	}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, d, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		unix.Close(hostFD)
 		return nil, err
@@ -109,6 +110,7 @@ func (dev *vfioDevice) Open(ctx context.Context, mnt *vfs.Mount, d *vfs.Dentry, 
 	}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, d, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		unix.Close(hostFD)
 		return nil, err

--- a/pkg/sentry/devices/tundev/tundev.go
+++ b/pkg/sentry/devices/tundev/tundev.go
@@ -54,6 +54,7 @@ func (tunDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opt
 	fd := &tunFD{}
 	if err := fd.vfsfd.Init(fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/fsimpl/fuse/dev.go
+++ b/pkg/sentry/fsimpl/fuse/dev.go
@@ -43,6 +43,7 @@ func (fuseDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, op
 	var fd DeviceFD
 	if err := fd.vfsfd.Init(&fd, opts.Flags, auth.CredentialsFromContext(ctx), mnt, vfsd, &vfs.FileDescriptionOptions{
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/fsimpl/gofer/special_file.go
+++ b/pkg/sentry/fsimpl/gofer/special_file.go
@@ -107,6 +107,7 @@ func newSpecialFileFD(h handle, mnt *vfs.Mount, d *dentry, flags uint32, creds *
 		AllowDirectIO: true,
 		DenyPRead:     !seekable,
 		DenyPWrite:    !seekable,
+		SpecialFile:   linux.FileMode(ftype).IsSpecialFile(),
 	}); err != nil {
 		if haveQueue {
 			fdnotifier.RemoveFD(h.fd)

--- a/pkg/sentry/kernel/pipe/vfs.go
+++ b/pkg/sentry/kernel/pipe/vfs.go
@@ -149,6 +149,7 @@ func (vp *VFSPipe) newFD(mnt *vfs.Mount, vfsd *vfs.Dentry, statusFlags uint32, l
 		DenyPRead:         true,
 		DenyPWrite:        true,
 		UseDentryMetadata: true,
+		SpecialFile:       true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/vfs/file_description.go
+++ b/pkg/sentry/vfs/file_description.go
@@ -132,6 +132,11 @@ type FileDescriptionOptions struct {
 
 	// If DenySpliceIn is true, splice into descriptor isn't allowed.
 	DenySpliceIn bool
+
+	// If SpecialFile is true, this file description is for a special file.
+	// Currently, the only difference for special files is that they can be
+	// opened for writing through read-only mounts.
+	SpecialFile bool
 }
 
 // FileCreationFlags are the set of flags passed to FileDescription.Init() but
@@ -143,8 +148,11 @@ const FileCreationFlags = linux.O_CREAT | linux.O_EXCL | linux.O_NOCTTY | linux.
 // is usually the full set of flags passed to open(2).
 func (fd *FileDescription) Init(impl FileDescriptionImpl, flags uint32, creds *auth.Credentials, mnt *Mount, d *Dentry, opts *FileDescriptionOptions) error {
 	if MayWriteFileWithOpenFlags(flags) {
-		if err := mnt.CheckBeginWrite(); err != nil {
-			return err
+		// Skip the mount writability check for special files.
+		if !opts.SpecialFile {
+			if err := mnt.CheckBeginWrite(); err != nil {
+				return err
+			}
 		}
 		fd.fmodeFlags |= linux.FMODE_WRITE
 	}
@@ -216,7 +224,8 @@ func (fd *FileDescription) DecRef(ctx context.Context) {
 
 		// Release implementation resources.
 		fd.impl.Release(ctx)
-		if fd.IsWritable() {
+		// Only release a mount write reference if Init() acquired one.
+		if fd.IsWritable() && !fd.opts.SpecialFile {
 			fd.vd.mount.EndWrite()
 		}
 		fd.vd.DecRef(ctx)

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -481,6 +481,70 @@ TEST(MountTest, BindMountReadonly) {
   EXPECT_EQ(s.st_size, strlen(msg));
 }
 
+// Special files (such as FIFO) should be openable for writing even on a
+// read-only mount. Regular files should not.
+TEST(MountTest, FifoWritableOnReadonlyMount) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto const dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  auto const mnt =
+      ASSERT_NO_ERRNO_AND_VALUE(Mount("", dir.path(), kTmpfs, 0, "", 0));
+
+  // Populate the still-writable mount with a FIFO and a regular file.
+  std::string const fifo_path = JoinPath(dir.path(), "fifo");
+  std::string const reg_path = JoinPath(dir.path(), "reg");
+  ASSERT_THAT(mkfifo(fifo_path.c_str(), 0666), SyscallSucceeds());
+  FileDescriptor reg_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open(reg_path, O_WRONLY | O_CREAT, 0644));
+  reg_fd.reset();
+
+  // Remount read-only.
+  ASSERT_THAT(
+      mount("", dir.path().c_str(), nullptr, MS_REMOUNT | MS_RDONLY, nullptr),
+      SyscallSucceeds());
+  ASSERT_THAT(access(dir.path().c_str(), W_OK), SyscallFailsWithErrno(EROFS));
+
+  // The FIFO opens writably despite the RO mount.
+  FileDescriptor fifo_fd = ASSERT_NO_ERRNO_AND_VALUE(Open(fifo_path, O_RDWR));
+  EXPECT_THAT(write(fifo_fd.get(), "x", 1), SyscallSucceedsWithValue(1));
+
+  // The regular file still fails a writable open with EROFS, but a read-only
+  // open succeeds.
+  EXPECT_THAT(open(reg_path.c_str(), O_WRONLY), SyscallFailsWithErrno(EROFS));
+  ASSERT_NO_ERRNO_AND_VALUE(Open(reg_path, O_RDONLY));
+}
+
+// Same test as above, but for a character device.
+TEST(MountTest, DeviceFileWritableOnReadonlyMount) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto const dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  auto const mnt =
+      ASSERT_NO_ERRNO_AND_VALUE(Mount("", dir.path(), kTmpfs, 0, "", 0));
+
+  // Create a /dev/null-style character device while the mount is writable.
+  std::string const dev_path = JoinPath(dir.path(), "null");
+  int ret = mknod(dev_path.c_str(), S_IFCHR | 0666, makedev(1, 3));
+  const bool was_eperm = Value(ret, SyscallFailsWithErrno(EPERM));
+
+  // In our test infrastructure, this may not always be possible to test on
+  // native since CAP_MKNOD is required in the *initial* user ns, and native
+  // tests are sometimes run in a user ns.
+  SKIP_IF(was_eperm);
+
+  // (But otherwise, mknod() should succeed.)
+  ASSERT_THAT(ret, SyscallSucceeds());
+
+  // Remount read-only.
+  ASSERT_THAT(
+      mount("", dir.path().c_str(), nullptr, MS_REMOUNT | MS_RDONLY, nullptr),
+      SyscallSucceeds());
+
+  // The device node opens writably and accepts writes despite the RO mount.
+  FileDescriptor dev_fd = ASSERT_NO_ERRNO_AND_VALUE(Open(dev_path, O_WRONLY));
+  EXPECT_THAT(write(dev_fd.get(), "x", 1), SyscallSucceedsWithValue(1));
+}
+
 // Test that bind mounting a directory onto a regular file fails with ENOTDIR.
 TEST(MountTest, BindMountDirectoryOntoFileFails) {
   SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));


### PR DESCRIPTION
On Linux, mount writability checks are skipped for special devices (char, fifo, socket, blockdevice) when opening a file with write access. gVisor currently does not handle this correctly.

This is an issue because some systemd unit files specify PrivateDevices=yes, one of the effects of which is to make /dev appear read-only to the service. For these services, writing to (for example) /dev/null gives EROFS. Apache2 in particular runs into this issue.