### PR TITLE
Prefault CUDA process memory before restore

### DIFF
--- a/pkg/sentry/control/BUILD
+++ b/pkg/sentry/control/BUILD
@@ -68,6 +68,7 @@ go_library(
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/ktime",
         "//pkg/sentry/limits",
+        "//pkg/sentry/memmap",
         "//pkg/sentry/socket/netstack",
         "//pkg/sentry/state",
         "//pkg/sentry/state/checkpointfiles",

--- a/pkg/sentry/control/state_cuda.go
+++ b/pkg/sentry/control/state_cuda.go
@@ -30,6 +30,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/fdcollector"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/pipefs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/memmap"
 	"gvisor.dev/gvisor/pkg/sentry/state"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/pkg/timing"
@@ -141,10 +142,14 @@ func cudaProcs(sctx context.Context, k *kernel.Kernel, cudaCheckpointPath string
 }
 
 func postRestoreCuda(k *kernel.Kernel, timeline *timing.Timeline) error {
-	return postResumeCuda(k, timeline)
+	return resumeCuda(k, timeline, true)
 }
 
 func postResumeCuda(k *kernel.Kernel, timeline *timing.Timeline) error {
+	return resumeCuda(k, timeline, false)
+}
+
+func resumeCuda(k *kernel.Kernel, timeline *timing.Timeline, restored bool) error {
 	cudaCheckpointPathVal := k.PopCheckpointState(cudaCheckpointPathKey)
 	if cudaCheckpointPathVal == nil {
 		return nil
@@ -152,6 +157,11 @@ func postResumeCuda(k *kernel.Kernel, timeline *timing.Timeline) error {
 	cudaCheckpointPath := cudaCheckpointPathVal.(string)
 	cudaCheckpointSequential := k.PopCheckpointState(cudaCheckpointSequentialKey).(bool)
 	cudaProcs := k.PopCheckpointState(cudaProcsKey).([]*kernel.ThreadGroup)
+	if restored {
+		if err := prefaultCudaMemory(k, cudaProcs, timeline); err != nil {
+			return err
+		}
+	}
 	timeline.Reached("starting cuda-ckpt")
 	// FIXME: b/460451448 - pass --device-map to cuda-checkpoint if accepted
 	err := toggleCudaProcs(k.SupervisorContext(), k, cudaCheckpointPath, cudaProcs, timeline, cudaCheckpointSequential)
@@ -160,6 +170,37 @@ func postResumeCuda(k *kernel.Kernel, timeline *timing.Timeline) error {
 		tg.SigsegvUnlock()
 	}
 	return err
+}
+
+func prefaultCudaMemory(k *kernel.Kernel, cudaProcs []*kernel.ThreadGroup, timeline *timing.Timeline) error {
+	if err := k.MemoryFile().AwaitLoadAll(); err != nil {
+		return fmt.Errorf("failed to load restored CUDA memory: %w", err)
+	}
+	timeline.Reached("cuda memory loaded")
+
+	var ranges []memmap.FileRange
+	for _, tg := range cudaProcs {
+		leader := tg.Leader()
+		if leader == nil {
+			continue
+		}
+		mm := leader.MemoryManager()
+		if mm == nil {
+			continue
+		}
+		ranges = append(ranges, mm.MappedFileRanges(k.MemoryFile())...)
+	}
+	start := time.Now()
+	prefaulted, complete, err := k.MemoryFile().PrefaultRanges(ranges)
+	if err != nil {
+		return fmt.Errorf("failed to prefault restored CUDA memory: %w", err)
+	}
+	if !complete {
+		log.Warningf("Unable to prefault all restored CUDA memory")
+	}
+	log.Infof("Prefaulted %d bytes of CUDA process memory in %s", prefaulted, time.Since(start))
+	timeline.Reached("cuda memory prefaulted")
+	return nil
 }
 
 type checkpointProc struct {

--- a/pkg/sentry/mm/mm_test.go
+++ b/pkg/sentry/mm/mm_test.go
@@ -15,6 +15,7 @@
 package mm
 
 import (
+	"reflect"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/context"
@@ -47,6 +48,36 @@ func testMemoryManagerWithMmapDirection(ctx context.Context, t *testing.T, mmapD
 
 func testMemoryManager(ctx context.Context, t *testing.T) *MemoryManager {
 	return testMemoryManagerWithMmapDirection(ctx, t, arch.MmapBottomUp)
+}
+
+func TestMappedFileRanges(t *testing.T) {
+	target := &pgalloc.MemoryFile{}
+	other := &pgalloc.MemoryFile{}
+	mm := &MemoryManager{}
+	page := hostarch.Addr(hostarch.PageSize)
+	mm.pmas.Insert(mm.pmas.FindGap(page), hostarch.AddrRange{Start: page, End: 3 * page}, pma{
+		file: target,
+		off:  5 * hostarch.PageSize,
+	})
+	mm.pmas.Insert(mm.pmas.FindGap(4*page), hostarch.AddrRange{Start: 4 * page, End: 5 * page}, pma{
+		file: other,
+		off:  9 * hostarch.PageSize,
+	})
+	mm.pmas.Insert(mm.pmas.FindGap(6*page), hostarch.AddrRange{Start: 6 * page, End: 7 * page}, pma{
+		file: target,
+		off:  2 * hostarch.PageSize,
+	})
+
+	want := []memmap.FileRange{
+		{Start: 5 * hostarch.PageSize, End: 7 * hostarch.PageSize},
+		{Start: 2 * hostarch.PageSize, End: 3 * hostarch.PageSize},
+	}
+	if got := mm.MappedFileRanges(target); !reflect.DeepEqual(got, want) {
+		t.Fatalf("MappedFileRanges got %v, want %v", got, want)
+	}
+	if got := mm.MappedFileRanges(nil); got != nil {
+		t.Fatalf("MappedFileRanges(nil) got %v, want nil", got)
+	}
 }
 
 func (mm *MemoryManager) realUsageAS() uint64 {

--- a/pkg/sentry/mm/pma.go
+++ b/pkg/sentry/mm/pma.go
@@ -791,6 +791,25 @@ func (mm *MemoryManager) Pin(ctx context.Context, ar hostarch.AddrRange, at host
 	return prs, verr
 }
 
+// MappedFileRanges returns the ranges in file that back existing PMAs in mm.
+// The returned ranges may overlap and do not hold references to file.
+func (mm *MemoryManager) MappedFileRanges(file memmap.File) []memmap.FileRange {
+	if file == nil {
+		return nil
+	}
+
+	mm.activeMu.RLock()
+	defer mm.activeMu.RUnlock()
+
+	var ranges []memmap.FileRange
+	for pseg := mm.pmas.FirstSegment(); pseg.Ok(); pseg = pseg.NextSegment() {
+		if pseg.ValuePtr().file == file {
+			ranges = append(ranges, pseg.fileRange())
+		}
+	}
+	return ranges
+}
+
 // PinnedRanges are returned by MemoryManager.Pin.
 type PinnedRange struct {
 	// Source is the corresponding range of addresses.

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -46,6 +47,11 @@ import (
 )
 
 const pagesPerHugePage = hostarch.HugePageSize / hostarch.PageSize
+
+const (
+	maxPrefaultWorkers = 8
+	prefaultChunkSize  = 256 << 20
+)
 
 // MemoryFile is a memmap.File whose pages may be allocated to arbitrary
 // users.
@@ -1459,6 +1465,93 @@ func (f *MemoryFile) MapInternal(fr memmap.FileRange, at hostarch.AccessType) (s
 		blocks = append(blocks, safemem.BlockFromSafeSlice(bs))
 	})
 	return safemem.BlockSeqFromSlice(blocks), nil
+}
+
+// PrefaultRanges installs writable host page table entries for ranges in f.
+// This is useful before a host device pins restored application memory,
+// including sparse ranges omitted from the checkpoint because they contained
+// only zero pages.
+func (f *MemoryFile) PrefaultRanges(ranges []memmap.FileRange) (uint64, bool, error) {
+	normalized, err := normalizeFileRanges(ranges)
+	if err != nil {
+		return 0, false, err
+	}
+
+	var blocks []safemem.Block
+	for _, fr := range normalized {
+		bs, err := f.MapInternal(fr, hostarch.Write)
+		if err != nil {
+			return 0, false, err
+		}
+		for !bs.IsEmpty() {
+			block := bs.Head()
+			for block.Len() > prefaultChunkSize {
+				blocks = append(blocks, block.TakeFirst(prefaultChunkSize))
+				block = block.DropFirst(prefaultChunkSize)
+			}
+			if block.Len() != 0 {
+				blocks = append(blocks, block)
+			}
+			bs = bs.Tail()
+		}
+	}
+	if len(blocks) == 0 {
+		return 0, true, nil
+	}
+
+	workers := min(maxPrefaultWorkers, len(blocks))
+	jobs := make(chan safemem.Block)
+	var (
+		wg        sync.WaitGroup
+		populated atomic.Uint64
+		failed    atomic.Bool
+	)
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for block := range jobs {
+				if tryPopulate(block) {
+					populated.Add(uint64(block.Len()))
+				} else {
+					failed.Store(true)
+				}
+			}
+		}()
+	}
+	for _, block := range blocks {
+		jobs <- block
+	}
+	close(jobs)
+	wg.Wait()
+	return populated.Load(), !failed.Load(), nil
+}
+
+func normalizeFileRanges(ranges []memmap.FileRange) ([]memmap.FileRange, error) {
+	ranges = slices.Clone(ranges)
+	for _, fr := range ranges {
+		if !fr.WellFormed() || fr.Length() == 0 {
+			return nil, fmt.Errorf("invalid range: %v", fr)
+		}
+	}
+	slices.SortFunc(ranges, func(a, b memmap.FileRange) int {
+		if a.Start < b.Start {
+			return -1
+		}
+		if a.Start > b.Start {
+			return 1
+		}
+		return 0
+	})
+	merged := ranges[:0]
+	for _, fr := range ranges {
+		if len(merged) == 0 || merged[len(merged)-1].End < fr.Start {
+			merged = append(merged, fr)
+		} else if fr.End > merged[len(merged)-1].End {
+			merged[len(merged)-1].End = fr.End
+		}
+	}
+	return merged, nil
 }
 
 // forEachMappingSlice invokes fn on a sequence of byte slices that

--- a/pkg/sentry/pgalloc/pgalloc_test.go
+++ b/pkg/sentry/pgalloc/pgalloc_test.go
@@ -17,11 +17,44 @@
 package pgalloc
 
 import (
+	"reflect"
+	"slices"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
 )
+
+func TestNormalizeFileRanges(t *testing.T) {
+	input := []memmap.FileRange{
+		{Start: 8 * page, End: 10 * page},
+		{Start: 2 * page, End: 4 * page},
+		{Start: 4 * page, End: 6 * page},
+		{Start: 3 * page, End: 5 * page},
+	}
+	want := []memmap.FileRange{
+		{Start: 2 * page, End: 6 * page},
+		{Start: 8 * page, End: 10 * page},
+	}
+	original := slices.Clone(input)
+
+	got, err := normalizeFileRanges(input)
+	if err != nil {
+		t.Fatalf("normalizeFileRanges failed: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeFileRanges got %v, want %v", got, want)
+	}
+	if !reflect.DeepEqual(input, original) {
+		t.Fatalf("normalizeFileRanges mutated input: got %v, want %v", input, original)
+	}
+}
+
+func TestNormalizeFileRangesRejectsEmptyRange(t *testing.T) {
+	if _, err := normalizeFileRanges([]memmap.FileRange{{Start: page, End: page}}); err == nil {
+		t.Fatal("normalizeFileRanges accepted an empty range")
+	}
+}
 
 const (
 	page     = hostarch.PageSize


### PR DESCRIPTION
## Summary

- wait for asynchronous MemoryFile loading before CUDA process resume
- collect only MemoryFile ranges mapped by restored CUDA processes
- prefault those ranges in parallel before invoking `cuda-checkpoint --toggle`

## Motivation

State serialization omits zero-filled sparse pages. CUDA workloads can still retain PMAs covering those ranges, and the NVIDIA restore path faults and pins them serially while resuming the process. For a vLLM Qwen2.5-1.5B workload, the checkpoint contained 7.57 GB of committed pages while the CUDA processes mapped 37.4 GB through MemoryFile. The serialized faults dominated restore time.

Prefaulting the deduplicated CUDA-process ranges with `MADV_POPULATE_WRITE` moves that work into an eight-way host-memory pass. It runs only after restore; ordinary CUDA suspend/resume is unchanged. A failed populate is best effort and leaves the existing NVIDIA fault path intact.

## Results

RTX 5090, Qwen2.5-1.5B-Instruct BF16, unchanged vLLM configuration and a valid chat completion after every restore:

- gVisor runtime restore before: 25.7-29 seconds
- scoped prefault: about 0.89 seconds for 37.4 GB
- gVisor runtime restore after: 5.5-6.5 seconds
- request to valid completion after: 7.3-8.1 seconds warm

Native checkpoint restore for the same workload measured 5.6-6.5 seconds, so the patched gVisor path is near the native floor.

## Tests

- `//pkg/sentry/mm:mm_test`
- `//pkg/sentry/pgalloc:pgalloc_test`
- `//runsc:runsc`
- repeated end-to-end checkpoint/restore with an exact `/v1/chat/completions` response
