### PR TITLE
feat(cgroup2fs): support extended attributes on cgroup directories

### DIFF
--- a/pkg/sentry/fsimpl/cgroup2fs/BUILD
+++ b/pkg/sentry/fsimpl/cgroup2fs/BUILD
@@ -21,6 +21,7 @@ go_library(
         "save_restore.go",
         "tasks_mutex.go",
         "tree_mutex.go",
+        "xattr.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [
@@ -36,6 +37,7 @@ go_library(
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/usage",
         "//pkg/sentry/vfs",
+        "//pkg/sentry/vfs/memxattr",
         "//pkg/sync",
         "//pkg/sync/locking",
         "//pkg/usermem",

--- a/pkg/sentry/fsimpl/cgroup2fs/cgroup.go
+++ b/pkg/sentry/fsimpl/cgroup2fs/cgroup.go
@@ -43,6 +43,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
+	"gvisor.dev/gvisor/pkg/sentry/vfs/memxattr"
 )
 
 // limitMax is the value for max.descendants and max.depth that indicates no limit.
@@ -125,6 +126,9 @@ type cgroup struct {
 	// killSeq tracks cgroup.kill invocations.
 	// +checklocks:fs.tasksMu
 	killSeq uint64
+
+	// xattrs stores extended attributes on this cgroup directory.
+	xattrs memxattr.SimpleExtendedAttributes
 }
 
 // +checklocks:c.fs.treeMu

--- a/pkg/sentry/fsimpl/cgroup2fs/xattr.go
+++ b/pkg/sentry/fsimpl/cgroup2fs/xattr.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroup2fs
+
+import (
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/sentry/fsimpl/kernfs"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+)
+
+var _ kernfs.InodeWithXattrs = (*cgroup)(nil)
+
+func cgroup2XattrAllowed(name string) bool {
+	return strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX) ||
+		strings.HasPrefix(name, linux.XATTR_SECURITY_PREFIX) ||
+		strings.HasPrefix(name, linux.XATTR_USER_PREFIX)
+}
+
+// GetXattr implements kernfs.InodeWithXattrs.GetXattr.
+func (c *cgroup) GetXattr(ctx context.Context, opts vfs.GetXattrOptions) (string, error) {
+	if !cgroup2XattrAllowed(opts.Name) {
+		return "", linuxerr.EOPNOTSUPP
+	}
+	creds := auth.CredentialsFromContext(ctx)
+	return c.xattrs.GetXattr(creds, c.Mode(), c.UID(), &opts)
+}
+
+// SetXattr implements kernfs.InodeWithXattrs.SetXattr.
+func (c *cgroup) SetXattr(ctx context.Context, opts vfs.SetXattrOptions) error {
+	if !cgroup2XattrAllowed(opts.Name) {
+		return linuxerr.EOPNOTSUPP
+	}
+	creds := auth.CredentialsFromContext(ctx)
+	return c.xattrs.SetXattr(creds, c.Mode(), c.UID(), c.GID(), &opts)
+}
+
+// ListXattr implements kernfs.InodeWithXattrs.ListXattr.
+func (c *cgroup) ListXattr(ctx context.Context, size uint64) ([]string, error) {
+	creds := auth.CredentialsFromContext(ctx)
+	return c.xattrs.ListXattr(creds, size)
+}
+
+// RemoveXattr implements kernfs.InodeWithXattrs.RemoveXattr.
+func (c *cgroup) RemoveXattr(ctx context.Context, name string) error {
+	if !cgroup2XattrAllowed(name) {
+		return linuxerr.EOPNOTSUPP
+	}
+	creds := auth.CredentialsFromContext(ctx)
+	return c.xattrs.RemoveXattr(creds, c.Mode(), c.UID(), name)
+}

--- a/test/syscalls/linux/cgroup2.cc
+++ b/test/syscalls/linux/cgroup2.cc
@@ -22,6 +22,7 @@
 #include <sys/mman.h>
 #include <sys/mount.h>
 #include <sys/statfs.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include <cerrno>
@@ -1763,6 +1764,47 @@ TEST_F(Cgroup2Test, CpuLimits) {
               PosixErrorIs(ERANGE));
   EXPECT_THAT(parent.WriteControlFile("cpu.weight", "abc"),
               PosixErrorIs(EINVAL));
+}
+
+TEST_F(Cgroup2Test, Xattr) {
+  const char* path = c().Path().c_str();
+  const char name[] = "trusted.test";
+  const char val = 'a';
+  const size_t size = sizeof(val);
+
+  EXPECT_THAT(setxattr(path, name, &val, size, /*flags=*/0), SyscallSucceeds());
+
+  char got = '\0';
+  EXPECT_THAT(getxattr(path, name, &got, size), SyscallSucceedsWithValue(size));
+  EXPECT_EQ(val, got);
+
+  char list[sizeof(name)];
+  EXPECT_THAT(listxattr(path, list, sizeof(list)),
+              SyscallSucceedsWithValue(sizeof(name)));
+  EXPECT_STREQ(list, name);
+
+  EXPECT_THAT(removexattr(path, name), SyscallSucceeds());
+  EXPECT_THAT(getxattr(path, name, &got, size), SyscallFailsWithErrno(ENODATA));
+}
+
+TEST_F(Cgroup2Test, TrustedXattrWithoutCapSysAdmin) {
+  const char* path = c().Path().c_str();
+  AutoCapability cap(CAP_SYS_ADMIN, false);
+
+  const char name[] = "trusted.test";
+  const char val = 'a';
+  const size_t size = sizeof(val);
+
+  EXPECT_THAT(setxattr(path, name, &val, size, /*flags=*/0),
+              SyscallFailsWithErrno(EPERM));
+
+  char got = '\0';
+  EXPECT_THAT(getxattr(path, name, &got, size), SyscallFailsWithErrno(ENODATA));
+
+  char list[sizeof(name)];
+  EXPECT_THAT(listxattr(path, list, sizeof(list)), SyscallSucceedsWithValue(0));
+
+  EXPECT_THAT(removexattr(path, name), SyscallFailsWithErrno(EPERM));
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- Implement `kernfs.InodeWithXattrs` on cgroup2 directory inodes using in-memory xattr storage.
- Allow `trusted.*`, `security.*`, and `user.*` namespaces to match Linux kernfs/cgroup2 behavior.
- Fixes #13639.

## Test plan

- [ ] `bazel test //pkg/sentry/fsimpl/cgroup2fs/...`
- [ ] Manual: set/get/list/remove xattrs on a cgroup2 directory inside runsc (e.g. `trusted.delegate`).


Made with [Cursor](https://cursor.com)