### PR TITLE
rdmaproxy: Adding support for Google NICs with netlink-based device discovery and generic driver

### DIFF
--- a/pkg/abi/linux/BUILD
+++ b/pkg/abi/linux/BUILD
@@ -59,6 +59,7 @@ go_library(
         "netfilter_ipv6.go",
         "netlink.go",
         "netlink_netfilter.go",
+        "netlink_rdma.go",
         "netlink_route.go",
         "nf_tables.go",
         "personality.go",

--- a/pkg/abi/linux/netlink_rdma.go
+++ b/pkg/abi/linux/netlink_rdma.go
@@ -1,0 +1,112 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linux
+
+// Netlink RDMA client IDs, from uapi/rdma/rdma_netlink.h.
+const (
+	RDMA_NL_IWCM  = 2
+	RDMA_NL_RSVD  = 3
+	RDMA_NL_LS    = 4
+	RDMA_NL_NLDEV = 5
+)
+
+// RDMANetlinkClient returns the RDMA netlink client ID encoded in the top 6
+// bits of the netlink message type, from uapi/rdma/rdma_netlink.h
+// (RDMA_NL_GET_CLIENT).
+func (hdr *NetlinkMessageHeader) RDMANetlinkClient() uint16 {
+	return (hdr.Type >> 10) & 0x3f
+}
+
+// RDMANetlinkOp returns the RDMA netlink operation encoded in the bottom 10
+// bits of the netlink message type, from uapi/rdma/rdma_netlink.h
+// (RDMA_NL_GET_OP).
+func (hdr *NetlinkMessageHeader) RDMANetlinkOp() uint16 {
+	return hdr.Type & 0x3ff
+}
+
+// RDMANetlinkTypeFor returns the netlink message type for an RDMA_NL_NLDEV
+// operation, from uapi/rdma/rdma_netlink.h (RDMA_NL_GET_TYPE).
+func RDMANetlinkTypeFor(op uint16) uint16 {
+	return (RDMA_NL_NLDEV << 10) | (op & 0x3ff)
+}
+
+// NLDEV commands, from uapi/rdma/rdma_netlink.h (enum rdma_nldev_command).
+const (
+	RDMA_NLDEV_CMD_UNSPEC      = 0
+	RDMA_NLDEV_CMD_GET         = 1
+	RDMA_NLDEV_CMD_SET         = 2
+	RDMA_NLDEV_CMD_NEWLINK     = 3
+	RDMA_NLDEV_CMD_DELLINK     = 4
+	RDMA_NLDEV_CMD_PORT_GET    = 5
+	RDMA_NLDEV_CMD_SYS_GET     = 6
+	RDMA_NLDEV_CMD_SYS_SET     = 7
+	RDMA_NLDEV_CMD_GET_CHARDEV = 15
+)
+
+// NLDEV attributes, from uapi/rdma/rdma_netlink.h (enum rdma_nldev_attr).
+// Only the attributes used by rdma-core device discovery are defined; the
+// enum is dense in Linux, so values here are explicit.
+const (
+	RDMA_NLDEV_ATTR_UNSPEC           = 0
+	RDMA_NLDEV_ATTR_PAD              = 0
+	RDMA_NLDEV_ATTR_DEV_INDEX        = 1
+	RDMA_NLDEV_ATTR_DEV_NAME         = 2
+	RDMA_NLDEV_ATTR_PORT_INDEX       = 3
+	RDMA_NLDEV_ATTR_NODE_GUID        = 6
+	RDMA_NLDEV_ATTR_DEV_NODE_TYPE    = 14
+	RDMA_NLDEV_SYS_ATTR_NETNS_MODE   = 66
+	RDMA_NLDEV_ATTR_CHARDEV_TYPE     = 69
+	RDMA_NLDEV_ATTR_CHARDEV_NAME     = 70
+	RDMA_NLDEV_ATTR_CHARDEV_ABI      = 71
+	RDMA_NLDEV_ATTR_CHARDEV          = 72
+	RDMA_NLDEV_ATTR_UVERBS_DRIVER_ID = 73
+	RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK = 93
+)
+
+// RDMA driver IDs, from uapi/rdma/ib_user_ioctl_verbs.h
+// (enum rdma_driver_id). Reported to userspace in
+// RDMA_NLDEV_ATTR_UVERBS_DRIVER_ID so that libibverbs can select a provider
+// library without PCI ID matching.
+const (
+	RDMA_DRIVER_UNKNOWN    = 0
+	RDMA_DRIVER_MLX5       = 1
+	RDMA_DRIVER_MLX4       = 2
+	RDMA_DRIVER_CXGB3      = 3
+	RDMA_DRIVER_CXGB4      = 4
+	RDMA_DRIVER_MTHCA      = 5
+	RDMA_DRIVER_BNXT_RE    = 6
+	RDMA_DRIVER_OCRDMA     = 7
+	RDMA_DRIVER_NES        = 8
+	RDMA_DRIVER_I40IW      = 9
+	RDMA_DRIVER_IRDMA      = 9
+	RDMA_DRIVER_VMW_PVRDMA = 10
+	RDMA_DRIVER_QEDR       = 11
+	RDMA_DRIVER_HNS        = 12
+	RDMA_DRIVER_USNIC      = 13
+	RDMA_DRIVER_RXE        = 14
+	RDMA_DRIVER_HFI1       = 15
+	RDMA_DRIVER_QIB        = 16
+	RDMA_DRIVER_EFA        = 17
+	RDMA_DRIVER_SIW        = 18
+	RDMA_DRIVER_ERDMA      = 19
+	RDMA_DRIVER_MANA       = 20
+)
+
+// HugeEncodeDev encodes a device major/minor pair in Linux's
+// huge_encode_dev() format, used by RDMA_NLDEV_ATTR_CHARDEV. From
+// include/linux/kdev_t.h:new_encode_dev.
+func HugeEncodeDev(major, minor uint32) uint64 {
+	return uint64(minor&0xff) | (uint64(major) << 8) | (uint64(minor&^0xff) << 12)
+}

--- a/pkg/rdma/BUILD
+++ b/pkg/rdma/BUILD
@@ -11,6 +11,7 @@ go_library(
         "snapshot.go",
     ],
     visibility = ["//visibility:public"],
+    deps = ["//pkg/abi/linux"],
 )
 
 go_test(

--- a/pkg/rdma/collect.go
+++ b/pkg/rdma/collect.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
 )
 
 // UverbsSpec identifies one /dev/infiniband/uverbs* device from the
