### PR TITLE
Implement ptrace access mode checking.

### DIFF
--- a/pkg/abi/linux/ptrace.go
+++ b/pkg/abi/linux/ptrace.go
@@ -93,3 +93,12 @@ const (
 	YAMA_SCOPE_DISABLED   = 0
 	YAMA_SCOPE_RELATIONAL = 1
 )
+
+// ptrace access modes from include/uapi/linux/ptrace.h.
+const (
+	PTRACE_MODE_READ      = 0x01
+	PTRACE_MODE_ATTACH    = 0x02
+	PTRACE_MODE_NOAUDIT   = 0x04
+	PTRACE_MODE_FSCREDS   = 0x08
+	PTRACE_MODE_REALCREDS = 0x10
+)

--- a/pkg/abi/linux/ptrace.go
+++ b/pkg/abi/linux/ptrace.go
@@ -93,3 +93,15 @@ const (
 	YAMA_SCOPE_DISABLED   = 0
 	YAMA_SCOPE_RELATIONAL = 1
 )
+
+// ptrace access modes from include/uapi/linux/ptrace.h.
+const (
+	PTRACE_MODE_READ      = 0x01
+	PTRACE_MODE_ATTACH    = 0x02
+	PTRACE_MODE_NOAUDIT   = 0x04
+	PTRACE_MODE_FSCREDS   = 0x08
+	PTRACE_MODE_REALCREDS = 0x10
+	PTRACE_MODE_SCHED     = 0x20
+	PTRACE_MODE_IBRS      = 0x40
+)
+

