### PR TITLE
Compatibility test suite: add MariaDB, PostgreSQL, Redis, Valkey

### DIFF
--- a/images/compatibility/mariadb/mariadb/Dockerfile
+++ b/images/compatibility/mariadb/mariadb/Dockerfile
@@ -1,0 +1,1 @@
+FROM mariadb:12.3.2

--- a/images/compatibility/postgresql/postgresql/Dockerfile
+++ b/images/compatibility/postgresql/postgresql/Dockerfile
@@ -1,0 +1,1 @@
+FROM postgres:18.4

--- a/images/compatibility/redis/redis/Dockerfile
+++ b/images/compatibility/redis/redis/Dockerfile
@@ -1,0 +1,1 @@
+FROM redis:8.8.0

--- a/images/compatibility/valkey/valkey/Dockerfile
+++ b/images/compatibility/valkey/valkey/Dockerfile
@@ -1,0 +1,1 @@
+FROM valkey/valkey:9.0.4

--- a/test/compatibility/BUILD
+++ b/test/compatibility/BUILD
@@ -39,3 +39,39 @@ compatibility_test(
         "//test/compatibility",
     ],
 )
+
+compatibility_test(
+    name = "mariadb",
+    srcs = ["mariadb/mariadb_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)
+
+compatibility_test(
+    name = "postgresql",
+    srcs = ["postgresql/postgresql_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)
+
+compatibility_test(
+    name = "redis",
+    srcs = ["redis/redis_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)
+
+compatibility_test(
+    name = "valkey",
+    srcs = ["valkey/valkey_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)

--- a/test/compatibility/mariadb/mariadb_test.go
+++ b/test/compatibility/mariadb/mariadb_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mariadb is a gVisor compatibility test for MariaDB.
+//
+// The MariaDB version under test is pinned in
+// images/compatibility/mariadb/mariadb/Dockerfile.
+package mariadb
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	mariadbImage = "compatibility/mariadb/mariadb"
+
+	dbName         = "gvisor"
+	dbUser         = "gvisor"
+	dbPassword     = "gvisorpass"
+	dbRootPassword = "rootpass"
+
+	want = "gvisor-row"
+
+	readyTimeout = 3 * time.Minute
+	pollInterval = 2 * time.Second
+)
+
+func TestMariaDB(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	if err := c.Spawn(ctx, dockerutil.RunOpts{
+		Image: mariadbImage,
+		Env: []string{
+			"MARIADB_ROOT_PASSWORD=" + dbRootPassword,
+			"MARIADB_DATABASE=" + dbName,
+			"MARIADB_USER=" + dbUser,
+			"MARIADB_PASSWORD=" + dbPassword,
+		},
+	}); err != nil {
+		t.Fatalf("failed to start mariadb: %v", err)
+	}
+
+	// Wait for MariaDB to be ready.
+	query := func(sql string) (string, error) {
+		return c.Exec(ctx, dockerutil.ExecOpts{},
+			"mariadb", "-u"+dbUser, "-p"+dbPassword, dbName, "-e", sql)
+	}
+	compatibility.Poll(ctx, t, "mariadb to accept queries", readyTimeout, pollInterval, func() error {
+		if out, err := query("SELECT 1"); err != nil {
+			return fmt.Errorf("mariadb query: %v (%s)", err, out)
+		}
+		return nil
+	})
+
+	// Write a row and read it back.
+	out, err := query("CREATE TABLE gv (id int PRIMARY KEY, v varchar(32)); " +
+		"INSERT INTO gv VALUES (1, '" + want + "'); " +
+		"SELECT v FROM gv WHERE id = 1;")
+	if err != nil {
+		t.Fatalf("mariadb roundtrip failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, want) {
+		t.Fatalf("mariadb roundtrip: output missing %q; got: %s", want, out)
+	}
+	t.Logf("mariadb roundtrip ok")
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/test/compatibility/postgresql/postgresql_test.go
+++ b/test/compatibility/postgresql/postgresql_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package postgresql is a gVisor compatibility test for PostgreSQL.
+//
+// The PostgreSQL version under test is pinned in
+// images/compatibility/postgresql/postgresql/Dockerfile.
+package postgresql
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	pgImage = "compatibility/postgresql/postgresql"
+
+	dbName     = "gvisor"
+	dbUser     = "gvisor"
+	dbPassword = "gvisorpass"
+
+	want = "gvisor-row"
+
+	readyTimeout = 2 * time.Minute
+	pollInterval = 2 * time.Second
+)
+
+func TestPostgreSQL(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	if err := c.Spawn(ctx, dockerutil.RunOpts{
+		Image: pgImage,
+		Env: []string{
+			"POSTGRES_DB=" + dbName,
+			"POSTGRES_USER=" + dbUser,
+			"POSTGRES_PASSWORD=" + dbPassword,
+		},
+	}); err != nil {
+		t.Fatalf("failed to start postgres: %v", err)
+	}
+
+	// Wait until Postgres accepts connections over TCP.
+	compatibility.Poll(ctx, t, "postgres to accept connections", readyTimeout, pollInterval, func() error {
+		if out, err := c.Exec(ctx, dockerutil.ExecOpts{}, "pg_isready", "-h", "127.0.0.1", "-U", dbUser, "-d", dbName); err != nil {
+			return fmt.Errorf("pg_isready: %v (%s)", err, out)
+		}
+		return nil
+	})
+
+	// Write a row and read it back via psql (local socket auth is "trust").
+	out, err := c.Exec(ctx, dockerutil.ExecOpts{}, "psql", "-U", dbUser, "-d", dbName, "-tAc",
+		"CREATE TABLE gv (id int PRIMARY KEY, v text); "+
+			"INSERT INTO gv VALUES (1, '"+want+"'); "+
+			"SELECT v FROM gv WHERE id = 1;")
+	if err != nil {
+		t.Fatalf("psql roundtrip failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, want) {
+		t.Fatalf("psql roundtrip: output missing %q; got: %s", want, out)
+	}
+	t.Logf("postgres roundtrip ok: %s", strings.TrimSpace(out))
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/test/compatibility/redis/redis_test.go
+++ b/test/compatibility/redis/redis_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package redis is a gVisor compatibility test for Redis.
+//
+// The Redis version under test is pinned in
+// images/compatibility/redis/redis/Dockerfile.
+package redis
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	redisImage = "compatibility/redis/redis"
+
+	key  = "gv-key"
+	want = "gvisor-value"
+
+	readyTimeout = 2 * time.Minute
+	pollInterval = 2 * time.Second
+)
+
+func TestRedis(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	if err := c.Spawn(ctx, dockerutil.RunOpts{Image: redisImage}); err != nil {
+		t.Fatalf("failed to start redis: %v", err)
+	}
+
+	cli := func(args ...string) (string, error) {
+		return c.Exec(ctx, dockerutil.ExecOpts{}, append([]string{"redis-cli"}, args...)...)
+	}
+
+	// Wait for the server to respond to PING.
+	compatibility.Poll(ctx, t, "redis to respond to PING", readyTimeout, pollInterval, func() error {
+		out, err := cli("ping")
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(out, "PONG") {
+			return fmt.Errorf("PING returned %q", strings.TrimSpace(out))
+		}
+		return nil
+	})
+
+	// SET then GET the key back.
+	if out, err := cli("set", key, want); err != nil {
+		t.Fatalf("SET failed: %v\n%s", err, out)
+	}
+	out, err := cli("get", key)
+	if err != nil {
+		t.Fatalf("GET failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, want) {
+		t.Fatalf("GET %s: got %q, want to contain %q", key, strings.TrimSpace(out), want)
+	}
+	t.Logf("redis roundtrip ok")
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/test/compatibility/valkey/valkey_test.go
+++ b/test/compatibility/valkey/valkey_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package valkey is a gVisor compatibility test for Valkey (a Redis fork).
+//
+// The Valkey version under test is pinned in
+// images/compatibility/valkey/valkey/Dockerfile.
+package valkey
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	valkeyImage = "compatibility/valkey/valkey"
+
+	key  = "gv-key"
+	want = "gvisor-value"
+
+	readyTimeout = 2 * time.Minute
+	pollInterval = 2 * time.Second
+)
+
+func TestValkey(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	if err := c.Spawn(ctx, dockerutil.RunOpts{Image: valkeyImage}); err != nil {
+		t.Fatalf("failed to start valkey: %v", err)
+	}
+
+	cli := func(args ...string) (string, error) {
+		return c.Exec(ctx, dockerutil.ExecOpts{}, append([]string{"valkey-cli"}, args...)...)
+	}
+
+	// Wait for the server to respond to PING.
+	compatibility.Poll(ctx, t, "valkey to respond to PING", readyTimeout, pollInterval, func() error {
+		out, err := cli("ping")
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(out, "PONG") {
+			return fmt.Errorf("PING returned %q", strings.TrimSpace(out))
+		}
+		return nil
+	})
+
+	// SET then GET the key back.
+	if out, err := cli("set", key, want); err != nil {
+		t.Fatalf("SET failed: %v\n%s", err, out)
+	}
+	out, err := cli("get", key)
+	if err != nil {
+		t.Fatalf("GET failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, want) {
+		t.Fatalf("GET %s: got %q, want to contain %q", key, strings.TrimSpace(out), want)
+	}
+	t.Logf("valkey roundtrip ok")
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
The second stage of the gVisor application compatibility test suite.