### PR TITLE
runsc: restore pod-shared overlays without duplicate MemoryFiles

### DIFF
--- a/runsc/boot/restore.go
+++ b/runsc/boot/restore.go
@@ -406,10 +406,13 @@ func (r *restorer) restore(l *Loader) error {
 
 	fdmap := make(map[checkpoint.ResourceID]int)
 	mfmap := make(map[checkpoint.ResourceID]*pgalloc.MemoryFile)
+	// Tracks pod-shared overlay sources so their single MemoryFile is registered
+	// once by the owning container, not duplicated by peers.
+	sharedMFSources := make(map[string]struct{})
 	for _, cont := range r.containers {
 		// TODO(b/298078576): Need to process hints here probably
 		mntr := l.newContainerMounter(cont)
-		if err = mntr.configureRestore(fdmap, mfmap); err != nil {
+		if err = mntr.configureRestore(fdmap, mfmap, sharedMFSources); err != nil {
 			return fmt.Errorf("configuring filesystem restore: %v", err)
 		}
 

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -1475,8 +1475,9 @@ func (c *containerMounter) makeMountPoint(
 }
 
 // configureRestore returns an updated context.Context including filesystem
-// state used by restore defined by conf.
-func (c *containerMounter) configureRestore(fdmap map[checkpoint.ResourceID]int, mfmap map[checkpoint.ResourceID]*pgalloc.MemoryFile) error {
+// state used by restore defined by conf. sharedMFSources records pod-shared
+// overlay sources already registered so peers reuse the owner's MemoryFile.
+func (c *containerMounter) configureRestore(fdmap map[checkpoint.ResourceID]int, mfmap map[checkpoint.ResourceID]*pgalloc.MemoryFile, sharedMFSources map[string]struct{}) error {
 	// Compare createMountNamespace(); rootfs always consumes a gofer FD and a
 	// filestore FD is consumed if the rootfs GoferMountConf indicates so.
 	rootKey := checkpoint.ResourceID{ContainerName: c.containerName, Path: "/"}
@@ -1501,6 +1502,18 @@ func (c *containerMounter) configureRestore(fdmap map[checkpoint.ResourceID]int,
 			fdmap[key] = submount.goferFD.Release()
 		}
 		if submount.filestoreFD != nil {
+			// A pod-shared overlay has one MemoryFile, owned by the first container
+			// to mount it; peers reuse that master. Skip the peer's duplicate and
+			// close its extra filestore FD so mfmap matches the saved owner. Assumes
+			// containers restore in the same order they were created at checkpoint.
+			if submount.hint != nil && submount.hint.ShouldShareMount() {
+				src := submount.hint.Mount.Source
+				if _, ok := sharedMFSources[src]; ok {
+					submount.filestoreFD.Close()
+					continue
+				}
+				sharedMFSources[src] = struct{}{}
+			}
 			key := checkpoint.ResourceID{ContainerName: c.containerName, Path: submount.mount.Destination}
 			mf, err := createPrivateMemoryFile(submount.filestoreFD.ReleaseToFile("overlay-filestore"), key, c.containerID, c.l.fsRestore)
 			if err != nil {


### PR DESCRIPTION
Why

When a pod's containers share an overlay mount through a `share=pod` mount hint whose upper is a disk-backed filestore, restore fails. At boot the first container to mount the shared source owns the overlay's single MemoryFile and peers reuse that master (`getSharedMount` closes the peer's filestore FD), so checkpoint saves exactly one MemoryFile for the overlay. `configureRestore` didn't know that: it created a private MemoryFile for every container's filestore FD, so each peer registered a duplicate. `mfmap` ended up with more entries than the checkpoint image and restore errored out.

What

- Thread a set of shared-overlay sources already registered across the containers processed by `configureRestore`.
- Only the first container to see a shared source registers its MemoryFile; peers close their extra filestore FD and skip registration, so `mfmap` matches the single owner recorded at checkpoint.

This mirrors the runtime's own ownership model, so the restored `mfmap` keys line up with what was saved.

One assumption worth a reviewer's eye: the owner is picked as the first container to reach the shared source during restore, so it relies on containers restoring in the same order they were created at checkpoint (the private MemoryFile is matched back by its `ResourceID{ContainerName, Path}`). The existing per-container filestore restore already depends on that same ordering, but happy to gate this behind something stronger if you'd prefer.

Verified end-to-end with a two-container pod sharing a disk-backed overlay: checkpoint then restore now succeeds where it previously failed on the duplicate MemoryFile.