### PR TITLE
make gopls work out of the box

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,9 +1,25 @@
 {
     "dockerFile": "images/default/Dockerfile",
     "overrideCommand": true,
-    "mounts": ["source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"],
-    "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
-    "extensions": [
-        "bazelbuild.vscode-bazel"
-    ]
+    "postStartCommand": "tools/devcontainer-init-go.sh",
+    "waitFor": "postStartCommand",
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
+    ],
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "bazelbuild.vscode-bazel",
+                "golang.go"
+            ],
+            "settings": {
+                "go.goroot": "${workspaceFolder}/bazel-${workspaceFolderBasename}/external/rules_go++go_sdk+main___download_0/"
+            }
+        }
+    }
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "bazelbuild.vscode-bazel",
+        "golang.go"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,33 @@
+{
+    "go.toolsEnvVars": {
+        "GOPACKAGESDRIVER": "${workspaceFolder}/tools/gopackagesdriver.sh"
+    },
+    "gopls": {
+        "build.workspaceFiles": [
+            "**/BUILD",
+            "**/*.{bzl,bazel}"
+        ],
+        "build.directoryFilters": [
+            "-bazel-bin",
+            "-bazel-out",
+            "-bazel-testlogs",
+            "-bazel-gvisor"
+        ],
+        "formatting.local": "gvisor.dev/gvisor",
+        "ui.codelenses": {
+            "gc_details": false,
+            "regenerate_cgo": false,
+            "generate": false,
+            "test": false,
+            "tidy": false,
+            "upgrade_dependency": false,
+            "vendor": false
+        }
+    },
+    "go.enableCodeLens": {
+        "runtest": false
+    },
+    "go.useLanguageServer": true,
+    "go.lintOnSave": "off",
+    "go.vetOnSave": "off"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Want to contribute? Great! First, read this page.
 
-### Contributor License Agreement
+## Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License
 Agreement. You (or your employer) retain the copyright to your contribution;
@@ -14,7 +14,7 @@ You generally only need to submit a CLA once, so if you've already submitted one
 (even if it was for a different project), you probably don't need to do it
 again.
 
-### AI tool Use
+## AI tool Use
 
 We expect our contributors to embrace AI tools.
 
@@ -22,7 +22,7 @@ This policy ensures that AI-generated contributions are always guided,
 validated, and owned by a skilled human, promoting better software and a
 stronger community than policing how code gets written.
 
-#### Policy
+### Policy
 
 While contributors can use any AI tools to create their contributions, **human
 oversight is mandatory**. All AI-generated content must be thoroughly reviewed
@@ -51,7 +51,50 @@ practices around AI tool usage. This policy includes, but is not limited to:
 -   Issues or security vulnerabilities
 -   Comments and feedback on pull requests or issues
 
-### Using GOPATH
+## Editor Setup
+
+### Visual Studio Code
+
+The easiest way to work on gVisor in VSCode is using the
+[Dev Containers](https://code.visualstudio.com/docs/devcontainers/containers)
+extension.
+
+Open the gVisor repository in VSCode, and a "Folder contains a Dev
+Container" popup will appear. Press "Reopen in Container". The first load will
+take a few minutes while the dev container is built and the Go packages are
+loaded. Afterwards, Go language server features (hover, autocomplete, reference
+search, format on save, etc) should work "out of the box". VSCode's terminal
+will open in the dev container, where you can run `bazel build`, `bazel test`,
+and so on to work on gVisor.
+
+For example, you can build and run `runsc` in the dev container as follows:
+```
+bazel run //runsc -- --rootless do bash
+```
+
+Alternatively, it is possible to develop gVisor without a dev container.
+For the Go language server to work, ensure you have an up-to-date version of
+[Go][go] and the correct version of Bazel (ideally through
+[bazelisk][bazelisk]) installed on the host. In this configuration, it is still
+recommended to build, run, and test gVisor in a container, which is handled
+automatically using `make`. For example, to build and run `runsc`:
+```
+make copy TARGETS=//runsc DESTINATION=./runsc-dev
+./runsc-dev --rootless do bash
+```
+For non-interactive commands, `make run` can be used as a shorthand as follows:
+```
+make run TARGETS=//runsc ARGS="--rootless do echo hello world"
+```
+
+### Other Editors
+
+For LSP integration in other editors, ensure that the environment variable
+`GOPACKAGESDRIVER=tools/gopackagesdriver.sh`
+is passed along to `gopls`.
+
+
+#### Using GOPATH (not recommended)
 
 Some editors may require the code to be structured in a `GOPATH` directory tree.
 In this case, you may use the `:gopath` target to generate a directory tree with
@@ -73,7 +116,7 @@ Dependencies can be added by using `go get`. In order to keep the `WORKSPACE`
 file in sync, run `bazel run //:gazelle -- update-repos -from_file=go.mod` in
 place of `go mod`.
 
-### Coding Guidelines
+## Coding Guidelines
 
 All code should comply with the [style guide](g3doc/style.md). Note that code
 may be automatically formatted per the guidelines when merged.
@@ -123,7 +166,7 @@ Rules:
 
 *   For performance reasons, `runsc boot` may not run the `netpoller` goroutine.
 
-### Code reviews
+## Code reviews
 
 Before sending code reviews, run `bazel test ...` to ensure tests are passing.
 
@@ -138,19 +181,19 @@ logical units of work that can be applied separately.
 When approved, the change will be submitted by a team member and automatically
 merged into the repository.
 
-### Presubmit checks
+## Presubmit checks
 
 Accessing check logs may require membership in the
 [gvisor-dev mailing list][gvisor-dev-list], which is public.
 
-### Bug IDs
+## Bug IDs
 
 Some TODOs and NOTEs sprinkled throughout the code have associated IDs of the
 form `b/1234`. These correspond to bugs in our internal bug tracker. Eventually
 these bugs will be moved to the GitHub Issues, but until then they can simply be
 ignored.
 
-### Build and test with Docker
+## Build and test with Docker
 
 Running `make dev` is a convenient way to build and install `runsc` as a Docker
 runtime. The output of this command will show the runtimes installed.
@@ -163,7 +206,7 @@ docker run --rm --runtime=my-branch --rm hello-world
 make refresh
 ```
 
-### Update golang dependencies
+## Update golang dependencies
 
 First, we need to update dependencies in the go.mod and go.sum files. To do
 that, we should checkout the go branch and update dependencies using the go get
@@ -182,7 +225,7 @@ git checkout origin/master
 bazel run //:gazelle -- update-repos -from_file=go.mod
 ```
 
-### The small print
+## The small print
 
 Contributions made by corporations are covered by a different agreement than the
 one above, the
@@ -192,3 +235,5 @@ one above, the
 [gccla]: https://cla.developers.google.com/about/google-corporate
 [github]: https://github.com/google/gvisor/compare
 [gvisor-dev-list]: https://groups.google.com/forum/#!forum/gvisor-dev
+[go]: https://go.dev/doc/install
+[bazelisk]: https://github.com/bazelbuild/bazelisk

--- a/images/default/Dockerfile
+++ b/images/default/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y curl gnupg2 git \
 RUN test "$(uname -m)" != x86_64 && exit 0 || apt-get install -y libc6-dev-i386
 #-------------------------------------------------------------------------------
 # The rest of the file is unnecessary for building `runsc`, but are necessary
-# for test targets.
+# for test targets and/or dev containers.
 #-------------------------------------------------------------------------------
 
 # Install Docker client for the website build.
@@ -39,6 +39,11 @@ RUN ARCH="$(uname -m | sed s/aarch64/arm/)" && \
     tar zxf - google-cloud-sdk && \
     google-cloud-sdk/install.sh --quiet && \
     ln -s /google-cloud-sdk/bin/gcloud /usr/bin/gcloud
+
+# Install buildifier.
+RUN ARCH="$(uname -m | sed -e s/aarch64/arm64/ -e s/x86_64/amd64/)" && \
+    curl -fsSL https://github.com/bazelbuild/buildtools/releases/download/v8.5.1/buildifier-linux-${ARCH} -o /usr/local/bin/buildifier && \
+    chmod ugo+x /usr/local/bin/buildifier
 
 # Download the official bazel binary. The APT repository isn't used because there is not packages for arm64.
 COPY bazelversion .

--- a/tools/devcontainer-init-go.sh
+++ b/tools/devcontainer-init-go.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# Running `go version` ensures that the appropriate Go binaries are downloaded.
+exec bazel run @io_bazel_rules_go//go version

--- a/tools/gopackagesdriver.sh
+++ b/tools/gopackagesdriver.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec bazel run -- @io_bazel_rules_go//go/tools/gopackagesdriver "${@}"


### PR DESCRIPTION
Long-term, we want to clean up our use of Bazel so that a container isn't necessary to build gVisor. As a stop-gap, let's make the out-of-box VSCode experience a little smoother by configuring a GOPACKAGESDRIVER for gopls out-of-the-box, and recommending using a dev container.

The advantage of recommending a dev container is that we can configure an on-start command to run `@io_bazel_rules_go//go` through Bazel *before* gopls starts, which installs the correct Go version in the container automatically. And in the future we can configure a `compile_commands.json` to be generated at startup for clangd (for the C++ tests).

- Updates the dev container configuration to install the Go extension and fetch the Go compiler at startup.
- Adds a settings.json that configures gopls to run a GOPACKAGESDRIVER through bazel, making LSP work for the auto-generated code.
- Updates the docs to explain how to get gopls working with or without a dev container, and marks GOPATH as "not recommended"
- Install `buildifier` in the default container, as used by the Bazel vscode extension for formatting BUILD files