### PR TITLE
shim: fetch sandbox stats without subprocesses

### DIFF
--- a/pkg/shim/v1/runsccmd/BUILD
+++ b/pkg/shim/v1/runsccmd/BUILD
@@ -13,6 +13,8 @@ go_library(
     ],
     visibility = ["//pkg/shim:__subpackages__"],
     deps = [
+        "//pkg/control/client",
+        "//runsc/cgroup",
         "@com_github_containerd_go_runc//:go_default_library",
         "@com_github_containerd_log//:go_default_library",
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
@@ -25,5 +27,8 @@ go_test(
     size = "small",
     srcs = ["runsc_test.go"],
     library = ":runsccmd",
-    deps = ["@com_github_opencontainers_runtime_spec//specs-go:go_default_library"],
+    deps = [
+        "@com_github_containerd_go_runc//:go_default_library",
+        "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
+    ],
 )

--- a/pkg/shim/v1/runsccmd/runsc.go
+++ b/pkg/shim/v1/runsccmd/runsc.go
@@ -25,13 +25,18 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	runc "github.com/containerd/go-runc"
 	"github.com/containerd/log"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/control/client"
+	"gvisor.dev/gvisor/runsc/cgroup"
 )
 
 // DefaultCommand is the default command for Runsc.
@@ -79,6 +84,10 @@ type Runsc struct {
 	LogFormat    runc.Format
 	PanicLog     string
 	Config       map[string]string
+	stats        func(context.Context, string, string) (*runc.Stats, error)
+
+	directStatsMu     sync.Mutex
+	directStatsClient *directStatsClient
 }
 
 // List returns all containers created inside the provided runsc root directory.
