### PR TITLE
fix(sync): arm64 race compare-and-swap

### DIFF
--- a/pkg/sync/BUILD
+++ b/pkg/sync/BUILD
@@ -55,6 +55,7 @@ go_test(
     size = "small",
     srcs = [
         "gate_test.go",
+        "race_test.go",
         "rwmutex_test.go",
         "seqcount_test.go",
     ],

--- a/pkg/sync/race_arm64.s
+++ b/pkg/sync/race_arm64.s
@@ -21,7 +21,7 @@
 TEXT ·RaceUncheckedAtomicCompareAndSwapUintptr(SB),NOSPLIT,$0-25
 	MOVD ptr+0(FP), R0
 	MOVD old+8(FP), R1
-	MOVD new+16(FP), R1
+	MOVD new+16(FP), R2
 again:
 	LDAXR (R0), R3
 	CMP R1, R3

--- a/pkg/sync/race_test.go
+++ b/pkg/sync/race_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import "testing"
+
+func TestRaceUncheckedAtomicCompareAndSwapUintptr(t *testing.T) {
+	const (
+		oldValue = uintptr(1)
+		newValue = uintptr(2)
+	)
+
+	value := oldValue
+	if !RaceUncheckedAtomicCompareAndSwapUintptr(&value, oldValue, newValue) {
+		t.Errorf("RaceUncheckedAtomicCompareAndSwapUintptr() = false, want true")
+	}
+	if value != newValue {
+		t.Errorf("value = %d, want %d", value, newValue)
+	}
+
+	value = newValue
+	if RaceUncheckedAtomicCompareAndSwapUintptr(&value, oldValue, newValue) {
+		t.Errorf("RaceUncheckedAtomicCompareAndSwapUintptr() = true, want false")
+	}
+	if value != newValue {
+		t.Errorf("value = %d after failed compare-and-swap, want %d", value, newValue)
+	}
+}


### PR DESCRIPTION
## Summary

Fix the arm64 implementation of
`RaceUncheckedAtomicCompareAndSwapUintptr` used when the Go race detector
is enabled, and add a regression test covering both successful and failed
compare-and-swap operations.

## Root cause

`RaceUncheckedAtomicCompareAndSwapUintptr` provides a CAS operation that
can safely be called from `runtime.gopark` callbacks without invoking the
race runtime. It is used by synchronization primitives in `pkg/sleep`,
`pkg/syncevent`, and `Gate`.

The arm64 race implementation incorrectly loads both the expected and
replacement values into R1:

```asm
MOVD old+8(FP), R1
MOVD new+16(FP), R1
```

The second instruction overwrites the expected value, while R2—the
register later used as the replacement value—remains unset.

This is particularly harmful in `sleep.commitSleep`. A sleeper first sets
`waitingG` to `preparingG` (`1`), then asks the runtime to park the current
goroutine. Immediately before parking, the runtime invokes
`commitSleep`, which attempts:

```text
CAS(waitingG, preparingG, current-goroutine-pointer)
```

With the broken arm64 implementation, the CAS compares `waitingG` against
the goroutine pointer instead of `preparingG`. Since `waitingG` is `1`,
the operation returns false.

A false return tells `runtime.gopark` not to park the goroutine. The
sleeper immediately retries, causing otherwise-idle goroutines to
busy-loop instead of sleeping.

## Impact

The bug is limited to `race && arm64` builds. Normal arm64 builds and
amd64 race builds use different, correct implementations.

In the downstream integration test that exposed the issue, a race-enabled
arm64 process running two gVisor netstacks showed the following behavior:

|                       | Before | After |
|-----------------------|-------:|------:|
| Observed process CPU  | 1390–1500% | ~0% while idle |
| Wall time             | 36.17s | 23.74s |
| User CPU time         | 491.87s | 0.59s |
| System CPU time       | 12.96s | 0.26s |

These numbers are from an integration reproduction rather than a
benchmark, but they demonstrate that the excessive CPU consumption comes
from failed parking rather than network processing.

## Fix

Load the replacement value into R2, matching the expected arm64 CAS
register layout:

```asm
MOVD old+8(FP), R1
MOVD new+16(FP), R2
```

Add a direct unit test that verifies:

- A matching expected value is replaced and returns true.
- A mismatched expected value is preserved and returns false.

The regression test fails with the original instruction and passes with
the fix.