--- a/pkg/sentry/fsimpl/proc/task_fds.go
+++ b/pkg/sentry/fsimpl/proc/task_fds.go
@@ -223,7 +223,9 @@ func (fs *filesystem) newFDSymlink(ctx context.Context, task *kernel.Task, fd in
 }
 
 func (s *fdSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error) {
-	if !kernel.ContextCanTrace(ctx, s.task, false) {
+	// Permission to read this symlink is governed by PTRACE_MODE_READ_FSCREDS;
+	// see fs/proc/base.c:proc_fd_link().
+	if !kernel.ContextCanTraceMode(ctx, s.task, kernel.PtraceAccessModeRead|kernel.PtraceAccessModeFsCreds) {
 		return "", linuxerr.EACCES
 	}
 	file, _ := getTaskFD(s.task, s.fd)
@@ -239,7 +241,9 @@ func (s *fdSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error) 
 }
 
 func (s *fdSymlink) Getlink(ctx context.Context, mnt *vfs.Mount) (vfs.VirtualDentry, string, error) {
-	if !kernel.ContextCanTrace(ctx, s.task, false) {
+	// Permission to read this symlink is governed by PTRACE_MODE_READ_FSCREDS;
+	// see fs/proc/base.c:proc_fd_link().
+	if !kernel.ContextCanTraceMode(ctx, s.task, kernel.PtraceAccessModeRead|kernel.PtraceAccessModeFsCreds) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
 	}
 	file, _ := getTaskFD(s.task, s.fd)

--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -502,10 +502,9 @@ func (f *memInode) init(ctx context.Context, creds *auth.Credentials, devMajor, 
 func (f *memInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
 	m := getMM(f.task)
 	for {
-		// TODO(gvisor.dev/issue/260): Add check for PTRACE_MODE_ATTACH_FSCREDS
-		// Permission to read this file is governed by PTRACE_MODE_ATTACH_FSCREDS
-		// Since we dont implement setfsuid/setfsgid we can just use PTRACE_MODE_ATTACH
-		if !kernel.ContextCanTrace(ctx, f.task, true) {
+		// Permission to read this file is governed by
+		// PTRACE_MODE_ATTACH_FSCREDS; see fs/proc/base.c:mem_open().
+		if !kernel.ContextCanTraceMode(ctx, f.task, kernel.PtraceAccessModeAttach|kernel.PtraceAccessModeFsCreds) {
 			return nil, linuxerr.EACCES
 		}
 		// Check that the task still has the same mm (hasn't called execve).
@@ -729,7 +728,10 @@ func (f *mmFile) Init(ctx context.Context, creds *auth.Credentials, devMajor, de
 func (f *mmFile) DataSource(ctx context.Context) (vfs.DynamicBytesSource, error) {
 	m := getMM(f.task)
 	for {
-		if !kernel.ContextCanTrace(ctx, f.task, false) {
+		// Permission to read these files is governed by
+		// PTRACE_MODE_READ_FSCREDS; see fs/proc/base.c:maps_open() (and the
+		// similar open functions for smaps, environ, and auxv).
+		if !kernel.ContextCanTraceMode(ctx, f.task, kernel.PtraceAccessModeRead|kernel.PtraceAccessModeFsCreds) {
 			return nil, linuxerr.EACCES
 		}
 		// Check that the task still has the same mm (hasn't called execve).
@@ -1186,7 +1188,9 @@ func (s *exeSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error)
 
 // Getlink implements kernfs.Inode.Getlink.
 func (s *exeSymlink) Getlink(ctx context.Context, _ *vfs.Mount) (vfs.VirtualDentry, string, error) {
-	if !kernel.ContextCanTrace(ctx, s.task, false) {
+	// Permission to read this symlink is governed by PTRACE_MODE_READ_FSCREDS;
+	// see fs/proc/base.c:proc_exe_link().
+	if !kernel.ContextCanTraceMode(ctx, s.task, kernel.PtraceAccessModeRead|kernel.PtraceAccessModeFsCreds) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
 	}
 	if err := checkTaskState(s.task); err != nil {
@@ -1260,7 +1264,9 @@ func (s *cwdSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error)
 
 // Getlink implements kernfs.Inode.Getlink.
 func (s *cwdSymlink) Getlink(ctx context.Context, _ *vfs.Mount) (vfs.VirtualDentry, string, error) {
-	if !kernel.ContextCanTrace(ctx, s.task, false) {
+	// Permission to read this symlink is governed by PTRACE_MODE_READ_FSCREDS;
+	// see fs/proc/base.c:proc_cwd_link().
+	if !kernel.ContextCanTraceMode(ctx, s.task, kernel.PtraceAccessModeRead|kernel.PtraceAccessModeFsCreds) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
 	}
 	if err := checkTaskState(s.task); err != nil {
@@ -1323,7 +1329,9 @@ func (s *rootSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error
 
 // Getlink implements kernfs.Inode.Getlink.
 func (s *rootSymlink) Getlink(ctx context.Context, _ *vfs.Mount) (vfs.VirtualDentry, string, error) {
-	if !kernel.ContextCanTrace(ctx, s.task, false) {
+	// Permission to read this symlink is governed by PTRACE_MODE_READ_FSCREDS;
+	// see fs/proc/base.c:proc_root_link().
+	if !kernel.ContextCanTraceMode(ctx, s.task, kernel.PtraceAccessModeRead|kernel.PtraceAccessModeFsCreds) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
 	}
 	if err := checkTaskState(s.task); err != nil {

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -442,6 +442,7 @@ go_test(
     size = "small",
     srcs = [
         "fd_table_test.go",
+        "ptrace_mode_test.go",
         "table_test.go",
         "task_test.go",
         "timekeeper_test.go",
@@ -449,6 +450,7 @@ go_test(
     library = ":kernel",
     deps = [
         "//pkg/abi",
+        "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/errors/linuxerr",
         "//pkg/hostarch",

--- a/pkg/sentry/kernel/context.go
+++ b/pkg/sentry/kernel/context.go
@@ -24,7 +24,7 @@ type contextID int
 
 const (
 	// CtxCanTrace is a Context.Value key for a function with the same
-	// signature and semantics as kernel.Task.CanTrace.
+	// signature and semantics as kernel.Task.CanTraceMode.
 	CtxCanTrace contextID = iota
 
 	// CtxKernel is a Context.Value key for a Kernel.
@@ -40,13 +40,25 @@ const (
 	CtxUTSNamespace
 )
 
-// ContextCanTrace returns true if ctx is permitted to trace t, in the same sense
-// as kernel.Task.CanTrace.
-func ContextCanTrace(ctx context.Context, t *Task, attach bool) bool {
+// ContextCanTraceMode returns true if ctx is permitted to trace t under the
+// given ptrace access mode, in the same sense as kernel.Task.CanTraceMode.
+func ContextCanTraceMode(ctx context.Context, t *Task, mode PtraceAccessMode) bool {
 	if v := ctx.Value(CtxCanTrace); v != nil {
-		return v.(func(*Task, bool) bool)(t, attach)
+		return v.(func(*Task, PtraceAccessMode) bool)(t, mode)
 	}
 	return false
+}
+
+// ContextCanTrace returns true if ctx is permitted to trace t, in the same
+// sense as kernel.Task.CanTrace. If attach is true, it checks for access mode
+// PTRACE_MODE_ATTACH; otherwise, it checks for access mode PTRACE_MODE_READ.
+// In both cases, the check uses PTRACE_MODE_REALCREDS.
+func ContextCanTrace(ctx context.Context, t *Task, attach bool) bool {
+	mode := PtraceAccessModeRead | PtraceAccessModeRealCreds
+	if attach {
+		mode = PtraceAccessModeAttach | PtraceAccessModeRealCreds
+	}
+	return ContextCanTraceMode(ctx, t, mode)
 }
 
 // KernelFromContext returns the Kernel in which ctx is executing, or nil if

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -2084,7 +2084,7 @@ func (ctx *supervisorContext) Value(key any) any {
 		// The supervisor context can trace anything. (None of
 		// supervisorContext's users are expected to invoke ptrace, but ptrace
 		// permissions are required for certain file accesses.)
-		return func(*Task, bool) bool { return true }
+		return func(*Task, PtraceAccessMode) bool { return true }
 	case CtxKernel:
 		return ctx.Kernel
 	case CtxPIDNamespace:

--- a/pkg/sentry/kernel/pidfd.go
+++ b/pkg/sentry/kernel/pidfd.go
@@ -144,7 +144,10 @@ func (t *Task) PIDFDGetFD(pidfd int32, targetfd int32, flags uint32) (uintptr, e
 	if err != nil {
 		return 0, err
 	}
-	if !t.CanTrace(target, true) {
+	// man pidfd_getfd(2): "Permission to duplicate another process's file
+	// descriptor is governed by a ptrace access mode PTRACE_MODE_ATTACH_REALCREDS
+	// check; see ptrace(2)."
+	if !t.CanTraceMode(target, PtraceAccessModeAttach|PtraceAccessModeRealCreds) {
 		return 0, linuxerr.EPERM
 	}
 

--- a/pkg/sentry/kernel/ptrace.go
+++ b/pkg/sentry/kernel/ptrace.go
@@ -21,6 +21,7 @@ import (
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/marshal/primitive"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/mm"
 	"gvisor.dev/gvisor/pkg/usermem"
 )
@@ -90,23 +91,61 @@ const (
 	ptraceSyscallEmu
 )
 
-// CanTrace checks that t is permitted to access target's state, as defined by
-// ptrace(2), subsection "Ptrace access mode checking". If attach is true, it
-// checks for access mode PTRACE_MODE_ATTACH; otherwise, it checks for access
-// mode PTRACE_MODE_READ.
+// PtraceAccessMode is a bitmask of access modes used in ptrace access checking,
+// as defined by include/uapi/linux/ptrace.h. Each flag corresponds to the
+// PTRACE_MODE_* constant of the same name.
+type PtraceAccessMode uint
+
+const (
+	// PtraceAccessModeRead corresponds to PTRACE_MODE_READ: access is being
+	// requested for the purpose of reading the target's memory or other state.
+	PtraceAccessModeRead PtraceAccessMode = linux.PTRACE_MODE_READ
+
+	// PtraceAccessModeAttach corresponds to PTRACE_MODE_ATTACH: access is being
+	// requested for the purpose of tracing (attaching to) the target.
+	PtraceAccessModeAttach PtraceAccessMode = linux.PTRACE_MODE_ATTACH
+
+	// PtraceAccessModeNoAudit corresponds to PTRACE_MODE_NOAUDIT: the access
+	// check should not be audited (e.g. because it is performed as a side
+	// effect of another system call). gVisor does not currently audit ptrace
+	// access checks, so this flag has no effect.
+	PtraceAccessModeNoAudit PtraceAccessMode = linux.PTRACE_MODE_NOAUDIT
+
+	// PtraceAccessModeFsCreds corresponds to PTRACE_MODE_FSCREDS: the access
+	// check should be performed using the caller's effective user and group
+	// IDs and effective capability set.
+	PtraceAccessModeFsCreds PtraceAccessMode = linux.PTRACE_MODE_FSCREDS
+
+	// PtraceAccessModeRealCreds corresponds to PTRACE_MODE_REALCREDS: the
+	// access check should be performed using the caller's real user and group
+	// IDs and permitted capability set.
+	PtraceAccessModeRealCreds PtraceAccessMode = linux.PTRACE_MODE_REALCREDS
+)
+
+// Contains returns true if mode contains all of the access mode flags in o.
+func (mode PtraceAccessMode) Contains(o PtraceAccessMode) bool {
+	return mode&o == o
+}
+
+// CanTraceMode checks that t is permitted to access target's state, as defined
+// by ptrace(2), subsection "Ptrace access mode checking", using the given
+// ptrace access mode. mode must specify exactly one of PtraceAccessModeFsCreds
+// and PtraceAccessModeRealCreds (e.g. PtraceAccessModeRead|
+// PtraceAccessModeFsCreds); the caller should use the access mode constants
+// defined above.
 //
 // In Linux, ptrace access restrictions may be configured by LSMs. While we do
 // not support LSMs, we do add additional restrictions based on the commoncap
 // and YAMA LSMs.
 //
-// TODO(gvisor.dev/issue/212): The result of CanTrace is immediately stale (e.g., a
-// racing setuid(2) may change traceability). This may pose a risk when a task
-// changes from traceable to not traceable. This is only problematic across
-// execve, where privileges may increase.
+// TODO(gvisor.dev/issue/212): The result of CanTraceMode is immediately stale
+// (e.g., a racing setuid(2) may change traceability). This may pose a risk
+// when a task changes from traceable to not traceable. This is only
+// problematic across execve, where privileges may increase.
 //
 // We currently do not implement privileged executables (set-user/group-ID bits
 // and file capabilities), so that case is not reachable.
-func (t *Task) CanTrace(target *Task, attach bool) bool {
+func (t *Task) CanTraceMode(target *Task, mode PtraceAccessMode) bool {
 	// "If the calling thread and the target thread are in the same thread
 	// group, access is always allowed." - ptrace(2)
 	//
@@ -119,11 +158,11 @@ func (t *Task) CanTrace(target *Task, attach bool) bool {
 		return true
 	}
 
-	if !t.canTraceStandard(target, attach) {
+	if !t.canTraceStandard(target, mode) {
 		return false
 	}
 
-	if attach && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
+	if mode.Contains(PtraceAccessModeAttach) && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
 		t.tg.pidns.owner.mu.RLock()
 		defer t.tg.pidns.owner.mu.RUnlock()
 		if !t.canTraceYAMALocked(target) {
@@ -133,18 +172,33 @@ func (t *Task) CanTrace(target *Task, attach bool) bool {
 	return true
 }
 
-// canTraceLocked is the same as CanTrace, except the caller must already hold
-// the TaskSet mutex (for reading or writing).
-func (t *Task) canTraceLocked(target *Task, attach bool) bool {
+// CanTrace checks that t is permitted to access target's state, as defined by
+// ptrace(2), subsection "Ptrace access mode checking". If attach is true, it
+// checks for access mode PTRACE_MODE_ATTACH; otherwise, it checks for access
+// mode PTRACE_MODE_READ. In both cases, the check uses PTRACE_MODE_REALCREDS.
+//
+// CanTrace is a convenience wrapper around CanTraceMode; prefer CanTraceMode
+// when a more specific access mode is required.
+func (t *Task) CanTrace(target *Task, attach bool) bool {
+	mode := PtraceAccessModeRead | PtraceAccessModeRealCreds
+	if attach {
+		mode = PtraceAccessModeAttach | PtraceAccessModeRealCreds
+	}
+	return t.CanTraceMode(target, mode)
+}
+
+// canTraceLocked is the same as CanTraceMode, except the caller must already
+// hold the TaskSet mutex (for reading or writing).
+func (t *Task) canTraceLocked(target *Task, mode PtraceAccessMode) bool {
 	if t.tg == target.tg {
 		return true
 	}
 
-	if !t.canTraceStandard(target, attach) {
+	if !t.canTraceStandard(target, mode) {
 		return false
 	}
 
-	if attach && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
+	if mode.Contains(PtraceAccessModeAttach) && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
 		if !t.canTraceYAMALocked(target) {
 			return false
 		}
@@ -156,61 +210,17 @@ func (t *Task) canTraceLocked(target *Task, attach bool) bool {
 // kernel/ptrace.c:__ptrace_may_access as well as the commoncap LSM
 // implementation of the security_ptrace_access_check() interface, which is
 // always invoked.
-func (t *Task) canTraceStandard(target *Task, attach bool) bool {
-	// """
-	// TODO(gvisor.dev/issue/260): 1. If the access mode specifies
-	// PTRACE_MODE_FSCREDS (ED: snipped, doesn't exist until Linux 4.5).
-	//
-	// Otherwise, the access mode specifies PTRACE_MODE_REALCREDS, so use the
-	// caller's real UID and GID for the checks in the next step. (Most APIs
-	// that check the caller's UID and GID use the effective IDs. For
-	// historical reasons, the PTRACE_MODE_REALCREDS check uses the real IDs
-	// instead.)
-	//
-	// 2. Deny access if neither of the following is true:
-	//
-	//	- The real, effective, and saved-set user IDs of the target match the
-	//		caller's user ID, *and* the real, effective, and saved-set group IDs of
-	//		the target match the caller's group ID.
-	//
-	//	- The caller has the CAP_SYS_PTRACE capability in the user namespace of
-	//		the target.
-	//
-	// 3. Deny access if the target process "dumpable" attribute has a value
-	// other than 1 (SUID_DUMP_USER; see the discussion of PR_SET_DUMPABLE in
-	// prctl(2)), and the caller does not have the CAP_SYS_PTRACE capability in
-	// the user namespace of the target process.
-	//
-	// 4. The commoncap LSM performs the following steps:
-	//
-	// a) If the access mode includes PTRACE_MODE_FSCREDS, then use the
-	// caller's effective capability set; otherwise (the access mode specifies
-	// PTRACE_MODE_REALCREDS, so) use the caller's permitted capability set.
-	//
-	// b) Deny access if neither of the following is true:
-	//
-	//	- The caller and the target process are in the same user namespace, and
-	//		the caller's capabilities are a proper superset of the target process's
-	//		permitted capabilities.
-	//
-	//	- The caller has the CAP_SYS_PTRACE capability in the target process's
-	//		user namespace.
-	//
-	// Note that the commoncap LSM does not distinguish between
-	// PTRACE_MODE_READ and PTRACE_MODE_ATTACH. (ED: From earlier in this
-	// section: "the commoncap LSM ... is always invoked".)
-	// """
+func (t *Task) canTraceStandard(target *Task, mode PtraceAccessMode) bool {
 	callerCreds := t.Credentials()
 	targetCreds := target.Credentials()
-	if callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace) {
-		return true
-	}
-	if cuid := callerCreds.RealKUID; cuid != targetCreds.RealKUID || cuid != targetCreds.EffectiveKUID || cuid != targetCreds.SavedKUID {
+	if !canTraceCreds(mode, callerCreds, targetCreds) {
 		return false
 	}
-	if cgid := callerCreds.RealKGID; cgid != targetCreds.RealKGID || cgid != targetCreds.EffectiveKGID || cgid != targetCreds.SavedKGID {
-		return false
-	}
+	// Step 3 of the access check procedure below: deny access if the target
+	// process's "dumpable" attribute has a value other than 1 (SUID_DUMP_USER;
+	// see the discussion of PR_SET_DUMPABLE in prctl(2)), and the caller does
+	// not have the CAP_SYS_PTRACE capability in the user namespace of the
+	// target process.
 	var targetMM *mm.MemoryManager
 	var targetUserDumpable bool
 	target.WithMuLocked(func(t *Task) {
@@ -218,18 +228,94 @@ func (t *Task) canTraceStandard(target *Task, attach bool) bool {
 		targetUserDumpable = t.userDumpable
 	})
 	if targetMM != nil {
-		if targetMM.Dumpability() != mm.UserDumpable {
+		if targetMM.Dumpability() != mm.UserDumpable && !callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace) {
 			return false
 		}
 	} else {
-		if !targetUserDumpable && !callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, t.Kernel().RootUserNamespace()) {
+		if !targetUserDumpable && !callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace) {
 			return false
 		}
+	}
+	return true
+}
+
+// canTraceCreds performs the credential-based portion of the standard ptrace
+// access checks (steps 1, 2, and 4 below) given the caller's and target's
+// credentials. It is split out from canTraceStandard so that it can be unit
+// tested without constructing Tasks.
+//
+// The checks mirror kernel/ptrace.c:__ptrace_may_access() and the commoncap
+// LSM implementation of security_ptrace_access_check(), which is always
+// invoked:
+//
+// """
+// 1. If the access mode specifies PTRACE_MODE_FSCREDS, use the caller's
+// effective UID and GID for the checks in the next step; otherwise, the access
+// mode specifies PTRACE_MODE_REALCREDS, so use the caller's real UID and GID.
+// (Most APIs that check the caller's UID and GID use the effective IDs. For
+// historical reasons, the PTRACE_MODE_REALCREDS check uses the real IDs
+// instead.)
+//
+// 2. Deny access if neither of the following is true:
+//
+//   - The real, effective, and saved-set user IDs of the target match the
+//     caller's user ID, *and* the real, effective, and saved-set group IDs of
+//     the target match the caller's group ID.
+//
+//   - The caller has the CAP_SYS_PTRACE capability in the user namespace of
+//     the target.
+//
+// 4. The commoncap LSM performs the following steps:
+//
+// a) If the access mode includes PTRACE_MODE_FSCREDS, then use the caller's
+// effective capability set; otherwise (the access mode specifies
+// PTRACE_MODE_REALCREDS, so) use the caller's permitted capability set.
+//
+// b) Deny access if neither of the following is true:
+//
+//   - The caller and the target process are in the same user namespace, and
+//     the caller's capabilities are a superset of the target process's
+//     permitted capabilities.
+//
+//   - The caller has the CAP_SYS_PTRACE capability in the target process's
+//     user namespace.
+//
+// Note that the commoncap LSM does not distinguish between PTRACE_MODE_READ
+// and PTRACE_MODE_ATTACH.
+// """
+//
+// Additionally, exactly one of PTRACE_MODE_FSCREDS and PTRACE_MODE_REALCREDS
+// must be specified, mirroring kernel/ptrace.c:__ptrace_may_access(); if it is
+// not, access is denied.
+func canTraceCreds(mode PtraceAccessMode, callerCreds, targetCreds *auth.Credentials) bool {
+	if !(mode.Contains(PtraceAccessModeFsCreds) != mode.Contains(PtraceAccessModeRealCreds)) {
+		return false
+	}
+	// If the caller has CAP_SYS_PTRACE in the target's user namespace, access
+	// is allowed; this is the second alternative of both step 2 and step 4b.
+	// Note that this check uses the caller's effective capabilities, as does
+	// Linux's ptrace_has_cap().
+	if callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace) {
+		return true
+	}
+	callerUID, callerGID := callerCreds.RealKUID, callerCreds.RealKGID
+	if mode.Contains(PtraceAccessModeFsCreds) {
+		callerUID, callerGID = callerCreds.EffectiveKUID, callerCreds.EffectiveKGID
+	}
+	if callerUID != targetCreds.RealKUID || callerUID != targetCreds.EffectiveKUID || callerUID != targetCreds.SavedKUID {
+		return false
+	}
+	if callerGID != targetCreds.RealKGID || callerGID != targetCreds.EffectiveKGID || callerGID != targetCreds.SavedKGID {
+		return false
 	}
 	if callerCreds.UserNamespace != targetCreds.UserNamespace {
 		return false
 	}
-	if targetCreds.PermittedCaps&^callerCreds.PermittedCaps != 0 {
+	callerCaps := callerCreds.PermittedCaps
+	if mode.Contains(PtraceAccessModeFsCreds) {
+		callerCaps = callerCreds.EffectiveCaps
+	}
+	if targetCreds.PermittedCaps&^callerCaps != 0 {
 		return false
 	}
 	return true
@@ -493,7 +579,9 @@ func (t *Task) ptraceTraceme() error {
 		// returning nil here is correct.
 		return nil
 	}
-	if !t.parent.canTraceLocked(t, true) {
+	// Linux's ptrace(PTRACE_TRACEME) checks access mode
+	// PTRACE_MODE_ATTACH_REALCREDS.
+	if !t.parent.canTraceLocked(t, PtraceAccessModeAttach|PtraceAccessModeRealCreds) {
 		return linuxerr.EPERM
 	}
 	if t.parent.exitStateLocked() != TaskExitNone {
@@ -511,7 +599,8 @@ func (t *Task) ptraceTraceme() error {
 func (t *Task) ptraceAttach(target *Task, seize bool, opts uintptr) error {
 	t.tg.pidns.owner.mu.Lock()
 	defer t.tg.pidns.owner.mu.Unlock()
-	if !t.canTraceLocked(target, true) {
+	// Linux's ptrace_attach() checks access mode PTRACE_MODE_ATTACH_REALCREDS.
+	if !t.canTraceLocked(target, PtraceAccessModeAttach|PtraceAccessModeRealCreds) {
 		return linuxerr.EPERM
 	}
 	if target.hasTracer() {

--- a/pkg/sentry/kernel/ptrace.go
+++ b/pkg/sentry/kernel/ptrace.go
@@ -21,6 +21,7 @@ import (
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/marshal/primitive"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/mm"
 	"gvisor.dev/gvisor/pkg/usermem"
 )
@@ -90,23 +91,74 @@ const (
 	ptraceSyscallEmu
 )
 
-// CanTrace checks that t is permitted to access target's state, as defined by
-// ptrace(2), subsection "Ptrace access mode checking". If attach is true, it
-// checks for access mode PTRACE_MODE_ATTACH; otherwise, it checks for access
-// mode PTRACE_MODE_READ.
+// PtraceAccessMode is a bitmask of access modes used in ptrace access checking,
+// as defined by include/uapi/linux/ptrace.h. Each flag corresponds to the
+// PTRACE_MODE_* constant of the same name.
+type PtraceAccessMode uint
+
+const (
+	// PtraceAccessModeRead corresponds to PTRACE_MODE_READ: access is being
+	// requested for the purpose of reading the target's memory or other state.
+	PtraceAccessModeRead PtraceAccessMode = linux.PTRACE_MODE_READ
+
+	// PtraceAccessModeAttach corresponds to PTRACE_MODE_ATTACH: access is being
+	// requested for the purpose of tracing (attaching to) the target.
+	PtraceAccessModeAttach PtraceAccessMode = linux.PTRACE_MODE_ATTACH
+
+	// PtraceAccessModeNoAudit corresponds to PTRACE_MODE_NOAUDIT: the access
+	// check should not be audited (e.g. because it is performed as a side
+	// effect of another system call). gVisor does not currently audit ptrace
+	// access checks, so this flag has no effect.
+	PtraceAccessModeNoAudit PtraceAccessMode = linux.PTRACE_MODE_NOAUDIT
+
+	// PtraceAccessModeFsCreds corresponds to PTRACE_MODE_FSCREDS: the access
+	// check should be performed using the caller's effective user and group
+	// IDs and effective capability set.
+	PtraceAccessModeFsCreds PtraceAccessMode = linux.PTRACE_MODE_FSCREDS
+
+	// PtraceAccessModeRealCreds corresponds to PTRACE_MODE_REALCREDS: the
+	// access check should be performed using the caller's real user and group
+	// IDs and permitted capability set.
+	PtraceAccessModeRealCreds PtraceAccessMode = linux.PTRACE_MODE_REALCREDS
+
+	// PtraceAccessModeSched corresponds to PTRACE_MODE_SCHED: the target
+	// process is being inspected for scheduler-related purposes (e.g.
+	// /proc/sys/kernel/sched_autogroup_enabled). This is not implemented in
+	// gVisor, and is defined only for completeness.
+	PtraceAccessModeSched PtraceAccessMode = linux.PTRACE_MODE_SCHED
+
+	// PtraceAccessModeIbrs corresponds to PTRACE_MODE_IBRS: access is being
+	// requested for the purpose of reading the target's indirect branch
+	// tracking information. This is not implemented in gVisor, and is defined
+	// only for completeness.
+	PtraceAccessModeIbrs PtraceAccessMode = linux.PTRACE_MODE_IBRS
+)
+
+// Contains returns true if mode contains all of the access mode flags in o.
+func (mode PtraceAccessMode) Contains(o PtraceAccessMode) bool {
+	return mode&o == o
+}
+
+// CanTraceMode checks that t is permitted to access target's state, as defined
+// by ptrace(2), subsection "Ptrace access mode checking", using the given
+// ptrace access mode. mode must specify exactly one of PtraceAccessModeFsCreds
+// and PtraceAccessModeRealCreds (e.g. PtraceAccessModeRead|
+// PtraceAccessModeFsCreds); the caller should use the access mode constants
+// defined by the relevant ptrace(2) man page for the specific check being
+// performed.
 //
 // In Linux, ptrace access restrictions may be configured by LSMs. While we do
 // not support LSMs, we do add additional restrictions based on the commoncap
 // and YAMA LSMs.
 //
-// TODO(gvisor.dev/issue/212): The result of CanTrace is immediately stale (e.g., a
-// racing setuid(2) may change traceability). This may pose a risk when a task
-// changes from traceable to not traceable. This is only problematic across
-// execve, where privileges may increase.
+// TODO(gvisor.dev/issue/212): The result of CanTraceMode is immediately stale
+// (e.g., a racing setuid(2) may change traceability). This may pose a risk
+// when a task changes from traceable to not traceable. This is only
+// problematic across execve, where privileges may increase.
 //
 // We currently do not implement privileged executables (set-user/group-ID bits
 // and file capabilities), so that case is not reachable.
-func (t *Task) CanTrace(target *Task, attach bool) bool {
+func (t *Task) CanTraceMode(target *Task, mode PtraceAccessMode) bool {
 	// "If the calling thread and the target thread are in the same thread
 	// group, access is always allowed." - ptrace(2)
 	//
@@ -119,11 +171,11 @@ func (t *Task) CanTrace(target *Task, attach bool) bool {
 		return true
 	}
 
-	if !t.canTraceStandard(target, attach) {
+	if !t.canTraceStandard(target, mode) {
 		return false
 	}
 
-	if attach && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
+	if mode.Contains(PtraceAccessModeAttach) && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
 		t.tg.pidns.owner.mu.RLock()
 		defer t.tg.pidns.owner.mu.RUnlock()
 		if !t.canTraceYAMALocked(target) {
@@ -133,18 +185,33 @@ func (t *Task) CanTrace(target *Task, attach bool) bool {
 	return true
 }
 
-// canTraceLocked is the same as CanTrace, except the caller must already hold
-// the TaskSet mutex (for reading or writing).
-func (t *Task) canTraceLocked(target *Task, attach bool) bool {
+// CanTrace checks that t is permitted to access target's state, as defined by
+// ptrace(2), subsection "Ptrace access mode checking". If attach is true, it
+// checks for access mode PTRACE_MODE_ATTACH; otherwise, it checks for access
+// mode PTRACE_MODE_READ. In both cases, the check uses PTRACE_MODE_REALCREDS.
+//
+// CanTrace is a convenience wrapper around CanTraceMode; prefer CanTraceMode
+// when a more specific access mode is required.
+func (t *Task) CanTrace(target *Task, attach bool) bool {
+	mode := PtraceAccessModeRead | PtraceAccessModeRealCreds
+	if attach {
+		mode = PtraceAccessModeAttach | PtraceAccessModeRealCreds
+	}
+	return t.CanTraceMode(target, mode)
+}
+
+// canTraceLocked is the same as CanTraceMode, except the caller must already
+// hold the TaskSet mutex (for reading or writing).
+func (t *Task) canTraceLocked(target *Task, mode PtraceAccessMode) bool {
 	if t.tg == target.tg {
 		return true
 	}
 
-	if !t.canTraceStandard(target, attach) {
+	if !t.canTraceStandard(target, mode) {
 		return false
 	}
 
-	if attach && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
+	if mode.Contains(PtraceAccessModeAttach) && t.k.YAMAPtraceScope.Load() == linux.YAMA_SCOPE_RELATIONAL {
 		if !t.canTraceYAMALocked(target) {
 			return false
 		}
@@ -156,61 +223,15 @@ func (t *Task) canTraceLocked(target *Task, attach bool) bool {
 // kernel/ptrace.c:__ptrace_may_access as well as the commoncap LSM
 // implementation of the security_ptrace_access_check() interface, which is
 // always invoked.
-func (t *Task) canTraceStandard(target *Task, attach bool) bool {
-	// """
-	// TODO(gvisor.dev/issue/260): 1. If the access mode specifies
-	// PTRACE_MODE_FSCREDS (ED: snipped, doesn't exist until Linux 4.5).
-	//
-	// Otherwise, the access mode specifies PTRACE_MODE_REALCREDS, so use the
-	// caller's real UID and GID for the checks in the next step. (Most APIs
-	// that check the caller's UID and GID use the effective IDs. For
-	// historical reasons, the PTRACE_MODE_REALCREDS check uses the real IDs
-	// instead.)
-	//
-	// 2. Deny access if neither of the following is true:
-	//
-	//	- The real, effective, and saved-set user IDs of the target match the
-	//		caller's user ID, *and* the real, effective, and saved-set group IDs of
-	//		the target match the caller's group ID.
-	//
-	//	- The caller has the CAP_SYS_PTRACE capability in the user namespace of
-	//		the target.
-	//
-	// 3. Deny access if the target process "dumpable" attribute has a value
-	// other than 1 (SUID_DUMP_USER; see the discussion of PR_SET_DUMPABLE in
-	// prctl(2)), and the caller does not have the CAP_SYS_PTRACE capability in
-	// the user namespace of the target process.
-	//
-	// 4. The commoncap LSM performs the following steps:
-	//
-	// a) If the access mode includes PTRACE_MODE_FSCREDS, then use the
-	// caller's effective capability set; otherwise (the access mode specifies
-	// PTRACE_MODE_REALCREDS, so) use the caller's permitted capability set.
-	//
-	// b) Deny access if neither of the following is true:
-	//
-	//	- The caller and the target process are in the same user namespace, and
-	//		the caller's capabilities are a proper superset of the target process's
-	//		permitted capabilities.
-	//
-	//	- The caller has the CAP_SYS_PTRACE capability in the target process's
-	//		user namespace.
-	//
-	// Note that the commoncap LSM does not distinguish between
-	// PTRACE_MODE_READ and PTRACE_MODE_ATTACH. (ED: From earlier in this
-	// section: "the commoncap LSM ... is always invoked".)
-	// """
-	callerCreds := t.Credentials()
-	targetCreds := target.Credentials()
-	if callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace) {
-		return true
-	}
-	if cuid := callerCreds.RealKUID; cuid != targetCreds.RealKUID || cuid != targetCreds.EffectiveKUID || cuid != targetCreds.SavedKUID {
+func (t *Task) canTraceStandard(target *Task, mode PtraceAccessMode) bool {
+	if !canTraceCreds(mode, t.Credentials(), target.Credentials()) {
 		return false
 	}
-	if cgid := callerCreds.RealKGID; cgid != targetCreds.RealKGID || cgid != targetCreds.EffectiveKGID || cgid != targetCreds.SavedKGID {
-		return false
-	}
+	// Step 3 of the access check procedure below: deny access if the target
+	// process's "dumpable" attribute has a value other than 1 (SUID_DUMP_USER;
+	// see the discussion of PR_SET_DUMPABLE in prctl(2)), and the caller does
+	// not have the CAP_SYS_PTRACE capability in the user namespace of the
+	// target process.
 	var targetMM *mm.MemoryManager
 	var targetUserDumpable bool
 	target.WithMuLocked(func(t *Task) {
@@ -222,14 +243,90 @@ func (t *Task) canTraceStandard(target *Task, attach bool) bool {
 			return false
 		}
 	} else {
-		if !targetUserDumpable && !callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, t.Kernel().RootUserNamespace()) {
+		if !targetUserDumpable && !t.Credentials().HasCapabilityIn(linux.CAP_SYS_PTRACE, t.Kernel().RootUserNamespace()) {
 			return false
 		}
+	}
+	return true
+}
+
+// canTraceCreds performs the credential-based portion of the standard ptrace
+// access checks (steps 1, 2, and 4 below) given the caller's and target's
+// credentials. It is split out from canTraceStandard so that it can be unit
+// tested without constructing Tasks.
+//
+// The checks mirror kernel/ptrace.c:__ptrace_may_access() and the commoncap
+// LSM implementation of security_ptrace_access_check(), which is always
+// invoked:
+//
+// """
+// 1. If the access mode specifies PTRACE_MODE_FSCREDS, use the caller's
+// effective UID and GID for the checks in the next step; otherwise, the access
+// mode specifies PTRACE_MODE_REALCREDS, so use the caller's real UID and GID.
+// (Most APIs that check the caller's UID and GID use the effective IDs. For
+// historical reasons, the PTRACE_MODE_REALCREDS check uses the real IDs
+// instead.)
+//
+// 2. Deny access if neither of the following is true:
+//
+//   - The real, effective, and saved-set user IDs of the target match the
+//     caller's user ID, *and* the real, effective, and saved-set group IDs of
+//     the target match the caller's group ID.
+//
+//   - The caller has the CAP_SYS_PTRACE capability in the user namespace of
+//     the target.
+//
+// 4. The commoncap LSM performs the following steps:
+//
+// a) If the access mode includes PTRACE_MODE_FSCREDS, then use the caller's
+// effective capability set; otherwise (the access mode specifies
+// PTRACE_MODE_REALCREDS, so) use the caller's permitted capability set.
+//
+// b) Deny access if neither of the following is true:
+//
+//   - The caller and the target process are in the same user namespace, and
+//     the caller's capabilities are a superset of the target process's
+//     permitted capabilities.
+//
+//   - The caller has the CAP_SYS_PTRACE capability in the target process's
+//     user namespace.
+//
+// Note that the commoncap LSM does not distinguish between PTRACE_MODE_READ
+// and PTRACE_MODE_ATTACH.
+// """
+//
+// Additionally, exactly one of PTRACE_MODE_FSCREDS and PTRACE_MODE_REALCREDS
+// must be specified, mirroring kernel/ptrace.c:__ptrace_may_access(); if it is
+// not, access is denied.
+func canTraceCreds(mode PtraceAccessMode, callerCreds, targetCreds *auth.Credentials) bool {
+	if !(mode.Contains(PtraceAccessModeFsCreds) != mode.Contains(PtraceAccessModeRealCreds)) {
+		return false
+	}
+	// If the caller has CAP_SYS_PTRACE in the target's user namespace, access
+	// is allowed; this is the second alternative of both step 2 and step 4b.
+	// Note that this check uses the caller's effective capabilities, as does
+	// Linux's ptrace_has_cap().
+	if callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace) {
+		return true
+	}
+	callerUID, callerGID := callerCreds.RealKUID, callerCreds.RealKGID
+	if mode.Contains(PtraceAccessModeFsCreds) {
+		callerUID, callerGID = callerCreds.EffectiveKUID, callerCreds.EffectiveKGID
+	}
+	if callerUID != targetCreds.RealKUID || callerUID != targetCreds.EffectiveKUID || callerUID != targetCreds.SavedKUID {
+		return false
+	}
+	if callerGID != targetCreds.RealKGID || callerGID != targetCreds.EffectiveKGID || callerGID != targetCreds.SavedKGID {
+		return false
 	}
 	if callerCreds.UserNamespace != targetCreds.UserNamespace {
 		return false
 	}
-	if targetCreds.PermittedCaps&^callerCreds.PermittedCaps != 0 {
+	callerCaps := callerCreds.PermittedCaps
+	if mode.Contains(PtraceAccessModeFsCreds) {
+		callerCaps = callerCreds.EffectiveCaps
+	}
+	if targetCreds.PermittedCaps&^callerCaps != 0 {
 		return false
 	}
 	return true
@@ -493,7 +590,9 @@ func (t *Task) ptraceTraceme() error {
 		// returning nil here is correct.
 		return nil
 	}
-	if !t.parent.canTraceLocked(t, true) {
+	// Linux's ptrace(PTRACE_TRACEME) checks access mode
+	// PTRACE_MODE_ATTACH_REALCREDS.
+	if !t.parent.canTraceLocked(t, PtraceAccessModeAttach|PtraceAccessModeRealCreds) {
 		return linuxerr.EPERM
 	}
 	if t.parent.exitStateLocked() != TaskExitNone {
@@ -511,7 +610,8 @@ func (t *Task) ptraceTraceme() error {
 func (t *Task) ptraceAttach(target *Task, seize bool, opts uintptr) error {
 	t.tg.pidns.owner.mu.Lock()
 	defer t.tg.pidns.owner.mu.Unlock()
-	if !t.canTraceLocked(target, true) {
+	// Linux's ptrace_attach() checks access mode PTRACE_MODE_ATTACH_REALCREDS.
+	if !t.canTraceLocked(target, PtraceAccessModeAttach|PtraceAccessModeRealCreds) {
 		return linuxerr.EPERM
 	}
 	if target.hasTracer() {

--- a/pkg/sentry/kernel/ptrace_mode_test.go
+++ b/pkg/sentry/kernel/ptrace_mode_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"fmt"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// testCreds returns a set of credentials with the given user and group IDs in
+// ns and no capabilities.
+func testCreds(ns *auth.UserNamespace, uid auth.KUID, gid auth.KGID) *auth.Credentials {
+	creds := auth.NewRootCredentials(ns).Fork()
+	creds.RealKUID, creds.EffectiveKUID, creds.SavedKUID = uid, uid, uid
+	creds.RealKGID, creds.EffectiveKGID, creds.SavedKGID = gid, gid, gid
+	creds.PermittedCaps = 0
+	creds.EffectiveCaps = 0
+	return creds
+}
+
+func TestCanTraceCredsModeValidation(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, test := range []struct {
+		name string
+		mode PtraceAccessMode
+		want bool
+	}{
+		{name: "zero", mode: 0, want: false},
+		{name: "read only", mode: PtraceAccessModeRead, want: false},
+		{name: "attach only", mode: PtraceAccessModeAttach, want: false},
+		{name: "both creds modes", mode: PtraceAccessModeFsCreds | PtraceAccessModeRealCreds, want: false},
+		{name: "all flags", mode: PtraceAccessModeRead | PtraceAccessModeAttach | PtraceAccessModeFsCreds | PtraceAccessModeRealCreds, want: false},
+		{name: "read realcreds", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds, want: true},
+		{name: "attach realcreds", mode: PtraceAccessModeAttach | PtraceAccessModeRealCreds, want: true},
+		{name: "read fscreds", mode: PtraceAccessModeRead | PtraceAccessModeFsCreds, want: true},
+		{name: "attach fscreds", mode: PtraceAccessModeAttach | PtraceAccessModeFsCreds, want: true},
+		{name: "read realcreds noaudit", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds | PtraceAccessModeNoAudit, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsSetuid(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller is a setuid-root binary: it retains its real UID and GID of
+	// 1000 while its effective UID and GID are root. The target is owned by
+	// UID/GID 1000.
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	caller.EffectiveKUID = auth.RootKUID
+	caller.EffectiveKGID = auth.RootKGID
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, test := range []struct {
+		name string
+		mode PtraceAccessMode
+		want bool
+	}{
+		// PTRACE_MODE_REALCREDS uses the caller's real IDs, which match the
+		// target, so access is granted.
+		{name: "realcreds", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds, want: true},
+		// PTRACE_MODE_FSCREDS uses the caller's effective IDs, which do not
+		// match the target, so access is denied.
+		{name: "fscreds", mode: PtraceAccessModeRead | PtraceAccessModeFsCreds, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsSetgid(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller's real and effective UIDs match the target's, but its
+	// effective GID is root while its real GID matches the target's.
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	caller.EffectiveKGID = auth.RootKGID
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, test := range []struct {
+		name string
+		mode PtraceAccessMode
+		want bool
+	}{
+		{name: "realcreds", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds, want: true},
+		{name: "fscreds", mode: PtraceAccessModeRead | PtraceAccessModeFsCreds, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsCapabilitySuperset(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller has CAP_SYS_ADMIN and CAP_KILL in its permitted set but only
+	// CAP_KILL in its effective set (e.g. a setuid-root program that retains
+	// permitted capabilities while dropping effective ones). It does not have
+	// CAP_SYS_PTRACE anywhere.
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	caller.PermittedCaps = auth.CapabilitySetOfMany([]linux.Capability{linux.CAP_SYS_ADMIN, linux.CAP_KILL})
+	caller.EffectiveCaps = auth.CapabilitySetOf(linux.CAP_KILL)
+	for _, test := range []struct {
+		name       string
+		targetPerm auth.CapabilitySet
+		mode       PtraceAccessMode
+		want       bool
+	}{
+		{
+			name:       "realcreds permitted superset",
+			targetPerm: auth.CapabilitySetOf(linux.CAP_SYS_ADMIN),
+			mode:       PtraceAccessModeRead | PtraceAccessModeRealCreds,
+			want:       true,
+		},
+		{
+			name:       "fscreds effective not superset",
+			targetPerm: auth.CapabilitySetOf(linux.CAP_SYS_ADMIN),
+			mode:       PtraceAccessModeRead | PtraceAccessModeFsCreds,
+			want:       false,
+		},
+		{
+			name:       "fscreds effective superset",
+			targetPerm: auth.CapabilitySetOf(linux.CAP_KILL),
+			mode:       PtraceAccessModeRead | PtraceAccessModeFsCreds,
+			want:       true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+			target.PermittedCaps = test.targetPerm
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsUserNamespace(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	childNS, err := auth.NewRootCredentials(rootNS).NewChildUserNamespace()
+	if err != nil {
+		t.Fatalf("NewChildUserNamespace: %v", err)
+	}
+	for _, test := range []struct {
+		name   string
+		caller *auth.Credentials
+		target *auth.Credentials
+		want   bool
+	}{
+		{
+			// The caller lives in a child user namespace with a full
+			// capability set there, but does not have CAP_SYS_PTRACE in the
+			// root user namespace. Even though its permitted capabilities are
+			// a superset of the target's, the commoncap check requires that
+			// both processes be in the same user namespace.
+			name:   "caller in child namespace",
+			caller: testCreds(childNS, auth.KUID(1000), auth.KGID(1000)),
+			target: testCreds(rootNS, auth.KUID(1000), auth.KGID(1000)),
+			want:   false,
+		},
+		{
+			// The caller and target are in the same child user namespace; the
+			// caller's permitted capabilities are a superset of the target's,
+			// so access is granted.
+			name:   "caller and target in child namespace",
+			caller: testCreds(childNS, auth.KUID(1000), auth.KGID(1000)),
+			target: testCreds(childNS, auth.KUID(1000), auth.KGID(1000)),
+			want:   true,
+		},
+	} {
+		// Grant the caller capabilities so that the check under test is the
+		// user namespace comparison rather than the capability superset
+		// check.
+		caller := test.caller
+		caller.PermittedCaps = auth.CapabilitySetOfMany([]linux.Capability{linux.CAP_DAC_OVERRIDE, linux.CAP_KILL})
+		caller.EffectiveCaps = auth.CapabilitySetOf(linux.CAP_KILL)
+		target := test.target
+		target.PermittedCaps = auth.CapabilitySetOf(linux.CAP_KILL)
+		for _, mode := range []PtraceAccessMode{
+			PtraceAccessModeRead | PtraceAccessModeRealCreds,
+			PtraceAccessModeRead | PtraceAccessModeFsCreds,
+		} {
+			t.Run(fmt.Sprintf("%s mode=%v", test.name, mode), func(t *testing.T) {
+				if got := canTraceCreds(mode, caller, target); got != test.want {
+					t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", mode, got, test.want)
+				}
+			})
+		}
+	}
+}
+
+func TestCanTraceCredsCapSysPtrace(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller is root in the root user namespace with all capabilities, so
+	// CAP_SYS_PTRACE grants access despite the mismatched UIDs.
+	caller := auth.NewRootCredentials(rootNS)
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, mode := range []PtraceAccessMode{
+		PtraceAccessModeRead | PtraceAccessModeRealCreds,
+		PtraceAccessModeRead | PtraceAccessModeFsCreds,
+	} {
+		if got := canTraceCreds(mode, caller, target); !got {
+			t.Errorf("canTraceCreds(%v, root caller, uid 1000 target) = false, want true", mode)
+		}
+	}
+}

--- a/pkg/sentry/kernel/ptrace_mode_test.go
+++ b/pkg/sentry/kernel/ptrace_mode_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"fmt"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
+)
+
+// testCreds returns a set of credentials with the given user and group IDs in
+// ns and no capabilities.
+func testCreds(ns *auth.UserNamespace, uid auth.KUID, gid auth.KGID) *auth.Credentials {
+	creds := auth.NewRootCredentials(ns).Fork()
+	creds.RealKUID, creds.EffectiveKUID, creds.SavedKUID = uid, uid, uid
+	creds.RealKGID, creds.EffectiveKGID, creds.SavedKGID = gid, gid, gid
+	creds.PermittedCaps = 0
+	creds.EffectiveCaps = 0
+	return creds
+}
+
+func TestCanTraceCredsModeValidation(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, test := range []struct {
+		name string
+		mode PtraceAccessMode
+		want bool
+	}{
+		{name: "zero", mode: 0, want: false},
+		{name: "read only", mode: PtraceAccessModeRead, want: false},
+		{name: "attach only", mode: PtraceAccessModeAttach, want: false},
+		{name: "both creds modes", mode: PtraceAccessModeFsCreds | PtraceAccessModeRealCreds, want: false},
+		{name: "all flags", mode: PtraceAccessModeRead | PtraceAccessModeAttach | PtraceAccessModeFsCreds | PtraceAccessModeRealCreds, want: false},
+		{name: "read realcreds", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds, want: true},
+		{name: "attach realcreds", mode: PtraceAccessModeAttach | PtraceAccessModeRealCreds, want: true},
+		{name: "read fscreds", mode: PtraceAccessModeRead | PtraceAccessModeFsCreds, want: true},
+		{name: "attach fscreds", mode: PtraceAccessModeAttach | PtraceAccessModeFsCreds, want: true},
+		{name: "read realcreds noaudit", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds | PtraceAccessModeNoAudit, want: true},
+		{name: "read fscreds sched", mode: PtraceAccessModeRead | PtraceAccessModeFsCreds | PtraceAccessModeSched, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsSetuid(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller is a setuid-root binary: it retains its real UID and GID of
+	// 1000 while its effective UID and GID are root. The target is owned by
+	// UID/GID 1000.
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	caller.EffectiveKUID = auth.RootKUID
+	caller.EffectiveKGID = auth.RootKGID
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, test := range []struct {
+		name string
+		mode PtraceAccessMode
+		want bool
+	}{
+		// PTRACE_MODE_REALCREDS uses the caller's real IDs, which match the
+		// target, so access is granted.
+		{name: "realcreds", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds, want: true},
+		// PTRACE_MODE_FSCREDS uses the caller's effective IDs, which do not
+		// match the target, so access is denied.
+		{name: "fscreds", mode: PtraceAccessModeRead | PtraceAccessModeFsCreds, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsSetgid(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller's real and effective UIDs match the target's, but its
+	// effective GID is root while its real GID matches the target's.
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	caller.EffectiveKGID = auth.RootKGID
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, test := range []struct {
+		name string
+		mode PtraceAccessMode
+		want bool
+	}{
+		{name: "realcreds", mode: PtraceAccessModeRead | PtraceAccessModeRealCreds, want: true},
+		{name: "fscreds", mode: PtraceAccessModeRead | PtraceAccessModeFsCreds, want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsCapabilitySuperset(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller has CAP_SYS_ADMIN and CAP_KILL in its permitted set but only
+	// CAP_KILL in its effective set (e.g. a setuid-root program that retains
+	// permitted capabilities while dropping effective ones). It does not have
+	// CAP_SYS_PTRACE anywhere.
+	caller := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	caller.PermittedCaps = auth.CapabilitySetOfMany([]linux.Capability{linux.CAP_SYS_ADMIN, linux.CAP_KILL})
+	caller.EffectiveCaps = auth.CapabilitySetOf(linux.CAP_KILL)
+	for _, test := range []struct {
+		name       string
+		targetPerm auth.CapabilitySet
+		mode       PtraceAccessMode
+		want       bool
+	}{
+		{
+			name:       "realcreds permitted superset",
+			targetPerm: auth.CapabilitySetOf(linux.CAP_SYS_ADMIN),
+			mode:       PtraceAccessModeRead | PtraceAccessModeRealCreds,
+			want:       true,
+		},
+		{
+			name:       "fscreds effective not superset",
+			targetPerm: auth.CapabilitySetOf(linux.CAP_SYS_ADMIN),
+			mode:       PtraceAccessModeRead | PtraceAccessModeFsCreds,
+			want:       false,
+		},
+		{
+			name:       "fscreds effective superset",
+			targetPerm: auth.CapabilitySetOf(linux.CAP_KILL),
+			mode:       PtraceAccessModeRead | PtraceAccessModeFsCreds,
+			want:       true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+			target.PermittedCaps = test.targetPerm
+			if got := canTraceCreds(test.mode, caller, target); got != test.want {
+				t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", test.mode, got, test.want)
+			}
+		})
+	}
+}
+
+func TestCanTraceCredsUserNamespace(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	childNS, err := auth.NewRootCredentials(rootNS).NewChildUserNamespace()
+	if err != nil {
+		t.Fatalf("NewChildUserNamespace: %v", err)
+	}
+	for _, test := range []struct {
+		name   string
+		caller *auth.Credentials
+		target *auth.Credentials
+		want   bool
+	}{
+		{
+			// The caller lives in a child user namespace with a full
+			// capability set there, but does not have CAP_SYS_PTRACE in the
+			// root user namespace. Even though its permitted capabilities are
+			// a superset of the target's, the commoncap check requires that
+			// both processes be in the same user namespace.
+			name:   "caller in child namespace",
+			caller: testCreds(childNS, auth.KUID(1000), auth.KGID(1000)),
+			target: testCreds(rootNS, auth.KUID(1000), auth.KGID(1000)),
+			want:   false,
+		},
+		{
+			// The caller and target are in the same child user namespace; the
+			// caller's permitted capabilities are a superset of the target's,
+			// so access is granted.
+			name:   "caller and target in child namespace",
+			caller: testCreds(childNS, auth.KUID(1000), auth.KGID(1000)),
+			target: testCreds(childNS, auth.KUID(1000), auth.KGID(1000)),
+			want:   true,
+		},
+	} {
+		// Grant the caller capabilities so that the check under test is the
+		// user namespace comparison rather than the capability superset
+		// check.
+		caller := test.caller
+		caller.PermittedCaps = auth.CapabilitySetOfMany([]linux.Capability{linux.CAP_DAC_OVERRIDE, linux.CAP_KILL})
+		caller.EffectiveCaps = auth.CapabilitySetOf(linux.CAP_KILL)
+		target := test.target
+		target.PermittedCaps = auth.CapabilitySetOf(linux.CAP_KILL)
+		for _, mode := range []PtraceAccessMode{
+			PtraceAccessModeRead | PtraceAccessModeRealCreds,
+			PtraceAccessModeRead | PtraceAccessModeFsCreds,
+		} {
+			t.Run(fmt.Sprintf("%s mode=%v", test.name, mode), func(t *testing.T) {
+				if got := canTraceCreds(mode, caller, target); got != test.want {
+					t.Errorf("canTraceCreds(%v, caller, target) = %t, want %t", mode, got, test.want)
+				}
+			})
+		}
+	}
+}
+
+func TestCanTraceCredsCapSysPtrace(t *testing.T) {
+	rootNS := auth.NewRootUserNamespace()
+	// The caller is root in the root user namespace with all capabilities, so
+	// CAP_SYS_PTRACE grants access despite the mismatched UIDs.
+	caller := auth.NewRootCredentials(rootNS)
+	target := testCreds(rootNS, auth.KUID(1000), auth.KGID(1000))
+	for _, mode := range []PtraceAccessMode{
+		PtraceAccessModeRead | PtraceAccessModeRealCreds,
+		PtraceAccessModeRead | PtraceAccessModeFsCreds,
+	} {
+		if got := canTraceCreds(mode, caller, target); !got {
+			t.Errorf("canTraceCreds(%v, root caller, uid 1000 target) = false, want true", mode)
+		}
+	}
+}

--- a/pkg/sentry/kernel/task_clone.go
+++ b/pkg/sentry/kernel/task_clone.go
@@ -601,7 +601,7 @@ func (nss *namespaceSet) initFromTask(t *Task, target *Task, flags int32) error 
 	if (uint32(flags) & ^supported) != 0 || flags == 0 {
 		return linuxerr.EINVAL
 	}
-	if !t.CanTrace(target, false) {
+	if !t.CanTraceMode(target, PtraceAccessModeRead|PtraceAccessModeRealCreds) {
 		return linuxerr.EPERM
 	}
 

--- a/pkg/sentry/kernel/task_context.go
+++ b/pkg/sentry/kernel/task_context.go
@@ -64,7 +64,7 @@ func (t *Task) Value(key any) any {
 func (t *Task) contextValue(key any, isTaskGoroutine bool) any {
 	switch key {
 	case CtxCanTrace:
-		return t.CanTrace
+		return t.CanTraceMode
 	case CtxKernel:
 		return t.k
 	case CtxPIDNamespace:

--- a/pkg/sentry/syscalls/linux/sys_process_vm.go
+++ b/pkg/sentry/syscalls/linux/sys_process_vm.go
@@ -74,7 +74,7 @@ func processVMOp(t *kernel.Task, args arch.SyscallArguments, op processVMOpType)
 	// man 2 process_vm_read: "Permission to read from or write to another
 	// process is governed by a ptrace access mode
 	// PTRACE_MODE_ATTACH_REALCREDS check; see ptrace(2)."
-	if !t.CanTrace(remoteTask, true /* attach */) {
+	if !t.CanTraceMode(remoteTask, kernel.PtraceAccessModeAttach|kernel.PtraceAccessModeRealCreds) {
 		return 0, nil, linuxerr.EPERM
 	}
 


### PR DESCRIPTION
Support the PTRACE_MODE_FSCREDS vs PTRACE_MODE_REALCREDS distinction from ptrace(2) "Ptrace access mode checking", progressing toward gvisor.dev/issue/260 (setfsuid/setfsgid).

Introduce PtraceAccessMode and Task.CanTraceMode, and switch proc files to filesystem-credential checks: /proc/[pid]/mem uses PTRACE_MODE_ATTACH_FSCREDS; maps/smaps/environ/auxv and the exe/cwd/root/fd symlinks use PTRACE_MODE_READ_FSCREDS. Explicit ptrace-adjacent syscalls (ptrace, process_vm_readv/writev, pidfd_open, clone) keep PTRACE_MODE_*_REALCREDS as before.

Assisted-by: opencode