### PR TITLE
nvproxy: fix integer overflow in ctrlClientSystemGetP2PCapsInitializeArray

### DIFF
--- a/pkg/sentry/devices/nvproxy/frontend_unsafe.go
+++ b/pkg/sentry/devices/nvproxy/frontend_unsafe.go
@@ -264,7 +264,7 @@ func ctrlClientSystemGetP2PCapsInitializeArray(origArr nvgpu.P64, gpuCount uint3
 	// portSafeMulU32(). See
 	// src/nvidia/src/kernel/rmapi/embedded_param_copy.c::embeddedParamCopyIn().
 	numEntries := uint64(gpuCount) * uint64(gpuCount)
-	if numEntries == 0 || numEntries*4 > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE {
+	if numEntries == 0 || numEntries > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE/4 {
 		return 0, nil, false
 	}
 


### PR DESCRIPTION
Fixes #13689

`ctrlClientSystemGetP2PCapsInitializeArray` widens the `gpuCount` multiplication to `uint64` to avoid a first overflow, but the size guard:

```go
if numEntries == 0 || numEntries*4 > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE {
```

performs a second multiplication (`numEntries*4`) that can itself overflow `uint64`. When `gpuCount = 2^31`, `numEntries = 2^62` and `numEntries*4` wraps to 0, so the guard passes and `make([]uint32, 2^62)` is called. Go's `makeslice` detects the internal size overflow and panics. There is no `recover()` in the sentry's execution path, so the sentry process terminates
and all containers in the sandbox are killed.

Fix: divide the constant by 4 before comparing, which involves no multiplication and cannot overflow.

```go
// Before
if numEntries == 0 || numEntries*4 > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE {

// After
if numEntries == 0 || numEntries > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE/4 {
```