### PR TITLE
seccomp: fix SECCOMP_RET_KILL_PROCESS killing only the calling thread

### DIFF
--- a/pkg/abi/linux/seccomp.go
+++ b/pkg/abi/linux/seccomp.go
@@ -55,6 +55,7 @@ const (
 	SECCOMP_RET_ERRNO        BPFAction = 0x00050000
 	SECCOMP_RET_TRACE        BPFAction = 0x7ff00000
 	SECCOMP_RET_USER_NOTIF   BPFAction = 0x7fc00000
+	SECCOMP_RET_LOG          BPFAction = 0x7ffc0000
 	SECCOMP_RET_ALLOW        BPFAction = 0x7fff0000
 )
 
@@ -82,6 +83,8 @@ func (a BPFAction) String() string {
 		return "allow"
 	case SECCOMP_RET_USER_NOTIF:
 		return "unotify"
+	case SECCOMP_RET_LOG:
+		return "log"
 	}
 	return fmt.Sprintf("invalid action: %#x", uint32(a))
 }

--- a/pkg/sentry/kernel/seccomp.go
+++ b/pkg/sentry/kernel/seccomp.go
@@ -34,6 +34,10 @@ const (
 	// It is used as a sentinel value in `taskSeccompFilters.cache` to indicate
 	// that a specific syscall number is uncachable.
 	uncacheableBPFAction = linux.SECCOMP_RET_ACTION_FULL
+
+	// maxSeccompErrno is Linux's MAX_ERRNO (include/linux/err.h), the
+	// largest errno that a SECCOMP_RET_ERRNO filter may return.
+	maxSeccompErrno = 4095
 )
 
 // taskSeccomp holds seccomp-related data for a `Task`.
@@ -113,8 +117,14 @@ func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip h
 
 	case linux.SECCOMP_RET_ERRNO:
 		// "Results in the lower 16-bits of the return value being passed to
-		// userland as the errno without executing the system call."
-		t.Arch().SetReturn(-uintptr(result.Data()))
+		// userland as the errno without executing the system call." Linux
+		// caps the errno at MAX_ERRNO; see
+		// kernel/seccomp.c:__seccomp_filter().
+		errno := result.Data()
+		if errno > maxSeccompErrno {
+			errno = maxSeccompErrno
+		}
+		t.Arch().SetReturn(-uintptr(errno))
 
 	case linux.SECCOMP_RET_TRACE:
 		// "When returned, this value will cause the kernel to attempt to
@@ -127,6 +137,24 @@ func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip h
 			t.Arch().SetReturn(-tmp)
 			return linux.SECCOMP_RET_ERRNO
 		}
+
+	case linux.SECCOMP_RET_USER_NOTIF:
+		// gVisor does not support seccomp user notification (there is no
+		// way to attach a listener to a filter), so behave as Linux does
+		// when a filter returns SECCOMP_RET_USER_NOTIF and no listener is
+		// attached: the system call is not executed and fails with ENOSYS.
+		// See kernel/seccomp.c:seccomp_do_user_notification().
+		// This useless-looking temporary is needed because Go.
+		tmp := uintptr(unix.ENOSYS)
+		t.Arch().SetReturn(-tmp)
+		return linux.SECCOMP_RET_ERRNO
+
+	case linux.SECCOMP_RET_LOG:
+		// "Results in the system call being executed after the action has
+		// been logged." Linux logs to the kernel audit log; log to the
+		// sentry debug log instead.
+		t.Debugf("Syscall %d: logged by seccomp filter", sysno)
+		return linux.SECCOMP_RET_ALLOW
 
 	case linux.SECCOMP_RET_ALLOW:
 		// "Results in the system call being executed."
@@ -142,8 +170,11 @@ func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip h
 		// SIGKILL."
 
 	default:
-		// consistent with Linux
-		return linux.SECCOMP_RET_KILL_THREAD
+		// Unknown actions kill the entire process, not just the thread:
+		// Linux's __seccomp_filter() groups the default case with
+		// SECCOMP_RET_KILL_PROCESS (see commit 4d671d922d51, "seccomp: kill
+		// process instead of thread for unknown actions").
+		return linux.SECCOMP_RET_KILL_PROCESS
 	}
 	return action
 }

