### PR TITLE
`runsc boot`: Do not re-exec when possible.

### DIFF
--- a/runsc/cmd/sandboxsetup/caps.go
+++ b/runsc/cmd/sandboxsetup/caps.go
@@ -17,9 +17,14 @@ package sandboxsetup
 
 import (
 	"fmt"
+	"structs"
+	"syscall"
+	"unsafe"
 
 	"github.com/moby/sys/capability"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/log"
 )
 
@@ -67,6 +72,118 @@ func ApplyCaps(caps *specs.LinuxCapabilities) error {
 		return err
 	}
 	log.Infof("Capabilities applied: %+v", newCaps)
+	return nil
+}
+
+// capHeader mirrors `struct __user_cap_header_struct`.
+type capHeader struct {
+	_       structs.HostLayout
+	version uint32
+	pid     int32
+}
+
+// capData mirrors `struct __user_cap_data_struct`.
+type capData struct {
+	_           structs.HostLayout
+	effective   uint32
+	permitted   uint32
+	inheritable uint32
+}
+
+// linuxCapVer3 is the V3 capability API version (struct pair of `capData`).
+const linuxCapVer3 = 0x20080522
+
+// capsetHdr and capsetData are package-level so that their addresses are
+// stable for the duration of the raw capset syscall issued on every thread
+// (Did you know? Unlike stack variables, globals are never moved by the Go
+// runtime.)
+var (
+	capsetHdr  capHeader
+	capsetData [2]capData
+)
+
+// allThreadsPrctl issues `prctl(option, arg2, arg3)` on every OS thread of the
+// process via `syscall.AllThreadsSyscall6`.
+func allThreadsPrctl(option, arg2, arg3 uintptr) error {
+	// EINVAL is ignored to mirror `capability.Apply`'s handling of unsupported caps.
+	if _, _, errno := syscall.AllThreadsSyscall6(unix.SYS_PRCTL, option, arg2, arg3, 0, 0, 0); errno != 0 && errno != unix.EINVAL {
+		return errno
+	}
+	return nil
+}
+
+// ApplyCapsAllThreads applies the capabilities in the spec to every thread of
+// the current process. Fails with ENOTSUP in cgo builds.
+func ApplyCapsAllThreads(caps *specs.LinuxCapabilities) error {
+	curCaps, err := capability.NewPid2(0)
+	if err != nil {
+		return err
+	}
+	if err := curCaps.Load(); err != nil {
+		return err
+	}
+	var bounding, effective, permitted, inheritable, ambient uint64
+	for i, mask := range [5]*uint64{&bounding, &effective, &permitted, &inheritable, &ambient} {
+		set, err := TrimCaps(GetCaps(AllCapTypes[i], caps), curCaps)
+		if err != nil {
+			return err
+		}
+		for _, c := range set {
+			*mask |= uint64(1) << uint(c)
+		}
+	}
+	last, err := capability.LastCap()
+	if err != nil {
+		return err
+	}
+
+	// 1. Trim the bounding set on every thread. This must happen before
+	// capset drops CAP_SETPCAP from the effective set (PR_CAPBSET_DROP
+	// requires it).
+	if curCaps.Get(capability.EFFECTIVE, capability.CAP_SETPCAP) {
+		for c := capability.Cap(0); c <= last; c++ {
+			if bounding&(uint64(1)<<uint(c)) != 0 {
+				continue
+			}
+			if err := allThreadsPrctl(unix.PR_CAPBSET_DROP, uintptr(c), 0); err != nil {
+				return fmt.Errorf("dropping bounding capability %v on all threads: %w", c, err)
+			}
+		}
+	}
+
+	// 2. Apply effective/permitted/inheritable via `capset(2)` on all threads.
+	capsetHdr = capHeader{
+		version: linuxCapVer3,
+		// PID 0 means "calling thread".
+		// The Go runtime will reuse this for all of its threads, so this will
+		// in turn mean each Go runtime thread.
+		pid: 0,
+	}
+	capsetData[0].effective = uint32(effective)
+	capsetData[1].effective = uint32(effective >> 32)
+	capsetData[0].permitted = uint32(permitted)
+	capsetData[1].permitted = uint32(permitted >> 32)
+	capsetData[0].inheritable = uint32(inheritable)
+	capsetData[1].inheritable = uint32(inheritable >> 32)
+	if _, _, errno := syscall.AllThreadsSyscall6(unix.SYS_CAPSET, uintptr(unsafe.Pointer(&capsetHdr)), uintptr(unsafe.Pointer(&capsetData[0])), 0, 0, 0, 0); errno != 0 {
+		return fmt.Errorf("capset on all threads: %w", errno)
+	}
+
+	// 3. Ambient set: clear everything, then raise the requested caps.
+	if err := allThreadsPrctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_CLEAR_ALL, 0); err != nil {
+		return fmt.Errorf("clearing ambient capabilities on all threads: %w", err)
+	}
+	for c := capability.Cap(0); c <= last; c++ {
+		if ambient&(uint64(1)<<uint(c)) == 0 {
+			continue
+		}
+		if err := allThreadsPrctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_RAISE, uintptr(c)); err != nil {
+			return fmt.Errorf("raising ambient capability %v on all threads: %w", c, err)
+		}
+	}
+
+	log.Infof("Capabilities applied to all threads: bounding=%#x effective=%#x permitted=%#x inheritable=%#x ambient=%#x",
+		bounding, effective, permitted, inheritable, ambient)
 	return nil
 }
 

