### PR TITLE
Support meta mark load in nftables

### DIFF
--- a/pkg/tcpip/nftables/nft_meta.go
+++ b/pkg/tcpip/nftables/nft_meta.go
@@ -83,6 +83,7 @@ var metaDataLengths = map[metaKey]int{
 	linux.NFT_META_L4PROTO:   1,
 	linux.NFT_META_SKUID:     4,
 	linux.NFT_META_SKGID:     4,
+	linux.NFT_META_MARK:      4,
 	linux.NFT_META_RTCLASSID: 4,
 	linux.NFT_META_PKTTYPE:   1,
 	linux.NFT_META_PRANDOM:   4,
@@ -98,6 +99,7 @@ func validateMetaKey(key metaKey) *syserr.AnnotatedError {
 	switch key {
 	case linux.NFT_META_LEN, linux.NFT_META_PROTOCOL, linux.NFT_META_NFPROTO,
 		linux.NFT_META_L4PROTO, linux.NFT_META_SKUID, linux.NFT_META_SKGID,
+		linux.NFT_META_MARK,
 		linux.NFT_META_RTCLASSID, linux.NFT_META_PKTTYPE, linux.NFT_META_PRANDOM,
 		linux.NFT_META_TIME_NS, linux.NFT_META_TIME_DAY, linux.NFT_META_TIME_HOUR,
 		linux.NFT_META_OIFNAME, linux.NFT_META_IIFNAME:

--- a/pkg/tcpip/nftables/nft_metaload.go
+++ b/pkg/tcpip/nftables/nft_metaload.go
@@ -121,6 +121,10 @@ func (op metaLoad) evaluate(regs *registerSet, evalCtx opEvalCtx) {
 		}
 		target = binary.NativeEndian.AppendUint32(nil, pkt.Owner.KGID())
 
+	// Packet Mark (32-bit, host order).
+	case linux.NFT_META_MARK:
+		target = binary.NativeEndian.AppendUint32(nil, pkt.Mark)
+
 	// Route Traffic Class ID, same as Route equivalent (32-bit, host order).
 	// Currently only implemented for IPv6, but should be for IPv4 as well.
 	case linux.NFT_META_RTCLASSID:

--- a/pkg/tcpip/nftables/nftables_metamark_test.go
+++ b/pkg/tcpip/nftables/nftables_metamark_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// TestMetaLoadMark verifies that `meta mark` (NFT_META_MARK) loads the packet
+// mark into the destination register as a 4-byte host-order value.
+func TestMetaLoadMark(t *testing.T) {
+	op, err := newMetaLoad(linux.NFT_META_MARK, linux.NFT_REG32_00)
+	if err != nil {
+		t.Fatalf("newMetaLoad(NFT_META_MARK): %v", err)
+	}
+
+	const mark = uint32(0x2a)
+	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{})
+	defer pkt.DecRef()
+	pkt.Mark = mark
+
+	var regs registerSet
+	op.evaluate(&regs, opEvalCtx{pkt: pkt})
+
+	if got := binary.NativeEndian.Uint32(regs.data[0:4]); got != mark {
+		t.Errorf("meta mark loaded %#x into the destination register, want %#x", got, mark)
+	}
+}


### PR DESCRIPTION
> ⚠️ **Merge order / dependencies: none.** This PR is **independent** — it touches only `nft_meta.go` / `nft_metaload.go` and does not overlap with the nftables set-backend stack (#13799 → #13800 → #13801). It can be merged at any time, before or after those. It is a single commit.

## Problem

Under runsc with nftables enabled (`--TESTONLY-nftables`), installing a `meta mark` rule fails:

```
$ nft add rule inet t out meta mark 0x1 accept
Error: Could not process rule: Invalid argument
```

`NFT_META_MARK` is present in the meta key name table but was **not** accepted by `validateMetaKey` and had **no** entry in `metaDataLengths`, so `newMetaLoad` rejected it with `ErrInvalidArgument`.

This blocks real-world rulesets that use `meta mark` — e.g. an egress-firewall sidecar that marks its own upstream traffic with `SO_MARK` and bypasses a redirect/policy chain with `meta mark 0x1 accept`.

## Solution

- `pkg/tcpip/nftables/nft_meta.go`: add `NFT_META_MARK` (4 bytes, host order) to `metaDataLengths` and to `validateMetaKey`.
- `pkg/tcpip/nftables/nft_metaload.go`: add a `NFT_META_MARK` case to `metaLoad.evaluate` that loads `pkt.Mark` as a 4-byte host-order value, mirroring the existing `NFT_META_SKUID` / `NFT_META_SKGID` handling. The netstack `PacketBuffer` already exposes `Mark uint32`.

## Testing

- **Unit test** `TestMetaLoadMark` (`go test ./pkg/tcpip/nftables/`): loads a packet's mark into a register via the `meta mark` op and asserts the register holds the mark value.
- **End-to-end**: built `runsc` (`CGO_ENABLED=0 go build ./runsc`) and ran a container under Docker with the runtime configured with `--TESTONLY-nftables`, using `iptables-nft`/`nft` from `debian:bookworm-slim`.

**Before:**
```
$ nft add rule inet t out meta mark 0x1 accept
Error: Could not process rule: Invalid argument
```

**After:**
```
$ nft add table inet t
$ nft add chain inet t out '{ type filter hook output priority 0; policy drop; }'
$ nft add rule inet t out meta mark 0x1 accept        # OK
$ nft list ruleset
table inet t {
    chain out {
        type filter hook output priority filter; policy drop;
        meta mark 0x00000001 accept
    }
}
```

Relates to #11778 (NETLINK_NETFILTER support) and #13796.
