### PR TITLE
nftables: fix sentry panic when MAP set uses verdict dreg with non-verdict data

### DIFF
--- a/pkg/tcpip/nftables/nft_lookup.go
+++ b/pkg/tcpip/nftables/nft_lookup.go
@@ -196,6 +196,9 @@ func initLookup(tab *Table, exprInfo ExprInfo) (*lookupOp, *syserr.AnnotatedErro
 			if err != nil {
 				return nil, err
 			}
+		} else if set.dataType != linux.NFT_DATA_VERDICT {
+			return nil, syserr.NewAnnotatedError(syserr.ErrInvalidArgument,
+				"verdict destination register requires a set with verdict data type")
 		}
 	}
 

--- a/pkg/tcpip/nftables/nftables_types.go
+++ b/pkg/tcpip/nftables/nftables_types.go
@@ -1088,6 +1088,9 @@ func validateDataRegister(regStartIdx int, dataSizeBytes int) *syserr.AnnotatedE
 	if dataSizeBytes == 0 {
 		return syserr.NewAnnotatedError(syserr.ErrRange, "data size cannot be zero")
 	}
+	if regStartIdx < 0 {
+		return syserr.NewAnnotatedError(syserr.ErrRange, "register start index is negative")
+	}
 	// Although this check is not needed as the next check will catch this,
 	// added it just for readable error messages.
 	if regStartIdx >= registersByteSize {


### PR DESCRIPTION
Fixes #13689

Two bugs in the nftables lookup path interact to allow a process inside a
gVisor container to crash the sentry by sending a crafted nftables
configuration followed by a matching packet.

**Root cause 1 — missing cross-type check in `initLookup`**

When `dreg == NFT_REG_VERDICT`, `initLookup` leaves `dregIdx` at its
sentinel value of `-1` and sets `fillData = true`, but never verifies that
the target set carries verdict data. A MAP set with non-verdict element data
(`NFT_DATA_VALUE`) can therefore be installed with this lookup rule.

At evaluation time `evaluate()` reaches:

```go
copy(regs.data[op.dregIdx:], d.data[:])  // copy(regs.data[-1:], ...)
```

Go's slice-bounds check fires and panics the sentry, killing all containers
in the sandbox.

The Linux kernel's `nft_lookup_init()` rejects this combination at rule
creation time. This fix adds the equivalent check to `initLookup`.

**Root cause 2 — signed-integer bypass in `validateDataRegister`**

`validateDataRegister` checks `regStartIdx >= registersByteSize` using a
signed `int` comparison. The sentinel value `-1` satisfies `-1 < 64`, so all
checks pass and a non-verdict element can be added to the set, reaching the
panic path at runtime.

This fix adds an explicit `regStartIdx < 0` guard before the existing checks.

**Changes**

- `pkg/tcpip/nftables/nft_lookup.go`: reject lookup when verdict register is
  the destination but `set.dataType != NFT_DATA_VERDICT`.
- `pkg/tcpip/nftables/nftables_types.go`: return an error from
  `validateDataRegister` when `regStartIdx < 0`.