### PR TITLE
Enrich security track record page.

### DIFF
--- a/website/_data/cve-track-record.yml
+++ b/website/_data/cve-track-record.yml
@@ -1,113 +1,114 @@
 cves:
   - date: "2016-01"
-    description: "A race condition in mm/gup.c allows local users to gain privileges by leveraging incorrect handling of a copy-on-write (COW) feature."
+    description: "A race condition in `mm/gup.c` allows local users to gain privileges by leveraging incorrect handling of a copy-on-write (COW) feature."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2016-5195"
     cvss: 7.2
     exploitable_under_gvisor: false
   - date: "2017-01"
-    description: "Insufficient data validation in waitid allowed an user to escape sandboxes on Linux."
+    description: "Insufficient data validation in `waitid` allowed an user to escape sandboxes on Linux."
     risk: "Pod-to-guest escalation"
     scope: "All Linux containers"
     cve: "CVE-2017-5123"
     cvss: null
     exploitable_under_gvisor: false
   - date: "2020-09"
-    description: "Memory corruption in the Linux kernel packet socket (AF_PACKET) allows unprivileged processes to gain root privileges."
+    description: "Memory corruption in the Linux kernel packet socket (`AF_PACKET`) allows unprivileged processes to gain root privileges."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2020-14386"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2021-05"
-    description: "A symlink-exchange race condition in runc allows container filesystem breakout via directory traversal."
+    description: "A symlink-exchange race condition in `runc` allows container filesystem breakout via directory traversal."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2021-30465"
     cvss: 8.5
     exploitable_under_gvisor: true
-    mitigation_gap: "runsc (gVisor) also handles mount paths similar to runc to prepare the container's rootfs"
+    patched: "PATCHED"
+    mitigation_gap: "`runsc` (gVisor) also handles mount paths similar to `runc` to prepare the container's rootfs"
     vm_prevented: false
   - date: "2021-07"
-    description: "An integer overflow in fs/seq_file.c buffer allocations leads to an out-of-bounds write and root privilege escalation."
+    description: "An integer overflow in `fs/seq_file.c` buffer allocations leads to an out-of-bounds write and root privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2021-33909"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2021-12"
-    description: "A use-after-free flaw in the Linux kernel cgroup v1 parser allows local privilege escalation and container breakout."
+    description: "A use-after-free flaw in the Linux kernel `cgroup` v1 parser allows local privilege escalation and container breakout."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2021-4154"
     cvss: 8.8
     exploitable_under_gvisor: false
   - date: "2022-01"
-    description: "A double free bug in packet_set_ring() in net/packet/af_packet.c can be exploited by a local user through crafted syscalls to escalate privileges or deny service."
+    description: "A double free bug in `packet_set_ring()` in `net/packet/af_packet.c` can be exploited by a local user through crafted syscalls to escalate privileges or deny service."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2021-22600"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-01"
-    description: "A heap-based buffer overflow flaw was found in the way the legacy_parse_param function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length."
+    description: "A heap-based buffer overflow flaw was found in the way the `legacy_parse_param` function in the Filesystem Context functionality of the Linux kernel verified the supplied parameters length."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-0185"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-02"
-    description: "A vulnerability was found in the Linux kernel’s cgroup_release_agent_write in the kernel/cgroup/cgroup-v1.c function."
+    description: "A vulnerability was found in the Linux kernel’s `cgroup_release_agent_write` in the `kernel/cgroup/cgroup-v1.c` function."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-0492"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-04"
-    description: "A flaw was found in the way the 'flags' member of the new pipe buffer structure was lacking proper initialization in copy_page_to_iter_pipe and push_pipe functions in the Linux kernel and could thus contain stale values."
+    description: "A flaw was found in the way the 'flags' member of the new pipe buffer structure was lacking proper initialization in `copy_page_to_iter_pipe` and `push_pipe` functions in the Linux kernel and could thus contain stale values."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-0847"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-04"
-    description: "A use-after-free exists in the Linux Kernel in tc_new_tfilter that could allow a local attacker to gain privilege escalation."
+    description: "A use-after-free exists in the Linux Kernel in `tc_new_tfilter` that could allow a local attacker to gain privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-1055"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-04"
-    description: "A heap buffer overflow flaw was found in IPsec ESP transformation code in net/ipv4/esp4.c and net/ipv6/esp6.c."
+    description: "A heap buffer overflow flaw was found in IPsec ESP transformation code in `net/ipv4/esp4.c` and `net/ipv6/esp6.c`."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-27666"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-06"
-    description: "Improper Update of Reference Count vulnerability in net/sched of Linux Kernel allows local attacker to cause privilege escalation to root."
+    description: "Improper Update of Reference Count vulnerability in `net/sched` of Linux Kernel allows local attacker to cause privilege escalation to root."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-29581"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-06"
-    description: "In the Linux kernel, fs/io_uring.c has a use-after-free due to a race condition in io_uring timeouts."
+    description: "In the Linux kernel, `fs/io_uring.c` has a use-after-free due to a race condition in `io_uring` timeouts."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-29582"
     cvss: 7.0
     exploitable_under_gvisor: false
   - date: "2022-06"
