### PR TITLE
Use `pidfd` to monitor for process deletion instead of 100ms poll loop

### DIFF
--- a/runsc/container/BUILD
+++ b/runsc/container/BUILD
@@ -39,7 +39,6 @@ go_library(
         "//runsc/sandbox",
         "//runsc/specutils",
         "//runsc/starttime",
-        "@com_github_cenkalti_backoff//:go_default_library",
         "@com_github_gofrs_flock//:go_default_library",
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -17,7 +17,6 @@ package container
 
 import (
 	"bufio"
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -30,7 +29,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 
@@ -1318,17 +1316,11 @@ func (c *Container) waitForStopped() error {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	b := backoff.WithContext(backoff.NewConstantBackOff(100*time.Millisecond), ctx)
-	op := func() error {
-		if err := unix.Kill(goferPid, 0); err == nil {
-			return fmt.Errorf("gofer is still running")
-		}
-		c.GoferPid.Store(0)
-		return nil
+	if err := specutils.WaitForNonChildExit(int(goferPid), 5*time.Second); err != nil {
+		return fmt.Errorf("waiting for gofer (PID %d) to exit: %v", goferPid, err)
 	}
-	return backoff.Retry(op, b)
+	c.GoferPid.Store(0)
+	return nil
 }
 
 // shouldCreateDeviceGofer indicates whether a device gofer connection should

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -16,7 +16,6 @@
 package sandbox
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,10 +32,10 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/moby/sys/capability"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/cleanup"
@@ -2224,16 +2223,11 @@ func (s *Sandbox) waitForStopped() error {
 		s.Pid.Store(0)
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), waitTimeout)
-	defer cancel()
-	b := backoff.WithContext(backoff.NewConstantBackOff(100*time.Millisecond), ctx)
-	op := func() error {
-		if s.IsRunning() {
-			return fmt.Errorf("sandbox is still running")
-		}
+	pid := s.Pid.Load()
+	if pid == 0 {
 		return nil
 	}
-	return backoff.Retry(op, b)
+	return specutils.WaitForNonChildExit(pid, waitTimeout)
 }
 
 // configureStdios change stdios ownership to give access to the sandbox

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -35,6 +35,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/opencontainers/runtime-spec/specs-go/features"
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -607,6 +608,48 @@ func WaitForReady(pid int, timeout time.Duration, ready func() (bool, error)) er
 		return fmt.Errorf("process %d not running yet", pid)
 	}
 	return backoff.Retry(op, b)
+}
+
+// WaitForNonChildExit waits for the given process to exit, up to `timeout`.
+// As the name implies, `pid` must not be a child of the current process.
+// Returns immediately if the process does not exist.
+func WaitForNonChildExit(pid int, timeout time.Duration) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid pid: %d", pid)
+	}
+	pidfd, err := unix.PidfdOpen(pid, 0)
+	if err == unix.ESRCH {
+		return nil // Already gone.
+	}
+	if err != nil {
+		// pidfd_open failed (Linux < 5.3). Fall back to polling.
+		b := backoff.WithMaxRetries(backoff.NewConstantBackOff(10*time.Millisecond), uint64(timeout/(10*time.Millisecond)))
+		return backoff.Retry(func() error {
+			if err := unix.Kill(pid, 0); err == nil {
+				return fmt.Errorf("process %d is still running", pid)
+			}
+			return nil
+		}, b)
+	}
+	defer unix.Close(pidfd)
+	deadline := time.Now().Add(timeout)
+	for {
+		timeoutMS := int(time.Until(deadline).Milliseconds())
+		if timeoutMS <= 0 {
+			return fmt.Errorf("process %d is still running after %v", pid, timeout)
+		}
+		pfds := []unix.PollFd{{Fd: int32(pidfd), Events: unix.POLLIN}}
+		n, err := unix.Poll(pfds, timeoutMS)
+		if err == unix.EINTR {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("polling pidfd for process %d: %v", pid, err)
+		}
+		if n > 0 {
+			return nil // The pidfd becomes "readable" when the process exits.
+		}
+	}
 }
 
 // OpenDebugLogFile opens a log file using 'logPattern' as location. If 'logPattern'


### PR DESCRIPTION
As expected, cuts ~100ms from `runsc create` + `runsc delete` cycle.

Doesn't make container startup faster, but for systems that maintain a constant number of idle sandboxes, this is a large difference in speed.

```
             │         old         │               new                   │
             │       sec/op        │   sec/op     vs base                │
CreateDelete           205.0m ± 4%   109.9m ± 8%  -46.39% (p=0.000 n=20)
```