### PR TITLE
runsc: don't follow symlinks when creating mount points

### DIFF
--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -303,20 +303,8 @@ func safeSetupAndMoveMount(srcFileFD int, src, dst, procPath string) error {
 	if err != nil {
 		return fmt.Errorf("stat(%q) failed: %v", src, err)
 	}
-	if fi.IsDir() {
-		if err := os.MkdirAll(dst, 0777); err != nil {
-			return fmt.Errorf("mkdir(%q) failed: %v", dst, err)
-		}
-	} else {
-		parent := filepath.Dir(dst)
-		if err := os.MkdirAll(parent, 0777); err != nil {
-			return fmt.Errorf("mkdir(%q) failed: %v", parent, err)
-		}
-		f, err := os.OpenFile(dst, unix.O_CREAT, 0777)
-		if err != nil {
-			return fmt.Errorf("open(%q) failed: %v", dst, err)
-		}
-		f.Close()
+	if err := specutils.SafeCreateMountPoint(dst, fi.IsDir()); err != nil {
+		return err
 	}
 
 	fd, err := unix.Open(dst, unix.O_PATH|unix.O_CLOEXEC, 0)

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -709,6 +709,83 @@ func TPUFunctionalityRequested(spec *specs.Spec, conf *config.Config) bool {
 	return false
 }
 
+// SafeCreateMountPoint creates the mount point at dst, along with any missing
+// parent directories. isDir selects whether dst is created as a directory or
+// as an empty regular file.
+//
+// Unlike os.MkdirAll and os.OpenFile, it never traverses a symlink: each path
+// component is created and opened relative to a file descriptor for its
+// parent, using O_NOFOLLOW. dst is expected to be free of symlinks already
+// (see the callers' use of resolveSymlink), and SafeMount rejects any dst that
+// is not, so this cannot reject a destination that would otherwise have been
+// mounted successfully. What it does prevent is creating the directories and
+// the file at a location the caller did not intend, which is observable even
+// when the subsequent SafeMount fails: dst is resolved by pathname, so a
+// symlink swapped into a component after it was resolved redirects the
+// creation outside the intended tree.
+func SafeCreateMountPoint(dst string, isDir bool) error {
+	if isDir {
+		dirFD, err := safeMkdirAll(dst)
+		if err != nil {
+			return fmt.Errorf("mkdir(%q) failed: %v", dst, err)
+		}
+		return unix.Close(dirFD)
+	}
+
+	// Create the parent destination directory, then the destination file
+	// relative to it, so that the parent cannot be exchanged in between.
+	parent := path.Dir(dst)
+	parentFD, err := safeMkdirAll(parent)
+	if err != nil {
+		return fmt.Errorf("mkdir(%q) failed: %v", parent, err)
+	}
+	defer unix.Close(parentFD)
+
+	// Create the destination file if it does not exist.
+	fd, err := unix.Openat(parentFD, path.Base(dst), unix.O_CREAT|unix.O_NOFOLLOW|unix.O_CLOEXEC, 0777)
+	if err != nil {
+		return fmt.Errorf("open(%q) failed: %v", dst, err)
+	}
+	return unix.Close(fd)
+}
+
+// safeMkdirAll creates dir and any missing parents without traversing a
+// symlink, and returns a file descriptor for dir. The caller owns the
+// descriptor and must close it.
+func safeMkdirAll(dir string) (int, error) {
+	if !path.IsAbs(dir) {
+		return -1, fmt.Errorf("path is not absolute")
+	}
+	// O_PATH is used so that components need not be readable, and is safe to
+	// pass as the directory argument of the *at(2) calls below. O_DIRECTORY
+	// rejects a symlink: with O_PATH|O_NOFOLLOW, opening a symlink succeeds and
+	// yields a descriptor for the link itself, which is not a directory.
+	const flags = unix.O_PATH | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	parentFD, err := unix.Open("/", flags, 0)
+	if err != nil {
+		return -1, fmt.Errorf("open(\"/\") failed: %v", err)
+	}
+	for _, name := range strings.Split(path.Clean(dir), "/") {
+		if name == "" {
+			continue
+		}
+		childFD, err := unix.Openat(parentFD, name, flags, 0)
+		if err == unix.ENOENT {
+			if err := unix.Mkdirat(parentFD, name, 0777); err != nil && err != unix.EEXIST {
+				unix.Close(parentFD)
+				return -1, fmt.Errorf("mkdirat(%q) failed: %v", name, err)
+			}
+			childFD, err = unix.Openat(parentFD, name, flags, 0)
+		}
+		unix.Close(parentFD)
+		if err != nil {
+			return -1, fmt.Errorf("openat(%q) failed: %v", name, err)
+		}
+		parentFD = childFD
+	}
+	return parentFD, nil
+}
+
 // SafeSetupAndMount creates the mount point and calls Mount with the given
 // flags. procPath is the path to procfs. If it is "", procfs is assumed to be
 // mounted at /proc.
@@ -725,23 +802,8 @@ func SafeSetupAndMount(src, dst, typ string, flags uint32, procPath string) erro
 		isDir = fi.IsDir()
 	}
 
-	if isDir {
-		// Create the destination directory.
-		if err := os.MkdirAll(dst, 0777); err != nil {
-			return fmt.Errorf("mkdir(%q) failed: %v", dst, err)
-		}
-	} else {
-		// Create the parent destination directory.
-		parent := path.Dir(dst)
-		if err := os.MkdirAll(parent, 0777); err != nil {
-			return fmt.Errorf("mkdir(%q) failed: %v", parent, err)
-		}
-		// Create the destination file if it does not exist.
-		f, err := os.OpenFile(dst, unix.O_CREAT, 0777)
-		if err != nil {
-			return fmt.Errorf("open(%q) failed: %v", dst, err)
-		}
-		f.Close()
+	if err := SafeCreateMountPoint(dst, isDir); err != nil {
+		return err
 	}
 
 	// Do the mount.

--- a/runsc/specutils/specutils_test.go
+++ b/runsc/specutils/specutils_test.go
@@ -16,7 +16,9 @@ package specutils
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -837,6 +839,114 @@ func TestTPUProxyEnabled(t *testing.T) {
 			got := TPUProxyEnabled(&tc.spec, &tc.conf)
 			if got != tc.want {
 				t.Errorf("TPUProxyEnabled() got: %v, want: %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// mountPointTestRoot returns a symlink-free temporary directory. Mount
+// destinations are expected to be free of symlinks (SafeMount rejects any that
+// are not), so the tests below must not inherit one from TMPDIR.
+func mountPointTestRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks failed: %v", err)
+	}
+	return root
+}
+
+func TestSafeCreateMountPoint(t *testing.T) {
+	root := mountPointTestRoot(t)
+
+	dir := filepath.Join(root, "a", "b", "c")
+	if err := SafeCreateMountPoint(dir, true /* isDir */); err != nil {
+		t.Fatalf("SafeCreateMountPoint(%q, true) failed: %v", dir, err)
+	}
+	if fi, err := os.Lstat(dir); err != nil || !fi.IsDir() {
+		t.Errorf("Lstat(%q) got: %v, %v; want a directory", dir, fi, err)
+	}
+
+	file := filepath.Join(root, "d", "e", "f")
+	if err := SafeCreateMountPoint(file, false /* isDir */); err != nil {
+		t.Fatalf("SafeCreateMountPoint(%q, false) failed: %v", file, err)
+	}
+	if fi, err := os.Lstat(file); err != nil || !fi.Mode().IsRegular() {
+		t.Errorf("Lstat(%q) got: %v, %v; want a regular file", file, fi, err)
+	}
+
+	// Creating an existing mount point is a no-op.
+	if err := SafeCreateMountPoint(dir, true /* isDir */); err != nil {
+		t.Errorf("re-creating %q failed: %v", dir, err)
+	}
+	if err := SafeCreateMountPoint(file, false /* isDir */); err != nil {
+		t.Errorf("re-creating %q failed: %v", file, err)
+	}
+}
+
+func TestSafeCreateMountPointDoesNotTruncate(t *testing.T) {
+	file := filepath.Join(mountPointTestRoot(t), "mountpoint")
+	if err := os.WriteFile(file, []byte("contents"), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	if err := SafeCreateMountPoint(file, false /* isDir */); err != nil {
+		t.Fatalf("SafeCreateMountPoint(%q, false) failed: %v", file, err)
+	}
+	got, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if want := "contents"; string(got) != want {
+		t.Errorf("contents got: %q, want: %q", got, want)
+	}
+}
+
+func TestSafeCreateMountPointDoesNotFollowSymlinks(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		isDir bool
+		// setup creates the symlink under root pointing at escaped, and returns
+		// the destination to create.
+		setup func(t *testing.T, root, escaped string) string
+	}{
+		{
+			name:  "intermediate component",
+			isDir: true,
+			setup: func(t *testing.T, root, escaped string) string {
+				link := filepath.Join(root, "vol")
+				if err := os.Symlink(escaped, link); err != nil {
+					t.Fatalf("Symlink failed: %v", err)
+				}
+				return filepath.Join(link, "deep", "mountpoint")
+			},
+		},
+		{
+			name:  "final component",
+			isDir: false,
+			setup: func(t *testing.T, root, escaped string) string {
+				link := filepath.Join(root, "mountpoint")
+				if err := os.Symlink(escaped, link); err != nil {
+					t.Fatalf("Symlink failed: %v", err)
+				}
+				return link
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := mountPointTestRoot(t)
+			root := filepath.Join(base, "tree")
+			if err := os.Mkdir(root, 0755); err != nil {
+				t.Fatalf("Mkdir failed: %v", err)
+			}
+			escaped := filepath.Join(base, "escaped")
+
+			dst := tc.setup(t, root, escaped)
+			err := SafeCreateMountPoint(dst, tc.isDir)
+			if err == nil {
+				t.Errorf("SafeCreateMountPoint(%q, %t) got: nil; want an error, the path contains a symlink", dst, tc.isDir)
+			}
+			if _, err := os.Lstat(escaped); err == nil {
+				t.Errorf("SafeCreateMountPoint(%q, %t) created %q, outside the intended tree", dst, tc.isDir, escaped)
 			}
 		})
 	}


### PR DESCRIPTION
`SafeSetupAndMount` and `safeSetupAndMoveMount` create the mount point with
`os.MkdirAll` and `os.OpenFile` before calling `SafeMount`. Both resolve the
destination by pathname, so a symlink that appears in a path component after
the destination was resolved redirects the creation outside the intended tree.

`SafeMount` already rejects such a destination: it opens `dst` with `O_PATH`
and compares `/proc/self/fd/N` against `dst`, so the mount itself does not
land. By then the directories and the file have been created, and they are not
cleaned up.

The window is not theoretical. The destination is resolved once, in
`resolveSymlink`, and then used as a pathname several syscalls later
(`OptionsToFlags`, the `unix.Access` probe, `os.Stat(src)`, and for an
ID-mapped or inaccessible source an RPC round trip). In a multi-container
sandbox the gofer for a joining container runs this setup as root, before
`setCapsAndCallSelf` drops capabilities, while the other containers are
running. Mounts are applied one at a time, so a destination nested under an
already-mounted shared volume is resolved through a directory that a running
container can write to. That is the same shape as CVE-2021-30465, which
`SafeMount` was added to fix; the mount was hardened, the creation above it
was not.

This replaces both copies with a single `SafeCreateMountPoint`, which walks
the destination one component at a time, opening each relative to a descriptor
for its parent with `O_NOFOLLOW`, and creates the destination file relative to
the parent descriptor rather than by pathname.

This cannot reject a destination that would otherwise have been mounted: any
destination containing a symlink already fails the `/proc/self/fd` check in
`SafeMount`. It only moves that rejection ahead of the side effects.

Tests cover both directions: that ordinary mount points are still created,
that an existing mount point is neither recreated nor truncated, and that a
symlink in an intermediate component or as the destination itself is rejected
without anything being created at the link target. The last two fail against
the previous implementation.

Built and tested outside the Bazel tree; I do not have a working Bazel setup
on this machine, so please let CI exercise the full build.