-    description: "Integer Overflow or Wraparound vulnerability in io_uring of Linux Kernel allows local attacker to cause memory corruption and escalate privileges to root."
+    description: "Integer Overflow or Wraparound vulnerability in `io_uring` of Linux Kernel allows local attacker to cause memory corruption and escalate privileges to root."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-1116"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-06"
-    description: "A use-after-free flaw was found in the Linux kernel’s io_uring subsystem in the way a user sets up a ring with IORING_SETUP_IOPOLL with more than one task completing submissions on this ring."
+    description: "A use-after-free flaw was found in the Linux kernel’s `io_uring` subsystem in the way a user sets up a ring with `IORING_SETUP_IOPOLL` with more than one task completing submissions on this ring."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-1786"
@@ -120,24 +121,25 @@ cves:
     cve: "CVE-2022-29900"
     cvss: 6.5
     exploitable_under_gvisor: true
+    patched: "EXTERNAL_MITIGATION_REQUIRED"
     mitigation_gap: "Hardware CPU vulnerability requiring microcode mitigation."
     vm_prevented: false
   - date: "2022-07"
-    description: "Io_uring use work_flags to determine which identity need to grab from the calling process to make sure it is consistent with the calling process when executing IORING_OP."
+    description: "`Io_uring` use `work_flags` to determine which identity need to grab from the calling process to make sure it is consistent with the calling process when executing `IORING_OP`."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2022-2327"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-09"
-    description: "There exists a use-after-free in io_uring in the Linux kernel."
+    description: "There exists a use-after-free in `io_uring` in the Linux kernel."
     risk: "Pod-to-guest escalation with root privs"
     scope: "All Linux VMs"
     cve: "CVE-2022-3176"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-09"
-    description: "In io_identity_cow of io_uring.c, there is a possible way to corrupt memory due to a use after free."
+    description: "In `io_identity_cow` of `io_uring.c`, there is a possible way to corrupt memory due to a use after free."
     risk: "Pod-to-guest escalation with root privs"
     scope: "All Linux VMs"
     cve: "CVE-2022-20409"
@@ -151,7 +153,7 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2022-10"
-    description: "Io_uring UAF, Unix SCM garbage collection."
+    description: "`Io_uring` UAF, Unix SCM garbage collection."
     risk: "Pod-to-guest escalation with root privs"
     scope: "All Linux VMs"
     cve: "CVE-2022-2602"
@@ -165,105 +167,105 @@ cves:
     cvss: 6.5
     exploitable_under_gvisor: false
   - date: "2023-02"
-    description: "Privilege escalation in io_uring"
+    description: "Privilege escalation in `io_uring`"
     risk: "Pod-to-guest escalation with root privs"
     scope: "All Linux VMs"
     cve: ""
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-03"
-    description: "Use After Free vulnerability in Linux kernel traffic control index filter (tcindex) allows Privilege Escalation."
+    description: "Use After Free vulnerability in Linux kernel traffic control index filter (`tcindex`) allows Privilege Escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-1281"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "This flaw makes curl overflow a heap based buffer in the SOCKS5 proxy handshake."
+    description: "This flaw makes `curl` overflow a heap based buffer in the SOCKS5 proxy handshake."
     risk: "Pod-to-guest escalation"
-    scope: "Container images using libcurl"
+    scope: "Container images using `libcurl`"
     cve: "CVE-2023-38545"
     cvss: 8.1
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free vulnerability in the Linux kernel's net/sched: cls_u32 component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `net/sched`: `cls_u32` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4208"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free vulnerability in the Linux kernel's netfilter: nf_tables component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `netfilter`: `nf_tables` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4015"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free vulnerability in the Linux kernel's net/sched: cls_fw component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `net/sched`: `cls_fw` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4207"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free vulnerability in the Linux kernel's net/sched: sch_hfsc (HFSC qdisc traffic control) component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `net/sched`: `sch_hfsc` (HFSC `qdisc` traffic control) component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4623"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free vulnerability in the Linux kernel's af_unix component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `af_unix` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4622"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free vulnerability in the Linux kernel's net/sched: cls_route component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `net/sched`: `cls_route` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4206"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free vulnerability in the Linux kernel's net/sched: sch_qfq component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `net/sched`: `sch_qfq` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4921"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-10"
-    description: "A use-after-free flaw was found in the Linux kernel’s Netfilter functionality when adding a rule with NFTA_RULE_CHAIN_ID."
+    description: "A use-after-free flaw was found in the Linux kernel’s `Netfilter` functionality when adding a rule with `NFTA_RULE_CHAIN_ID`."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-4147"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-12"
-    description: "A use-after-free vulnerability in the Linux kernel's netfilter: nf_tables component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `netfilter`: `nf_tables` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-6111"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2023-12"
-    description: "A use-after-free vulnerability in the Linux kernel's netfilter: nf_tables component can be exploited to achieve local privilege escalation."
+    description: "A use-after-free vulnerability in the Linux kernel's `netfilter`: `nf_tables` component can be exploited to achieve local privilege escalation."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-6817"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-01"
-    description: "Runc is a CLI tool for spawning and running containers on Linux according to the OCI specification."
+    description: "`Runc` is a CLI tool for spawning and running containers on Linux according to the OCI specification."
     risk: "Pod-to-guest escalation"
     scope: "All Linux containers"
     cve: "CVE-2024-21626"
     cvss: 8.2
     exploitable_under_gvisor: false
   - date: "2024-02"
-    description: "A use-after-free flaw was found in the netfilter subsystem of the Linux kernel."
+    description: "A use-after-free flaw was found in the `netfilter` subsystem of the Linux kernel."
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2024-0193"
@@ -298,35 +300,35 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-02"
-    description: "Privilege escalation due to use-after-free in nf_tables"
+    description: "Privilege escalation due to use-after-free in `nf_tables`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2024-26581"
     cvss: 7.0
     exploitable_under_gvisor: false
   - date: "2024-03"
