### PR TITLE
Create /dev/char and /dev/block symlinks in devtmpfs

### DIFF
--- a/pkg/sentry/fsimpl/dev/dev.go
+++ b/pkg/sentry/fsimpl/dev/dev.go
@@ -18,6 +18,7 @@ package dev
 import (
 	"fmt"
 	"path"
+	"strings"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
@@ -137,6 +138,46 @@ func CreateDeviceFile(ctx context.Context, vfsObj *vfs.VirtualFilesystem, creds 
 		if err := vfsObj.SetStatAt(ctx, creds, pop, &opts); err != nil {
 			return fmt.Errorf("failed to set UID/GID for device file %q: %w", pathname, err)
 		}
+	}
+	return createDeviceNumberSymlink(ctx, vfsObj, creds, root, pathname, major, minor, mode)
+}
+
+// createDeviceNumberSymlink creates a /dev/{char,block}/<major>:<minor>
+// symlink to the device special file at pathname. On Linux, udev maintains
+// these symlinks for all device nodes it manages (systemd: src/udev/udev-node.c).
+func createDeviceNumberSymlink(ctx context.Context, vfsObj *vfs.VirtualFilesystem, creds *auth.Credentials, root vfs.VirtualDentry, pathname string, major, minor uint32, mode linux.FileMode) error {
+	var subdir string
+	switch mode.FileType() {
+	case linux.S_IFCHR:
+		subdir = "char"
+	case linux.S_IFBLK:
+		subdir = "block"
+	default:
+		return nil
+	}
+	// pathname is relative to the devtmpfs root, or absolute (with a /dev/
+	// prefix) when root is a container root.
+	prefix := ""
+	relPath := pathname
+	if path.IsAbs(pathname) {
+		const devDir = "/dev/"
+		if !strings.HasPrefix(pathname, devDir) {
+			// udev only manages device nodes under /dev.
+			return nil
+		}
+		prefix = devDir
+		relPath = pathname[len(devDir):]
+	}
+	linkDir := prefix + subdir
+	if err := vfsObj.MkdirAllAt(ctx, linkDir, root, creds, &vfs.MkdirOptions{
+		Mode: 0755,
+	}, true /* mustBeDir */); err != nil {
+		return fmt.Errorf("failed to create directory %q: %v", linkDir, err)
+	}
+	linkPath := fmt.Sprintf("%s/%d:%d", linkDir, major, minor)
+	target := "../" + relPath
+	if err := vfsObj.SymlinkAt(ctx, creds, pathOperationAt(root, linkPath), target); err != nil && !linuxerr.Equals(linuxerr.EEXIST, err) {
+		return fmt.Errorf("failed to create symlink %q => %q: %v", linkPath, target, err)
 	}
 	return nil
 }

--- a/pkg/sentry/fsimpl/dev/dev_test.go
+++ b/pkg/sentry/fsimpl/dev/dev_test.go
@@ -15,6 +15,7 @@
 package dev
 
 import (
+	"fmt"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
@@ -150,5 +151,16 @@ func TestDeviceFile(t *testing.T) {
 	}
 	if wantMode := uint16(linux.S_IFCHR | testDevPerms); stat.Mode != wantMode {
 		t.Errorf("device file mode: got %v, wanted %v", stat.Mode, wantMode)
+	}
+
+	// Test that the /dev/char/<major>:<minor> symlink is created.
+	linkPath := fmt.Sprintf("char/%d:%d", testDevMajor, testDevMinor)
+	wantTarget := "../" + testDevPathname
+	if gotTarget, err := vfsObj.ReadlinkAt(ctx, creds, &vfs.PathOperation{
+		Root:  root,
+		Start: root,
+		Path:  fspath.Parse(linkPath),
+	}); err != nil || gotTarget != wantTarget {
+		t.Errorf("readlink(%q): got (%q, %v), wanted (%q, nil)", linkPath, gotTarget, err, wantTarget)
 	}
 }


### PR DESCRIPTION
On Linux, udev maintains /dev/char/<major>:<minor> and
/dev/block/<major>:<minor> symlinks to all device nodes it manages.
Applications open devices by device number through these symlinks; e.g.
rdma-core uses /dev/char to locate uverbs device nodes from the device
numbers advertised in sysfs.

There is no udev in the sandbox, so create these symlinks when device
files are created in devtmpfs. This covers both sentry-registered
devices and devices injected via the OCI runtime spec.