@@ -497,11 +506,217 @@ func (r *Runsc) Kill(context context.Context, id string, sig int, opts *KillOpts
 
 // Stats return the stats for a container like cpu, memory, and I/O.
 func (r *Runsc) Stats(context context.Context, id string) (*runc.Stats, error) {
+	stats := r.stats
+	if stats == nil {
+		stats = r.directStats
+	}
+	if result, err := stats(context, r.Root, id); err == nil {
+		return result, nil
+	} else {
+		log.L.WithError(err).Debug("Direct runsc stats failed; falling back to the runsc CLI")
+	}
+
+	return r.cliStats(context, id)
+}
+
+type directStatsClient struct {
+	controlSocketPath string
+	cgroup            cgroup.Cgroup
+}
+
+type statsEventOut struct {
+	Event          runc.Event        `json:"event"`
+	ContainerUsage map[string]uint64 `json:"containerUsage"`
+}
+
+type statsContainerState struct {
+	ID      string             `json:"id"`
+	Sandbox *statsSandboxState `json:"sandbox"`
+}
+
+type statsSandboxState struct {
+	ID                string `json:"id"`
+	PID               int    `json:"pid"`
+	ControlSocketPath string `json:"controlSocketPath"`
+}
+
+var containerIDRegexp = regexp.MustCompile(`^[\w+\.-]+$`)
+
+// directStats gets stats from the sandbox control server without starting a
+// runsc subprocess. Metadata that is immutable for the sandbox lifetime is
+// cached after the first successful call.
+func (r *Runsc) directStats(context context.Context, root, id string) (*runc.Stats, error) {
+	r.directStatsMu.Lock()
+	direct := r.directStatsClient
+	if direct == nil {
+		var err error
+		direct, err = loadDirectStatsClient(root, id)
+		if err != nil {
+			r.directStatsMu.Unlock()
+			return nil, err
+		}
+		r.directStatsClient = direct
+	}
+	r.directStatsMu.Unlock()
+
+	stats, err := direct.stats(context, id)
+	if err != nil {
+		r.directStatsMu.Lock()
+		if r.directStatsClient == direct {
+			r.directStatsClient = nil
+		}
+		r.directStatsMu.Unlock()
+		return nil, err
+	}
+	return stats, nil
+}
+
+// loadDirectStatsClient reads the same state file used by runsc commands while
+// holding its advisory lock, then resolves the sandbox socket and host cgroup.
+func loadDirectStatsClient(root, id string) (*directStatsClient, error) {
+	if !containerIDRegexp.MatchString(id) {
+		return nil, fmt.Errorf("invalid container id %q", id)
+	}
+	stateFiles, err := filepath.Glob(filepath.Join(root, id+"_sandbox:*.state"))
+	if err != nil {
+		return nil, fmt.Errorf("finding container state: %w", err)
+	}
+	if len(stateFiles) != 1 {
+		return nil, fmt.Errorf("found %d state files for container %q, want 1", len(stateFiles), id)
+	}
+
+	statePath := stateFiles[0]
+	lockPath := strings.TrimSuffix(statePath, ".state") + ".lock"
+	lockFile, err := os.Open(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening container state lock: %w", err)
+	}
+	defer lockFile.Close()
+	if err := unix.Flock(int(lockFile.Fd()), unix.LOCK_SH); err != nil {
+		return nil, fmt.Errorf("locking container state: %w", err)
+	}
+	defer unix.Flock(int(lockFile.Fd()), unix.LOCK_UN)
+
+	stateJSON, err := os.ReadFile(statePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading container state: %w", err)
+	}
+	var state statsContainerState
+	if err := json.Unmarshal(stateJSON, &state); err != nil {
+		return nil, fmt.Errorf("parsing container state: %w", err)
+	}
+	if state.ID != id {
+		return nil, fmt.Errorf("container state ID is %q, want %q", state.ID, id)
+	}
+	if state.Sandbox == nil || state.Sandbox.PID <= 0 {
+		return nil, fmt.Errorf("container state has no running sandbox")
+	}
+	if !containerIDRegexp.MatchString(state.Sandbox.ID) {
+		return nil, fmt.Errorf("invalid sandbox id %q", state.Sandbox.ID)
+	}
+
+	controlSocketPath := state.Sandbox.ControlSocketPath
+	if unix.Access(controlSocketPath, unix.F_OK) != nil {
+		controlSocketPath = filepath.Join(root, "runsc-"+state.Sandbox.ID+".sock")
+		if err := unix.Access(controlSocketPath, unix.F_OK); err != nil {
+			return nil, fmt.Errorf("finding sandbox control socket: %w", err)
+		}
+	}
+	cg, err := cgroup.NewFromPid(state.Sandbox.PID, false)
+	if err != nil {
+		return nil, fmt.Errorf("loading sandbox cgroup: %w", err)
+	}
+	return &directStatsClient{controlSocketPath: controlSocketPath, cgroup: cg}, nil
+}
+
+// stats calls the same sandbox RPC as "runsc events --stats" and then applies
+// the host-cgroup CPU correction used by runsc's container.Event path.
+func (c *directStatsClient) stats(context context.Context, id string) (*runc.Stats, error) {
+	if err := context.Err(); err != nil {
+		return nil, err
+	}
+	path := c.controlSocketPath
+	var socketFD int = -1
+	if len(path) >= 108 {
+		fd, err := unix.Open(path, unix.O_PATH, 0)
+		if err != nil {
+			return nil, fmt.Errorf("opening sandbox control socket: %w", err)
+		}
+		socketFD = fd
+		defer unix.Close(socketFD)
+		path = filepath.Join("/proc/self/fd", strconv.Itoa(socketFD))
+	}
+	conn, err := client.ConnectTo(path)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to sandbox control socket: %w", err)
+	}
+	defer conn.Close()
+
+	var event statsEventOut
+	callDone := make(chan error, 1)
+	go func() {
+		callDone <- conn.Call("containerManager.Event", &id, &event)
+	}()
+	select {
+	case err := <-callDone:
+		if err != nil {
+			return nil, fmt.Errorf("getting sandbox event: %w", err)
+		}
+	case <-context.Done():
+		_ = conn.Socket.Close()
+		<-callDone
+		return nil, context.Err()
+	}
+
+	if event.Event.Type != "stats" || event.Event.Stats == nil {
+		return nil, fmt.Errorf("sandbox returned event type %q without stats", event.Event.Type)
+	}
+	cgroupUsage, err := c.cgroup.CPUUsage()
+	if err != nil {
+		return nil, fmt.Errorf("getting sandbox cgroup CPU usage: %w", err)
+	}
+	populateStatsCPU(event.Event.Stats, id, event.ContainerUsage, cgroupUsage)
+	return event.Event.Stats, nil
+}
+
+// populateStatsCPU apportions host-cgroup CPU usage using the sandbox's
+// per-container accounting. This mirrors runsc/container.populateStats.
+func populateStatsCPU(stats *runc.Stats, id string, containerUsage map[string]uint64, cgroupUsage uint64) {
+	numContainers := uint64(len(containerUsage))
+	if numContainers == 0 {
+		stats.Cpu.Usage.Total = 0
+		return
+	}
+
+	var selectedUsage uint64
+	var totalUsage uint64
+	for containerID, usage := range containerUsage {
+		totalUsage += usage
+		if containerID == id {
+			selectedUsage = usage
+		}
+	}
+	if cgroupUsage == 0 {
+		stats.Cpu.Usage.Total = selectedUsage
+		return
+	}
+	if totalUsage == 0 {
+		totalUsage = cgroupUsage
+		selectedUsage = cgroupUsage / numContainers
+	}
+	stats.Cpu.Usage.Total = uint64(float64(selectedUsage) * (float64(cgroupUsage) / float64(totalUsage)))
+}
+
+func (r *Runsc) cliStats(context context.Context, id string) (*runc.Stats, error) {
 	cmd := r.command(context, "events", "--stats", id)
 	data, stderr, err := cmdOutput(cmd, false)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", err, stderr)
 	}