-    description: "Privilege escalation due to anonymous set in nf_tables"
+    description: "Privilege escalation due to anonymous set in `nf_tables`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: ""
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-03"
-    description: "Privilege escalation due to race condition in nf_tables"
+    description: "Privilege escalation due to race condition in `nf_tables`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: ""
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-03"
-    description: "Privilege escalation due to use-after-free in nf_tables"
+    description: "Privilege escalation due to use-after-free in `nf_tables`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: ""
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-03"
-    description: "Privilege escalation in nft_verdict_init"
+    description: "Privilege escalation in `nft_verdict_init`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: ""
@@ -347,14 +349,14 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-05"
-    description: "Vulnerability in io_uring and SCM_RIGHTS"
+    description: "Vulnerability in `io_uring` and `SCM_RIGHTS`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: ""
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-05"
-    description: "Privilege escalation in net/packet / nf_tables"
+    description: "Privilege escalation in `net/packet` / `nf_tables`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2024-26925"
@@ -375,14 +377,14 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2024-06"
-    description: "Capabilities inheritance flaw in containerd 1.4"
+    description: "Capabilities inheritance flaw in `containerd` 1.4"
     risk: "Pod-to-guest escalation"
     scope: "Containerd 1.4"
     cve: "GHSA-c9cp-9c75-9v8c"
     cvss: 7.5
     exploitable_under_gvisor: false
   - date: "2024-10"
-    description: "Use-after-free flaw in Qdisc"
+    description: "Use-after-free flaw in `Qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2024-46800"
@@ -395,80 +397,81 @@ cves:
     cve: "CVE-2024-0132"
     cvss: 8.7
     exploitable_under_gvisor: true
+    patched: "PATCHED"
     mitigation_gap: "The flaw occurs outside of the container sandbox."
     vm_prevented: true
   - date: "2025-02"
-    description: "Privilege escalation in netfilters"
+    description: "Privilege escalation in `netfilters`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2024-53141"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-03"
-    description: "Linux qdisc implementation flaw"
+    description: "Linux `qdisc` implementation flaw"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2024-53164"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-03"
-    description: "Vsock privilege escalation"
+    description: "`Vsock` privilege escalation"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-21756"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-03"
-    description: "Privilege escalation in netfilter"
+    description: "Privilege escalation in `netfilter`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-52927"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-04"
-    description: "Local privilege escalation in qdisc"
+    description: "Local privilege escalation in `qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-21703"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-04"
-    description: "Local privilege escalation in qdisc"
+    description: "Local privilege escalation in `qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-21700"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-05"
-    description: "io_uring ring mapped supplied buffers vulnerability"
+    description: "`io_uring` ring mapped supplied buffers vulnerability"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-40364"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-05"
-    description: "Local privilege escalation in qdisc"
+    description: "Local privilege escalation in `qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-37798"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-05"
-    description: "Local privilege escalation in qdisc"
+    description: "Local privilege escalation in `qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-37797"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-05"
-    description: "Local privilege escalation in qdisc"
+    description: "Local privilege escalation in `qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-37752"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-05"
-    description: "ctstate RELATED iptables rule flaw"
+    description: "`ctstate` `RELATED` `iptables` rule flaw"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2023-52927"
@@ -496,14 +499,14 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-06"
-    description: "Race in PRIO qdisc"
+    description: "Race in PRIO `qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-38083"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-07"
-    description: "Use-after-free in Qdisc"
+    description: "Use-after-free in `Qdisc`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-38350"
@@ -517,21 +520,21 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-08"
-    description: "Use-after-free in xfrm interface"
+    description: "Use-after-free in `xfrm` interface"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-38500"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-08"
-    description: "Use-after-free in net/packet"
+    description: "Use-after-free in `net/packet`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-38617"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-08"
-    description: "Use-after-free in vsock"
+    description: "Use-after-free in `vsock`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-38618"
@@ -552,7 +555,7 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2025-10"
-    description: "Data race in AF_ALG socket"
+    description: "Data race in `AF_ALG` socket"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2025-39964"
@@ -594,35 +597,35 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2026-02"
-    description: "NULL pointer dereference in authencesn"
+    description: "NULL pointer dereference in `authencesn`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-23060"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2026-02"
-    description: "Use-after-free in teql"
+    description: "Use-after-free in `teql`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-23074"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2026-02"
-    description: "Use-after-free in nftables map"
+    description: "Use-after-free in `nftables` map"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-23111"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2026-02"
-    description: "Use-after-free in macvlan"
+    description: "Use-after-free in `macvlan`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-23209"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2026-03"
-    description: "Use-after-free in nf_tables"
+    description: "Use-after-free in `nf_tables`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-23231"
@@ -642,31 +645,32 @@ cves:
     cve: ""
     cvss: 8.2
     exploitable_under_gvisor: true
+    patched: "PATCHED"
     mitigation_gap: ""
     vm_prevented: true
   - date: "2026-03"
-    description: "Local privilege escalation in snap-confine and systemd-tmpfiles"
+    description: "Local privilege escalation in `snap-confine` and `systemd-tmpfiles`"
     risk: "Pod-to-guest escalation"
     scope: "Ubuntu VMs"
     cve: "CVE-2026-3888"
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2026-03"
-    description: "Denial of Service due to cleanup failure in nf_tables"
+    description: "Denial of Service due to cleanup failure in `nf_tables`"
     risk: "Denial of Service"
     scope: "All Linux VMs"
     cve: "CVE-2026-23278"
     cvss: 7.5
     exploitable_under_gvisor: false
   - date: "2026-03"
