### PR TITLE
lisafs: fix out-of-bounds slice in PReadResp.CheckedUnmarshal

### DIFF
--- a/pkg/lisafs/message.go
+++ b/pkg/lisafs/message.go
@@ -911,7 +911,11 @@ func (r *PReadResp) MarshalBytes(dst []byte) []byte {
 // CheckedUnmarshal implements marshal.CheckedMarshallable.CheckedUnmarshal.
 func (r *PReadResp) CheckedUnmarshal(src []byte) ([]byte, bool) {
 	srcRemain, ok := r.NumBytes.CheckedUnmarshal(src)
-	if !ok || uint32(r.NumBytes) > uint32(len(srcRemain)) || uint32(r.NumBytes) > uint32(len(r.Buf)) {
+	// NumBytes is a Uint64; compare at full width. Truncating to uint32 (the
+	// previous behavior) let a NumBytes whose low 32 bits are in-bounds but
+	// with a high bit set pass validation, after which r.Buf[:r.NumBytes] below
+	// sliced out of bounds and panicked.
+	if !ok || uint64(r.NumBytes) > uint64(len(srcRemain)) || uint64(r.NumBytes) > uint64(len(r.Buf)) {
 		return src, false
 	}
 


### PR DESCRIPTION
pkg/lisafs/message.go: `PReadResp.NumBytes` is a `primitive.Uint64`, but `CheckedUnmarshal` validates it by truncating to `uint32` while `r.Buf[:r.NumBytes]` slices at the full 64-bit width:

```go
srcRemain, ok := r.NumBytes.CheckedUnmarshal(src)
if !ok || uint32(r.NumBytes) > uint32(len(srcRemain)) || uint32(r.NumBytes) > uint32(len(r.Buf)) {
    return src, false
}
r.Buf = r.Buf[:r.NumBytes]   // slices at full width
```

A `NumBytes` whose low 32 bits are within bounds but with a high bit set (e.g. `0x3030303000000000`) passes all three checks; `r.Buf[:r.NumBytes]` then slices out of bounds → `runtime error: slice bounds out of range`, panicking the sentry while parsing a gofer `PRead` response.

`PWriteReq` is unaffected — its `NumBytes` is a genuine `primitive.Uint32`. This is the same class as the OOB fixed in `RenameAt2Req.CheckedUnmarshal`.

The fix compares at full width. Reproducing input (8 bytes): `00 00 00 00 30 30 30 30`. Found by Go-native fuzzing of the lisafs `CheckedUnmarshal` parsers.