### PR TITLE
Implement shared "null netns" to avoid netns creation overhead on start

### DIFF
--- a/g3doc/user_guide/filesystem.md
+++ b/g3doc/user_guide/filesystem.md
@@ -309,14 +309,3 @@ needs beyond the stock gofer allowlist. `PrepareGofer` can return
 `FlagOverrides` for state that must survive gofer re-exec, such as file
 descriptor numbers. Extensions that pass file descriptors this way must clear
 `FD_CLOEXEC` on those descriptors before returning.
-
-## Gofer network namespace
-
-By default, each gofer runs in a new, empty network namespace. To avoid creating
-a network namespace for every gofer, set `--gofer-network-namespace=host`; the
-gofer then uses runsc caller's current network namespace. To use another
-existing network namespace, pass its absolute path, for example
-`--gofer-network-namespace=/var/run/netns/gofer`.
-
-This removes the gofer's default network isolation. Only use `host` or an
-existing namespace when that network access is acceptable.

--- a/pkg/test/testutil/testutil.go
+++ b/pkg/test/testutil/testutil.go
@@ -309,7 +309,10 @@ func SetupRootDir() (string, func(), error) {
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating root dir: %v", err)
 	}
-	return rootDir, func() { os.RemoveAll(rootDir) }, nil
+	return rootDir, func() {
+		specutils.UnmountNullNetNS(rootDir)
+		os.RemoveAll(rootDir)
+	}, nil
 }
 
 // SetupContainer creates a bundle and root dir for the container, generates a

--- a/runsc/cmd/alias/bwrap/bwrap_integration_test.go
+++ b/runsc/cmd/alias/bwrap/bwrap_integration_test.go
@@ -19,15 +19,23 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"gvisor.dev/gvisor/pkg/test/testutil"
 	"gvisor.dev/gvisor/runsc/specutils"
 )