-    description: "Local Denial of Service in netfilter"
+    description: "Local Denial of Service in `netfilter`"
     risk: "Denial of Service"
     scope: "All Linux VMs"
     cve: "CVE-2026-23351"
     cvss: 7.5
     exploitable_under_gvisor: false
   - date: "2026-03"
-    description: "Use-after-free in af_unix GC"
+    description: "Use-after-free in `af_unix` GC"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-23394"
@@ -680,7 +684,7 @@ cves:
     cvss: 9.8
     exploitable_under_gvisor: false
   - date: "2026-04"
-    description: "Use-after-free in netfilter"
+    description: "Use-after-free in `netfilter`"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-23392"
@@ -694,28 +698,28 @@ cves:
     cvss: 7.8
     exploitable_under_gvisor: false
   - date: "2026-04"
-    description: "Data structure mishandling in ipset"
+    description: "Data structure mishandling in `ipset`"
     risk: "Network policy bypass"
     scope: "All Linux VMs"
     cve: "CVE-2026-31418"
     cvss: 7.5
     exploitable_under_gvisor: false
   - date: "2026-04"
-    description: "Use-after-free in packet_release via NETDEV_UP race"
+    description: "Use-after-free in `packet_release` via `NETDEV_UP` race"
     risk: "Denial of Service"
     scope: "All Linux VMs"
     cve: "CVE-2026-31504"
     cvss: 7.5
     exploitable_under_gvisor: false
   - date: "2026-04"
-    description: "Use-after-free in tls_do_encryption"
+    description: "Use-after-free in `tls_do_encryption`"
     risk: "Denial of Service"
     scope: "All Linux VMs"
     cve: "CVE-2026-31533"
     cvss: 7.5
     exploitable_under_gvisor: false
   - date: "2026-04"
-    description: "Chained attack in AF_ALG + splice syscall"
+    description: "Chained attack in `AF_ALG` + `splice` syscall"
     risk: "Pod-to-guest escalation"
     scope: "All Linux VMs"
     cve: "CVE-2026-31431"

--- a/website/cve-track-record.schema.json
+++ b/website/cve-track-record.schema.json
@@ -49,6 +49,15 @@
           "description": "Whether the vulnerability is exploitable under gVisor.",
           "type": "boolean"
         },
+        "patched": {
+          "description": "The current mitigation status of a vulnerability that was initially exploitable under gVisor: PATCHED (fixed in gVisor), UNPATCHED (still vulnerable), or EXTERNAL_MITIGATION_REQUIRED (requires mitigation outside of gVisor, e.g. CPU microcode).",
+          "type": "string",
+          "enum": [
+            "PATCHED",
+            "UNPATCHED",
+            "EXTERNAL_MITIGATION_REQUIRED"
+          ]
+        },
         "mitigation_gap": {
           "description": "Explanation as to why gVisor didn't save the day.",
           "type": "string"
@@ -80,7 +89,8 @@
       "then": {
         "required": [
           "vm_prevented",
-          "mitigation_gap"
+          "mitigation_gap",
+          "patched"
         ]
       },
       "additionalProperties": false

--- a/website/security_track_record/index.html
+++ b/website/security_track_record/index.html
@@ -22,14 +22,28 @@ permalink: /security-track-record/
         background-color: #94a3b8;
         transition: all 0.25s ease;
       }
