### PR TITLE
Fix deadlock in an error handling path

### DIFF
--- a/pkg/tcpip/tests/integration/iptables_test.go
+++ b/pkg/tcpip/tests/integration/iptables_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"gvisor.dev/gvisor/pkg/buffer"
@@ -3733,6 +3734,164 @@ func TestRejectWithTCPReset(t *testing.T) {
 						checker.TCPSeqNum(0),
 					),
 				)
+			}
+		})
+	}
+}
+
+func newICMPPortUnreachableTarget(t *testing.T, s *stack.Stack, netProto tcpip.NetworkProtocolNumber) stack.Target {
+	t.Helper()
+
+	proto := s.NetworkProtocolInstance(netProto)
+	switch netProto {
+	case header.IPv4ProtocolNumber:
+		handler, ok := proto.(stack.RejectIPv4WithHandler)
+		if !ok {
+			t.Fatalf("got %T, want stack.RejectIPv4WithHandler", proto)
+		}
+		return &stack.RejectIPv4Target{
+			Handler:    handler,
+			RejectWith: stack.RejectIPv4WithICMPPortUnreachable,
+		}
+	case header.IPv6ProtocolNumber:
+		handler, ok := proto.(stack.RejectIPv6WithHandler)
+		if !ok {
+			t.Fatalf("got %T, want stack.RejectIPv6WithHandler", proto)
+		}
+		return &stack.RejectIPv6Target{
+			Handler:    handler,
+			RejectWith: stack.RejectIPv6WithICMPPortUnreachable,
+		}
+	default:
+		t.Fatalf("unsupported network protocol: %d", netProto)
+		return nil
+	}
+}
+
+func TestRejectICMPOutputDoesNotDeadlockConnect(t *testing.T) {
+	const (
+		port    = 12345
+		timeout = 5 * time.Second
+	)
+
+	tests := []struct {
+		name      string
+		netProto  tcpip.NetworkProtocolNumber
+		addr      tcpip.AddressWithPrefix
+		route     tcpip.Subnet
+		ipv6Table bool
+	}{
+		{
+			name:      "IPv4",
+			netProto:  header.IPv4ProtocolNumber,
+			addr:      utils.Ipv4Addr,
+			route:     header.IPv4EmptySubnet,
+			ipv6Table: false,
+		},
+		{
+			name:      "IPv6",
+			netProto:  header.IPv6ProtocolNumber,
+			addr:      utils.Ipv6Addr,
+			route:     header.IPv6EmptySubnet,
+			ipv6Table: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := stack.New(stack.Options{
+				NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
+				TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol},
+			})
+			if err := s.CreateNIC(nicID, loopback.New()); err != nil {
+				t.Fatalf("s.CreateNIC(%d, _): %s", nicID, err)
+			}
+			protoAddr := tcpip.ProtocolAddress{
+				Protocol:          test.netProto,
+				AddressWithPrefix: test.addr,
+			}
+			if err := s.AddProtocolAddress(nicID, protoAddr, stack.AddressProperties{}); err != nil {
+				t.Fatalf("s.AddProtocolAddress(%d, %+v, {}): %s", nicID, protoAddr, err)
+			}
+			s.SetRouteTable([]tcpip.Route{
+				{Destination: test.route, NIC: nicID},
+			})
+
+			ipt := s.IPTables()
+			table := ipt.GetTable(stack.FilterID, test.ipv6Table)
+			ruleIdx := table.BuiltinChains[stack.Output]
+			table.Rules[ruleIdx].Filter = stack.IPHeaderFilter{
+				Protocol:      header.TCPProtocolNumber,
+				CheckProtocol: true,
+			}
+			table.Rules[ruleIdx].Target = newICMPPortUnreachableTarget(t, s, test.netProto)
+			table.Rules[ruleIdx+1].Target = &stack.AcceptTarget{}
+			ipt.ForceReplaceTable(stack.FilterID, table, test.ipv6Table)
+
+			// A real listener ensures ErrConnectionRefused comes from the
+			// iptables-generated ICMP error, not from a closed port.
+			var listenerWQ waiter.Queue
+			listenerEP, err := s.NewEndpoint(tcp.ProtocolNumber, test.netProto, &listenerWQ)
+			if err != nil {
+				t.Fatalf("s.NewEndpoint(listener): %s", err)
+			}
+			if err := listenerEP.Bind(tcpip.FullAddress{Port: port}); err != nil {
+				t.Fatalf("listenerEP.Bind(%d): %s", port, err)
+			}
+			if err := listenerEP.Listen(1); err != nil {
+				t.Fatalf("listenerEP.Listen(1): %s", err)
+			}
+
+			var clientWQ waiter.Queue
+			we, ch := waiter.NewChannelEntry(waiter.EventErr | waiter.EventHUp)
+			clientWQ.EventRegister(&we)
+			defer clientWQ.EventUnregister(&we)
+			clientEP, err := s.NewEndpoint(tcp.ProtocolNumber, test.netProto, &clientWQ)
+			if err != nil {
+				t.Fatalf("s.NewEndpoint(client): %s", err)
+			}
+
+			safeToCleanup := true
+			defer func() {
+				// Before the fix, Connect remains blocked while holding the
+				// endpoint lock. Closing that endpoint may block on the same
+				// lock, so avoid cleanup only in the deadlock failure case.
+				if !safeToCleanup {
+					return
+				}
+				clientEP.Close()
+				listenerEP.Close()
+				s.Destroy()
+			}()
+
+			connectAddr := tcpip.FullAddress{
+				NIC:  nicID,
+				Addr: test.addr.Address,
+				Port: port,
+			}
+			connectErr := make(chan tcpip.Error, 1)
+			go func() {
+				connectErr <- clientEP.Connect(connectAddr)
+			}()
+
+			select {
+			case err := <-connectErr:
+				if _, ok := err.(*tcpip.ErrConnectStarted); !ok {
+					t.Fatalf("got clientEP.Connect(%#v) = %s, want = %s", connectAddr, err, &tcpip.ErrConnectStarted{})
+				}
+			case <-time.After(timeout):
+				safeToCleanup = false
+				t.Fatalf("clientEP.Connect(%#v) did not return within %s", connectAddr, timeout)
+			}
+
+			select {
+			case <-ch:
+			case <-time.After(timeout):
+				t.Fatal("timed out waiting for the ICMP error")
+			}
+			got := clientEP.LastError()
+			if _, ok := got.(*tcpip.ErrConnectionRefused); !ok {
+				t.Fatalf("got clientEP.LastError() = %s, want = %s", got, &tcpip.ErrConnectionRefused{})
 			}
 		})
 	}

