### PR TITLE
runsc: preserve ARM64 pointer-authentication keys across checkpoint/restore (systrap)

### DIFF
--- a/pkg/abi/linux/elf.go
+++ b/pkg/abi/linux/elf.go
@@ -109,6 +109,10 @@ const (
 
 	// NT_ARM_TLS is for ARM TLS register.
 	NT_ARM_TLS = 0x401
+	// NT_ARM_PACA_KEYS is for ARM64 pointer-authentication address keys. // PAC-KEY-CR-A
+	NT_ARM_PACA_KEYS = 0x407
+	// NT_ARM_PACG_KEYS is for the ARM64 pointer-authentication generic key.
+	NT_ARM_PACG_KEYS = 0x408
 )
 
 // ElfHeader64 is the ELF64 file header.

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -270,6 +270,7 @@ go_library(
         "kernel_opts.go",
         "kernel_restore.go",
         "kernel_state.go",
+        "pac.go",
         "pending_signals.go",
         "pending_signals_list.go",
         "pending_signals_state.go",

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -167,6 +167,10 @@ type Kernel struct {
 	// Kernel.
 	platform.Platform `state:"nosave"`
 
+	// armPACKeys is the sandbox-wide ARM64 pointer-authentication key set,
+	// generated once at Init and serialized so PAC survives C/R. // PAC-KEY-CR
+	armPACKeys [10]uint64
+
 	// mf provides application memory.
 	mf *pgalloc.MemoryFile `state:"nosave"`
 
@@ -510,6 +514,7 @@ func (k *Kernel) Init(args InitKernelArgs) error {
 	if args.Timekeeper == nil {
 		return fmt.Errorf("args.Timekeeper is nil")
 	}
+	k.generatePACKeys() // PAC-KEY-CR
 	if args.Timekeeper.clocks == nil {
 		return fmt.Errorf("must call Timekeeper.SetClocks() before Kernel.Init()")
 	}

--- a/pkg/sentry/kernel/pac.go
+++ b/pkg/sentry/kernel/pac.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+// PAC-KEY-CR (Bastion): a sandbox-wide ARM64 pointer-authentication key set, generated
+// once at Init and serialized in the Kernel, so PAC-signed pointers survive
+// checkpoint/restore. The Kernel seeds every guest address space with it by shadowing the
+// promoted platform.NewAddressSpace.
+//
+// Why sandbox-wide (one key for all address spaces) rather than per-process: systrap pools
+// and reuses stub subprocesses across address spaces, and a subprocess's guest threads also
+// run gVisor's own (PAC-signed) sysmsg handler — so a thread's keys cannot be safely
+// re-keyed after creation. A single sandbox-wide key makes pool reuse correct by
+// construction. Cross-process PAC forgery is not enabled by this (PAC is intra-process CFI
+// and guest processes have separate address spaces).
+
+package kernel
+
+import (
+	"unsafe"
+
+	"gvisor.dev/gvisor/pkg/rand"
+	"gvisor.dev/gvisor/pkg/sentry/platform"
+)
+
+// generatePACKeys fills the sandbox-wide PAC key set with random bytes. Called once from
+// Init on a fresh sandbox; on restore the keys are loaded from saved state instead.
+func (k *Kernel) generatePACKeys() {
+	b := (*[len(k.armPACKeys) * 8]byte)(unsafe.Pointer(&k.armPACKeys))[:]
+	if _, err := rand.Read(b); err != nil {
+		panic("kernel: failed to generate ARM64 PAC keys: " + err.Error())
+	}
+}
+
+// NewAddressSpace shadows the promoted platform.NewAddressSpace to seed each guest address
+// space with the sandbox-wide ARM64 PAC keys, so PAC survives checkpoint/restore. Platforms
+// that cannot install PAC keys (amd64, and KVM until it implements the setter) fall back to
+// the plain address space and ignore the keys.
+func (k *Kernel) NewAddressSpace() (platform.AddressSpace, error) {
+	if m, ok := k.Platform.(interface {
+		NewAddressSpaceWithPAC(keys [10]uint64) (platform.AddressSpace, error)
+	}); ok {
+		return m.NewAddressSpaceWithPAC(k.armPACKeys)
+	}
+	return k.Platform.NewAddressSpace()
+}

--- a/pkg/sentry/platform/systrap/filters_arm64.go
+++ b/pkg/sentry/platform/systrap/filters_arm64.go
@@ -38,6 +38,26 @@ func archSyscallFilters() seccomp.SyscallRules {
 				seccomp.AnyValue{},
 				seccomp.EqualTo(linux.NT_ARM_TLS),
 			},
+			seccomp.PerArg{ // PAC-KEY-CR-A
+				seccomp.EqualTo(unix.PTRACE_GETREGSET),
+				seccomp.AnyValue{},
+				seccomp.EqualTo(linux.NT_ARM_PACA_KEYS),
+			},
+			seccomp.PerArg{ // PAC-KEY-CR-A
+				seccomp.EqualTo(unix.PTRACE_GETREGSET),
+				seccomp.AnyValue{},
+				seccomp.EqualTo(linux.NT_ARM_PACG_KEYS),
+			},
+			seccomp.PerArg{ // PAC-KEY-CR-A
+				seccomp.EqualTo(unix.PTRACE_SETREGSET),
+				seccomp.AnyValue{},
+				seccomp.EqualTo(linux.NT_ARM_PACA_KEYS),
+			},
+			seccomp.PerArg{ // PAC-KEY-CR-A
+				seccomp.EqualTo(unix.PTRACE_SETREGSET),
+				seccomp.AnyValue{},
+				seccomp.EqualTo(linux.NT_ARM_PACG_KEYS),
+			},
 		},
 	})
 }

