### PR TITLE
Fix false EPERM in setpgid across PID namespaces

### DIFF
--- a/pkg/sentry/kernel/sessions.go
+++ b/pkg/sentry/kernel/sessions.go
@@ -283,7 +283,7 @@ func (tg *ThreadGroup) createSession() (SessionID, error) {
 			return -1, linuxerr.EPERM
 		}
 		for pg := s.processGroups.Front(); pg != nil; pg = pg.Next() {
-			if pg.id == ProcessGroupID(id) {
+			if pgID, ok := tg.pidns.pgids[pg]; ok && pgID == ProcessGroupID(id) {
 				return -1, linuxerr.EPERM
 			}
 		}
@@ -384,7 +384,7 @@ func (tg *ThreadGroup) CreateProcessGroup() error {
 			return linuxerr.EPERM
 		}
 		for pg := s.processGroups.Front(); pg != nil; pg = pg.Next() {
-			if pg.id == ProcessGroupID(id) {
+			if pgID, ok := tg.pidns.pgids[pg]; ok && pgID == ProcessGroupID(id) {
 				return linuxerr.EPERM
 			}
 		}


### PR DESCRIPTION
Fixes #13556 : `setpgid(0,0)` returned a spurious EPERM when a process group originated in a child PID namespace.

CreateProcessGroup/createSession compared pg.id (the PG's originator-namespace ID) against the caller's namespace TID. Since allocateTID keys on namespace-relative PGIDs, it could allocate a TID colliding with a child-namespace pg.id, causing `posix_spawnp` with `POSIX_SPAWN_SETPGROUP` to fail intermittently. Now compares against `tg.pidns.pgids[pg]`.

related to: https://github.com/google/syzkaller/issues/7478