### PR TITLE
Disable protobuf's `internal/detrand` self-reading behavior.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -671,6 +671,11 @@ go_deps.module(
     sum = "h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=",
     version = "v0.0.0-20220907171357-04be3eba64a2",
 )
+go_deps.module_override(
+    patch_strip = 1,
+    patches = ["//tools:protobuf.disable-binary-reading-on-init.patch"],
+    path = "google.golang.org/protobuf",
+)
 go_deps.gazelle_override(
     directives = [
         "gazelle:proto disable",

--- a/tools/protobuf.disable-binary-reading-on-init.patch
+++ b/tools/protobuf.disable-binary-reading-on-init.patch
@@ -1,0 +1,55 @@
+diff --git a/internal/detrand/rand.go b/internal/detrand/rand.go
+index 49c8676..d62c007 100644
+--- a/internal/detrand/rand.go
++++ b/internal/detrand/rand.go
+@@ -9,12 +9,6 @@
+ // while ensuring that the output is unstable across different builds.
+ package detrand
+ 
+-import (
+-	"encoding/binary"
+-	"hash/fnv"
+-	"os"
+-)
+-
+ // Disable disables detrand such that all functions returns the zero value.
+ // This function is not concurrent-safe and must be called during program init.
+ func Disable() {
+@@ -34,36 +28,4 @@ func Intn(n int) int {
+ 	return int(randSeed % uint64(n))
+ }
+ 
+-// randSeed is a best-effort at an approximate hash of the Go binary.
+-var randSeed = binaryHash()
+-
+-func binaryHash() uint64 {
+-	// Open the Go binary.
+-	s, err := os.Executable()
+-	if err != nil {
+-		return 0
+-	}
+-	f, err := os.Open(s)
+-	if err != nil {
+-		return 0
+-	}
+-	defer f.Close()
+-
+-	// Hash the size and several samples of the Go binary.
+-	const numSamples = 8
+-	var buf [64]byte
+-	h := fnv.New64()
+-	fi, err := f.Stat()
+-	if err != nil {
+-		return 0
+-	}
+-	binary.LittleEndian.PutUint64(buf[:8], uint64(fi.Size()))
+-	h.Write(buf[:8])
+-	for i := int64(0); i < numSamples; i++ {
+-		if _, err := f.ReadAt(buf[:], i*fi.Size()/numSamples); err != nil {
+-			return 0
+-		}
+-		h.Write(buf[:])
+-	}
+-	return h.Sum64()
+-}
++var randSeed uint64


### PR DESCRIPTION
This function reads a few binary pages from the binary during Go `init` as a seed.

Non-load-bearing, this is only used to make textproto output nondeterministic (lol, yes really).

Shaves 1~2ms off gVisor cold start. If the patch truly becomes unmaintainable, we can always drop it and pay this cost again.