@@ -42,7 +44,7 @@ var pciAttrNames = []string{
 	"class", "vendor", "device", "subsystem_vendor", "subsystem_device",
 	"revision", "numa_node", "local_cpus", "local_cpulist",
 	"max_link_speed", "max_link_width", "current_link_speed",
-	"current_link_width", "modalias", "uevent",
+	"current_link_width", "modalias", "uevent", "resource",
 }
 
 // Static identity attributes of /sys/class/infiniband/<ibdev>/.
@@ -75,6 +77,21 @@ var numaAggregateNames = []string{
 // GPU/accelerator PCI classes included as leaves (beyond the NIC leaves
 // derived from the spec): 3D controller, VGA controller, NVSwitch bridge.
 var gpuClassPrefixes = []string{"0x0302", "0x0300", "0x0680"}
+
+// Maps a host PCI driver module name (the DRIVER= field of the leaf PCI
+// function's uevent) to the kernel's enum rdma_driver_id value
+// (linux.RDMA_DRIVER_*) of the RDMA driver stacked on that module. The
+// sentry's NETLINK_RDMA shim reports it in RDMA_NLDEV_ATTR_UVERBS_DRIVER_ID,
+// which is how libibverbs binds a provider library before its fallback to PCI
+// ID matching.
+var rdmaDriverIDFromName = map[string]uint32{
+	"mlx5_core": linux.RDMA_DRIVER_MLX5,
+	"irdma":     linux.RDMA_DRIVER_IRDMA,
+	"ice":       linux.RDMA_DRIVER_IRDMA,
+	"idpf":      linux.RDMA_DRIVER_IRDMA,
+	"i40e":      linux.RDMA_DRIVER_I40IW,
+	"efa":       linux.RDMA_DRIVER_EFA,
+}
 
 // Collect builds a snapshot for the given spec devices by reading host
 // sysfs rooted at sysRoot (normally "/sys"; overridable for tests).
@@ -191,6 +208,20 @@ func Collect(sysRoot string, uverbs []UverbsSpec) (*Snapshot, error) {
 		s.PCINodes = append(s.PCINodes, PCINode{Path: p, Attrs: attrs})
 	}
 	sort.Slice(s.PCINodes, func(i, j int) bool { return s.PCINodes[i].Path < s.PCINodes[j].Path })
+
+	// Assign driver IDs to each driver by matching the driver name from the
+	// DRIVER= line in the uevent of each PCI node.
+	uevents := make(map[string]string, len(s.PCINodes))
+	for i := range s.PCINodes {
+		uevents[s.PCINodes[i].Path] = s.PCINodes[i].Attrs["uevent"]
+	}
+	for i := range s.Devices {
+		driver_name, err := pciDriverName(uevents[s.Devices[i].LeafPCI])
+		if err != nil {
+			return nil, err
+		}
+		s.Devices[i].DriverID = rdmaDriverIDFromName[driver_name]
+	}
 
 	numa, err := collectNUMA(sysRoot)
 	if err != nil {
@@ -352,6 +383,17 @@ func collectNUMA(sysRoot string) (*NUMA, error) {
 		return nil, err
 	}
 	return &NUMA{Aggregate: agg}, nil
+}
+
+// pciDriverName returns the DRIVER= field of a PCI uevent, or errors if
+// field is missing.
+func pciDriverName(uevent string) (string, error) {
+	for _, line := range strings.Split(uevent, "\n") {
+		if driver, ok := strings.CutPrefix(line, "DRIVER="); ok {
+			return driver, nil
+		}
+	}
+	return "", errors.New("DRIVER= field not found in uevent")
 }
 
 // relRealpath resolves p and returns it relative to sysRoot.

--- a/pkg/rdma/snapshot.go
+++ b/pkg/rdma/snapshot.go
@@ -75,6 +75,10 @@ type Device struct {
 	// Dev is the host "major:minor" of the uverbs char device.
 	Dev        string `json:"dev"`
 	ABIVersion string `json:"abi_version"`
+	// DriverID is the kernel's enum rdma_driver_id value (RDMA_DRIVER_*)
+	// for the device, inferred at collection time from the DRIVER= field of
+	// the leaf PCI function's uevent.
+	DriverID uint32 `json:"driver_id"`
 	// IBAttrs are the static identity attributes of
 	// /sys/class/infiniband/<ibdev>/ (node_guid, fw_ver, ...).
 	IBAttrs map[string]string `json:"ib_attrs"`

--- a/pkg/sentry/devices/rdmaproxy/driver.go
+++ b/pkg/sentry/devices/rdmaproxy/driver.go
@@ -15,6 +15,7 @@
 package rdmaproxy
 
 import (
+	"slices"
 	"sync"
 
 	"gvisor.dev/gvisor/pkg/log"
@@ -88,12 +89,36 @@ func RegisterDriver(drv Driver) {
 	log.Infof("rdmaproxy: registered driver name=%s", name)
 }
 
-// LookupDriver returns the driver registered under name, or nil if none.
+// GenericDriverName is the registry name of the no-op generic plug-in
+// (pkg/sentry/devices/rdmaproxy/genericproxy). LookupDriver falls back to it
+// for host driver names in genericDriverAllowList.
+const GenericDriverName = "generic"
+
+// genericDriverAllowList is the explicit allow-list of host PCI driver names
+// the generic no-op plug-in may serve, matched against the DRIVER= field of
+// the uverbs device's leaf PCI uevent (see runsc's rdmaproxyRegisterDevices).
+//
+// For iRDMA devices, we actually don't need a proxy to translate guest VAs in
+// driver payloads for CQ/QPs because iRDMA implements them as MRs, which are
+// already handled correctly by rdmaproxy core.
+var genericDriverAllowList = []string{"ice", "i40e", "idpf", "irdma"}
+
+// LookupDriver returns the driver serving host driver name. The driver
+// registered under exactly that name wins, so a vendor-specific plug-in takes
+// priority; otherwise, if name is in genericDriverAllowList, the generic
+// no-op plug-in is returned (if registered). Returns nil if no driver
+// matches.
 func LookupDriver(name string) Driver {
 	reg := driverReg()
 	reg.mu.RLock()
 	defer reg.mu.RUnlock()
-	return reg.drivers[name]
+	if drv, ok := reg.drivers[name]; ok {
+		return drv
+	}
+	if slices.Contains(genericDriverAllowList, name) {
+		return reg.drivers[GenericDriverName]
+	}
+	return nil
 }
 
 // rangeDrivers calls f for each registered driver.

--- a/pkg/sentry/devices/rdmaproxy/genericproxy/BUILD
+++ b/pkg/sentry/devices/rdmaproxy/genericproxy/BUILD
@@ -1,0 +1,21 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "genericproxy",
+    srcs = [
+        "genericproxy.go",
+    ],
+    visibility = [
+        "//pkg/sentry:internal",
+        "//runsc:__subpackages__",
+    ],
+    deps = [
+        "//pkg/sentry/devices/rdmaproxy",
+        "//pkg/sentry/kernel",
+    ],
+)

--- a/pkg/sentry/devices/rdmaproxy/genericproxy/genericproxy.go
+++ b/pkg/sentry/devices/rdmaproxy/genericproxy/genericproxy.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package genericproxy implements a no-op rdmaproxy.Driver plug-in for an explicit
+// allow-list of host RDMA drivers.
+//
+// To make this driver available, Init() must be called.
+package genericproxy
+
+import (
+	"gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+)
+
+// genericDriver is the no-op rdmaproxy.Driver implementation. A single
+// instance is registered under rdmaproxy.GenericDriverName; rdmaproxy's
+// LookupDriver returns it for allow-listed host driver names that have no
+// vendor-specific plug-in of their own.
+type genericDriver struct{}
+
+// Name implements rdmaproxy.Driver.Name.
+func (d genericDriver) Name() string { return rdmaproxy.GenericDriverName }
+
+// PrepareCreateDMA implements rdmaproxy.Driver.PrepareCreateDMA. It is a
+// no-op: the UHW payload is forwarded verbatim and no pages are mirrored.
+func (genericDriver) PrepareCreateDMA(t *kernel.Task, uhwIn []byte) (*rdmaproxy.PinnedDMABufs, error) {
+	return nil, nil
+}
+
+// Schemas implements rdmaproxy.Driver.Schemas. No driver-namespace methods
+// are modeled; driver-private ioctl methods are rejected by the core.
+func (genericDriver) Schemas() map[uint32]*rdmaproxy.MethodSchema {
+	return nil
+}
+
+// Init registers the no-op plug-in once under rdmaproxy.GenericDriverName.
+func Init() { rdmaproxy.RegisterDriver(genericDriver{}) }

--- a/pkg/sentry/socket/netlink/rdma/BUILD
+++ b/pkg/sentry/socket/netlink/rdma/BUILD
@@ -1,0 +1,24 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "rdma",
+    srcs = ["protocol.go"],
+    visibility = ["//pkg/sentry:internal"],
+    deps = [
+        "//pkg/abi/ib",
+        "//pkg/abi/linux",
+        "//pkg/context",
+        "//pkg/log",
+        "//pkg/marshal/primitive",
+        "//pkg/rdma",
+        "//pkg/sentry/kernel",
+        "//pkg/sentry/socket/netlink",
+        "//pkg/sentry/socket/netlink/nlmsg",
+        "//pkg/syserr",
+    ],
+)

--- a/pkg/sentry/socket/netlink/rdma/protocol.go
+++ b/pkg/sentry/socket/netlink/rdma/protocol.go
@@ -1,0 +1,288 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rdma provides a NETLINK_RDMA socket protocol.
+//
+// gVisor implements the subset of the kernel's nldev interface that
+// rdma-core uses: libibverbs device discovery (RDMA_NLDEV_CMD_GET dumps and
+// RDMA_NLDEV_CMD_GET_CHARDEV for "uverbs") and fork safety detection
+// (RDMA_NLDEV_CMD_SYS_GET). GET_CHARDEV for any other client, including
+// librdmacm's rdma_cm, fails with ENOENT exactly as Linux does when the
+// corresponding kernel client is not registered.
+package rdma
+
+import (
+	"encoding/hex"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/abi/ib"
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/marshal/primitive"
+	"gvisor.dev/gvisor/pkg/rdma"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/socket/netlink"
+	"gvisor.dev/gvisor/pkg/sentry/socket/netlink/nlmsg"
+	"gvisor.dev/gvisor/pkg/syserr"
+)
+
+// devData is the host sysfs snapshot served over NETLINK_RDMA, or nil if
+// rdmaproxy is disabled. It is written exactly once, by Init, and never
+// mutated afterwards, so readers need no synchronization (see Init).
+var devData *rdma.Snapshot
+
+// Protocol implements netlink.Protocol.
+//
+// +stateify savable
+type Protocol struct{}
+
+var _ netlink.Protocol = (*Protocol)(nil)
+
+// Init publishes RDMA device data to NETLINK_RDMA sockets. If it is never
+// called (or called with nil), socket(AF_NETLINK, ..., NETLINK_RDMA) fails
+// with EPROTONOSUPPORT, matching a host kernel without RDMA support.
+//
+// Preconditions: Init is called at most once, during boot, before any
+// application task exists. Calling Init any later could be a data race. The
+// snapshot must not be mutated after Init.
+func Init(snap *rdma.Snapshot) {
+	devData = snap
+}
+
+// NewProtocol creates a NETLINK_RDMA netlink.Protocol.
+func NewProtocol(t *kernel.Task) (netlink.Protocol, *syserr.Error) {
+	if devData == nil {
+		return nil, syserr.ErrProtocolNotSupported
+	}
+	return &Protocol{}, nil
+}
+
+// Protocol implements netlink.Protocol.Protocol.
+func (p *Protocol) Protocol() int {
+	return linux.NETLINK_RDMA
+}
+
+// CanSend implements netlink.Protocol.CanSend.
+func (p *Protocol) CanSend() bool {
+	return true
+}
+
+// Receive implements netlink.Protocol.Receive.
+func (p *Protocol) Receive(ctx context.Context, s *netlink.Socket, buf []byte) *syserr.Error {
+	return s.ProcessMessages(ctx, buf)
+}
+
+// ProcessMessage implements netlink.Protocol.ProcessMessage.
+//
+// From drivers/infiniband/core/netlink.c:rdma_nl_rcv_msg.
+func (p *Protocol) ProcessMessage(ctx context.Context, s *netlink.Socket, msg *nlmsg.Message, ms *nlmsg.MessageSet) *syserr.Error {
+	hdr := msg.Header()
+	if hdr.RDMANetlinkClient() != linux.RDMA_NL_NLDEV {
+		log.Debugf("Netlink RDMA: unsupported client %d", hdr.RDMANetlinkClient())
+		return syserr.ErrInvalidArgument
+	}
+
+	data := devData
+	if data == nil {
+		// Unreachable: sockets can only be created after Init publishes a
+		// non-nil snapshot, which never changes afterwards. Be defensive
+		// anyway.
+		return syserr.ErrInvalidArgument
+	}
+
+	switch hdr.RDMANetlinkOp() {
+	case linux.RDMA_NLDEV_CMD_GET:
+		return p.dumpDevices(data, msg, ms)
+	case linux.RDMA_NLDEV_CMD_GET_CHARDEV:
+		return p.getChardev(data, msg, ms)
+	case linux.RDMA_NLDEV_CMD_SYS_GET:
+		return p.sysGet(msg, ms)
+	default:
+		// Linux returns EINVAL for ops without a registered handler.
+		// rdma-core treats the NLMSG_ERROR as "netlink unavailable" and
+		// falls back to sysfs discovery.
+		return syserr.ErrInvalidArgument
+	}
+}
+
+// dumpDevices handles RDMA_NLDEV_CMD_GET dump requests, from
+// drivers/infiniband/core/nldev.c:nldev_get_dumpit.
+//
+// rdma-core requires DEV_INDEX, DEV_NAME, PORT_INDEX, DEV_NODE_TYPE and
+// NODE_GUID in every message, and skips devices missing any of them
+// (rdma-core libibverbs/ibdev_nl.c:find_sysfs_devs_nl_cb).
+func (p *Protocol) dumpDevices(data *rdma.Snapshot, msg *nlmsg.Message, ms *nlmsg.MessageSet) *syserr.Error {
+	hdr := msg.Header()
+	// Only the dump variant is supported; the doit variant is unused by
+	// rdma-core.
+	if hdr.Flags&linux.NLM_F_DUMP != linux.NLM_F_DUMP {
+		return syserr.ErrNotSupported
+	}
+
+	ms.Multi = true
+	for i, dev := range data.Devices {
+		m := ms.AddMessage(linux.NetlinkMessageHeader{
+			Type: hdr.Type,
+		})
+		m.PutAttr(linux.RDMA_NLDEV_ATTR_DEV_INDEX, primitive.AllocateUint32(uint32(i)))
+		m.PutAttrString(linux.RDMA_NLDEV_ATTR_DEV_NAME, dev.IBDev)
+		m.PutAttr(linux.RDMA_NLDEV_ATTR_PORT_INDEX, primitive.AllocateUint32(uint32(len(dev.Ports))))
+		m.PutAttr(linux.RDMA_NLDEV_ATTR_DEV_NODE_TYPE, primitive.AllocateUint8(parseNodeType(dev.IBAttrs["node_type"])))
+		guid := parseNodeGUID(dev.IBAttrs["node_guid"])
+		guidAttr := primitive.ByteSlice(guid[:])
+		m.PutAttr(linux.RDMA_NLDEV_ATTR_NODE_GUID, &guidAttr)
+	}
+	return nil
+}
+
+// getChardev handles RDMA_NLDEV_CMD_GET_CHARDEV requests, from
+// drivers/infiniband/core/nldev.c:nldev_get_chardev.
+func (p *Protocol) getChardev(data *rdma.Snapshot, msg *nlmsg.Message, ms *nlmsg.MessageSet) *syserr.Error {
+	attrs, ok := chardevAttrs(msg)
+	if !ok {
+		return syserr.ErrInvalidArgument
+	}
+	typAttr, ok := attrs[linux.RDMA_NLDEV_ATTR_CHARDEV_TYPE]
+	if !ok {
+		return syserr.ErrInvalidArgument
+	}
+
+	hdr := msg.Header()
+	switch typ := typAttr.String(); typ {
+	case "uverbs":
+		idxAttr, ok := attrs[linux.RDMA_NLDEV_ATTR_DEV_INDEX]
+		if !ok {
+			// The uverbs client is per-device; Linux fails requests
+			// without a device.
+			return syserr.ErrInvalidArgument
+		}
+		idx, ok := idxAttr.Uint32()
+		if !ok || int(idx) >= len(data.Devices) {
+			return syserr.ErrInvalidArgument
+		}
+		dev := &data.Devices[idx]
+
+		minor, ok := parseDevMinor(dev.Dev)
+		if !ok {
+			log.Warningf("Netlink RDMA: cannot parse dev %q of %s", dev.Dev, dev.Uverbs)
+			return syserr.ErrInvalidArgument
+		}
+
+		m := ms.AddMessage(linux.NetlinkMessageHeader{Type: hdr.Type})
+		m.PutAttrString(linux.RDMA_NLDEV_ATTR_CHARDEV_NAME, dev.Uverbs)
+		m.PutAttr(linux.RDMA_NLDEV_ATTR_CHARDEV_ABI, primitive.AllocateUint64(parseUint64(dev.ABIVersion)))
+		m.PutAttr(linux.RDMA_NLDEV_ATTR_CHARDEV, primitive.AllocateUint64(linux.HugeEncodeDev(ib.IB_UVERBS_MAJOR, minor)))
+		// DriverID was inferred at collection time, which means we don't need
+		// to run the sysfs scan fallback to match devices to driver IDs.
+		m.PutAttr(linux.RDMA_NLDEV_ATTR_UVERBS_DRIVER_ID, primitive.AllocateUint32(dev.DriverID))
+		return nil
+
+	default:
+		// Linux fails with ENOENT when no client matches the requested type.
+		log.Debugf("Netlink RDMA: unsupported chardev type %q", typ)
+		return syserr.ErrNoFileOrDir
+	}
+}
+
+// sysGet handles RDMA_NLDEV_CMD_SYS_GET requests, from
+// drivers/infiniband/core/nldev.c:nldev_sys_get_doit.
+//
+// RDMA pins MR pages to prevent them from being swapped out. If you fork a
+// parent process that uses RDMA that then writes to a page, the parent
+// receives a new copy of that page, while the child keeps the old one.
+// Meanwhile, the rNIC continues to DMA into the same physical page, now in the
+// child's address space. libibverbs addresses this issue with ibv_fork_init,
+// but it has multiple problems (see man pages). Linux 5.9 made it so that
+// DMA-pinned pages would be copied on fork, solving this issue. PR #14031
+// introduces this feature in gVisor, so we return 1 to tell the sRDMA
+// submodule that copy-on-fork is implemented.
+func (p *Protocol) sysGet(msg *nlmsg.Message, ms *nlmsg.MessageSet) *syserr.Error {
+	m := ms.AddMessage(linux.NetlinkMessageHeader{Type: msg.Header().Type})
+
+	// Devices are visible in all (i.e. the only) network namespaces,
+	// matching Linux's default ib_devices_shared_netns=true.
+	m.PutAttr(linux.RDMA_NLDEV_SYS_ATTR_NETNS_MODE, primitive.AllocateUint8(1))
+	m.PutAttr(linux.RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK, primitive.AllocateUint8(1))
+	return nil
+}
+
+// chardevAttrs returns the parsed attributes of a GET_CHARDEV message.
+func chardevAttrs(msg *nlmsg.Message) (map[uint16]nlmsg.BytesView, bool) {
+	// nldev messages carry no fixed payload header: attributes immediately
+	// follow the netlink header, so the fixed portion extracted by GetData is
+	// empty.
+	var empty primitive.ByteSlice
+	attrsView, ok := msg.GetData(&empty)
+	if !ok {
+		return nil, false
+	}
+	return attrsView.Parse()
+}
+
+// parseNodeType parses a sysfs node_type string such as "1: CA".
+func parseNodeType(s string) uint8 {
+	num, _, _ := strings.Cut(s, ":")
+	n, err := strconv.ParseUint(strings.TrimSpace(num), 10, 8)
+	if err != nil {
+		log.Warningf("Netlink RDMA: cannot parse node_type %q, defaulting to CA", s)
+		return 1 // RDMA_NODE_IB_CA
+	}
+	return uint8(n)
+}
+
+// parseNodeGUID parses a sysfs node_guid string such as
+// "0c42:a103:0065:2202" into raw big-endian bytes, the byte order Linux
+// sends the __be64 GUID in.
+func parseNodeGUID(s string) [8]byte {
+	var guid [8]byte
+	b, err := hex.DecodeString(strings.ReplaceAll(strings.TrimSpace(s), ":", ""))
+	if err != nil || len(b) != len(guid) {
+		log.Warningf("Netlink RDMA: cannot parse node_guid %q", s)
+		return guid
+	}
+	copy(guid[:], b)
+	return guid
+}
+
+// parseDevMinor returns the minor number of a sysfs dev file value, e.g.
+// "231:192".
+func parseDevMinor(s string) (uint32, bool) {
+	_, minStr, found := strings.Cut(strings.TrimSpace(s), ":")
+	if !found {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(minStr, 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(n), true
+}
+
+// parseUint64 parses a decimal sysfs value, returning 0 on error. Snapshot
+// attribute values are verbatim sysfs file contents including the trailing
+// newline, hence the trim.
+func parseUint64(s string) uint64 {
+	n, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// init registers the NETLINK_RDMA provider.
+func init() {
+	netlink.RegisterProvider(linux.NETLINK_RDMA, NewProtocol)
+}

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -106,6 +106,7 @@ go_library(
         "//pkg/sentry/socket/netfilter",
         "//pkg/sentry/socket/netlink",
         "//pkg/sentry/socket/netlink/netfilter",
+        "//pkg/sentry/socket/netlink/rdma",
         "//pkg/sentry/socket/netlink/route",
         "//pkg/sentry/socket/netlink/uevent",
         "//pkg/sentry/socket/netstack",

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -68,6 +68,7 @@ go_library(
         "//pkg/sentry/devices/nvproxy/nvconf",
         "//pkg/sentry/devices/rdmaproxy",
         "//pkg/sentry/devices/rdmaproxy/cxproxy",
+        "//pkg/sentry/devices/rdmaproxy/genericproxy",
         "//pkg/sentry/devices/tpuproxy",
         "//pkg/sentry/devices/tpuproxy/vfio",
         "//pkg/sentry/devices/ttydev",

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -96,6 +96,7 @@ import (
 	// Include other supported socket providers.
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink/netfilter"
+	rdmanetlink "gvisor.dev/gvisor/pkg/sentry/socket/netlink/rdma"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink/route"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink/uevent"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/unix"
@@ -575,6 +576,16 @@ func New(args Args) (*Loader, error) {
 	if specutils.RDMAEnabled(args.Spec, args.Conf) {
 		cxproxy.Init()
 		args.StartupTimer.Reached("RDMA proxy initialized")
+	}
+
+	// Publish the RDMA sysfs snapshot to the NETLINK_RDMA nldev shim before
+	// any application socket can exist. rdma-core discovers devices and binds
+	// userspace providers through nldev (RDMA_NLDEV_ATTR_UVERBS_DRIVER_ID);
+	// providers without a PCI-ID match table (e.g. libirdma) are unusable
+	// without it. A nil snapshot leaves the protocol unregistered-equivalent:
+	// socket(AF_NETLINK, ..., NETLINK_RDMA) fails as on a host without RDMA.
+	if args.RDMASysfs != nil {
+		rdmanetlink.Init(args.RDMASysfs)
 	}
 
 	eid := execID{cid: args.ID}

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -45,6 +45,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy"
 	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
 	"gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy/cxproxy"
+	"gvisor.dev/gvisor/pkg/sentry/devices/rdmaproxy/genericproxy"
 	"gvisor.dev/gvisor/pkg/sentry/fdimport"
 	cgroup2fs "gvisor.dev/gvisor/pkg/sentry/fsimpl/cgroup2fs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/host"
@@ -575,6 +576,7 @@ func New(args Args) (*Loader, error) {
 	}
 	if specutils.RDMAEnabled(args.Spec, args.Conf) {
 		cxproxy.Init()
+		genericproxy.Init()
 		args.StartupTimer.Reached("RDMA proxy initialized")
 	}
 


### PR DESCRIPTION
Addresses https://github.com/google/gvisor/issues/13686.

This PR adds support for Google NICs using the RDMA-Falcon stack. It adds two main features:
- A new RDMA_NETLINK protocol
-  A generic no-op driver plugin to rdmaproxy

In libibverbs, in the function `ibv_get_device_list`, uses netlink to discover
    devices available on a machine. If netlink is not supported, it will scan the
    sysfs tree and collect information about devices there as a fallback. In the
    second phase of device discovery, any devices are matched with a known driver.
    If a device was found through netlink, a driver is automatically matched, while
    devices found with sysfs will have to be matched to a driver through a known
    vendor PCI ID table. Google's custom rNICs are not in the rdma-core table, and
    so device discovery does not work with the current form of rdmaproxy out of the
    box.

 All information required by the protocol is gathered during the RDMA sysfs
    snapshot collection, before chroot. Then any netlink messages produced by a
    guest process will be served using the data collected in the snapshot, so the
    sentry never has to make a real netlink request to the kernel.

A generic plugin is needed because in iRDMA, CQ and QPs are actually implemented 
as MRs, which already get handled correctly by rdmaproxy core. Furthermore, these 
MRs are indexed by virtual addresses, so a guest VA is never dereferenced in kernel 
space for CQ/QP operations. Therefore a specialized driver plugin to rdmaproxy is not 
required.
    
Since we still have to register a driver-plugin for each device at registration
    time, we instead register a generic plugin which does nothing. We only register
    the generic plugin for an allow-list of drivers such as idpf or ice, which are
    all managed by the irdma subsystem.

Tested with successful completion of `ib_write_bw`, `ibv_rc_pingpong` between two h4d 
GCE VMs that achieves parity with un-sandboxed bandwidth rates.