### PR TITLE
runsc: add a no-root-container boot mode

### DIFF
--- a/g3doc/user_guide/BUILD
+++ b/g3doc/user_guide/BUILD
@@ -160,3 +160,11 @@ doc(
     permalink = "/docs/user_guide/rootless/",
     weight = "94",
 )
+
+doc(
+    name = "sandbox_only",
+    src = "sandbox_only.md",
+    category = "User Guide",
+    permalink = "/docs/user_guide/sandbox_only/",
+    weight = "95",
+)

--- a/g3doc/user_guide/sandbox_only.md
+++ b/g3doc/user_guide/sandbox_only.md
@@ -1,0 +1,148 @@
+# Sandbox-Only Mode
+
+[TOC]
+
+`runsc create --sandbox-only` boots a sandbox that contains nothing: no root
+container, no root filesystem, no process, and no gofer. The sentry comes up
+empty and containers are added to it afterwards, each with its own bundle.
+
+This is the pod without a pause container. Normally the first container `runsc`
+is asked to run owns the sandbox: it provides the rootfs the sandbox is built
+from, its PID 1 is the pod's init, and the sandbox lives exactly as long as it
+does. Under CRI that first container is the pause container, an image whose only
+job is to exist. In sandbox-only mode there is no such container, and nothing
+inside the sandbox owns its lifetime: whoever created the sandbox is responsible
+for deleting it.
+
+The mode exists for the containerd Sandbox API, where containerd manages the pod
+sandbox itself and gives the runtime no spec to run. It is usable directly from
+the `runsc` command line, which is what this page shows.
+
+## Try it
+
+You need root and a `runsc` binary. Two bundles: one for the sandbox, one for a
+container to put in it.
+
+The sandbox bundle needs a `config.json` with no `process` and no `root` --
+there is nothing to run and nothing to run it on. That leaves very little:
+
+```bash
+mkdir -p /tmp/pod
+echo '{"ociVersion": "1.0.0"}' > /tmp/pod/config.json
+```
+
+The container bundle is an ordinary one. The `sandbox-id` annotation is what
+puts the container in the sandbox rather than in one of its own:
+
+```bash
+mkdir -p /tmp/cont/rootfs/bin
+cp /bin/busybox /tmp/cont/rootfs/bin/
+for c in sh sleep ps ls ip; do ln -sf busybox /tmp/cont/rootfs/bin/$c; done
+
+cat > /tmp/cont/config.json <<'EOF'
+{
+  "ociVersion": "1.0.0",
+  "annotations": {
+    "io.kubernetes.cri.container-type": "container",
+    "io.kubernetes.cri.sandbox-id": "pod1"
+  },
+  "process": {"cwd": "/", "args": ["/bin/sleep", "1000"], "user": {"uid": 0, "gid": 0}},
+  "root": {"path": "rootfs", "readonly": true}
+}
+EOF
+```
+
+Boot the sandbox, then add the container to it:
+
+```bash
+runsc create --sandbox-only --bundle /tmp/pod pod1
+runsc start pod1
+
+runsc create --bundle /tmp/cont c1
+runsc start c1
+```
+
+`runsc list` shows both sharing one sentry -- the sandbox reports the sentry's
+PID because it has no process of its own to report:
+
+```
+ID     PID       STATUS    BUNDLE      CREATED                          OWNER
+c1     1733764   running   /tmp/cont   2026-08-05T23:47:10.995780167Z   root
+pod1   1733764   running   /tmp/pod    2026-08-05T23:47:10.848767233Z   root
+```
+
+`runsc exec c1 /bin/ps` shows the pod has no init:
+
+```
+PID   USER     COMMAND
+    2 0        /bin/sleep 1000
+    3 0        /bin/ps
+```
+
+The first process in the pod is PID 2, not PID 1. PID 1 is reserved and never
+handed out, precisely because no container should become the pod's init: if one
+did, the pod would die with it. Nothing reaps orphans on the pod's behalf
+either; the sentry reaps them directly.
+
+## Stopping it
+
+Tear the pod down container-first, and delete the sandbox last:
+
+```bash
+runsc kill c1 KILL
+runsc delete c1
+runsc delete pod1
+```
+
+`runsc kill pod1` does not apply and says so: there is no root container process
+to deliver a signal to. This is also why `runsc delete pod1` works while the
+sandbox is still running, where deleting a running container would normally
+require `--force`: a sandbox-only sandbox can never stop on its own, so
+requiring `--force` would mean requiring it always.
+
+Deleting the sandbox while it still holds containers takes them down with it, so
+that does require `--force`:
+
+```bash
+runsc delete pod1
+cannot delete sandbox "pod1" while it still holds 1 container(s) without --force flag
+
+runsc delete --force pod1   # destroys the sandbox and everything in it
+runsc delete c1             # container state files outlive the sandbox
+```
+
+## Networking
+
+Networking works as it does for any other pod, because the network namespace
+belongs to the sandbox and never belonged to the root container. Name it in the
+*sandbox* bundle's `config.json`:
+
+```json
+{
+  "ociVersion": "1.0.0",
+  "linux": {
+    "namespaces": [{"type": "network", "path": "/var/run/netns/pod1-netns"}]
+  }
+}
+```
+
+The sentry starts inside that namespace and copies its interfaces and routes
+into netstack. Containers added to the sandbox share that one network stack,
+which is what makes them a pod. Under CRI the path is the network namespace CNI
+created for the pod.
+
+Note that `runsc` takes the addresses over: it removes them from the host-side
+interfaces in the namespace, so if you boot a second sandbox in a namespace you
+set up by hand, re-add the addresses first.
+
+## What is different from a normal pod
+
+*   There is no pause container, so no pause image to pull and no container
+    whose only job is to hold the sandbox open.
+*   The pod has no PID 1. Processes in containers sharing the pod's PID
+    namespace still see each other, which is what PID namespace sharing is for,
+    but there is no init to reap them.
+*   The sandbox outlives its containers. It stays up with zero containers in it
+    and accepts new ones.
+*   `runsc kill` does not apply to the sandbox; `runsc delete` stops it.
+*   Checkpoint and restore are not supported for a sandbox-only sandbox.