--- a/pkg/tcpip/transport/tcp/dispatcher.go
+++ b/pkg/tcpip/transport/tcp/dispatcher.go
@@ -313,6 +313,10 @@ func (p *processor) start(wg *sync.WaitGroup) {
 				if ep == nil {
 					break
 				}
+				if !ep.hasQueuedWork() {
+					continue
+				}
+				ep.handleQueuedTransportErrors()
 				if ep.segmentQueue.empty() {
 					continue
 				}
@@ -337,10 +341,10 @@ func (p *processor) start(wg *sync.WaitGroup) {
 				default:
 					panic(fmt.Sprintf("unexpected tcp state in processor: %v", state))
 				}
-				// If there are more segments to process and the
+				// If there is more work to process and the
 				// endpoint lock is not held by user then
 				// requeue this endpoint for processing.
-				if !ep.segmentQueue.empty() && !ep.isOwnedByUser() {
+				if ep.hasQueuedWork() && !ep.isOwnedByUser() {
 					p.epQ.enqueue(ep)
 				}
 			}

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -75,6 +75,8 @@ const (
 	SegOverheadFactor = 2
 )
 
+const maxQueuedTransportErrors = 128
+
 type connDirectionState uint32
 
 // Connection direction states used for directionState checks in endpoint struct
@@ -177,6 +179,101 @@ func (s EndpointState) String() string {
 	default:
 		panic("unreachable")
 	}
+}
+
+type queuedTransportError struct {
+	transErr stack.TransportError
+	pkt      *stack.PacketBuffer
+}
+
+// transportErrorQueue is a bounded, thread-safe queue of transport errors.
+type transportErrorQueue struct {
+	mu     sync.Mutex `state:"nosave"`
+	errors []queuedTransportError
+}
+
+// emptyLocked determines if the queue is empty.
+//
+// Preconditions: q.mu must be held.
+func (q *transportErrorQueue) emptyLocked() bool {
+	return len(q.errors) == 0
+}
+
+// empty determines if the queue is empty.
+func (q *transportErrorQueue) empty() bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.emptyLocked()
+}
+
+// enqueue adds the given transport error to the queue.
+//
+// Returns true when the error is successfully added to the queue, in which case
+// ownership of pkt is transferred to the queue. Returns false if the queue is
+// full, in which case ownership is retained by the caller.
+func (q *transportErrorQueue) enqueue(transErr stack.TransportError, pkt *stack.PacketBuffer) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.errors) >= maxQueuedTransportErrors {
+		return false
+	}
+
+	q.errors = append(q.errors, queuedTransportError{
+		transErr: transErr,
+		pkt:      pkt,
+	})
+	return true
+}
+
+// dequeue removes and returns the next transport error from queue, if one
+// exists. Ownership of the packet buffer is transferred to the caller.
+func (q *transportErrorQueue) dequeue() (queuedTransportError, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.errors) == 0 {
+		return queuedTransportError{}, false
+	}
+
+	err := q.errors[0]
+	copy(q.errors, q.errors[1:])
+	q.errors[len(q.errors)-1] = queuedTransportError{}
+	q.errors = q.errors[:len(q.errors)-1]
+	return err, true
+}
+
+func (e *Endpoint) enqueueTransportError(transErr stack.TransportError, pkt *stack.PacketBuffer) {
+	pkt = pkt.Clone()
+	if !e.transportErrorQueue.enqueue(transErr, pkt) {
+		pkt.DecRef()
+		e.stack.Stats().DroppedPackets.Increment()
+		return
+	}
+
+	if !e.isOwnedByUser() {
+		e.protocol.dispatcher.selectProcessor(e.ID).queueEndpoint(e)
+	}
+}
+
+func (e *Endpoint) handleQueuedTransportErrors() {
+	for {
+		if e.isOwnedByUser() {
+			return
+		}
+
+		err, ok := e.transportErrorQueue.dequeue()
+		if !ok {
+			return
+		}
+
+		e.HandleError(err.transErr, err.pkt)
+		err.pkt.DecRef()
+	}
+}
+
+func (e *Endpoint) hasQueuedWork() bool {
+	return !e.segmentQueue.empty() || !e.transportErrorQueue.empty()
 }
 
 // SACKInfo holds TCP SACK related information for a given endpoint.
