### PR TITLE
Enforce release matching in sidecar binaries.

### DIFF
--- a/runsc/checkpointgofer/BUILD
+++ b/runsc/checkpointgofer/BUILD
@@ -22,6 +22,7 @@ go_binary(
         "//runsc/cli",
         "//runsc/cmd/util",
         "//runsc/flag",
+        "//runsc/gvisorbinaries",
         "@com_github_google_subcommands//:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
     ],

--- a/runsc/checkpointgofer/main.go
+++ b/runsc/checkpointgofer/main.go
@@ -31,6 +31,7 @@ import (
 	"gvisor.dev/gvisor/runsc/cli"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/flag"
+	"gvisor.dev/gvisor/runsc/gvisorbinaries"
 )
 
 // GCSOptions holds options that configure a checkpoint gofer to access GCS.
@@ -168,7 +169,7 @@ func (cmd *checkpointGoferCmd) runGCS(ctx context.Context, sock *unet.Socket, op
 
 // main is the binary's entry point.
 func main() {
-	cli.Run(map[util.SubCommand]string{
+	cli.Run(&gvisorbinaries.CheckpointGofer, map[util.SubCommand]string{
 		new(checkpointGoferCmd): "",
 	}, nil)
 }

--- a/runsc/cli/BUILD
+++ b/runsc/cli/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//runsc/cmd/util",
         "//runsc/config",
         "//runsc/flag",
+        "//runsc/gvisorbinaries",
         "//runsc/specutils",
         "//runsc/starttime",
         "//runsc/version",

--- a/runsc/cli/cli.go
+++ b/runsc/cli/cli.go
@@ -36,6 +36,7 @@ import (
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/flag"
+	"gvisor.dev/gvisor/runsc/gvisorbinaries"
 	"gvisor.dev/gvisor/runsc/specutils"
 	"gvisor.dev/gvisor/runsc/starttime"
 	"gvisor.dev/gvisor/runsc/version"
@@ -58,9 +59,12 @@ var (
 )
 
 // Run runs the binary, whose behavior is determined by the subcommand passed
-// on the command line. commands is a mapping of all top level runsc commands
-// to their command group name. helpTopics is a list of additional help topics.
-func Run(commands map[util.SubCommand]string, helpTopics []subcommands.Command) {
+// on the command line.
+// `sidecar` is the calling sidecar binary, or `nil` when called by `runsc`.
+// `commands` is a mapping of all top-level commands to their command group
+// name.
+// `helpTopics` is a list of additional help topics.
+func Run(sidecar *gvisorbinaries.Binary, commands map[util.SubCommand]string, helpTopics []subcommands.Command) {
 	// Set the start time as soon as possible.
 	startTime := starttime.Get()
 
@@ -281,6 +285,8 @@ func Run(commands map[util.SubCommand]string, helpTopics []subcommands.Command) 
 		}
 	}
 	log.Infof(delimString)
+	gvisorbinaries.ReleaseEnforcementPolicy = conf.SidecarReleaseEnforcementPolicy
+	gvisorbinaries.VerifyMatchingRelease(sidecar)
 
 	if *coverageFD >= 0 {
 		f := os.NewFile(uintptr(*coverageFD), "coverage file")

--- a/runsc/cli/maincli/maincli.go
+++ b/runsc/cli/maincli/maincli.go
@@ -41,7 +41,7 @@ const (
 func Main() {
 	alias.HandleAlias()
 	cmds, helpCmds := commands()
-	cli.Run(cmds, helpCmds)
+	cli.Run(nil, cmds, helpCmds)
 }
 
 func commands() (map[util.SubCommand]string, []subcommands.Command) {

--- a/runsc/cmd/install.go
+++ b/runsc/cmd/install.go
@@ -37,9 +37,9 @@ type Install struct {
 	Experimental     bool
 	Clobber          bool
 	CgroupDriver     string
-	DownloadSidecars sidecarPolicy
+	DownloadSidecars config.SidecarPolicy
 	SidecarURL       string
-	RequireSidecars  sidecarPolicy
+	RequireSidecars  config.SidecarPolicy
 	executablePath   string
 	runtimeArgs      []string
 }
@@ -67,8 +67,8 @@ func (i *Install) SetFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&i.Clobber, "clobber", true, "clobber existing runtime configuration")
 	fs.StringVar(&i.CgroupDriver, "cgroupdriver", "", "docker cgroup driver")
 	// TODO(gvisor.dev/issue/13718): flip defaults to `IF_RELEASE_BUILD`.
-	i.DownloadSidecars = sidecarNever
-	i.RequireSidecars = sidecarNever
+	i.DownloadSidecars = config.SidecarNever
+	i.RequireSidecars = config.SidecarNever
 	fs.Var(&i.DownloadSidecars, "download-sidecars", "when to download missing sidecar binaries into gvisor-bin/ next to runsc: NEVER, ALWAYS, or IF_RELEASE_BUILD. This flag will go away in a few weeks! See gvisor.dev/issue/13718")
 	fs.Var(&i.RequireSidecars, "require-sidecars", "when missing sidecar binaries that cannot be installed are fatal: NEVER, ALWAYS, or IF_RELEASE_BUILD. This flag will go away in a few weeks! See gvisor.dev/issue/13718")
 	fs.StringVar(&i.SidecarURL, "sidecar-url", "", "download sidecar binaries from this gvisor.tar.bz2 URL instead of the release URL derived from the runsc version. This flag will go away in a few weeks! See gvisor.dev/issue/13718")
@@ -117,7 +117,7 @@ func (i *Install) Execute(_ context.Context, f *flag.FlagSet, args ...any) subco
 	}
 
 	if err := i.installSidecars(); err != nil {
-		if i.RequireSidecars.applies() {
+		if i.RequireSidecars.Applies() {
 			log.Fatalf("Cannot install sidecar binaries: %v", err)
 		}
 		log.Printf("WARNING: cannot install sidecar binaries; sidecar-dependent features (metric server, GCS checkpoints) may be unavailable: %v", err)

--- a/runsc/cmd/install_sidecars.go
+++ b/runsc/cmd/install_sidecars.go
@@ -27,58 +27,13 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 
+	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/gvisorbinaries"
 	"gvisor.dev/gvisor/runsc/version"
 )
-
-// sidecarPolicy controls when a sidecar-related action applies.
-// It implements flag.Value.
-type sidecarPolicy string
-
-// Valid sidecarPolicy values.
-const (
-	sidecarNever          sidecarPolicy = "NEVER"
-	sidecarAlways         sidecarPolicy = "ALWAYS"
-	sidecarIfReleaseBuild sidecarPolicy = "IF_RELEASE_BUILD"
-)
-
-// String implements flag.Value.String.
-func (p *sidecarPolicy) String() string {
-	return string(*p)
-}
-
-// Get implements flag.Value.Get.
-func (p *sidecarPolicy) Get() any {
-	return *p
-}
-
-// Set implements flag.Value.Set.
-func (p *sidecarPolicy) Set(s string) error {
-	v := sidecarPolicy(strings.ToUpper(s))
-	switch v {
-	case sidecarNever, sidecarAlways, sidecarIfReleaseBuild:
-		*p = v
-		return nil
-	}
-	return fmt.Errorf("invalid value %q; must be %s, %s, or %s", s, sidecarNever, sidecarAlways, sidecarIfReleaseBuild)
-}
-
-// applies returns whether the policy is in effect for this runsc build.
-func (p sidecarPolicy) applies() bool {
-	return p == sidecarAlways || (p == sidecarIfReleaseBuild && isReleaseBuild())
-}
-
-// releaseVersionRE matches the version string of tagged release builds.
-var releaseVersionRE = regexp.MustCompile(`^release-(\d{8}(?:\.\d+)?)$`)
-
-// isReleaseBuild returns whether this runsc's version is a tagged release.
-func isReleaseBuild() bool {
-	return releaseVersionRE.MatchString(version.Version())
-}
 
 // releaseArches maps GOARCH to the architecture names used in release URLs.
 var releaseArches = map[string]string{
@@ -87,15 +42,16 @@ var releaseArches = map[string]string{
 }
 
 func releaseTarballURL(ver, goarch string) (string, error) {
-	m := releaseVersionRE.FindStringSubmatch(ver)
-	if m == nil {
+	if !config.IsReleaseVersion(ver) {
 		return "", fmt.Errorf("cannot map version %q to a release download URL; please download sidecar binaries manually", ver)
 	}
 	arch, ok := releaseArches[goarch]
 	if !ok {
 		return "", fmt.Errorf("unknown architecture %q", goarch)
 	}
-	return fmt.Sprintf("https://storage.googleapis.com/gvisor/releases/release/%s/%s/gvisor.tar.bz2", m[1], arch), nil
+	// The release date follows the first dash, whichever the prefix.
+	date := ver[strings.IndexByte(ver, '-')+1:]
+	return fmt.Sprintf("https://storage.googleapis.com/gvisor/releases/release/%s/%s/gvisor.tar.bz2", date, arch), nil
 }
 
 // fetch downloads url to dest using curl or wget, whichever exists.
@@ -224,8 +180,8 @@ func (i *Install) installSidecars() error {
 	if err != nil {
 		return err
 	}
-	if !i.DownloadSidecars.applies() {
-		return fmt.Errorf("sidecar binaries %v missing (expected under %q); not downloading them (--download-sidecars=%s, release build: %t)", missing, dir, i.DownloadSidecars, isReleaseBuild())
+	if !i.DownloadSidecars.Applies() {
+		return fmt.Errorf("sidecar binaries %v missing (expected under %q); not downloading them (--download-sidecars=%s, release build: %t)", missing, dir, i.DownloadSidecars, config.IsReleaseVersion(version.Version()))
 	}
 	url := i.SidecarURL
 	if url == "" {

--- a/runsc/cmd/install_test.go
+++ b/runsc/cmd/install_test.go
@@ -293,7 +293,11 @@ func TestReleaseTarballURL(t *testing.T) {
 	}{
 		{"release-20260706.0", "amd64", "https://storage.googleapis.com/gvisor/releases/release/20260706.0/x86_64/gvisor.tar.bz2"},
 		{"release-20260706", "arm64", "https://storage.googleapis.com/gvisor/releases/release/20260706/aarch64/gvisor.tar.bz2"},
+		{"gfoo-20260706.0", "amd64", "https://storage.googleapis.com/gvisor/releases/release/20260706.0/x86_64/gvisor.tar.bz2"},
 		{"release-20260706.0-14-gabcdef123456", "amd64", ""},
+		{"gfoo-20260706.0-14-gabcdef123456", "amd64", ""},
+		{"xfoo-20260706.0", "amd64", ""},
+		{"g1-20260706.0", "amd64", ""},
 		{"VERSION_MISSING", "amd64", ""},
 		{"release-20260706.0", "riscv64", ""},
 	} {

--- a/runsc/cmd/metricserver/BUILD
+++ b/runsc/cmd/metricserver/BUILD
@@ -15,12 +15,14 @@ go_binary(
     visibility = [
         "//:sandbox",
     ],
+    x_defs = {"gvisor.dev/gvisor/runsc/version.version": "{STABLE_VERSION}"},
     deps = [
         "//pkg/log",
         "//runsc/cmd/metricserver/metricservercmd",
         "//runsc/cmd/util",
         "//runsc/config",
         "//runsc/flag",
+        "//runsc/gvisorbinaries",
         "//runsc/metricserver",
         "@com_github_google_subcommands//:go_default_library",
     ],

--- a/runsc/cmd/metricserver/metricserver_main.go
+++ b/runsc/cmd/metricserver/metricserver_main.go
@@ -26,6 +26,7 @@ import (
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/flag"
+	"gvisor.dev/gvisor/runsc/gvisorbinaries"
 	"gvisor.dev/gvisor/runsc/metricserver"
 )
 
@@ -61,6 +62,7 @@ func main() {
 	subcommands.Register(&cmd{}, "metrics")
 	config.RegisterFlags(flag.CommandLine)
 	flag.Parse()
+	gvisorbinaries.VerifyMatchingRelease(&gvisorbinaries.MetricServer)
 	subcmdCode := subcommands.Execute(context.Background())
 	if subcmdCode == subcommands.ExitSuccess {
 		os.Exit(0)

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -180,6 +181,10 @@ type Config struct {
 	// an indication that the container being created wishes that its metrics should be exported).
 	// The value of this flag must also match across the two command lines.
 	MetricServer string `flag:"metric-server"`
+
+	// SidecarReleaseEnforcementPolicy controls when spawned sidecar binaries
+	// must match `runsc`'s build label.
+	SidecarReleaseEnforcementPolicy SidecarPolicy `flag:"sidecar-release-enforcement-policy"`
 
 	// FinalMetricsLog is the file to which all metric data should be written
 	// upon sandbox termination.
@@ -1208,6 +1213,57 @@ func (p HostSettingsPolicy) String() string {
 	default:
 		panic(fmt.Sprintf("Invalid host settings policy %d", p))
 	}
+}
+
+// SidecarPolicy controls when a sidecar-related action applies.
+type SidecarPolicy string
+
+// SidecarPolicy values.
+const (
+	SidecarNever          SidecarPolicy = "NEVER"
+	SidecarAlways         SidecarPolicy = "ALWAYS"
+	SidecarIfReleaseBuild SidecarPolicy = "IF_RELEASE_BUILD"
+)
+
+// Set implements flag.Value. Set(String()) should be idempotent.
+func (p *SidecarPolicy) Set(v string) error {
+	sp := SidecarPolicy(strings.ToUpper(v))
+	switch sp {
+	case SidecarNever, SidecarAlways, SidecarIfReleaseBuild:
+		*p = sp
+		return nil
+	}
+	return fmt.Errorf("invalid value %q; must be %s, %s, or %s", v, SidecarNever, SidecarAlways, SidecarIfReleaseBuild)
+}
+
+// Ptr returns a pointer to `p`.
+// Useful in flag declaration line.
+func (p SidecarPolicy) Ptr() *SidecarPolicy {
+	return &p
+}
+
+// Get implements flag.Get.
+func (p *SidecarPolicy) Get() any {
+	return *p
+}
+
+// String implements flag.String.
+func (p SidecarPolicy) String() string {
+	return string(p)
+}
+
+// Applies returns whether the policy is in effect for this runsc build.
+func (p SidecarPolicy) Applies() bool {
+	return p == SidecarAlways || (p == SidecarIfReleaseBuild && IsReleaseVersion(version.Version()))
+}
+
+// releaseVersionRE matches the version strings of production release builds:
+// a `release-` or `g<lowercase>-` prefix, then the release date.
+var releaseVersionRE = regexp.MustCompile(`^(?:release|g[a-z]*)-\d{8}(?:\.\d+)?$`)
+
+// IsReleaseVersion returns whether ver is a tagged-release version string.
+func IsReleaseVersion(ver string) bool {
+	return releaseVersionRE.MatchString(ver)
 }
 
 // RestoreSpecValidationPolicy dictates how spec validation should be handled.

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -117,6 +117,8 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("enable-core-tags", false, "enables core tagging. Requires host linux kernel >= 5.14.")
 	flagSet.String("pod-init-config", "", "path to configuration file with additional steps to take during pod creation.")
 	flagSet.Var(HostSettingsCheck.Ptr(), "host-settings", "how to handle non-optimal host kernel settings: check (default, advisory-only), ignore (do not check), adjust (best-effort auto-adjustment), or enforce (auto-adjustment must succeed).")
+	// TODO(gvisor.dev/issue/13718): flip default to `IF_RELEASE_BUILD`.
+	flagSet.Var(SidecarNever.Ptr(), "sidecar-release-enforcement-policy", "when spawned sidecar binaries must match runsc's release: NEVER, ALWAYS, or IF_RELEASE_BUILD. May be overridden by setting GVISOR_ENFORCE_RELEASE=SKIP as env var.")
 	flagSet.Var(RestoreSpecValidationEnforce.Ptr(), "restore-spec-validation", "how to handle spec validation during restore.")
 	flagSet.Bool("systrap-disable-syscall-patching", false, "disables syscall patching when using the Systrap platform. May be necessary to use in case the workload uses the GS register, or uses ptrace within gVisor. Has significant performance implications and is only recommended when the sandbox is known to run otherwise-incompatible workloads. Only relevant for x86.")
 	flagSet.Bool("systrap-disable-fast-path", false, "unconditionally disables the Systrap fast path.")

--- a/runsc/gvisorbinaries/BUILD
+++ b/runsc/gvisorbinaries/BUILD
@@ -13,7 +13,9 @@ go_library(
     ],
     deps = [
         "//pkg/log",
+        "//runsc/config",
         "//runsc/specutils",
+        "//runsc/version",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/runsc/gvisorbinaries/gvisorbinaries.go
+++ b/runsc/gvisorbinaries/gvisorbinaries.go
@@ -21,17 +21,48 @@
 // itself, which can be extracted and exec'd when the on-disk copy is not
 // available. This will go away after some time in order to lighten up the
 // size of the runsc binary.
+//
+// # Release enforcement
+//
+// On-disk sidecars can come from a different gVisor release than the `runsc`
+// binary, which can lead to hard-to-debug issue reports.
+// The `GVISOR_ENFORCE_RELEASE` environment variable makes this skew obvious
+// by panic'ing in the sidecar rather than silently failing
+//
+// Semantics of this env var:
+//
+//   - "<label>": panic at startup if its own build label is any different.
+//   - "SKIP" or "SKIP:<expected>": no enforcement, but warning log on
+//     mismatch.
+//   - "TESTONLY_SKIP[:<expected>]": same as SKIP, but info-level log.
+//
+// Spawning sidecars always sets GVISOR_ENFORCE_RELEASE in the sidecar's env.
+//
+//   - A skip form in the parent keeps being skipped, but env var is suffixed
+//     to make the sidecar still log a better error message by knowing the
+//     parent's release version.
+//   - If `config.ReleaseEnforcementPolicy` applies, then sidecar gets that.
+//   - Otherwise, it gets "SKIP:<label>".
+//
+// `VerifyMatchingRelease` is where we check, intended to be called
+// both by `runsc` and by every sidecar at startup.
+// An unset variable is normal for `runsc`, but logged as a warning in
+// sidecars (should only happen when sidecars are launched by hand, which is
+// never supported).
 package gvisorbinaries
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/specutils"
+	"gvisor.dev/gvisor/runsc/version"
 )
 
 // Sidecar binary filenames under the "gvisor-bin/" directory.
@@ -48,6 +79,114 @@ const binDirName = "gvisor-bin"
 // the directory in which sidecar binaries are located.
 // Specified by tests.
 const sidecarBinariesDirEnv = "GVISOR_SIDECAR_BINARIES_DIR"
+
+const (
+	// enforceReleaseEnv is set in spawned sidecar env vars and checked by
+	// VerifyMatchingRelease.
+	enforceReleaseEnv = "GVISOR_ENFORCE_RELEASE"
+)
+
+// Special prefixes that bypass the check.
+const (
+	enforceReleaseSkip         = "SKIP"
+	enforceReleaseTestonlySkip = "TESTONLY_SKIP"
+)
+
+// cutSkip returns the expected release embedded in `val` (env var).
+func cutSkip(val, prefix string) (string, bool) {
+	if val == prefix {
+		return "", true
+	}
+	return strings.CutPrefix(val, prefix+":")
+}
+
+// ReleaseEnforcementPolicy controls whether Exec/ForkExec set
+// GVISOR_ENFORCE_RELEASE in the sidecar env.
+// Set from config flag.
+var ReleaseEnforcementPolicy = config.SidecarNever
+
+// withEnforceRelease returns envv with `GVISOR_ENFORCE_RELEASE` set for
+// sidecar processes.
+func withEnforceRelease(envv []string) []string {
+	val := os.Getenv(enforceReleaseEnv)
+	prefix, want := "", ""
+	if w, ok := cutSkip(val, enforceReleaseTestonlySkip); ok {
+		prefix, want = enforceReleaseTestonlySkip, w
+	} else if w, ok := cutSkip(val, enforceReleaseSkip); ok {
+		prefix, want = enforceReleaseSkip, w
+	} else if !ReleaseEnforcementPolicy.Applies() {
+		prefix = enforceReleaseSkip
+	}
+	value := version.Version()
+	if prefix != "" {
+		if want == "" {
+			want = version.Version()
+		}
+		value = prefix + ":" + want
+	}
+	out := make([]string, 0, len(envv)+1)
+	for _, kv := range envv {
+		if !strings.HasPrefix(kv, enforceReleaseEnv+"=") {
+			out = append(out, kv)
+		}
+	}
+	return append(out, enforceReleaseEnv+"="+value)
+}
+
+// VerifyMatchingRelease panics if `GVISOR_ENFORCE_RELEASE` is set and doesn't
+// match this binary's build label.
+// See `gvisorbinaries` top-level package comment for full semantics.
+func VerifyMatchingRelease(b *Binary) {
+	val := os.Getenv(enforceReleaseEnv)
+	got := version.Version()
+	var who string
+	if b != nil {
+		who = fmt.Sprintf(" in sidecar %q", b.Name)
+	}
+	if val == "" {
+		if b != nil {
+			log.Warningf("Release match check not enforced%s (did you start this sidecar binary manually?); this build is %q.", who, got)
+		}
+		return
+	}
+	want, skip := cutSkip(val, enforceReleaseSkip)
+	wantTest, testOnly := cutSkip(val, enforceReleaseTestonlySkip)
+	if testOnly {
+		want, skip = wantTest, true
+	}
+	if !skip {
+		if got != val {
+			errMsg := fmt.Sprintf("this binary's build label %q%s does not match the expected release %q; all gVisor binaries must come from the same release (fix your gVisor installation deployment, or disable enforcement with `--sidecar-release-enforcement-policy=...` at your own risk)", got, who, val)
+			log.Warningf("Release check: %s.", errMsg)
+			panic(errMsg)
+		}
+		if b != nil {
+			log.Infof("[Sidecar release match check] Build label %q matches the expected release%s.", got, who)
+		} else {
+			log.Infof("[Release match check] Build label %q matches the expected release%s.", got, who)
+		}
+		return
+	}
+	if b == nil {
+		return
+	}
+	var msg string
+	info := testOnly
+	switch want {
+	case "":
+		msg = fmt.Sprintf("Sidecar release match check not enforced%s; this build is %q.", who, got)
+	case got:
+		msg = fmt.Sprintf("Sidecar release match check not enforced%s; build label %q matches the expected release.", who, got)
+		info = true
+	default:
+		msg = fmt.Sprintf("Sidecar release match check not enforced%s; this build is %q but the expected release is %q.", who, got, want)
+	}
+	if info {
+		log.Infof("%s", msg)
+	} else {
+		log.Warningf("%s", msg)
+	}
+}
 
 // The sidecar binaries that runsc may need to execute.
 // Their embedded fallbacks are not wired here directly to avoid import cycles.
@@ -157,6 +296,7 @@ func (b *Binary) notAvailableError() error {
 // Exec resolves the binary and replaces the current process with it. It only
 // returns if execution could not be started.
 func (b *Binary) Exec(opts Options) error {
+	opts.Envv = withEnforceRelease(opts.Envv)
 	if p, err := b.Path(); err == nil {
 		log.Infof("sidecar %q found: executing %s (%v)", b.Name, p, &opts)
 		return execDisk(p, opts)
@@ -171,6 +311,7 @@ func (b *Binary) Exec(opts Options) error {
 // ForkExec resolves the binary and runs it in a new process, returning the
 // child's PID.
 func (b *Binary) ForkExec(opts Options) (int, error) {
+	opts.Envv = withEnforceRelease(opts.Envv)
 	if p, err := b.Path(); err == nil {
 		log.Infof("sidecar %q: executing %s (%v)", b.Name, p, &opts)
 		return forkExecDisk(p, opts)


### PR DESCRIPTION
This ensures that sidecars must be installed from the same release.

See issue #13718.