### PR TITLE
Support interval sets in nftables

### DIFF
--- a/pkg/tcpip/nftables/nftables_interval_test.go
+++ b/pkg/tcpip/nftables/nftables_interval_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nftables
+
+import "testing"
+
+// TestSetIntervalBackendEndpoints verifies interval membership when nft sends
+// an interval as individual endpoints (start + NFT_SET_ELEM_INTERVAL_END), as
+// it does for e.g. `add element allow4 { 140.82.112.0/20 }`.
+func TestSetIntervalBackendEndpoints(t *testing.T) {
+	b := &setIntervalBackend{keyLen: 4}
+	// 140.82.112.0/20 == [140.82.112.0, 140.82.127.255]; nft sends the lower
+	// sentinel (0.0.0.0 END), the start (140.82.112.0), and the exclusive upper
+	// bound (140.82.128.0 END).
+	adds := []struct {
+		key []byte
+		end bool
+	}{
+		{[]byte{0, 0, 0, 0}, true},
+		{[]byte{140, 82, 112, 0}, false},
+		{[]byte{140, 82, 128, 0}, true},
+	}
+	for i, a := range adds {
+		if _, err := b.Add(&nftSetElem{startKey: a.key, intervalEnd: a.end}, i); err != nil {
+			t.Fatalf("Add(%v, end=%t) failed: %v", a.key, a.end, err)
+		}
+	}
+	for _, tc := range []struct {
+		name string
+		key  []byte
+		want bool
+	}{
+		{"start is inclusive", []byte{140, 82, 112, 0}, true},
+		{"inside range", []byte{140, 82, 120, 1}, true},
+		{"last address in range", []byte{140, 82, 127, 255}, true},
+		{"end is exclusive", []byte{140, 82, 128, 0}, false},
+		{"below range", []byte{8, 8, 8, 8}, false},
+		{"above range", []byte{200, 0, 0, 0}, false},
+	} {
+		if got := b.Find(tc.key) != -1; got != tc.want {
+			t.Errorf("%s: Find(%v) member=%v, want %v", tc.name, tc.key, got, tc.want)
+		}
+	}
+}
+
+// TestSetIntervalBackendConcatRange verifies interval membership when an
+// interval is expressed as a single element carrying an inclusive
+// [startKey, endKey] range.
+func TestSetIntervalBackendConcatRange(t *testing.T) {
+	b := &setIntervalBackend{keyLen: 4}
+	if _, err := b.Add(&nftSetElem{startKey: []byte{10, 0, 0, 0}, endKey: []byte{10, 0, 0, 255}}, 0); err != nil {
+		t.Fatalf("Add range failed: %v", err)
+	}
+	for _, tc := range []struct {
+		key  []byte
+		want bool
+	}{
+		{[]byte{10, 0, 0, 0}, true},     // start inclusive
+		{[]byte{10, 0, 0, 128}, true},   // middle
+		{[]byte{10, 0, 0, 255}, true},   // end inclusive
+		{[]byte{10, 0, 1, 0}, false},    // just above
+		{[]byte{9, 255, 255, 255}, false}, // just below
+	} {
+		if got := b.Find(tc.key) != -1; got != tc.want {
+			t.Errorf("Find(%v) member=%v, want %v", tc.key, got, tc.want)
+		}
+	}
+}

--- a/pkg/tcpip/nftables/nftables_set.go
+++ b/pkg/tcpip/nftables/nftables_set.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"math"
 	"slices"
+	"sort"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/log"
@@ -462,12 +463,16 @@ func (nf *NFTables) NewSet(attrs map[uint16]nlmsg.BytesView, family stack.Addres
 		return syserr.NewAnnotatedError(syserr.ErrNotSupported, "NLM_F_CREATE is required for set creation")
 	}
 
-	// TODO: b/505409691 - Support non-map sets.
-	if setFlags&linux.NFT_SET_MAP == 0 {
-		return syserr.NewAnnotatedError(syserr.ErrNotSupported, "only map sets are supported yet")
+	// Select the set backend based on the set flags.
+	// TODO: b/505409691 - Support the remaining non-map set types.
+	switch {
+	case setFlags&linux.NFT_SET_MAP != 0:
+		newSet.backend = nf.newSetMapBackend(int(keyLen), int(dataLen))
+	case setFlags&linux.NFT_SET_INTERVAL != 0:
+		newSet.backend = nf.newSetIntervalBackend(int(keyLen))
+	default:
+		return syserr.NewAnnotatedError(syserr.ErrNotSupported, "only map and interval sets are supported yet")
 	}
-
-	newSet.backend = nf.newSetMapBackend(int(keyLen), int(dataLen))
 	return nf.addSetToTable(tab, newSet)
 }
 
