### PR TITLE
nvproxy: return realistic sets from PopularCapabilitySets()

### DIFF
--- a/pkg/sentry/devices/nvproxy/nvconf/caps.go
+++ b/pkg/sentry/devices/nvproxy/nvconf/caps.go
@@ -196,19 +196,11 @@ func (c DriverCaps) NVIDIAFlags() []string {
 // PopularCapabilitySets returns the most commonly used capability sets.
 func PopularCapabilitySets() []DriverCaps {
 	capSets := make(map[DriverCaps]struct{})
-	capSets[SupportedDriverCaps] = struct{}{}
 	capSets[DefaultDriverCaps] = struct{}{}
-	// Add every individual supported capability together with CapUtility.
-	for i := 0; i < numValidCaps; i++ {
-		cap := DriverCaps(1 << i)
-		if cap == CapUtility {
-			continue
-		}
-		if cap&SupportedDriverCaps == 0 {
-			continue
-		}
-		capSets[cap|CapUtility] = struct{}{}
-	}
+	capSets[DefaultDriverCaps|CapGraphics] = struct{}{}
+	capSets[DefaultDriverCaps|CapVideo] = struct{}{}
+	capSets[AllContainerDriverCaps] = struct{}{}
+	capSets[AllContainerDriverCaps|CapProfiling] = struct{}{}
 	// Return as a sorted list.
 	return slices.Sorted(maps.Keys(capSets))
 }


### PR DESCRIPTION
PopularCapabilitySets() previously returned SupportedDriverCaps plus every
individual supported capability paired with CapUtility. Several of these
combinations (e.g. compat32, ngx, display with utility) are not sets that
users actually request, so the precompiled seccomp filters covered
configurations that never occur in practice while still paying the cost of
precompiling them.

Return instead the capability sets that are commonly used:

  - compute + utility (the default)
  - compute + graphics + utility
  - compute + video + utility
  - all container caps (compute + utility + graphics + video)
  - all container caps + profiling