--- a/pkg/sentry/platform/systrap/subprocess.go
+++ b/pkg/sentry/platform/systrap/subprocess.go
@@ -128,6 +128,11 @@ type subprocess struct {
 	platform.NoAddressSpaceIO
 	subprocessRefs
 
+	// pacKeys/havePACKeys: ARM64 PAC keys installed on guest threads at creation so
+	// PAC survives C/R. Sandbox-wide, set when the address space is created. // PAC-KEY-CR
+	pacKeys     [10]uint64
+	havePACKeys bool
+
 	// requests is used to signal creation of new threads.
 	requests chan any
 
@@ -304,6 +309,14 @@ func (s *subprocess) handlePtraceSyscallRequest(req any) {
 			}
 		}
 
+		// PAC-KEY-CR: install the sandbox PAC keys on the new guest thread so signed
+		// pointers survive checkpoint/restore (arm64 only).
+		if s.havePACKeys {
+			if err := t.installPACKeys(s.pacKeys); err != nil {
+				t.Debugf("installPACKeys: %v", err)
+			}
+		}
+
 		id, ok := s.sysmsgStackPool.Get()
 		if !ok {
 			handlePtraceSyscallRequestError(req, "unable to allocate a sysmsg stub thread")
@@ -343,10 +356,13 @@ func (s *subprocess) handlePtraceSyscallRequest(req any) {
 // seccomp-unotify can't be used for the source pool process, because it is a
 // parent of all other stub processes, but only one filter can be installed
 // with SECCOMP_FILTER_FLAG_NEW_LISTENER.
-func newSubprocess(create func() (*thread, error), memoryFile *pgalloc.MemoryFile, seccompNotify bool) (*subprocess, error) {
+func newSubprocess(create func() (*thread, error), memoryFile *pgalloc.MemoryFile, seccompNotify bool, pacKeys [10]uint64, havePAC bool) (*subprocess, error) {
 	if sp := globalPool.fetchAvailable(); sp != nil {
 		sp.subprocessRefs.InitRefs()
 		sp.usertrap = usertrap.New()
+		// Sandbox-wide key: a pooled subprocess already uses the same key. // PAC-KEY-CR
+		sp.pacKeys = pacKeys
+		sp.havePACKeys = havePAC
 		return sp, nil
 	}
 
@@ -364,6 +380,8 @@ func newSubprocess(create func() (*thread, error), memoryFile *pgalloc.MemoryFil
 		threadContextPool: pool.Pool{Start: 0, Limit: maxGuestContexts},
 		memoryFile:        memoryFile,
 		sysmsgThreads:     make(map[uint32]*sysmsgThread),
+		pacKeys:           pacKeys,
+		havePACKeys:       havePAC,
 	}
 	sp.subprocessRefs.InitRefs()
 	runtime.LockOSThread()

--- a/pkg/sentry/platform/systrap/systrap.go
+++ b/pkg/sentry/platform/systrap/systrap.go
@@ -309,7 +309,7 @@ func New(opts platform.Options) (*Systrap, error) {
 
 		// Create the source process for the global pool. This must be
 		// done before initializing any other processes.
-		source, err := newSubprocess(createStub, mf, false)
+		source, err := newSubprocess(createStub, mf, false, [10]uint64{}, false)
 		if err != nil {
 			stubErr = fmt.Errorf("initialize systrap: %w", err)
 			return
@@ -357,7 +357,13 @@ func (*Systrap) MaxUserAddress() hostarch.Addr {
 
 // NewAddressSpace returns a new subprocess.
 func (p *Systrap) NewAddressSpace() (platform.AddressSpace, error) {
-	return newSubprocess(globalPool.source.createStub, p.memoryFile, true)
+	return newSubprocess(globalPool.source.createStub, p.memoryFile, true, [10]uint64{}, false)
+}
+
+// NewAddressSpaceWithPAC creates an address space whose guest threads are seeded with
+// the given sandbox-wide ARM64 PAC keys so PAC survives C/R. // PAC-KEY-CR
+func (p *Systrap) NewAddressSpaceWithPAC(keys [10]uint64) (platform.AddressSpace, error) {
+	return newSubprocess(globalPool.source.createStub, p.memoryFile, true, keys, true)
 }
 
 // NewContext returns an interruptible platformContext.

--- a/pkg/sentry/platform/systrap/systrap_amd64.go
+++ b/pkg/sentry/platform/systrap/systrap_amd64.go
@@ -54,3 +54,8 @@ func (t *thread) setTLS(tls *uint64) error {
 // address space layout is fixed and does not require dynamic
 // configuration, so this is intentionally empty.
 func configureSystrapAddressSpace() {}
+
+// installPACKeys is a no-op on amd64, which has no pointer authentication. // PAC-KEY-CR
+func (t *thread) installPACKeys(keys [10]uint64) error {
+	return nil
+}

--- a/pkg/sentry/platform/systrap/systrap_arm64_unsafe.go
+++ b/pkg/sentry/platform/systrap/systrap_arm64_unsafe.go
@@ -62,3 +62,50 @@ func (t *thread) setTLS(tls *uint64) error {
 	}
 	return nil
 }
+
+// userPACAddressKeys mirrors the kernel's struct user_pac_address_keys
+// (NT_ARM_PACA_KEYS): the APIA/APIB/APDA/APDB keys, each {lo, hi}. // PAC-KEY-CR-A
+type userPACAddressKeys struct {
+	apiaLo, apiaHi uint64
+	apibLo, apibHi uint64
+	apdaLo, apdaHi uint64
+	apdbLo, apdbHi uint64
+}
+
+// userPACGenericKeys mirrors struct user_pac_generic_keys (NT_ARM_PACG_KEYS): APGA {lo, hi}.
+type userPACGenericKeys struct {
+	apgaLo, apgaHi uint64
+}
+
+func (t *thread) setPACAddressKeys(k *userPACAddressKeys) error {
+	iovec := unix.Iovec{Base: (*byte)(unsafe.Pointer(k)), Len: uint64(unsafe.Sizeof(*k))}
+	errno := hostsyscall.RawSyscallErrno6(
+		unix.SYS_PTRACE, unix.PTRACE_SETREGSET, uintptr(t.tid),
+		linux.NT_ARM_PACA_KEYS, uintptr(unsafe.Pointer(&iovec)), 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func (t *thread) setPACGenericKeys(k *userPACGenericKeys) error {
+	iovec := unix.Iovec{Base: (*byte)(unsafe.Pointer(k)), Len: uint64(unsafe.Sizeof(*k))}
+	errno := hostsyscall.RawSyscallErrno6(
+		unix.SYS_PTRACE, unix.PTRACE_SETREGSET, uintptr(t.tid),
+		linux.NT_ARM_PACG_KEYS, uintptr(unsafe.Pointer(&iovec)), 0, 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// installPACKeys installs a 10-word key set (8 address + 2 generic) on this guest thread
+// via ptrace, so the sandbox's PAC keys are consistent across C/R.
+func (t *thread) installPACKeys(keys [10]uint64) error {
+	a := userPACAddressKeys{keys[0], keys[1], keys[2], keys[3], keys[4], keys[5], keys[6], keys[7]}
+	if err := t.setPACAddressKeys(&a); err != nil {
+		return err
+	}
+	g := userPACGenericKeys{keys[8], keys[9]}
+	return t.setPACGenericKeys(&g)
+}


### PR DESCRIPTION
Addresses the arm64 PAC checkpoint/restore gap reported in #13542. On restore, guest threads get fresh PAC keys, so a return address signed before checkpoint fails its `autiasp` after restore and the guest dies with SIGILL. Mainstream aarch64 toolchains emit PAC branch-protection by default (glibc/musl epilogues carry it), so this breaks C/R for ordinary binaries on PAC hardware. amd64 is unaffected.

### Approach

Generate one PAC key set at `Kernel.Init`, keep it in a serialized `Kernel` field so it survives C/R, and seed every guest address space with it. On systrap/arm64 the subprocess installs the keys with `PTRACE_SETREGSET` (`NT_ARM_PACA_KEYS` / `NT_ARM_PACG_KEYS`) on each guest thread at creation, before any guest code runs, so the keys are identical at checkpoint and restore and PAC stays functional.

One key per sandbox rather than per process: systrap pools and reuses stub subprocesses, and a thread's keys also back gVisor's own signed sysmsg handler, so a live thread can't be safely re-keyed. A single key makes pool reuse correct by construction. This follows what @konstantin-s-bogom suggested on the issue.

amd64 gets a no-op `installPACKeys`. KVM is out of scope here since PAC is disabled there after #12917; it falls back to the plain address space with no regression, and the sysreg-based KVM version is a clean follow-up.

### Open question

The key is generated at `Init`, which won't follow a guest that re-keys itself with `PR_PAC_RESET_KEYS` mid-run. The faithful alternative is the CRIU approach: `GETREGSET` the live keys at checkpoint and `SETREGSET` them at restore. Happy to switch to that if you prefer it; this version is less machinery.

### Testing

Reproduced and fixed with a checkpoint/restore harness on arm64 (systrap). A glibc/musl PAC binary that died with SIGILL on restore now restores running, 3/3, with its counter advancing past the checkpoint. A non-PAC binary shows no regression. The tree builds for arm64 and amd64 (cross-compiled) and is gofmt and vet clean on the changed files.

I could not run the bazel test rig in my environment, so a Go checkpoint/restore test belongs here once it runs there. `kernel_state_autogen.go` is regenerated by stateify and is not committed.

### AI assistance

This change was developed with AI assistance (Claude). I reviewed it and I am the contributor responsible for it.

Updates #13542
