### PR TITLE
Compatibiltiy test suite: add ollama, openclaw, picoclaw, hermes, claude

### DIFF
--- a/website/_data/application-compatibility.yml
+++ b/website/_data/application-compatibility.yml
@@ -1,4 +1,33 @@
 apps:
+  - name: "Claude Code"
+    category: "AI & agents"
+    verdict: "yes"
+    version: "2.1.220"
+
+  - name: "OpenClaw"
+    category: "AI & agents"
+    verdict: "yes"
+    version: "2026.7.1-2"
+    notes: "See [blog post](https://gvisor.dev/blog/2026/04/15/magi-multi-agent-gvisor-isolation/)."
+
+  - name: "PicoClaw"
+    category: "AI & agents"
+    verdict: "yes"
+    version: "0.2.6"
+    notes: "See [blog post](https://gvisor.dev/blog/2026/04/15/magi-multi-agent-gvisor-isolation/)."
+
+  - name: "Hermes Agent"
+    category: "AI & agents"
+    verdict: "yes"
+    version: "v2026.4.13"
+    notes: "See [blog post](https://gvisor.dev/blog/2026/04/15/magi-multi-agent-gvisor-isolation/)."
+
+  - name: "Ollama"
+    category: "AI & agents"
+    verdict: "yes"
+    version: "0.31.1"
+    test_source: "test/gpu/textgen_test.go"
+
   - name: "PostgreSQL"
     category: "Databases & data stores"
     verdict: "yes"

--- a/website/application-compatibility.schema.json
+++ b/website/application-compatibility.schema.json
@@ -30,7 +30,8 @@
             "Web servers, proxies & gateways",
             "CI/CD & developer tooling",
             "Applications & platforms",
-            "System software"
+            "System software",
+            "AI & agents"
           ]
         },
         "verdict": {


### PR DESCRIPTION
Add an agents category to the compatibility dashboard, along with Ollama, OpenClaw, PicoClaw, Hermes Agent, and Claude Code.

Ollama has a test included. The *claws and Hermes reference the MAGI blog post.

No test for claude code since they require an account, and testing claude code with a local model would likely require a beefy GPU (since claude's system prompt is pretty big).