### PR TITLE
Document why application memory appears as shmem in cgroup stats.

### DIFF
--- a/g3doc/architecture_guide/resources.md
+++ b/g3doc/architecture_guide/resources.md
@@ -125,6 +125,15 @@ application usage will not appear as anonymous memory usage, and will instead be
 accounted to the `memfd`. All anonymous memory will correspond to Sentry usage,
 and host memory charged to the container will work as standard.
 
+This has a confusing consequence when reading `memory.stat` (or `memory.current`)
+for a gVisor sandbox's cgroup: since application memory is backed by a `memfd`,
+the kernel accounts it as **shmem**, not **anon**. So the `anon` field in
+`memory.stat` will stay low even for a container running a memory-hungry
+application, while `shmem` (or `file`, depending on the kernel version) reflects
+most of the application's actual memory usage. If you need a breakdown of
+application memory usage from inside the sandbox, look at `memory.current` for
+the total, or use the Sentry's own accounting via `runsc usage <container id>`.
+
 The cgroups can be monitored for standard signals: pressure indicators,
 threshold notifiers, etc. and can also be adjusted dynamically. Note that the
 Sentry itself may listen for pressure signals in its containing cgroup, in order


### PR DESCRIPTION
Because gVisor backs all application memory with a memfd, the host kernel
accounts it as shmem rather than anon. This makes the `anon` field in
`memory.stat` confusingly low even for memory-hungry sandboxed applications,
while `shmem` reflects the real usage. This has repeatedly confused people
inspecting a sandbox's cgroup memory stats.

Add a note to the Resource Model guide explaining this artifact of the
memfd-backed memory model, and point at `runsc usage` for an accurate
breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)