### PR TITLE
runtime_in_docker_test: Use `runsc` from data files rather than configured runtime.

### DIFF
--- a/test/e2e/runtime_in_docker_test.go
+++ b/test/e2e/runtime_in_docker_test.go
@@ -132,9 +132,9 @@ func (test testVariant) failureCases() []testVariant {
 // https://gvisor.dev/blog/2024/09/23/safe-ride-into-the-dangerzone/
 func TestGVisorInDocker(t *testing.T) {
 	ctx := context.Background()
-	runscPath, err := dockerutil.RuntimePath()
+	runscPath, err := testutil.FindFile("runsc/runsc")
 	if err != nil {
-		t.Fatalf("Cannot locate runtime path: %v", err)
+		t.Fatalf("Cannot locate runsc binary: %v", err)
 	}
 	for _, test := range []testVariant{
 		{


### PR DESCRIPTION
Makes it easier to run the test.