### PR TITLE
nvproxy: add NVIDIA driver 580.95.05 as unsupported

### DIFF
--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -1079,7 +1079,8 @@ func Init() {
 			return abi
 		})
 
-		v580_105_08 := addDriverABI(580, 105, 8, "d9c6e8188672f3eb74dd04cfa69dd58479fa1d0162c8c28c8d17625763293475", ChecksumNoDriver, v580_65_06)
+		v580_95_05 := addUnsupportedDriverABI(580, 95, 05, v580_65_06)
+		v580_105_08 := addDriverABI(580, 105, 8, "d9c6e8188672f3eb74dd04cfa69dd58479fa1d0162c8c28c8d17625763293475", ChecksumNoDriver, v580_95_05)
 
 		// The following versions exist on the "580" branch, which was branched
 		// from the main branch at 580.105.08.


### PR DESCRIPTION
This partially reverts 2499a4804947 ("Remove un-needed drivers") which removed
580.95.05 driver support. However, it is still being used at Modal. Add it back
as an unsupported driver, so gVisor project doesn't need to run GPU tests on it.
This is as per the GPU driver support window policy at
https://gvisor.dev/docs/user_guide/gpu/#driver-versions.
