### PR TITLE
checklocks: don't flag inherited locks held at return of inline analyses

### DIFF
--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -727,7 +727,11 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 
 // checkBasicBlock traverses the control flow graph starting at a set of given
 // block and checks each instruction for allowed operations.
-func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, lff *lockFunctionFacts, parent *lockState, seen map[*ssa.BasicBlock]*lockState, rg map[*ssa.BasicBlock]struct{}) *lockState {
+//
+// entry is the lock state at function entry for inline analyses (anonymous
+// functions and closures, which inherit the caller's lock state); it is nil
+// when a function is analyzed on its own.
+func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, lff *lockFunctionFacts, parent *lockState, seen map[*ssa.BasicBlock]*lockState, rg map[*ssa.BasicBlock]struct{}, entry *lockState) *lockState {
 	// Check for cached results from entering this block from a *different*
 	// execution path. Note that this is not the same path, which is
 	// checked with the recursion guard below.
@@ -789,8 +793,19 @@ func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, 
 				}
 			}
 			// Check for other locks, but only if the above didn't trip.
-			if !failed && rls.count() != len(lff.HeldOnExit) && !lff.Ignore {
-				pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
+			if !failed && !lff.Ignore {
+				if entry != nil {
+					// This is an inline analysis, which inherits the
+					// caller's lock state: locks held on entry may
+					// legitimately still be held on return (they belong
+					// to the caller). Flag only locks acquired within
+					// this function and never released.
+					if !rls.isSubset(entry) {
+						pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
+					}
+				} else if rls.count() != len(lff.HeldOnExit) {
+					pc.maybeFail(rv.Pos(), "return with unexpected locks held (locks: %s)", rls.String())
+				}
 			}
 		}
 	}
@@ -802,7 +817,7 @@ func (pc *passContext) checkBasicBlock(fn *ssa.Function, block *ssa.BasicBlock, 
 		// above. Note that checkBasicBlock will recursively analyze
 		// the lock state to ensure that Releases and Acquires are
 		// respected.
-		if pls := pc.checkBasicBlock(fn, succ, lff, ls, seen, rg); pls != nil {
+		if pls := pc.checkBasicBlock(fn, succ, lff, ls, seen, rg, entry); pls != nil {
 			if rls != nil && !rls.isCompatible(pls) {
 				if _, ok := pc.forced[pc.positionKey(fn.Pos())]; !ok && !lff.Ignore {
 					pc.maybeFail(fn.Pos(), "incompatible return states (first: %s, second: %s)", rls.String(), pls.String())
@@ -870,13 +885,20 @@ func (pc *passContext) checkFunction(call callCommon, fn *ssa.Function, lff *loc
 
 	// Scan the blocks.
 	seen := make(map[*ssa.BasicBlock]*lockState)
+	var entry *lockState
+	if parent != nil {
+		// Snapshot the entry state for inline analyses; see
+		// checkBasicBlock. The fork ensures copy-on-write semantics
+		// for any subsequent modifications.
+		entry = ls.fork()
+	}
 	if len(fn.Blocks) > 0 {
-		pc.checkBasicBlock(fn, fn.Blocks[0], lff, ls, seen, nil)
+		pc.checkBasicBlock(fn, fn.Blocks[0], lff, ls, seen, nil, entry)
 	}
 
 	// Scan the recover block.
 	if fn.Recover != nil {
-		pc.checkBasicBlock(fn, fn.Recover, lff, ls, seen, nil)
+		pc.checkBasicBlock(fn, fn.Recover, lff, ls, seen, nil, entry)
 	}
 
 	// Update all lock state accordingly. This will be called only if we

--- a/tools/checklocks/test/defer.go
+++ b/tools/checklocks/test/defer.go
@@ -36,3 +36,23 @@ func testDeferInvalidAccess(tc *oneGuardStruct) {
 	}()
 	tc.mu.Unlock()
 }
+
+func testDeferAnonymousWithLockHeld(tc *oneGuardStruct) {
+	// The deferred anonymous function runs before the deferred Unlock
+	// (defers run LIFO), so tc.mu is legitimately still held when the
+	// anonymous function returns. This must not be reported as a lock
+	// unexpectedly held at return; the lock belongs to the caller.
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	defer func() {
+		tc.guardedField = 1
+	}()
+}
+
+func testDeferEmptyAnonymousWithLockHeld(tc *oneGuardStruct) {
+	// Same as above, with an empty function body.
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	defer func() {
+	}()
+}


### PR DESCRIPTION
Updates #11203

## Problem

As reported in #11203, checklocks emits diagnostics with no source position for valid code:

```go
func (f *F) uselessFunc() {
	f.mu.Lock()
	defer f.mu.Unlock()
	defer func() {}()
}
```
```
-: return with unexpected locks held (locks: &({param:f}.mu) exclusively)
```

This is a false positive, not just a formatting problem. Anonymous functions and closures invoked inline (directly or via `defer`) are analyzed with the caller's lock state inherited, so that guarded-field accesses inside them are validated against the locks actually held. But the exit check in `checkBasicBlock` required **all** locks to be released by the time the anonymous function returns (`rls.count() != len(lff.HeldOnExit)`, and anonymous functions cannot carry annotations). A caller-owned lock still held at the closure's return — the normal case — was therefore reported as a leak, anchored to the closure's synthetic return instruction, which has no position (hence `-`).

I believe this is also why these reports are excluded internally via `nogo.yaml` (`checklocks: exclude: "^-$"`, b/181776900); external users running the analyzer standalone see the spurious failures — the analyzer currently even reports them on its own `tools/checklocks/test` package (e.g. `testClosureInline`).

## Fix

Snapshot the lock state at function entry for inline analyses (`parent != nil`) and thread it through `checkBasicBlock`. At a return, report only locks that were acquired within the function and never released (`!rls.isSubset(entry)`); locks inherited from the caller belong to the caller and are checked at the caller's own return. Behavior for functions analyzed on their own (top-level, or closures analyzed without caller context) is unchanged.

## Verification

- The repro from #11203 and four variants (deferred/inline, empty/non-empty body, with/without params) no longer produce the spurious report; locks leaked inside an inline-analyzed function are still detected.
- Added two regression tests to `tools/checklocks/test/defer.go` covering the deferred-anonymous-function pattern.
- Ran the previous and fixed analyzer over `pkg/sync/...`, `pkg/tcpip/stack`, `pkg/waiter`, and `pkg/sentry/kernel`: diagnostics are identical, so no new findings are introduced on the existing tree.

## Notes

This is complementary to #12347/#13270, which improve the *position reporting* for these diagnostics: this change removes the false positive itself, while real failures at synthetic returns would still benefit from the position fallback in those PRs. Two smaller remaining sources of `-:` diagnostics (deferred-closure unlocks not propagating to the caller's state, and analysis of synthetic `sync` wrappers) are independent and could be addressed in follow-ups.
