### PR TITLE
SO_PEERCRED: fix race against thread-group reap

### DIFF
--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -293,12 +293,11 @@ func (ns *PIDNamespace) ID() uint64 {
 	return ns.id
 }
 
-// ThreadGroupWithID returns the thread group led by the task with thread ID
-// tid in PID namespace ns. If no task has that TID, or if the task with that
-// TID is not a thread group leader, ThreadGroupWithID returns nil.
-func (ns *PIDNamespace) ThreadGroupWithID(tid ThreadID) *ThreadGroup {
-	ns.owner.mu.RLock()
-	defer ns.owner.mu.RUnlock()
+// threadGroupWithIDLocked returns the thread group led by the task with thread ID
+// tid in PID namespace ns.
+//
+// Preconditions: ns.owner.mu must be locked (for reading or writing).
+func (ns *PIDNamespace) threadGroupWithIDLocked(tid ThreadID) *ThreadGroup {
 	t := ns.tasks[tid]
 	if t == nil {
 		return nil
@@ -307,6 +306,15 @@ func (ns *PIDNamespace) ThreadGroupWithID(tid ThreadID) *ThreadGroup {
 		return nil
 	}
 	return t.tg
+}
+
+// ThreadGroupWithID returns the thread group led by the task with thread ID
+// tid in PID namespace ns. If no task has that TID, or if the task with that
+// TID is not a thread group leader, ThreadGroupWithID returns nil.
+func (ns *PIDNamespace) ThreadGroupWithID(tid ThreadID) *ThreadGroup {
+	ns.owner.mu.RLock()
+	defer ns.owner.mu.RUnlock()
+	return ns.threadGroupWithIDLocked(tid)
 }
 
 // IDOfTask returns the TID assigned to the given task in PID namespace ns. If
@@ -356,18 +364,11 @@ func (ns *PIDNamespace) IDOfThreadGroup(tg *ThreadGroup) ThreadID {
 	return id
 }
 
-// PIDNamespacedIDs returns a snapshot mapping each PID namespace in which tg's
-// leader is visible (tg's PID namespace and every ancestor) to tg's ID (PID)
-// in that namespace.
+// pidNamespacedIDsLocked returns a PID-namespaced snapshot of thread IDs
+// for tg's PID namespace and every ancestor.
 //
-// The returned map is intended to be indexed by a PID namespace to which the
-// caller holds a reference. Because the returned map does not hold references
-// on its own, the other keys in the map *MUST NOT* be dereferenced.
-//
-// tg must be visible in its own PID namespace.
-func (tg *ThreadGroup) PIDNamespacedIDs() map[*PIDNamespace]ThreadID {
-	tg.pidns.owner.mu.RLock()
-	defer tg.pidns.owner.mu.RUnlock()
+// Preconditions: tg.pidns.owner.mu must be locked (for reading or writing).
+func (tg *ThreadGroup) pidNamespacedIDsLocked() map[*PIDNamespace]ThreadID {
 	ids := make(map[*PIDNamespace]ThreadID)
 	for ns := tg.pidns; ns != nil; ns = ns.parent {
 		id, ok := ns.tgids[tg]
@@ -379,6 +380,46 @@ func (tg *ThreadGroup) PIDNamespacedIDs() map[*PIDNamespace]ThreadID {
 		ids[ns] = id
 	}
 	return ids
+}
+
+// PIDNamespacedIDs returns a snapshot mapping each PID namespace in which t's
+// thread group is visible (its PID namespace and every ancestor) to the thread
+// group's ID (PID) in that namespace.
+//
+// The returned map is intended to be indexed by a PID namespace to which the
+// caller holds a reference. Because the returned map does not hold references
+// on its own, the other keys in the map *MUST NOT* be dereferenced.
+//
+// Preconditions: t MUST not be reaped for the duration of this method.
+// Generally, t should be the current task from a syscall context.
+func (t *Task) PIDNamespacedIDs() map[*PIDNamespace]ThreadID {
+	tg := t.ThreadGroup()
+	tg.pidns.owner.mu.RLock()
+	defer tg.pidns.owner.mu.RUnlock()
+
+	return tg.pidNamespacedIDsLocked()
+}
+
+// PIDNamespacedIDs returns a snapshot mapping each PID namespace in which tid's
+// ThreadGroup is visible (tid's PID namespace and every ancestor) to tg's ID (PID)
+// in that namespace.
+//
+// tid is looked up in ns.
+//
+// The returned map is intended to be indexed by a PID namespace to which the
+// caller holds a reference. Because the returned map does not hold references
+// on its own, the other keys in the map *MUST NOT* be dereferenced.
+//
+// If no thread group tid exists in ns, the nil map is returned.
+func (ns *PIDNamespace) PIDNamespacedIDs(tid ThreadID) map[*PIDNamespace]ThreadID {
+	ns.owner.mu.RLock()
+	defer ns.owner.mu.RUnlock()
+	tg := ns.threadGroupWithIDLocked(tid)
+	if tg == nil {
+		return nil
+	}
+
+	return tg.pidNamespacedIDsLocked()
 }
 
 // Tasks returns a snapshot of the tasks in ns.

--- a/pkg/sentry/socket/control/control.go
+++ b/pkg/sentry/socket/control/control.go
@@ -73,11 +73,11 @@ func NewSCMCredentials(t *kernel.Task, cred linux.ControlMessageCredentials) (SC
 	if kernel.ThreadID(cred.PID) != t.ThreadGroup().ID() && !t.HasCapabilityIn(linux.CAP_SYS_ADMIN, t.PIDNamespace().UserNamespace()) {
 		return nil, linuxerr.EPERM
 	}
-	tg := t.PIDNamespace().ThreadGroupWithID(kernel.ThreadID(cred.PID))
-	if tg == nil {
+	namespacedIDs := t.PIDNamespace().PIDNamespacedIDs(kernel.ThreadID(cred.PID))
+	if namespacedIDs == nil {
 		return nil, linuxerr.ESRCH
 	}
-	return &scmCredentials{tg.PIDNamespacedIDs(), kuid, kgid}, nil
+	return &scmCredentials{namespacedIDs, kuid, kgid}, nil
 }
 
 // Equals implements transport.CredentialsControlMessage.Equals.
@@ -647,7 +647,7 @@ func MakeCreds(t *kernel.Task) SCMCredentials {
 		return nil
 	}
 	tcred := t.Credentials()
-	return &scmCredentials{t.ThreadGroup().PIDNamespacedIDs(), tcred.EffectiveKUID, tcred.EffectiveKGID}
+	return &scmCredentials{t.PIDNamespacedIDs(), tcred.EffectiveKUID, tcred.EffectiveKGID}
 }
 
 // New creates default control messages if needed.

--- a/test/syscalls/linux/socket_unix_peercred.cc
+++ b/test/syscalls/linux/socket_unix_peercred.cc
@@ -14,7 +14,9 @@
 
 #include "test/syscalls/linux/socket_unix_peercred.h"
 
+#include <errno.h>
 #include <sched.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -22,8 +24,14 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <array>
+#include <atomic>
+#include <memory>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "test/util/cleanup.h"
+#include "test/util/file_descriptor.h"
 #include "test/util/linux_capability_util.h"
 #include "test/util/logging.h"
 #include "test/util/memory_util.h"
@@ -32,6 +40,7 @@
 #include "test/util/save_util.h"
 #include "test/util/socket_util.h"
 #include "test/util/test_util.h"
+#include "test/util/thread_util.h"
 
 namespace gvisor {
 namespace testing {
@@ -268,8 +277,8 @@ struct PeerCredNSChildArgs {
 // peerCredNSConnectChild is the entry point of a process cloned into a new PID
 // namespace (so getpid() returns 1). It connects to addr, reports its
 // in-namespace PID, then blocks until the parent closes the connection.
-int peerCredNSConnectChild(void* arg) {
-  auto* a = static_cast<PeerCredNSChildArgs*>(arg);
+int peerCredNSConnectChild(void *arg) {
+  auto *a = static_cast<PeerCredNSChildArgs *>(arg);
   int s = socket(AF_UNIX, SOCK_STREAM, 0);
   TEST_PCHECK_MSG(s >= 0, "child socket failed");
   TEST_PCHECK_MSG(connect(s, AsSockAddr(&a->addr), sizeof(a->addr)) == 0,
@@ -318,7 +327,7 @@ TEST_P(UnixSocketPeerCredTest, PeerCredAcrossPIDNamespace) {
       Mmap(nullptr, kStackSize, PROT_READ | PROT_WRITE,
            MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0));
   pid_t child_pid = clone(peerCredNSConnectChild,
-                          reinterpret_cast<char*>(stack.ptr()) + stack.len(),
+                          reinterpret_cast<char *>(stack.ptr()) + stack.len(),
                           CLONE_NEWPID | SIGCHLD, &args);
   ASSERT_THAT(child_pid, SyscallSucceeds());
   ASSERT_THAT(close(sync_pipe[1]), SyscallSucceeds());
@@ -350,6 +359,128 @@ TEST_P(UnixSocketPeerCredTest, PeerCredAcrossPIDNamespace) {
               SyscallSucceedsWithValue(child_pid));
   EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
       << "child exited abnormally: status=" << status;
+}
+
+// SendCredsFor sends a message on fd carrying an SCM_CREDENTIALS control
+// message that names pid. It returns 0 on success, or the errno on failure.
+int SendCredsFor(int fd, pid_t pid) {
+  static char data[4096];
+  struct iovec iov = {
+      .iov_base = data,
+      .iov_len = sizeof(data),
+  };
+  char control[CMSG_SPACE(sizeof(struct ucred))] = {};
+  struct msghdr msg = {};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = control;
+  msg.msg_controllen = sizeof(control);
+
+  struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_CREDENTIALS;
+  cmsg->cmsg_len = CMSG_LEN(sizeof(struct ucred));
+  struct ucred cred = {
+      .pid = pid,
+      .uid = getuid(),
+      .gid = getgid(),
+  };
+  memcpy(CMSG_DATA(cmsg), &cred, sizeof(cred));
+
+  if (RetryEINTR(sendmsg)(fd, &msg, MSG_DONTWAIT) < 0) {
+    return errno;
+  }
+  return 0;
+}
+
+// Sending SCM_CREDENTIALS naming a PID that is concurrently being reaped must
+// fail cleanly with ESRCH.
+//
+// Regression test for b/540679345.
+TEST(UnixSocketPeerCredRaceTest, SendCredsRacesWithPeerReap) {
+  DisableSave ds;  // Forks a lot across many threads.
+
+  // Naming a PID other than our own in SCM_CREDENTIALS requires CAP_SYS_ADMIN.
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  // The number of threads racing sendmsg() against the reap of a forked child.
+  constexpr int kCredRaceSenders = 4;
+
+  // The number of children forked and reaped while the senders race.
+  constexpr int kCredRaceIterations = 5000;
+
+  int fds[2];
+  ASSERT_THAT(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), SyscallSucceeds());
+  FileDescriptor sender_fd(fds[0]);
+  FileDescriptor receiver_fd(fds[1]);
+
+  // Hands each child's PID to each sender.
+  // Closing the write end causes the sender to exit.
+  int pipe_fds[2];
+  ASSERT_THAT(pipe(pipe_fds), SyscallSucceeds());
+  FileDescriptor pids_r(pipe_fds[0]);
+  FileDescriptor pids_w(pipe_fds[1]);
+
+  // Used by sender threads to signal errors to the main thread
+  std::atomic<int> sender_errno(0);
+
+  std::array<std::unique_ptr<ScopedThread>, kCredRaceSenders> senders;
+
+  // Declared after senders so that it is destroyed before the senders
+  // are joined.
+  Cleanup stop_senders([&] { pids_w.reset(); });
+
+  for (auto &sender : senders) {
+    sender = std::make_unique<ScopedThread>([&] {
+      pid_t pid;
+      while (RetryEINTR(read)(pids_r.get(), &pid, sizeof(pid)) == sizeof(pid)) {
+        int err;
+        do {
+          err = SendCredsFor(sender_fd.get(), pid);
+
+          // ESRCH once the child has been reaped, and EAGAIN once the socket
+          // buffer fills, are both expected. Anything else should fail.
+        } while (err == 0 || err == EAGAIN);
+        if (err != ESRCH) {
+          int expected = 0;
+          sender_errno.compare_exchange_strong(expected, err,
+                                               std::memory_order_relaxed);
+        }
+      }
+    });
+  }
+
+  pid_t batch[kCredRaceSenders];
+  for (int i = 0; i < kCredRaceIterations; i++) {
+    const pid_t child = fork();
+    if (child == 0) {
+      _exit(0);
+    }
+    ASSERT_THAT(child, SyscallSucceeds());
+
+    // Send the child to every sender in one write, then reap it. Doing this
+    // over many iterations will reproduce the race condition, if present.
+    for (int j = 0; j < kCredRaceSenders; j++) {
+      batch[j] = child;
+    }
+    ASSERT_THAT(RetryEINTR(write)(pids_w.get(), batch, sizeof(batch)),
+                SyscallSucceedsWithValue(sizeof(batch)));
+    ASSERT_THAT(RetryEINTR(waitpid)(child, nullptr, 0),
+                SyscallSucceedsWithValue(child));
+
+    if (sender_errno.load(std::memory_order_relaxed) != 0) {
+      break;
+    }
+  }
+
+  stop_senders.Release()();  // Causes sender threads to exit.
+  for (const auto &sender : senders) {
+    sender->Join();
+  }
+
+  const int err = sender_errno.load(std::memory_order_relaxed);
+  EXPECT_EQ(err, 0) << "sendmsg failed with unexpected error: "
+                    << strerror(err);
 }
 
 }  // namespace


### PR DESCRIPTION
NewSCMCredentials previously resolved the specified PID into a thread group with separate calls to ThreadGroupWithID() and PIDNamespacedIDs(). Both of these functions separately take and release the TaskSet lock.

This causes a race condition where between the two function calls, the thread group might get reaped, leading to the panic() being reached.

This commit addresses this issue by moving the thread group resolution/PID namespace map creation into a single critical section. A regression syscall test is also included.

Reported-by: syzbot+f2ee1dd4c598b8b89c72@syzkaller.appspotmail.com