### PR TITLE
Add support for user systemd in systemd cgroup driver

### DIFF
--- a/g3doc/user_guide/systemd.md
+++ b/g3doc/user_guide/systemd.md
@@ -56,9 +56,15 @@ The resource limits of the systemd unit are set by runsc by translating the
 runtime spec resources to systemd unit properties.
 
 Such translation is by no means complete, as there are some cgroup properties
-that can not be set via systemd. Therefore, runsc systemd cgroup driver is
-backed by fs driver (in other words, cgroup limits are first set via systemd
-unit properties, and when by writing to cgroupfs files).
+that can not be set via systemd. Resources with no systemd equivalent are
+currently not applied; unlike runc, the runsc systemd cgroup driver does not
+fall back to writing them to cgroupfs.
+
+Note that systemd accepts properties for controllers that have not been
+delegated to it, and silently does not apply them. When runsc runs
+unprivileged, controllers other than those delegated to the per-user systemd
+instance are therefore unavailable. See `systemd.resource-control(5)` and the
+`Delegate=` directive in `systemd.exec(5)`.
 
 The set of runtime spec resources which is translated by runsc to systemd unit
 properties depends on kernel cgroup version being used (v1 or v2), and on the

--- a/runsc/cgroup/cgroup_v2.go
+++ b/runsc/cgroup/cgroup_v2.go
@@ -118,8 +118,39 @@ func (c *cgroupV2) createCgroupPaths() (bool, error) {
 		}
 		// enable all known controllers for subtree
 		if i < len(elements)-1 {
-			if err := writeFile(filepath.Join(current, subtreeControl), []byte(val), 0700); err != nil {
-				return false, err
+			subtreeFile := filepath.Join(current, subtreeControl)
+			if err := writeFile(subtreeFile, []byte(val), 0700); err != nil {
+				// Enabling all controllers at once fails if any single one of them
+				// cannot be enabled, so retry them individually before giving up.
+				//
+				// An unprivileged caller cannot enable controllers above the cgroup
+				// that was delegated to it, which is the normal case for rootless
+				// containers. This is not fatal: a controller that is genuinely
+				// unusable reports an error when its limits are applied. runc behaves
+				// the same way, see
+				// https://github.com/opencontainers/cgroups/blob/79cbc7c/fs2/create.go
+				var mandatoryFailed, otherFailed []string
+				var mandatoryErr error
+				for _, controller := range c.Controllers {
+					err := writeFile(subtreeFile, []byte("+"+controller), 0700)
+					if err == nil {
+						continue
+					}
+					if ctrlr, ok := controllers2[controller]; ok && !ctrlr.optional() {
+						mandatoryFailed = append(mandatoryFailed, controller)
+						if mandatoryErr == nil {
+							mandatoryErr = err
+						}
+						continue
+					}
+					otherFailed = append(otherFailed, controller)
+				}
+				if len(otherFailed) > 0 {
+					log.Debugf("Unable to enable cgroup controllers %s in %q: %v", strings.Join(otherFailed, ","), current, err)
+				}
+				if len(mandatoryFailed) > 0 {
+					log.Warningf("Unable to enable mandatory cgroup controllers %s in %q: %v; resource limits for them will NOT be applied", strings.Join(mandatoryFailed, ","), current, mandatoryErr)
+				}
 			}
 		}
 	}

