### PR TITLE
`runsc`: Add `--shared-root` to share control files across the system.

### DIFF
--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -471,6 +471,13 @@ type Config struct {
 	// once their current RPC finishes. Setting this to 0 closes idle clients
 	// immediately.
 	ControlRPCStopTimeout time.Duration `flag:"control-rpc-stop-timeout"`
+
+	// SharedRootDir is the directory used for state shared across sandboxes
+	// regardless of their runtime root directory (e.g. the null gofer network
+	// namespace bind mount). If empty, RootDir is used.
+	// Access to SharedRootDir grants the ability to identify sandboxes, but
+	// not to control them.
+	SharedRootDir string `flag:"shared-root"`
 }
 
 // Validate checks that the Config is in a consistent state, e.g. that no
@@ -569,6 +576,15 @@ func (c *Config) Log() {
 			}
 		}
 	}
+}
+
+// SharedRoot returns the effective directory for state shared across
+// sandboxes: SharedRootDir if set, otherwise RootDir.
+func (c *Config) SharedRoot() string {
+	if c.SharedRootDir != "" {
+		return c.SharedRootDir
+	}
+	return c.RootDir
 }
 
 // GetHostUDS returns the FS gofer communication that is allowed, taking into
@@ -781,9 +797,9 @@ const (
 	GoferNetworkNamespaceHost GoferNetworkNamespace = "host"
 
 	// GoferNetworkNamespaceNull runs gofers in a shared empty network
-	// namespace. The namespace is pinned by a bind mount under the runtime
-	// root directory (same hack as `ip netns add`), and shared by all
-	// gofers using the same root dir.
+	// namespace. The namespace is pinned by a bind mount under the shared
+	// root directory (`--shared-root`, defaulting to `--root`; same hack as
+	// `ip netns add`), and shared by all gofers using the same directory.
 	// This provides the same isolation as `GoferNetworkNamespaceNew`
 	// without the cost of a new nets per gofer.
 	// Falls back to `GoferNetworkNamespaceNew` if the shared namespace cannot

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -126,6 +126,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("kvm-use-cpu-nums", false, "on KVM use vCPU numbers as CPU numbers in the sentry. This is necessary to support features like rseq.")
 	flagSet.Bool("allow-rootfs-tar-annotation", false, "allows the rootfs tar annotation to be set.")
 	flagSet.Duration("control-rpc-stop-timeout", 15*time.Second, "grace period given to in-flight RPCs on the sandbox control socket when the sandbox is shutting down. Once this timeout elapses, client connections are closed, and connections still processing an RPC are closed when their current RPC finishes. Set to 0 to close idle clients immediately.")
+	flagSet.String("shared-root", "", "directory for storage of state shared across sandboxes on the system. Defaults to the value of --root. Point this at a shared system-wide directory if --root is not reused across sandboxes. Access to --shared-root allows identification of running sandboxes, but not control over them.")
 
 	// Flags that control sandbox runtime behavior: MM related.
 	flagSet.Bool("app-huge-pages", true, "enable use of huge pages for application memory; requires /sys/kernel/mm/transparent_hugepage/shmem_enabled = advise")
@@ -155,7 +156,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 
 	// Flags that control sandbox runtime behavior: network related.
 	flagSet.Var(networkTypePtr(NetworkSandbox), "network", "specifies which network to use: sandbox (default), host, none. Using network inside the sandbox is more secure because it's isolated from the host network.")
-	flagSet.Var(goferNetworkNamespacePtr(GoferNetworkNamespaceNull), "gofer-network-namespace", "network namespace for gofers: null (default; an empty namespace shared by all gofers using the same --root), new (a new empty namespace per gofer), host (the current namespace), or an absolute path to an existing namespace.")
+	flagSet.Var(goferNetworkNamespacePtr(GoferNetworkNamespaceNull), "gofer-network-namespace", "network namespace for gofers: null (default; an empty namespace shared by all gofers using the same --shared-root, which defaults to --root), new (a new empty namespace per gofer), host (the current namespace), or an absolute path to an existing namespace.")
 	flagSet.Bool("net-raw", false, "enable raw sockets. When false, raw sockets are disabled by removing CAP_NET_RAW from containers (`runsc exec` will still be able to utilize raw sockets). Raw sockets allow malicious containers to craft packets and potentially attack the network.")
 	flagSet.Bool("allow-packet-socket-write", false, "allow writes on AF_PACKET sockets. When false, writes on AF_PACKET sockets will fail. When turned on, untrusted workloads may potentially attack the network because of the ability to craft arbitrary packets.")
 	flagSet.Bool("allow-live-tcp-migration", true, "allow TCP connection state to be migrated. If false, connected TCP endpoints will be terminated during save/restore.")
@@ -306,6 +307,16 @@ func isFlagExplicitlySet(flagSet *flag.FlagSet, name string) bool {
 	return explicit
 }
 
+// DefaultRootDir returns the value used for the runtime root directory when
+// the --root flag is not set (or set to the empty string).
+func DefaultRootDir() string {
+	// NOTE: empty values for XDG_RUNTIME_DIR should be ignored.
+	if runtimeDir := os.Getenv(xdgRuntimeDirEnvVar); runtimeDir != "" {
+		return filepath.Join(runtimeDir, "runsc")
+	}
+	return defaultRootDir
+}
+
 // NewFromFlags creates a new Config with values coming from command line flags.
 func NewFromFlags(flagSet *flag.FlagSet) (*Config, error) {
 	conf := &Config{explicitlySet: map[string]struct{}{}}
@@ -332,11 +343,7 @@ func NewFromFlags(flagSet *flag.FlagSet) (*Config, error) {
 
 	if len(conf.RootDir) == 0 {
 		// If not set, set default root dir to something (hopefully) user-writeable.
-		conf.RootDir = defaultRootDir
-		// NOTE: empty values for XDG_RUNTIME_DIR should be ignored.
-		if runtimeDir := os.Getenv(xdgRuntimeDirEnvVar); runtimeDir != "" {
-			conf.RootDir = filepath.Join(runtimeDir, "runsc")
-		}
+		conf.RootDir = DefaultRootDir()
 	}
 
 	if err := conf.Validate(); err != nil {

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1710,7 +1710,9 @@ func goferNetworkNamespace(conf *config.Config) (ns *specs.LinuxNamespace, nsFil
 		nsFile, err := openNullNetNS(nullNetNSPath(conf))
 		if err != nil {
 			if !os.IsNotExist(err) {
-				log.Infof("No usable null network namespace at %q (%v); creating a new one. This is expected if this sandbox is the first sandbox to start with this `--root` (%v). If this is not the first sandbox, this issue is slowing down your sandboxes' startup.", nullNetNSPath(conf), conf.RootDir, err)
+				log.Infof("No usable null network namespace at %q (%v); creating a new one. This is expected if this sandbox is the first sandbox to start with this shared root directory (%v). If this is not the first sandbox, this issue is slowing down your sandboxes' startup.", nullNetNSPath(conf), err, conf.SharedRoot())
+			} else if conf.SharedRootDir == "" && conf.RootDir != config.DefaultRootDir() {
+				log.Infof("If --root is not reused across multiple sandboxes, you can speed up sandbox startup by setting --shared-root to a shared system-wide directory so that the null gofer network namespace is reused across sandboxes.")
 			}
 			return &specs.LinuxNamespace{Type: specs.NetworkNamespace}, nil, true
 		}

--- a/runsc/container/null_netns.go
+++ b/runsc/container/null_netns.go
@@ -28,7 +28,7 @@ import (
 // nullNetNSPath returns the path of the bind mount pinning the shared "null"
 // network namespace.
 func nullNetNSPath(conf *config.Config) string {
-	return filepath.Join(conf.RootDir, specutils.NullNetNSFilename)
+	return filepath.Join(conf.SharedRoot(), specutils.NullNetNSFilename)
 }
 
 // openNullNetNS opens the network namespace bind-mounted at `path`.
@@ -66,7 +66,7 @@ func openNullNetNS(path string) (*os.File, error) {
 // This is OK: all of them pin valid empty network namespaces, and future
 // invocations join whichever one is mounted on top.
 // (Expected to happen very infrequently in practice, as it requires multiple
-// concurrent cold starts using the same root directory.)
+// concurrent cold starts using the same shared root directory.)
 func pinNullNetNS(conf *config.Config, pid int) error {
 	path := nullNetNSPath(conf)
 	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0444)

--- a/runsc/specutils/namespace.go
+++ b/runsc/specutils/namespace.go
@@ -305,20 +305,20 @@ func MaybeRunAsRoot() error {
 	panic("unreachable")
 }
 
-// NullNetNSFilename is the name of the file (relative to `--root`)
-// that the shared empty ("null") gofer network namespace is
-// bind-mounted to.
+// NullNetNSFilename is the name of the file (relative to `--shared-root`,
+// which defaults to `--root`) that the shared empty ("null") gofer network
+// namespace is bind-mounted to.
 const NullNetNSFilename = "null-netns"
 
 // UnmountNullNetNS unmounts null gofer network namespace bind mounts under
-// `rootDir`, if any.
-// Must be called before removing a runtime root directory, which would
-// otherwise fail with `EBUSY`.
-func UnmountNullNetNS(rootDir string) {
+// `sharedRootDir`, if any.
+// Must be called before removing a shared root (or runtime root) directory,
+// which would otherwise fail with `EBUSY`.
+func UnmountNullNetNS(sharedRootDir string) {
 	// Namespace creation isn't serialized across invocations, so concurrent
 	// creations may stack bind mounts on the same path.
 	// So loop until none are left.
-	path := filepath.Join(rootDir, NullNetNSFilename)
+	path := filepath.Join(sharedRootDir, NullNetNSFilename)
 	for unix.Unmount(path, unix.MNT_DETACH) == nil {
 	}
 }


### PR DESCRIPTION
`--root` is the OCI parameter for the control directory for sandboxes. `--shared-root` defaults to that, but can be specified separately.

Semantically, the distinction is that having access to `--root` gives you full control over the sandboxes with that `--root`, whereas access to `--shared-root` only gives you the ability to identify and list sandboxes using that `--shared-root`, but no control over them.

It is used to put the `null-netns` control file, which is safe to reuse across sandboxes.

This allows systems such as Substrate, which specify a separate `--root` per sandbox, to still benefit from the shared `null` netns speedup introduced in 4164f91101bcd92c92e43d30c171ea2ff091adad.