+
+// newRunRootDir returns a runtime root directory, deleted at test cleanup.
+func newRunRootDir(t *testing.T) string {
+	t.Helper()
+	runRootDir := t.TempDir()
+	t.Cleanup(func() { specutils.UnmountNullNetNS(runRootDir) })
+	return runRootDir
+}
 
 func TestEnvVars(t *testing.T) {
 	if err := testutil.ConfigureExePath(); err != nil {
@@ -36,8 +44,6 @@ func TestEnvVars(t *testing.T) {
 
 	stop := testutil.StartReaper()
 	defer stop()
-
-	rootDir := t.TempDir()
 
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -102,10 +108,7 @@ func TestEnvVars(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			runRootDir := filepath.Join(rootDir, tc.name)
-			if err := os.MkdirAll(runRootDir, 0755); err != nil {
-				t.Fatalf("creating root dir: %v", err)
-			}
+			runRootDir := newRunRootDir(t)
 
 			args := append([]string{
 				"--root", runRootDir,
@@ -142,8 +145,6 @@ func TestUserAndGroup(t *testing.T) {
 
 	stop := testutil.StartReaper()
 	defer stop()
-
-	rootDir := t.TempDir()
 
 	tests := []struct {
 		name      string
@@ -200,10 +201,7 @@ func TestUserAndGroup(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			runRootDir := filepath.Join(rootDir, tc.name)
-			if err := os.MkdirAll(runRootDir, 0755); err != nil {
-				t.Fatalf("creating root dir: %v", err)
-			}
+			runRootDir := newRunRootDir(t)
 
 			args := append([]string{
 				"--root", runRootDir,
@@ -244,8 +242,6 @@ func TestHostname(t *testing.T) {
 	stop := testutil.StartReaper()
 	defer stop()
 
-	rootDir := t.TempDir()
-
 	tests := []struct {
 		name       string
 		bwrapArgs  []string
@@ -265,10 +261,7 @@ func TestHostname(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			runRootDir := filepath.Join(rootDir, tc.name)
-			if err := os.MkdirAll(runRootDir, 0755); err != nil {
-				t.Fatalf("creating root dir: %v", err)
-			}
+			runRootDir := newRunRootDir(t)
 
 			args := append([]string{
 				"--root", runRootDir,
@@ -300,8 +293,6 @@ func TestProc(t *testing.T) {
 	stop := testutil.StartReaper()
 	defer stop()
 
-	rootDir := t.TempDir()
-
 	tests := []struct {
 		name       string
 		bwrapArgs  []string
@@ -322,10 +313,7 @@ func TestProc(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			runRootDir := filepath.Join(rootDir, tc.name)
-			if err := os.MkdirAll(runRootDir, 0755); err != nil {
-				t.Fatalf("creating root dir: %v", err)
-			}
+			runRootDir := newRunRootDir(t)
 
 			args := append([]string{
 				"--root", runRootDir,

--- a/runsc/cmd/do.go
+++ b/runsc/cmd/do.go
@@ -494,7 +494,10 @@ func startContainerAndWait(spec *specs.Spec, conf *config.Config, cid string, wa
 	if err != nil {
 		return util.Errorf("Error to create tmp dir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
+	defer func() {
+		specutils.UnmountNullNetNS(tmpDir)
+		os.RemoveAll(tmpDir)
+	}()
 
 	log.Infof("Changing configuration RootDir to %q", tmpDir)
 	conf.RootDir = tmpDir

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -121,7 +121,7 @@ type Config struct {
 	Network NetworkType `flag:"network"`
 
 	// GoferNetworkNamespace controls the network namespace used by gofer
-	// processes. The default is a new, empty network namespace.
+	// processes. The default is the shared empty "null" network namespace.
 	GoferNetworkNamespace GoferNetworkNamespace `flag:"gofer-network-namespace"`
 
 	// EnableRaw indicates whether raw sockets should be enabled. Raw
@@ -779,6 +779,16 @@ const (
 
 	// GoferNetworkNamespaceHost runs gofers in runsc's current network namespace.
 	GoferNetworkNamespaceHost GoferNetworkNamespace = "host"
+
+	// GoferNetworkNamespaceNull runs gofers in a shared empty network
+	// namespace. The namespace is pinned by a bind mount under the runtime
+	// root directory (same hack as `ip netns add`), and shared by all
+	// gofers using the same root dir.
+	// This provides the same isolation as `GoferNetworkNamespaceNew`
+	// without the cost of a new nets per gofer.
+	// Falls back to `GoferNetworkNamespaceNew` if the shared namespace cannot
+	// be set up (e.g. rootless).
+	GoferNetworkNamespaceNull GoferNetworkNamespace = "null"
 )
 
 func goferNetworkNamespacePtr(v GoferNetworkNamespace) *GoferNetworkNamespace {
@@ -788,11 +798,11 @@ func goferNetworkNamespacePtr(v GoferNetworkNamespace) *GoferNetworkNamespace {
 // Set implements flag.Value. Set(String()) should be idempotent.
 func (n *GoferNetworkNamespace) Set(v string) error {
 	switch v {
-	case string(GoferNetworkNamespaceHost), string(GoferNetworkNamespaceNew):
+	case string(GoferNetworkNamespaceHost), string(GoferNetworkNamespaceNew), string(GoferNetworkNamespaceNull):
 		*n = GoferNetworkNamespace(v)
 	default:
 		if !filepath.IsAbs(v) {
-			return fmt.Errorf("invalid gofer network namespace %q; must be new, host, or an absolute path", v)
+			return fmt.Errorf("invalid gofer network namespace %q; must be new, host, null, or an absolute path", v)
 		}
 		*n = GoferNetworkNamespace(v)
 	}

--- a/runsc/config/config_test.go
+++ b/runsc/config/config_test.go
@@ -34,8 +34,8 @@ func TestDefault(t *testing.T) {
 	// "--root" is always set to something different than the default. Reset it
 	// to make it easier to test that default values do not generate flags.
 	c.RootDir = ""
-	if c.GoferNetworkNamespace != GoferNetworkNamespaceNew {
-		t.Errorf("GoferNetworkNamespace=%q, want new", c.GoferNetworkNamespace)
+	if c.GoferNetworkNamespace != GoferNetworkNamespaceNull {
+		t.Errorf("GoferNetworkNamespace=%q, want null", c.GoferNetworkNamespace)
 	}
 
 	// All defaults doesn't require setting flags.

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -155,7 +155,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 
 	// Flags that control sandbox runtime behavior: network related.
 	flagSet.Var(networkTypePtr(NetworkSandbox), "network", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")
-	flagSet.Var(goferNetworkNamespacePtr(GoferNetworkNamespaceNew), "gofer-network-namespace", "network namespace for gofers: new (default), host (the current namespace), or an absolute path to an existing namespace.")
+	flagSet.Var(goferNetworkNamespacePtr(GoferNetworkNamespaceNull), "gofer-network-namespace", "network namespace for gofers: null (default; an empty namespace shared by all gofers using the same --root), new (a new empty namespace per gofer), host (the current namespace), or an absolute path to an existing namespace.")
 	flagSet.Bool("net-raw", false, "enable raw sockets. When false, raw sockets are disabled by removing CAP_NET_RAW from containers (`runsc exec` will still be able to utilize raw sockets). Raw sockets allow malicious containers to craft packets and potentially attack the network.")
 	flagSet.Bool("allow-packet-socket-write", false, "allow writes on AF_PACKET sockets. When false, writes on AF_PACKET sockets will fail. When turned on, untrusted workloads may potentially attack the network because of the ability to craft arbitrary packets.")
 	flagSet.Bool("allow-live-tcp-migration", true, "allow TCP connection state to be migrated. If false, connected TCP endpoints will be terminated during save/restore.")

--- a/runsc/container/BUILD
+++ b/runsc/container/BUILD
@@ -10,6 +10,7 @@ go_library(
     srcs = [
         "container.go",
         "gofer_to_host_rpc.go",
+        "null_netns.go",
         "state_file.go",
         "status.go",
     ],

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cenkalti/backoff"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
@@ -1583,8 +1584,13 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 		{Type: specs.PIDNamespace},
 		{Type: specs.UTSNamespace},
 	}
-	if ns, ok := goferNetworkNamespace(conf.GoferNetworkNamespace); ok {
-		nss = append(nss, ns)
+	goferNetNS, goferNetNSFile, pinGoferNetNS := goferNetworkNamespace(conf)
+	if goferNetNSFile != nil {
+		// goferNetNS.Path must remain open until the gofer has started.
+		defer goferNetNSFile.Close()
+	}
+	if goferNetNS != nil {
+		nss = append(nss, *goferNetNS)
 	}
 
 	rootlessEUID := unix.Geteuid() != 0
@@ -1653,6 +1659,16 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 	c.goferIsChild = true
 	rpcPidCh <- cmd.Process.Pid
 
+	if pinGoferNetNS {
+		// The gofer was started in a new empty network namespace.
+		// Pin it, future gofers will join it instead of creating a new one.
+		if err := pinNullNetNS(conf, cmd.Process.Pid); err != nil {
+			log.Warningf("Unable to pin the gofer's network namespace at %q (%v); future gofers will create new network namespaces. This slows down gVisor startup.", nullNetNSPath(conf), err)
+		} else {
+			log.Infof("Pinned null network namespace at %q", nullNetNSPath(conf))
+		}
+	}
+
 	// Set up and synchronize rootless mode userns mappings.
 	if setUserMappings {
 		if err := sandbox.SetUserMappings(c.Spec, cmd.Process.Pid); err != nil {
@@ -1676,17 +1692,39 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 	return sandEnds, goferFilestores, devSandEnd, mountsSand, nil
 }
 
-func goferNetworkNamespace(namespace config.GoferNetworkNamespace) (specs.LinuxNamespace, bool) {
-	switch namespace {
+// goferNetworkNamespace returns the network namespace that the gofer process
+// should be started in.
+// A nil namespace means to stay in the current network namespace.
+// The returned `os.File` keeps the namespace referred to by the returned
+// namespace's Path alive, so it must be kept open until gofer start.
+// If `pinNetNS` is true, the gofer should be started in a new network
+// namespace, which should then be pinned as the shared "null" network
+// namespace (see `pinNullNetNS`) once the gofer starts.
+func goferNetworkNamespace(conf *config.Config) (ns *specs.LinuxNamespace, nsFile *os.File, pinNetNS bool) {
+	switch conf.GoferNetworkNamespace {
 	case config.GoferNetworkNamespaceNew:
-		return specs.LinuxNamespace{Type: specs.NetworkNamespace}, true
+		return &specs.LinuxNamespace{Type: specs.NetworkNamespace}, nil, false
 	case config.GoferNetworkNamespaceHost:
-		return specs.LinuxNamespace{}, false
-	default:
-		return specs.LinuxNamespace{
+		return nil, nil, false
+	case config.GoferNetworkNamespaceNull:
+		nsFile, err := openNullNetNS(nullNetNSPath(conf))
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Infof("No usable null network namespace at %q (%v); creating a new one. This is expected if this sandbox is the first sandbox to start with this `--root` (%v). If this is not the first sandbox, this issue is slowing down your sandboxes' startup.", nullNetNSPath(conf), conf.RootDir, err)
+			}
+			return &specs.LinuxNamespace{Type: specs.NetworkNamespace}, nil, true
+		}
+		return &specs.LinuxNamespace{
 			Type: specs.NetworkNamespace,
-			Path: string(namespace),
-		}, true
+			// Refer to the namespace through our own open FD so that
+			// it stays valid even if racing with an unmount.
+			Path: fmt.Sprintf("/proc/self/fd/%d", nsFile.Fd()),
+		}, nsFile, false
+	default:
+		return &specs.LinuxNamespace{
+			Type: specs.NetworkNamespace,
+			Path: string(conf.GoferNetworkNamespace),
+		}, nil, false
 	}
 }
 

--- a/runsc/container/null_netns.go
+++ b/runsc/container/null_netns.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+
+	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/specutils"
+)
+
+// nullNetNSPath returns the path of the bind mount pinning the shared "null"
+// network namespace.
+func nullNetNSPath(conf *config.Config) string {
+	return filepath.Join(conf.RootDir, specutils.NullNetNSFilename)
+}
+
+// openNullNetNS opens the network namespace bind-mounted at `path`.
+func openNullNetNS(path string) (*os.File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	var st unix.Statfs_t
+	if err := unix.Fstatfs(int(f.Fd()), &st); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("statfs %q: %w", path, err)
+	}
+	if st.Type != unix.NSFS_MAGIC {
+		f.Close()
+		return nil, fmt.Errorf("%q is not a namespace mount", path)
+	}
+	if nsType, err := unix.IoctlRetInt(int(f.Fd()), unix.NS_GET_NSTYPE); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("getting namespace type of %q: %w", path, err)
+	} else if nsType != unix.CLONE_NEWNET {
+		f.Close()
+		return nil, fmt.Errorf("%q is not a network namespace", path)
+	}
+	return f, nil
+}
+
+// pinNullNetNS pins the network namespace of the process `pid` by
+// bind-mounting its `nsfs` file at the null network namespace path, so that
+// future gofers can join it. The process must have been started in a new,
+// empty network namespace, and must not have exited yet.
+//
+// Pinning is not serialized across invocations, so concurrent invocations
+// may stack bind mounts on top of each other.
+// This is OK: all of them pin valid empty network namespaces, and future
+// invocations join whichever one is mounted on top.
+// (Expected to happen very infrequently in practice, as it requires multiple
+// concurrent cold starts using the same root directory.)
+func pinNullNetNS(conf *config.Config, pid int) error {
+	path := nullNetNSPath(conf)
+	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0444)
+	if err != nil {
+		return fmt.Errorf("creating mount point: %w", err)
+	}
+	_ = f.Close()
+	if err := unix.Mount(fmt.Sprintf("/proc/%d/ns/net", pid), path, "", unix.MS_BIND, ""); err != nil {
+		_ = os.Remove(path) // Best effort.
+		return fmt.Errorf("bind-mounting namespace of PID %d: %w", pid, err)
+	}
+	return nil
+}

--- a/runsc/specutils/namespace.go
+++ b/runsc/specutils/namespace.go
@@ -26,6 +26,7 @@ import (
 	"github.com/moby/sys/capability"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/log"
 )
 
@@ -302,6 +303,24 @@ func MaybeRunAsRoot() error {
 	// Child completed with success.
 	os.Exit(0)
 	panic("unreachable")
+}
+
+// NullNetNSFilename is the name of the file (relative to `--root`)
+// that the shared empty ("null") gofer network namespace is
+// bind-mounted to.
+const NullNetNSFilename = "null-netns"
+
+// UnmountNullNetNS unmounts null gofer network namespace bind mounts under
+// `rootDir`, if any.
+// Must be called before removing a runtime root directory, which would
+// otherwise fail with `EBUSY`.
+func UnmountNullNetNS(rootDir string) {
+	// Namespace creation isn't serialized across invocations, so concurrent
+	// creations may stack bind mounts on the same path.
+	// So loop until none are left.
+	path := filepath.Join(rootDir, NullNetNSFilename)
+	for unix.Unmount(path, unix.MNT_DETACH) == nil {
+	}
 }
 
 // KnownNamespaces returns a list of all supported namespace types.


### PR DESCRIPTION
See issue #13764 for motivation and idea. This approach yields the benefit without the security compromise of moving the fsgofer out of a network-disabled netns, so it is a safe new default.

Benchmarks:

```
                            │ gofer-netns-new │          gofer-netns-null          │
                            │     sec/op      │   sec/op     vs base               │
OCIStartup/load=idle             118.6m ±  5%   119.3m ± 4%       ~ (p=0.756 n=40)
OCIStartup/load=netns-churn      236.5m ± 13%   215.2m ± 7%  -8.99% (p=0.033 n=20)
geomean                          167.5m         160.2m       -4.32%
```

`netns-churn` is simulated with this bash thingy in the background:

```
for j in $(seq 1 8); do
  ( while :; do unshare -n /bin/true; done ) &
done
```

The effect gets stronger at higher core counts on real servers.