@@ -804,13 +809,14 @@ func (nf *NFTables) addElemToSet(tab *Table, set *nftSet, elemAttrs map[uint16]n
 	}
 
 	newSetElem := nftSetElem{
-		startKey:   startKey,
-		endKey:     endKey,
-		timeout:    timeout,
-		expiration: expiration,
-		ops:        ops,
-		userData:   userData,
-		data:       dv,
+		startKey:    startKey,
+		endKey:      endKey,
+		intervalEnd: flag&linux.NFT_SET_ELEM_INTERVAL_END != 0,
+		timeout:     timeout,
+		expiration:  expiration,
+		ops:         ops,
+		userData:    userData,
+		data:        dv,
 	}
 
 	if flag&linux.NFT_SET_ELEM_CATCHALL != 0 {
@@ -1033,6 +1039,9 @@ func dumpSetElem(set *nftSet, elem *nftSetElem, isCatchAll bool) (nlmsg.NestedAt
 			}
 			elemAttrs.PutAttr(linux.NFTA_SET_ELEM_KEY_END, primitive.AsByteSlice(b))
 		}
+		if elem.intervalEnd {
+			elemAttrs.PutAttr(linux.NFTA_SET_ELEM_FLAGS, nlmsg.PutU32(uint32(linux.NFT_SET_ELEM_INTERVAL_END)))
+		}
 	} else {
 		elemAttrs.PutAttr(linux.NFTA_SET_ELEM_FLAGS, nlmsg.PutU32(uint32(linux.NFT_SET_ELEM_CATCHALL)))
 	}
@@ -1112,7 +1121,21 @@ func (nf *NFTables) fillSetElemListInfo(set *nftSet, tab *Table, family stack.Ad
 		elemAttrList = nil
 	}
 
