### PR TITLE
Fix build-from-source instructions to make a `-c opt` build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ test: ## Tests the given $(TARGETS) with the given $(OPTIONS). E.g. make test TA
 	@$(call test,$(OPTIONS) -- $(TARGETS))
 .PHONY: test
 
-copy: ## Copies the given $(TARGETS) to the given $(DESTINATION). E.g. make copy TARGETS=runsc DESTINATION=/tmp
-	@$(call copy,$(TARGETS),$(DESTINATION))
+copy: ## Copies the given $(TARGETS), built with the given $(OPTIONS), to the given $(DESTINATION). E.g. make copy TARGETS=runsc DESTINATION=/tmp
+	@$(call copy,$(OPTIONS) -- $(TARGETS),$(DESTINATION))
 .PHONY: copy
 
 run: ## Runs the given $(TARGETS), built with $(OPTIONS), using $(ARGS). E.g. make run TARGETS=runsc ARGS=-version
@@ -824,6 +824,12 @@ release: $(RELEASE_KEY) $(RELEASE_ARTIFACTS)/$(ARCH)
 	@mkdir -p $(RELEASE_ROOT)
 	@NIGHTLY=$(RELEASE_NIGHTLY) tools/make_release.sh $(RELEASE_KEY) $(RELEASE_ROOT) $$(find $(RELEASE_ARTIFACTS) -type f)
 .PHONY: release
+
+release-tarball: DESTINATION ?= .
+release-tarball: ## Builds an optimized release tarball (gvisor.tar.bz2) and copies it to $(DESTINATION). E.g. make release-tarball DESTINATION=bin/
+	@mkdir -p "$(DESTINATION)"
+	@$(call copy,-c opt //debian:gvisor-release-tar,$(DESTINATION))
+.PHONY: release-tarball
 
 staged-binaries-check: ## Verifies STAGED_BINARIES contains all files from the //debian:gvisor-release-tar fileset.
 ifeq (,$(STAGED_BINARIES))

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Make sure the following dependencies are installed:
 
 ### Building
 
-Build and install `runsc`, the `containerd-shim-runsc-v1` containerd shim, and a
-few sidecar binaries that `runsc` expects to find in a `gvisor-bin/` directory
-next to itself:
+Build a release tarball containing `runsc`, the
+`containerd-shim-runsc-v1` containerd shim, and a few sidecar binaries that
+`runsc` expects to find in a `gvisor-bin/` directory next to itself, then
+extract it to `/usr/local/bin`:
 
 ```sh
-mkdir -p bin
-make copy TARGETS=//:release DESTINATION=bin/
-sudo cp -r --preserve=mode bin/runsc bin/containerd-shim-runsc-v1 bin/gvisor-bin /usr/local/bin/
+make release-tarball DESTINATION=bin/
+sudo tar -C /usr/local/bin -xf bin/gvisor.tar.bz2
 ```
 
 To build specific libraries or binaries, you can specify the target:
@@ -102,7 +102,7 @@ to get started:
 After setting up dependencies, using Bazel is similar to the Makefile:
 
 ```sh
-bazel build //:release
+bazel build -c opt //debian:gvisor-release-tar
 ```
 
 ### Testing


### PR DESCRIPTION
Also make `make copy` propagate bazel `OPTIONS`.