+	return parseStats(data)
+}
+
+func parseStats(data []byte) (*runc.Stats, error) {
 	var e runc.Event
 	if err := json.Unmarshal(data, &e); err != nil {
 		log.L.Debugf("Parsing events error: %v", err)

--- a/pkg/shim/v1/runsccmd/runsc_test.go
+++ b/pkg/shim/v1/runsccmd/runsc_test.go
@@ -17,6 +17,7 @@
 package runsccmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -24,8 +25,135 @@ import (
 	"strings"
 	"testing"
 
+	runc "github.com/containerd/go-runc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
+
+func TestRunscStatsUsesDirectProvider(t *testing.T) {
+	want := &runc.Stats{}
+	r := &Runsc{
+		Command: filepath.Join(t.TempDir(), "missing-runsc"),
+		Root:    "/run/runsc",
+		stats: func(_ context.Context, root, id string) (*runc.Stats, error) {
+			if root != "/run/runsc" || id != "cid-1" {
+				t.Fatalf("stats provider got root=%q id=%q", root, id)
+			}
+			return want, nil
+		},
+	}
+
+	got, err := r.Stats(t.Context(), "cid-1")
+	if err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+	if got != want {
+		t.Fatalf("Stats returned %p, want %p", got, want)
+	}
+}
+
+func TestRunscStatsFallsBackToCLI(t *testing.T) {
+	dir := t.TempDir()
+	script := filepath.Join(dir, "fake-runsc")
+	event, err := json.Marshal(runc.Event{Type: "stats", Stats: &runc.Stats{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	scriptBody := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' %q\n", string(event))
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := &Runsc{
+		Command: script,
+		Root:    filepath.Join(dir, "root"),
+		stats: func(context.Context, string, string) (*runc.Stats, error) {
+			return nil, fmt.Errorf("direct stats unavailable")
+		},
+	}
+
+	if _, err := r.Stats(t.Context(), "cid-1"); err != nil {
+		t.Fatalf("Stats: %v", err)
+	}
+}
+
+func TestLoadDirectStatsClient(t *testing.T) {
+	root := t.TempDir()
+	id := "cid-1"
+	sandboxID := "sandbox-1"
+	socketPath := filepath.Join(root, "runsc-"+sandboxID+".sock")
+	if err := os.WriteFile(socketPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	state := statsContainerState{
+		ID: id,
+		Sandbox: &statsSandboxState{
+			ID:                sandboxID,
+			PID:               os.Getpid(),
+			ControlSocketPath: filepath.Join(root, "old", "runsc.sock"),
+		},
+	}
+	stateJSON, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateBase := filepath.Join(root, id+"_sandbox:"+sandboxID)
+	if err := os.WriteFile(stateBase+".state", stateJSON, 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(stateBase+".lock", nil, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	direct, err := loadDirectStatsClient(root, id)
+	if err != nil {
+		t.Fatalf("loadDirectStatsClient: %v", err)
+	}
+	if direct.controlSocketPath != socketPath {
+		t.Fatalf("control socket path = %q, want %q", direct.controlSocketPath, socketPath)
+	}
+	if direct.cgroup == nil {
+		t.Fatal("cgroup is nil")
+	}
+}
+
+func TestPopulateStatsCPU(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		containerUsage map[string]uint64
+		cgroupUsage    uint64
+		want           uint64
+	}{
+		{
+			name:           "scales selected container",
+			containerUsage: map[string]uint64{"cid-1": 20, "cid-2": 30},
+			cgroupUsage:    100,
+			want:           40,
+		},
+		{
+			name:           "splits cgroup usage when sentry usage is zero",
+			containerUsage: map[string]uint64{"cid-1": 0, "cid-2": 0},
+			cgroupUsage:    100,
+			want:           50,
+		},
+		{
+			name:           "uses sentry usage when cgroup usage is zero",
+			containerUsage: map[string]uint64{"cid-1": 20, "cid-2": 30},
+			want:           20,
+		},
+		{
+			name:        "reports zero without containers",
+			cgroupUsage: 100,
+			want:        0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stats := &runc.Stats{}
+			populateStatsCPU(stats, "cid-1", tc.containerUsage, tc.cgroupUsage)
+			if got := stats.Cpu.Usage.Total; got != tc.want {
+				t.Fatalf("CPU usage total = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
 
 // TestRunscUpdateCLI verifies Update runs the OCI update flow: JSON resources on
 // stdin and "update --resources - <id>" in argv (same contract as go-runc).


### PR DESCRIPTION
## Background

The containerd shim implements each `Runsc.Stats` request by starting a new `runsc events --stats` process. Kubernetes CRI stats collection calls this path once per sandbox container. On dense nodes, a single `ListPodSandboxStats` request therefore creates hundreds of short-lived processes, and recurring kubelet and observability scrapes turn that into sustained fork/exec and context-switch overhead even when the sandboxes are idle.

In a controlled deployment with 443 gVisor sandboxes on an 8-vCPU node, the existing path averaged 72.80% host CPU and repeatedly saturated the node. Client-side pacing reduced peak concurrency, but it did not reduce the number of stats subprocesses and made steady CPU worse. This makes the subprocess boundary, rather than request fan-out alone, the useful optimization point.

Related production investigation: https://github.com/sandbox0-ai/sandbox0/issues/704

## How it works

This change keeps the existing shim and CRI contracts, but makes `Runsc.Stats` use the sandbox control RPC directly:

- Read the existing runsc container state while holding its advisory state lock.
- Resolve and cache immutable sandbox-lifetime metadata: the control socket and host cgroup.
- Connect to the sandbox control server and call `containerManager.Event`, the same RPC used by `runsc events --stats`.
- Apply the host-cgroup CPU correction used by runsc's existing container event path.
- Invalidate cached metadata after a direct-path failure.
- Fall back to the current `runsc events --stats` CLI implementation when the direct path is unavailable or fails.

The fallback keeps compatibility with unexpected state layouts or runtime conditions while removing recurring subprocess creation from the normal path.

## Validation

- `bazel test //pkg/shim/v1/runsccmd:runsccmd_test`
- Focused tests cover direct-provider success, CLI fallback, state discovery and locking, and host-cgroup CPU apportionment.
- A 444-sandbox ACK validation reduced steady host CPU from the 72.80% baseline to 35.63%.
- A production comparison used the same fixed worker and matched 424/424 ready sandboxes for both 180-second windows, with 406 active plus 18 idle sandboxes, `metrics-server` absent, and ctld metrics enabled. The direct path reduced average host CPU from 60.68% to 16.70%, CPU p95 from 100% to 36.70%, and forks from 271.30/s to 17.18/s.
- The production process trace observed 11,254 `runsc events --stats` execs in the baseline window and zero in the direct-path window.
- The existing CRI stats contract and metric fields remained available through the normal collection path.

Assisted-by: OpenAI Codex
