### PR TITLE
Compatibility test suite: add Kafka, Keycloak, Mosquitto, RabbitMQ

### DIFF
--- a/images/compatibility/kafka/kafka/Dockerfile
+++ b/images/compatibility/kafka/kafka/Dockerfile
@@ -1,0 +1,1 @@
+FROM apache/kafka:4.3.1

--- a/images/compatibility/keycloak/keycloak/Dockerfile
+++ b/images/compatibility/keycloak/keycloak/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/keycloak/keycloak:26.6.4

--- a/images/compatibility/mosquitto/mosquitto/Dockerfile
+++ b/images/compatibility/mosquitto/mosquitto/Dockerfile
@@ -1,0 +1,1 @@
+FROM eclipse-mosquitto:2.0.22

--- a/images/compatibility/rabbitmq/rabbitmq/Dockerfile
+++ b/images/compatibility/rabbitmq/rabbitmq/Dockerfile
@@ -1,0 +1,1 @@
+FROM rabbitmq:4.3.2-management

--- a/test/compatibility/BUILD
+++ b/test/compatibility/BUILD
@@ -75,3 +75,39 @@ compatibility_test(
         "//test/compatibility",
     ],
 )
+
+compatibility_test(
+    name = "kafka",
+    srcs = ["kafka/kafka_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)
+
+compatibility_test(
+    name = "mosquitto",
+    srcs = ["mosquitto/mosquitto_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)
+
+compatibility_test(
+    name = "rabbitmq",
+    srcs = ["rabbitmq/rabbitmq_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)
+
+compatibility_test(
+    name = "keycloak",
+    srcs = ["keycloak/keycloak_test.go"],
+    deps = [
+        "//pkg/test/dockerutil",
+        "//test/compatibility",
+    ],
+)

--- a/test/compatibility/kafka/kafka_test.go
+++ b/test/compatibility/kafka/kafka_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kafka is a gVisor compatibility test for Apache Kafka (KRaft mode).
+//
+// The Kafka version under test is pinned in
+// images/compatibility/kafka/kafka/Dockerfile.
+package kafka
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	kafkaImage = "compatibility/kafka/kafka"
+
+	bootstrap = "localhost:9092"
+	binDir    = "/opt/kafka/bin/"
+	topic     = "gv"
+	want      = "gvisor-msg"
+
+	readyTimeout = 3 * time.Minute
+	pollInterval = 3 * time.Second
+)
+
+func TestKafka(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	if err := c.Spawn(ctx, dockerutil.RunOpts{Image: kafkaImage}); err != nil {
+		t.Fatalf("failed to start kafka: %v", err)
+	}
+
+	// run executes a shell command inside the container.
+	run := func(cmd string) (string, error) {
+		return c.Exec(ctx, dockerutil.ExecOpts{}, "sh", "-c", cmd)
+	}
+
+	// Wait for the broker to accept admin requests.
+	compatibility.Poll(ctx, t, "kafka broker to be ready", readyTimeout, pollInterval, func() error {
+		if out, err := run(binDir + "kafka-topics.sh --bootstrap-server " + bootstrap + " --list"); err != nil {
+			return fmt.Errorf("kafka-topics --list: %v (%s)", err, out)
+		}
+		return nil
+	})
+
+	// Create a topic.
+	if out, err := run(binDir + "kafka-topics.sh --bootstrap-server " + bootstrap +
+		" --create --topic " + topic + " --partitions 1 --replication-factor 1"); err != nil {
+		t.Fatalf("create topic: %v\n%s", err, out)
+	}
+
+	// Produce a single message.
+	if out, err := run("echo " + want + " | " + binDir + "kafka-console-producer.sh --bootstrap-server " +
+		bootstrap + " --topic " + topic); err != nil {
+		t.Fatalf("produce: %v\n%s", err, out)
+	}
+
+	// Consume it back.
+	out, err := run(binDir + "kafka-console-consumer.sh --bootstrap-server " + bootstrap +
+		" --topic " + topic + " --from-beginning --max-messages 1 --timeout-ms 30000")
+	if err != nil {
+		t.Fatalf("consume: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, want) {
+		t.Fatalf("consume: output missing %q; got: %s", want, out)
+	}
+	t.Logf("kafka produce/consume roundtrip ok")
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/test/compatibility/keycloak/keycloak_test.go
+++ b/test/compatibility/keycloak/keycloak_test.go
@@ -1,0 +1,151 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package keycloak is a gVisor compatibility test for Keycloak.
+//
+// The Keycloak version under test is pinned in
+// images/compatibility/keycloak/keycloak/Dockerfile.
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	keycloakImage = "compatibility/keycloak/keycloak"
+	keycloakPort  = 8080
+
+	adminUser     = "admin"
+	adminPassword = "admin-gvtest-1234"
+
+	realm    = "gvtest"
+	appUser  = "alice"
+	appPass  = "alicepw"
+	appCl    = "gvapp"
+	adminCli = "admin-cli"
+
+	readyTimeout = 4 * time.Minute
+	pollInterval = 3 * time.Second
+)
+
+func TestKeycloak(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	if err := c.Spawn(ctx, dockerutil.RunOpts{
+		Image: keycloakImage,
+		Env: []string{
+			"KC_BOOTSTRAP_ADMIN_USERNAME=" + adminUser,
+			"KC_BOOTSTRAP_ADMIN_PASSWORD=" + adminPassword,
+			"KC_HEALTH_ENABLED=true",
+		},
+	}, "start-dev"); err != nil {
+		t.Fatalf("failed to start keycloak: %v", err)
+	}
+
+	ip, err := c.FindIP(ctx, false)
+	if err != nil {
+		t.Fatalf("failed to find keycloak IP: %v", err)
+	}
+	base := fmt.Sprintf("http://%s:%d", ip.String(), keycloakPort)
+
+	// Wait for the master realm to be served.
+	compatibility.Poll(ctx, t, "keycloak master realm to be ready", readyTimeout, pollInterval, func() error {
+		status, _, err := compatibility.Get(base + "/realms/master")
+		if err != nil {
+			return err
+		}
+		if status != http.StatusOK {
+			return fmt.Errorf("GET /realms/master: status %d", status)
+		}
+		return nil
+	})
+
+	// Authenticate as the bootstrap admin.
+	adminToken := token(t, base, "master", adminCli, adminUser, adminPassword)
+
+	bearer := map[string]string{"Authorization": "Bearer " + adminToken}
+	adminJSON := func(method, path, body string, want int) {
+		compatibility.Request{
+			Method: method, URL: base + path, ContentType: "application/json",
+			Headers: bearer, Body: body,
+		}.DoOrFatal(t, want)
+	}
+
+	// Create a realm, a user (with a password), and a public direct-grant client.
+	adminJSON(http.MethodPost, "/admin/realms",
+		fmt.Sprintf(`{"realm":%q,"enabled":true}`, realm), http.StatusCreated)
+	// A complete profile (name/email) and no required actions are needed, else
+	// Keycloak's "Verify Profile" action blocks the direct-grant login below.
+	adminJSON(http.MethodPost, "/admin/realms/"+realm+"/users",
+		fmt.Sprintf(`{"username":%q,"enabled":true,"emailVerified":true,"firstName":"Alice","lastName":"Test",`+
+			`"email":"alice@example.com","requiredActions":[],`+
+			`"credentials":[{"type":"password","value":%q,"temporary":false}]}`, appUser, appPass),
+		http.StatusCreated)
+	adminJSON(http.MethodPost, "/admin/realms/"+realm+"/clients",
+		fmt.Sprintf(`{"clientId":%q,"publicClient":true,"directAccessGrantsEnabled":true,"enabled":true}`, appCl),
+		http.StatusCreated)
+
+	// Verify the realm exists.
+	adminJSON(http.MethodGet, "/admin/realms/"+realm, "", http.StatusOK)
+
+	// Mint a token for the new user in the new realm: exercises JWT signing and a
+	// DB-backed user credential.
+	if userToken := token(t, base, realm, appCl, appUser, appPass); userToken == "" {
+		t.Fatalf("minted user token is empty")
+	}
+	t.Logf("keycloak: created realm/user/client and minted a user token")
+}
+
+// token performs an OpenID Connect password grant and returns the access token.
+func token(t *testing.T, base, realm, clientID, username, password string) string {
+	t.Helper()
+	form := url.Values{
+		"grant_type": {"password"},
+		"client_id":  {clientID},
+		"username":   {username},
+		"password":   {password},
+	}
+	body := compatibility.Request{
+		Method:      http.MethodPost,
+		URL:         base + "/realms/" + realm + "/protocol/openid-connect/token",
+		ContentType: "application/x-www-form-urlencoded",
+		Body:        form.Encode(),
+	}.DoOrFatal(t, http.StatusOK)
+	var tok struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal([]byte(body), &tok); err != nil || tok.AccessToken == "" {
+		t.Fatalf("token (%s/%s): no access_token (%v); body: %s", realm, clientID, err, body)
+	}
+	return tok.AccessToken
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/test/compatibility/mosquitto/mosquitto_test.go
+++ b/test/compatibility/mosquitto/mosquitto_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mosquitto is a gVisor compatibility test for the Eclipse Mosquitto
+// MQTT broker.
+//
+// The Mosquitto version under test is pinned in
+// images/compatibility/mosquitto/mosquitto/Dockerfile.
+package mosquitto
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	mosquittoImage = "compatibility/mosquitto/mosquitto"
+
+	topic = "gv/test"
+	want  = "gvisor-msg"
+
+	readyTimeout = 1 * time.Minute
+	pollInterval = 2 * time.Second
+)
+
+const mosquittoConfig = `listener 1883 0.0.0.0
+allow_anonymous true
+`
+
+func TestMosquitto(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	opts := dockerutil.RunOpts{Image: mosquittoImage}
+	c.CopyFiles(&opts, "/mosquitto/config", compatibility.WriteConfigFile(t, "mosquitto.conf", mosquittoConfig))
+	if err := c.Spawn(ctx, opts); err != nil {
+		t.Fatalf("failed to start mosquitto: %v", err)
+	}
+
+	// Wait for the broker to accept a publish.
+	compatibility.Poll(ctx, t, "mosquitto to accept connections", readyTimeout, pollInterval, func() error {
+		if out, err := c.Exec(ctx, dockerutil.ExecOpts{}, "mosquitto_pub", "-t", "gv/ready", "-m", "ping"); err != nil {
+			return fmt.Errorf("mosquitto_pub: %v (%s)", err, out)
+		}
+		return nil
+	})
+
+	// Publish a retained message.
+	if out, err := c.Exec(ctx, dockerutil.ExecOpts{}, "mosquitto_pub", "-t", topic, "-m", want, "-r"); err != nil {
+		t.Fatalf("publish: %v\n%s", err, out)
+	}
+
+	// Subscribe and read the retained message back (exit after one message).
+	out, err := c.Exec(ctx, dockerutil.ExecOpts{}, "mosquitto_sub", "-t", topic, "-C", "1", "-W", "10")
+	if err != nil {
+		t.Fatalf("subscribe: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, want) {
+		t.Fatalf("subscribe: output missing %q; got: %q", want, strings.TrimSpace(out))
+	}
+	t.Logf("mosquitto publish/subscribe roundtrip ok")
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/test/compatibility/rabbitmq/rabbitmq_test.go
+++ b/test/compatibility/rabbitmq/rabbitmq_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rabbitmq is a gVisor compatibility test for RabbitMQ.
+//
+// The RabbitMQ version under test is pinned in
+// images/compatibility/rabbitmq/rabbitmq/Dockerfile.
+package rabbitmq
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/test/dockerutil"
+	"gvisor.dev/gvisor/test/compatibility"
+)
+
+const (
+	rabbitmqImage = "compatibility/rabbitmq/rabbitmq"
+
+	user     = "gvisor"
+	password = "gvisorpass"
+	mgmtPort = 15672
+
+	queue = "gv"
+	want  = "gvisor-msg"
+
+	readyTimeout = 3 * time.Minute
+	pollInterval = 3 * time.Second
+)
+
+func TestRabbitMQ(t *testing.T) {
+	ctx := context.Background()
+
+	c := dockerutil.MakeContainer(ctx, t)
+	defer c.CleanUp(ctx)
+	if err := c.Spawn(ctx, dockerutil.RunOpts{
+		Image: rabbitmqImage,
+		Env: []string{
+			"RABBITMQ_DEFAULT_USER=" + user,
+			"RABBITMQ_DEFAULT_PASS=" + password,
+		},
+	}); err != nil {
+		t.Fatalf("failed to start rabbitmq: %v", err)
+	}
+
+	ip, err := c.FindIP(ctx, false)
+	if err != nil {
+		t.Fatalf("failed to find rabbitmq IP: %v", err)
+	}
+	base := fmt.Sprintf("http://%s:%d", ip.String(), mgmtPort)
+
+	// Wait for the management API to be up.
+	compatibility.Poll(ctx, t, "rabbitmq management API to be ready", readyTimeout, pollInterval, func() error {
+		status, _, err := compatibility.Request{URL: base + "/api/overview", Username: user, Password: password}.Do()
+		if err != nil {
+			return err
+		}
+		if status != http.StatusOK {
+			return fmt.Errorf("GET /api/overview: status %d", status)
+		}
+		return nil
+	})
+
+	// Declare a durable queue on the default vhost ("/" urlencoded).
+	defaultVHost := "%2f"
+	compatibility.Request{
+		Method:      http.MethodPut,
+		URL:         base + "/api/queues/" + defaultVHost + "/" + queue,
+		ContentType: "application/json",
+		Username:    user,
+		Password:    password,
+		Body:        `{"durable":true}`,
+	}.DoOrFatal(t, http.StatusCreated)
+
+	// Publish a message through the default exchange, routed by queue name.
+	published := compatibility.Request{
+		Method:      http.MethodPost,
+		URL:         base + "/api/exchanges/" + defaultVHost + "/amq.default/publish",
+		ContentType: "application/json",
+		Username:    user,
+		Password:    password,
+		Body: fmt.Sprintf(`{"properties":{},"routing_key":%q,"payload":%q,"payload_encoding":"string"}`,
+			queue, want),
+	}.DoOrFatal(t, http.StatusOK)
+	if !strings.Contains(published, `"routed":true`) {
+		t.Fatalf("publish: message not routed; body: %s", published)
+	}
+
+	// Read it back.
+	got := compatibility.Request{
+		Method:      http.MethodPost,
+		URL:         base + "/api/queues/" + defaultVHost + "/" + queue + "/get",
+		ContentType: "application/json",
+		Username:    user,
+		Password:    password,
+		Body:        `{"count":1,"ackmode":"ack_requeue_false","encoding":"auto"}`,
+	}.DoOrFatal(t, http.StatusOK)
+	if !strings.Contains(got, want) {
+		t.Fatalf("get: expected payload %q; body: %s", want, got)
+	}
+	t.Logf("rabbitmq publish/get roundtrip ok")
+}
+
+func TestMain(m *testing.M) {
+	dockerutil.EnsureSupportedDockerVersion()
+	flag.Parse()
+	os.Exit(m.Run())
+}

--- a/website/_data/application-compatibility.yml
+++ b/website/_data/application-compatibility.yml
@@ -68,3 +68,27 @@ apps:
   - name: "systemd"
     category: "System software"
     verdict: "experimental"
+
+  - name: "Apache Kafka"
+    category: "Messaging & streaming"
+    verdict: "yes"
+    version: "4.3.1"
+    test_source: "test/compatibility/kafka/kafka_test.go"
+
+  - name: "Eclipse Mosquitto"
+    category: "Messaging & streaming"
+    verdict: "yes"
+    version: "2.0.22"
+    test_source: "test/compatibility/mosquitto/mosquitto_test.go"
+
+  - name: "RabbitMQ"
+    category: "Messaging & streaming"
+    verdict: "yes"
+    version: "4.3.2"
+    test_source: "test/compatibility/rabbitmq/rabbitmq_test.go"
+
+  - name: "Keycloak"
+    category: "Secrets & security"
+    verdict: "yes"
+    version: "26.6.4"
+    test_source: "test/compatibility/keycloak/keycloak_test.go"


### PR DESCRIPTION
The third stage of the gVisor application compatibility test suite.