-	for i := range set.elements {
+	// nftables stores interval sets as their raw boundary endpoints and dumps
+	// them in ascending key order with the interval-end flag preserved; nft
+	// userspace reconstructs the ranges. Non-interval sets dump in insertion
+	// order.
+	order := make([]int, len(set.elements))
+	for i := range order {
+		order[i] = i
+	}
+	if set.flags&linux.NFT_SET_INTERVAL != 0 {
+		sort.SliceStable(order, func(a, b int) bool {
+			return bytes.Compare(set.elements[order[a]].startKey, set.elements[order[b]].startKey) < 0
+		})
+	}
+
+	for _, i := range order {
 		elemAttrs, err := dumpSetElem(set, &set.elements[i], false)
 		if err != nil {
 			return err
@@ -1348,3 +1371,158 @@ func (nf *NFTables) newSetMapBackend(keyLen int, dataLen int) *setMapBackend {
 		m:       make(map[string]int),
 	}
 }
+
+// setIntervalEndpoint is one boundary in an interval set. nft represents an
+// interval set as a sorted sequence of endpoints; a key is a member iff the
+// greatest endpoint whose key is <= the lookup key is an interval start (not an
+// interval-end marker). This is the half-open [start, end) model used by the
+// kernel's rbtree set.
+type setIntervalEndpoint struct {
+	key   []byte
+	isEnd bool // NFT_SET_ELEM_INTERVAL_END: exclusive upper bound of an interval.
+	idx   int
+}
+
+// setIntervalBackend is a backend for interval sets (NFT_SET_INTERVAL). It
+// stores endpoints sorted by key and matches a key when the greatest endpoint
+// with key <= the lookup key is an interval start.
+//
+// Keys are compared as big-endian byte slices, which matches the numeric
+// ordering of the network-order ipv4_addr/ipv6_addr keys interval sets use.
+type setIntervalBackend struct {
+	keyLen    int
+	endpoints []setIntervalEndpoint // sorted by key.
+}
+
+// search returns the index of the first endpoint whose key is >= the given key.
+func (s *setIntervalBackend) search(key []byte) int {
+	return sort.Search(len(s.endpoints), func(i int) bool {
+		return bytes.Compare(s.endpoints[i].key, key) >= 0
+	})
+}
+
+// Evaluate implements NftSetBackend.Evaluate.
+func (s *setIntervalBackend) Evaluate(regs *registerSet, keyIdx int) int {
+	return s.Find(regs.data[keyIdx : keyIdx+s.keyLen])
+}
+
+// Find implements NftSetBackend.Find: returns the element index of the
+// containing interval's start endpoint, or -1 if the key is not a member.
+func (s *setIntervalBackend) Find(keyData []byte) int {
+	if len(keyData) != s.keyLen {
+		return -1
+	}
+	// Locate the greatest endpoint whose key is <= keyData.
+	pos := s.search(keyData)
+	if pos >= len(s.endpoints) || !bytes.Equal(s.endpoints[pos].key, keyData) {
+		// No exact match: the candidate is the endpoint just before pos.
+		pos--
+	}
+	if pos < 0 {
+		return -1
+	}
+	if s.endpoints[pos].isEnd {
+		return -1
+	}
+	return s.endpoints[pos].idx
+}
+
+// insertEndpoint inserts a single endpoint keeping endpoints sorted by key. If
+// an endpoint with the same key already exists, its idx is returned unchanged.
+func (s *setIntervalBackend) insertEndpoint(key []byte, isEnd bool, idx int) int {
+	pos := s.search(key)
+	if pos < len(s.endpoints) && bytes.Equal(s.endpoints[pos].key, key) {
+		return s.endpoints[pos].idx
+	}
+	ep := setIntervalEndpoint{key: slices.Clone(key), isEnd: isEnd, idx: idx}
+	s.endpoints = append(s.endpoints, setIntervalEndpoint{})
+	copy(s.endpoints[pos+1:], s.endpoints[pos:])
+	s.endpoints[pos] = ep
+	return idx
+}
+
+// removeEndpoint removes the endpoint with the given key, if present.
+func (s *setIntervalBackend) removeEndpoint(key []byte) (int, bool) {
+	pos := s.search(key)
+	if pos < len(s.endpoints) && bytes.Equal(s.endpoints[pos].key, key) {
+		idx := s.endpoints[pos].idx
+		s.endpoints = append(s.endpoints[:pos], s.endpoints[pos+1:]...)
+		return idx, true
+	}
+	return -1, false
+}
+
+// Add implements NftSetBackend.Add.
+func (s *setIntervalBackend) Add(e *nftSetElem, idx int) (int, *syserr.AnnotatedError) {
+	if e == nil {
+		return -1, syserr.NewAnnotatedError(syserr.ErrInvalidArgument, "element is nil")
+	}
+	if len(e.startKey) != s.keyLen {
+		return -1, syserr.NewAnnotatedError(syserr.ErrInvalidArgument, "key length does not match set key length")
+	}
+	// nft sends interval bounds as individual endpoints: a start endpoint and a
+	// separate NFT_SET_ELEM_INTERVAL_END endpoint (the exclusive upper bound).
+	if len(e.endKey) == 0 {
+		return s.insertEndpoint(e.startKey, e.intervalEnd, idx), nil
+	}
+	// Concatenated range form: a single element carrying [startKey, endKey]
+	// (both inclusive). Represent it as a start endpoint at startKey and an
+	// interval-end endpoint at endKey+1 (exclusive).
+	if len(e.endKey) != s.keyLen {
+		return -1, syserr.NewAnnotatedError(syserr.ErrInvalidArgument, "interval end key length does not match set key length")
+	}
+	s.insertEndpoint(e.startKey, false, idx)
+	if end := incrementKey(e.endKey); end != nil {
+		s.insertEndpoint(end, true, idx)
+	}
+	return idx, nil
+}
+
+// Remove implements NftSetBackend.Remove.
+func (s *setIntervalBackend) Remove(e *nftSetElem) (int, *syserr.AnnotatedError) {
+	if e == nil {
+		return -1, syserr.NewAnnotatedError(syserr.ErrInvalidArgument, "element is nil")
+	}
+	idx, ok := s.removeEndpoint(e.startKey)
+	if !ok {
+		return -1, syserr.NewAnnotatedError(syserr.ErrInvalidArgument, "key not found")
+	}
+	if len(e.endKey) == s.keyLen {
+		if end := incrementKey(e.endKey); end != nil {
+			s.removeEndpoint(end)
+		}
+	}
+	return idx, nil
+}
+
+// Clone implements NftSetBackend.Clone.
+func (s *setIntervalBackend) Clone() NftSetBackend {
+	c := &setIntervalBackend{
+		keyLen:    s.keyLen,
+		endpoints: make([]setIntervalEndpoint, len(s.endpoints)),
+	}
+	for i, ep := range s.endpoints {
+		c.endpoints[i] = setIntervalEndpoint{key: slices.Clone(ep.key), isEnd: ep.isEnd, idx: ep.idx}
+	}
+	return c
+}
+
+// newSetIntervalBackend creates a new interval backend.
+func (nf *NFTables) newSetIntervalBackend(keyLen int) *setIntervalBackend {
+	return &setIntervalBackend{keyLen: keyLen}
+}
+
+// incrementKey returns a copy of the big-endian key incremented by one, or nil
+// if the key is already the maximum value (all ones), i.e. the interval extends
+// to the maximum key.
+func incrementKey(key []byte) []byte {
+	out := slices.Clone(key)
+	for i := len(out) - 1; i >= 0; i-- {
+		out[i]++
+		if out[i] != 0 {
+			return out
+		}
+	}
+	return nil
+}
+

--- a/pkg/tcpip/nftables/nftables_types.go
+++ b/pkg/tcpip/nftables/nftables_types.go
@@ -1067,6 +1067,10 @@ type nftSetElem struct {
 	// userData represents the user data that can be associated with the element.
 	// It's only for the user to see and has no affect on the set element.
 	userData []byte
+	// intervalEnd reports whether this element is an interval-end marker
+	// (NFT_SET_ELEM_INTERVAL_END), i.e. the exclusive upper bound of an
+	// interval in an interval set.
+	intervalEnd bool
 }
 
 // AFtoNetlinkAF converts a generic address family to a netfilter address family.
@@ -1287,13 +1291,14 @@ func deepCopyChain(chain *Chain, tableCopy *Table) *Chain {
 
 func deepCopySetElement(elem *nftSetElem) *nftSetElem {
 	elemCopy := &nftSetElem{
-		startKey:   slices.Clone(elem.startKey),
-		endKey:     slices.Clone(elem.endKey),
-		data:       elem.data,
-		timeout:    elem.timeout,
-		expiration: elem.expiration,
-		ops:        make([]operation, 0, len(elem.ops)),
-		userData:   slices.Clone(elem.userData),
+		startKey:    slices.Clone(elem.startKey),
+		endKey:      slices.Clone(elem.endKey),
+		intervalEnd: elem.intervalEnd,
+		data:        elem.data,
+		timeout:     elem.timeout,
+		expiration:  elem.expiration,
+		ops:         make([]operation, 0, len(elem.ops)),
+		userData:    slices.Clone(elem.userData),
 	}
 	elemCopy.data.data = slices.Clone(elem.data.data)
 	for _, op := range elem.ops {


### PR DESCRIPTION
> ⚠️ **Merge order / dependencies: none, but this is the base of the stack.** This PR has **no dependencies** (it can merge onto `master` as-is), but it is the **base** of the nftables set-backend stack and must be merged **first**, **before** #13800 (timeout sets) and #13801 (redir), which are stacked on top of it (all three add cases to the same `newSet` backend dispatch). It is a single commit (`546931c`).

## Problem

Interval sets (`flags interval`) were rejected at creation under runsc (with `--TESTONLY-nftables`):

```
$ nft add set inet t allow4 '{ type ipv4_addr; flags interval; }'
Error: Could not process rule: Operation not supported
```

`newSet` only supported map sets (`"only map sets are supported yet"`), so rulesets that gate traffic on address ranges — e.g. an egress firewall's `ip daddr @allowlist accept` over CIDR allow/deny sets — could not be installed at all.

## Solution

Add support for interval sets (`NFT_SET_INTERVAL`):

- **Interval backend** (`nftables_set.go`): a new `setIntervalBackend` stores the boundary endpoints nft emits — an interval start endpoint, an `NFT_SET_ELEM_INTERVAL_END` endpoint (the exclusive upper bound), and the all-zeros lower sentinel — sorted by key. A key is a member iff the greatest endpoint `<=` the key is an interval start (inclusive start, exclusive end), matching the kernel's `nft_set_rbtree` semantics. Keys are compared as big-endian byte slices (network-order `ipv4_addr`/`ipv6_addr`).
- **Interval-end flag** (`nftables_types.go`): track it on `nftSetElem` (`intervalEnd`) and — importantly — **preserve it in `deepCopySetElement`**. The nftables state is deep-copied for every batch; without copying this field, existing interval boundaries were silently corrupted (their end flag reset) on any subsequent set modification, so a set was only correct until its next change.
- **Dump** (`nftables_set.go`): emit the interval-end flag and dump interval-set elements in ascending key order, so `nft` reconstructs the ranges/prefixes correctly on `nft list`.
- **Tests** (`nftables_interval_test.go`): interval membership for both the endpoint form and the concatenated-range form, including boundary conditions (inclusive start, exclusive end, in/out of range).

## Testing

`go test ./pkg/tcpip/nftables/` (new tests pass), plus end-to-end under `runsc` built with `--TESTONLY-nftables` (Docker + `nft`/`iptables-nft` from `debian:bookworm-slim`):

- Creating an `flags interval` set and adding CIDR / single-IP / multiple elements (IPv4 and IPv6) plus an `ip daddr @set accept` rule all succeed (previously rejected at set creation).
- Multi-element round-trip (incremental `add element`) **and** atomic `nft -f` both produce correct state, and `nft list ruleset` renders the reconstructed ranges correctly:
  ```
  set allow4 { type ipv4_addr; flags interval
      elements = { 1.1.1.1, 10.0.0.0/8, 140.82.112.0/20 } }
  set allow6 { type ipv6_addr; flags interval
      elements = { 2001:db8::/32 } }
  ```

Element deletion (`NFT_MSG_DELSETELEM`) remains unsupported (#13789) and is orthogonal to this change.

Relates to #11778 and #13796.

