### PR TITLE
pgalloc: throttle UpdateUsage() scans in proportion to their cost

### DIFF
--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -158,8 +158,11 @@ type MemoryFile struct {
 	// commitSeq is a sequence counter used to detect races between scans for
 	// committed pages and concurrent decommitment.
 	//
-	// nextCommitScan is the next time at which UpdateUsage() may scan the
+	// nextCommitScan is the next time at which UpdateUsage(nil) may scan the
 	// backing file for commitment information.
+	//
+	// ongoingCommitScan is true while UpdateUsage(nil) is in progress. Writing
+	// to it requires f.mu to be locked, but reading it does not.
 	//
 	// isSaving is true during f.SaveTo() to prevent concurrent calls to
 	// f.UpdateUsage() from marking pages as committed.
@@ -169,6 +172,7 @@ type MemoryFile struct {
 	knownCommittedBytes uint64
 	commitSeq           uint64
 	nextCommitScan      time.Time
+	ongoingCommitScan   atomic.Bool
 	isSaving            bool
 
 	// evictable maps EvictableMemoryUsers to eviction state.
@@ -1554,11 +1558,28 @@ func (f *MemoryFile) ShouldCacheEvictable() bool {
 	return f.opts.DelayedEviction == DelayedEvictionManual || f.opts.UseHostMemcgPressure
 }
 
-// UpdateUsage ensures that the memory usage statistics in
-// usage.MemoryAccounting are up to date. If memCgIDs is nil, all the pages
+// commitScanIntervalRatio is the minimum ratio of the interval between
+// consecutive scans for committed pages to the duration of the preceding
+// scan, limiting scanning to 1/commitScanIntervalRatio of a CPU. It trades
+// scanning cost against how far usage.MemoryAccounting may lag: scans cost
+// tens of milliseconds for tens of GB of memory, but seconds once a sandbox
+// commits hundreds of GB. If the previous scan took 2 seconds, the next scan
+// will be delayed by at least 16 seconds.
+const commitScanIntervalRatio = 8
+
+// UpdateUsage attempts to bring the memory usage statistics in
+// usage.MemoryAccounting up to date. If memCgIDs is nil, all the pages
 // will be scanned. Else only the pages which belong to the memory cgroup ids
 // in memCgIDs will be scanned and the memory usage will be updated.
+//
+// Scanning is throttled, so statistics may lag page commitment by an
+// unbounded amount; only callers that tolerate stale statistics may use
+// UpdateUsage.
 func (f *MemoryFile) UpdateUsage(memCgIDs map[uint32]struct{}) error {
+	if memCgIDs == nil && f.ongoingCommitScan.Load() {
+		return nil
+	}
+
 	// If we already know of every committed page, skip scanning.
 	currentUsage, err := f.TotalUsage()
 	if err != nil {
@@ -1575,24 +1596,35 @@ func (f *MemoryFile) UpdateUsage(memCgIDs map[uint32]struct{}) error {
 		return nil
 	}
 
-	// Linux updates usage values at CONFIG_HZ; throttle our scans to the same
-	// frequency.
+	// Linux updates usage values at CONFIG_HZ, so scanning more frequently is
+	// never useful. Scanning is also far more expensive for us than it is for
+	// Linux: pages are committed by the host kernel without our involvement,
+	// so each scan must ask the host about every page not already known to be
+	// committed, making it O(uncommitted pages). So scanning is throttled
+	// proportional to the previous scan duration to avoid excessive CPU usage.
 	startTime := time.Now()
-	if startTime.Before(f.nextCommitScan) {
-		return nil
-	}
 	if memCgIDs == nil {
-		f.nextCommitScan = startTime.Add(time.Second / linux.CLOCKS_PER_SEC)
+		if startTime.Before(f.nextCommitScan) || f.ongoingCommitScan.Load() {
+			return nil
+		}
+		f.ongoingCommitScan.Store(true)
+	}
+	err = f.updateUsageLocked(memCgIDs)
+	if memCgIDs == nil {
+		f.ongoingCommitScan.Store(false)
+	}
+	scanTime := time.Since(startTime)
+	if memCgIDs == nil {
+		f.nextCommitScan = startTime.Add(max(linux.ClockTick, scanTime*commitScanIntervalRatio))
 	}
 
-	err = f.updateUsageLocked(memCgIDs)
 	if _, ok := err.(updateUsageDuringSaveErr); ok {
 		log.Debugf("pgalloc.MemoryFile.UpdateUsage() inhibited during MemoryFile save")
 		return nil
 	}
 	if log.IsLogging(log.Debug) {
 		log.Debugf("UpdateUsage: took %v, currentUsage=%d knownCommittedBytes=%d",
-			time.Since(startTime), currentUsage, f.knownCommittedBytes)
+			scanTime, currentUsage, f.knownCommittedBytes)
 	}
 	return err
 }


### PR DESCRIPTION
MemoryFile.UpdateUsage() detects newly-committed pages by asking the host, via mincore(), about every page not already known to be committed. This is O(uncommitted pages); in a sandbox with hundreds of GB of memory under allocation churn, where pages are constantly decommitted and recommitted, a single scan takes seconds.

Scans were throttled to CONFIG_HZ, which assumes that they are cheap. Worse, the 10ms deadline was armed before the scan rather than after it, so a scan exceeding 10ms did not prevent concurrent callers from starting their own redundant scans.

Both are easy to hit, since reads of /proc/meminfo call UpdateUsage() and are commonly polled. In a 2-node 8xH200 training job with a ~100GB resident set, where a Ray memory monitor and the trainer's per-step logging both read /proc/meminfo periodically, the sentry spent 78% of its CPU in UpdateUsage() -- 1.65 CPUs' worth, i.e. more than one scan running at all times. Scanning also contends for the lock that page allocation needs, so this slowed the application itself: NCCL weight-sync buckets took ~10s instead of the ~0.23s they take under runc.

Arm the deadline after the scan instead, at commitScanIntervalRatio times the duration of the scan just completed, bounding scans to 1/8th of a CPU regardless of sandbox size, and skip scans that would duplicate one already in progress. Both apply only to full scans (memCgIDs == nil); a scan restricted to specific memory cgroups is much cheaper and runs unthrottled, so per-cgroup statistics stay fresh.

Track the in-progress scan in an atomic checked before mu is locked, so that callers arriving during a scan neither block on mu nor contend for it with the scan and with page allocation. Such a caller goes on to read usage.MemoryAccounting, which the ongoing scan updates incrementally under a different lock, so it observes a partially updated snapshot rather than a stale one; since a scan only ever increases the counters, that snapshot lies between the pre-scan and post-scan values. Callers could already observe a scan's intermediate state, as they read usage.MemoryAccounting after UpdateUsage() has returned and released mu.

All callers report statistics (/proc/meminfo, cgroupfs memory files, `runsc events`, `runsc usage`) and already tolerated both the previous throttle and scans skipped during checkpointing.