### PR TITLE
sentry: Use raw exit fields for raw syscall exit events.

### DIFF
--- a/pkg/sentry/kernel/task_syscall.go
+++ b/pkg/sentry/kernel/task_syscall.go
@@ -173,7 +173,7 @@ func (t *Task) executeSyscall(sysno uintptr, args arch.SyscallArguments) (rval u
 				Errorno: int64(ExtractErrno(err, int(sysno))),
 			},
 		}
-		fields := seccheck.Global.GetFieldSet(seccheck.GetPointForSyscall(seccheck.SyscallRawEnter, sysno))
+		fields := seccheck.Global.GetFieldSet(seccheck.GetPointForSyscall(seccheck.SyscallRawExit, sysno))
 		if !fields.Context.Empty() {
 			info.ContextData = &pb.ContextData{}
 			LoadSeccheckData(t, fields.Context, info.ContextData)


### PR DESCRIPTION
## Description

Raw syscall exit events incorrectly fetched the field set associated with
`SyscallRawEnter`. This caused exit-specific context field selections to be
ignored.

Use `SyscallRawExit` when retrieving fields for raw syscall exit events.