--- a/pkg/sentry/control/fs.go
+++ b/pkg/sentry/control/fs.go
@@ -140,7 +140,10 @@ func (f *fdReader) Read(p []byte) (int, error) {
 func cat(k *kernel.Kernel, path string, output *os.File) error {
 	ctx := k.SupervisorContext()
 	creds := auth.NewRootCredentials(k.RootUserNamespace())
-	mns := k.GlobalInit().Leader().MountNamespace()
+	mns := k.GlobalInitMountNamespace()
+	if mns == nil {
+		return fmt.Errorf("cannot read file %s: sandbox has no root mount namespace", path)
+	}
 	root := mns.Root(ctx)
 	defer root.DecRef(ctx)
 

--- a/pkg/sentry/control/proc.go
+++ b/pkg/sentry/control/proc.go
@@ -231,7 +231,10 @@ func (proc *Proc) execAsync(args *ExecArgs) (*kernel.ThreadGroup, kernel.ThreadI
 
 	if initArgs.MountNamespace == nil {
 		// Set initArgs so that 'ctx' returns the namespace.
-		initArgs.MountNamespace = proc.Kernel.GlobalInit().Leader().MountNamespace()
+		initArgs.MountNamespace = proc.Kernel.GlobalInitMountNamespace()
+		if initArgs.MountNamespace == nil {
+			return nil, 0, nil, fmt.Errorf("cannot exec: sandbox has no root mount namespace")
+		}
 	}
 	// initArgs must hold a reference on MountNamespace, which will
 	// be donated to the new process in CreateProcess.

--- a/pkg/sentry/control/proc.go
+++ b/pkg/sentry/control/proc.go
@@ -242,7 +242,10 @@ func (proc *Proc) execAsync(args *ExecArgs) (*kernel.ThreadGroup, kernel.ThreadI
 
 	if initArgs.MountNamespace == nil {
 		// Set initArgs so that 'ctx' returns the namespace.
-		initArgs.MountNamespace = proc.Kernel.GlobalInit().Leader().MountNamespace()
+		initArgs.MountNamespace = proc.Kernel.GlobalInitMountNamespace()
+		if initArgs.MountNamespace == nil {
+			return nil, 0, nil, fmt.Errorf("cannot exec: sandbox has no root mount namespace")
+		}
 	}
 	// initArgs must hold a reference on MountNamespace, which will
 	// be donated to the new process in CreateProcess.

--- a/pkg/sentry/control/state.go
+++ b/pkg/sentry/control/state.go
@@ -446,7 +446,11 @@ func ConfigureSaveRestoreExec(k *kernel.Kernel, argv []string, timeout time.Dura
 // the given containerID. If containerID is empty, the global init process is returned.
 func findContainerInitProcess(k *kernel.Kernel, containerID string) (*kernel.Task, error) {
 	if containerID == "" {
-		return k.GlobalInit().Leader(), nil
+		init := k.GlobalInit()
+		if init == nil {
+			return nil, fmt.Errorf("sandbox has no global init process")
+		}
+		return init.Leader(), nil
 	}
 	// To find the init process of a container, we look for the process with no
 	// parent (root of execution) that is not an exec process.

--- a/pkg/sentry/control/state.go
+++ b/pkg/sentry/control/state.go
@@ -446,7 +446,15 @@ func ConfigureSaveRestoreExec(k *kernel.Kernel, argv []string, timeout time.Dura
 // the given containerID. If containerID is empty, the global init process is returned.
 func findContainerInitProcess(k *kernel.Kernel, containerID string) (*kernel.Task, error) {
 	if containerID == "" {
-		return k.GlobalInit().Leader(), nil
+		init := k.GlobalInit()
+		if init == nil {
+			return nil, fmt.Errorf("sandbox has no global init process")
+		}
+		leader := init.Leader()
+		if leader == nil {
+			return nil, fmt.Errorf("global init process has exited")
+		}
+		return leader, nil
 	}
 	// To find the init process of a container, we look for the process with no
 	// parent (root of execution) that is not an exec process.

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1091,7 +1091,11 @@ func (k *Kernel) ExtractRootfsUpperLayer(ctx context.Context, r io.Reader, async
 	log.Infof("Overall load took [%s] after async work", time.Since(loadStart))
 
 	// Now call TarRootfsUpperLayer on the root filesystem
-	root := k.GlobalInit().Leader().MountNamespace().Root(ctx)
+	mntns := k.GlobalInitMountNamespace()
+	if mntns == nil {
+		return fmt.Errorf("cannot serialize rootfs upper layer: sandbox has no root mount namespace")
+	}
+	root := mntns.Root(ctx)
 	defer root.DecRef(ctx)
 	ts, ok := root.Mount().Filesystem().Impl().(vfs.TarSerializer)
 	if !ok {
@@ -1248,12 +1252,11 @@ func (ctx *createProcessContext) Value(key any) any {
 		root := ctx.args.MountNamespace.Root(ctx)
 		return root
 	case vfs.CtxMountNamespace:
-		if ctx.kernel.globalInit == nil {
+		if ctx.args.MountNamespace == nil {
 			return nil
 		}
-		mntns := ctx.kernel.GlobalInit().Leader().MountNamespace()
-		mntns.IncRef()
-		return mntns
+		ctx.args.MountNamespace.IncRef()
+		return ctx.args.MountNamespace
 	case devutil.CtxDevGoferClient:
 		return ctx.kernel.GetDevGoferClient(ctx.kernel.ContainerName(ctx.args.ContainerID))
 	case inet.CtxStack:
@@ -1314,11 +1317,10 @@ func (k *Kernel) CreateProcess(args CreateProcessArgs) (*ThreadGroup, ThreadID, 
 	ctx := args.NewContext(k)
 	mntns := args.MountNamespace
 	if mntns == nil {
-		if k.globalInit == nil {
+		if mntns = k.globalInitMountNamespace(); mntns == nil {
 			return nil, 0, fmt.Errorf("mount namespace is nil")
 		}
 		// Add a reference to the namespace, which is transferred to the new process.
-		mntns = k.globalInit.Leader().MountNamespace()
 		mntns.IncRef()
 	}
 	// Get the root directory from the MountNamespace.
@@ -1458,7 +1460,8 @@ func (k *Kernel) CreateProcess(args CreateProcessArgs) (*ThreadGroup, ThreadID, 
 	// Success.
 	cu.Release()
 	tgid := k.tasks.Root.IDOfThreadGroup(tg)
-	if k.globalInit == nil {
+	// A namespace with a reserved init TID never gets a global init.
+	if k.globalInit == nil && !k.tasks.Root.noInit {
 		k.globalInit = tg
 	}
 	return tg, tgid, nil
@@ -1777,8 +1780,6 @@ func (k *Kernel) Unpause() {
 // SendExternalSignal injects a signal into the kernel.
 //
 // context is used only for debugging to describe how the signal was received.
-//
-// Preconditions: Kernel must have an init process.
 func (k *Kernel) SendExternalSignal(info *linux.SignalInfo, context string) {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -1912,6 +1913,30 @@ func (k *Kernel) GlobalInit() *ThreadGroup {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
 	return k.globalInit
+}
+
+// GlobalInitMountNamespace returns the mount namespace of the global init task
+// without taking a reference, or nil if there is none.
+func (k *Kernel) GlobalInitMountNamespace() *vfs.MountNamespace {
+	k.extMu.Lock()
+	defer k.extMu.Unlock()
+	return k.globalInitMountNamespace()
+}
+
+// globalInitMountNamespace returns the mount namespace of the global init
+// task, or nil if there is no global init or it has already exited.
+//
+// Does not take k.extMu; CreateProcess calls this while holding it.
+func (k *Kernel) globalInitMountNamespace() *vfs.MountNamespace {
+	tg := k.globalInit
+	if tg == nil {
+		return nil
+	}
+	leader := tg.Leader()
+	if leader == nil {
+		return nil
+	}
+	return leader.MountNamespace()
 }
 
 // TestOnlySetGlobalInit sets the thread group with ID 1 in the root PID namespace.
@@ -2139,16 +2164,17 @@ func (ctx *supervisorContext) Value(key any) any {
 		// The supervisor context is global root.
 		return auth.NewRootCredentials(ctx.Kernel.rootUserNamespace)
 	case vfs.CtxRoot:
-		if ctx.Kernel.globalInit == nil || ctx.Kernel.globalInit.Leader() == nil {
+		mntns := ctx.Kernel.globalInitMountNamespace()
+		if mntns == nil {
 			return vfs.VirtualDentry{}
 		}
-		root := ctx.Kernel.GlobalInit().Leader().MountNamespace().Root(ctx)
+		root := mntns.Root(ctx)
 		return root
 	case vfs.CtxMountNamespace:
-		if ctx.Kernel.globalInit == nil || ctx.Kernel.globalInit.Leader() == nil {
+		mntns := ctx.Kernel.globalInitMountNamespace()
+		if mntns == nil {
 			return nil
 		}
-		mntns := ctx.Kernel.GlobalInit().Leader().MountNamespace()
 		mntns.IncRef()
 		return mntns
 	case inet.CtxStack:

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1092,7 +1092,11 @@ func (k *Kernel) ExtractRootfsUpperLayer(ctx context.Context, r io.Reader, async
 	log.Infof("Overall load took [%s] after async work", time.Since(loadStart))
 
 	// Now call TarRootfsUpperLayer on the root filesystem
-	root := k.GlobalInit().Leader().MountNamespace().Root(ctx)
+	mntns := k.GlobalInitMountNamespace()
+	if mntns == nil {
+		return fmt.Errorf("cannot serialize rootfs upper layer: sandbox has no root mount namespace")
+	}
+	root := mntns.Root(ctx)
 	defer root.DecRef(ctx)
 	ts, ok := root.Mount().Filesystem().Impl().(vfs.TarSerializer)
 	if !ok {
@@ -1229,10 +1233,10 @@ func (ctx *createProcessContext) Value(key any) any {
 		root := ctx.args.MountNamespace.Root(ctx)
 		return root
 	case vfs.CtxMountNamespace:
-		if ctx.kernel.globalInit == nil {
+		mntns := ctx.kernel.globalInitMountNamespace()
+		if mntns == nil {
 			return nil
 		}
-		mntns := ctx.kernel.GlobalInit().Leader().MountNamespace()
 		mntns.IncRef()
 		return mntns
 	case devutil.CtxDevGoferClient:
@@ -1295,11 +1299,10 @@ func (k *Kernel) CreateProcess(args CreateProcessArgs) (*ThreadGroup, ThreadID, 
 	ctx := args.NewContext(k)
 	mntns := args.MountNamespace
 	if mntns == nil {
-		if k.globalInit == nil {
+		if mntns = k.globalInitMountNamespace(); mntns == nil {
 			return nil, 0, fmt.Errorf("mount namespace is nil")
 		}
 		// Add a reference to the namespace, which is transferred to the new process.
-		mntns = k.globalInit.Leader().MountNamespace()
 		mntns.IncRef()
 	}
 	// Get the root directory from the MountNamespace.
@@ -1885,6 +1888,48 @@ func (k *Kernel) GlobalInit() *ThreadGroup {
 	return k.globalInit
 }
 
+// GlobalInitMountNamespace returns the mount namespace of the global init
+// task, or nil if there is none. The caller does not own a reference on the
+// returned namespace. See globalInitMountNamespace for when nil happens.
+func (k *Kernel) GlobalInitMountNamespace() *vfs.MountNamespace {
+	k.extMu.Lock()
+	defer k.extMu.Unlock()
+	return k.globalInitMountNamespace()
+}
+
+// globalInitMountNamespace returns the mount namespace of the global init
+// task, or nil if there is none.
+//
+// Note that k.globalInit is whichever thread group CreateProcess made first,
+// which is not necessarily the init of the root PID namespace: a sandbox booted
+// without a root container reserves TID 1 and never assigns it (see
+// PIDNamespace.ReserveInitTID), so its first container becomes k.globalInit
+// while the namespace still has no init.
+//
+// This returns nil in two cases. There is no global init before the first
+// container starts, which for such a sandbox is the whole time it sits empty.
+// And once global init exits, Task.exitNotify drops its mount namespace while
+// the thread group stays reachable; that is reachable whenever global init is a
+// workload container rather than a pause container, since the sandbox outlives
+// it. Callers use this as a stand-in for a sandbox-wide mount namespace and
+// must cope with not getting one.
+//
+// This reads k.globalInit without holding k.extMu. That is what lets
+// CreateProcess, which does hold it, call this; the remaining callers hold
+// nothing and race with a concurrent exit, as they did before this was
+// factored out of them.
+func (k *Kernel) globalInitMountNamespace() *vfs.MountNamespace {
+	tg := k.globalInit
+	if tg == nil {
+		return nil
+	}
+	leader := tg.Leader()
+	if leader == nil {
+		return nil
+	}
+	return leader.MountNamespace()
+}
+
 // TestOnlySetGlobalInit sets the thread group with ID 1 in the root PID namespace.
 func (k *Kernel) TestOnlySetGlobalInit(tg *ThreadGroup) {
 	k.globalInit = tg
@@ -2101,16 +2146,17 @@ func (ctx *supervisorContext) Value(key any) any {
 		// The supervisor context is global root.
 		return auth.NewRootCredentials(ctx.Kernel.rootUserNamespace)
 	case vfs.CtxRoot:
-		if ctx.Kernel.globalInit == nil || ctx.Kernel.globalInit.Leader() == nil {
+		mntns := ctx.Kernel.globalInitMountNamespace()
+		if mntns == nil {
 			return vfs.VirtualDentry{}
 		}
-		root := ctx.Kernel.GlobalInit().Leader().MountNamespace().Root(ctx)
+		root := mntns.Root(ctx)
 		return root
 	case vfs.CtxMountNamespace:
-		if ctx.Kernel.globalInit == nil || ctx.Kernel.globalInit.Leader() == nil {
+		mntns := ctx.Kernel.globalInitMountNamespace()
+		if mntns == nil {
 			return nil
 		}
-		mntns := ctx.Kernel.GlobalInit().Leader().MountNamespace()
 		mntns.IncRef()
 		return mntns
 	case inet.CtxStack:

--- a/pkg/sentry/kernel/signal.go
+++ b/pkg/sentry/kernel/signal.go
@@ -15,8 +15,6 @@
 package kernel
 
 import (
-	"fmt"
-
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
@@ -33,8 +31,6 @@ const SignalPanic = linux.SIGUSR2
 // application context").
 //
 // context is used only for debugging to differentiate these cases.
-//
-// Preconditions: Kernel must have an init process.
 func (k *Kernel) sendExternalSignal(info *linux.SignalInfo, context string) {
 	switch linux.Signal(info.Signo) {
 	case linux.SIGURG:
@@ -52,7 +48,8 @@ func (k *Kernel) sendExternalSignal(info *linux.SignalInfo, context string) {
 	default:
 		log.Infof("Received external signal %d in %s context", info.Signo, context)
 		if k.globalInit == nil {
-			panic(fmt.Sprintf("Received external signal %d before init created", info.Signo))
+			log.Warningf("Dropping external signal %d: sandbox has no init process", info.Signo)
+			return
 		}
 		k.globalInit.SendSignal(info)
 	}

--- a/pkg/sentry/kernel/signal.go
+++ b/pkg/sentry/kernel/signal.go
@@ -15,8 +15,6 @@
 package kernel
 
 import (
-	"fmt"
-
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
@@ -33,8 +31,6 @@ const SignalPanic = linux.SIGUSR2
 // application context").
 //
 // context is used only for debugging to differentiate these cases.
-//
-// Preconditions: Kernel must have an init process.
 func (k *Kernel) sendExternalSignal(info *linux.SignalInfo, context string) {
 	switch linux.Signal(info.Signo) {
 	case linux.SIGURG:
@@ -52,7 +48,11 @@ func (k *Kernel) sendExternalSignal(info *linux.SignalInfo, context string) {
 	default:
 		log.Infof("Received external signal %d in %s context", info.Signo, context)
 		if k.globalInit == nil {
-			panic(fmt.Sprintf("Received external signal %d before init created", info.Signo))
+			// There is no init to deliver to. This is normal in a sandbox
+			// booted without a root container and still empty; it used to be
+			// impossible, hence the log rather than silence.
+			log.Warningf("Dropping external signal %d: sandbox has no init process", info.Signo)
+			return
 		}
 		k.globalInit.SendSignal(info)
 	}

--- a/pkg/sentry/kernel/task_exit.go
+++ b/pkg/sentry/kernel/task_exit.go
@@ -394,7 +394,7 @@ func (t *Task) exitThreadGroup() bool {
 // Preconditions: The TaskSet mutex must be locked for writing.
 func (t *Task) exitChildrenLocked() {
 	newParent := t.findReparentTargetLocked()
-	if newParent == nil {
+	if newParent == nil && !t.tg.pidns.noInit {
 		// "If the init process of a PID namespace terminates, the kernel
 		// terminates all of the processes in the namespace via a SIGKILL
 		// signal." - pid_namespaces(7)

--- a/pkg/sentry/kernel/task_exit.go
+++ b/pkg/sentry/kernel/task_exit.go
@@ -391,7 +391,13 @@ func (t *Task) exitThreadGroup() bool {
 // Preconditions: The TaskSet mutex must be locked for writing.
 func (t *Task) exitChildrenLocked() {
 	newParent := t.findReparentTargetLocked()
-	if newParent == nil {
+	// findReparentTargetLocked returns nil in several cases besides "t is
+	// init": init exists but is itself exiting, a subreaper walk dead-ends, or
+	// -- new -- the namespace has no init at all, which is how a sandbox booted
+	// without a root container starts out (see PIDNamespace.ReserveInitTID).
+	// Only the last of those must not tear the namespace down, so test for it
+	// directly rather than widening the condition for the others.
+	if newParent == nil && !t.tg.pidns.noInit {
 		// "If the init process of a PID namespace terminates, the kernel
 		// terminates all of the processes in the namespace via a SIGKILL
 		// signal." - pid_namespaces(7)

--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -172,6 +172,11 @@ type PIDNamespace struct {
 	// last is the last ThreadID to be allocated in this namespace.
 	last ThreadID
 
+	// noInit indicates that initTID has been reserved by ReserveInitTID and
+	// will never be allocated, so this namespace has no init process and never
+	// will. See ReserveInitTID.
+	noInit bool
+
 	// tasks is a mapping from ThreadIDs in this namespace to tasks visible in
 	// the namespace.
 	tasks map[ThreadID]*Task
@@ -277,6 +282,25 @@ func (ns *PIDNamespace) NewChild(ctx context.Context, k *Kernel, userns *auth.Us
 	pidns := newPIDNamespace(ns.owner, ns, userns)
 	pidns.InitInode(ctx, k)
 	return pidns
+}
+
+// ReserveInitTID marks initTID as used in ns without assigning it to a task,
+// so that ns never gets an init process. It must be called before any task is
+// added to ns.
+//
+// This is for sandboxes that are booted without a root container: the first
+// container to start would otherwise become init, and its exit would kill
+// every other container in the sandbox and stop new ones from being created
+// (see pid_namespaces(7)). A sandbox is expected to outlive its containers, so
+// it is better to have no init at all.
+func (ns *PIDNamespace) ReserveInitTID() {
+	ns.owner.mu.Lock()
+	defer ns.owner.mu.Unlock()
+	if ns.last >= initTID {
+		panic("ReserveInitTID called after a task was added to the PID namespace")
+	}
+	ns.last = initTID
+	ns.noInit = true
 }
 
 // TaskWithID returns the task with thread ID tid in PID namespace ns. If no

--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -172,6 +172,10 @@ type PIDNamespace struct {
 	// last is the last ThreadID to be allocated in this namespace.
 	last ThreadID
 
+	// noInit indicates that initTID is reserved, so this namespace has no init
+	// process and never will. See ReserveInitTID.
+	noInit bool
+
 	// tasks is a mapping from ThreadIDs in this namespace to tasks visible in
 	// the namespace.
 	tasks map[ThreadID]*Task
@@ -277,6 +281,22 @@ func (ns *PIDNamespace) NewChild(ctx context.Context, k *Kernel, userns *auth.Us
 	pidns := newPIDNamespace(ns.owner, ns, userns)
 	pidns.InitInode(ctx, k)
 	return pidns
+}
+
+// ReserveInitTID marks initTID as used without assigning it to a task. ns then
+// has no init process, so nothing in it can trigger the namespace-wide SIGKILL
+// that init's exit sends (see pid_namespaces(7)). The first task added gets
+// TID 2.
+//
+// Preconditions: no task has been added to ns.
+func (ns *PIDNamespace) ReserveInitTID() {
+	ns.owner.mu.Lock()
+	defer ns.owner.mu.Unlock()
+	if ns.last >= initTID {
+		panic("ReserveInitTID called after a task was added to the PID namespace")
+	}
+	ns.last = initTID
+	ns.noInit = true
 }
 
 // TaskWithID returns the task with thread ID tid in PID namespace ns. If no

--- a/pkg/sentry/syscalls/linux/sys_sem.go
+++ b/pkg/sentry/syscalls/linux/sys_sem.go
@@ -116,7 +116,7 @@ func semTimedOp(t *kernel.Task, id ipc.ID, ops []linux.Sembuf, haveTimeout bool,
 		return linuxerr.EINVAL
 	}
 	creds := auth.CredentialsFromContext(t)
-	pid := t.Kernel().GlobalInit().PIDNamespace().IDOfThreadGroup(t.ThreadGroup())
+	pid := t.Kernel().RootPIDNamespace().IDOfThreadGroup(t.ThreadGroup())
 	for {
 		ch, num, err := set.ExecuteOps(t, ops, creds, int32(pid))
 		if ch == nil || err != nil {
@@ -294,7 +294,7 @@ func setVal(t *kernel.Task, id ipc.ID, num int32, val int16) error {
 		return linuxerr.EINVAL
 	}
 	creds := auth.CredentialsFromContext(t)
-	pid := t.Kernel().GlobalInit().PIDNamespace().IDOfThreadGroup(t.ThreadGroup())
+	pid := t.Kernel().RootPIDNamespace().IDOfThreadGroup(t.ThreadGroup())
 	return set.SetVal(t, num, val, creds, int32(pid))
 }
 
@@ -309,7 +309,7 @@ func setValAll(t *kernel.Task, id ipc.ID, array hostarch.Addr) error {
 		return err
 	}
 	creds := auth.CredentialsFromContext(t)
-	pid := t.Kernel().GlobalInit().PIDNamespace().IDOfThreadGroup(t.ThreadGroup())
+	pid := t.Kernel().RootPIDNamespace().IDOfThreadGroup(t.ThreadGroup())
 	return set.SetValAll(t, vals, creds, int32(pid))
 }
 

--- a/runsc/boot/limits.go
+++ b/runsc/boot/limits.go
@@ -123,7 +123,11 @@ func createLimitSet(spec *specs.Spec, enableTPUProxy bool) (*limits.LimitSet, er
 	if enableTPUProxy {
 		ls.SetUnchecked(limits.MemoryLocked, limits.Limit{Cur: limits.Infinity, Max: limits.Infinity})
 	}
-	// Then apply overwrites on top of defaults.
+	// Then apply overwrites on top of defaults. A sandbox-only spec has no
+	// Process at all, and so nothing to overwrite the defaults with.
+	if spec.Process == nil {
+		return ls, nil
+	}
 	for _, rl := range spec.Process.Rlimits {
 		lt, ok := limits.FromLinuxResourceName[rl.Type]
 		if !ok {

--- a/runsc/boot/limits.go
+++ b/runsc/boot/limits.go
@@ -123,6 +123,9 @@ func createLimitSet(spec *specs.Spec, enableTPUProxy bool) (*limits.LimitSet, er
 	if enableTPUProxy {
 		ls.SetUnchecked(limits.MemoryLocked, limits.Limit{Cur: limits.Infinity, Max: limits.Infinity})
 	}
+	if spec.Process == nil {
+		return ls, nil
+	}
 	// Then apply overwrites on top of defaults.
 	for _, rl := range spec.Process.Rlimits {
 		lt, ok := limits.FromLinuxResourceName[rl.Type]

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -252,6 +252,8 @@ type Loader struct {
 	// sandboxID is the ID for the whole sandbox.
 	sandboxID string
 
+	noRootContainer noRootContainer
+
 	// mountHints provides extra information about mounts for containers that
 	// apply to the entire pod.
 	mountHints *PodMountHints
@@ -359,6 +361,23 @@ type Loader struct {
 
 	// hostinetNetSNMPFile is the pre-opened /proc/net/snmp file for hostinet restore.
 	hostinetNetSNMPFile *os.File
+}
+
+// noRootContainer is the state of a sandbox with no root container.
+type noRootContainer struct {
+	enabled  bool
+	exit     chan struct{}
+	exitOnce sync.Once
+}
+
+// stop releases waitExit. It is idempotent.
+func (n *noRootContainer) stop() {
+	n.exitOnce.Do(func() { close(n.exit) })
+}
+
+// waitExit blocks until stop is called.
+func (n *noRootContainer) waitExit() {
+	<-n.exit
 }
 
 // execID uniquely identifies a sentry process that is executed in a container.
@@ -494,6 +513,9 @@ type Args struct {
 	// RootfsUpperTarFD is the file descriptor to the tar file containing the rootfs
 	// upper layer changes.
 	RootfsUpperTarFD int
+	// NoRootContainer boots without a root container; Spec then has neither
+	// Process nor Root. See Loader.noRootContainer.
+	NoRootContainer bool
 
 	// StartupTimer tracks overall sandbox startup.
 	// The `Loader` records midpoints on it as it goes through loader creation
@@ -531,15 +553,20 @@ const (
 )
 
 func getRootCredentials(spec *specs.Spec, conf *config.Config, userNs *auth.UserNamespace) *auth.Credentials {
+	process := spec.Process
+	if process == nil {
+		process = &specs.Process{}
+	}
+
 	// Create capabilities.
-	caps, err := specutils.Capabilities(conf.EnableRaw, spec.Process.Capabilities)
+	caps, err := specutils.Capabilities(conf.EnableRaw, process.Capabilities)
 	if err != nil {
 		return nil
 	}
 
 	// Convert the spec's additional GIDs to KGIDs.
-	extraKGIDs := make([]auth.KGID, 0, len(spec.Process.User.AdditionalGids))
-	for _, GID := range spec.Process.User.AdditionalGids {
+	extraKGIDs := make([]auth.KGID, 0, len(process.User.AdditionalGids))
+	for _, GID := range process.User.AdditionalGids {
 		extraKGIDs = append(extraKGIDs, auth.KGID(GID))
 	}
 
@@ -548,8 +575,8 @@ func getRootCredentials(spec *specs.Spec, conf *config.Config, userNs *auth.User
 	}
 	// Create credentials.
 	creds := auth.NewUserCredentials(
-		auth.KUID(spec.Process.User.UID),
-		auth.KGID(spec.Process.User.GID),
+		auth.KUID(process.User.UID),
+		auth.KGID(process.User.GID),
 		extraKGIDs,
 		caps,
 		userNs)
@@ -622,7 +649,11 @@ func New(args Args) (*Loader, error) {
 
 	eid := execID{cid: args.ID}
 	l := &Loader{
-		sandboxID:             args.ID,
+		sandboxID: args.ID,
+		noRootContainer: noRootContainer{
+			enabled: args.NoRootContainer,
+			exit:    make(chan struct{}),
+		},
 		processes:             map[execID]*execProcess{eid: {}},
 		sharedMounts:          make(map[string]*vfs.Mount),
 		stopProfiling:         stopProfiling,
@@ -869,11 +900,21 @@ func New(args Args) (*Loader, error) {
 	}
 	l.watchdog = watchdog.New(l.k, dogOpts)
 
-	procArgs, err := createProcessArgs(args.ID, args.Spec, args.Conf, creds, l.k, l.k.RootPIDNamespace())
-	if err != nil {
-		return nil, fmt.Errorf("creating init process for root container: %w", err)
+	// Populate the default limit set: it needs getrlimit(2), which the seccomp
+	// filters later deny.
+	if _, err := defaults.get(); err != nil {
+		return nil, fmt.Errorf("getting default limits: %w", err)
 	}
-	l.root.procArgs = procArgs
+
+	if !args.NoRootContainer {
+		procArgs, err := createProcessArgs(args.ID, args.Spec, args.Conf, creds, l.k, l.k.RootPIDNamespace())
+		if err != nil {
+			return nil, fmt.Errorf("creating init process for root container: %w", err)
+		}
+		l.root.procArgs = procArgs
+	} else {
+		l.k.RootPIDNamespace().ReserveInitTID()
+	}
 	args.StartupTimer.Reached("process args created")
 
 	if err := initCompatLogs(args.UserLogFD); err != nil {
@@ -1026,6 +1067,7 @@ func createProcessArgs(id string, spec *specs.Spec, conf *config.Config, creds *
 // been closed. For that reason, this should NOT be called in a defer, because
 // a panic in a control server rpc would then hang forever.
 func (l *Loader) Destroy() {
+	l.noRootContainer.stop()
 	if l.stopSignalForwarding != nil {
 		l.stopSignalForwarding()
 	}
@@ -1272,37 +1314,39 @@ func (l *Loader) run() error {
 		}
 		l.startupTimer.Reached("seccomp filters installed")
 
-		// Create the root container init task. It will begin running
-		// when the kernel is started.
-		l.root.procArgs.StartupTimeline = l.startupTimer.Fork("root container")
-		var (
-			tg  *kernel.ThreadGroup
-			err error
-		)
-		tg, ep.tty, err = l.createContainerProcess(&l.root)
-		if err != nil {
-			return err
-		}
-		l.startupTimer.Reached("root container created")
+		if !l.noRootContainer.enabled {
+			// Create the root container init task. It will begin running
+			// when the kernel is started.
+			l.root.procArgs.StartupTimeline = l.startupTimer.Fork("root container")
+			var (
+				tg  *kernel.ThreadGroup
+				err error
+			)
+			tg, ep.tty, err = l.createContainerProcess(&l.root)
+			if err != nil {
+				return err
+			}
+			l.startupTimer.Reached("root container created")
 
-		if seccheck.Global.Enabled(seccheck.PointContainerStart) {
-			evt := pb.Start{
-				Id:       l.sandboxID,
-				Cwd:      l.root.spec.Process.Cwd,
-				Args:     l.root.spec.Process.Args,
-				Terminal: l.root.spec.Process.Terminal,
+			if seccheck.Global.Enabled(seccheck.PointContainerStart) {
+				evt := pb.Start{
+					Id:       l.sandboxID,
+					Cwd:      l.root.spec.Process.Cwd,
+					Args:     l.root.spec.Process.Args,
+					Terminal: l.root.spec.Process.Terminal,
+				}
+				fields := seccheck.Global.GetFieldSet(seccheck.PointContainerStart)
+				if fields.Local.Contains(seccheck.FieldContainerStartEnv) {
+					evt.Env = l.root.spec.Process.Env
+				}
+				if !fields.Context.Empty() {
+					evt.ContextData = &pb.ContextData{}
+					kernel.LoadSeccheckData(tg.Leader(), fields.Context, evt.ContextData)
+				}
+				_ = seccheck.Global.SentToSinks(func(c seccheck.Sink) error {
+					return c.ContainerStart(context.Background(), fields, &evt)
+				})
 			}
-			fields := seccheck.Global.GetFieldSet(seccheck.PointContainerStart)
-			if fields.Local.Contains(seccheck.FieldContainerStartEnv) {
-				evt.Env = l.root.spec.Process.Env
-			}
-			if !fields.Context.Empty() {
-				evt.ContextData = &pb.ContextData{}
-				kernel.LoadSeccheckData(tg.Leader(), fields.Context, evt.ContextData)
-			}
-			_ = seccheck.Global.SentToSinks(func(c seccheck.Sink) error {
-				return c.ContainerStart(context.Background(), fields, &evt)
-			})
 		}
 	case restoringUnstarted:
 		// If we are restoring, we do not want to create a process.
@@ -1310,7 +1354,9 @@ func (l *Loader) run() error {
 		return fmt.Errorf("Loader.Run() called in unexpected state=%s", l.state)
 	}
 
-	ep.tg = l.k.GlobalInit()
+	if !l.noRootContainer.enabled {
+		ep.tg = l.k.GlobalInit()
+	}
 	if ns, ok := specutils.GetNS(specs.PIDNamespace, l.root.spec); ok {
 		ep.pidnsPath = ns.Path
 	}
@@ -1321,6 +1367,19 @@ func (l *Loader) run() error {
 		// Panic signal should cause a panic.
 		if l.root.conf.PanicSignal != -1 && sig == linux.Signal(l.root.conf.PanicSignal) {
 			panic("Signal-induced panic")
+		}
+
+		// No root container to forward to: SIGTERM and SIGINT stop the
+		// sandbox, the rest are dropped.
+		if l.noRootContainer.enabled {
+			switch sig {
+			case linux.SIGTERM, linux.SIGINT:
+				log.Infof("Received external signal %d, stopping sandbox", sig)
+				l.noRootContainer.stop()
+			default:
+				log.Infof("Received external signal %d, ignoring: sandbox has no root container", sig)
+			}
+			return
 		}
 
 		// Otherwise forward to root container.
@@ -1398,10 +1457,20 @@ func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid st
 	var pidns *kernel.PIDNamespace
 	if ns, ok := specutils.GetNS(specs.PIDNamespace, spec); ok {
 		if ns.Path != "" {
-			for _, p := range l.processes {
-				if ns.Path == p.pidnsPath {
+			for eid, p := range l.processes {
+				if ns.Path != p.pidnsPath {
+					continue
+				}
+				if p.tg != nil {
 					log.Debugf("Joining PID namespace named %q", ns.Path)
 					pidns = p.tg.PIDNamespace()
+					break
+				}
+				// The sandbox's entry has no thread group; its PID namespace
+				// is the root one.
+				if l.noRootContainer.enabled && eid.cid == l.sandboxID {
+					log.Debugf("Joining sandbox PID namespace named %q", ns.Path)
+					pidns = l.k.RootPIDNamespace()
 					break
 				}
 			}
@@ -1782,6 +1851,13 @@ func (l *Loader) executeAsync(args *control.ExecArgs) (kernel.ThreadID, error) {
 
 // waitContainer waits for the init process of a container to exit.
 func (l *Loader) waitContainer(cid string, waitStatus *uint32) error {
+	if l.noRootContainer.enabled && cid == l.sandboxID {
+		// No init to wait on; the only event left is the sandbox going away.
+		l.noRootContainer.waitExit()
+		*waitStatus = 0
+		return nil
+	}
+
 	l.mu.Lock()
 	state := l.state
 	if state == restoringUnstarted {
@@ -1898,8 +1974,20 @@ func (l *Loader) WaitForStartSignal() {
 	<-l.ctrl.manager.startChan
 }
 
-// WaitExit waits for the root container to exit, and returns its exit status.
+// WaitExit waits for the sandbox to finish and returns the root container's
+// exit status, or zero if there is no root container.
 func (l *Loader) WaitExit() linux.WaitStatus {
+	if l.noRootContainer.enabled {
+		// Not k.WaitExited(): it returns as soon as nothing is running and
+		// blocks new tasks, so the sandbox could never take another container.
+		l.noRootContainer.waitExit()
+		// Kill whatever is left and wait for it: Destroy releases the kernel
+		// next.
+		l.k.Kill(linux.WaitStatusTerminationSignal(linux.SIGKILL))
+		l.k.WaitExited()
+		return 0
+	}
+
 	// Wait for container.
 	l.k.WaitExited()
 
@@ -2448,6 +2536,9 @@ func (l *Loader) SpecEnviron(containerName string) []string {
 	spec := l.getContainerSpec(containerName)
 	if spec == nil {
 		log.Warningf("Container spec not found for container %q", containerName)
+		return nil
+	}
+	if spec.Process == nil {
 		return nil
 	}
 	return spec.Process.Env

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -241,6 +241,28 @@ type Loader struct {
 	// sandboxID is the ID for the whole sandbox.
 	sandboxID string
 
+	// sandboxOnly indicates that the sandbox was booted without a root
+	// container. The root container process is never created, so l.root carries
+	// only sandbox-wide settings (conf, spec, nvproxy) and l.root.procArgs is
+	// zero. TID 1 in the root PID namespace is reserved and never assigned (see
+	// PIDNamespace.ReserveInitTID), so the namespace has no init process and a
+	// container's exit never takes the rest of the sandbox down with it. Note
+	// that the first subcontainer does still become Kernel.globalInit, which is
+	// a distinct notion: CreateProcess assigns it to the first thread group it
+	// makes, whatever that thread group's TID.
+	sandboxOnly bool
+
+	// sandboxExit is closed by stopSandbox when a sandbox-only sandbox should
+	// stop. Nothing closes it while containers may still be added, so WaitExit
+	// blocks on it until the sandbox is torn down. Only used when sandboxOnly is
+	// true.
+	//
+	// Note that the normal teardown path for a sandbox-only sandbox is
+	// `runsc delete --force`, which SIGKILLs the sentry rather than going
+	// through here; see Sandbox.destroy in runsc/sandbox/sandbox.go.
+	sandboxExit     chan struct{}
+	sandboxExitOnce sync.Once
+
 	// mountHints provides extra information about mounts for containers that
 	// apply to the entire pod.
 	mountHints *PodMountHints
@@ -465,6 +487,11 @@ type Args struct {
 	// RootfsUpperTarFD is the file descriptor to the tar file containing the rootfs
 	// upper layer changes.
 	RootfsUpperTarFD int
+	// SandboxOnly boots the sandbox without a root container. Spec describes
+	// only the sandbox (namespaces, cgroup, annotations) and carries neither a
+	// process to run nor a rootfs; all containers are added afterwards as
+	// subcontainers. See Loader.sandboxOnly.
+	SandboxOnly bool
 }
 
 // HostTHP holds host transparent hugepage settings.
@@ -490,15 +517,24 @@ const (
 )
 
 func getRootCredentials(spec *specs.Spec, conf *config.Config, userNs *auth.UserNamespace) *auth.Credentials {
+	// A sandbox-only spec has no process. Fall back to an empty one, which
+	// yields root credentials with the default capability set. These credentials
+	// are only used to set up sandbox-wide state (e.g. the root network
+	// namespace); containers added later bring their own.
+	process := spec.Process
+	if process == nil {
+		process = &specs.Process{}
+	}
+
 	// Create capabilities.
-	caps, err := specutils.Capabilities(conf.EnableRaw, spec.Process.Capabilities)
+	caps, err := specutils.Capabilities(conf.EnableRaw, process.Capabilities)
 	if err != nil {
 		return nil
 	}
 
 	// Convert the spec's additional GIDs to KGIDs.
-	extraKGIDs := make([]auth.KGID, 0, len(spec.Process.User.AdditionalGids))
-	for _, GID := range spec.Process.User.AdditionalGids {
+	extraKGIDs := make([]auth.KGID, 0, len(process.User.AdditionalGids))
+	for _, GID := range process.User.AdditionalGids {
 		extraKGIDs = append(extraKGIDs, auth.KGID(GID))
 	}
 
@@ -507,8 +543,8 @@ func getRootCredentials(spec *specs.Spec, conf *config.Config, userNs *auth.User
 	}
 	// Create credentials.
 	creds := auth.NewUserCredentials(
-		auth.KUID(spec.Process.User.UID),
-		auth.KGID(spec.Process.User.GID),
+		auth.KUID(process.User.UID),
+		auth.KGID(process.User.GID),
 		extraKGIDs,
 		caps,
 		userNs)
@@ -547,6 +583,8 @@ func New(args Args) (*Loader, error) {
 	eid := execID{cid: args.ID}
 	l := &Loader{
 		sandboxID:             args.ID,
+		sandboxOnly:           args.SandboxOnly,
+		sandboxExit:           make(chan struct{}),
 		processes:             map[execID]*execProcess{eid: {}},
 		sharedMounts:          make(map[string]*vfs.Mount),
 		stopProfiling:         stopProfiling,
@@ -780,11 +818,28 @@ func New(args Args) (*Loader, error) {
 	}
 	l.watchdog = watchdog.New(l.k, dogOpts)
 
-	procArgs, err := createProcessArgs(args.ID, args.Spec, args.Conf, creds, l.k, l.k.RootPIDNamespace())
-	if err != nil {
-		return nil, fmt.Errorf("creating init process for root container: %w", err)
+	// A sandbox-only sandbox has no root container, so there is no root process
+	// to build arguments for. l.root.procArgs is left zeroed.
+	if !args.SandboxOnly {
+		procArgs, err := createProcessArgs(args.ID, args.Spec, args.Conf, creds, l.k, l.k.RootPIDNamespace())
+		if err != nil {
+			return nil, fmt.Errorf("creating init process for root container: %w", err)
+		}
+		l.root.procArgs = procArgs
+	} else {
+		if _, err := defaults.get(); err != nil {
+			// The default limit set is normally computed as a side effect of
+			// createProcessArgs() above. Force it here instead: it reads the host
+			// rlimits with getrlimit(2), which is not allowed once the seccomp filters
+			// are installed, and the first subcontainer starts after that point.
+			return nil, fmt.Errorf("getting default limits: %w", err)
+		}
+		// Keep the first container that starts from becoming the root PID
+		// namespace's init process. Otherwise its exit would kill every other
+		// container in the sandbox and prevent new ones from starting, whereas the
+		// sandbox is meant to outlive the containers in it.
+		l.k.RootPIDNamespace().ReserveInitTID()
 	}
-	l.root.procArgs = procArgs
 
 	if err := initCompatLogs(args.UserLogFD); err != nil {
 		return nil, fmt.Errorf("initializing compat logs: %w", err)
@@ -932,6 +987,7 @@ func createProcessArgs(id string, spec *specs.Spec, conf *config.Config, creds *
 // been closed. For that reason, this should NOT be called in a defer, because
 // a panic in a control server rpc would then hang forever.
 func (l *Loader) Destroy() {
+	l.stopSandbox()
 	if l.stopSignalForwarding != nil {
 		l.stopSignalForwarding()
 	}
@@ -1163,35 +1219,40 @@ func (l *Loader) run() error {
 			return err
 		}
 
-		// Create the root container init task. It will begin running
-		// when the kernel is started.
-		var (
-			tg  *kernel.ThreadGroup
-			err error
-		)
-		tg, ep.tty, err = l.createContainerProcess(&l.root)
-		if err != nil {
-			return err
-		}
+		// A sandbox-only sandbox has no root container to create. The kernel is
+		// started empty and its root PID namespace never gets an init;
+		// subcontainers are added later by startSubcontainer.
+		if !l.sandboxOnly {
+			// Create the root container init task. It will begin running
+			// when the kernel is started.
+			var (
+				tg  *kernel.ThreadGroup
+				err error
+			)
+			tg, ep.tty, err = l.createContainerProcess(&l.root)
+			if err != nil {
+				return err
+			}
 
-		if seccheck.Global.Enabled(seccheck.PointContainerStart) {
-			evt := pb.Start{
-				Id:       l.sandboxID,
-				Cwd:      l.root.spec.Process.Cwd,
-				Args:     l.root.spec.Process.Args,
-				Terminal: l.root.spec.Process.Terminal,
+			if seccheck.Global.Enabled(seccheck.PointContainerStart) {
+				evt := pb.Start{
+					Id:       l.sandboxID,
+					Cwd:      l.root.spec.Process.Cwd,
+					Args:     l.root.spec.Process.Args,
+					Terminal: l.root.spec.Process.Terminal,
+				}
+				fields := seccheck.Global.GetFieldSet(seccheck.PointContainerStart)
+				if fields.Local.Contains(seccheck.FieldContainerStartEnv) {
+					evt.Env = l.root.spec.Process.Env
+				}
+				if !fields.Context.Empty() {
+					evt.ContextData = &pb.ContextData{}
+					kernel.LoadSeccheckData(tg.Leader(), fields.Context, evt.ContextData)
+				}
+				_ = seccheck.Global.SentToSinks(func(c seccheck.Sink) error {
+					return c.ContainerStart(context.Background(), fields, &evt)
+				})
 			}
-			fields := seccheck.Global.GetFieldSet(seccheck.PointContainerStart)
-			if fields.Local.Contains(seccheck.FieldContainerStartEnv) {
-				evt.Env = l.root.spec.Process.Env
-			}
-			if !fields.Context.Empty() {
-				evt.ContextData = &pb.ContextData{}
-				kernel.LoadSeccheckData(tg.Leader(), fields.Context, evt.ContextData)
-			}
-			_ = seccheck.Global.SentToSinks(func(c seccheck.Sink) error {
-				return c.ContainerStart(context.Background(), fields, &evt)
-			})
 		}
 	case restoringUnstarted:
 		// If we are restoring, we do not want to create a process.
@@ -1199,7 +1260,9 @@ func (l *Loader) run() error {
 		return fmt.Errorf("Loader.Run() called in unexpected state=%s", l.state)
 	}
 
-	ep.tg = l.k.GlobalInit()
+	if !l.sandboxOnly {
+		ep.tg = l.k.GlobalInit()
+	}
 	if ns, ok := specutils.GetNS(specs.PIDNamespace, l.root.spec); ok {
 		ep.pidnsPath = ns.Path
 	}
@@ -1210,6 +1273,14 @@ func (l *Loader) run() error {
 		// Panic signal should cause a panic.
 		if l.root.conf.PanicSignal != -1 && sig == linux.Signal(l.root.conf.PanicSignal) {
 			panic("Signal-induced panic")
+		}
+
+		// A sandbox-only sandbox has no root container to forward to. Swallow the
+		// signal rather than let the default disposition kill the sentry out from
+		// under the containers running inside it.
+		if l.sandboxOnly {
+			log.Infof("Received external signal %d, ignoring: sandbox has no root container", sig)
+			return
 		}
 
 		// Otherwise forward to root container.
@@ -1283,10 +1354,23 @@ func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid st
 	var pidns *kernel.PIDNamespace
 	if ns, ok := specutils.GetNS(specs.PIDNamespace, spec); ok {
 		if ns.Path != "" {
-			for _, p := range l.processes {
-				if ns.Path == p.pidnsPath {
+			for eid, p := range l.processes {
+				if ns.Path != p.pidnsPath {
+					continue
+				}
+				if p.tg != nil {
 					log.Debugf("Joining PID namespace named %q", ns.Path)
 					pidns = p.tg.PIDNamespace()
+					break
+				}
+				// p.tg is nil for a container that has not started yet, and for the
+				// sandbox itself when running sandbox-only. In the latter case the
+				// namespace exists even though no process was created for it: it is
+				// the one a root container process would have run in, that is, the
+				// kernel's root PID namespace.
+				if l.sandboxOnly && eid.cid == l.sandboxID {
+					log.Debugf("Joining sandbox PID namespace named %q", ns.Path)
+					pidns = l.k.RootPIDNamespace()
 					break
 				}
 			}
@@ -1631,6 +1715,16 @@ func (l *Loader) executeAsync(args *control.ExecArgs) (kernel.ThreadID, error) {
 
 // waitContainer waits for the init process of a container to exit.
 func (l *Loader) waitContainer(cid string, waitStatus *uint32) error {
+	if l.sandboxOnly && cid == l.sandboxID {
+		// There is no root container process to wait on, so the only event worth
+		// reporting is the sandbox itself going away. Block until then; the caller
+		// normally sees this RPC fail with a connection error, because the usual
+		// teardown path SIGKILLs the sentry before it can reply.
+		<-l.sandboxExit
+		*waitStatus = 0
+		return nil
+	}
+
 	l.mu.Lock()
 	state := l.state
 	if state == restoringUnstarted {
@@ -1747,8 +1841,23 @@ func (l *Loader) WaitForStartSignal() {
 	<-l.ctrl.manager.startChan
 }
 
+// stopSandbox unblocks WaitExit for a sandbox-only sandbox. It is idempotent.
+func (l *Loader) stopSandbox() {
+	l.sandboxExitOnce.Do(func() { close(l.sandboxExit) })
+}
+
 // WaitExit waits for the root container to exit, and returns its exit status.
 func (l *Loader) WaitExit() linux.WaitStatus {
+	if l.sandboxOnly {
+		// There is no root container whose exit ends the sandbox. Crucially, we
+		// must not call k.WaitExited() here: it returns immediately while no
+		// container is running, and it sets noNewTasksIfZeroLive, which would
+		// permanently prevent subcontainers from being added. The sandbox lives
+		// until it is explicitly torn down.
+		<-l.sandboxExit
+		return 0
+	}
+
 	// Wait for container.
 	l.k.WaitExited()
 

--- a/runsc/boot/no_root_container.md
+++ b/runsc/boot/no_root_container.md
@@ -1,0 +1,150 @@
+# Sandboxes with no root container
+
+`runsc create --no-root-container` boots a sandbox that contains nothing: no
+root container, no root filesystem, no process, and no gofer. The sentry comes
+up empty and containers are added to it afterwards, each with its own bundle.
+
+This is the pod without a pause container. Normally the first container `runsc`
+is asked to run owns the sandbox: it provides the rootfs the sandbox is built
+from, its init process is PID 1, and the sandbox lives exactly as long as it
+does. Under CRI that first container is the pause container, an image whose only
+job is to exist. With `--no-root-container` there is no such container, and
+nothing inside the sandbox owns its lifetime: whoever created the sandbox is
+responsible for deleting it.
+
+The mode exists for the containerd Sandbox API, where containerd manages the pod
+sandbox itself and gives the runtime no spec to run. That is the only intended
+caller. `--no-root-container` is not a user-facing workflow; it is what makes the
+mode reachable without containerd, for testing and for the walkthrough below.
+
+## Driving it by hand
+
+You need root and a `runsc` binary. Two bundles: one for the sandbox, one for a
+container to put in it.
+
+The sandbox bundle needs a `config.json` with no `process` and no `root` --
+there is nothing to run and nothing to run it on. That leaves very little:
+
+```bash
+mkdir -p /tmp/pod
+echo '{"ociVersion": "1.0.0"}' > /tmp/pod/config.json
+```
+
+The container bundle is an ordinary one. The `sandbox-id` annotation is what
+puts the container in the sandbox rather than in one of its own:
+
+```bash
+mkdir -p /tmp/cont/rootfs/bin
+cp /bin/busybox /tmp/cont/rootfs/bin/
+for c in sh sleep ps ls ip; do ln -sf busybox /tmp/cont/rootfs/bin/$c; done
+
+cat > /tmp/cont/config.json <<'EOF'
+{
+  "ociVersion": "1.0.0",
+  "annotations": {
+    "io.kubernetes.cri.container-type": "container",
+    "io.kubernetes.cri.sandbox-id": "pod1"
+  },
+  "process": {"cwd": "/", "args": ["/bin/sleep", "1000"], "user": {"uid": 0, "gid": 0}},
+  "root": {"path": "rootfs", "readonly": true}
+}
+EOF
+```
+
+Boot the sandbox, then add the container to it:
+
+```bash
+runsc create --no-root-container --bundle /tmp/pod pod1
+runsc start pod1
+
+runsc create --bundle /tmp/cont c1
+runsc start c1
+```
+
+`runsc list` shows both sharing one sentry -- the sandbox reports the sentry's
+PID because it has no process of its own to report:
+
+```
+ID     PID       STATUS    BUNDLE      CREATED                          OWNER
+c1     1733764   running   /tmp/cont   2026-08-05T23:47:10.995780167Z   root
+pod1   1733764   running   /tmp/pod    2026-08-05T23:47:10.848767233Z   root
+```
+
+`runsc exec c1 /bin/ps` shows the pod has no init:
+
+```
+PID   USER     COMMAND
+    2 0        /bin/sleep 1000
+    3 0        /bin/ps
+```
+
+The first process in the pod is PID 2, not PID 1: PID 1 is reserved so that no
+container becomes the pod's init and takes the pod down with it when it exits.
+Orphans are reparented to nil, which `exitNotifyLocked` handles by acking the
+exit itself, so they do not linger as zombies. See
+`PIDNamespace.ReserveInitTID`.
+
+## Stopping it
+
+Tear the pod down container-first, and delete the sandbox last:
+
+```bash
+runsc kill c1 KILL
+runsc delete c1
+runsc delete pod1
+```
+
+`runsc kill pod1` does not apply and says so: there is no root container process
+to deliver a signal to. This is also why `runsc delete pod1` works while the
+sandbox is still running, where deleting a running container would normally
+require `--force`: such a sandbox can never stop on its own, so requiring
+`--force` would mean requiring it always.
+
+Deleting the sandbox while it still holds containers takes them down with it, so
+that does require `--force`:
+
+```bash
+runsc delete pod1
+cannot delete sandbox "pod1" while it still holds 1 container(s) without --force flag
+
+runsc delete --force pod1   # destroys the sandbox and everything in it
+runsc delete c1             # container state files outlive the sandbox
+```
+
+## Networking
+
+Networking works as it does for any other pod, because the network namespace
+belongs to the sandbox and never belonged to the root container. Name it in the
+*sandbox* bundle's `config.json`:
+
+```json
+{
+  "ociVersion": "1.0.0",
+  "linux": {
+    "namespaces": [{"type": "network", "path": "/var/run/netns/pod1-netns"}]
+  }
+}
+```
+
+The sentry starts inside that namespace and copies its interfaces and routes
+into netstack. Containers added to the sandbox share that one network stack,
+which is what makes them a pod. Under CRI the path is the network namespace CNI
+created for the pod.
+
+Note that `runsc` takes the addresses over: it removes them from the host-side
+interfaces in the namespace, so if you boot a second sandbox in a namespace you
+set up by hand, re-add the addresses first.
+
+## What is different from a pod with a pause container
+
+*   There is no pause container, so no pause image to pull and no container
+    whose only job is to hold the sandbox open.
+*   The pod has no PID 1. Processes in containers sharing the pod's PID
+    namespace still see each other, which is what PID namespace sharing is for,
+    but there is no init to reap them, and none is needed: an orphan with no
+    parent is released as soon as it exits.
+*   The sandbox outlives its containers. It stays up with zero containers in it
+    and accepts new ones.
+*   `runsc kill` does not apply to the sandbox; `runsc delete` stops it.
+*   Checkpoint and restore are refused. See
+    `Container.checkpointRestoreSupported`.

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -138,6 +138,7 @@ go_test(
         "//runsc/container",
         "//runsc/flag",
         "//runsc/mitigate",
+        "//runsc/sandbox",
         "//runsc/specutils",
         "//sandboxexec/proto:sandbox_options_go_proto",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -139,6 +139,7 @@ go_test(
         "//runsc/container",
         "//runsc/flag",
         "//runsc/mitigate",
+        "//runsc/sandbox",
         "//runsc/specutils",
         "//sandboxexec/proto:sandbox_options_go_proto",
         "@com_github_google_go_cmp//cmp:go_default_library",

--- a/runsc/cmd/create.go
+++ b/runsc/cmd/create.go
@@ -57,6 +57,10 @@ type Create struct {
 	fsRestoreImagePath string
 	fsRestoreDirect    bool
 
+	// noRootContainer creates a sandbox with no root container: the spec holds
+	// sandbox-wide settings only and containers are added afterwards.
+	noRootContainer bool
+
 	// spec is the cached OCI spec.
 	spec *specs.Spec
 }
@@ -84,6 +88,7 @@ func (c *Create) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&c.userLog, "user-log", "", "filename to send user-visible logs to. Empty means no logging.")
 	f.StringVar(&c.fsRestoreImagePath, "fs-restore-image-path", "", "path to filesystem checkpoint to restore")
 	f.BoolVar(&c.fsRestoreDirect, "fs-restore-direct", false, "open files in fs-restore-image-path with O_DIRECT")
+	f.BoolVar(&c.noRootContainer, "no-root-container", false, "create a sandbox with no root container; the bundle spec describes only the sandbox and containers are added later as subcontainers")
 }
 
 // FetchSpec implements util.SubCommand.FetchSpec.
@@ -98,7 +103,7 @@ func (c *Create) FetchSpec(conf *config.Config, f *flag.FlagSet) (string, *specs
 	if c.bundleDir == "" {
 		c.bundleDir = getwdOrDie()
 	}
-	spec, err := specutils.ReadSpec(c.bundleDir, conf)
+	spec, err := specutils.ReadSpec(c.bundleDir, specutils.SpecOpts{Conf: conf, NoRootContainer: c.noRootContainer})
 	if err != nil {
 		return cid, nil, fmt.Errorf("reading spec: %w", err)
 	}
@@ -136,6 +141,7 @@ func (c *Create) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcom
 		UserLog:            c.userLog,
 		FSRestoreImagePath: c.fsRestoreImagePath,
 		FSRestoreDirect:    c.fsRestoreDirect,
+		NoRootContainer:    c.noRootContainer,
 	}
 	if _, err := container.New(conf, contArgs); err != nil {
 		return util.Errorf("creating container: %v", err)

--- a/runsc/cmd/create.go
+++ b/runsc/cmd/create.go
@@ -57,6 +57,13 @@ type Create struct {
 	fsRestoreImagePath string
 	fsRestoreDirect    bool
 
+	// sandboxOnly creates a sandbox with no root container. The spec describes
+	// the sandbox itself (namespaces, cgroup, annotations) and carries neither a
+	// process to run nor a rootfs. Containers are added afterwards as
+	// subcontainers. This is used by the containerd sandbox API, which gives the
+	// runtime no pause image and no OCI spec to reconstruct one from.
+	sandboxOnly bool
+
 	// spec is the cached OCI spec.
 	spec *specs.Spec
 }
@@ -84,6 +91,7 @@ func (c *Create) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&c.userLog, "user-log", "", "filename to send user-visible logs to. Empty means no logging.")
 	f.StringVar(&c.fsRestoreImagePath, "fs-restore-image-path", "", "path to filesystem checkpoint to restore")
 	f.BoolVar(&c.fsRestoreDirect, "fs-restore-direct", false, "open files in fs-restore-image-path with O_DIRECT")
+	f.BoolVar(&c.sandboxOnly, "sandbox-only", false, "create a sandbox with no root container; the bundle spec describes only the sandbox and containers are added later as subcontainers")
 }
 
 // FetchSpec implements util.SubCommand.FetchSpec.
@@ -98,7 +106,7 @@ func (c *Create) FetchSpec(conf *config.Config, f *flag.FlagSet) (string, *specs
 	if c.bundleDir == "" {
 		c.bundleDir = getwdOrDie()
 	}
-	spec, err := specutils.ReadSpec(c.bundleDir, conf)
+	spec, err := specutils.ReadSpec(c.bundleDir, conf, c.sandboxOnly)
 	if err != nil {
 		return cid, nil, fmt.Errorf("reading spec: %w", err)
 	}
@@ -136,6 +144,7 @@ func (c *Create) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcom
 		UserLog:            c.userLog,
 		FSRestoreImagePath: c.fsRestoreImagePath,
 		FSRestoreDirect:    c.fsRestoreDirect,
+		SandboxOnly:        c.sandboxOnly,
 	}
 	if _, err := container.New(conf, contArgs); err != nil {
 		return util.Errorf("creating container: %v", err)

--- a/runsc/cmd/delete.go
+++ b/runsc/cmd/delete.go
@@ -102,11 +102,36 @@ func (d *Delete) execute(f *flag.FlagSet, conf *config.Config) error {
 			return fmt.Errorf("loading container %q: %v", id, err)
 		}
 		if !d.force && c.Status != container.Created && c.Status != container.Stopped {
-			return fmt.Errorf("cannot delete container that is not stopped without --force flag")
+			if err := requireForce(conf, c); err != nil {
+				return err
+			}
 		}
 		if err := c.Destroy(); err != nil {
 			return fmt.Errorf("destroying container: %v", err)
 		}
+	}
+	return nil
+}
+
+// requireForce returns an error saying that --force is needed to delete a
+// running container, unless the container is a sandbox that holds nothing.
+//
+// A sandbox-only sandbox has no root container process, so nothing inside it
+// can ever make it stop: it stays Running until something destroys it, and
+// without this it could never be deleted without --force. Deleting one is
+// harmless once it holds no containers. While it still does, deleting it takes
+// them down too, which is what --force is there to ask for.
+func requireForce(conf *config.Config, c *container.Container) error {
+	if c.Sandbox == nil || !c.Sandbox.SandboxOnly || !c.Sandbox.IsRootContainer(c.ID) {
+		return fmt.Errorf("cannot delete container that is not stopped without --force flag")
+	}
+	containers, err := container.LoadSandbox(conf.RootDir, c.Sandbox.ID, container.LoadOpts{})
+	if err != nil {
+		return fmt.Errorf("loading containers of sandbox %q: %w", c.Sandbox.ID, err)
+	}
+	// The sandbox itself is one of them.
+	if n := len(containers) - 1; n > 0 {
+		return fmt.Errorf("cannot delete sandbox %q while it still holds %d container(s) without --force flag", c.Sandbox.ID, n)
 	}
 	return nil
 }

--- a/runsc/cmd/delete.go
+++ b/runsc/cmd/delete.go
@@ -102,11 +102,30 @@ func (d *Delete) execute(f *flag.FlagSet, conf *config.Config) error {
 			return fmt.Errorf("loading container %q: %v", id, err)
 		}
 		if !d.force && c.Status != container.Created && c.Status != container.Stopped {
-			return fmt.Errorf("cannot delete container that is not stopped without --force flag")
+			if err := requireForce(conf, c); err != nil {
+				return err
+			}
 		}
 		if err := c.Destroy(); err != nil {
 			return fmt.Errorf("destroying container: %v", err)
 		}
+	}
+	return nil
+}
+
+// requireForce returns an error unless the target is a sandbox with no root
+// container and no containers left.
+func requireForce(conf *config.Config, c *container.Container) error {
+	if c.Sandbox == nil || !c.Sandbox.NoRootContainer || !c.Sandbox.IsRootContainer(c.ID) {
+		return fmt.Errorf("cannot delete container that is not stopped without --force flag")
+	}
+	containers, err := container.LoadSandbox(conf.RootDir, c.Sandbox.ID, container.LoadOpts{})
+	if err != nil {
+		return fmt.Errorf("loading containers of sandbox %q: %w", c.Sandbox.ID, err)
+	}
+	// LoadSandbox counts the sandbox itself.
+	if n := len(containers) - 1; n > 0 {
+		return fmt.Errorf("cannot delete sandbox %q while it still holds %d container(s) without --force flag", c.Sandbox.ID, n)
 	}
 	return nil
 }

--- a/runsc/cmd/delete_test.go
+++ b/runsc/cmd/delete_test.go
@@ -15,11 +15,15 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/container"
 	"gvisor.dev/gvisor/runsc/flag"
+	"gvisor.dev/gvisor/runsc/sandbox"
 )
 
 func TestNotFound(t *testing.T) {
@@ -39,5 +43,55 @@ func TestNotFound(t *testing.T) {
 	d = Delete{force: true}
 	if err := d.execute(f, conf); err != nil {
 		t.Errorf("Deleting non-existent container with --force should NOT have failed: %v", err)
+	}
+}
+
+// writeStateFile writes a state file for a container of the given sandbox, so
+// that container.LoadSandbox() finds it.
+func writeStateFile(t *testing.T, rootDir, sbID, cid string) {
+	t.Helper()
+	path := filepath.Join(rootDir, fmt.Sprintf("%s_sandbox:%s.state", cid, sbID))
+	state := fmt.Sprintf(`{"id":%q,"status":"running","sandbox":{"id":%q,"noRootContainer":true}}`, cid, sbID)
+	if err := os.WriteFile(path, []byte(state), 0644); err != nil {
+		t.Fatalf("error writing state file %q: %v", path, err)
+	}
+}
+
+// TestDeleteRunningRequiresForce checks that deleting a running container
+// needs --force, except for an empty sandbox. See requireForce.
+func TestDeleteRunningRequiresForce(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		noRootContainer bool
+		// subcontainers is how many containers the sandbox still holds.
+		subcontainers []string
+		wantErr       bool
+	}{
+		{name: "regular container", wantErr: true},
+		{name: "empty sandbox", noRootContainer: true},
+		{name: "sandbox with containers", noRootContainer: true, subcontainers: []string{"cont"}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+			conf := &config.Config{RootDir: rootDir}
+			const sbID = "sandbox"
+			writeStateFile(t, rootDir, sbID, sbID)
+			for _, cid := range tc.subcontainers {
+				writeStateFile(t, rootDir, sbID, cid)
+			}
+
+			c := &container.Container{
+				ID:     sbID,
+				Status: container.Running,
+				Sandbox: &sandbox.Sandbox{
+					ID:              sbID,
+					NoRootContainer: tc.noRootContainer,
+				},
+			}
+			err := requireForce(conf, c)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Errorf("requireForce() = %v, wantErr: %t", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/runsc/cmd/delete_test.go
+++ b/runsc/cmd/delete_test.go
@@ -15,11 +15,15 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/container"
 	"gvisor.dev/gvisor/runsc/flag"
+	"gvisor.dev/gvisor/runsc/sandbox"
 )
 
 func TestNotFound(t *testing.T) {
@@ -39,5 +43,57 @@ func TestNotFound(t *testing.T) {
 	d = Delete{force: true}
 	if err := d.execute(f, conf); err != nil {
 		t.Errorf("Deleting non-existent container with --force should NOT have failed: %v", err)
+	}
+}
+
+// writeStateFile writes a state file for a container of the given sandbox, so
+// that container.LoadSandbox() finds it.
+func writeStateFile(t *testing.T, rootDir, sbID, cid string) {
+	t.Helper()
+	path := filepath.Join(rootDir, fmt.Sprintf("%s_sandbox:%s.state", cid, sbID))
+	state := fmt.Sprintf(`{"id":%q,"status":"running","sandbox":{"id":%q,"sandboxOnly":true}}`, cid, sbID)
+	if err := os.WriteFile(path, []byte(state), 0644); err != nil {
+		t.Fatalf("error writing state file %q: %v", path, err)
+	}
+}
+
+// TestDeleteRunningRequiresForce checks that a running container needs --force
+// to be deleted, except for an empty sandbox-only sandbox, which can never
+// stop on its own.
+func TestDeleteRunningRequiresForce(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		sandboxOnly bool
+		// subcontainers are containers other than the sandbox itself that are
+		// still in the sandbox.
+		subcontainers []string
+		wantErr       bool
+	}{
+		{name: "regular container", wantErr: true},
+		{name: "empty sandbox-only sandbox", sandboxOnly: true},
+		{name: "sandbox-only sandbox with containers", sandboxOnly: true, subcontainers: []string{"cont"}, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+			conf := &config.Config{RootDir: rootDir}
+			const sbID = "sandbox"
+			writeStateFile(t, rootDir, sbID, sbID)
+			for _, cid := range tc.subcontainers {
+				writeStateFile(t, rootDir, sbID, cid)
+			}
+
+			c := &container.Container{
+				ID:     sbID,
+				Status: container.Running,
+				Sandbox: &sandbox.Sandbox{
+					ID:          sbID,
+					SandboxOnly: tc.sandboxOnly,
+				},
+			}
+			err := requireForce(conf, c)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Errorf("requireForce() = %v, wantErr: %t", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/runsc/cmd/exec.go
+++ b/runsc/cmd/exec.go
@@ -132,6 +132,10 @@ func (ex *Exec) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 		util.Fatalf("loading container failed: %v", err)
 	}
 
+	if c.Spec.Process == nil {
+		util.Fatalf("cannot exec in %q: it is a sandbox booted without a root container; exec into its containers by their own IDs instead", c.ID)
+	}
+
 	e, err := ex.parseArgs(f, c.Spec.Process, conf.EnableRaw)
 	if err != nil {
 		util.Fatalf("parsing process spec: %v", err)

--- a/runsc/cmd/exec.go
+++ b/runsc/cmd/exec.go
@@ -132,6 +132,13 @@ func (ex *Exec) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 		util.Fatalf("loading container failed: %v", err)
 	}
 
+	// A sandbox booted without a root container has no process spec to take
+	// defaults (cwd, env, capabilities) from. Its containers are exec'd into
+	// individually, by their own IDs.
+	if c.Spec.Process == nil {
+		util.Fatalf("cannot exec in %q: it is a sandbox booted without a root container", c.ID)
+	}
+
 	e, err := ex.parseArgs(f, c.Spec.Process, conf.EnableRaw)
 	if err != nil {
 		util.Fatalf("parsing process spec: %v", err)

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -177,7 +177,7 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 
 	specFile := os.NewFile(uintptr(g.specFD), "spec file")
 	defer specFile.Close()
-	spec, err := specutils.ReadSpecFromFile(g.bundleDir, specFile, conf)
+	spec, err := specutils.ReadSpecFromFile(g.bundleDir, specFile, conf, false /* sandboxOnly */)
 	if err != nil {
 		util.Fatalf("reading spec: %v", err)
 	}

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -200,7 +200,7 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 
 	specFile := os.NewFile(uintptr(g.specFD), "spec file")
 	defer specFile.Close()
-	spec, err := specutils.ReadSpecFromFile(g.bundleDir, specFile, conf)
+	spec, err := specutils.ReadSpecFromFile(g.bundleDir, specFile, specutils.SpecOpts{Conf: conf})
 	if err != nil {
 		util.Fatalf("reading spec: %v", err)
 	}

--- a/runsc/cmd/restore.go
+++ b/runsc/cmd/restore.go
@@ -163,7 +163,7 @@ func (r *Restore) Execute(_ context.Context, f *flag.FlagSet, args ...any) subco
 
 		// Read the spec from the bundle directory.
 		if r.spec == nil {
-			if r.spec, err = specutils.ReadSpec(bundleDir, conf); err != nil {
+			if r.spec, err = specutils.ReadSpec(bundleDir, conf, false /* sandboxOnly */); err != nil {
 				return util.Errorf("reading spec: %v", err)
 			}
 		}

--- a/runsc/cmd/restore.go
+++ b/runsc/cmd/restore.go
@@ -163,7 +163,7 @@ func (r *Restore) Execute(_ context.Context, f *flag.FlagSet, args ...any) subco
 
 		// Read the spec from the bundle directory.
 		if r.spec == nil {
-			if r.spec, err = specutils.ReadSpec(bundleDir, conf); err != nil {
+			if r.spec, err = specutils.ReadSpec(bundleDir, specutils.SpecOpts{Conf: conf}); err != nil {
 				return util.Errorf("reading spec: %v", err)
 			}
 		}

--- a/runsc/cmd/run.go
+++ b/runsc/cmd/run.go
@@ -88,7 +88,7 @@ func (r *Run) FetchSpec(conf *config.Config, f *flag.FlagSet) (string, *specs.Sp
 	if r.bundleDir == "" {
 		r.bundleDir = getwdOrDie()
 	}
-	spec, err := specutils.ReadSpec(r.bundleDir, conf)
+	spec, err := specutils.ReadSpec(r.bundleDir, specutils.SpecOpts{Conf: conf, NoRootContainer: r.noRootContainer})
 	if err != nil {
 		return "", nil, fmt.Errorf("reading spec: %w", err)
 	}
@@ -123,8 +123,10 @@ func (r *Run) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomman
 	}
 	specutils.LogSpecDebug(spec, conf.OCISeccomp)
 
-	if err := validateProcessSpec(spec.Process); err != nil {
-		return util.Errorf("invalid process spec: %v", err)
+	if !r.noRootContainer {
+		if err := validateProcessSpec(spec.Process); err != nil {
+			return util.Errorf("invalid process spec: %v", err)
+		}
 	}
 
 	// Create files from file descriptors.
@@ -168,6 +170,7 @@ func (r *Run) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomman
 		ExecFile:           execFile,
 		FSRestoreImagePath: r.fsRestoreImagePath,
 		FSRestoreDirect:    r.fsRestoreDirect,
+		NoRootContainer:    r.noRootContainer,
 	}
 	ws, err := container.Run(conf, runArgs)
 	if err != nil {

--- a/runsc/cmd/run.go
+++ b/runsc/cmd/run.go
@@ -88,7 +88,7 @@ func (r *Run) FetchSpec(conf *config.Config, f *flag.FlagSet) (string, *specs.Sp
 	if r.bundleDir == "" {
 		r.bundleDir = getwdOrDie()
 	}
-	spec, err := specutils.ReadSpec(r.bundleDir, conf)
+	spec, err := specutils.ReadSpec(r.bundleDir, conf, r.sandboxOnly)
 	if err != nil {
 		return "", nil, fmt.Errorf("reading spec: %w", err)
 	}
@@ -123,8 +123,12 @@ func (r *Run) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomman
 	}
 	specutils.LogSpecDebug(spec, conf.OCISeccomp)
 
-	if err := validateProcessSpec(spec.Process); err != nil {
-		return util.Errorf("invalid process spec: %v", err)
+	// A sandbox-only spec has no process; ValidateSpec has already required its
+	// absence.
+	if !r.sandboxOnly {
+		if err := validateProcessSpec(spec.Process); err != nil {
+			return util.Errorf("invalid process spec: %v", err)
+		}
 	}
 
 	// Create files from file descriptors.
@@ -168,6 +172,7 @@ func (r *Run) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomman
 		ExecFile:           execFile,
 		FSRestoreImagePath: r.fsRestoreImagePath,
 		FSRestoreDirect:    r.fsRestoreDirect,
+		SandboxOnly:        r.sandboxOnly,
 	}
 	ws, err := container.Run(conf, runArgs)
 	if err != nil {

--- a/runsc/cmd/sentry/sentrycmd/boot.go
+++ b/runsc/cmd/sentry/sentrycmd/boot.go
@@ -221,6 +221,9 @@ type Boot struct {
 
 	// rootfsUpperTarFD is the file descriptor to a tar file that has rootfs change at startup.
 	rootfsUpperTarFD int
+
+	// sandboxOnly boots a sandbox with no root container. See Create.sandboxOnly.
+	sandboxOnly bool
 }
 
 // Name implements subcommands.Command.Name.
@@ -262,6 +265,7 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&b.hostTHP.Defrag, "host-thp-defrag", "", "value of /sys/kernel/mm/transparent_hugepage/defrag on the host")
 	f.IntVar(&b.uid, "uid", 0, "user ID")
 	f.IntVar(&b.gid, "gid", 0, "user ID")
+	f.BoolVar(&b.sandboxOnly, "sandbox-only", false, "if true, boot the sandbox without a root container; containers are added later as subcontainers")
 
 	// Open FDs that are donated to the sandbox.
 	f.IntVar(&b.specFD, "spec-fd", -1, "required fd with the container spec")
@@ -375,7 +379,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 	// the call setCapsAndCallSelf, otherwise the FD will be closed and the
 	// child process cannot read it
 	specFile := os.NewFile(uintptr(b.specFD), "spec file")
-	spec, err := specutils.ReadSpecFromFile(b.bundleDir, specFile, conf)
+	spec, err := specutils.ReadSpecFromFile(b.bundleDir, specFile, conf, b.sandboxOnly)
 	if err != nil {
 		util.Fatalf("reading spec: %v", err)
 	}
@@ -632,6 +636,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		FSRestoreFDs:             b.fsRestoreFDs.GetFDs(),
 		FSRestoreCheckpointGofer: b.fsRestoreCheckpointGofer,
 		RootfsUpperTarFD:         b.rootfsUpperTarFD,
+		SandboxOnly:              b.sandboxOnly,
 	}
 	l, err := boot.New(bootArgs)
 	if err != nil {

--- a/runsc/cmd/sentry/sentrycmd/boot.go
+++ b/runsc/cmd/sentry/sentrycmd/boot.go
@@ -231,6 +231,9 @@ type Boot struct {
 
 	// rootfsUpperTarFD is the file descriptor to a tar file that has rootfs change at startup.
 	rootfsUpperTarFD int
+
+	// noRootContainer boots without a root container. See Create.noRootContainer.
+	noRootContainer bool
 }
 
 // Name implements subcommands.Command.Name.
@@ -272,6 +275,7 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&b.hostTHP.Defrag, "host-thp-defrag", "", "value of /sys/kernel/mm/transparent_hugepage/defrag on the host")
 	f.IntVar(&b.uid, "uid", 0, "user ID")
 	f.IntVar(&b.gid, "gid", 0, "user ID")
+	f.BoolVar(&b.noRootContainer, "no-root-container", false, "if true, boot the sandbox without a root container; containers are added later as subcontainers")
 
 	// Open FDs that are donated to the sandbox.
 	f.IntVar(&b.specFD, "spec-fd", -1, "required fd with the container spec")
@@ -410,7 +414,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 	// the call setCapsAndCallSelf, otherwise the FD will be closed and the
 	// child process cannot read it
 	specFile := os.NewFile(uintptr(b.specFD), "spec file")
-	spec, err := specutils.ReadSpecFromFile(b.bundleDir, specFile, conf)
+	spec, err := specutils.ReadSpecFromFile(b.bundleDir, specFile, specutils.SpecOpts{Conf: conf, NoRootContainer: b.noRootContainer})
 	if err != nil {
 		util.Fatalf("reading spec: %v", err)
 	}
@@ -701,6 +705,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		FSRestoreFDs:             b.fsRestoreFDs.GetFDs(),
 		FSRestoreCheckpointGofer: b.fsRestoreCheckpointGofer,
 		RootfsUpperTarFD:         b.rootfsUpperTarFD,
+		NoRootContainer:          b.noRootContainer,
 		StartupTimer:             timer,
 	}
 	l, err := boot.New(bootArgs)

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -197,6 +197,13 @@ type Args struct {
 	// for containers in a new Sandbox process.
 	FSRestoreImagePath string
 	FSRestoreDirect    bool
+
+	// SandboxOnly creates a sandbox with no root container. Spec describes only
+	// the sandbox and carries neither a process to run nor a rootfs, so no gofer
+	// is started. Containers are added afterwards as subcontainers.
+	//
+	// It is only valid for a root container, i.e. one whose ID is the sandbox ID.
+	SandboxOnly bool
 }
 
 // New creates the container in a new Sandbox process, unless the metadata
@@ -225,6 +232,25 @@ func New(conf *config.Config, args Args) (*Container, error) {
 		}
 		if args.FSRestoreImagePath != "" {
 			return nil, fmt.Errorf("cannot set FSRestoreImagePath when creating container in existing sandbox")
+		}
+	}
+
+	if args.SandboxOnly {
+		if !specutils.IsRootContainer(args.Spec) {
+			return nil, fmt.Errorf("SandboxOnly can only be set for the root container")
+		}
+		// These all configure a root container process or its rootfs, and a
+		// sandbox-only sandbox has neither. The code that would consume them is
+		// skipped, so accepting them would mean silently doing nothing -- or, for
+		// FSRestoreImagePath, donating FDs for a restore that cannot happen.
+		if args.ConsoleSocket != "" {
+			return nil, fmt.Errorf("ConsoleSocket cannot be set with SandboxOnly: there is no root container process to give a terminal to")
+		}
+		if args.FSRestoreImagePath != "" {
+			return nil, fmt.Errorf("FSRestoreImagePath cannot be set with SandboxOnly: there is no root container filesystem to restore")
+		}
+		if len(args.PassFiles) > 0 || args.ExecFile != nil {
+			return nil, fmt.Errorf("PassFiles and ExecFile cannot be set with SandboxOnly: there is no root container process to pass them to")
 		}
 	}
 
@@ -367,9 +393,21 @@ func (c *Container) createRoot(conf *config.Config, args Args, sandboxID string)
 		return err
 	}
 	if err := cgroup.RunInCgroup(containerCgroup, func() error {
-		ioFiles, goferFilestores, devIOFile, specFile, err := c.createGoferProcess(conf, mountHints, args.Attached)
-		if err != nil {
-			return fmt.Errorf("cannot create gofer process: %w", err)
+		// A sandbox-only sandbox has no rootfs and no mounts of its own, so there
+		// is nothing for a gofer to serve. Subcontainers get their own gofers when
+		// they are created.
+		var (
+			ioFiles         []*os.File
+			goferFilestores []*os.File
+			devIOFile       *os.File
+			specFile        *os.File
+		)
+		if !args.SandboxOnly {
+			var err error
+			ioFiles, goferFilestores, devIOFile, specFile, err = c.createGoferProcess(conf, mountHints, args.Attached)
+			if err != nil {
+				return fmt.Errorf("cannot create gofer process: %w", err)
+			}
 		}
 
 		// Start a new sandbox for this container. Any errors after this point
@@ -392,6 +430,7 @@ func (c *Container) createRoot(conf *config.Config, args Args, sandboxID string)
 			ExecFile:            args.ExecFile,
 			FSRestoreImagePath:  args.FSRestoreImagePath,
 			FSRestoreDirect:     args.FSRestoreDirect,
+			SandboxOnly:         args.SandboxOnly,
 		}
 		sand, err := sandbox.New(conf, sandArgs)
 		if err != nil {
@@ -443,6 +482,9 @@ func (c *Container) Start(conf *config.Config) error {
 // to restore a container from its state file.
 func (c *Container) Restore(conf *config.Config, imagePath string, direct, background bool, networkArgs *boot.CreateLinksAndRoutesArgs) error {
 	log.Debugf("Restore container, cid: %s", c.ID)
+	if err := c.checkpointRestoreSupported("restore"); err != nil {
+		return err
+	}
 
 	restore := func(conf *config.Config, spec *specs.Spec) error {
 		return c.Sandbox.Restore(conf, spec, c.ID, imagePath, direct, background, networkArgs)
@@ -561,8 +603,9 @@ func Run(conf *config.Config, args Args) (unix.WaitStatus, error) {
 
 	// If we allocate a terminal, forward signals to the sandbox process.
 	// Otherwise, Ctrl+C will terminate this process and its children,
-	// including the terminal.
-	if c.Spec.Process.Terminal {
+	// including the terminal. A sandbox-only sandbox has no process, and so no
+	// terminal.
+	if c.Spec.Process != nil && c.Spec.Process.Terminal {
 		stopForwarding := c.ForwardSignals(0, true /* fgProcess */)
 		defer stopForwarding()
 	}
@@ -775,6 +818,12 @@ func (c *Container) SignalContainer(sig unix.Signal, all bool) error {
 	if !c.IsSandboxRunning() {
 		return fmt.Errorf("sandbox is not running")
 	}
+	if c.Sandbox.SandboxOnly && c.Sandbox.IsRootContainer(c.ID) {
+		// There is no root container process to signal, and the sentry does not
+		// take signals on its behalf. Say so, rather than letting the sentry
+		// report that it cannot find PID 0.
+		return fmt.Errorf("cannot signal sandbox %q: it was booted without a root container process; use `runsc delete` to stop it", c.ID)
+	}
 	return c.Sandbox.SignalContainer(c.ID, sig, all)
 }
 
@@ -824,6 +873,9 @@ func (c *Container) ForwardSignals(pid int32, fgProcess bool) func() {
 // The statefile will be written to f, the file at the specified image-path.
 func (c *Container) Checkpoint(conf *config.Config, imagePath string, opts sandbox.CheckpointOpts) error {
 	log.Debugf("Checkpoint container, cid: %s", c.ID)
+	if err := c.checkpointRestoreSupported("checkpoint"); err != nil {
+		return err
+	}
 	if err := c.requireStatus("checkpoint", Created, Running, Paused); err != nil {
 		return err
 	}
@@ -1771,6 +1823,10 @@ func (c *Container) IsSandboxRunning() bool {
 // HasCapabilityInAnySet returns true if the given capability is in any of the
 // capability sets of the container process.
 func (c *Container) HasCapabilityInAnySet(capability linux.Capability) bool {
+	if c.Spec.Process == nil {
+		// Sandbox-only "containers" have no process.
+		return false
+	}
 	capString := capability.String()
 	for _, set := range [5][]string{
 		c.Spec.Process.Capabilities.Bounding,
@@ -1790,6 +1846,10 @@ func (c *Container) HasCapabilityInAnySet(capability linux.Capability) bool {
 
 // RunsAsUID0 returns true if the container process runs with UID 0 (root).
 func (c *Container) RunsAsUID0() bool {
+	if c.Spec.Process == nil {
+		// Sandbox-only "containers" have no process.
+		return false
+	}
 	return c.Spec.Process.User.UID == 0
 }
 
@@ -1800,6 +1860,33 @@ func (c *Container) requireStatus(action string, statuses ...Status) error {
 		}
 	}
 	return fmt.Errorf("cannot %s container %q in state %s", action, c.ID, c.Status)
+}
+
+// checkpointRestoreSupported returns an error if action cannot be performed
+// because the sandbox was booted without a root container.
+//
+// The kernel state itself round-trips: Kernel.globalInit and
+// PIDNamespace.noInit are both saved. Two things above it do not. `runsc
+// restore` has no way to be told that the spec it reads back describes a
+// sandbox rather than a container, so it rejects the process-less spec via
+// ValidateSpec, and the path that skips that check goes on to dereference the
+// absent Spec.Process. And the loader restores every container it was given,
+// including the sandbox itself, which has no gofer: containerMounter.
+// configureRestore consumes a gofer FD and indexes goferMountConfs[0] for the
+// rootfs, and would panic on both. Refuse the checkpoint rather than write an
+// image that cannot be restored, and refuse the restore for symmetry, since no
+// such image should exist.
+//
+// Lifting this needs the loader to skip the sandbox in that loop, plus a way to
+// plumb sandbox-only-ness into `runsc restore`: c.Sandbox.SandboxOnly covers an
+// already-created container, but restoring from a bare bundle would need a
+// --sandbox-only flag, since the container-type annotation alone does not
+// distinguish this from a legacy pause container.
+func (c *Container) checkpointRestoreSupported(action string) error {
+	if c.Sandbox != nil && c.Sandbox.SandboxOnly {
+		return fmt.Errorf("cannot %s container %q: not supported for a sandbox booted without a root container", action, c.ID)
+	}
+	return nil
 }
 
 // IsSandboxRoot returns true if this container is its sandbox's root container.
@@ -1851,6 +1938,13 @@ func adjustSandboxOOMScoreAdj(s *sandbox.Sandbox, spec *specs.Spec, rootDir stri
 		// We will use OOMScoreAdj in the single-container case where the
 		// containerd container-type annotation is not present.
 		if specutils.SpecContainerType(container.Spec) == specutils.ContainerTypeSandbox {
+			continue
+		}
+
+		// A sandbox booted without a root container has no process, and so no
+		// score to contribute. It is usually skipped above, but the sandbox
+		// annotation is not mandatory.
+		if container.Spec.Process == nil {
 			continue
 		}
 

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -208,6 +208,11 @@ type Args struct {
 	// for containers in a new Sandbox process.
 	FSRestoreImagePath string
 	FSRestoreDirect    bool
+
+	// NoRootContainer creates a sandbox with no root container: Spec has
+	// neither Process nor Root, and no gofer is started. Only valid when ID is
+	// the sandbox ID.
+	NoRootContainer bool
 }
 
 // New creates the container in a new Sandbox process, unless the metadata
@@ -236,6 +241,21 @@ func New(conf *config.Config, args Args) (*Container, error) {
 		}
 		if args.FSRestoreImagePath != "" {
 			return nil, fmt.Errorf("cannot set FSRestoreImagePath when creating container in existing sandbox")
+		}
+	}
+
+	if args.NoRootContainer {
+		if !specutils.IsRootContainer(args.Spec) {
+			return nil, fmt.Errorf("NoRootContainer can only be set when creating the sandbox, not a subcontainer")
+		}
+		if args.ConsoleSocket != "" {
+			return nil, fmt.Errorf("ConsoleSocket cannot be set with NoRootContainer: there is no root container process to give a terminal to")
+		}
+		if args.FSRestoreImagePath != "" {
+			return nil, fmt.Errorf("FSRestoreImagePath cannot be set with NoRootContainer: there is no root container filesystem to restore")
+		}
+		if len(args.PassFiles) > 0 || args.ExecFile != nil {
+			return nil, fmt.Errorf("PassFiles and ExecFile cannot be set with NoRootContainer: there is no root container process to pass them to")
 		}
 	}
 
@@ -378,9 +398,20 @@ func (c *Container) createRoot(conf *config.Config, args Args, sandboxID string)
 		return err
 	}
 	if err := cgroup.RunInCgroup(containerCgroup, func(cloneIntoCgroupFD *os.File) error {
-		ioFiles, goferFilestores, devIOFile, specFile, err := c.createGoferProcess(conf, mountHints, args.Attached, cloneIntoCgroupFD)
-		if err != nil {
-			return fmt.Errorf("cannot create gofer process: %w", err)
+		// No rootfs and no mounts, so nothing for a gofer to serve.
+		// Subcontainers get their own.
+		var (
+			ioFiles         []*os.File
+			goferFilestores []*os.File
+			devIOFile       *os.File
+			specFile        *os.File
+		)
+		if !args.NoRootContainer {
+			var err error
+			ioFiles, goferFilestores, devIOFile, specFile, err = c.createGoferProcess(conf, mountHints, args.Attached, cloneIntoCgroupFD)
+			if err != nil {
+				return fmt.Errorf("cannot create gofer process: %w", err)
+			}
 		}
 
 		// Start a new sandbox for this container. Any errors after this point
@@ -405,6 +436,7 @@ func (c *Container) createRoot(conf *config.Config, args Args, sandboxID string)
 			FSRestoreImagePath:  args.FSRestoreImagePath,
 			FSRestoreDirect:     args.FSRestoreDirect,
 			PinRingFile:         c.pinRingFile,
+			NoRootContainer:     args.NoRootContainer,
 		}
 		sand, err := sandbox.New(conf, sandArgs)
 		if err != nil {
@@ -466,6 +498,9 @@ func (c *Container) Start(conf *config.Config) error {
 // to restore a container from its state file.
 func (c *Container) Restore(conf *config.Config, imagePath string, direct, background bool, networkArgs *boot.CreateLinksAndRoutesArgs) error {
 	log.Debugf("Restore container, cid: %s", c.ID)
+	if err := c.checkpointRestoreSupported("restore"); err != nil {
+		return err
+	}
 
 	restore := func(conf *config.Config, spec *specs.Spec) error {
 		return c.Sandbox.Restore(conf, spec, c.ID, imagePath, direct, background, networkArgs)
@@ -586,7 +621,7 @@ func Run(conf *config.Config, args Args) (unix.WaitStatus, error) {
 	// If we allocate a terminal, forward signals to the sandbox process.
 	// Otherwise, Ctrl+C will terminate this process and its children,
 	// including the terminal.
-	if c.Spec.Process.Terminal {
+	if c.Spec.Process != nil && c.Spec.Process.Terminal {
 		stopForwarding := c.ForwardSignals(0, true /* fgProcess */)
 		defer stopForwarding()
 	}
@@ -808,6 +843,9 @@ func (c *Container) signalRunning(sig unix.Signal, all bool) error {
 	if !c.IsSandboxRunning() {
 		return fmt.Errorf("sandbox is not running")
 	}
+	if c.Sandbox.NoRootContainer && c.Sandbox.IsRootContainer(c.ID) {
+		return fmt.Errorf("cannot signal sandbox %q: it was booted without a root container process; use `runsc delete` to stop it", c.ID)
+	}
 	return c.Sandbox.SignalContainer(c.ID, sig, all)
 }
 
@@ -896,6 +934,9 @@ func (c *Container) ForwardSignals(pid int32, fgProcess bool) func() {
 // The statefile will be written to f, the file at the specified image-path.
 func (c *Container) Checkpoint(conf *config.Config, imagePath string, opts sandbox.CheckpointOpts) error {
 	log.Debugf("Checkpoint container, cid: %s", c.ID)
+	if err := c.checkpointRestoreSupported("checkpoint"); err != nil {
+		return err
+	}
 	if err := c.requireStatus("checkpoint", Created, Running, Paused); err != nil {
 		return err
 	}
@@ -1891,6 +1932,9 @@ func (c *Container) IsSandboxRunning() bool {
 // HasCapabilityInAnySet returns true if the given capability is in any of the
 // capability sets of the container process.
 func (c *Container) HasCapabilityInAnySet(capability linux.Capability) bool {
+	if c.Spec.Process == nil {
+		return false
+	}
 	capString := capability.String()
 	for _, set := range [5][]string{
 		c.Spec.Process.Capabilities.Bounding,
@@ -1910,6 +1954,9 @@ func (c *Container) HasCapabilityInAnySet(capability linux.Capability) bool {
 
 // RunsAsUID0 returns true if the container process runs with UID 0 (root).
 func (c *Container) RunsAsUID0() bool {
+	if c.Spec.Process == nil {
+		return false
+	}
 	return c.Spec.Process.User.UID == 0
 }
 
@@ -1920,6 +1967,16 @@ func (c *Container) requireStatus(action string, statuses ...Status) error {
 		}
 	}
 	return fmt.Errorf("cannot %s container %q in state %s", action, c.ID, c.Status)
+}
+
+// checkpointRestoreSupported returns an error if the sandbox has no root
+// container: restore gives every container a gofer, so the image would not be
+// restorable.
+func (c *Container) checkpointRestoreSupported(action string) error {
+	if c.Sandbox != nil && c.Sandbox.NoRootContainer {
+		return fmt.Errorf("cannot %s container %q: not supported for a sandbox booted without a root container", action, c.ID)
+	}
+	return nil
 }
 
 // IsSandboxRoot returns true if this container is its sandbox's root container.
@@ -1971,6 +2028,12 @@ func adjustSandboxOOMScoreAdj(s *sandbox.Sandbox, spec *specs.Spec, rootDir stri
 		// We will use OOMScoreAdj in the single-container case where the
 		// containerd container-type annotation is not present.
 		if specutils.SpecContainerType(container.Spec) == specutils.ContainerTypeSandbox {
+			continue
+		}
+
+		// The annotation check above usually catches the sandbox, but
+		// annotations are not mandatory.
+		if container.Spec.Process == nil {
 			continue
 		}
 

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -1324,6 +1324,114 @@ func testCheckpointRestore(t *testing.T, conf *config.Config, compression statef
 	cont3.Destroy()
 }
 
+// TestCheckpointRestoreSandboxOnly checks that checkpoint and restore are
+// refused for a sandbox booted without a root container, rather than writing an
+// image that cannot be restored. See Container.checkpointRestoreSupported.
+func TestCheckpointRestoreSandboxOnly(t *testing.T) {
+	const wantErr = "not supported for a sandbox booted without a root container"
+
+	for _, tc := range []struct {
+		name        string
+		sandboxOnly bool
+		want        bool
+	}{
+		{name: "sandbox-only", sandboxOnly: true, want: true},
+		{name: "normal", sandboxOnly: false, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Container{ID: "test-cid", Sandbox: &sandbox.Sandbox{SandboxOnly: tc.sandboxOnly}}
+			err := c.checkpointRestoreSupported("checkpoint")
+			if got := err != nil; got != tc.want {
+				t.Errorf("checkpointRestoreSupported() error = %v, want error: %t", err, tc.want)
+			} else if tc.want && !strings.Contains(err.Error(), wantErr) {
+				t.Errorf("checkpointRestoreSupported() error = %v, want it to contain %q", err, wantErr)
+			}
+		})
+	}
+
+	// Both entry points must consult the guard. These calls return before
+	// touching the sandbox or the state file, so no container is needed.
+	conf := testutil.TestConfig(t)
+	c := &Container{ID: "test-cid", Sandbox: &sandbox.Sandbox{SandboxOnly: true}}
+	if err := c.Checkpoint(conf, "" /* imagePath */, sandbox.CheckpointOpts{}); err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("Checkpoint() error = %v, want it to contain %q", err, wantErr)
+	}
+	if err := c.Restore(conf, "" /* imagePath */, false /* direct */, false /* background */, nil /* networkArgs */); err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("Restore() error = %v, want it to contain %q", err, wantErr)
+	}
+}
+
+// TestSandboxOnlyRejectsRootContainerArgs checks that Args that only make sense
+// for a root container process or its rootfs are refused with SandboxOnly,
+// rather than being accepted and silently dropped. New is the choke point for
+// both `runsc create` and `runsc run`.
+func TestSandboxOnlyRejectsRootContainerArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    Args
+		wantErr string
+	}{
+		{
+			name:    "console socket",
+			args:    Args{ConsoleSocket: "/tmp/console.sock"},
+			wantErr: "ConsoleSocket cannot be set with SandboxOnly",
+		},
+		{
+			name:    "fs restore image path",
+			args:    Args{FSRestoreImagePath: "/tmp/image"},
+			wantErr: "FSRestoreImagePath cannot be set with SandboxOnly",
+		},
+		{
+			name:    "pass files",
+			args:    Args{PassFiles: map[int]*os.File{3: os.Stdin}},
+			wantErr: "PassFiles and ExecFile cannot be set with SandboxOnly",
+		},
+		{
+			name:    "exec file",
+			args:    Args{ExecFile: os.Stdin},
+			wantErr: "PassFiles and ExecFile cannot be set with SandboxOnly",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := testutil.TestConfig(t)
+			rootDir, cleanupRoot, err := testutil.SetupRootDir()
+			if err != nil {
+				t.Fatalf("error creating root dir: %v", err)
+			}
+			defer cleanupRoot()
+			conf.RootDir = rootDir
+
+			// A sandbox-only spec has neither a process to run nor a rootfs to serve.
+			spec := &specs.Spec{
+				Version: specs.Version,
+				Annotations: map[string]string{
+					specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+				},
+			}
+			bundleDir, cleanupBundle, err := testutil.SetupBundleDir(spec)
+			if err != nil {
+				t.Fatalf("error setting up bundle: %v", err)
+			}
+			defer cleanupBundle()
+
+			args := tc.args
+			args.ID = testutil.RandomContainerID()
+			args.Spec = spec
+			args.BundleDir = bundleDir
+			args.SandboxOnly = true
+
+			c, err := New(conf, args)
+			if err == nil {
+				c.Destroy()
+				t.Fatalf("New() succeeded, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("New() error = %v, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestCheckpointRestore does the checkpoint/restore test on each platform.
 func TestCheckpointRestore(t *testing.T) {
 	// Skip overlay because test requires writing to host file.

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -1405,6 +1405,110 @@ func testCheckpointRestore(t *testing.T, conf *config.Config, compression statef
 	cont3.Destroy()
 }
 
+// TestCheckpointRestoreNoRootContainer checks that checkpoint and restore both
+// refuse a sandbox with no root container.
+func TestCheckpointRestoreNoRootContainer(t *testing.T) {
+	const wantErr = "not supported for a sandbox booted without a root container"
+
+	for _, tc := range []struct {
+		name            string
+		noRootContainer bool
+		want            bool
+	}{
+		{name: "no-root-container", noRootContainer: true, want: true},
+		{name: "normal", noRootContainer: false, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Container{ID: "test-cid", Sandbox: &sandbox.Sandbox{NoRootContainer: tc.noRootContainer}}
+			err := c.checkpointRestoreSupported("checkpoint")
+			if got := err != nil; got != tc.want {
+				t.Errorf("checkpointRestoreSupported() error = %v, want error: %t", err, tc.want)
+			} else if tc.want && !strings.Contains(err.Error(), wantErr) {
+				t.Errorf("checkpointRestoreSupported() error = %v, want it to contain %q", err, wantErr)
+			}
+		})
+	}
+
+	// The guard runs before anything touches the sandbox, so nothing to set up.
+	conf := testutil.TestConfig(t)
+	c := &Container{ID: "test-cid", Sandbox: &sandbox.Sandbox{NoRootContainer: true}}
+	if err := c.Checkpoint(conf, "" /* imagePath */, sandbox.CheckpointOpts{}); err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("Checkpoint() error = %v, want it to contain %q", err, wantErr)
+	}
+	if err := c.Restore(conf, "" /* imagePath */, false /* direct */, false /* background */, nil /* networkArgs */); err == nil || !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("Restore() error = %v, want it to contain %q", err, wantErr)
+	}
+}
+
+// TestNoRootContainerRejectsRootArgs checks that Args describing a root
+// container process or its rootfs are refused rather than dropped.
+func TestNoRootContainerRejectsRootArgs(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    Args
+		wantErr string
+	}{
+		{
+			name:    "console socket",
+			args:    Args{ConsoleSocket: "/tmp/console.sock"},
+			wantErr: "ConsoleSocket cannot be set with NoRootContainer",
+		},
+		{
+			name:    "fs restore image path",
+			args:    Args{FSRestoreImagePath: "/tmp/image"},
+			wantErr: "FSRestoreImagePath cannot be set with NoRootContainer",
+		},
+		{
+			name:    "pass files",
+			args:    Args{PassFiles: map[int]*os.File{3: os.Stdin}},
+			wantErr: "PassFiles and ExecFile cannot be set with NoRootContainer",
+		},
+		{
+			name:    "exec file",
+			args:    Args{ExecFile: os.Stdin},
+			wantErr: "PassFiles and ExecFile cannot be set with NoRootContainer",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := testutil.TestConfig(t)
+			rootDir, cleanupRoot, err := testutil.SetupRootDir()
+			if err != nil {
+				t.Fatalf("error creating root dir: %v", err)
+			}
+			defer cleanupRoot()
+			conf.RootDir = rootDir
+
+			// A sandbox spec has no process and no rootfs.
+			spec := &specs.Spec{
+				Version: specs.Version,
+				Annotations: map[string]string{
+					specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+				},
+			}
+			bundleDir, cleanupBundle, err := testutil.SetupBundleDir(spec)
+			if err != nil {
+				t.Fatalf("error setting up bundle: %v", err)
+			}
+			defer cleanupBundle()
+
+			args := tc.args
+			args.ID = testutil.RandomContainerID()
+			args.Spec = spec
+			args.BundleDir = bundleDir
+			args.NoRootContainer = true
+
+			c, err := New(conf, args)
+			if err == nil {
+				c.Destroy()
+				t.Fatalf("New() succeeded, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("New() error = %v, want it to contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestCheckpointRestore does the checkpoint/restore test on each platform.
 func TestCheckpointRestore(t *testing.T) {
 	// Skip overlay because test requires writing to host file.

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -117,6 +117,528 @@ func startContainersWithArgs(conf *config.Config, specs []*specs.Spec, ids []str
 	return containers, cu.Release(), nil
 }
 
+// TestMultiContainerNoRootContainer checks that a sandbox with no root
+// container outlives its containers, including the first and the last.
+func TestMultiContainerNoRootContainer(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupTestRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+
+	// A sandbox spec has no process and no rootfs.
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+	}
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	t.Cleanup(cleanupBundle)
+
+	sb, err := New(conf, Args{ID: sbID, Spec: sbSpec, BundleDir: sbBundle, NoRootContainer: true})
+	if err != nil {
+		t.Fatalf("error creating sandbox: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sb.Destroy(); err != nil {
+			t.Errorf("error destroying sandbox: %v", err)
+		}
+	})
+	if err := sb.Start(conf); err != nil {
+		t.Fatalf("error starting sandbox: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox is not running after start")
+	}
+
+	// startSub adds a subcontainer running sleepCmd to the sandbox.
+	startSub := func(t *testing.T, name string) *Container {
+		t.Helper()
+		spec := testutil.NewSpecWithArgs(sleepCmd...)
+		spec.Annotations = map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeContainer,
+			specutils.ContainerdSandboxIDAnnotation:     sbID,
+		}
+		bundle, cleanupBundle, err := testutil.SetupBundleDir(spec)
+		if err != nil {
+			t.Fatalf("error setting up bundle for %s: %v", name, err)
+		}
+		t.Cleanup(cleanupBundle)
+
+		cont, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: spec, BundleDir: bundle})
+		if err != nil {
+			t.Fatalf("error creating %s: %v", name, err)
+		}
+		t.Cleanup(func() { cont.Destroy() })
+		if err := cont.Start(conf); err != nil {
+			t.Fatalf("error starting %s: %v", name, err)
+		}
+		return cont
+	}
+
+	// pidOf returns the in-sandbox PID of the container's only process.
+	pidOf := func(t *testing.T, name string, c *Container) int32 {
+		t.Helper()
+		pl, err := c.Processes()
+		if err != nil {
+			t.Fatalf("error getting processes of %s: %v", name, err)
+		}
+		if len(pl) != 1 {
+			t.Fatalf("got %d processes in %s, want 1: %v", len(pl), name, pl)
+		}
+		return int32(pl[0].PID)
+	}
+
+	// TID 1 is reserved. See PIDNamespace.ReserveInitTID.
+	c1 := startSub(t, "c1")
+	pid1 := pidOf(t, "c1", c1)
+	c2 := startSub(t, "c2")
+	pid2 := pidOf(t, "c2", c2)
+	if pid1 == 1 || pid2 == 1 {
+		t.Errorf("got PIDs %d and %d, want TID 1 to be reserved", pid1, pid2)
+	}
+	if pid1 == pid2 {
+		t.Errorf("both containers got PID %d, want distinct PIDs", pid1)
+	}
+
+	// The first container is neither the namespace's init nor
+	// Kernel.globalInit, so its exit leaves the sandbox and its peers alone.
+	if err := c1.Destroy(); err != nil {
+		t.Fatalf("error destroying c1: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox stopped running after its first container was destroyed")
+	}
+	if got := pidOf(t, "c2", c2); got != pid2 {
+		t.Errorf("c2 PID changed from %d to %d after c1 was destroyed", pid2, got)
+	}
+
+	// Going empty does not end the sandbox; it keeps taking containers.
+	if err := c2.Destroy(); err != nil {
+		t.Fatalf("error destroying c2: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox stopped running after the last container was destroyed")
+	}
+	c3 := startSub(t, "c3")
+	if got := pidOf(t, "c3", c3); got == 1 {
+		t.Errorf("c3 got PID 1, want TID 1 to be reserved")
+	}
+}
+
+// TestNoRootContainerRun covers `runsc run --no-root-container` detached.
+// Attached would block forever, since nothing but destruction ends the wait.
+func TestNoRootContainerRun(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	rootDir := setupTestRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+	}
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	defer cleanupBundle()
+
+	// Detached, Run() returns once the sandbox is up.
+	ws, err := Run(conf, Args{
+		ID:              sbID,
+		Spec:            sbSpec,
+		BundleDir:       sbBundle,
+		NoRootContainer: true,
+		Attached:        false,
+	})
+	if err != nil {
+		t.Fatalf("error running sandbox: %v", err)
+	}
+	if ws != 0 {
+		t.Errorf("got wait status %v, want 0", ws)
+	}
+
+	// Detached Run() returns no container, so load it like `runsc start` does.
+	sb, err := Load(rootDir, FullID{ContainerID: sbID}, LoadOpts{})
+	if err != nil {
+		t.Fatalf("error loading sandbox: %v", err)
+	}
+	t.Cleanup(func() { sb.Destroy() })
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox is not running after Run")
+	}
+
+	// It takes containers like any other sandbox.
+	spec := testutil.NewSpecWithArgs(sleepCmd...)
+	spec.Annotations = map[string]string{
+		specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeContainer,
+		specutils.ContainerdSandboxIDAnnotation:     sbID,
+	}
+	bundle, cleanupContBundle, err := testutil.SetupBundleDir(spec)
+	if err != nil {
+		t.Fatalf("error setting up container bundle: %v", err)
+	}
+	defer cleanupContBundle()
+
+	cont, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: spec, BundleDir: bundle})
+	if err != nil {
+		t.Fatalf("error creating container: %v", err)
+	}
+	t.Cleanup(func() { cont.Destroy() })
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("error starting container: %v", err)
+	}
+	if got := cont.Status; got != Running {
+		t.Errorf("got container status %v, want %v", got, Running)
+	}
+}
+
+// TestNoRootContainerWithoutAnnotations covers a bundle with no annotations.
+// adjustSandboxOOMScoreAdj reads Spec.Process of every container, so it must
+// skip the sandbox without relying on its container-type annotation.
+func TestNoRootContainerWithoutAnnotations(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupTestRootDir(t, conf)
+
+	sbSpec := &specs.Spec{Version: specs.Version}
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	defer cleanupBundle()
+
+	sb, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: sbSpec, BundleDir: sbBundle, NoRootContainer: true})
+	if err != nil {
+		t.Fatalf("error creating sandbox: %v", err)
+	}
+	defer sb.Destroy()
+	if err := sb.Start(conf); err != nil {
+		t.Fatalf("error starting sandbox: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox is not running after start")
+	}
+	// Destroy recomputes oom_score_adj too; call it here so its error is seen.
+	if err := sb.Destroy(); err != nil {
+		t.Fatalf("error destroying sandbox: %v", err)
+	}
+}
+
+// TestNoRootContainerSignal checks that signaling a sandbox is refused up
+// front and leaves it running.
+func TestNoRootContainerSignal(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupTestRootDir(t, conf)
+
+	sb := startNoRootContainerSandbox(t, conf, testutil.RandomContainerID())
+	for _, all := range []bool{false, true} {
+		err := sb.SignalContainer(unix.SIGTERM, all)
+		if err == nil {
+			t.Errorf("SignalContainer(all=%t) succeeded, want error", all)
+		} else if !strings.Contains(err.Error(), "root container process") {
+			t.Errorf("SignalContainer(all=%t) failed with %v, want an error about the missing root container process", all, err)
+		}
+	}
+	if !sb.IsSandboxRunning() {
+		t.Errorf("sandbox is not running after being signaled")
+	}
+}
+
+// TestNoRootContainerSIGTERM checks that SIGTERM to the sandbox process stops
+// the sandbox and releases waiters.
+func TestNoRootContainerSIGTERM(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupTestRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+	sb := startNoRootContainerSandbox(t, conf, sbID)
+	startNoRootContainerSub(t, conf, sbID, nil)
+
+	if err := unix.Kill(sb.Sandbox.Pid.Load(), unix.SIGTERM); err != nil {
+		t.Fatalf("error sending SIGTERM to sandbox: %v", err)
+	}
+	ws, err := sb.Wait()
+	if err != nil {
+		t.Fatalf("error waiting on sandbox: %v", err)
+	}
+	if es := ws.ExitStatus(); es != 0 {
+		t.Errorf("sandbox exited with status %d, want 0", es)
+	}
+	if sb.IsSandboxRunning() {
+		t.Errorf("sandbox is still running after SIGTERM")
+	}
+}
+
+// setupTestRootDir creates a root dir, points conf at it and registers its
+// removal, returning the dir.
+//
+// Removal must be a t.Cleanup, never a defer: Go runs every t.Cleanup after
+// every defer, so a deferred removal would take the state files out from under
+// the Destroy() calls the tests register, leaking a sandbox that never exits.
+func setupTestRootDir(t *testing.T, conf *config.Config) string {
+	t.Helper()
+
+	rootDir, cleanupRoot, err := testutil.SetupRootDir()
+	if err != nil {
+		t.Fatalf("error creating root dir: %v", err)
+	}
+	t.Cleanup(cleanupRoot)
+	conf.RootDir = rootDir
+	return rootDir
+}
+
+// startNoRootContainerSandbox boots a sandbox with no root container,
+// registering its teardown with t.Cleanup.
+func startNoRootContainerSandbox(t *testing.T, conf *config.Config, sbID string) *Container {
+	t.Helper()
+
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+	}
+	return startNoRootContainerSandboxWithSpec(t, conf, sbID, sbSpec)
+}
+
+// startNoRootContainerSandboxWithSpec is startNoRootContainerSandbox with a
+// caller-provided spec.
+func startNoRootContainerSandboxWithSpec(t *testing.T, conf *config.Config, sbID string, sbSpec *specs.Spec) *Container {
+	t.Helper()
+
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	t.Cleanup(cleanupBundle)
+
+	sb, err := New(conf, Args{ID: sbID, Spec: sbSpec, BundleDir: sbBundle, NoRootContainer: true})
+	if err != nil {
+		t.Fatalf("error creating sandbox: %v", err)
+	}
+	// Do not swallow this error: an undestroyed sandbox stays up for good.
+	t.Cleanup(func() {
+		if err := sb.Destroy(); err != nil {
+			t.Errorf("error destroying sandbox: %v", err)
+		}
+	})
+	if err := sb.Start(conf); err != nil {
+		t.Fatalf("error starting sandbox: %v", err)
+	}
+	return sb
+}
+
+// startNoRootContainerSub adds a subcontainer running sleepCmd to sandbox sbID.
+//
+// pidnsPath, if non-nil, becomes the spec's PID namespace path. Nil leaves the
+// container in the sandbox's root PID namespace; a pointer to "" unshares, as
+// CRI's NamespaceMode_CONTAINER asks.
+func startNoRootContainerSub(t *testing.T, conf *config.Config, sbID string, pidnsPath *string) *Container {
+	t.Helper()
+	return startNoRootContainerSubWithArgs(t, conf, sbID, pidnsPath, sleepCmd...)
+}
+
+// startNoRootContainerSubWithArgs is startNoRootContainerSub with a
+// caller-provided command.
+func startNoRootContainerSubWithArgs(t *testing.T, conf *config.Config, sbID string, pidnsPath *string, args ...string) *Container {
+	t.Helper()
+
+	spec := testutil.NewSpecWithArgs(args...)
+	spec.Annotations[specutils.ContainerdContainerTypeAnnotation] = specutils.ContainerdContainerTypeContainer
+	spec.Annotations[specutils.ContainerdSandboxIDAnnotation] = sbID
+	if pidnsPath != nil {
+		spec.Linux = &specs.Linux{
+			Namespaces: []specs.LinuxNamespace{
+				{Type: specs.PIDNamespace, Path: *pidnsPath},
+			},
+		}
+	}
+	bundle, cleanupBundle, err := testutil.SetupBundleDir(spec)
+	if err != nil {
+		t.Fatalf("error setting up container bundle: %v", err)
+	}
+	t.Cleanup(cleanupBundle)
+
+	cont, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: spec, BundleDir: bundle})
+	if err != nil {
+		t.Fatalf("error creating container: %v", err)
+	}
+	t.Cleanup(func() { cont.Destroy() })
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("error starting container: %v", err)
+	}
+	return cont
+}
+
+// TestNoRootContainerPIDNS tests PID namespace sharing the way CRI asks for it.
+// containerd names the pod's namespace /proc/<sandbox pid>/ns/pid, which
+// Sandbox.fixPidns resolves to the root PID namespace; NamespaceMode_CONTAINER
+// arrives as an empty path and yields a namespace of its own.
+func TestNoRootContainerPIDNS(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupTestRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+	sb := startNoRootContainerSandbox(t, conf, sbID)
+
+	shared := fmt.Sprintf("/proc/%d/ns/pid", sb.SandboxPid())
+	private := ""
+	// One at a time, so the PIDs below are predictable. TID 1 is reserved, so
+	// numbering starts at 2.
+	shared1 := startNoRootContainerSub(t, conf, sbID, &shared)
+	if err := waitForProcessList(shared1, []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+	shared2 := startNoRootContainerSub(t, conf, sbID, &shared)
+	if err := waitForProcessList(shared2, []*control.Process{
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+	isolated := startNoRootContainerSub(t, conf, sbID, &private)
+	if err := waitForProcessList(isolated, []*control.Process{
+		newProcessBuilder().PID(4).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+
+	// The sharers see each other, and the isolated container, whose namespace
+	// is a child of theirs.
+	expectedPL := []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+		newProcessBuilder().PID(4).Cmd("sleep").Process(),
+		newProcessBuilder().Cmd("ps").Process(),
+	}
+	for _, c := range []*Container{shared1, shared2} {
+		got, err := execPS(conf, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !procListsEqual(got, expectedPL) {
+			t.Errorf("shared container got process list: %s, want: %s", procListToString(got), procListToString(expectedPL))
+		}
+	}
+
+	// The isolated container sees only itself, and its init is PID 1.
+	expectedPL = []*control.Process{
+		newProcessBuilder().PID(1).Cmd("sleep").Process(),
+		newProcessBuilder().Cmd("ps").Process(),
+	}
+	got, err := execPS(conf, isolated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !procListsEqual(got, expectedPL) {
+		t.Errorf("isolated container got process list: %s, want: %s", procListToString(got), procListToString(expectedPL))
+	}
+}
+
+// TestNoRootContainerPIDNSSandboxSpec tests a container naming a PID namespace
+// that the sandbox's own spec declares. The sandbox entry has no process behind
+// it, but the namespace it names is the root one, so the container lands there
+// rather than in a new namespace.
+func TestNoRootContainerPIDNSSandboxSpec(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupTestRootDir(t, conf)
+
+	// Any path but /proc/<sandbox pid>/ns/pid, which Sandbox.fixPidns strips
+	// from a subcontainer's spec before the loader ever sees it.
+	const pidnsPath = "/proc/1/ns/pid"
+	sbID := testutil.RandomContainerID()
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+		Linux: &specs.Linux{
+			Namespaces: []specs.LinuxNamespace{
+				{Type: specs.PIDNamespace, Path: pidnsPath},
+			},
+		},
+	}
+	startNoRootContainerSandboxWithSpec(t, conf, sbID, sbSpec)
+
+	// Two ways into the root namespace: name none, or name the sandbox's.
+	root := startNoRootContainerSub(t, conf, sbID, nil)
+	if err := waitForProcessList(root, []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+	path := pidnsPath
+	joiner := startNoRootContainerSub(t, conf, sbID, &path)
+	if err := waitForProcessList(joiner, []*control.Process{
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+
+	expectedPL := []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+		newProcessBuilder().Cmd("ps").Process(),
+	}
+	got, err := execPS(conf, joiner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !procListsEqual(got, expectedPL) {
+		t.Errorf("container got process list: %s, want: %s", procListToString(got), procListToString(expectedPL))
+	}
+}
+
+// TestNoRootContainerOrphan checks that a container's init exiting with a live
+// child leaves the rest of the pod running, the orphan among it, and no zombie.
+func TestNoRootContainerOrphan(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupTestRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+	startNoRootContainerSandbox(t, conf, sbID)
+
+	bystander := startNoRootContainerSub(t, conf, sbID, nil)
+	if err := waitForProcessList(bystander, []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for bystander to start: %v", err)
+	}
+
+	orphaner := startNoRootContainerSubWithArgs(t, conf, sbID, nil, "sh", "-c", "/bin/sleep 1000 & exit 0")
+	ws, err := orphaner.Wait()
+	if err != nil {
+		t.Fatalf("error waiting on orphaner: %v", err)
+	}
+	if es := ws.ExitStatus(); es != 0 {
+		t.Fatalf("orphaner exited with status %d, want 0", es)
+	}
+
+	expectedPL := []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+		newProcessBuilder().PID(4).Cmd("sleep").Process(),
+		newProcessBuilder().Cmd("ps").Process(),
+	}
+	if err := testutil.Poll(func() error {
+		got, err := execPS(conf, bystander)
+		if err != nil {
+			return &backoff.PermanentError{Err: fmt.Errorf("error listing processes: %w", err)}
+		}
+		if !procListsEqual(got, expectedPL) {
+			return fmt.Errorf("pod got process list: %s, want: %s", procListToString(got), procListToString(expectedPL))
+		}
+		return nil
+	}, pollTimeout); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestMultiContainerTarRootfsUpperLayer(t *testing.T) {
 	conf := testutil.TestConfig(t)
 	conf.Overlay2.Set("all:memory")

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -114,6 +114,479 @@ func startContainersWithArgs(conf *config.Config, specs []*specs.Spec, ids []str
 	return containers, cu.Release(), nil
 }
 
+// TestMultiContainerSandboxOnly tests a sandbox booted without a root
+// container. Containers are added to it afterwards as subcontainers, and the
+// sandbox outlives all of them.
+func TestMultiContainerSandboxOnly(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupSandboxOnlyRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+
+	// A sandbox-only spec has neither a process to run nor a rootfs to serve.
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+	}
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	t.Cleanup(cleanupBundle)
+
+	sb, err := New(conf, Args{ID: sbID, Spec: sbSpec, BundleDir: sbBundle, SandboxOnly: true})
+	if err != nil {
+		t.Fatalf("error creating sandbox: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := sb.Destroy(); err != nil {
+			t.Errorf("error destroying sandbox: %v", err)
+		}
+	})
+	if err := sb.Start(conf); err != nil {
+		t.Fatalf("error starting sandbox: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox is not running after start")
+	}
+
+	// startSub adds a subcontainer running sleepCmd to the sandbox.
+	startSub := func(t *testing.T, name string) *Container {
+		t.Helper()
+		spec := testutil.NewSpecWithArgs(sleepCmd...)
+		spec.Annotations = map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeContainer,
+			specutils.ContainerdSandboxIDAnnotation:     sbID,
+		}
+		bundle, cleanupBundle, err := testutil.SetupBundleDir(spec)
+		if err != nil {
+			t.Fatalf("error setting up bundle for %s: %v", name, err)
+		}
+		t.Cleanup(cleanupBundle)
+
+		cont, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: spec, BundleDir: bundle})
+		if err != nil {
+			t.Fatalf("error creating %s: %v", name, err)
+		}
+		t.Cleanup(func() { cont.Destroy() })
+		if err := cont.Start(conf); err != nil {
+			t.Fatalf("error starting %s: %v", name, err)
+		}
+		return cont
+	}
+
+	// pidOf returns the in-sandbox PID of the container's only process.
+	pidOf := func(t *testing.T, name string, c *Container) int32 {
+		t.Helper()
+		pl, err := c.Processes()
+		if err != nil {
+			t.Fatalf("error getting processes of %s: %v", name, err)
+		}
+		if len(pl) != 1 {
+			t.Fatalf("got %d processes in %s, want 1: %v", len(pl), name, pl)
+		}
+		return int32(pl[0].PID)
+	}
+
+	// No container may get TID 1. It is reserved so that the PID namespace has
+	// no init and no container's exit can kill the rest of the pod. See
+	// PIDNamespace.ReserveInitTID.
+	c1 := startSub(t, "c1")
+	pid1 := pidOf(t, "c1", c1)
+	c2 := startSub(t, "c2")
+	pid2 := pidOf(t, "c2", c2)
+	if pid1 == 1 || pid2 == 1 {
+		t.Errorf("got PIDs %d and %d, want TID 1 to be reserved", pid1, pid2)
+	}
+	if pid1 == pid2 {
+		t.Errorf("both containers got PID %d, want distinct PIDs", pid1)
+	}
+
+	// Destroying the first container must take down neither the sandbox nor its
+	// peers, even though it is the one that became Kernel.globalInit.
+	if err := c1.Destroy(); err != nil {
+		t.Fatalf("error destroying c1: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox stopped running after its first container was destroyed")
+	}
+	if got := pidOf(t, "c2", c2); got != pid2 {
+		t.Errorf("c2 PID changed from %d to %d after c1 was destroyed", pid2, got)
+	}
+
+	// An empty sandbox must still accept new containers. Loader.WaitExit must
+	// not call Kernel.WaitExited, which returns immediately when nothing is
+	// running and sets noNewTasksIfZeroLive.
+	if err := c2.Destroy(); err != nil {
+		t.Fatalf("error destroying c2: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox stopped running after the last container was destroyed")
+	}
+	c3 := startSub(t, "c3")
+	if got := pidOf(t, "c3", c3); got == 1 {
+		t.Errorf("c3 got PID 1, want TID 1 to be reserved")
+	}
+}
+
+// TestSandboxOnlyRun tests Run() on a sandbox booted without a root container,
+// which is what `runsc run --sandbox-only` does. Only the detached case is
+// covered: attached blocks by design until the sandbox is destroyed, since
+// there is no root container process whose exit could end the wait.
+func TestSandboxOnlyRun(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	rootDir := setupSandboxOnlyRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+	}
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	defer cleanupBundle()
+
+	// Run() is Create + Start + Wait. Detached, so it must return once the
+	// sandbox is up rather than waiting on a root container that does not exist.
+	ws, err := Run(conf, Args{
+		ID:          sbID,
+		Spec:        sbSpec,
+		BundleDir:   sbBundle,
+		SandboxOnly: true,
+		Attached:    false,
+	})
+	if err != nil {
+		t.Fatalf("error running sandbox: %v", err)
+	}
+	if ws != 0 {
+		t.Errorf("got wait status %v, want 0", ws)
+	}
+
+	// Run() does not hand back the container when detached, so load it from the
+	// state file the way `runsc start`/`delete` would.
+	sb, err := Load(rootDir, FullID{ContainerID: sbID}, LoadOpts{})
+	if err != nil {
+		t.Fatalf("error loading sandbox: %v", err)
+	}
+	t.Cleanup(func() { sb.Destroy() })
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox is not running after Run")
+	}
+
+	// The sandbox must accept a subcontainer, the same as one created with
+	// New()/Start().
+	spec := testutil.NewSpecWithArgs(sleepCmd...)
+	spec.Annotations = map[string]string{
+		specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeContainer,
+		specutils.ContainerdSandboxIDAnnotation:     sbID,
+	}
+	bundle, cleanupContBundle, err := testutil.SetupBundleDir(spec)
+	if err != nil {
+		t.Fatalf("error setting up container bundle: %v", err)
+	}
+	defer cleanupContBundle()
+
+	cont, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: spec, BundleDir: bundle})
+	if err != nil {
+		t.Fatalf("error creating container: %v", err)
+	}
+	t.Cleanup(func() { cont.Destroy() })
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("error starting container: %v", err)
+	}
+	if got := cont.Status; got != Running {
+		t.Errorf("got container status %v, want %v", got, Running)
+	}
+}
+
+// TestSandboxOnlyWithoutAnnotations tests a sandbox booted without a root
+// container from a spec that carries no annotations at all, which is what
+// `runsc create/run --sandbox-only` accepts from a hand-written bundle. The
+// container-type annotation is what usually keeps such a sandbox out of the
+// oom_score_adj calculation, which reads Spec.Process of every container in the
+// sandbox.
+func TestSandboxOnlyWithoutAnnotations(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupSandboxOnlyRootDir(t, conf)
+
+	sbSpec := &specs.Spec{Version: specs.Version}
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	defer cleanupBundle()
+
+	sb, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: sbSpec, BundleDir: sbBundle, SandboxOnly: true})
+	if err != nil {
+		t.Fatalf("error creating sandbox: %v", err)
+	}
+	defer sb.Destroy()
+	if err := sb.Start(conf); err != nil {
+		t.Fatalf("error starting sandbox: %v", err)
+	}
+	if !sb.IsSandboxRunning() {
+		t.Fatalf("sandbox is not running after start")
+	}
+	// Destroy takes the same path with destroy=true.
+	if err := sb.Destroy(); err != nil {
+		t.Fatalf("error destroying sandbox: %v", err)
+	}
+}
+
+// TestSandboxOnlySignal checks that signaling a sandbox booted without a root
+// container is refused with an error saying why, rather than reaching the
+// sentry and failing there on a process that does not exist. The sandbox must
+// survive the attempt: `runsc delete` is what stops it.
+func TestSandboxOnlySignal(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupSandboxOnlyRootDir(t, conf)
+
+	sb := startSandboxOnly(t, conf, testutil.RandomContainerID())
+	for _, all := range []bool{false, true} {
+		err := sb.SignalContainer(unix.SIGTERM, all)
+		if err == nil {
+			t.Errorf("SignalContainer(all=%t) succeeded, want error", all)
+		} else if !strings.Contains(err.Error(), "root container process") {
+			t.Errorf("SignalContainer(all=%t) failed with %v, want an error about the missing root container process", all, err)
+		}
+	}
+	if !sb.IsSandboxRunning() {
+		t.Errorf("sandbox is not running after being signaled")
+	}
+}
+
+// setupSandboxOnlyRootDir creates a root dir for a sandbox-only test, points
+// conf at it and registers its removal, returning the dir.
+//
+// The removal is registered with t.Cleanup rather than deferred on purpose.
+// Every t.Cleanup runs after every deferred call, so a deferred removal would
+// take the state files away first, and the Destroy() calls that these tests
+// register with t.Cleanup would then fail to lock them and return without
+// stopping anything. A sandbox leaked that way never exits, having no process
+// inside it whose exit could end it, and it holds the test binary's stdout
+// open until the test framework times out.
+func setupSandboxOnlyRootDir(t *testing.T, conf *config.Config) string {
+	t.Helper()
+
+	rootDir, cleanupRoot, err := testutil.SetupRootDir()
+	if err != nil {
+		t.Fatalf("error creating root dir: %v", err)
+	}
+	t.Cleanup(cleanupRoot)
+	conf.RootDir = rootDir
+	return rootDir
+}
+
+// startSandboxOnly boots a sandbox with no root container and returns it. The
+// caller is responsible for the returned containers' cleanup only through
+// t.Cleanup, which is registered here.
+func startSandboxOnly(t *testing.T, conf *config.Config, sbID string) *Container {
+	t.Helper()
+
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+	}
+	return startSandboxOnlyWithSpec(t, conf, sbID, sbSpec)
+}
+
+// startSandboxOnlyWithSpec is startSandboxOnly with a caller-provided spec.
+func startSandboxOnlyWithSpec(t *testing.T, conf *config.Config, sbID string, sbSpec *specs.Spec) *Container {
+	t.Helper()
+
+	sbBundle, cleanupBundle, err := testutil.SetupBundleDir(sbSpec)
+	if err != nil {
+		t.Fatalf("error setting up sandbox bundle: %v", err)
+	}
+	t.Cleanup(cleanupBundle)
+
+	sb, err := New(conf, Args{ID: sbID, Spec: sbSpec, BundleDir: sbBundle, SandboxOnly: true})
+	if err != nil {
+		t.Fatalf("error creating sandbox: %v", err)
+	}
+	// Report a Destroy() failure rather than swallowing it: a sandbox-only
+	// sandbox that is not destroyed stays up for good.
+	t.Cleanup(func() {
+		if err := sb.Destroy(); err != nil {
+			t.Errorf("error destroying sandbox: %v", err)
+		}
+	})
+	if err := sb.Start(conf); err != nil {
+		t.Fatalf("error starting sandbox: %v", err)
+	}
+	return sb
+}
+
+// startSandboxOnlySub adds a subcontainer running sleepCmd to a sandbox booted
+// without a root container. pidnsPath, when non-nil, becomes the container's
+// PID namespace: the empty string asks for a new namespace, as CRI does for
+// NamespaceMode_CONTAINER.
+func startSandboxOnlySub(t *testing.T, conf *config.Config, sbID string, pidnsPath *string) *Container {
+	t.Helper()
+
+	spec := testutil.NewSpecWithArgs(sleepCmd...)
+	spec.Annotations[specutils.ContainerdContainerTypeAnnotation] = specutils.ContainerdContainerTypeContainer
+	spec.Annotations[specutils.ContainerdSandboxIDAnnotation] = sbID
+	if pidnsPath != nil {
+		spec.Linux = &specs.Linux{
+			Namespaces: []specs.LinuxNamespace{
+				{Type: specs.PIDNamespace, Path: *pidnsPath},
+			},
+		}
+	}
+	bundle, cleanupBundle, err := testutil.SetupBundleDir(spec)
+	if err != nil {
+		t.Fatalf("error setting up container bundle: %v", err)
+	}
+	t.Cleanup(cleanupBundle)
+
+	cont, err := New(conf, Args{ID: testutil.RandomContainerID(), Spec: spec, BundleDir: bundle})
+	if err != nil {
+		t.Fatalf("error creating container: %v", err)
+	}
+	t.Cleanup(func() { cont.Destroy() })
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("error starting container: %v", err)
+	}
+	return cont
+}
+
+// TestSandboxOnlyPIDNS tests PID namespace sharing between containers of a
+// sandbox booted without a root container, the way CRI asks for it. containerd
+// names the pod's PID namespace after the sandbox process,
+// /proc/<sandbox pid>/ns/pid, whatever the pod's pause container would have
+// been; the sandbox API reports the sentry's PID there just as the pause
+// container flow does, and Sandbox.fixPidns resolves it to the sandbox's root
+// PID namespace. A container asking for NamespaceMode_CONTAINER instead gets an
+// empty path, and must stay in a namespace of its own.
+func TestSandboxOnlyPIDNS(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupSandboxOnlyRootDir(t, conf)
+
+	sbID := testutil.RandomContainerID()
+	sb := startSandboxOnly(t, conf, sbID)
+
+	shared := fmt.Sprintf("/proc/%d/ns/pid", sb.SandboxPid())
+	private := ""
+	// Start them one at a time so that their PIDs are predictable. TID 1 is
+	// reserved in a sandbox booted without a root container, so the first
+	// container's process gets TID 2.
+	shared1 := startSandboxOnlySub(t, conf, sbID, &shared)
+	if err := waitForProcessList(shared1, []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+	shared2 := startSandboxOnlySub(t, conf, sbID, &shared)
+	if err := waitForProcessList(shared2, []*control.Process{
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+	isolated := startSandboxOnlySub(t, conf, sbID, &private)
+	if err := waitForProcessList(isolated, []*control.Process{
+		newProcessBuilder().PID(4).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+
+	// The two containers sharing the pod's namespace see each other, which is
+	// the point of the feature. They also see the isolated container, since its
+	// namespace is a child of theirs.
+	expectedPL := []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+		newProcessBuilder().PID(4).Cmd("sleep").Process(),
+		newProcessBuilder().Cmd("ps").Process(),
+	}
+	for _, c := range []*Container{shared1, shared2} {
+		got, err := execPS(conf, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !procListsEqual(got, expectedPL) {
+			t.Errorf("shared container got process list: %s, want: %s", procListToString(got), procListToString(expectedPL))
+		}
+	}
+
+	// The isolated container sees only itself, and numbers itself from 1.
+	expectedPL = []*control.Process{
+		newProcessBuilder().PID(1).Cmd("sleep").Process(),
+		newProcessBuilder().Cmd("ps").Process(),
+	}
+	got, err := execPS(conf, isolated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !procListsEqual(got, expectedPL) {
+		t.Errorf("isolated container got process list: %s, want: %s", procListToString(got), procListToString(expectedPL))
+	}
+}
+
+// TestSandboxOnlyPIDNSSandboxSpec tests a container joining a PID namespace
+// named by the sandbox's own spec. There is no root container process to take
+// the namespace from, but the namespace the process would have run in exists:
+// it is the sandbox's root PID namespace, and containers naming it must land
+// there rather than in a new namespace of their own.
+func TestSandboxOnlyPIDNSSandboxSpec(t *testing.T) {
+	conf := testutil.TestConfig(t)
+	setupSandboxOnlyRootDir(t, conf)
+
+	// Any path but /proc/<sandbox pid>/ns/pid, which Sandbox.fixPidns strips
+	// from a subcontainer's spec before the loader ever sees it.
+	const pidnsPath = "/proc/1/ns/pid"
+	sbID := testutil.RandomContainerID()
+	sbSpec := &specs.Spec{
+		Version: specs.Version,
+		Annotations: map[string]string{
+			specutils.ContainerdContainerTypeAnnotation: specutils.ContainerdContainerTypeSandbox,
+		},
+		Linux: &specs.Linux{
+			Namespaces: []specs.LinuxNamespace{
+				{Type: specs.PIDNamespace, Path: pidnsPath},
+			},
+		},
+	}
+	startSandboxOnlyWithSpec(t, conf, sbID, sbSpec)
+
+	// The first container runs in the sandbox's root namespace by not asking for
+	// a namespace at all; the second gets there by naming the sandbox's.
+	root := startSandboxOnlySub(t, conf, sbID, nil)
+	if err := waitForProcessList(root, []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+	path := pidnsPath
+	joiner := startSandboxOnlySub(t, conf, sbID, &path)
+	if err := waitForProcessList(joiner, []*control.Process{
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+	}); err != nil {
+		t.Fatalf("failed to wait for sleep to start: %v", err)
+	}
+
+	expectedPL := []*control.Process{
+		newProcessBuilder().PID(2).Cmd("sleep").Process(),
+		newProcessBuilder().PID(3).Cmd("sleep").Process(),
+		newProcessBuilder().Cmd("ps").Process(),
+	}
+	got, err := execPS(conf, joiner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !procListsEqual(got, expectedPL) {
+		t.Errorf("container got process list: %s, want: %s", procListToString(got), procListToString(expectedPL))
+	}
+}
+
 func TestMultiContainerTarRootfsUpperLayer(t *testing.T) {
 	conf := testutil.TestConfig(t)
 	conf.Overlay2.Set("all:memory")

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -211,6 +211,10 @@ type Sandbox struct {
 	// StartTime is the time the sandbox was started.
 	StartTime time.Time `json:"startTime"`
 
+	// NoRootContainer records how the sandbox was booted. See
+	// Args.NoRootContainer.
+	NoRootContainer bool `json:"noRootContainer"`
+
 	// rootDir is the same as config.Config.RootDir. It represents the runtime
 	// root directory being used by the current runsc invocation. It's not saved
 	// to json, because the RootDir can change across runsc invocations.
@@ -325,6 +329,10 @@ type Args struct {
 	// PinRingFile, if non-nil, is the pin ring to donate to the boot
 	// process (see `//pkg/pinring`).
 	PinRingFile *os.File
+
+	// NoRootContainer boots without a root container: no gofer FDs, no root
+	// process. See container.Args.NoRootContainer.
+	NoRootContainer bool
 }
 
 // New creates the sandbox process. The caller must call Destroy() on the
@@ -341,6 +349,7 @@ func New(conf *config.Config, args *Args) (*Sandbox, error) {
 		MetricServerAddress: conf.MetricServer,
 		MountHints:          args.MountHints,
 		StartTime:           starttime.Get(),
+		NoRootContainer:     args.NoRootContainer,
 	}
 	if args.Spec != nil && args.Spec.Annotations != nil {
 		s.PodName = args.Spec.Annotations[podNameAnnotation]
@@ -1001,6 +1010,9 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	//
 	// All flags after this must be for the boot command
 	cmd.Args = append(cmd.Args, "boot", "--bundle="+args.BundleDir)
+	if args.NoRootContainer {
+		cmd.Args = append(cmd.Args, "--no-root-container")
+	}
 
 	if conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
 		// --TESTONLY-unsafe-nonroot is set, so keep env.
@@ -1040,7 +1052,9 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	}
 
 	// Pass gofer mount configs.
-	cmd.Args = append(cmd.Args, "--gofer-mount-confs="+args.GoferMountConfs.String())
+	if len(args.GoferMountConfs) > 0 {
+		cmd.Args = append(cmd.Args, "--gofer-mount-confs="+args.GoferMountConfs.String())
+	}
 
 	// Create a socket for the control server and donate it to the sandbox.
 	controlSocketPath, sockFD, err := createControlSocket(conf.RootDir, s.ID)
@@ -1265,7 +1279,7 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 
 	// If the console control socket file is provided, then create a new
 	// pty master/replica pair and set the TTY on the sandbox process.
-	if args.Spec.Process.Terminal && args.ConsoleSocket != "" {
+	if args.Spec.Process != nil && args.Spec.Process.Terminal && args.ConsoleSocket != "" {
 		// console.NewWithSocket will send the master on the given
 		// socket, and return the replica.
 		tty, err := console.NewWithSocket(args.ConsoleSocket)
@@ -1451,6 +1465,10 @@ func SandboxUserGroupIDs(spec *specs.Spec) (uint32, uint32) {
 	uid := uint32(0)
 	gid := uint32(0)
 
+	if spec.Process == nil {
+		return uid, gid
+	}
+
 	if !rootMappedInContainer(spec.Linux.UIDMappings) {
 		uid = spec.Process.User.UID
 	}
@@ -1507,6 +1525,9 @@ func (s *Sandbox) Wait(cid string) (unix.WaitStatus, error) {
 		return unix.WaitStatus(0), err
 	}
 	if !s.child {
+		if s.NoRootContainer && s.IsRootContainer(cid) {
+			return unix.WaitStatus(0), nil
+		}
 		return unix.WaitStatus(0), fmt.Errorf("sandbox no longer running and its exit status is unavailable")
 	}
 

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -211,6 +211,10 @@ type Sandbox struct {
 	// StartTime is the time the sandbox was started.
 	StartTime time.Time `json:"startTime"`
 
+	// SandboxOnly is true if the sandbox was booted without a root container.
+	// See Args.SandboxOnly.
+	SandboxOnly bool `json:"sandboxOnly"`
+
 	// rootDir is the same as config.Config.RootDir. It represents the runtime
 	// root directory being used by the current runsc invocation. It's not saved
 	// to json, because the RootDir can change across runsc invocations.
@@ -317,6 +321,11 @@ type Args struct {
 	// open filesystem checkpoint files using O_DIRECT.
 	FSRestoreImagePath string
 	FSRestoreDirect    bool
+
+	// SandboxOnly boots the sandbox without a root container. Spec describes
+	// only the sandbox, so no gofer FDs are donated and no root process is
+	// created. See container.Args.SandboxOnly.
+	SandboxOnly bool
 }
 
 // New creates the sandbox process. The caller must call Destroy() on the
@@ -333,6 +342,7 @@ func New(conf *config.Config, args *Args) (*Sandbox, error) {
 		MetricServerAddress: conf.MetricServer,
 		MountHints:          args.MountHints,
 		StartTime:           starttime.Get(),
+		SandboxOnly:         args.SandboxOnly,
 	}
 	if args.Spec != nil && args.Spec.Annotations != nil {
 		s.PodName = args.Spec.Annotations[podNameAnnotation]
@@ -976,6 +986,9 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	//
 	// All flags after this must be for the boot command
 	cmd.Args = append(cmd.Args, "boot", "--bundle="+args.BundleDir)
+	if args.SandboxOnly {
+		cmd.Args = append(cmd.Args, "--sandbox-only")
+	}
 
 	if conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
 		// --TESTONLY-unsafe-nonroot is set, so keep env.
@@ -1013,8 +1026,12 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 		return fmt.Errorf("donating rootfs tar file: %w", err)
 	}
 
-	// Pass gofer mount configs.
-	cmd.Args = append(cmd.Args, "--gofer-mount-confs="+args.GoferMountConfs.String())
+	// Pass gofer mount configs. There are none when there is no gofer, e.g. for
+	// a sandbox-only sandbox. Passing the flag with an empty value would fail to
+	// parse, so skip it entirely.
+	if len(args.GoferMountConfs) > 0 {
+		cmd.Args = append(cmd.Args, "--gofer-mount-confs="+args.GoferMountConfs.String())
+	}
 
 	// Create a socket for the control server and donate it to the sandbox.
 	controlSocketPath, sockFD, err := createControlSocket(conf.RootDir, s.ID)
@@ -1239,7 +1256,7 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 
 	// If the console control socket file is provided, then create a new
 	// pty master/replica pair and set the TTY on the sandbox process.
-	if args.Spec.Process.Terminal && args.ConsoleSocket != "" {
+	if args.Spec.Process != nil && args.Spec.Process.Terminal && args.ConsoleSocket != "" {
 		// console.NewWithSocket will send the master on the given
 		// socket, and return the replica.
 		tty, err := console.NewWithSocket(args.ConsoleSocket)
@@ -1425,6 +1442,11 @@ func SandboxUserGroupIDs(spec *specs.Spec) (uint32, uint32) {
 	uid := uint32(0)
 	gid := uint32(0)
 
+	// A sandbox-only spec has no process, so there is no user to run as.
+	if spec.Process == nil {
+		return uid, gid
+	}
+
 	if !rootMappedInContainer(spec.Linux.UIDMappings) {
 		uid = spec.Process.User.UID
 	}
@@ -1481,6 +1503,13 @@ func (s *Sandbox) Wait(cid string) (unix.WaitStatus, error) {
 		return unix.WaitStatus(0), err
 	}
 	if !s.child {
+		if s.SandboxOnly && s.IsRootContainer(cid) {
+			// A sandbox-only sandbox has no root container process, so the only exit
+			// status it could report is its own -- and since we did not fork it,
+			// Linux will not tell us what that was. The sandbox being gone is what
+			// the caller is really waiting for, so report that as a clean exit.
+			return unix.WaitStatus(0), nil
+		}
 		return unix.WaitStatus(0), fmt.Errorf("sandbox no longer running and its exit status is unavailable")
 	}
 

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -135,19 +135,34 @@ func LogSpecCustomLogger(orig *specs.Spec, logSeccomp bool, logf func(format str
 }
 
 // ValidateSpec validates that the spec is compatible with runsc.
-func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
-	// Mandatory fields.
-	if spec.Process == nil {
-		return fmt.Errorf("Spec.Process must be defined: %+v", spec)
-	}
-	if len(spec.Process.Args) == 0 {
-		return fmt.Errorf("Spec.Process.Arg must be defined: %+v", spec.Process)
-	}
-	if spec.Root == nil {
-		return fmt.Errorf("Spec.Root must be defined: %+v", spec)
-	}
-	if len(spec.Root.Path) == 0 {
-		return fmt.Errorf("Spec.Root.Path must be defined: %+v", spec.Root)
+//
+// sandboxOnly indicates that the spec describes a sandbox that is booted
+// without a root container, in which case it carries no process to run and no
+// rootfs to serve. See Loader.sandboxOnly in runsc/boot/loader.go.
+func ValidateSpec(spec *specs.Spec, conf *config.Config, sandboxOnly bool) error {
+	// Mandatory fields. A sandbox-only spec has neither a process nor a rootfs;
+	// requiring their absence rather than merely tolerating it keeps the spec
+	// honest, since boot.New silently ignores both in that mode.
+	if sandboxOnly {
+		if spec.Process != nil {
+			return fmt.Errorf("Spec.Process must not be defined for a sandbox-only spec: %+v", spec.Process)
+		}
+		if spec.Root != nil {
+			return fmt.Errorf("Spec.Root must not be defined for a sandbox-only spec: %+v", spec.Root)
+		}
+	} else {
+		if spec.Process == nil {
+			return fmt.Errorf("Spec.Process must be defined: %+v", spec)
+		}
+		if len(spec.Process.Args) == 0 {
+			return fmt.Errorf("Spec.Process.Arg must be defined: %+v", spec.Process)
+		}
+		if spec.Root == nil {
+			return fmt.Errorf("Spec.Root must be defined: %+v", spec)
+		}
+		if len(spec.Root.Path) == 0 {
+			return fmt.Errorf("Spec.Root.Path must be defined: %+v", spec.Root)
+		}
 	}
 
 	// Unsupported fields.
@@ -157,13 +172,15 @@ func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
 	if spec.Windows != nil {
 		return fmt.Errorf("Spec.Windows is not supported: %+v", spec)
 	}
-	if len(spec.Process.SelinuxLabel) != 0 {
-		return fmt.Errorf("SELinux is not supported: %s", spec.Process.SelinuxLabel)
-	}
+	if spec.Process != nil {
+		if len(spec.Process.SelinuxLabel) != 0 {
+			return fmt.Errorf("SELinux is not supported: %s", spec.Process.SelinuxLabel)
+		}
 
-	// Docker uses AppArmor by default, so just log that it's being ignored.
-	if spec.Process.ApparmorProfile != "" {
-		log.Warningf("AppArmor profile %q is being ignored", spec.Process.ApparmorProfile)
+		// Docker uses AppArmor by default, so just log that it's being ignored.
+		if spec.Process.ApparmorProfile != "" {
+			log.Warningf("AppArmor profile %q is being ignored", spec.Process.ApparmorProfile)
+		}
 	}
 
 	if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
@@ -181,6 +198,9 @@ func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
 	if path := RootfsTarUpperPath(spec); path != "" {
 		if !conf.AllowRootfsTarAnnotation {
 			return fmt.Errorf("rootfs tar annotation is disabled, use --allow-rootfs-tar-annotation to enable it")
+		}
+		if spec.Root == nil {
+			return fmt.Errorf("rootfs tar upper path is set but Spec.Root is not defined")
 		}
 		if spec.Root.Readonly {
 			return fmt.Errorf("rootfs tar upper path is set but rootfs is readonly")
@@ -222,13 +242,13 @@ func OpenSpec(bundleDir string) (*os.File, error) {
 // ReadSpec reads an OCI runtime spec from the given bundle directory.
 // ReadSpec also normalizes all potential relative paths into absolute
 // path, e.g. spec.Root.Path, mount.Source.
-func ReadSpec(bundleDir string, conf *config.Config) (*specs.Spec, error) {
+func ReadSpec(bundleDir string, conf *config.Config, sandboxOnly bool) (*specs.Spec, error) {
 	specFile, err := OpenSpec(bundleDir)
 	if err != nil {
 		return nil, fmt.Errorf("error opening spec file %q: %v", filepath.Join(bundleDir, "config.json"), err)
 	}
 	defer specFile.Close()
-	return ReadSpecFromFile(bundleDir, specFile, conf)
+	return ReadSpecFromFile(bundleDir, specFile, conf, sandboxOnly)
 }
 
 // ReadSpecFromFile reads an OCI runtime spec from the given file. It also fixes
@@ -237,7 +257,7 @@ func ReadSpec(bundleDir string, conf *config.Config) (*specs.Spec, error) {
 //     dir to them.
 //  2. Looks for flag overrides and applies them if any.
 //  3. Removes seccomp rules if `RuntimeDefault` was used.
-func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) (*specs.Spec, error) {
+func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config, sandboxOnly bool) (*specs.Spec, error) {
 	if _, err := specFile.Seek(0, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("error seeking to beginning of file %q: %v", specFile.Name(), err)
 	}
@@ -255,7 +275,7 @@ func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) 
 			log.Warningf("OCI spec file %q contains fields unknown to `runsc`: %v. Ignoring these fields and continuing anyway.", specFile.Name(), errStrictDecode)
 		}
 	}
-	if err := ValidateSpec(&spec, conf); err != nil {
+	if err := ValidateSpec(&spec, conf, sandboxOnly); err != nil {
 		return nil, err
 	}
 	if err := fixSpec(&spec, bundleDir, conf); err != nil {
@@ -266,7 +286,10 @@ func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) 
 
 func fixSpec(spec *specs.Spec, bundleDir string, conf *config.Config) error {
 	// Turn any relative paths in the spec to absolute by prepending the bundleDir.
-	spec.Root.Path = absPath(bundleDir, spec.Root.Path)
+	// A sandbox-only spec has no rootfs.
+	if spec.Root != nil {
+		spec.Root.Path = absPath(bundleDir, spec.Root.Path)
+	}
 	for i := range spec.Mounts {
 		m := &spec.Mounts[i]
 		if m.Source != "" {

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -135,19 +135,30 @@ func LogSpecCustomLogger(orig *specs.Spec, logSeccomp bool, logf func(format str
 }
 
 // ValidateSpec validates that the spec is compatible with runsc.
-func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
+//
+// noRootContainer requires the spec to have no Process and no Root.
+func ValidateSpec(spec *specs.Spec, conf *config.Config, noRootContainer bool) error {
 	// Mandatory fields.
-	if spec.Process == nil {
-		return fmt.Errorf("Spec.Process must be defined: %+v", spec)
-	}
-	if len(spec.Process.Args) == 0 {
-		return fmt.Errorf("Spec.Process.Arg must be defined: %+v", spec.Process)
-	}
-	if spec.Root == nil {
-		return fmt.Errorf("Spec.Root must be defined: %+v", spec)
-	}
-	if len(spec.Root.Path) == 0 {
-		return fmt.Errorf("Spec.Root.Path must be defined: %+v", spec.Root)
+	if noRootContainer {
+		if spec.Process != nil {
+			return fmt.Errorf("Spec.Process must not be defined with --no-root-container: %+v", spec.Process)
+		}
+		if spec.Root != nil {
+			return fmt.Errorf("Spec.Root must not be defined with --no-root-container: %+v", spec.Root)
+		}
+	} else {
+		if spec.Process == nil {
+			return fmt.Errorf("Spec.Process must be defined: %+v", spec)
+		}
+		if len(spec.Process.Args) == 0 {
+			return fmt.Errorf("Spec.Process.Arg must be defined: %+v", spec.Process)
+		}
+		if spec.Root == nil {
+			return fmt.Errorf("Spec.Root must be defined: %+v", spec)
+		}
+		if len(spec.Root.Path) == 0 {
+			return fmt.Errorf("Spec.Root.Path must be defined: %+v", spec.Root)
+		}
 	}
 
 	// Unsupported fields.
@@ -157,13 +168,15 @@ func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
 	if spec.Windows != nil {
 		return fmt.Errorf("Spec.Windows is not supported: %+v", spec)
 	}
-	if len(spec.Process.SelinuxLabel) != 0 {
-		return fmt.Errorf("SELinux is not supported: %s", spec.Process.SelinuxLabel)
-	}
+	if spec.Process != nil {
+		if len(spec.Process.SelinuxLabel) != 0 {
+			return fmt.Errorf("SELinux is not supported: %s", spec.Process.SelinuxLabel)
+		}
 
-	// Docker uses AppArmor by default, so just log that it's being ignored.
-	if spec.Process.ApparmorProfile != "" {
-		log.Warningf("AppArmor profile %q is being ignored", spec.Process.ApparmorProfile)
+		// Docker uses AppArmor by default, so just log that it's being ignored.
+		if spec.Process.ApparmorProfile != "" {
+			log.Warningf("AppArmor profile %q is being ignored", spec.Process.ApparmorProfile)
+		}
 	}
 
 	if spec.Linux != nil && spec.Linux.RootfsPropagation != "" {
@@ -181,6 +194,9 @@ func ValidateSpec(spec *specs.Spec, conf *config.Config) error {
 	if path := RootfsTarUpperPath(spec); path != "" {
 		if !conf.AllowRootfsTarAnnotation {
 			return fmt.Errorf("rootfs tar annotation is disabled, use --allow-rootfs-tar-annotation to enable it")
+		}
+		if spec.Root == nil {
+			return fmt.Errorf("rootfs tar upper path is set but Spec.Root is not defined")
 		}
 		if spec.Root.Readonly {
 			return fmt.Errorf("rootfs tar upper path is set but rootfs is readonly")
@@ -219,16 +235,24 @@ func OpenSpec(bundleDir string) (*os.File, error) {
 	return os.Open(filepath.Join(bundleDir, "config.json"))
 }
 
+// SpecOpts says how to read a spec.
+type SpecOpts struct {
+	Conf *config.Config
+
+	// NoRootContainer requires the spec to have no Process and no Root.
+	NoRootContainer bool
+}
+
 // ReadSpec reads an OCI runtime spec from the given bundle directory.
 // ReadSpec also normalizes all potential relative paths into absolute
 // path, e.g. spec.Root.Path, mount.Source.
-func ReadSpec(bundleDir string, conf *config.Config) (*specs.Spec, error) {
+func ReadSpec(bundleDir string, opts SpecOpts) (*specs.Spec, error) {
 	specFile, err := OpenSpec(bundleDir)
 	if err != nil {
 		return nil, fmt.Errorf("error opening spec file %q: %v", filepath.Join(bundleDir, "config.json"), err)
 	}
 	defer specFile.Close()
-	return ReadSpecFromFile(bundleDir, specFile, conf)
+	return ReadSpecFromFile(bundleDir, specFile, opts)
 }
 
 // ReadSpecFromFile reads an OCI runtime spec from the given file. It also fixes
@@ -237,7 +261,7 @@ func ReadSpec(bundleDir string, conf *config.Config) (*specs.Spec, error) {
 //     dir to them.
 //  2. Looks for flag overrides and applies them if any.
 //  3. Removes seccomp rules if `RuntimeDefault` was used.
-func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) (*specs.Spec, error) {
+func ReadSpecFromFile(bundleDir string, specFile *os.File, opts SpecOpts) (*specs.Spec, error) {
 	if _, err := specFile.Seek(0, io.SeekStart); err != nil {
 		return nil, fmt.Errorf("error seeking to beginning of file %q: %v", specFile.Name(), err)
 	}
@@ -255,10 +279,10 @@ func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) 
 			log.Warningf("OCI spec file %q contains fields unknown to `runsc`: %v. Ignoring these fields and continuing anyway.", specFile.Name(), errStrictDecode)
 		}
 	}
-	if err := ValidateSpec(&spec, conf); err != nil {
+	if err := ValidateSpec(&spec, opts.Conf, opts.NoRootContainer); err != nil {
 		return nil, err
 	}
-	if err := fixSpec(&spec, bundleDir, conf); err != nil {
+	if err := fixSpec(&spec, bundleDir, opts.Conf); err != nil {
 		return nil, err
 	}
 	return &spec, nil
@@ -266,7 +290,9 @@ func ReadSpecFromFile(bundleDir string, specFile *os.File, conf *config.Config) 
 
 func fixSpec(spec *specs.Spec, bundleDir string, conf *config.Config) error {
 	// Turn any relative paths in the spec to absolute by prepending the bundleDir.
-	spec.Root.Path = absPath(bundleDir, spec.Root.Path)
+	if spec.Root != nil {
+		spec.Root.Path = absPath(bundleDir, spec.Root.Path)
+	}
 	for i := range spec.Mounts {
 		m := &spec.Mounts[i]
 		if m.Source != "" {

--- a/runsc/specutils/specutils_test.go
+++ b/runsc/specutils/specutils_test.go
@@ -110,10 +110,11 @@ func TestWaitForReadyTimeout(t *testing.T) {
 
 func TestSpecInvalid(t *testing.T) {
 	for _, test := range []struct {
-		name  string
-		spec  specs.Spec
-		conf  config.Config
-		error string
+		name            string
+		spec            specs.Spec
+		conf            config.Config
+		noRootContainer bool
+		error           string
 	}{
 		{
 			name: "valid",
@@ -310,8 +311,61 @@ func TestSpecInvalid(t *testing.T) {
 			},
 			error: "rootfs tar upper path is set but rootfs is readonly",
 		},
+		{
+			name: "sandbox spec",
+			spec: specs.Spec{
+				Hostname: "pod",
+				Linux: &specs.Linux{
+					CgroupsPath: "/kubepods/pod123",
+					Namespaces: []specs.LinuxNamespace{
+						{Type: specs.NetworkNamespace, Path: "/var/run/netns/cni-1"},
+					},
+				},
+			},
+			noRootContainer: true,
+			error:           "",
+		},
+		{
+			name: "sandbox spec with process",
+			spec: specs.Spec{
+				Process: &specs.Process{
+					Args: []string{"/bin/true"},
+				},
+			},
+			noRootContainer: true,
+			error:           "Spec.Process must not be defined",
+		},
+		{
+			name: "sandbox spec with root",
+			spec: specs.Spec{
+				Root: &specs.Root{Path: "/"},
+			},
+			noRootContainer: true,
+			error:           "Spec.Root must not be defined",
+		},
+		{
+			name: "sandbox spec still validates mounts",
+			spec: specs.Spec{
+				Mounts: []specs.Mount{
+					{
+						Source:      "src",
+						Destination: "dst", // Not absolute.
+					},
+				},
+			},
+			noRootContainer: true,
+			error:           "Mount.Destination must be an absolute path",
+		},
+		{
+			name: "sandbox spec rejects unsupported fields",
+			spec: specs.Spec{
+				Windows: &specs.Windows{},
+			},
+			noRootContainer: true,
+			error:           "Spec.Windows is not supported",
+		},
 	} {
-		err := ValidateSpec(&test.spec, &test.conf)
+		err := ValidateSpec(&test.spec, &test.conf, test.noRootContainer)
 		if len(test.error) == 0 {
 			if err != nil {
 				t.Errorf("ValidateSpec(%q) failed, err: %v", test.name, err)

--- a/runsc/specutils/specutils_test.go
+++ b/runsc/specutils/specutils_test.go
@@ -110,10 +110,11 @@ func TestWaitForReadyTimeout(t *testing.T) {
 
 func TestSpecInvalid(t *testing.T) {
 	for _, test := range []struct {
-		name  string
-		spec  specs.Spec
-		conf  config.Config
-		error string
+		name        string
+		spec        specs.Spec
+		conf        config.Config
+		sandboxOnly bool
+		error       string
 	}{
 		{
 			name: "valid",
@@ -310,8 +311,65 @@ func TestSpecInvalid(t *testing.T) {
 			},
 			error: "rootfs tar upper path is set but rootfs is readonly",
 		},
+		{
+			// A sandbox-only spec carries no process to run and no rootfs to
+			// serve, only sandbox-wide settings.
+			name: "sandbox-only valid",
+			spec: specs.Spec{
+				Hostname: "pod",
+				Linux: &specs.Linux{
+					CgroupsPath: "/kubepods/pod123",
+					Namespaces: []specs.LinuxNamespace{
+						{Type: specs.NetworkNamespace, Path: "/var/run/netns/cni-1"},
+					},
+				},
+			},
+			sandboxOnly: true,
+			error:       "",
+		},
+		{
+			name: "sandbox-only with process",
+			spec: specs.Spec{
+				Process: &specs.Process{
+					Args: []string{"/bin/true"},
+				},
+			},
+			sandboxOnly: true,
+			error:       "Spec.Process must not be defined",
+		},
+		{
+			name: "sandbox-only with root",
+			spec: specs.Spec{
+				Root: &specs.Root{Path: "/"},
+			},
+			sandboxOnly: true,
+			error:       "Spec.Root must not be defined",
+		},
+		{
+			// Skipping the process and rootfs checks must not skip the checks
+			// that follow them.
+			name: "sandbox-only still validates mounts",
+			spec: specs.Spec{
+				Mounts: []specs.Mount{
+					{
+						Source:      "src",
+						Destination: "dst", // Not absolute.
+					},
+				},
+			},
+			sandboxOnly: true,
+			error:       "Mount.Destination must be an absolute path",
+		},
+		{
+			name: "sandbox-only rejects unsupported fields",
+			spec: specs.Spec{
+				Windows: &specs.Windows{},
+			},
+			sandboxOnly: true,
+			error:       "Spec.Windows is not supported",
+		},
 	} {
-		err := ValidateSpec(&test.spec, &test.conf)
+		err := ValidateSpec(&test.spec, &test.conf, test.sandboxOnly)
 		if len(test.error) == 0 {
 			if err != nil {
 				t.Errorf("ValidateSpec(%q) failed, err: %v", test.name, err)


### PR DESCRIPTION
Add `runsc create/run/boot --no-root-container`, which boots a sandbox from a
spec describing only the sandbox: no Process and no Root. The kernel comes up
empty and containers are added afterwards as subcontainers.

This exists for the containerd Sandbox API, which lands separately. Under
CRI with `sandboxer = "shim"` there is no pause container to stand in for
the pod: containerd leaves Sandbox.Spec unset, so the sandbox bundle has no
config.json, and there is neither a rootfs nor a process to run. runsc has
so far required both.

runsc/boot/no_root_container.md walks through booting one from the
command line and says what a pod without a pause container does not have.

Limitations:

- Checkpoint/restore is refused for a no-root-container sandbox. The kernel
  state round-trips, but `runsc restore` cannot be told the spec describes a
  sandbox, so it either rejects it or dereferences the absent Process, and
  the loader would restore the sandbox as if it had a gofer. Lifting it is a
  --no-root-container flag, a nil guard, and skipping the sandbox in the
  restorer's per-container loop; deferred rather than shipped untested.