--- a/runsc/cgroup/systemd.go
+++ b/runsc/cgroup/systemd.go
@@ -61,7 +61,41 @@ type cgroupSystemd struct {
 	ManagerCG string
 
 	properties []systemdDbus.Property
-	dbusConn   *systemdDbus.Conn
+	// propControllers are the controllers for which properties were generated,
+	// i.e. those the runtime spec actually requests limits for.
+	propControllers []string
+	dbusConn        *systemdDbus.Conn
+}
+
+// checkControllers returns an error if a limit was requested for a controller
+// that is not available in the cgroup. systemd accepts properties for
+// controllers it was not delegated and silently drops them, so looking
+// afterwards is the only way to know whether a limit took effect.
+//
+// Preconditions: The cgroup must have been created.
+func (c *cgroupSystemd) checkControllers() error {
+	if len(c.propControllers) == 0 {
+		return nil
+	}
+	path := c.MakePath("")
+	data, err := os.ReadFile(filepath.Join(path, controllersFile))
+	if err != nil {
+		return fmt.Errorf("reading cgroup controllers for %q: %w", path, err)
+	}
+	available := make(map[string]struct{})
+	for _, name := range strings.Fields(string(data)) {
+		available[name] = struct{}{}
+	}
+	var missing []string
+	for _, name := range c.propControllers {
+		if _, ok := available[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("resource limits were requested for cgroup controllers %s, but they are not available in %q; they may not be delegated to this systemd instance", strings.Join(missing, ","), path)
+	}
+	return nil
 }
 
 // translateUID translates uid through the user namespace ID map in mapPath.
@@ -316,6 +350,11 @@ func (c *cgroupSystemd) Join() (func(), error) {
 	if _, err = c.createCgroupPaths(); err != nil {
 		return nil, err
 	}
+	// The scope is a transient unit, so systemd releases it once this process
+	// exits; returning an error here does not leak it.
+	if err := c.checkControllers(); err != nil {
+		return nil, err
+	}
 	return clean.Release(), nil
 }
 
@@ -434,6 +473,8 @@ func newProp(name string, units any) systemdDbus.Property {
 }
 
 func (c *cgroupSystemd) updateControllersProps(res *specs.LinuxResources) error {
+	// Update() may be called more than once.
+	c.propControllers = nil
 	for controllerName, ctrlr := range controllers2 {
 		// First check if our controller is found in the system.
 		found := false
@@ -447,6 +488,9 @@ func (c *cgroupSystemd) updateControllersProps(res *specs.LinuxResources) error 
 			props, err := ctrlr.generateProperties(res)
 			if err != nil {
 				return err
+			}
+			if len(props) > 0 {
+				c.propControllers = append(c.propControllers, controllerName)
 			}
 			c.properties = append(c.properties, props...)
 			continue

--- a/runsc/cgroup/systemd.go
+++ b/runsc/cgroup/systemd.go
@@ -52,9 +52,129 @@ type cgroupSystemd struct {
 	Parent string
 	// ScopePrefix is the prefix for the scope name.
 	ScopePrefix string
+	// Rootless indicates that the unit is managed by the per-user systemd
+	// instance rather than the system instance.
+	Rootless bool
+	// ManagerCG is the cgroup of the systemd instance that manages this unit.
+	// Unit cgroups are nested under it. It is empty for the system instance,
+	// which manages units at the root of the hierarchy.
+	ManagerCG string
 
 	properties []systemdDbus.Property
 	dbusConn   *systemdDbus.Conn
+}
+
+// translateUID translates uid through the user namespace ID map in mapPath.
+// See user_namespaces(7) for the format.
+func translateUID(uid int, mapPath string) int {
+	data, err := os.ReadFile(mapPath)
+	if err != nil {
+		log.Debugf("Unable to read %q, using UID %d as-is: %v", mapPath, uid, err)
+		return uid
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			continue
+		}
+		inside, err1 := strconv.ParseUint(fields[0], 10, 32)
+		outside, err2 := strconv.ParseUint(fields[1], 10, 32)
+		length, err3 := strconv.ParseUint(fields[2], 10, 32)
+		if err1 != nil || err2 != nil || err3 != nil {
+			continue
+		}
+		if u := uint64(uid); u >= inside && u < inside+length {
+			return int(outside + (u - inside))
+		}
+	}
+	log.Debugf("UID %d is not mapped in %q, using it as-is", uid, mapPath)
+	return uid
+}
+
+// hostUID returns the caller's effective UID as seen outside of any user
+// namespace it may be running in.
+func hostUID() int {
+	return translateUID(os.Geteuid(), "/proc/self/uid_map")
+}
+
+// useUserSystemd reports whether cgroup operations should be directed at the
+// per-user systemd instance rather than the system instance. Unprivileged users
+// cannot create system-wide transient units, but they can create per-user ones.
+//
+// Note that geteuid() alone is not sufficient: container runtimes may run runsc
+// inside a user namespace in which the unprivileged caller is mapped to UID 0.
+func useUserSystemd() bool {
+	return hostUID() != 0
+}
+
+// userBusAddress returns the address of the caller's session bus, which is
+// where the per-user systemd instance can be reached.
+func userBusAddress() (string, error) {
+	if addr := os.Getenv("DBUS_SESSION_BUS_ADDRESS"); addr != "" {
+		return addr, nil
+	}
+	// Container runtimes do not always propagate DBUS_SESSION_BUS_ADDRESS. The
+	// session bus lives at a well-known path under XDG_RUNTIME_DIR, so fall back
+	// to that when the socket is present.
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		busPath := filepath.Join(dir, "bus")
+		if _, err := os.Stat(busPath); err == nil {
+			return "unix:path=" + dbus.EscapeBusAddressValue(busPath), nil
+		}
+	}
+	return "", errors.New("no session bus: DBUS_SESSION_BUS_ADDRESS unset and $XDG_RUNTIME_DIR/bus missing")
+}
+
+// newDBusConn connects to the systemd instance that manages this cgroup.
+func (c *cgroupSystemd) newDBusConn(ctx context.Context) (*systemdDbus.Conn, error) {
+	if !c.Rootless {
+		return systemdDbus.NewWithContext(ctx)
+	}
+	addr, err := userBusAddress()
+	if err != nil {
+		return nil, err
+	}
+	// systemdDbus.NewUserConnectionContext is not usable here: it authenticates
+	// as geteuid(), which is 0 inside the user namespace a rootless runtime puts
+	// us in, and it falls back to spawning dbus-launch(1) when it cannot find an
+	// existing bus.
+	//
+	// Note that systemdDbus.NewConnection calls this function more than once and
+	// requires each call to return an independent connection.
+	uid := hostUID()
+	return systemdDbus.NewConnection(func() (*dbus.Conn, error) {
+		conn, err := dbus.Dial(addr, dbus.WithContext(ctx))
+		if err != nil {
+			return nil, fmt.Errorf("dialing %q: %w", addr, err)
+		}
+		// The bus resolves peer credentials in its own user namespace, so it must
+		// be given the UID from that namespace rather than the one we see.
+		if err := conn.Auth([]dbus.Auth{dbus.AuthExternal(strconv.Itoa(uid))}); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("authenticating to %q as UID %d: %w", addr, uid, err)
+		}
+		if err := conn.Hello(); err != nil {
+			_ = conn.Close()
+			return nil, fmt.Errorf("sending Hello to %q: %w", addr, err)
+		}
+		return conn, nil
+	})
+}
+
+// managerControlGroup returns the cgroup of the systemd instance that conn is
+// connected to. Units it manages are nested under it.
+func managerControlGroup(conn *systemdDbus.Conn) (string, error) {
+	// GetManagerProperty returns the property's dbus.Variant rendering, which
+	// quotes strings.
+	quoted, err := conn.GetManagerProperty("ControlGroup")
+	if err != nil {
+		return "", fmt.Errorf("getting systemd ControlGroup property: %w", err)
+	}
+	cg, err := strconv.Unquote(quoted)
+	if err != nil {
+		return "", fmt.Errorf("parsing systemd ControlGroup property %q: %w", quoted, err)
+	}
+	return cg, nil
 }
 
 func newCgroupV2Systemd(cgv2 *cgroupV2) (*cgroupSystemd, error) {
@@ -75,9 +195,8 @@ func newCgroupV2Systemd(cgv2 *cgroupV2) (*cgroupSystemd, error) {
 	if err := validSlice(cg.Parent); err != nil {
 		return nil, fmt.Errorf("%w: %v", ErrInvalidGroupPath, err)
 	}
-	// Rewrite Path so that it is compatible with cgroupv2 methods.
-	cg.Path = filepath.Join(expandSlice(cg.Parent), cg.unitName())
-	conn, err := systemdDbus.NewWithContext(ctx)
+	cg.Rootless = useUserSystemd()
+	conn, err := cg.newDBusConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +207,13 @@ func newCgroupV2Systemd(cgv2 *cgroupV2) (*cgroupSystemd, error) {
 	if version < 244 {
 		return nil, fmt.Errorf("systemd version %d not supported, please upgrade to at least 244", version)
 	}
+	if cg.Rootless {
+		if cg.ManagerCG, err = managerControlGroup(conn); err != nil {
+			return nil, err
+		}
+	}
+	// Rewrite Path so that it is compatible with cgroupv2 methods.
+	cg.Path = filepath.Join(cg.ManagerCG, expandSlice(cg.Parent), cg.unitName())
 	cg.dbusConn = conn
 	return cg, err
 }
@@ -96,6 +222,8 @@ func newCgroupV2Systemd(cgv2 *cgroupV2) (*cgroupSystemd, error) {
 // unit.
 func (c *cgroupSystemd) Install(res *specs.LinuxResources) error {
 	log.Debugf("Installing systemd cgroup resource controller under %v", c.Parent)
+	// The slice is named relative to the systemd instance that manages it, so it
+	// must not be prefixed with ManagerCG even though the cgroup path is.
 	c.properties = append(c.properties, systemdDbus.PropSlice(c.Parent))
 	c.properties = append(c.properties, systemdDbus.PropDescription("Secure container "+c.Name))
 	pid := os.Getpid()
@@ -122,7 +250,7 @@ func (c *cgroupSystemd) Update(res *specs.LinuxResources) error {
 	}
 
 	ctx := context.Background()
-	conn, err := systemdDbus.NewWithContext(ctx)
+	conn, err := c.newDBusConn(ctx)
 	if err != nil {
 		return err
 	}
@@ -141,7 +269,7 @@ func (c *cgroupSystemd) unitName() string {
 // MakePath builds a path to the given controller.
 func (c *cgroupSystemd) MakePath(string) string {
 	fullSlicePath := expandSlice(c.Parent)
-	path := filepath.Join(c.Mountpoint, fullSlicePath, c.unitName())
+	path := filepath.Join(c.Mountpoint, c.ManagerCG, fullSlicePath, c.unitName())
 	return path
 }
 
@@ -155,7 +283,7 @@ func (c *cgroupSystemd) Join() (func(), error) {
 	clean := cleanup.Make(func() { _ = c.Uninstall() })
 	defer clean.Clean()
 
-	conn, err := systemdDbus.NewWithContext(ctx)
+	conn, err := c.newDBusConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +311,7 @@ func (c *cgroupSystemd) Join() (func(), error) {
 		}
 		return clean.Release(), nil
 	} else {
-		return nil, fmt.Errorf("systemd error: %v", err)
+		return nil, fmt.Errorf("systemd error: %w", err)
 	}
 	if _, err = c.createCgroupPaths(); err != nil {
 		return nil, err

--- a/runsc/cgroup/systemd_test.go
+++ b/runsc/cgroup/systemd_test.go
@@ -226,6 +226,69 @@ func TestMakePath(t *testing.T) {
 	}
 }
 
+func TestCheckControllers(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		controllers string
+		requested   []string
+		wantErr     bool
+	}{
+		{
+			name:        "nothing requested",
+			controllers: "cpu memory\n",
+			requested:   nil,
+		},
+		{
+			name:        "all available",
+			controllers: "cpuset cpu io memory pids\n",
+			requested:   []string{"cpu", "memory"},
+		},
+		{
+			// systemd accepts properties for controllers it was not delegated and
+			// silently drops them, so this must be caught here.
+			name:        "requested but not delegated",
+			controllers: "cpuset cpu memory pids\n",
+			requested:   []string{"cpu", "io"},
+			wantErr:     true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cg := cgroupSystemd{
+				Name:            "123",
+				Parent:          "test.slice",
+				ScopePrefix:     "runsc",
+				propControllers: tc.requested,
+				cgroupV2:        cgroupV2{Mountpoint: t.TempDir()},
+			}
+			path := cg.MakePath("")
+			if err := os.MkdirAll(path, 0755); err != nil {
+				t.Fatalf("os.MkdirAll(%q): %v", path, err)
+			}
+			ctrlFile := filepath.Join(path, controllersFile)
+			if err := os.WriteFile(ctrlFile, []byte(tc.controllers), 0644); err != nil {
+				t.Fatalf("os.WriteFile(%q): %v", ctrlFile, err)
+			}
+			err := cg.checkControllers()
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Errorf("checkControllers() error = %v, wantErr = %t", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckControllersUnreadable(t *testing.T) {
+	cg := cgroupSystemd{
+		Name:            "123",
+		Parent:          "test.slice",
+		ScopePrefix:     "runsc",
+		propControllers: []string{"cpu"},
+		cgroupV2:        cgroupV2{Mountpoint: t.TempDir()},
+	}
+	if err := cg.checkControllers(); err == nil {
+		t.Error("checkControllers() = nil, want error when cgroup.controllers is missing")
+	}
+}
+
 func TestInstall(t *testing.T) {
 	const dialErr = "dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory"
 	for _, tc := range []struct {

--- a/runsc/cgroup/systemd_test.go
+++ b/runsc/cgroup/systemd_test.go
@@ -18,6 +18,8 @@ package cgroup
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
@@ -81,6 +83,146 @@ func TestExpandSlice(t *testing.T) {
 	expanded := expandSlice(original)
 	if expanded != want {
 		t.Errorf("expandSlice(%q) = %q, want %q", original, expanded, want)
+	}
+}
+
+func TestTranslateUID(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		uid    int
+		uidMap string
+		want   int
+	}{
+		{
+			name:   "initial user namespace",
+			uid:    1000,
+			uidMap: "         0          0 4294967295\n",
+			want:   1000,
+		},
+		{
+			// Rootless container runtimes map the unprivileged caller to UID 0, so
+			// the UID visible to runsc says nothing about its privileges.
+			name:   "caller mapped to root",
+			uid:    0,
+			uidMap: "         0       1000          1\n         1     100000      65536\n",
+			want:   1000,
+		},
+		{
+			name:   "offset within range",
+			uid:    5,
+			uidMap: "         0       1000          1\n         1     100000      65536\n",
+			want:   100004,
+		},
+		{
+			name:   "unmapped",
+			uid:    99999,
+			uidMap: "         0       1000          1\n",
+			want:   99999,
+		},
+		{
+			name:   "malformed",
+			uid:    7,
+			uidMap: "this is not a uid map\n",
+			want:   7,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "uid_map")
+			if err := os.WriteFile(path, []byte(tc.uidMap), 0644); err != nil {
+				t.Fatalf("os.WriteFile(%q): %v", path, err)
+			}
+			if got := translateUID(tc.uid, path); got != tc.want {
+				t.Errorf("translateUID(%d, %q) = %d, want %d", tc.uid, path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTranslateUIDMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist")
+	if got := translateUID(1000, path); got != 1000 {
+		t.Errorf("translateUID(1000, %q) = %d, want 1000", path, got)
+	}
+}
+
+func TestUserBusAddress(t *testing.T) {
+	t.Run("from environment", func(t *testing.T) {
+		const want = "unix:path=/run/user/1000/bus"
+		t.Setenv("DBUS_SESSION_BUS_ADDRESS", want)
+		t.Setenv("XDG_RUNTIME_DIR", "")
+		got, err := userBusAddress()
+		if err != nil {
+			t.Fatalf("userBusAddress() failed: %v", err)
+		}
+		if got != want {
+			t.Errorf("userBusAddress() = %q, want %q", got, want)
+		}
+	})
+
+	// Container runtimes do not always propagate DBUS_SESSION_BUS_ADDRESS, so the
+	// well-known path under XDG_RUNTIME_DIR must also be found.
+	t.Run("from XDG_RUNTIME_DIR", func(t *testing.T) {
+		dir := t.TempDir()
+		busPath := filepath.Join(dir, "bus")
+		if err := os.WriteFile(busPath, nil, 0644); err != nil {
+			t.Fatalf("os.WriteFile(%q): %v", busPath, err)
+		}
+		t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
+		t.Setenv("XDG_RUNTIME_DIR", dir)
+		got, err := userBusAddress()
+		if err != nil {
+			t.Fatalf("userBusAddress() failed: %v", err)
+		}
+		if want := "unix:path=" + dbus.EscapeBusAddressValue(busPath); got != want {
+			t.Errorf("userBusAddress() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		t.Setenv("DBUS_SESSION_BUS_ADDRESS", "")
+		t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+		if got, err := userBusAddress(); err == nil {
+			t.Errorf("userBusAddress() = %q, want error", got)
+		}
+	})
+}
+
+func TestMakePath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cg   cgroupSystemd
+		want string
+	}{
+		{
+			name: "system instance",
+			cg: cgroupSystemd{
+				Name:        "123",
+				Parent:      "system.slice",
+				ScopePrefix: "runsc",
+				cgroupV2:    cgroupV2{Mountpoint: "/sys/fs/cgroup"},
+			},
+			want: "/sys/fs/cgroup/system.slice/runsc-123.scope",
+		},
+		{
+			// Units managed by a per-user systemd instance are nested under that
+			// instance's own cgroup.
+			name: "user instance",
+			cg: cgroupSystemd{
+				Name:        "123",
+				Parent:      "user.slice",
+				ScopePrefix: "libpod",
+				Rootless:    true,
+				ManagerCG:   "/user.slice/user-1000.slice/user@1000.service",
+				cgroupV2:    cgroupV2{Mountpoint: "/sys/fs/cgroup"},
+			},
+			want: "/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/user.slice/libpod-123.scope",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cg.MakePath(""); got != tc.want {
+				t.Errorf("MakePath() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 
@@ -237,7 +379,9 @@ func TestInstall(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cg := cgroupSystemd{Name: "123", Parent: "parent.slice"}
+			// Rootless is set explicitly because the expected properties and the
+			// dial error below describe the system instance.
+			cg := cgroupSystemd{Name: "123", Parent: "parent.slice", Rootless: false}
 			cg.Controllers = mandatoryControllers
 			err := cg.Install(tc.res)
 			if !errors.Is(err, tc.err) {


### PR DESCRIPTION
## Summary

runsc supports rootless deployments, but on a host using the systemd cgroup driver it fails for unprivileged users. #11543 has been open since March 2025. The only workaround is ``--ignore-cgroups``, which disables resource limits.

The fix is two commits. One is the proper fix and the second is hardening. It can be dropped without affecting the overall fix.

### 1. `runsc/cgroup: support rootless containers with the systemd cgroup driver`

- **The driver always talked to the system service manager.** This was diagnosed by DemiMarie in #11543. Unprivileged users cannot create system-wide transient units, so polkit rejects the request as requiring interactive authorization. It now connects to the per-user instance when unprivileged, and mirrors runc's implementation. 

- **Enabling controllers was fatal.** The cgroupv2 path walk starts at the cgroup mount root, whose `cgroup.subtree_control` no unprivileged caller can write, so `Join()` aborted before the delegated scope could be used. This contrasted with runc's implementation. Controllers are now retried individually, and failures warn rather than abort.

Privilege is determined by translating the effective UID through `/proc/self/uid_map`, not `geteuid()`: rootless podman runs the OCI runtime inside a user namespace with the caller mapped to UID 0, so `geteuid()` returns 0 in exactly the case being fixed. The translated UID is also the credential the session bus requires for EXTERNAL authentication.

This commit also corrects `g3doc/user_guide/systemd.md`, which claimed the systemd driver is backed by the fs driver as runc's is. The text appears to have been reproduced from runc but was left unimplemented.

### 2. `runsc/cgroup: fail when a requested limit's controller is unavailable`

runsc generates unit properties from what the kernel supports, but not what is explicitly delegated to the user. runsc can request a limit for a controller that is not available in the container's cgroup. This can cause cases where limits are left silently unenforced. 

Every controller that properties were generated for, that a spec actually requests a limit for, is recorded and verified against the leaf once the scope exists. Container creation fails, naming any that are missing. Controllers with no requested limit are not checked, so a delegation omitting something nobody is using still works.

Fixes #11543

## Testing

Ubuntu 24.04, aarch64, kernel 6.14, cgroup v2, systemd 255, podman 4.9.3.
Requires CPU/cpuset delegation to user sessions, a standard rootless prerequisite (runc `docs/cgroup-v2.md`, "Configuring delegation"):

    /etc/systemd/system/user@.service.d/delegate.conf
    [Service]
    Delegate=cpu cpuset io memory pids

### Automated

    //runsc/cgroup:cgroup_test   PASSED   (both commits, and the first alone)
    //runsc/cgroup:cgroup_nogo   PASSED

`//runsc/container:container_test` fails identically on master and on this
branch in my environment, so it could not serve as a signal.

### Rootless, end to end

Checks against three builds — `master`, first commit only (`c1`), both
(`c1+2`):

| Check | master | c1 | c1+2 |
|---|---|---|---|
| Container starts (systemd driver) | FAIL | PASS | PASS |
| Scope created at manager-relative path | FAIL | PASS | PASS |
| `memory.max` / `cpu.max` applied | SKIP | PASS | PASS |
| Unit owned by user manager, not system | SKIP | PASS | PASS |
| Memory limit enforced (OOM) | FAIL | PASS | PASS |
| Teardown removes the cgroup | SKIP | PASS | PASS |
| Mandatory-controller warning emitted | — | PASS | PASS |

Before, on master:

    Error: OCI runtime error: creating container:
      systemd error: Interactive authentication required.

After:

    $ podman run --rm --network=none --runtime=runsc alpine echo "Hello, gVisor rootless!"
    Hello, gVisor rootless!

runsc runs inside a user namespace here, confirming the uid_map translation is
load-bearing rather than merely unit-tested:

    $ cat /proc/self/uid_map     # as seen by runsc
             0       1000          1
             1     100000      65536

Limits reach the kernel:

    $ cat $SCOPE/memory.max ; cat $SCOPE/cpu.max
    268435456
    50000 100000

And they are applied by the *user* manager, not the system one. `LoadState` is
the property that distinguishes a unit a manager has from one it does not;
`systemctl show` exits 0 and reports defaults for unknown units:

    $ systemctl --user show libpod-$CID.scope -p LoadState -p MemoryMax
    LoadState=loaded
    MemoryMax=268435456

    $ systemctl show libpod-$CID.scope -p LoadState -p MemoryMax
    LoadState=not-found
    MemoryMax=infinity

Enforced, and cleaned up — the `delete` path runs without
`DBUS_SESSION_BUS_ADDRESS`, exercising the `$XDG_RUNTIME_DIR/bus` fallback and
the persisted state:

    $ podman run --rm --memory=256m alpine sh -c 'tail /dev/zero'; echo "exit=$?"
    exit=137
    $ podman rm -f lim && find /sys/fs/cgroup -path '*libpod*'
    (no output)

`podman update` exercises the second D-Bus connection, made in a separate
process using `Rootless` restored from the state file:

    $ podman update --memory=512m upd
    $ cat $SCOPE/memory.max
    536870912
    $ systemctl --user show libpod-$CID.scope -p MemoryMax
    MemoryMax=536870912

A container created by a master build and torn down after swapping in the
patched binary exits cleanly, confirming old state files still decode:

    $ sudo podman rm -f compat; echo "exit=$?"
    exit=0

### Rootful — unchanged

Both builds, both cgroup drivers, all exit 0:

    master systemd exit=0      c1+2 systemd exit=0
    master cgroupfs exit=0     c1+2 cgroupfs exit=0

Limits still land on the *system* manager, with the cgroup under
`machine.slice` rather than `user@1000.service`, confirming `Rootless=false`
takes the original path with an empty `ManagerCG`:

    $ sudo systemctl show libpod-$CID.scope -p MemoryMax -p CPUQuotaPerSecUSec
    CPUQuotaPerSecUSec=500ms
    MemoryMax=268435456
    /sys/fs/cgroup/machine.slice/libpod-$CID.scope

### Second commit: a requested limit that cannot be enforced is now fatal

The check applies to any controller the spec requests a limit for. `io` is used
to demonstrate it.

With `io` removed from `Delegate=` and an io limit requested, the first commit
alone warns and runs anyway:

    W ... Unable to enable mandatory cgroup controllers io in
      ".../user@1000.service": ...; resource limits for them will NOT be applied

    $ podman run --rm --runtime=runsc --blkio-weight=100 alpine true; echo "exit=$?"
    exit=0
    $ systemctl --user show $SCOPE -p IOWeight
    IOWeight=910                       # systemd recorded it
    $ cat $SCOPE/cgroup.controllers
    cpuset cpu memory pids             # io absent; no io.weight file exists

With both commits the same command fails and names the controller. Containers requesting no io limit are unaffected, every other check still passes with io undelegated. No systemd unit or cgroup is left behind by the failure, since the scope is transient.

## Not covered

- The fs cgroup driver remains unusable for rootless containers. Out of scope for this change.
- The second commit checks controllers at container creation. A limit changed later via `runsc update` for an undelegated controller is not re-checked.
- Only `io` was tested un-delegated; the other controllers are covered by the same code path but were not exercised. On Ubuntu, I could not easily un-delegate the other controllers besides cpuset, which caused a crash anyway without commit 2. 
- aarch64, Ubuntu 24.04, systemd 255, cgroup v2 only. No checkpoint/restore or concurrent-creation testing.
- `hugeTLB2.generateProperties` returns nothing, so hugepage limits are never sent to systemd and the new check does not cover them. Pre-existing and unchanged.