### PR TITLE
systrap: Eliminate false sharing in `contextQueue` struct fields.

### DIFF
--- a/pkg/sentry/platform/systrap/BUILD
+++ b/pkg/sentry/platform/systrap/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
@@ -104,5 +104,15 @@ go_library(
         "//pkg/sync",
         "//pkg/syncevent",
         "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
+go_test(
+    name = "systrap_test",
+    size = "small",
+    srcs = ["context_queue_test.go"],
+    library = ":systrap",
+    deps = [
+        "//pkg/hostarch",
     ],
 )

--- a/pkg/sentry/platform/systrap/context_queue.go
+++ b/pkg/sentry/platform/systrap/context_queue.go
@@ -17,6 +17,7 @@ package systrap
 import (
 	"sync/atomic"
 
+	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
 )
 
@@ -37,11 +38,42 @@ type queuedContext struct {
 // It is a lockless ringbuffer where threads try to police themselves on whether
 // they should continue waiting for a context or go to sleep if they are
 // unneeded.
+//
+// The control words below are atomically read and written by the Sentry and
+// by stub threads from different CPUs.
+// To avoid false sharing (a write to one word invalidating the cache line for
+// cores that only access other words), the words are grouped by writer and
+// each group is padded out to its own cache line. A field shares a line only
+// with fields written by the same side, so a writer never invalidates a line
+// that another core needs for an unrelated read-mostly field.
+// The ringbuffer starts on its own cache line instead of sharing the first
+// line with the control words. This also guarantees the 8-byte alignment
+// required by Go's 64-bit atomic ints.
+//
+// The layout must stay byte-identical to `context_queue` in
+// `sysmsg/sysmsg_lib.c`.
 type contextQueue struct {
-	// start is an index used for taking contexts out of the ringbuffer.
-	start uint32
 	// end is an index used for putting new contexts into the ringbuffer.
+	// It is written only by the Sentry (add) and read by stub threads.
 	end uint32
+	_   [hostarch.CacheLineSize - 4]byte
+
+	// start is an index used for taking contexts out of the ringbuffer.
+	// It is written only by stub threads and read by both sides.
+	start uint32
+	_     [hostarch.CacheLineSize - 4]byte
+
+	// Sentry-written control words, read by spinning stub threads.
+
+	// fastPathDisabled is set by the Sentry to make stub threads sleep in a
+	// futex instead of spinning when no context is available.
+	fastPathDisabled uint32
+	// numAwakeContexts is the number of awake contexts. It includes all
+	// active contexts and contexts that are running in the Sentry.
+	numAwakeContexts uint32
+	_                [hostarch.CacheLineSize - 8]byte
+
+	// Stub-written status words, read by the Sentry.
 
 	// numActiveThreads indicates to the sentry how many stubs are running.
 	// It is changed only by stub threads.
@@ -49,19 +81,28 @@ type contextQueue struct {
 	// numSpinningThreads indicates to the sentry how many stubs are waiting
 	// to receive a context from the queue, and are not doing useful work.
 	numSpinningThreads uint32
+	_                  [hostarch.CacheLineSize - 8]byte
+
 	// numThreadsToWakeup is the number of threads requested by Sentry to wake up.
 	// The Sentry increments it and stub threads decrements.
 	// Protected by subprocess.kickSysmsgMu for sentry-side writes.
+	//
+	// It is written by both sides and is also used for `FUTEX_WAIT` in
+	// the stub, `FUTEX_WAKE` in the Sentry. So it gets a line of its own.
 	numThreadsToWakeup uint32
-	// numActiveContext is a number of running and waiting contexts
-	numActiveContexts uint32
-	// numAwakeContexts is the number of awake contexts. It includes all
-	// active contexts and contexts that are running in the Sentry.
-	numAwakeContexts uint32
+	_                  [hostarch.CacheLineSize - 4]byte
 
-	fastPathDisabled uint32
-	usedFastPath     uint32
-	ringbuffer       [maxContextQueueEntries]uint64
+	// Words written by both sides.
+
+	// numActiveContext is a number of running and waiting contexts.
+	numActiveContexts uint32
+	// usedFastPath is set by stub threads when they take the fast path and
+	// swapped to zero by the Sentry in `add`.
+	usedFastPath uint32
+	_            [hostarch.CacheLineSize - 8]byte
+
+	// ringbuffer starts on its own cache line.
+	ringbuffer [maxContextQueueEntries]uint64
 }
 
 const (
@@ -107,11 +148,7 @@ func (q *contextQueue) add(ctx *sharedContext) *platform.ContextError {
 	// it has parked itself while the sandbox was idle.
 	fastpath.recordActivity()
 
-	if fastpath.stubFastPath() {
-		q.enableFastPath()
-	} else {
-		q.disableFastPath()
-	}
+	q.setFastPathDisabled(!fastpath.stubFastPath())
 	contextID := ctx.contextID
 	atomic.AddUint32(&q.numActiveContexts, 1)
 	next := atomic.AddUint32(&q.end, 1)
@@ -125,18 +162,31 @@ func (q *contextQueue) add(ctx *sharedContext) *platform.ContextError {
 	v := (uint64(idx) << contextQueueIndexShift) + uint64(contextID)
 	atomic.StoreUint64(&q.ringbuffer[next], v)
 
-	if atomic.SwapUint32(&q.usedFastPath, 0) != 0 {
+	// Check before swapping: usedFastPath is usually zero, and the swap's
+	// write would invalidate the cache line for stub threads even when it
+	// does not change the value.
+	if atomic.LoadUint32(&q.usedFastPath) != 0 && atomic.SwapUint32(&q.usedFastPath, 0) != 0 {
 		fastpath.usedStubFastPath.Store(true)
 	}
 	return nil
 }
 
-func (q *contextQueue) disableFastPath() {
-	atomic.StoreUint32(&q.fastPathDisabled, 1)
-}
-
-func (q *contextQueue) enableFastPath() {
-	atomic.StoreUint32(&q.fastPathDisabled, 0)
+// setFastPathDisabled makes stub threads sleep (disabled=true) or spin
+// (disabled=false) when no context is queued. The word is read by every
+// spinning stub thread, so store only on a real change (same reasoning as
+// `fastPathState.park`).
+// Can't use CAS as it acquires the cache line in exclusive state, even when
+// the "C" part of CAS fails.
+// A racing `add` storing the opposite value can make the flag contain the
+// wrong fastPath decision, but the flag is only advisory.
+func (q *contextQueue) setFastPathDisabled(disabled bool) {
+	val := uint32(0)
+	if disabled {
+		val = 1
+	}
+	if atomic.LoadUint32(&q.fastPathDisabled) != val {
+		atomic.StoreUint32(&q.fastPathDisabled, val)
+	}
 }
 
 func (q *contextQueue) fastPathEnabled() bool {

--- a/pkg/sentry/platform/systrap/context_queue_test.go
+++ b/pkg/sentry/platform/systrap/context_queue_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systrap
+
+import (
+	"testing"
+	"unsafe"
+
+	"gvisor.dev/gvisor/pkg/hostarch"
+)
+
+// TestContextQueueLayout ensures layout consistency of contextQueue.
+func TestContextQueueLayout(t *testing.T) {
+	var q contextQueue
+	const line = uintptr(hostarch.CacheLineSize)
+	for _, tc := range []struct {
+		field string
+		got   uintptr
+		want  uintptr
+	}{
+		{"end", unsafe.Offsetof(q.end), 0 * line},
+		{"start", unsafe.Offsetof(q.start), 1 * line},
+		{"fastPathDisabled", unsafe.Offsetof(q.fastPathDisabled), 2 * line},
+		{"numAwakeContexts", unsafe.Offsetof(q.numAwakeContexts), 2*line + 4},
+		{"numActiveThreads", unsafe.Offsetof(q.numActiveThreads), 3 * line},
+		{"numSpinningThreads", unsafe.Offsetof(q.numSpinningThreads), 3*line + 4},
+		{"numThreadsToWakeup", unsafe.Offsetof(q.numThreadsToWakeup), 4 * line},
+		{"numActiveContexts", unsafe.Offsetof(q.numActiveContexts), 5 * line},
+		{"usedFastPath", unsafe.Offsetof(q.usedFastPath), 5*line + 4},
+		{"ringbuffer", unsafe.Offsetof(q.ringbuffer), 6 * line},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("unsafe.Offsetof(contextQueue.%s) = %d, want %d", tc.field, tc.got, tc.want)
+		}
+	}
+	if got, want := unsafe.Sizeof(q), 6*line+uintptr(maxContextQueueEntries)*8; got != want {
+		t.Errorf("unsafe.Sizeof(contextQueue{}) = %d, want %d", got, want)
+	}
+	// Go's sync/atomic requires 64-bit words to be 8-byte aligned.
+	if off := unsafe.Offsetof(q.ringbuffer); off%8 != 0 {
+		t.Errorf("ringbuffer offset %d is not 8-byte aligned", off)
+	}
+}

--- a/pkg/sentry/platform/systrap/sysmsg/sysmsg_lib.c
+++ b/pkg/sentry/platform/systrap/sysmsg/sysmsg_lib.c
@@ -40,19 +40,28 @@ uint64_t __export_deep_sleep_timeout;
 #define CQ_INDEX_SHIFT 32
 #define CQ_CONTEXT_MASK ((1UL << CQ_INDEX_SHIFT) - 1)
 
-// See systrap/context_queue.go
+#define CACHE_LINE_SIZE 64
+
+// See `systrap/context_queue.go` for the bye layout of this struct and the
+// semantics of the fields.
 struct context_queue {
-  uint32_t start;
   uint32_t end;
+  uint8_t _pad_end[CACHE_LINE_SIZE - 4];
+  uint32_t start;
+  uint8_t _pad_start[CACHE_LINE_SIZE - 4];
+  uint32_t fast_path_disabled;
+  uint32_t num_awake_contexts;
+  uint8_t _pad_sentry_written[CACHE_LINE_SIZE - 8];
   uint32_t num_active_threads;
   uint32_t num_spinning_threads;
+  uint8_t _pad_stub_written[CACHE_LINE_SIZE - 8];
   uint32_t num_threads_to_wakeup;
+  uint8_t _pad_futex[CACHE_LINE_SIZE - 4];
   uint32_t num_active_contexts;
-  uint32_t num_awake_contexts;
-  uint32_t fast_path_disabled;
   uint32_t used_fast_path;
+  uint8_t _pad_both_written[CACHE_LINE_SIZE - 8];
   uint64_t ringbuffer[MAX_CONTEXT_QUEUE_ENTRIES];
-};
+} __attribute__((aligned(CACHE_LINE_SIZE)));
 
 struct context_queue *__export_context_queue_addr;
 
@@ -415,4 +424,27 @@ void verify_offsets() {
 
   BUILD_BUG_ON(sizeof(struct thread_context) >
                ALLOCATED_SIZEOF_THREAD_CONTEXT_STRUCT);
+
+  // struct context_queue must stay byte-identical to the Go `contextQueue`.
+  BUILD_BUG_ON(offsetof(struct context_queue, end) != 0 * CACHE_LINE_SIZE);
+  BUILD_BUG_ON(offsetof(struct context_queue, start) != 1 * CACHE_LINE_SIZE);
+  BUILD_BUG_ON(offsetof(struct context_queue, fast_path_disabled) !=
+               2 * CACHE_LINE_SIZE);
+  BUILD_BUG_ON(offsetof(struct context_queue, num_awake_contexts) !=
+               2 * CACHE_LINE_SIZE + 4);
+  BUILD_BUG_ON(offsetof(struct context_queue, num_active_threads) !=
+               3 * CACHE_LINE_SIZE);
+  BUILD_BUG_ON(offsetof(struct context_queue, num_spinning_threads) !=
+               3 * CACHE_LINE_SIZE + 4);
+  BUILD_BUG_ON(offsetof(struct context_queue, num_threads_to_wakeup) !=
+               4 * CACHE_LINE_SIZE);
+  BUILD_BUG_ON(offsetof(struct context_queue, num_active_contexts) !=
+               5 * CACHE_LINE_SIZE);
+  BUILD_BUG_ON(offsetof(struct context_queue, used_fast_path) !=
+               5 * CACHE_LINE_SIZE + 4);
+  BUILD_BUG_ON(offsetof(struct context_queue, ringbuffer) !=
+               6 * CACHE_LINE_SIZE);
+  BUILD_BUG_ON(sizeof(struct context_queue) !=
+               6 * CACHE_LINE_SIZE +
+                   MAX_CONTEXT_QUEUE_ENTRIES * sizeof(uint64_t));
 }


### PR DESCRIPTION
Any writes invalidates the cache line for other threads, so:

- Group fields by writer (Sentry-written, stub-written, both-written)
- Add padding between groups
- Ensure `fastPathDisabled` writes occur only for real bit flips.

Also add tests to ensure the context queue fields align across languages.

Memory usage unchanged (+348 bytes padding, doesn't change number of pages)

Benchmarks on my corp laptop:

```
                                                              │    before    │                after                 │
                                                              │    sec/op    │    sec/op     vs base                │
Syscallbench/syscall.getpid-20                                  2.255µ ±  0%   2.255µ ±  0%        ~ (p=1.000 n=16)
Hackbench/ipcMode.pipe/processMode.thread-20                    4.180m ±  0%   3.446m ±  8%  -17.57% (p=0.000 n=8)
Redis/operation.SET-20                                          27.97µ ±  3%   27.77µ ±  2%        ~ (p=0.809 n=16)
Redis/operation.LPUSH-20                                        28.08µ ±  3%   27.66µ ±  4%        ~ (p=0.108 n=16)
Redis/operation.LRANGE_100-20                                   46.25µ ±  2%   46.35µ ±  1%        ~ (p=0.817 n=16)
Ffmpeg-20                                                        25.22 ±  1%    25.26 ±  1%        ~ (p=0.752 n=16)
IperfOneConnection/operation.Upload-20                          2.723µ ± 35%   1.788µ ± 55%        ~ (p=0.274 n=16)
IperfOneConnection/operation.Download-20                        2.160µ ± 25%   2.134µ ± 23%        ~ (p=0.724 n=16)
IperfManyConnections/operation.Upload/parallel.16-20            2.677µ ±  1%   2.668µ ±  1%        ~ (p=0.596 n=16)
IperfManyConnections/operation.Download/parallel.16-20          2.618µ ±  2%   2.592µ ±  1%   -0.99% (p=0.048 n=16)
NginxDocSize/filesize.1Kb/concurrency.100/filesystem.tmpfs-20   31.44µ ±  2%   30.73µ ±  1%   -2.25% (p=0.023 n=16)
NginxDocSize/filesize.1Kb/concurrency.1/filesystem.tmpfs-20     161.6µ ±  2%   159.0µ ±  3%        ~ (p=0.491 n=16)
Ruby/concurrency.25-20                                          192.7µ ±  1%   192.0µ ±  2%        ~ (p=0.642 n=16)
geomean                                                         64.70µ         61.31µ         -5.24%

                                             │      before      │                  after                  │
                                             │ execution_time.s │ execution_time.s  vs base               │
Hackbench/ipcMode.pipe/processMode.thread-20         7.703 ± 2%         6.232 ± 6%  -19.08% (p=0.000 n=8)

                                             │          before           │                      after                       │
                                             │ execution_time_per_loop.s │ execution_time_per_loop.s  vs base               │
Hackbench/ipcMode.pipe/processMode.thread-20                 3.851m ± 2%                 3.116m ± 6%  -19.09% (p=0.000 n=8)

                                                       │    before     │                 after                 │
                                                       │      B/s      │      B/s       vs base                │
IperfOneConnection/operation.Upload-20                   44.84Gi ± 54%   68.30Gi ± 35%        ~ (p=0.270 n=16)
IperfOneConnection/operation.Download-20                 59.25Gi ± 25%   59.78Gi ± 25%        ~ (p=0.724 n=16)
IperfManyConnections/operation.Upload/parallel.16-20     45.60Gi ±  1%   45.75Gi ±  1%        ~ (p=0.590 n=16)
IperfManyConnections/operation.Download/parallel.16-20   46.63Gi ±  2%   47.10Gi ±  1%        ~ (p=0.051 n=16)
geomean                                                  48.75Gi         54.46Gi        +11.71%

                                                       │           before           │                       after                       │
                                                       │ bandwidth.bytes_per_second │ bandwidth.bytes_per_second  vs base               │
IperfOneConnection/operation.Upload-20                                 4.537G ±  8%                 4.537G ±  0%       ~ (p=0.956 n=16)
IperfOneConnection/operation.Download-20                               2.284G ± 98%                 2.670G ± 69%       ~ (p=0.809 n=16)
IperfManyConnections/operation.Upload/parallel.16-20                   788.9M ±  2%                 789.1M ±  0%       ~ (p=0.897 n=16)
IperfManyConnections/operation.Download/parallel.16-20                 652.2M ± 19%                 652.3M ± 19%       ~ (p=0.564 n=16)
geomean                                                                1.520G                       1.580G        +4.00%

                                                              │         before          │                     after                      │
                                                              │ requests_per_second.QPS │ requests_per_second.QPS  vs base               │
NginxDocSize/filesize.1Kb/concurrency.100/filesystem.tmpfs-20               40.83k ± 2%               41.67k ± 2%  +2.04% (p=0.021 n=16)
NginxDocSize/filesize.1Kb/concurrency.1/filesystem.tmpfs-20                 8.298k ± 4%               8.460k ± 4%       ~ (p=0.539 n=16)
Ruby/concurrency.25-20                                                      6.290k ± 2%               6.256k ± 2%       ~ (p=0.918 n=16)
geomean                                                                     12.87k                    13.02k       +1.15%
```

All other benchmarks show no changes after n=16.