### PR TITLE
IPv6: Compute extension header offset in uint32 to avoid overflow.

### DIFF
--- a/pkg/tcpip/header/BUILD
+++ b/pkg/tcpip/header/BUILD
@@ -72,6 +72,7 @@ go_test(
     size = "small",
     srcs = [
         "eth_test.go",
+        "ipv6_extension_headers_offset_test.go",
         "ipv6_extension_headers_test.go",
         "mld_test.go",
         "ndp_test.go",

--- a/pkg/tcpip/header/ipv6_extension_headers.go
+++ b/pkg/tcpip/header/ipv6_extension_headers.go
@@ -717,7 +717,11 @@ func (i *IPv6PayloadIterator) nextHeaderData(ignoreLength bool, bytes []byte) (I
 	// in section 4.8 for new extension headers at the top of page 24.
 	//   [ Hdr Ext Len ] ... Length of the Destination Options header in 8-octet
 	//   units, not including the first 8 octets.
-	i.nextOffset += uint32((length + 1) * ipv6ExtHdrLenBytesPerUnit)
+	// Compute the increment in uint32: (length+1)*8. Evaluating this in the
+	// uint8 domain (as `(length+1)*ipv6ExtHdrLenBytesPerUnit`) overflows for
+	// length >= 31 and yields a too-small nextOffset, which corrupts the
+	// offsets reported by HeaderOffset()/ParseOffset().
+	i.nextOffset += (uint32(length) + 1) * ipv6ExtHdrLenBytesPerUnit
 
 	bytesLen := int(length)*ipv6ExtHdrLenBytesPerUnit + ipv6ExtHdrLenBytesExcluded
 	if ignoreLength {

--- a/pkg/tcpip/header/ipv6_extension_headers_offset_test.go
+++ b/pkg/tcpip/header/ipv6_extension_headers_offset_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/buffer"
+)
+
+// TestIPv6ExtHdrOffsetNoOverflow is a regression test for an integer overflow
+// in the extension-header offset accounting.
+//
+// nextOffset was advanced by `(length+1)*ipv6ExtHdrLenBytesPerUnit` evaluated
+// in the uint8 domain, which wraps for any Hdr Ext Len >= 31. The wrapped,
+// too-small value corrupts HeaderOffset()/ParseOffset(), which are used to
+// locate the transport header (link/fdbased/processors.go) and to report the
+// ICMP Parameter-Problem pointer.
+//
+// Here we place a Destination Options header with Hdr Ext Len = 31 (a 256-byte
+// header, the smallest value that triggers the wrap) followed by a second
+// Destination Options header, and assert that HeaderOffset() for the second
+// header reflects the true position.
+func TestIPv6ExtHdrOffsetNoOverflow(t *testing.T) {
+	const (
+		hdrExtLen  = 31             // 8-octet units, not counting the first 8.
+		firstBytes = (hdrExtLen + 1) * 8 // 256 bytes total for the first header.
+	)
+
+	// First header: NextHeader = Destination Options (points at header #2),
+	// Hdr Ext Len = 31, followed by 254 bytes of padding to reach 256 bytes.
+	payload := make([]byte, 0, firstBytes+8)
+	payload = append(payload, uint8(IPv6DestinationOptionsExtHdrIdentifier), hdrExtLen)
+	payload = append(payload, make([]byte, firstBytes-2)...)
+	// Second header: NextHeader = No Next Header, Hdr Ext Len = 0, plus 6 bytes.
+	payload = append(payload, uint8(IPv6NoNextHeaderIdentifier), 0)
+	payload = append(payload, make([]byte, 6)...)
+
+	it := MakeIPv6PayloadIterator(IPv6DestinationOptionsExtHdrIdentifier, buffer.MakeWithData(payload))
+	defer it.Release()
+
+	// Consume the first (long) Destination Options header.
+	if _, done, err := it.Next(); err != nil || done {
+		t.Fatalf("first Next() = (done %t, err %v), want a header", done, err)
+	}
+	// Consume the second header; HeaderOffset() now reports the start of the
+	// second header, i.e. IPv6FixedHeaderSize + firstBytes.
+	if _, done, err := it.Next(); err != nil || done {
+		t.Fatalf("second Next() = (done %t, err %v), want a header", done, err)
+	}
+
+	want := uint32(IPv6FixedHeaderSize + firstBytes) // 40 + 256 = 296
+	if got := it.HeaderOffset(); got != want {
+		t.Errorf("HeaderOffset() = %d, want %d (uint8 overflow would yield %d)", got, want, IPv6FixedHeaderSize)
+	}
+}


### PR DESCRIPTION
IPv6PayloadIterator advanced nextOffset by
(length + 1) * ipv6ExtHdrLenBytesPerUnit. Because length is uint8 and ipv6ExtHdrLenBytesPerUnit is the untyped constant 8, the expression was evaluated in uint8 and wrapped for any Hdr Ext Len >= 31, advancing nextOffset by a too-small amount.

nextOffset feeds HeaderOffset() and ParseOffset(), which are used to locate the transport header in the fdbased receive path and to report the ICMP Parameter-Problem pointer. The extension header data itself was already read with correct int math, so this only affects the reported offsets, not memory safety.

Compute the increment in uint32. Add a regression test that parses a Destination Options header with Hdr Ext Len = 31 and checks HeaderOffset().

Assisted-by: Claude Code