--- a/runsc/cmd/sandboxsetup/process.go
+++ b/runsc/cmd/sandboxsetup/process.go
@@ -23,6 +23,7 @@ import (
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/runsc/cmd/util"
 	"gvisor.dev/gvisor/runsc/flag"
@@ -156,7 +157,13 @@ func ExecProcUmounter() (*exec.Cmd, *os.File) {
 // UmountProc writes to syncFD signalling the process started by
 // ExecProcUmounter() to umount /proc.
 func UmountProc(syncFD int) {
-	syncFile := os.NewFile(uintptr(syncFD), "procfs umount sync FD")
+	UmountProcFile(os.NewFile(uintptr(syncFD), "procfs umount sync FD"))
+}
+
+// UmountProcFile is like `UmountProc`, but takes the pipe's write end as an
+// `os.File`. This must be used when the caller already holds a `os.File`
+// (e.g. when the boot process continues without re-exec'ing).
+func UmountProcFile(syncFile *os.File) {
 	buf := make([]byte, 1)
 	if w, err := syncFile.Write(buf); err != nil || w != 1 {
 		util.Fatalf("unable to write into the proc umounter descriptor: %v", err)

--- a/runsc/cmd/sentry/sentrycmd/boot.go
+++ b/runsc/cmd/sentry/sentrycmd/boot.go
@@ -200,6 +200,11 @@ type Boot struct {
 	// procfs mount isn't needed anymore.
 	procMountSyncFD int
 
+	// procMountSyncFile holds the *os.File for procMountSyncFD when this
+	// process continues without re-exec'ing itself (see
+	// `applyCapsAllThreads`). It keeps the FD alive.
+	procMountSyncFile *os.File
+
 	// syncUsernsFD is the file descriptor that has to be closed when the
 	// boot process should invoke setuid/setgid for root user. This is mainly
 	// used to synchronize rootless user namespace initialization.
@@ -297,6 +302,23 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&b.nvidiaDriverVersion, "nvidia-driver-version", "", "Nvidia driver version on the host")
 	f.StringVar(&b.procDriverNvidiaParams, "nvidia-host-params", "", "value of /proc/driver/nvidia/params on the host")
 	f.Int64Var(&b.nvidiaFabricIMEXManagementDevMinor, "nvidia-fabric-imex-mgmt-minor", -1, "DeviceFileMinor in /proc/driver/nvidia/capabilities/fabric-imex-mgmt on the host")
+}
+
+// willReexec returns true if this boot process will re-execute itself to
+// apply credential/capability changes to all of its threads, rather than
+// applying capabilities to all threads in-process.
+func (b *Boot) willReexec() bool {
+	if config.CgoEnabled {
+		// When cgo is on, we can't control non-Go threads, so need reexec.
+		return true
+	}
+	if !b.applyCaps {
+		return true // No caps to change but will change UID/GID to `nobody`.
+	}
+	if b.syncUsernsFD >= 0 {
+		return true // Rootless mode.
+	}
+	return false
 }
 
 // Execute implements subcommands.Command.Execute.  It starts a sandbox in a
@@ -405,19 +427,24 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 
 		if !conf.Rootless {
 			// /proc is umounted from a forked process, because the
-			// current one is going to re-execute itself without
-			// capabilities.
+			// current one is going to drop capabilities and won't be
+			// able to umount it.
 			cmd, w := sandboxsetup.ExecProcUmounter()
-			defer cmd.Wait()
-			defer w.Close()
+			if b.willReexec() {
+				defer cmd.Wait()
+				defer w.Close()
+			} else {
+				// Keep `w` alive until UmountProcFile uses it.
+				b.procMountSyncFile = w
+			}
 			if b.procMountSyncFD != -1 {
 				panic("procMountSyncFD is set")
 			}
 			b.procMountSyncFD = int(w.Fd())
 			argOverride["proc-mount-sync-fd"] = strconv.Itoa(b.procMountSyncFD)
 
-			// Clear FD_CLOEXEC. Regardless of b.applyCaps, this process will be
-			// re-executed. procMountSyncFD should remain open.
+			// Clear FD_CLOEXEC in case this process re-executes itself.
+			// procMountSyncFD should remain open.
 			if _, _, errno := unix.RawSyscall(unix.SYS_FCNTL, w.Fd(), unix.F_SETFD, 0); errno != 0 {
 				util.Fatalf("error clearing CLOEXEC: %v", errno)
 			}
@@ -486,22 +513,42 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 				})
 			}
 		}
