### PR TITLE
tcp: prevent CUBIC ACKs from reducing cwnd

### DIFF
--- a/pkg/tcpip/transport/tcp/cubic.go
+++ b/pkg/tcpip/transport/tcp/cubic.go
@@ -260,6 +260,11 @@ func (c *cubicState) getCwnd(packetsAcked, sndCwnd int, srtt time.Duration) int 
 	// As per 4.3 for each received ACK cwnd must be incremented
 	// by (w_cubic(t+RTT) - cwnd/cwnd.
 	cwnd := float64(sndCwnd)
+	// RFC 9438 section 4.2 bounds the target at cwnd so an ACK does not
+	// reduce the congestion window.
+	if wtRtt < cwnd {
+		wtRtt = cwnd
+	}
 	for i := 0; i < packetsAcked; i++ {
 		// Concave/Convex regions of cubic have the same formulas.
 		// See: https://tools.ietf.org/html/rfc8312#section-4.3


### PR DESCRIPTION
CUBIC currently applies the per-ACK window update even when the computed `W_cubic(t + RTT)` value is below the current congestion window. In that case, the update becomes negative and receiving an ACK can reduce `cwnd` without a congestion signal.

Clamp the computed CUBIC window to the current `cwnd` before processing ACKs. This applies the lower-bound rule from RFC 9438, Section 4.2, and ensures that ACK processing does not reduce the congestion window.