### PR TITLE
website: fix parenthetical periods on `/users` page

### DIFF
--- a/website/users/index.html
+++ b/website/users/index.html
@@ -296,7 +296,7 @@ layout: base
           <div class="panel-body">
               <p class="info-users-text">
                 Compute jobs at Modal are containerized and virtualized using gVisor.
-                (<a href="https://modal.com/docs/guide/security">Security at Modal</a>).
+                (<a href="https://modal.com/docs/guide/security">Security at Modal</a>.)
               </p>
           </div>
         </div> <!-- end panel -->
@@ -373,7 +373,7 @@ layout: base
           <div class="panel-body">
               <p class="info-users-text"> In userspace mode, Tailscale uses the
                 gVisor netstack library, implementing networking in userspace.
-                (<a href="https://tailscale.com/kb/1177/kernel-vs-userspace-routers">Kernel vs. netstack subnet routing &amp; exit nodes</a>).
+                (<a href="https://tailscale.com/kb/1177/kernel-vs-userspace-routers">Kernel vs. netstack subnet routing &amp; exit nodes</a>.)
               </p>
           </div>
         </div> <!-- end panel -->


### PR DESCRIPTION
Reported by a user who noticed it.