-		argOverride["apply-caps"] = "false"
+		if b.willReexec() {
+			if config.CgoEnabled {
+				log.Warningf("Need to re-exec in order to drop capabilities, due to cgo build. This slows down gVisor startup. Use a pure-Go gVisor build for faster startup.")
+			} else {
+				log.Infof("Re-execing. FYI, this step isn't necessary when running with root. gVisor will start up faster (and is just as secure) when started as root, as it has to do fewer hoops to get to its as-sandboxed-as-possible state.")
+			}
+			argOverride["apply-caps"] = "false"
 
-		// Remove the args that have already been done before calling self.
-		args := sandboxsetup.PrepareArgs(b.Name(), f, argOverride)
+			// Remove the args that have already been done before calling self.
+			args := sandboxsetup.PrepareArgs(b.Name(), f, argOverride)
 
-		// Note that we've already read the spec from the spec FD, and
-		// we will read it again after the exec call. This works
-		// because the ReadSpecFromFile function seeks to the beginning
-		// of the file before reading.
-		util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, caps, sandboxsetup.SetCapsAndCallSelf(args, caps))
+			// Note that we've already read the spec from the spec FD, and
+			// we will read it again after the exec call. This works
+			// because the ReadSpecFromFile function seeks to the beginning
+			// of the file before reading.
+			util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, caps, sandboxsetup.SetCapsAndCallSelf(args, caps))
 
-		// This prevents the specFile finalizer from running and closed
-		// the specFD, which we have passed to ourselves when
-		// re-execing.
-		runtime.KeepAlive(specFile)
-		panic("unreachable")
+			// This prevents the specFile finalizer from running and closed
+			// the specFD, which we have passed to ourselves when
+			// re-execing.
+			runtime.KeepAlive(specFile)
+			panic("unreachable")
+		}
+
+		if err := sandboxsetup.ApplyCapsAllThreads(caps); err != nil {
+			util.Fatalf("applying caps to all threads: %v", err)
+		}
+		if b.attached {
+			// Re-arm the parent death signal in case the credential change
+			// cleared it. (A pure capability drop should not clear it, but
+			// re-arming is free and preserves the re-exec path's behavior,
+			// which re-arms after the exec.)
+			if err := unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(unix.SIGKILL), 0, 0, 0); err != nil {
+				util.Fatalf("error setting parent death signal: %v", err)
+			}
+		}
 	}
 
 	if b.syncUsernsFD >= 0 {
@@ -646,7 +693,11 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 			// Call validateOpenFDs() before umounting /proc.
 			validateOpenFDs(bootArgs.PassFDs)
 			// Umount /proc right before installing seccomp filters.
-			sandboxsetup.UmountProc(b.procMountSyncFD)
+			if b.procMountSyncFile != nil {
+				sandboxsetup.UmountProcFile(b.procMountSyncFile)
+			} else {
+				sandboxsetup.UmountProc(b.procMountSyncFD)
+			}
 		}
 	}
 


### PR DESCRIPTION
This drops caps using `syscall.AllThreadsSyscall6` instead of re-exec'ing.

A follow-up PR will do the same for the gofer process (which also re-execs currently).

```
┌───────────────────────────┬─────────────────┬────────────────────────────┬──────────────────────────────────┐
│         Benchmark         │     before      │   no runsc boot re-exec    │ no runsc boot + no gofer re-exec │
├───────────────────────────┼─────────────────┼────────────────────────────┼──────────────────────────────────┤
│ docker run alpine true    │ 817ms           │ −8.4ms, ~ (p=0.131, n=100) │ −10.3ms, −1.26% (p=0.048, n=100) │
│ runsc create              │ 157ms           │ −4.2ms, ~ (p=0.123)        │ −9.0ms, −5.68% (p=0.019)         │
│ runsc create + start      │ 303ms           │ −10.2ms, ~ (p=0.081)       │ −19.9ms, −6.54% (p=0.002)        │
└───────────────────────────┴─────────────────┴────────────────────────────┴──────────────────────────────────┘
```