### PR TITLE
website: register fuse user guide doc

### DIFF
--- a/g3doc/user_guide/fuse.md
+++ b/g3doc/user_guide/fuse.md
@@ -2,8 +2,8 @@
 
 [TOC]
 
-gVisor supports [FUSE](Filesystem in Userspace), allowing userspace programs to
-serve filesystems inside a sandbox. There are two modes of operation:
+gVisor supports Filesystem in Userspace ([FUSE]), allowing userspace programs
+to serve filesystems inside a sandbox. There are two modes of operation:
 
 *   **In-sandbox FUSE**: A FUSE daemon runs inside the sandbox and communicates
     with the gVisor kernel via `/dev/fuse`. This is the standard FUSE model.

--- a/website/BUILD
+++ b/website/BUILD
@@ -163,6 +163,7 @@ docs(
         "//g3doc/user_guide:debugging",
         "//g3doc/user_guide:filesystem",
         "//g3doc/user_guide:fs_snapshot",
+        "//g3doc/user_guide:fuse",
         "//g3doc/user_guide:gpu",
         "//g3doc/user_guide:install",
         "//g3doc/user_guide:networking",


### PR DESCRIPTION
website: register fuse user guide doc

The fuse.md doc() target was added to g3doc/user_guide/BUILD in
31c3363db7 but website/BUILD was never updated to list it, so
gvisor.dev/docs/user_guide/fuse/ was not being rendered on the site.

Also fix a broken link in fuse.md that html-proofer flags once the
page is included in the website build: "[FUSE](Filesystem in
Userspace)" parses as an inline link pointing to the literal URL
"Filesystem in Userspace" instead of using the [FUSE] reference
definition at the bottom of the file.