### PR TITLE
mm: implement `MAP_FIXED_NOREPLACE`

### DIFF
--- a/pkg/abi/linux/mm.go
+++ b/pkg/abi/linux/mm.go
@@ -33,21 +33,22 @@ const (
 
 // Flags for mmap(2).
 const (
-	MAP_SHARED     = 1 << 0
-	MAP_PRIVATE    = 1 << 1
-	MAP_DROPPABLE  = 1 << 3
-	MAP_FIXED      = 1 << 4
-	MAP_ANONYMOUS  = 1 << 5
-	MAP_32BIT      = 1 << 6 // arch/x86/include/uapi/asm/mman.h
-	MAP_GROWSDOWN  = 1 << 8
-	MAP_DENYWRITE  = 1 << 11
-	MAP_EXECUTABLE = 1 << 12
-	MAP_LOCKED     = 1 << 13
-	MAP_NORESERVE  = 1 << 14
-	MAP_POPULATE   = 1 << 15
-	MAP_NONBLOCK   = 1 << 16
-	MAP_STACK      = 1 << 17
-	MAP_HUGETLB    = 1 << 18
+	MAP_SHARED          = 1 << 0
+	MAP_PRIVATE         = 1 << 1
+	MAP_DROPPABLE       = 1 << 3
+	MAP_FIXED           = 1 << 4
+	MAP_ANONYMOUS       = 1 << 5
+	MAP_32BIT           = 1 << 6 // arch/x86/include/uapi/asm/mman.h
+	MAP_GROWSDOWN       = 1 << 8
+	MAP_DENYWRITE       = 1 << 11
+	MAP_EXECUTABLE      = 1 << 12
+	MAP_LOCKED          = 1 << 13
+	MAP_NORESERVE       = 1 << 14
+	MAP_POPULATE        = 1 << 15
+	MAP_NONBLOCK        = 1 << 16
+	MAP_STACK           = 1 << 17
+	MAP_HUGETLB         = 1 << 18
+	MAP_FIXED_NOREPLACE = 1 << 20
 )
 
 // Flags for mremap(2).

--- a/pkg/abi/linux/mm.go
+++ b/pkg/abi/linux/mm.go
@@ -48,6 +48,8 @@ const (
 	MAP_NONBLOCK   = 1 << 16
 	MAP_STACK      = 1 << 17
 	MAP_HUGETLB    = 1 << 18
+
+	MAP_FIXED_NOREPLACE = 1 << 20
 )
 
 // Flags for mremap(2).

--- a/pkg/sentry/memmap/memmap.go
+++ b/pkg/sentry/memmap/memmap.go
@@ -333,6 +333,12 @@ type MMapOpts struct {
 	// be replaced. If Unmap is true, Fixed must be true.
 	Unmap bool
 
+	// NoReplace is true if MAP_FIXED_NOREPLACE semantics apply: the mapping
+	// must be located at Addr, and EEXIST (rather than ENOMEM) is returned if
+	// any mapping already exists in the range. If NoReplace is true, Fixed
+	// must be true and Unmap must be false.
+	NoReplace bool
+
 	// If Map32Bit is true, all addresses in the created mapping must fit in a
 	// 32-bit integer. (Note that the "end address" of the mapping, i.e. the
 	// address of the first byte *after* the mapping, need not fit in a 32-bit

--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -110,6 +110,9 @@ func (mm *MemoryManager) MMap(ctx context.Context, opts memmap.MMapOpts) (hostar
 	if opts.Unmap && !opts.Fixed {
 		return 0, linuxerr.EINVAL
 	}
+	if opts.NoReplace && (!opts.Fixed || opts.Unmap) {
+		return 0, linuxerr.EINVAL
+	}
 	if opts.GrowsDown && opts.Mappable != nil {
 		return 0, linuxerr.EINVAL
 	}

--- a/pkg/sentry/mm/vma.go
+++ b/pkg/sentry/mm/vma.go
@@ -50,6 +50,7 @@ func (mm *MemoryManager) createVMALocked(ctx context.Context, opts memmap.MMapOp
 		Stack:     opts.Stack,
 		Private:   opts.Private,
 		Unmap:     opts.Unmap,
+		NoReplace: opts.NoReplace,
 		Map32Bit:  opts.Map32Bit,
 	})
 	if err != nil {
@@ -148,6 +149,9 @@ type findAvailableOpts struct {
 	//	- Addr must be page-aligned.
 	//
 	//	- Unmap allows existing guard pages in the returned range.
+	//
+	//	- NoReplace allows existing guard pages (but not existing vmas) in the
+	//		returned range.
 
 	Addr      hostarch.Addr
 	Fixed     bool
@@ -155,6 +159,7 @@ type findAvailableOpts struct {
 	Stack     bool
 	Private   bool
 	Unmap     bool
+	NoReplace bool
 	Map32Bit  bool
 }
 
@@ -183,8 +188,19 @@ func (mm *MemoryManager) findAvailableLocked(length uint64, opts findAvailableOp
 			if opts.Unmap {
 				return ar.Start, nil
 			}
+			vgap := mm.vmas.FindGap(ar.Start)
+			if opts.NoReplace {
+				// MAP_FIXED_NOREPLACE fails with EEXIST iff the requested
+				// range overlaps an existing vma; like Linux, it may map over
+				// guard pages of adjacent MAP_GROWSDOWN mappings. Compare
+				// Linux's mm/mmap.c:do_mmap() => find_vma_intersection().
+				if vgap.Ok() && vgap.Range().IsSupersetOf(ar) {
+					return ar.Start, nil
+				}
+				return 0, linuxerr.EEXIST
+			}
 			// Check for the presence of an existing vma or guard page.
-			if vgap := mm.vmas.FindGap(ar.Start); vgap.Ok() && vgap.availableRange().IsSupersetOf(ar) {
+			if vgap.Ok() && vgap.availableRange().IsSupersetOf(ar) {
 				return ar.Start, nil
 			}
 		}
@@ -603,7 +619,7 @@ func (vseg vmaIterator) seekNextLowerBound(addr hostarch.Addr) vmaIterator {
 }
 
 // availableRange returns the subset of vgap.Range() in which new vmas may be
-// created without MMapOpts.Unmap == true.
+// created without MMapOpts.Unmap or MMapOpts.NoReplace set.
 func (vgap vmaGapIterator) availableRange() hostarch.AddrRange {
 	ar := vgap.Range()
 	next := vgap.NextSegment()

--- a/pkg/sentry/strace/mmap.go
+++ b/pkg/sentry/strace/mmap.go
@@ -89,4 +89,8 @@ var MmapFlagSet = abi.FlagSet{
 		Flag: linux.MAP_HUGETLB,
 		Name: "MAP_HUGETLB",
 	},
+	{
+		Flag: linux.MAP_FIXED_NOREPLACE,
+		Name: "MAP_FIXED_NOREPLACE",
+	},
 }

--- a/pkg/sentry/syscalls/linux/sys_mmap.go
+++ b/pkg/sentry/syscalls/linux/sys_mmap.go
@@ -47,6 +47,7 @@ func Mmap(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr, *
 	flags := args[3].Int()
 	fd := args[4].Int()
 	fixed := flags&linux.MAP_FIXED != 0
+	noReplace := flags&linux.MAP_FIXED_NOREPLACE != 0
 	private := flags&linux.MAP_PRIVATE != 0
 	shared := flags&linux.MAP_SHARED != 0
 	anon := flags&linux.MAP_ANONYMOUS != 0
@@ -58,13 +59,14 @@ func Mmap(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr, *
 	}
 
 	opts := memmap.MMapOpts{
-		Length:   args[1].Uint64(),
-		Offset:   args[5].Uint64(),
-		Addr:     args[0].Pointer(),
-		Fixed:    fixed,
-		Unmap:    fixed,
-		Map32Bit: map32bit,
-		Private:  private,
+		Length:    args[1].Uint64(),
+		Offset:    args[5].Uint64(),
+		Addr:      args[0].Pointer(),
+		Fixed:     fixed || noReplace,
+		Unmap:     fixed && !noReplace,
+		NoReplace: noReplace,
+		Map32Bit:  map32bit,
+		Private:   private,
 		Perms: hostarch.AccessType{
 			Read:    linux.PROT_READ&prot != 0,
 			Write:   linux.PROT_WRITE&prot != 0,

--- a/test/syscalls/linux/mmap.cc
+++ b/test/syscalls/linux/mmap.cc
@@ -51,6 +51,10 @@ using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::Gt;
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 namespace gvisor {
 namespace testing {
 
@@ -384,6 +388,91 @@ TEST_F(MMapTest, MapFixed64) {
               SyscallSucceedsWithValue(0x300000000000));
 }
 #endif
+
+// Kernels predating Linux 4.17 silently ignore MAP_FIXED_NOREPLACE, treating
+// addr as a hint; partially overlapping requests return EEXIST only from 4.19
+// (Linux commit 7aa867dd8952 "mm/mmap.c: don't clobber partially overlapping
+// mappings with MAP_FIXED_NOREPLACE").
+#define SKIP_IF_NO_MAP_FIXED_NOREPLACE()                                     \
+  do {                                                                       \
+    if (!IsRunningOnGvisor()) {                                              \
+      auto version = ASSERT_NO_ERRNO_AND_VALUE(GetKernelVersion());          \
+      SKIP_IF(version.major < 4 ||                                           \
+              (version.major == 4 && version.minor < 19));                   \
+    }                                                                        \
+  } while (0)
+
+// MAP_FIXED_NOREPLACE gives us exactly the requested address when the range
+// is free.
+TEST_F(MMapTest, MapFixedNoReplaceEmpty) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  EXPECT_THAT(Map(0x30000000, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0),
+              SyscallSucceedsWithValue(0x30000000));
+}
+
+// MAP_FIXED_NOREPLACE fails with EEXIST if any mapping already exists in the
+// requested range; it must not fall back to a different address or clobber
+// the existing mapping.
+TEST_F(MMapTest, MapFixedNoReplaceExisting) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  // Establish a writable mapping and store a sentinel value in it.
+  ASSERT_THAT(Map(0x30000000, kPageSize, PROT_READ | PROT_WRITE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+              SyscallSucceedsWithValue(0x30000000));
+  constexpr uint32_t kSentinel = 0xdeadbeef;
+  auto* val = reinterpret_cast<volatile uint32_t*>(addr_);
+  *val = kSentinel;
+
+  // MAP_FIXED_NOREPLACE over the occupied range must fail with EEXIST, without
+  // relocating to a different address.
+  EXPECT_THAT(
+      reinterpret_cast<uintptr_t>(
+          mmap(reinterpret_cast<void*>(0x30000000), kPageSize, PROT_NONE,
+               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0)),
+      SyscallFailsWithErrno(EEXIST));
+
+  // The existing mapping must be untouched: the sentinel is still there.
+  EXPECT_EQ(*val, kSentinel);
+}
+
+// MAP_FIXED_NOREPLACE fails with EEXIST even if the requested range only
+// partially overlaps an existing mapping. Compare Linux commit 7aa867dd8952
+// ("mm/mmap.c: don't clobber partially overlapping mappings with
+// MAP_FIXED_NOREPLACE").
+TEST_F(MMapTest, MapFixedNoReplacePartialOverlap) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  ASSERT_THAT(Map(0x30001000, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+              SyscallSucceedsWithValue(0x30001000));
+  EXPECT_THAT(
+      reinterpret_cast<uintptr_t>(
+          mmap(reinterpret_cast<void*>(0x30000000), 2 * kPageSize, PROT_NONE,
+               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0)),
+      SyscallFailsWithErrno(EEXIST));
+}
+
+// MAP_FIXED_NOREPLACE takes precedence over MAP_FIXED: existing mappings are
+// not clobbered.
+TEST_F(MMapTest, MapFixedNoReplaceWithMapFixed) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  ASSERT_THAT(Map(0x30000000, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+              SyscallSucceedsWithValue(0x30000000));
+  EXPECT_THAT(reinterpret_cast<uintptr_t>(mmap(
+                  reinterpret_cast<void*>(0x30000000), kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED | MAP_FIXED_NOREPLACE,
+                  -1, 0)),
+              SyscallFailsWithErrno(EEXIST));
+}
+
+// Like MAP_FIXED, MAP_FIXED_NOREPLACE requires a page-aligned address.
+TEST_F(MMapTest, MapFixedNoReplaceAlignment) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  EXPECT_THAT(Map(0x30000001, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0),
+              SyscallFailsWithErrno(EINVAL));
+}
 
 // MAP_STACK allowed.
 // There isn't a good way to verify it did anything.

--- a/test/syscalls/linux/mmap.cc
+++ b/test/syscalls/linux/mmap.cc
@@ -51,6 +51,10 @@ using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::Gt;
 
+#ifndef MAP_FIXED_NOREPLACE
+#define MAP_FIXED_NOREPLACE 0x100000
+#endif
+
 namespace gvisor {
 namespace testing {
 
@@ -384,6 +388,81 @@ TEST_F(MMapTest, MapFixed64) {
               SyscallSucceedsWithValue(0x300000000000));
 }
 #endif
+
+// Kernels predating Linux 4.17 silently ignore MAP_FIXED_NOREPLACE, treating
+// addr as a hint; partially overlapping requests return EEXIST only from 4.19
+// (Linux commit 7aa867dd8952 "mm/mmap.c: don't clobber partially overlapping
+// mappings with MAP_FIXED_NOREPLACE").
+#define SKIP_IF_NO_MAP_FIXED_NOREPLACE()                                     \
+  do {                                                                       \
+    if (!IsRunningOnGvisor()) {                                              \
+      auto version = ASSERT_NO_ERRNO_AND_VALUE(GetKernelVersion());          \
+      SKIP_IF(version.major < 4 ||                                           \
+              (version.major == 4 && version.minor < 19));                   \
+    }                                                                        \
+  } while (0)
+
+// MAP_FIXED_NOREPLACE gives us exactly the requested address when the range
+// is free.
+TEST_F(MMapTest, MapFixedNoReplaceEmpty) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  EXPECT_THAT(Map(0x30000000, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0),
+              SyscallSucceedsWithValue(0x30000000));
+}
+
+// MAP_FIXED_NOREPLACE fails with EEXIST if any mapping already exists in the
+// requested range; it must not fall back to a different address or clobber
+// the existing mapping.
+TEST_F(MMapTest, MapFixedNoReplaceExisting) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  ASSERT_THAT(Map(0x30000000, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+              SyscallSucceedsWithValue(0x30000000));
+  EXPECT_THAT(
+      reinterpret_cast<uintptr_t>(
+          mmap(reinterpret_cast<void*>(0x30000000), kPageSize, PROT_NONE,
+               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0)),
+      SyscallFailsWithErrno(EEXIST));
+}
+
+// MAP_FIXED_NOREPLACE fails with EEXIST even if the requested range only
+// partially overlaps an existing mapping. Compare Linux commit 7aa867dd8952
+// ("mm/mmap.c: don't clobber partially overlapping mappings with
+// MAP_FIXED_NOREPLACE").
+TEST_F(MMapTest, MapFixedNoReplacePartialOverlap) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  ASSERT_THAT(Map(0x30001000, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+              SyscallSucceedsWithValue(0x30001000));
+  EXPECT_THAT(
+      reinterpret_cast<uintptr_t>(
+          mmap(reinterpret_cast<void*>(0x30000000), 2 * kPageSize, PROT_NONE,
+               MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0)),
+      SyscallFailsWithErrno(EEXIST));
+}
+
+// MAP_FIXED_NOREPLACE takes precedence over MAP_FIXED: existing mappings are
+// not clobbered.
+TEST_F(MMapTest, MapFixedNoReplaceWithMapFixed) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  ASSERT_THAT(Map(0x30000000, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0),
+              SyscallSucceedsWithValue(0x30000000));
+  EXPECT_THAT(reinterpret_cast<uintptr_t>(mmap(
+                  reinterpret_cast<void*>(0x30000000), kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED | MAP_FIXED_NOREPLACE,
+                  -1, 0)),
+              SyscallFailsWithErrno(EEXIST));
+}
+
+// Like MAP_FIXED, MAP_FIXED_NOREPLACE requires a page-aligned address.
+TEST_F(MMapTest, MapFixedNoReplaceAlignment) {
+  SKIP_IF_NO_MAP_FIXED_NOREPLACE();
+  EXPECT_THAT(Map(0x30000001, kPageSize, PROT_NONE,
+                  MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0),
+              SyscallFailsWithErrno(EINVAL));
+}
 
 // MAP_STACK allowed.
 // There isn't a good way to verify it did anything.


### PR DESCRIPTION
gVisor ignored [`MAP_FIXED_NOREPLACE`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a4ff8e8620d3f4f50ac4b41e8067b7d395056843), treating the address as a hint. Reservations over occupied ranges silently landed elsewhere instead of failing with `EEXIST`. This breaks the NVIDIA driver's `PROT_NONE` placeholders over released `/dev/nvidia*` ranges during `cuda-checkpoint`: the ranges stay vacant in a memory snapshot, get reused on restore, and are then clobbered by the driver's `MAP_FIXED` remap → SIGSEGV.

Implement Linux semantics (`mm/mmap.c:do_mmap()`): exact placement or `EEXIST` on any overlap (including partial), never clobbering — even combined with `MAP_FIXED`. Unaligned addr → `EINVAL`. Existing `Fixed && !Unmap` callers keep `ENOMEM`. Also decode the flag in strace.

Adding this simple reproduction: 

```cpp
// MAP_FIXED_NOREPLACE must place at exactly `addr` or fail with EEXIST.
#include <errno.h>
#include <stdio.h>
#include <sys/mman.h>
#ifndef MAP_FIXED_NOREPLACE
#define MAP_FIXED_NOREPLACE 0x100000
#endif

int main(void) {
  char *p = mmap(0, 4096, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
  void *r = mmap(p, 4096, PROT_NONE,
                 MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
  if (r == MAP_FAILED && errno == EEXIST) { printf("OK: EEXIST\n"); return 0; }
  printf("BUG: flag ignored, relocated %p -> %p\n", (void *)p, r);
  return 1;
}

```

Then we can repro with:

```shell
$ gcc -static -o min_repro min_repro.c
$ ./min_repro                                 # native Linux 6.1
OK: EEXIST                                     # exit 0
$ sudo runsc-master do ./min_repro             # gVisor @ 05b57c9
BUG: flag ignored, relocated 0x7eadda46c000 -> 0x7eadda46b000   # exit 1
$ sudo runsc-pr do ./min_repro                 # gVisor @ this PR
OK: EEXIST                                     # exit 0

```

Then, strace will show: 
```shell
# 05b57c9: flag not even decoded (shows as 0x100000), addr treated as a hint
#         -> "success" at the WRONG address
mmap(..., MAP_PRIVATE|MAP_ANONYMOUS|0x100000, -1, 0)             = 0x7eadda46b000   (req 0x7eadda46c000)

# this PR: flag honored -> correct EEXIST on conflict
mmap(..., MAP_PRIVATE|MAP_ANONYMOUS|MAP_FIXED_NOREPLACE, -1, 0)  = -1 errno=17 (file exists)
```

This was originally discovered in combination with `cuda-checkpoint` where restored containers would fail because it expected the original memory reservation address to be respected. This happens on NVIDIA driver version `580.95.05` but NVIDIA reportedly fixed this issue in later driver versions. 

I am admittedly very ignored in the memory management domain, so please tear this apart if it makes no sense. 

Assisted-by: Claude