-      .year-chart-btn .chart-bar-not-defended {
+      .year-chart-btn .chart-bar-patched {
+        background-color: #cbd5e1;
+        transition: all 0.25s ease;
+      }
+      .year-chart-btn .chart-bar-mitigated {
+        background-color: #cbd5e1;
+        transition: all 0.25s ease;
+      }
+      .year-chart-btn .chart-bar-vulnerable {
         background-color: #cbd5e1;
         transition: all 0.25s ease;
       }
       .year-chart-btn:hover .chart-bar-defended {
         background-color: #64748b;
       }
-      .year-chart-btn:hover .chart-bar-not-defended {
+      .year-chart-btn:hover .chart-bar-patched {
+        background-color: #94a3b8;
+      }
+      .year-chart-btn:hover .chart-bar-mitigated {
+        background-color: #94a3b8;
+      }
+      .year-chart-btn:hover .chart-bar-vulnerable {
         background-color: #94a3b8;
       }
       .year-chart-btn.active-chart-col {
@@ -41,9 +55,17 @@ permalink: /security-track-record/
         background-color: #286FD7;
         box-shadow: 0 4px 12px rgba(40, 111, 215, 0.3);
       }
-      .year-chart-btn.active-chart-col .chart-bar-not-defended {
-        background-color: #d9534f;
-        box-shadow: 0 4px 12px rgba(217, 83, 79, 0.3);
+      .year-chart-btn.active-chart-col .chart-bar-patched {
+        background-color: #f4c430;
+        box-shadow: 0 4px 12px rgba(244, 196, 48, 0.3);
+      }
+      .year-chart-btn.active-chart-col .chart-bar-mitigated {
+        background-color: #ed7d31;
+        box-shadow: 0 4px 12px rgba(237, 125, 49, 0.3);
+      }
+      .year-chart-btn.active-chart-col .chart-bar-vulnerable {
+        background-color: #b91c1c;
+        box-shadow: 0 4px 12px rgba(185, 28, 28, 0.3);
       }
       .year-chart-btn.active-chart-col .chart-year-label {
         color: #286FD7 !important;
@@ -61,34 +83,96 @@ permalink: /security-track-record/
         color: #1e293b;
         font-weight: 700;
       }
+      .cve-meta-col {
+        border-left: 1px solid #e5e5e5;
+      }
+      @media (max-width: 991px) {
+        /* The two detail columns stack vertically below Bootstrap's md breakpoint,
+           so the divider border-left would appear as a stray vertical line. */
+        .cve-meta-col {
+          border-left: none;
+        }
+      }
+      .cve-item code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        background-color: #f1f5f9;
+        color: #0f172a;
+        padding: 1px 5px;
+        border-radius: 4px;
+        font-size: 0.88em;
+      }
     </style>
 
     <div class="marketing-chart-card" style="background: #ffffff; border: 1px solid #e2e8f0; border-radius: 16px; box-shadow: 0 12px 36px rgba(0, 0, 0, 0.06); margin-top: 35px; margin-bottom: 45px; overflow: hidden;">
       <div style="padding: 32px 32px 10px 32px;">
+        {% assign legend_cves = site.data['cve-track-record'].cves %}
+        {% assign total_defended = 0 %}
+        {% assign total_patched = 0 %}
+        {% assign total_mitigatable = 0 %}
+        {% assign total_vulnerable = 0 %}
+        {% for item in legend_cves %}
+          {% if item.exploitable_under_gvisor %}
+            {% if item.patched == "PATCHED" %}
+              {% assign total_patched = total_patched | plus: 1 %}
+            {% elsif item.patched == "EXTERNAL_MITIGATION_REQUIRED" %}
+              {% assign total_mitigatable = total_mitigatable | plus: 1 %}
+            {% else %}
+              {% assign total_vulnerable = total_vulnerable | plus: 1 %}
+            {% endif %}
+          {% else %}
+            {% assign total_defended = total_defended | plus: 1 %}
+          {% endif %}
+        {% endfor %}
+        {% assign legend_total = legend_cves | size %}
+        {% assign pct_defended = total_defended | times: 100.0 | divided_by: legend_total | round %}
+        {% assign pct_patched = total_patched | times: 100.0 | divided_by: legend_total | round %}
+        {% assign pct_mitigatable = total_mitigatable | times: 100.0 | divided_by: legend_total | round %}
+        {% assign pct_vulnerable = total_vulnerable | times: 100.0 | divided_by: legend_total | round %}
         <div style="display: flex; flex-wrap: wrap; justify-content: space-between; align-items: flex-start;">
           <div>
             <h3 style="font-size: 24px; font-weight: 700; color: #1a202c; margin: 0 0 8px 0;">Vulnerabilities Defended by Year</h3>
             <p style="font-size: 15px; color: #64748b; margin: 0; max-width: 540px;">An overview of high-impact Linux kernel vulnerabilities mitigated by gVisor over time.</p>
           </div>
-          <div style="display: flex; align-items: center; background: #f8fafc; padding: 8px 16px; border-radius: 20px; border: 1px solid #e2e8f0; margin-top: 10px;">
+          <div style="display: flex; flex-wrap: wrap; row-gap: 6px; align-items: center; background: #f8fafc; padding: 8px 16px; border-radius: 20px; border: 1px solid #e2e8f0; margin-top: 10px;">
             <div style="display: flex; align-items: center; margin-right: 16px;">
               <span style="display: inline-block; width: 12px; height: 12px; border-radius: 3px; background-color: #286FD7; margin-right: 6px;"></span>
-              <span style="font-size: 13px; font-weight: 600; color: #334155;">Defended</span>
+              <span style="font-size: 13px; font-weight: 600; color: #334155;">Defended ({{ pct_defended }}%)</span>
+            </div>
+            <div style="display: flex; align-items: center; margin-right: 16px;">
+              <span style="display: inline-block; width: 12px; height: 12px; border-radius: 3px; background-color: #f4c430; margin-right: 6px;"></span>
+              <span style="font-size: 13px; font-weight: 600; color: #334155;">Patched ({{ pct_patched }}%)</span>
+            </div>
+            <div style="display: flex; align-items: center; margin-right: 16px;">
+              <span style="display: inline-block; width: 12px; height: 12px; border-radius: 3px; background-color: #ed7d31; margin-right: 6px;"></span>
+              <span style="font-size: 13px; font-weight: 600; color: #334155;">Mitigatable ({{ pct_mitigatable }}%)</span>
             </div>
             <div style="display: flex; align-items: center;">
-              <span style="display: inline-block; width: 12px; height: 12px; border-radius: 3px; background-color: #d9534f; margin-right: 6px;"></span>
-              <span style="font-size: 13px; font-weight: 600; color: #334155;">Unmitigated</span>
+              <span style="display: inline-block; width: 12px; height: 12px; border-radius: 3px; background-color: #b91c1c; margin-right: 6px;"></span>
+              <span style="font-size: 13px; font-weight: 600; color: #334155;">Vulnerable ({{ pct_vulnerable }}%)</span>
             </div>
           </div>
         </div>
       </div>
       <div style="padding: 10px 32px 32px 32px;">
-        <div class="chart-container" style="display: flex; align-items: flex-end; justify-content: space-between; height: 260px; padding: 20px 10px 10px 10px;">
-          {% assign valid_cves = site.data['cve-track-record'].cves | where_exp: "item", "item.cve != nil and item.cve != ''" %}
+        <div class="chart-container" style="display: flex; align-items: flex-end; justify-content: flex-start; height: 260px; padding: 32px 10px 10px 10px; overflow-x: auto; -webkit-overflow-scrolling: touch;">
+          {% assign valid_cves = site.data['cve-track-record'].cves %}
           {% assign grouped_cves = valid_cves | group_by_exp: "item", "item.date | slice: 0, 4" %}
+          {% comment %} Current year + day-of-year (assuming 365-day years) for the ghost extrapolation. {% endcomment %}
+          {% assign current_year = site.time | date: "%Y" %}
+          {% assign day_of_year = site.time | date: "%j" | plus: 0 %}
           {% assign max_cves = 1 %}
           {% for group in grouped_cves %}
             {% assign group_size = group.items | size %}
+            {% if group.name == current_year %}
+              {% assign group_projected = group_size | times: 365.0 | divided_by: day_of_year | round %}
+              {% assign group_days_remaining = 365 | minus: day_of_year %}
+              {% assign group_projected_scaled = group_projected | times: 100 %}
+              {% assign group_actual_threshold = group_size | times: 115 %}
+              {% comment %} Only let the projection drive the scale when it is shown: >= 2 months left and >= 15% above the actual count. {% endcomment %}
+              {% if group_projected_scaled >= group_actual_threshold and group_days_remaining >= 61 %}
+                {% assign group_size = group_projected %}
+              {% endif %}
+            {% endif %}
             {% if group_size > max_cves %}
               {% assign max_cves = group_size %}
             {% endif %}
@@ -97,22 +181,54 @@ permalink: /security-track-record/
           {% for group in grouped_cves %}
             {% assign total = group.items | size %}
             {% assign saved_count = 0 %}
-            {% assign unsaved_count = 0 %}
+            {% assign patched_count = 0 %}
+            {% assign mitigated_count = 0 %}
+            {% assign vulnerable_count = 0 %}
             {% for item in group.items %}
               {% if item.exploitable_under_gvisor %}
-                {% assign unsaved_count = unsaved_count | plus: 1 %}
+                {% if item.patched == "PATCHED" %}
+                  {% assign patched_count = patched_count | plus: 1 %}
+                {% elsif item.patched == "EXTERNAL_MITIGATION_REQUIRED" %}
+                  {% assign mitigated_count = mitigated_count | plus: 1 %}
+                {% else %}
+                  {% assign vulnerable_count = vulnerable_count | plus: 1 %}
+                {% endif %}
               {% else %}
                 {% assign saved_count = saved_count | plus: 1 %}
               {% endif %}
             {% endfor %}
             {% assign total_percentage = total | times: 100.0 | divided_by: max_cves_float %}
+            {% assign is_current_year = false %}
+            {% assign projected = 0 %}
+            {% assign projected_percentage = 0 %}
+            {% if group.name == current_year %}
+              {% assign projected = total | times: 365.0 | divided_by: day_of_year | round %}
+              {% assign days_remaining = 365 | minus: day_of_year %}
+              {% assign projected_scaled = projected | times: 100 %}
+              {% assign actual_threshold = total | times: 115 %}
+              {% comment %} Suppress the extrapolation when the year is nearly over (< 2 months left) or the projection is within 15% of the actual count. {% endcomment %}
+              {% if projected_scaled >= actual_threshold and days_remaining >= 61 %}
+                {% assign is_current_year = true %}
+                {% assign projected_percentage = projected | times: 100.0 | divided_by: max_cves_float %}
+              {% endif %}
+            {% endif %}
             {% assign saved_ratio = saved_count | times: 100.0 | divided_by: total %}
-            {% assign unsaved_ratio = unsaved_count | times: 100.0 | divided_by: total %}
-            <div class="chart-column year-chart-btn {% if forloop.last %}active-chart-col{% endif %}" data-year="{{ group.name }}" style="display: flex; flex-direction: column; justify-content: flex-end; align-items: center; flex-grow: 1; height: 100%; margin: 0 4px;">
-              <div class="chart-count-label">{{ saved_count }}/{{ total }}</div>
-              <div class="chart-bar-wrapper" style="height: {{ total_percentage | at_most: 100 }}%; min-height: 6px; width: 100%; max-width: 48px; display: flex; flex-direction: column; justify-content: flex-end; border-radius: 6px 6px 0 0; box-shadow: 0 2px 4px rgba(0,0,0,0.06); overflow: hidden;">
-                <div class="chart-bar-not-defended" style="height: {{ unsaved_ratio }}%; width: 100%;"></div>
-                <div class="chart-bar-defended" style="height: {{ saved_ratio }}%; width: 100%;"></div>
+            {% assign patched_ratio = patched_count | times: 100.0 | divided_by: total %}
+            {% assign mitigated_ratio = mitigated_count | times: 100.0 | divided_by: total %}
+            {% assign vulnerable_ratio = vulnerable_count | times: 100.0 | divided_by: total %}
+            <div class="chart-column year-chart-btn {% if forloop.last %}active-chart-col{% endif %}" data-year="{{ group.name }}" style="display: flex; flex-direction: column; justify-content: flex-end; align-items: center; flex-grow: 1; flex-shrink: 0; min-width: 52px; height: 100%; margin: 0 4px;">
+              <div class="chart-bar-area" style="position: relative; flex: 1 1 0%; min-height: 0; width: 100%; max-width: 48px; display: flex; flex-direction: column; justify-content: flex-end; align-items: stretch;">
+                {% if is_current_year %}
+                <div class="chart-ghost-bar" title="Projected total for {{ group.name }} at current pace" style="position: absolute; left: 0; right: 0; bottom: 0; height: {{ projected_percentage | at_most: 100 }}%; border: 2px dashed #cbd5e1; border-bottom: none; border-radius: 6px 6px 0 0; background-color: rgba(203, 213, 225, 0.08); z-index: 1; pointer-events: none;"></div>
+                <div class="chart-ghost-label" title="Extrapolated: projected total for {{ group.name }} at current pace" style="position: absolute; left: 0; right: 0; bottom: {{ projected_percentage | at_most: 100 }}%; margin-bottom: 4px; z-index: 1; pointer-events: auto; cursor: help; font-size: 12px; font-weight: 600; font-style: italic; color: #94a3b8; text-align: center; white-space: nowrap;">~{{ projected }}</div>
+                {% endif %}
+                <div class="chart-count-label" style="position: absolute; left: 0; right: 0; bottom: {{ total_percentage | at_most: 100 }}%; white-space: nowrap; z-index: 3;">{{ saved_count }}/{{ total }}</div>
+                <div class="chart-bar-wrapper" style="position: relative; z-index: 2; height: {{ total_percentage | at_most: 100 }}%; min-height: 6px; width: 100%; display: flex; flex-direction: column; justify-content: flex-end; border-radius: 6px 6px 0 0; box-shadow: 0 2px 4px rgba(0,0,0,0.06); overflow: hidden;">
+                  <div class="chart-bar-vulnerable" style="height: {{ vulnerable_ratio }}%; width: 100%;"></div>
+                  <div class="chart-bar-mitigated" style="height: {{ mitigated_ratio }}%; width: 100%;"></div>
+                  <div class="chart-bar-patched" style="height: {{ patched_ratio }}%; width: 100%;"></div>
+                  <div class="chart-bar-defended" style="height: {{ saved_ratio }}%; width: 100%;"></div>
+                </div>
               </div>
               <div class="chart-year-label" style="margin-top: 14px; font-weight: 600; font-size: 14px; color: #64748b; text-align: center; transition: color 0.25s ease;">{{ group.name }}</div>
             </div>
@@ -123,21 +239,50 @@ permalink: /security-track-record/
 
     <script>
       document.addEventListener('DOMContentLoaded', function() {
+        const chartContainer = document.querySelector('.chart-container');
         const chartBtns = document.querySelectorAll('.year-chart-btn');
+
+        // Horizontally scroll the chart so the given year's column is centered in view.
+        function centerChartOn(btn) {
+          if (!chartContainer || !btn) return;
+          const cRect = chartContainer.getBoundingClientRect();
+          const bRect = btn.getBoundingClientRect();
+          chartContainer.scrollLeft += (bRect.left - cRect.left) - (chartContainer.clientWidth / 2) + (bRect.width / 2);
+        }
+
+        // Highlight a year's chart column and show its CVE list. Returns true on success.
+        function activateYear(year) {
+          const btn = document.querySelector('.year-chart-btn[data-year="' + year + '"]');
+          if (!btn) return false;
+          chartBtns.forEach(b => b.classList.remove('active-chart-col'));
+          btn.classList.add('active-chart-col');
+          document.querySelectorAll('.tab-pane').forEach(pane => pane.classList.remove('active'));
+          const activePane = document.getElementById('year-' + year);
+          if (activePane) activePane.classList.add('active');
+          return true;
+        }
+
+        // Restore the highlighted year from the URL anchor (e.g. #2026), if present.
+        const hashYear = (window.location.hash || '').replace('#', '');
+        let restored = false;
+        if (/^\d{4}$/.test(hashYear) && activateYear(hashYear)) {
+          restored = true;
+          centerChartOn(document.querySelector('.year-chart-btn[data-year="' + hashYear + '"]'));
+        }
+        // Default: start scrolled all the way right so the most recent year is visible
+        // by default on narrow/mobile viewports.
+        if (!restored && chartContainer) {
+          chartContainer.scrollLeft = chartContainer.scrollWidth;
+        }
+
         chartBtns.forEach(btn => {
           btn.addEventListener('click', function() {
-            chartBtns.forEach(b => b.classList.remove('active-chart-col'));
-            this.classList.add('active-chart-col');
-
             const targetYear = this.getAttribute('data-year');
+            activateYear(targetYear);
 
-            document.querySelectorAll('.tab-pane').forEach(pane => {
-              pane.classList.remove('active');
-            });
-
-            const activePane = document.getElementById('year-' + targetYear);
-            if (activePane) {
-              activePane.classList.add('active');
+            // Preserve the highlighted year in the URL anchor (without jumping the page).
+            if (targetYear) {
+              history.replaceState(null, '', '#' + targetYear);
             }
 
             const header = document.getElementById('defense-database-header');
@@ -187,12 +332,31 @@ permalink: /security-track-record/
                   <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
                     <div style="display: flex; align-items: center;">
                       <span style="font-size: 18px; font-weight: 600; margin-right: 15px;">
-                        <a href="https://nvd.nist.gov/vuln/detail/{{ item.cve }}" target="_blank" rel="noopener noreferrer" style="color: #286FD7; text-decoration: none;">{{ item.cve }}</a>
+                        {% if item.cve != nil and item.cve != '' %}
+                          <a href="https://nvd.nist.gov/vuln/detail/{{ item.cve }}" target="_blank" rel="noopener noreferrer" style="color: #286FD7; text-decoration: none;">{{ item.cve }}</a>
+                        {% else %}
+                          <span style="color: #64748b;">No CVE assigned</span>
+                        {% endif %}
                       </span>
+                      {% if item.cvss != nil %}
+                        {% comment %} CVSS chip: 11-color green→yellow→orange→red palette indexed by the rounded score (0-10), with a per-swatch readable text color. {% endcomment %}
+                        {% assign cvss_index = item.cvss | round %}
+                        {% if cvss_index < 0 %}{% assign cvss_index = 0 %}{% endif %}
+                        {% if cvss_index > 10 %}{% assign cvss_index = 10 %}{% endif %}
+                        {% assign cvss_bg_palette = "#2f6b4d,#3d8a5e,#82b481,#b9cf94,#d8e0a6,#eee9c2,#e8d3a2,#e0ad82,#d07a5e,#c0564d,#9c4a48" | split: "," %}
+                        {% assign cvss_fg_palette = "#ffffff,#ffffff,#333333,#333333,#333333,#333333,#333333,#333333,#ffffff,#ffffff,#ffffff" | split: "," %}
+                        <span class="label" title="CVSS: {{ item.cvss }}" style="background-color: {{ cvss_bg_palette[cvss_index] }}; color: {{ cvss_fg_palette[cvss_index] }}; padding: 2px 7px; font-size: 11px; font-weight: 600; border-radius: 10px;">{{ item.cvss }}</span>
+                      {% endif %}
                     </div>
                     <div>
                       {% if item.exploitable_under_gvisor %}
-                        <span class="label label-danger" style="padding: 6px 12px; font-size: 13px; border-radius: 12px;">Unmitigated</span>
+                        {% if item.patched == "PATCHED" %}
+                          <span class="label" style="background-color: #f4c430; color: #333; padding: 6px 12px; font-size: 13px; border-radius: 12px;">Patched</span>
+                        {% elsif item.patched == "EXTERNAL_MITIGATION_REQUIRED" %}
+                          <span class="label" style="background-color: #ed7d31; color: #fff; padding: 6px 12px; font-size: 13px; border-radius: 12px;">External mitigation required</span>
+                        {% else %}
+                          <span class="label" style="background-color: #b91c1c; color: #fff; padding: 6px 12px; font-size: 13px; border-radius: 12px;">Vulnerable</span>
+                        {% endif %}
                       {% else %}
                         <span class="label label-success" style="padding: 6px 12px; font-size: 13px; border-radius: 12px;">Defended</span>
                       {% endif %}
@@ -200,8 +364,10 @@ permalink: /security-track-record/
                   </div>
                   <div class="row" style="font-size: 15px; line-height: 1.6;">
                     <div class="col-md-7" style="margin-bottom: 15px;">
-                      <h5 style="font-weight: 600; color: #333; margin-top: 0; margin-bottom: 10px;">Vulnerability Overview &amp; Impact</h5>
-                      <p style="color: #444;">{{ item.description }}</p>
+                      {% comment %} Render markdown-style `backticks` as monospace. Segments between paired backticks (odd split indices) become <code>. {% endcomment %}
+                      {% assign desc_parts = item.description | split: '`' %}
+                      {% capture rendered_description %}{% for desc_part in desc_parts %}{% assign part_parity = forloop.index0 | modulo: 2 %}{% if part_parity == 1 %}<code>{{ desc_part }}</code>{% else %}{{ desc_part }}{% endif %}{% endfor %}{% endcapture %}
+                      <p style="color: #444;">{{ rendered_description }}</p>
                       {% if item.exploitable_under_gvisor and item.mitigation_gap != nil and item.mitigation_gap != '' %}
                         <div style="margin-top: 10px;"><strong>Mitigation Gap:</strong> <span style="color: #555;">{{ item.mitigation_gap }}</span></div>
                       {% endif %}
@@ -209,9 +375,9 @@ permalink: /security-track-record/
                         <div style="margin-top: 10px;"><strong>VM Runtime Prevented:</strong> <span style="color: #555;">{% if item.vm_prevented %}Yes{% else %}No{% endif %}</span></div>
                       {% endif %}
                     </div>
-                    <div class="col-md-5" style="border-left: 1px solid #e5e5e5;">
+                    <div class="col-md-5 cve-meta-col">
                       <div style="margin-bottom: 6px;"><strong>Escalation Vector:</strong> <span style="color: #555;">{{ item.risk }}</span></div>
-                      <div style="margin-bottom: 6px;"><strong>Target Ecosystem Scope:</strong> <span style="color: #555;">{{ item.scope }}</span></div>
+                      <div style="margin-bottom: 6px;"><strong>Scope:</strong> <span style="color: #555;">{{ item.scope }}</span></div>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Improvements to the gVisor Security Record page:

- Replace binary "Defended"/"Unmitigated" status with a richer `patched` field (tri-state: `PATCHED`, `EXTERNAL_MITIGATION_REQUIRED`, `UNPATCHED`). Required when `exploitable_under_gvisor` is true.
- Chart: distinct yellow/orange/red bar segments per status. Legend shows percentages.
- Chart: add a dashed "ghost" extrapolation on current-year bar projecting the expected year-end CVE count (suppressed when <2 months remain or projection within 15% of the actual count to avoid visual crowding).
- Display entries without a CVE ID so chart and table counts are complete.
- Add a CVSS chip, colored by score.
- Render markdown-style backticks in descriptions as monospace, and wrap code identifiers throughout the data file in backticks.
- Mobile: horizontally scrollable chart that starts scrolled to the most recent year; wrapped legend; fix stray divider border on stacked columns.
- Preserve highlighted year in URL anchor.
- Remove redundant "Vulnerability Overview & Impact" header and shorten "Target Ecosystem Scope" to "Scope".