### PR TITLE
UDS: Transfer `SCM_RIGHTS` into enqueued messages.

### DIFF
--- a/pkg/sentry/socket/control/control.go
+++ b/pkg/sentry/socket/control/control.go
@@ -715,6 +715,13 @@ func (fs *RightsFiles) Clone() transport.RightsControlMessage {
 	return &nfs
 }
 
+// TransferRights implements transport.RightsControlMessage.TransferRights.
+func (fs *RightsFiles) TransferRights() transport.RightsControlMessage {
+	nfs := *fs
+	*fs = nil
+	return &nfs
+}
+
 // Release implements transport.RightsControlMessage.Release.
 func (fs *RightsFiles) Release(ctx context.Context) {
 	for _, f := range *fs {

--- a/pkg/sentry/socket/unix/transport/BUILD
+++ b/pkg/sentry/socket/unix/transport/BUILD
@@ -1,5 +1,5 @@
 load("//pkg/sync/locking:locking.bzl", "declare_mutex")
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
@@ -106,5 +106,16 @@ go_library(
         "//pkg/unet",
         "//pkg/waiter",
         "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
+go_test(
+    name = "transport_test",
+    size = "small",
+    srcs = ["queue_test.go"],
+    library = ":transport",
+    deps = [
+        "//pkg/context",
+        "//pkg/syserr",
     ],
 )

--- a/pkg/sentry/socket/unix/transport/host.go
+++ b/pkg/sentry/socket/unix/transport/host.go
@@ -42,6 +42,13 @@ func (c *SCMRights) Clone() RightsControlMessage {
 	return nil
 }
 
+// TransferRights implements RightsControlMessage.TransferRights.
+func (c *SCMRights) TransferRights() RightsControlMessage {
+	nc := &SCMRights{FDs: c.FDs}
+	c.FDs = nil
+	return nc
+}
+
 // Release implements RightsControlMessage.Release.
 func (c *SCMRights) Release(ctx context.Context) {
 	for _, fd := range c.FDs {

--- a/pkg/sentry/socket/unix/transport/queue.go
+++ b/pkg/sentry/socket/unix/transport/queue.go
@@ -115,6 +115,13 @@ func (q *queue) IsWritable() bool {
 // Otherwise, the entire message must fit. If l is less than the size of data,
 // err indicates why.
 //
+// Ownership of c.Rights transfers to the queue if and only if the message is
+// consumed: either enqueued, which includes a truncated write returning a
+// non-zero l along with syserr.ErrWouldBlock, or dropped on account of
+// discardEmpty, in which case the rights are released here. Whenever Enqueue
+// instead bails out early with an error and l == 0, the caller retains
+// ownership of c.Rights and remains responsible for releasing them.
+//
 // If notify is true, ReaderQueue.Notify must be called:
 // q.ReaderQueue.Notify(waiter.ReadableEvents)
 func (q *queue) Enqueue(ctx context.Context, data [][]byte, c ControlMessages, from Address, discardEmpty bool, truncate bool) (l int64, notify bool, err *syserr.Error) {
@@ -169,6 +176,16 @@ func (q *queue) Enqueue(ctx context.Context, data [][]byte, c ControlMessages, f
 
 	notify = true
 	q.used += l
+	if c.Rights != nil {
+		// `c` is passed by value, but `c.Rights` is an interface over a
+		// pointer pointing to the same `RightsControlMessage` implementation
+		// (e.g. `*RightsFiles`) regardless of `c` being passed by value.
+		// Here we empty that underlying shared `RightsControlMessage`
+		// implementation and allocate a new one specifically so that we can
+		// queue it as such with the queued `ControlMessages` being the only
+		// one that has it.
+		c.Rights = c.Rights.TransferRights()
+	}
 	q.dataList.PushBack(&message{
 		Data:    v,
 		Control: c,

--- a/pkg/sentry/socket/unix/transport/queue_test.go
+++ b/pkg/sentry/socket/unix/transport/queue_test.go
@@ -1,0 +1,192 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/syserr"
+)
+
+// mockRights is a test RightsControlMessage that models refcounted FDs as a
+// set of counters.
+type mockRights struct {
+	refs []*int
+}
+
+// Clone implements RightsControlMessage.Clone.
+func (m *mockRights) Clone() RightsControlMessage {
+	nrefs := append([]*int(nil), m.refs...)
+	for _, r := range nrefs {
+		*r++
+	}
+	return &mockRights{refs: nrefs}
+}
+
+// TransferRights implements RightsControlMessage.TransferRights.
+func (m *mockRights) TransferRights() RightsControlMessage {
+	nrefs := append([]*int(nil), m.refs...)
+	m.refs = nil
+	return &mockRights{refs: nrefs}
+}
+
+// Release implements RightsControlMessage.Release.
+func (m *mockRights) Release(ctx context.Context) {
+	for _, r := range m.refs {
+		*r--
+	}
+	m.refs = nil
+}
+
+// TestEnqueueRightsOwnership verifies ownership of SCM rights as a function
+// of the success/error paths of the Enqueue call.
+func TestEnqueueRightsOwnership(t *testing.T) {
+	for _, test := range []struct {
+		name string
+
+		// limit and used are the initial capacity and occupancy of the queue.
+		limit int64
+		used  int64
+		// closed closes the queue before enqueuing.
+		closed bool
+
+		data         [][]byte
+		discardEmpty bool
+		truncate     bool
+
+		wantN           int64
+		wantErr         *syserr.Error
+		wantQueued      bool
+		wantTransferred bool
+	}{
+		{
+			name:            "whole message enqueued",
+			limit:           8,
+			data:            [][]byte{{42, 13, 37}},
+			wantN:           3,
+			wantQueued:      true,
+			wantTransferred: true,
+		},
+		{
+			name:            "partial enqueue",
+			limit:           8,
+			used:            6,
+			data:            [][]byte{{42, 13, 37}},
+			truncate:        true,
+			wantN:           2,
+			wantErr:         syserr.ErrWouldBlock,
+			wantQueued:      true,
+			wantTransferred: true,
+		},
+		{
+			name:            "empty message discarded",
+			limit:           8,
+			data:            [][]byte{{}},
+			discardEmpty:    true,
+			wantTransferred: true,
+		},
+		{
+			name:    "closed for send",
+			limit:   8,
+			closed:  true,
+			data:    [][]byte{{42, 13, 37}},
+			wantErr: syserr.ErrClosedForSend,
+		},
+		{
+			name:    "message too long",
+			limit:   2,
+			data:    [][]byte{{42, 13, 37}},
+			wantErr: syserr.ErrMessageTooLong,
+		},
+		{
+			name:    "queue full",
+			limit:   8,
+			used:    8,
+			data:    [][]byte{{42, 13, 37}},
+			wantErr: syserr.ErrWouldBlock,
+		},
+		{
+			name:     "queue full while truncating",
+			limit:    8,
+			used:     8,
+			data:     [][]byte{{42, 13, 37}},
+			truncate: true,
+			wantErr:  syserr.ErrWouldBlock,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			q := &queue{limit: test.limit, used: test.used}
+			if test.closed {
+				q.Close()
+			}
+
+			refcount := 1
+			rights := &mockRights{refs: []*int{&refcount}}
+			caller := ControlMessages{Rights: rights}
+
+			n, notify, err := q.Enqueue(nil, test.data, caller, Address{}, test.discardEmpty, test.truncate)
+			if err != test.wantErr {
+				t.Fatalf("Enqueue error = %v, want %v", err, test.wantErr)
+			}
+			if n != test.wantN {
+				t.Fatalf("Enqueue wrote %d bytes, want %d", n, test.wantN)
+			}
+			if notify != test.wantQueued {
+				t.Fatalf("Enqueue notify = %t, want %t", notify, test.wantQueued)
+			}
+			if gotRetained, wantRetained := len(rights.refs) != 0, !test.wantTransferred; gotRetained != wantRetained {
+				t.Errorf("caller retains rights after Enqueue = %t, want %t", gotRetained, wantRetained)
+			}
+			wantRefcount := 1
+			if test.wantTransferred && !test.wantQueued {
+				wantRefcount = 0
+			}
+			if refcount != wantRefcount {
+				t.Errorf("after Enqueue, refcount = %d, want %d", refcount, wantRefcount)
+			}
+
+			// Callers release their `ControlMessages` on the paths where
+			// Enqueue does not take them. So the refcount should always be
+			// unchanged (1) if enqueued, and 0 (decref'd) if not enqueued.
+			// The patterns callers follow is to always call `Release`,
+			// which should be a no-op in the enqueued case. So do that now.
+			caller.Release(nil)
+			if test.wantQueued && refcount != 1 {
+				t.Errorf("caller release dropped a queued reference: refcount = %d, want 1", refcount)
+			} else if !test.wantQueued && refcount != 0 {
+				t.Errorf("caller release did not free the rights: refcount = %d, want 0", refcount)
+			}
+
+			if !test.wantQueued {
+				if q.dataList.Front() != nil {
+					t.Errorf("queue holds a message, want none")
+				}
+				return
+			}
+
+			// Draining the queue should finally decref down to zero.
+			// In all cases, caller release + queue drain yields 0 refcount.
+			e, _, err := q.Dequeue()
+			if err != nil {
+				t.Fatalf("Dequeue failed: %v", err)
+			}
+			e.Release(nil)
+			if refcount != 0 {
+				t.Errorf("after dequeue release, refcount = %d, want 0", refcount)
+			}
+		})
+	}
+}

--- a/pkg/sentry/socket/unix/transport/unix.go
+++ b/pkg/sentry/socket/unix/transport/unix.go
@@ -43,6 +43,11 @@ type RightsControlMessage interface {
 	// Clone returns a copy of the RightsControlMessage.
 	Clone() RightsControlMessage
 
+	// TransferRights moves ownership of the underlying FDs to a new
+	// `RightsControlMessage`, leaving the receiver empty.
+	// Reference counts are left unchanged.
+	TransferRights() RightsControlMessage
+
 	// Release releases any resources owned by the RightsControlMessage.
 	Release(ctx context.Context)
 }
@@ -169,7 +174,14 @@ type Endpoint interface {
 	// SendMsg writes data and a control message to the endpoint's peer.
 	// This method does not block if the data cannot be written.
 	//
-	// SendMsg does not take ownership of any of its arguments on error.
+	// Ownership of the ControlMessages' Rights transfers to the callee iff
+	// the message is consumed, i.e. either enqueued or deliberately dropped
+	// (see `queue.Enqueue`).
+	// That is the case whenever `SendMsg` returns a nil error, or returns
+	// `syserr.ErrWouldBlock` along with a non-zero number of bytes written
+	// (i.e. a truncated stream write).
+	// In every other case, the caller retains ownership and must release
+	// them. Ownership of all other arguments stays with the caller.
 	//
 	// If set, notify is a callback that should be called after RecvMesg
 	// completes without mm.activeMu held.
@@ -692,6 +704,9 @@ type ConnectedEndpoint interface {
 	//
 	// syserr.ErrWouldBlock can be returned along with a partial write if
 	// the caller should block to send the rest of the data.
+	//
+	// Ownership of c.Rights follows the same rules as Endpoint.SendMsg: it
+	// transfers to the callee if and only if err is nil or n is non-zero.
 	Send(ctx context.Context, data [][]byte, c ControlMessages, from Address) (n int64, notify bool, err *syserr.Error)
 
 	// SendNotify notifies the ConnectedEndpoint of a successful Send. This


### PR DESCRIPTION
Avoids accidentally decref'ing the queued-in FDs by the callers of `queue.Enqueue`.