--- a/pkg/sentry/kernel/seccomp.go
+++ b/pkg/sentry/kernel/seccomp.go
@@ -95,7 +95,11 @@ func seccompSiginfo(t *Task, errno, sysno int32, ip hostarch.Addr) *linux.Signal
 // Preconditions: The caller must be running on the task goroutine.
 func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip hostarch.Addr) linux.BPFAction {
 	result := linux.BPFAction(t.evaluateSyscallFilters(sysno, args, ip))
-	action := result & linux.SECCOMP_RET_ACTION
+	// The action must be masked with SECCOMP_RET_ACTION_FULL rather than
+	// SECCOMP_RET_ACTION; the latter drops the high bit, which would truncate
+	// SECCOMP_RET_KILL_PROCESS (0x80000000) to SECCOMP_RET_KILL_THREAD (0).
+	// Compare Linux's kernel/seccomp.c:__seccomp_filter().
+	action := result & linux.SECCOMP_RET_ACTION_FULL
 	switch action {
 	case linux.SECCOMP_RET_TRAP:
 		// "Results in the kernel sending a SIGSYS signal to the triggering
@@ -126,6 +130,11 @@ func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip h
 
 	case linux.SECCOMP_RET_ALLOW:
 		// "Results in the system call being executed."
+
+	case linux.SECCOMP_RET_KILL_PROCESS:
+		// "Results in the entire process exiting immediately without executing
+		// the system call. The exit status of the task will be SIGSYS, not
+		// SIGKILL."
 
 	case linux.SECCOMP_RET_KILL_THREAD:
 		// "Results in the task exiting immediately without executing the
@@ -186,7 +195,13 @@ func (t *Task) evaluateSyscallFilters(sysno int32, args arch.SyscallArguments, i
 		// "The ordering ensures that a min_t() over composed return values
 		// always selects the least permissive choice." -
 		// include/uapi/linux/seccomp.h
-		if (thisRet & linux.SECCOMP_RET_ACTION) < (ret & linux.SECCOMP_RET_ACTION) {
+		//
+		// Note that the comparison is signed over the full action mask,
+		// matching ACTION_ONLY() in Linux's kernel/seccomp.c:
+		// "#define ACTION_ONLY(ret) ((s32)((ret) & (SECCOMP_RET_ACTION_FULL)))"
+		// This gives SECCOMP_RET_KILL_PROCESS (0x80000000, negative as s32)
+		// precedence over all other actions.
+		if int32(thisRet&linux.SECCOMP_RET_ACTION_FULL) < int32(ret&linux.SECCOMP_RET_ACTION_FULL) {
 			ret = thisRet
 		}
 	}
@@ -252,7 +267,7 @@ func (ts *taskSeccomp) populateCache(t *Task) {
 				sysnoIsCacheable = false
 				break
 			}
-			if (linux.BPFAction(result) & linux.SECCOMP_RET_ACTION) < (ret & linux.SECCOMP_RET_ACTION) {
+			if int32(linux.BPFAction(result)&linux.SECCOMP_RET_ACTION_FULL) < int32(ret&linux.SECCOMP_RET_ACTION_FULL) {
 				ret = linux.BPFAction(result)
 			}
 		}

--- a/pkg/sentry/kernel/task_syscall.go
+++ b/pkg/sentry/kernel/task_syscall.go
@@ -242,6 +242,10 @@ func (t *Task) doSyscall() taskRunState {
 			return (*runSyscallExit)(nil)
 		case linux.SECCOMP_RET_ALLOW:
 			// ok
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("Syscall %d: process killed by seccomp", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
 		case linux.SECCOMP_RET_KILL_THREAD:
 			t.Debugf("Syscall %d: killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
@@ -399,6 +403,10 @@ func (t *Task) doVsyscall(addr hostarch.Addr, sysno uintptr) taskRunState {
 		case linux.SECCOMP_RET_TRACE:
 			t.Debugf("vsyscall %d, caller %x: stopping for PTRACE_EVENT_SECCOMP", sysno, t.Arch().Value(caller))
 			return &runVsyscallAfterPtraceEventSeccomp{addr, sysno, caller}
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("vsyscall %d: process killed by seccomp", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
 		case linux.SECCOMP_RET_KILL_THREAD:
 			t.Debugf("vsyscall %d: killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))

--- a/pkg/sentry/syscalls/linux/sys_seccomp.go
+++ b/pkg/sentry/syscalls/linux/sys_seccomp.go
@@ -19,6 +19,7 @@ import (
 	"gvisor.dev/gvisor/pkg/bpf"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/marshal/primitive"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 )
@@ -39,10 +40,40 @@ type userSockFprog struct {
 	Filter uint64
 }
 
+// seccompGetActionAvail implements seccomp(SECCOMP_GET_ACTION_AVAIL).
+func seccompGetActionAvail(t *kernel.Task, flags uint64, addr hostarch.Addr) error {
+	if flags != 0 {
+		return linuxerr.EINVAL
+	}
+	var actionParam primitive.Uint32
+	if _, err := actionParam.CopyIn(t, addr); err != nil {
+		return err
+	}
+	switch linux.BPFAction(actionParam) {
+	case linux.SECCOMP_RET_KILL_PROCESS,
+		linux.SECCOMP_RET_KILL_THREAD,
+		linux.SECCOMP_RET_TRAP,
+		linux.SECCOMP_RET_ERRNO,
+		linux.SECCOMP_RET_TRACE,
+		linux.SECCOMP_RET_LOG,
+		linux.SECCOMP_RET_ALLOW:
+		return nil
+	}
+	// This includes SECCOMP_RET_USER_NOTIF: gVisor does not support seccomp
+	// user notification, so don't advertise it.
+	return linuxerr.EOPNOTSUPP
+}
+
 // seccomp applies a seccomp policy to the current task.
 func seccomp(t *kernel.Task, mode, flags uint64, addr hostarch.Addr) (*kernel.SyscallControl, error) {
-	// We only support SECCOMP_SET_MODE_FILTER at the moment.
-	if mode != linux.SECCOMP_SET_MODE_FILTER {
+	// We support SECCOMP_SET_MODE_FILTER and SECCOMP_GET_ACTION_AVAIL at the
+	// moment.
+	switch mode {
+	case linux.SECCOMP_SET_MODE_FILTER:
+		// Handled below.
+	case linux.SECCOMP_GET_ACTION_AVAIL:
+		return nil, seccompGetActionAvail(t, flags, addr)
+	default:
 		// Unsupported mode.
 		return nil, linuxerr.EINVAL
 	}

--- a/runsc/specutils/seccomp/seccomp.go
+++ b/runsc/specutils/seccomp/seccomp.go
@@ -30,8 +30,9 @@ import (
 )
 
 var (
-	killThreadAction = seccomp.KillThread
-	trapAction       = seccomp.Trap
+	killThreadAction  = seccomp.KillThread
+	killProcessAction = seccomp.KillProcess
+	trapAction        = seccomp.Trap
 	// runc always returns EPERM as the errorcode for SECCOMP_RET_ERRNO
 	errnoAction = seccomp.ReturnError.Code(uint16(unix.EPERM))
 	// runc always returns EPERM as the errorcode for SECCOMP_RET_TRACE
@@ -95,11 +96,13 @@ func lookupSyscallNo(arch uint32, name string) (uint32, error) {
 
 // convertAction converts a LinuxSeccompAction to BPFAction
 func convertAction(act specs.LinuxSeccompAction) (seccomp.Action, error) {
-	// TODO(gvisor.dev/issue/3124): Update specs package to include ActLog and ActKillProcess.
+	// TODO(gvisor.dev/issue/3124): Add support for ActLog.
 	// LINT.IfChange
 	switch act {
-	case specs.ActKill:
+	case specs.ActKill, specs.ActKillThread:
 		return killThreadAction, nil
+	case specs.ActKillProcess:
+		return killProcessAction, nil
 	case specs.ActTrap:
 		return trapAction, nil
 	case specs.ActErrno:
@@ -245,6 +248,8 @@ func KnownActions() []string {
 	// LINT.IfChange
 	return []string{
 		string(specs.ActKill),
+		string(specs.ActKillThread),
+		string(specs.ActKillProcess),
 		string(specs.ActTrap),
 		string(specs.ActErrno),
 		string(specs.ActTrace),

--- a/runsc/specutils/seccomp/seccomp_test.go
+++ b/runsc/specutils/seccomp/seccomp_test.go
@@ -74,6 +74,30 @@ var (
 			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.EPERM))),
 		},
 		{
+			name: "default_kill_process",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActKillProcess,
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_KILL_PROCESS),
+		},
+		{
+			name: "match_name_kill_process",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"getcwd",
+						},
+						Action: specs.ActKillProcess,
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "getcwd", nil),
+			expected: uint32(linux.SECCOMP_RET_KILL_PROCESS),
+		},
+		{
 			name: "deny_arch",
 			config: specs.LinuxSeccomp{
 				DefaultAction: specs.ActAllow,

--- a/test/syscalls/linux/seccomp.cc
+++ b/test/syscalls/linux/seccomp.cc
@@ -46,6 +46,10 @@
 #define SYS_SECCOMP 1
 #endif
 
+#ifndef SECCOMP_RET_KILL_PROCESS
+#define SECCOMP_RET_KILL_PROCESS 0x80000000U
+#endif
+
 namespace gvisor {
 namespace testing {
 
@@ -161,6 +165,34 @@ void RegisterSignalHandler(int signum,
   MaybeSave();
 }
 
+// Spawns a thread that invokes kFilteredSyscall, which is expected to kill
+// the entire thread group, then exits 0 if the original thread survives.
+// Must be called from a forked, otherwise-single-threaded child process whose
+// seccomp filters return SECCOMP_RET_KILL_PROCESS for kFilteredSyscall.
+// Async-signal-safe.
+void TriggerFilteredSyscallInCloneThreadThenExit(void* stack_top) {
+  // Pass CLONE_VFORK to block the original thread in the child process until
+  // the clone thread exits.
+  //
+  // N.B. clone(2) is not officially async-signal-safe, but at minimum glibc's
+  // x86_64 implementation is safe. See glibc
+  // sysdeps/unix/sysv/linux/x86_64/clone.S.
+  clone(
+      +[](void* arg) {
+        syscall(kFilteredSyscall);  // should kill the whole thread group
+        _exit(1);                   // should be unreachable
+        return 2;  // should be very unreachable, shut up the compiler
+      },
+      stack_top,
+      CLONE_FILES | CLONE_FS | CLONE_SIGHAND | CLONE_THREAD | CLONE_VM |
+          CLONE_VFORK,
+      nullptr);
+  // This is only reachable if the seccomp violation in the clone thread
+  // killed only that thread, i.e. if SECCOMP_RET_KILL_PROCESS incorrectly
+  // behaved like SECCOMP_RET_KILL_THREAD (gvisor.dev/issue/13819).
+  _exit(0);
+}
+
 // All of the following tests execute in a subprocess to ensure that each test
 // is run in a separate process. This avoids cross-contamination of seccomp
 // state between tests, and is necessary to ensure that test processes killed
@@ -214,6 +246,44 @@ TEST(SeccompTest, RetKillOnlyKillsOneThread) {
   int status;
   ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
   EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "status " << status;
+}
+
+TEST(SeccompTest, RetKillProcessCausesDeathBySIGSYS) {
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL_PROCESS);
+    syscall(kFilteredSyscall);
+    TEST_CHECK_MSG(false, "Survived invocation of test syscall");
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
+// Unlike SECCOMP_RET_KILL_THREAD, SECCOMP_RET_KILL_PROCESS kills the entire
+// thread group, not only the thread that invoked the filtered syscall.
+// Regression test for gvisor.dev/issue/13819, in which
+// SECCOMP_RET_KILL_PROCESS was truncated to SECCOMP_RET_KILL_THREAD.
+TEST(SeccompTest, RetKillProcessKillsAllThreads) {
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE));
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL_PROCESS);
+    TriggerFilteredSyscallInCloneThreadThenExit(stack.endptr());
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
       << "status " << status;
 }
 
@@ -298,6 +368,25 @@ TEST(SeccompTest, RetKillVsyscallCausesDeathBySIGSYS) {
     // Register a signal handler for SIGSYS that we don't expect to be invoked.
     RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
     ApplySeccompFilter(SYS_time, SECCOMP_RET_KILL);
+    vsyscall_time(nullptr);  // Should result in death.
+    TEST_CHECK_MSG(false, "Survived invocation of test syscall");
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
+TEST(SeccompTest, RetKillProcessVsyscallCausesDeathBySIGSYS) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(IsVsyscallEnabled()));
+  SKIP_IF(PlatformSupportVsyscall() == PlatformSupport::NotSupported);
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(SYS_time, SECCOMP_RET_KILL_PROCESS);
     vsyscall_time(nullptr);  // Should result in death.
     TEST_CHECK_MSG(false, "Survived invocation of test syscall");
   }
@@ -429,6 +518,51 @@ TEST(SeccompTest, LeastPermissiveFilterReturnValueApplies) {
     ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_ERRNO | ENOTNAM);
     syscall(kFilteredSyscall);
     TEST_CHECK_MSG(false, "Survived invocation of test syscall");
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
+// The return value comparison across stacked filters is signed over the full
+// action mask (see ACTION_ONLY() in Linux's kernel/seccomp.c), so
+// SECCOMP_RET_KILL_PROCESS (0x80000000) is the least permissive action and
+// takes precedence over SECCOMP_RET_KILL_THREAD (0), regardless of the order
+// in which the filters were installed.
+TEST(SeccompTest, RetKillProcessTakesPrecedenceOverRetKillThread) {
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE));
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL_PROCESS);
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL);
+    TriggerFilteredSyscallInCloneThreadThenExit(stack.endptr());
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
+// Same as RetKillProcessTakesPrecedenceOverRetKillThread, with the filters
+// installed in the opposite order.
+TEST(SeccompTest, RetKillProcessTakesPrecedenceOverEarlierRetKillThread) {
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE));
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL);
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL_PROCESS);
+    TriggerFilteredSyscallInCloneThreadThenExit(stack.endptr());
   }
   ASSERT_THAT(pid, SyscallSucceeds());
   int status;

--- a/test/syscalls/linux/seccomp.cc
+++ b/test/syscalls/linux/seccomp.cc
@@ -50,6 +50,18 @@
 #define SECCOMP_RET_KILL_PROCESS 0x80000000U
 #endif
 
+#ifndef SECCOMP_RET_USER_NOTIF
+#define SECCOMP_RET_USER_NOTIF 0x7fc00000U
+#endif
+
+#ifndef SECCOMP_RET_LOG
+#define SECCOMP_RET_LOG 0x7ffc0000U
+#endif
+
+#ifndef SECCOMP_GET_ACTION_AVAIL
+#define SECCOMP_GET_ACTION_AVAIL 2
+#endif
+
 namespace gvisor {
 namespace testing {
 
@@ -177,16 +189,18 @@ void TriggerFilteredSyscallInCloneThreadThenExit(void* stack_top) {
   // N.B. clone(2) is not officially async-signal-safe, but at minimum glibc's
   // x86_64 implementation is safe. See glibc
   // sysdeps/unix/sysv/linux/x86_64/clone.S.
-  clone(
-      +[](void* arg) {
-        syscall(kFilteredSyscall);  // should kill the whole thread group
-        _exit(1);                   // should be unreachable
-        return 2;  // should be very unreachable, shut up the compiler
-      },
-      stack_top,
-      CLONE_FILES | CLONE_FS | CLONE_SIGHAND | CLONE_THREAD | CLONE_VM |
-          CLONE_VFORK,
-      nullptr);
+  TEST_PCHECK(clone(
+                  +[](void* arg) {
+                    syscall(kFilteredSyscall);  // should kill the whole
+                                                // thread group
+                    _exit(1);                   // should be unreachable
+                    return 2;  // should be very unreachable, shut up the
+                               // compiler
+                  },
+                  stack_top,
+                  CLONE_FILES | CLONE_FS | CLONE_SIGHAND | CLONE_THREAD |
+                      CLONE_VM | CLONE_VFORK,
+                  nullptr) != -1);
   // This is only reachable if the seccomp violation in the clone thread
   // killed only that thread, i.e. if SECCOMP_RET_KILL_PROCESS incorrectly
   // behaved like SECCOMP_RET_KILL_THREAD (gvisor.dev/issue/13819).
@@ -284,6 +298,89 @@ TEST(SeccompTest, RetKillProcessKillsAllThreads) {
   int status;
   ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
   EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
+// Installing an uncacheable filter alongside the SECCOMP_RET_KILL_PROCESS
+// filter forces the sentry to evaluate the filters at syscall time rather
+// than serving the action from its per-syscall-number cache, covering both
+// evaluation paths.
+TEST(SeccompTest, RetKillProcessKillsAllThreadsNonCacheable) {
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE));
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL_PROCESS);
+    ApplyUncacheableFilter(kFilteredSyscall);
+    TriggerFilteredSyscallInCloneThreadThenExit(stack.endptr());
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
+// Unknown filter return values kill the entire thread group, like
+// SECCOMP_RET_KILL_PROCESS. See Linux commit 4d671d922d51 ("seccomp: kill
+// process instead of thread for unknown actions").
+TEST(SeccompTest, RetUnknownActionKillsProcess) {
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE));
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, 0x00010000);
+    TriggerFilteredSyscallInCloneThreadThenExit(stack.endptr());
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
+TEST(SeccompTest, RetLogAllowsSyscall) {
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(SYS_getpid, SECCOMP_RET_LOG);
+    // The syscall must be executed: getpid() succeeds rather than being
+    // killed, trapped, or failed with an error.
+    TEST_CHECK(syscall(SYS_getpid) > 0);
+    _exit(0);
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "status " << status;
+}
+
+// A filter returning SECCOMP_RET_USER_NOTIF without an attached listener
+// causes the syscall to fail with ENOSYS without being executed. gVisor never
+// has listeners (SECCOMP_FILTER_FLAG_NEW_LISTENER is unsupported), so this is
+// always the behavior there; on Linux, filters installed via prctl cannot
+// have a listener either.
+TEST(SeccompTest, RetUserNotifWithoutListenerReturnsENOSYS) {
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(SYS_getpid, SECCOMP_RET_USER_NOTIF);
+    TEST_CHECK(syscall(SYS_getpid) == -1 && errno == ENOSYS);
+    _exit(0);
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
       << "status " << status;
 }
 
@@ -428,6 +525,22 @@ TEST(SeccompTest, RetErrnoReturnsErrno) {
       << "status " << status;
 }
 
+// The errno provided by a SECCOMP_RET_ERRNO filter is capped at MAX_ERRNO
+// (4095). See Linux's kernel/seccomp.c:__seccomp_filter().
+TEST(SeccompTest, RetErrnoIsCappedAtMaxErrno) {
+  pid_t const pid = fork();
+  if (pid == 0) {
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_ERRNO | 5000);
+    TEST_CHECK(syscall(kFilteredSyscall) == -1 && errno == 4095);
+    _exit(0);
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "status " << status;
+}
+
 TEST(SeccompTest, RetAllowAllowsSyscall) {
   pid_t const pid = fork();
   if (pid == 0) {
@@ -505,6 +618,48 @@ TEST(SeccompTest, SeccompRejectsUnknownFlags) {
   ASSERT_THAT(
       syscall(__NR_seccomp, SECCOMP_SET_MODE_FILTER, kInvalidFlag, nullptr),
       SyscallFailsWithErrno(EINVAL));
+}
+
+TEST(SeccompTest, SeccompGetActionAvail) {
+  uint32_t action = SECCOMP_RET_KILL_THREAD;
+  // Probe for SECCOMP_GET_ACTION_AVAIL support; kernels predating it fail
+  // with EINVAL.
+  SKIP_IF(syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 0, &action) == -1 &&
+          errno == EINVAL);
+
+  const uint32_t supported_actions[] = {
+      SECCOMP_RET_KILL_PROCESS, SECCOMP_RET_KILL_THREAD, SECCOMP_RET_TRAP,
+      SECCOMP_RET_ERRNO,        SECCOMP_RET_TRACE,       SECCOMP_RET_LOG,
+      SECCOMP_RET_ALLOW,
+  };
+  for (uint32_t supported_action : supported_actions) {
+    action = supported_action;
+    EXPECT_THAT(syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 0, &action),
+                SyscallSucceeds())
+        << "action " << std::hex << supported_action;
+  }
+
+  // An unknown action value is reported as unavailable.
+  action = 0x12340000;
+  EXPECT_THAT(syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 0, &action),
+              SyscallFailsWithErrno(EOPNOTSUPP));
+
+  // Flags must be zero.
+  action = SECCOMP_RET_KILL_PROCESS;
+  EXPECT_THAT(syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 7, &action),
+              SyscallFailsWithErrno(EINVAL));
+
+  // The action is read from user memory.
+  EXPECT_THAT(syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 0, nullptr),
+              SyscallFailsWithErrno(EFAULT));
+
+  // gVisor does not support seccomp user notification, so it reports
+  // SECCOMP_RET_USER_NOTIF as unavailable; modern Linux supports it.
+  action = SECCOMP_RET_USER_NOTIF;
+  if (IsRunningOnGvisor()) {
+    EXPECT_THAT(syscall(__NR_seccomp, SECCOMP_GET_ACTION_AVAIL, 0, &action),
+                SyscallFailsWithErrno(EOPNOTSUPP));
+  }
 }
 
 TEST(SeccompTest, LeastPermissiveFilterReturnValueApplies) {


### PR DESCRIPTION
@AzoteGwei
Use the full seccomp action mask so KILL_PROCESS is not treated as KILL_THREAD. Align related action handling with Linux and add coverage for cached and uncached filters.
Fixes #13819.Closes #13819.