@@ -475,6 +572,10 @@ type Endpoint struct {
 	// and dropped when it is.
 	segmentQueue segmentQueue `state:"wait"`
 
+	// transportErrorQueue is used to hand transport errors received while the
+	// endpoint is owned by a user goroutine to the protocol goroutine.
+	transportErrorQueue transportErrorQueue `state:"nosave"`
+
 	// userMSS if non-zero is the MSS value explicitly set by the user
 	// for this endpoint using the TCP_MAXSEG setsockopt.
 	userMSS uint16
@@ -702,10 +803,10 @@ func (e *Endpoint) LockUser() {
 	e.ownedByUser.Store(1)
 }
 
-// UnlockUser will check if there are any segments already queued for processing
-// and wake up a processor goroutine to process them before unlocking e.mu.
-// This is required because we when packets arrive and endpoint lock is already
-// held then such packets are queued up to be processed.
+// UnlockUser will check if there is any work already queued for processing and
+// wake up a processor goroutine to process it before unlocking e.mu. This is
+// required because when packets or transport errors arrive and endpoint lock is
+// already held then such work is queued up to be processed.
 //
 // Precondition: e.LockUser() must have been called before calling e.UnlockUser()
 // +checklocksrelease:e.mu
@@ -714,14 +815,17 @@ func (e *Endpoint) UnlockUser() {
 	// segments can be queued between the time we check if queue is empty
 	// and actually unlock the endpoint mutex.
 	e.segmentQueue.mu.Lock()
-	if e.segmentQueue.emptyLocked() {
+	e.transportErrorQueue.mu.Lock()
+	if e.segmentQueue.emptyLocked() && e.transportErrorQueue.emptyLocked() {
 		if e.ownedByUser.Swap(0) != 1 {
 			panic("e.UnlockUser() called without calling e.LockUser()")
 		}
 		e.mu.Unlock()
+		e.transportErrorQueue.mu.Unlock()
 		e.segmentQueue.mu.Unlock()
 		return
 	}
+	e.transportErrorQueue.mu.Unlock()
 	e.segmentQueue.mu.Unlock()
 
 	// Since we are waking the processor goroutine here just unlock
@@ -2958,6 +3062,11 @@ func (e *Endpoint) onICMPError(err tcpip.Error, transErr stack.TransportError, p
 
 // HandleError implements stack.TransportEndpoint.
 func (e *Endpoint) HandleError(transErr stack.TransportError, pkt *stack.PacketBuffer) {
+	if e.isOwnedByUser() {
+		e.enqueueTransportError(transErr, pkt)
+		return
+	}
+
 	handlePacketTooBig := func(mtu uint32) {
 		e.sndQueueInfo.sndQueueMu.Lock()
 		update := false


### PR DESCRIPTION
The Connect() holds a TCP endpoint lock as it sends a connection attempt when the outgoing packet hits an iptable REJECT rule, an error is generated and TCP tries to handle it on the same endpoint still owned by Connect() 

The fix is to check whether a syscall owns the endpoint In the event that it is owned - the packet will be cloned, it will queue the error and not handle it immediately, resulting in Connect() finishing and releasing the lock and TCP handling the queued 