### PR TITLE
nvproxy: support exporting GPU memory to a dma-buf fd

### DIFF
--- a/pkg/abi/nvgpu/frontend.go
+++ b/pkg/abi/nvgpu/frontend.go
@@ -28,15 +28,16 @@ const NV_IOCTL_MAGIC = uint32('F')
 // Note that these are only the IOC_NR part of the ioctl command.
 const (
 	// From kernel-open/common/inc/nv-ioctl-numbers.h:
-	NV_IOCTL_BASE             = 200
-	NV_ESC_CARD_INFO          = NV_IOCTL_BASE + 0
-	NV_ESC_REGISTER_FD        = NV_IOCTL_BASE + 1
-	NV_ESC_ALLOC_OS_EVENT     = NV_IOCTL_BASE + 6
-	NV_ESC_FREE_OS_EVENT      = NV_IOCTL_BASE + 7
-	NV_ESC_CHECK_VERSION_STR  = NV_IOCTL_BASE + 10
-	NV_ESC_ATTACH_GPUS_TO_FD  = NV_IOCTL_BASE + 12
-	NV_ESC_SYS_PARAMS         = NV_IOCTL_BASE + 14
-	NV_ESC_WAIT_OPEN_COMPLETE = NV_IOCTL_BASE + 18
+	NV_IOCTL_BASE              = 200
+	NV_ESC_CARD_INFO           = NV_IOCTL_BASE + 0
+	NV_ESC_REGISTER_FD         = NV_IOCTL_BASE + 1
+	NV_ESC_ALLOC_OS_EVENT      = NV_IOCTL_BASE + 6
+	NV_ESC_FREE_OS_EVENT       = NV_IOCTL_BASE + 7
+	NV_ESC_CHECK_VERSION_STR   = NV_IOCTL_BASE + 10
+	NV_ESC_ATTACH_GPUS_TO_FD   = NV_IOCTL_BASE + 12
+	NV_ESC_SYS_PARAMS          = NV_IOCTL_BASE + 14
+	NV_ESC_EXPORT_TO_DMABUF_FD = NV_IOCTL_BASE + 17
+	NV_ESC_WAIT_OPEN_COMPLETE  = NV_IOCTL_BASE + 18
 
 	// From kernel-open/common/inc/nv-ioctl-numa.h:
 	NV_ESC_NUMA_INFO = NV_IOCTL_BASE + 15
@@ -202,6 +203,114 @@ func (p *IoctlWaitOpenComplete) GetStatus() uint32 {
 func (p *IoctlWaitOpenComplete) SetStatus(status uint32) {
 	p.AdapterStatus = status
 }
+
+// NV_DMABUF_EXPORT_MAX_HANDLES is the fixed size of the handle/offset/size
+// arrays in nv_ioctl_export_to_dma_buf_fd_t.
+// From kernel-open/common/inc/nv-ioctl.h.
+const NV_DMABUF_EXPORT_MAX_HANDLES = 128
+
+// IoctlExportToDMABufFD is nv_ioctl_export_to_dma_buf_fd_t, the parameter type
+// for NV_ESC_EXPORT_TO_DMABUF_FD (kernel-open/common/inc/nv-ioctl.h).
+//
+// +marshal
+type IoctlExportToDMABufFD struct {
+	_            structs.HostLayout
+	FD           int32
+	HClient      Handle
+	TotalObjects uint32
+	NumObjects   uint32
+	Index        uint32
+	Pad0         uint32
+	TotalSize    uint64
+	Handles      [NV_DMABUF_EXPORT_MAX_HANDLES]Handle
+	Offsets      [NV_DMABUF_EXPORT_MAX_HANDLES]uint64
+	Sizes        [NV_DMABUF_EXPORT_MAX_HANDLES]uint64
+	Status       uint32
+	Pad1         uint32
+}
+
+// GetFrontendFD implements HasFrontendFD.GetFrontendFD.
+func (p *IoctlExportToDMABufFD) GetFrontendFD() int32 { return p.FD }
+
+// SetFrontendFD implements HasFrontendFD.SetFrontendFD.
+func (p *IoctlExportToDMABufFD) SetFrontendFD(fd int32) { p.FD = fd }
+
+// GetStatus implements HasStatus.GetStatus.
+func (p *IoctlExportToDMABufFD) GetStatus() uint32 { return p.Status }
+
+// SetStatus implements HasStatus.SetStatus.
+func (p *IoctlExportToDMABufFD) SetStatus(status uint32) { p.Status = status }
+
+// IoctlExportToDMABufFD_V570 is the updated version of
+// nv_ioctl_export_to_dma_buf_fd_t since 570.86.15.
+//
+// +marshal
+type IoctlExportToDMABufFD_V570 struct {
+	_            structs.HostLayout
+	FD           int32
+	HClient      Handle
+	TotalObjects uint32
+	NumObjects   uint32
+	Index        uint32
+	Pad0         uint32
+	TotalSize    uint64
+	MappingType  uint8
+	Pad1         [3]byte
+	Handles      [NV_DMABUF_EXPORT_MAX_HANDLES]Handle
+	Pad2         uint32
+	Offsets      [NV_DMABUF_EXPORT_MAX_HANDLES]uint64
+	Sizes        [NV_DMABUF_EXPORT_MAX_HANDLES]uint64
+	Status       uint32
+	Pad3         uint32
+}
+
+// GetFrontendFD implements HasFrontendFD.GetFrontendFD.
+func (p *IoctlExportToDMABufFD_V570) GetFrontendFD() int32 { return p.FD }
+
+// SetFrontendFD implements HasFrontendFD.SetFrontendFD.
+func (p *IoctlExportToDMABufFD_V570) SetFrontendFD(fd int32) { p.FD = fd }
+
+// GetStatus implements HasStatus.GetStatus.
+func (p *IoctlExportToDMABufFD_V570) GetStatus() uint32 { return p.Status }
+
+// SetStatus implements HasStatus.SetStatus.
+func (p *IoctlExportToDMABufFD_V570) SetStatus(status uint32) { p.Status = status }
+
+// IoctlExportToDMABufFD_V580 is the updated version of
+// nv_ioctl_export_to_dma_buf_fd_t since 580.65.06.
+//
+// +marshal
+type IoctlExportToDMABufFD_V580 struct {
+	_            structs.HostLayout
+	FD           int32
+	HClient      Handle
+	TotalObjects uint32
+	NumObjects   uint32
+	Index        uint32
+	Pad0         uint32
+	TotalSize    uint64
+	MappingType  uint8
+	AllowMmap    uint8
+	Pad1         [2]byte
+	Handles      [NV_DMABUF_EXPORT_MAX_HANDLES]Handle
+	Pad2         uint32
+	Offsets      [NV_DMABUF_EXPORT_MAX_HANDLES]uint64
+	Sizes        [NV_DMABUF_EXPORT_MAX_HANDLES]uint64
+	Status       uint32
+	Pad3         uint32
+}
+
+// GetFrontendFD implements HasFrontendFD.GetFrontendFD.
+func (p *IoctlExportToDMABufFD_V580) GetFrontendFD() int32 { return p.FD }
+
+// SetFrontendFD implements HasFrontendFD.SetFrontendFD.
+func (p *IoctlExportToDMABufFD_V580) SetFrontendFD(fd int32) { p.FD = fd }
+
+// GetStatus implements HasStatus.GetStatus.
+func (p *IoctlExportToDMABufFD_V580) GetStatus() uint32 { return p.Status }
+
+// SetStatus implements HasStatus.SetStatus.
+func (p *IoctlExportToDMABufFD_V580) SetStatus(status uint32) { p.Status = status }
 
 // IoctlNVOS02ParametersWithFD is the parameter type for NV_ESC_RM_ALLOC_MEMORY.
 //

--- a/pkg/sentry/devices/nvproxy/frontend.go
+++ b/pkg/sentry/devices/nvproxy/frontend.go
@@ -369,6 +369,125 @@ func frontendRegisterFD(fi *frontendIoctlState) (uintptr, error) {
 	return frontendIoctlInvokeNoStatus(fi, &ioctlParams)
 }
 
+// frontendExportToDMABufFD handles NV_ESC_EXPORT_TO_DMABUF_FD. CUDA uses this
+// to export GPU memory as a dma-buf fd for ibv_reg_dmabuf_mr (GPUDirect RDMA).
+func frontendExportToDMABufFD[Params any, PtrParams hasFrontendFDAndStatusPtr[Params]](fi *frontendIoctlState) (uintptr, error) {
+	var ioctlParamsValue Params
+	ioctlParams := PtrParams(&ioctlParamsValue)
+	if int(fi.ioctlParamsSize) != ioctlParams.SizeBytes() {
+		return 0, linuxerr.EINVAL
+	}
+	if _, err := ioctlParams.CopyIn(fi.t, fi.ioctlParamsAddr); err != nil {
+		return 0, err
+	}
+
+	// The FD field is both input and output (see nv_dma_buf_export() in
+	// kernel-open/nvidia/nv-dmabuf.c):
+	//   - FD == -1: the driver creates a new dma-buf and returns its fd by
+	//     updating the ioctlParams. We wrap that host fd in a new application
+	//     FD installed in the task's fd table and return it via ioctlParams to
+	//     the app, so the app can hand it to the RDMA verbs library.
+	//   - FD >= 0: the app is appending more handles to a dma-buf it exported
+	//     in an earlier call, identified by that fd. The value is an app FD,
+	//     we translate it back to the host fd of the dma-buf we wrapped
+	//     before. The driver leaves the host fd unchanged, so we restore the
+	//     app fd on the way out.
+	if appFD := ioctlParams.GetFrontendFD(); appFD >= 0 {
+		fileGeneric, _ := fi.t.FDTable().Get(appFD)
+		if fileGeneric == nil {
+			return 0, linuxerr.EINVAL
+		}
+		defer fileGeneric.DecRef(fi.ctx)
+		wrapper, ok := fileGeneric.Impl().(*dmaBufFDWrapper)
+		if !ok {
+			return 0, linuxerr.EINVAL
+		}
+		ioctlParams.SetFrontendFD(wrapper.hostFD)
+		n, err := frontendIoctlInvokeNoStatus(fi, ioctlParams)
+		ioctlParams.SetFrontendFD(appFD)
+		if err != nil {
+			return n, err
+		}
+		if _, err := ioctlParams.CopyOut(fi.t, fi.ioctlParamsAddr); err != nil {
+			return n, err
+		}
+		return n, nil
+	}
+
+	// Create path: FD == -1 (any other negative value is rejected by the
+	// driver, so FD < -1 will fail below).
+	n, err := frontendIoctlInvokeNoStatus(fi, ioctlParams)
+	if err != nil {
+		return n, err
+	}
+
+	// The driver only allocates a dma-buf fd when the export succeeded.
+	if ioctlParams.GetStatus() == nvgpu.NV_OK && ioctlParams.GetFrontendFD() >= 0 {
+		sandboxFD, err := newDMABufFDWrapper(fi.t, ioctlParams.GetFrontendFD())
+		if err != nil {
+			return n, err
+		}
+		ioctlParams.SetFrontendFD(sandboxFD)
+		if _, err := ioctlParams.CopyOut(fi.t, fi.ioctlParamsAddr); err != nil {
+			// Roll back the fd we installed so the guest doesn't retain a
+			// dma-buf it never learned the number of. Remove drops the table's
+			// reference; DecRef releases it (closing the host fd).
+			if removed := fi.t.FDTable().Remove(fi.ctx, sandboxFD); removed != nil {
+				removed.DecRef(fi.ctx)
+			}
+			return n, err
+		}
+		return n, nil
+	}
+
+	if _, err := ioctlParams.CopyOut(fi.t, fi.ioctlParamsAddr); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// dmaBufFDWrapper wraps a host dma-buf fd returned by the NVIDIA driver's
+// export operation as an application FD. It implements vfs.HostFDProvider so
+// that rdmaproxy can recover the host fd to hand to ibv_reg_dmabuf_mr.
+//
+// +stateify savable
+type dmaBufFDWrapper struct {
+	vfsfd vfs.FileDescription
+	vfs.FileDescriptionDefaultImpl
+	vfs.DentryMetadataFileDescriptionImpl
+	vfs.NoLockFD
+
+	hostFD int32
+}
+
+// HostFD implements vfs.HostFDProvider.HostFD.
+func (fd *dmaBufFDWrapper) HostFD() int {
+	return int(fd.hostFD)
+}
+
+// Release implements vfs.FileDescriptionImpl.Release.
+func (fd *dmaBufFDWrapper) Release(ctx context.Context) {
+	unix.Close(int(fd.hostFD))
+}
+
+// newDMABufFDWrapper takes ownership of hostFD, wraps it in an application
+// FileDescription and installs it in t's FD table. It returns the application
+// FD number.
+func newDMABufFDWrapper(t *kernel.Task, hostFD int32) (int32, error) {
+	vfsObj := t.Kernel().VFS()
+	vd := vfsObj.NewAnonVirtualDentry("[nvidia-dmabuf]")
+	defer vd.DecRef(t)
+	w := &dmaBufFDWrapper{hostFD: hostFD}
+	if err := w.vfsfd.Init(w, linux.O_RDWR, t.Credentials(), vd.Mount(), vd.Dentry(), &vfs.FileDescriptionOptions{
+		UseDentryMetadata: true,
+	}); err != nil {
+		unix.Close(int(hostFD))
+		return -1, err
+	}
+	defer w.vfsfd.DecRef(t)
+	return t.NewFDFrom(0, &w.vfsfd, kernel.FDFlags{CloseOnExec: true})
+}
+
 func frontendIoctlHasFD[Params any, PtrParams hasFrontendFDAndStatusPtr[Params]](fi *frontendIoctlState) (uintptr, error) {
 	var ioctlParamsValue Params
 	ioctlParams := PtrParams(&ioctlParamsValue)

--- a/pkg/sentry/devices/nvproxy/nvconf/caps.go
+++ b/pkg/sentry/devices/nvproxy/nvconf/caps.go
@@ -41,6 +41,7 @@ const (
 	// requiring to be enabled explicitly.
 	CapFabricIMEXManagement // NV_RM_CAP_SYS_FABRIC_IMEX_MGMT
 	CapProfiling            // GPU hardware performance counter access (Nsight Compute/Systems)
+	CapRDMA                 // GPUDirect RDMA: exporting GPU memory to a dma-buf fd
 
 	numValidCaps int = iota
 )
@@ -55,7 +56,7 @@ const (
 
 	// SupportedDriverCaps is the set of driver capabilities that are supported by
 	// nvproxy.
-	SupportedDriverCaps = AllContainerDriverCaps | CapFabricIMEXManagement | CapProfiling
+	SupportedDriverCaps = AllContainerDriverCaps | CapFabricIMEXManagement | CapProfiling | CapRDMA
 
 	// AllContainerDriverCaps is the subset of SupportedDriverCaps that are
 	// enabled when enabling "all" capabilities is requested, which excludes
@@ -91,6 +92,8 @@ func (c DriverCaps) individualString() string {
 		return "fabric-imex-mgmt"
 	case CapProfiling:
 		return "profiling"
+	case CapRDMA:
+		return "rdma"
 	default:
 		panic(fmt.Sprintf("capability has no string mapping: %x", uint16(c)))
 	}

--- a/pkg/sentry/devices/nvproxy/seccomp_filters.go
+++ b/pkg/sentry/devices/nvproxy/seccomp_filters.go
@@ -49,6 +49,7 @@ func frontendIoctlFilters(enabledCaps nvconf.DriverCaps) []seccomp.SyscallRule {
 		{seccomp.EqualTo(frontendIoctlCmd(nvgpu.NV_ESC_FREE_OS_EVENT, nvgpu.SizeofIoctlFreeOSEvent)), compUtil},
 		{seccomp.EqualTo(frontendIoctlCmd(nvgpu.NV_ESC_SYS_PARAMS, nvgpu.SizeofIoctlSysParams)), compUtil},
 		{seccomp.EqualTo(frontendIoctlCmd(nvgpu.NV_ESC_WAIT_OPEN_COMPLETE, nvgpu.SizeofIoctlWaitOpenComplete)), compUtil},
+		{seccomp.MaskedEqual(notIocSizeMask, frontendIoctlCmd(nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD, 0)), nvconf.CapRDMA},
 		{seccomp.EqualTo(frontendIoctlCmd(nvgpu.NV_ESC_RM_ALLOC_MEMORY, nvgpu.SizeofIoctlNVOS02ParametersWithFD)), compUtil | nvconf.CapGraphics},
 		{seccomp.EqualTo(frontendIoctlCmd(nvgpu.NV_ESC_RM_FREE, nvgpu.SizeofNVOS00Parameters)), compUtil},
 		{seccomp.EqualTo(frontendIoctlCmd(nvgpu.NV_ESC_RM_CONTROL, nvgpu.SizeofNVOS54Parameters)), compUtil},

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -175,6 +175,7 @@ func Init() {
 					nvgpu.NV_ESC_ALLOC_OS_EVENT:                feHandler(frontendIoctlHasFD[nvgpu.IoctlAllocOSEvent], compUtil),
 					nvgpu.NV_ESC_FREE_OS_EVENT:                 feHandler(frontendIoctlHasFD[nvgpu.IoctlFreeOSEvent], compUtil),
 					nvgpu.NV_ESC_NUMA_INFO:                     feHandler(rmNumaInfo, compUtil),
+					nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD:           feHandler(frontendExportToDMABufFD[nvgpu.IoctlExportToDMABufFD], nvconf.CapRDMA),
 					nvgpu.NV_ESC_RM_ALLOC_CONTEXT_DMA2:         feHandler(rmAllocContextDMA2, nvconf.CapGraphics),
 					nvgpu.NV_ESC_RM_ALLOC_MEMORY:               feHandler(rmAllocMemory, compUtil|nvconf.CapGraphics),
 					nvgpu.NV_ESC_RM_FREE:                       feHandler(rmFree, compUtil),
@@ -490,6 +491,7 @@ func Init() {
 							nvgpu.NV_ESC_ALLOC_OS_EVENT:                ioctlInfoWithStructName("NV_ESC_ALLOC_OS_EVENT", nvgpu.IoctlAllocOSEvent{}, "nv_ioctl_alloc_os_event_t"),
 							nvgpu.NV_ESC_FREE_OS_EVENT:                 ioctlInfoWithStructName("NV_ESC_FREE_OS_EVENT", nvgpu.IoctlFreeOSEvent{}, "nv_ioctl_free_os_event_t"),
 							nvgpu.NV_ESC_NUMA_INFO:                     simpleIoctlInfo("NV_ESC_NUMA_INFO"), // No params struct because nvproxy ignores this ioctl
+							nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD:           ioctlInfoWithStructName("NV_ESC_EXPORT_TO_DMABUF_FD", nvgpu.IoctlExportToDMABufFD{}, "nv_ioctl_export_to_dma_buf_fd_t"),
 							nvgpu.NV_ESC_RM_ALLOC_MEMORY:               ioctlInfoWithStructName("NV_ESC_RM_ALLOC_MEMORY", nvgpu.IoctlNVOS02ParametersWithFD{}, "nv_ioctl_nvos02_parameters_with_fd"),
 							nvgpu.NV_ESC_RM_FREE:                       ioctlInfo("NV_ESC_RM_FREE", nvgpu.NVOS00_PARAMETERS{}),
 							nvgpu.NV_ESC_RM_CONTROL:                    ioctlInfo("NV_ESC_RM_CONTROL", nvgpu.NVOS54_PARAMETERS{}),
@@ -1005,9 +1007,11 @@ func Init() {
 			abi.allocationClass[nvgpu.BLACKWELL_COMPUTE_B] = allocHandler(rmAllocSimple[nvgpu.NV_GR_ALLOCATION_PARAMETERS], compUtil)
 			abi.allocationClass[nvgpu.BLACKWELL_USERMODE_A] = allocHandler(rmAllocSimple[nvgpu.NV_HOPPER_USERMODE_A_PARAMS], compUtil)
 			abi.allocationClass[nvgpu.NVCFB7_VIDEO_ENCODER] = allocHandler(rmAllocSimple[nvgpu.NV_MSENC_ALLOCATION_PARAMETERS], nvconf.CapVideo)
+			abi.frontendIoctl[nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD] = feHandler(frontendExportToDMABufFD[nvgpu.IoctlExportToDMABufFD_V570], nvconf.CapRDMA)
 			prevGetInfo := abi.getInfo
 			abi.getInfo = func() *DriverABIInfo {
 				info := prevGetInfo()
+				info.FrontendInfos[nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD] = ioctlInfoWithStructName("NV_ESC_EXPORT_TO_DMABUF_FD", nvgpu.IoctlExportToDMABufFD_V570{}, "nv_ioctl_export_to_dma_buf_fd_t")
 				info.ControlInfos[nvgpu.NVB0CC_CTRL_CMD_RESERVE_CCU_PROF] = simpleIoctlInfo("NVB0CC_CTRL_CMD_RESERVE_CCU_PROF", "NVB0CC_CTRL_RESERVE_CCUPROF_PARAMS")
 				info.ControlInfos[nvgpu.NV2080_CTRL_CMD_FB_QUERY_DRAM_ENCRYPTION_INFOROM_SUPPORT] = simpleIoctlInfo("NV2080_CTRL_CMD_FB_QUERY_DRAM_ENCRYPTION_INFOROM_SUPPORT", "NV2080_CTRL_FB_DRAM_ENCRYPTION_INFOROM_SUPPORT_PARAMS")
 				info.ControlInfos[nvgpu.NV2080_CTRL_CMD_FB_QUERY_DRAM_ENCRYPTION_STATUS] = simpleIoctlInfo("NV2080_CTRL_CMD_FB_QUERY_DRAM_ENCRYPTION_STATUS", "NV2080_CTRL_FB_QUERY_DRAM_ENCRYPTION_STATUS_PARAMS")
@@ -1064,10 +1068,12 @@ func Init() {
 			abi.allocationClass[nvgpu.NVD1B7_VIDEO_ENCODER] = allocHandler(rmAllocSimple[nvgpu.NV_MSENC_ALLOCATION_PARAMETERS], nvconf.CapVideo)
 			abi.controlCmd[nvgpu.NV2080_CTRL_CMD_GPU_GET_SKYLINE_INFO] = ctrlHandler(rmControlSimple, compUtil|nvconf.CapGraphics)
 			abi.controlCmd[nvgpu.NV2080_CTRL_CMD_ECC_GET_REPAIR_STATUS] = ctrlHandler(rmControlSimple, nvconf.CapGraphics)
+			abi.frontendIoctl[nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD] = feHandler(frontendExportToDMABufFD[nvgpu.IoctlExportToDMABufFD_V580], nvconf.CapRDMA)
 
 			prevGetInfo := abi.getInfo
 			abi.getInfo = func() *DriverABIInfo {
 				info := prevGetInfo()
+				info.FrontendInfos[nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD] = ioctlInfoWithStructName("NV_ESC_EXPORT_TO_DMABUF_FD", nvgpu.IoctlExportToDMABufFD_V580{}, "nv_ioctl_export_to_dma_buf_fd_t")
 				info.FrontendInfos[nvgpu.NV_ESC_RM_MAP_MEMORY_DMA] = ioctlInfoWithStructName("NV_ESC_RM_MAP_MEMORY_DMA", nvgpu.NVOS46_PARAMETERS_V580{}, "NVOS46_PARAMETERS")
 				info.AllocationInfos[nvgpu.FERMI_VASPACE_A] = ioctlInfoWithStructName("FERMI_VASPACE_A", nvgpu.NV_VASPACE_ALLOCATION_PARAMETERS_V580{}, "NV_VASPACE_ALLOCATION_PARAMETERS")
 				info.AllocationInfos[nvgpu.NVCEB7_VIDEO_ENCODER] = ioctlInfo("NVCEB7_VIDEO_ENCODER", nvgpu.NV_MSENC_ALLOCATION_PARAMETERS{})

--- a/runsc/specutils/nvidia.go
+++ b/runsc/specutils/nvidia.go
@@ -186,6 +186,12 @@ func NVProxyDriverCapsAllowed(conf *config.Config) (nvconf.DriverCaps, error) {
 	if hasAll {
 		allowedDriverCaps |= nvconf.AllContainerDriverCaps
 	}
+	// GPUDirect RDMA requires the privileged CapRDMA capability to export GPU
+	// memory to a dma-buf fd. There is no container-facing driver-capability
+	// flag for it, so enable it implicitly whenever RDMA passthrough is on.
+	if conf.RDMAProxy {
+		allowedDriverCaps |= nvconf.CapRDMA
+	}
 	return allowedDriverCaps, nil
 }
 


### PR DESCRIPTION
Add support for NV_ESC_EXPORT_TO_DMABUF_FD, which CUDA issues to export
GPU memory as a dma-buf file descriptor. This is the mechanism used for
GPUDirect RDMA: the returned fd is handed to ibv_reg_dmabuf_mr so a NIC
can DMA directly to and from GPU memory.

The driver allocates a host dma-buf and returns its fd in the ioctl's FD
field; nvproxy wraps that host fd in a sentry file description installed
in the application's fd table. The wrapper implements vfs.HostFDProvider
so the RDMA device proxy can recover the host fd for registration.

This ioctl exposes GPU memory to external devices, so it is gated behind
a new privileged driver capability, CapRDMA, and is only permitted (and
its seccomp filter only installed) when that capability is enabled.
CapRDMA is enabled automatically when RDMA support is requested.

Co-authored-by: Alessio Ricci Toniolo <alessio@modal.com>