### PR TITLE
socket/netlink: implement NETLINK_RDMA to report copy-on-fork

### DIFF
--- a/pkg/abi/linux/BUILD
+++ b/pkg/abi/linux/BUILD
@@ -59,6 +59,7 @@ go_library(
         "netfilter_ipv6.go",
         "netlink.go",
         "netlink_netfilter.go",
+        "netlink_rdma.go",
         "netlink_route.go",
         "nf_tables.go",
         "personality.go",

--- a/pkg/abi/linux/netlink_rdma.go
+++ b/pkg/abi/linux/netlink_rdma.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package linux
+
+// NETLINK_RDMA message clients and commands, from
+// include/uapi/rdma/rdma_netlink.h.
+const (
+	RDMA_NL_NLDEV = 5
+
+	RDMA_NLDEV_CMD_SYS_GET = 6
+)
+
+// RDMA_NLDEV_SYS_ATTR_* netlink attributes.
+const (
+	RDMA_NLDEV_SYS_ATTR_NETNS_MODE   = 66
+	RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK = 93
+)
+
+// RDMANLMsgType composes an NETLINK_RDMA message type from a client and op,
+// matching RDMA_NL_GET_TYPE in include/uapi/rdma/rdma_netlink.h.
+func RDMANLMsgType(client, op uint16) uint16 {
+	return (client << 10) | op
+}

--- a/pkg/sentry/socket/netlink/rdma/BUILD
+++ b/pkg/sentry/socket/netlink/rdma/BUILD
@@ -1,0 +1,21 @@
+load("//tools:defs.bzl", "go_library")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "rdma",
+    srcs = ["protocol.go"],
+    visibility = ["//pkg/sentry:internal"],
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/context",
+        "//pkg/marshal/primitive",
+        "//pkg/sentry/kernel",
+        "//pkg/sentry/socket/netlink",
+        "//pkg/sentry/socket/netlink/nlmsg",
+        "//pkg/syserr",
+    ],
+)

--- a/pkg/sentry/socket/netlink/rdma/protocol.go
+++ b/pkg/sentry/socket/netlink/rdma/protocol.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rdma provides a NETLINK_RDMA socket protocol.
+//
+// Only RDMA_NLDEV_CMD_SYS_GET is emulated. rdma-core's fork-safety detection
+// (ibv_is_fork_initialized) queries it to learn whether the host kernel does
+// copy-on-fork for pinned pages; without it, providers such as EFA arm an
+// abort-on-fork handler. The sentry implements copy-on-fork for pinned pages,
+// so registered memory is fork-safe; report copy-on-fork as supported.
+package rdma
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/marshal/primitive"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+	"gvisor.dev/gvisor/pkg/sentry/socket/netlink"
+	"gvisor.dev/gvisor/pkg/sentry/socket/netlink/nlmsg"
+	"gvisor.dev/gvisor/pkg/syserr"
+)
+
+// Protocol implements netlink.Protocol.
+//
+// +stateify savable
+type Protocol struct{}
+
+var _ netlink.Protocol = (*Protocol)(nil)
+
+// NewProtocol creates a NETLINK_RDMA netlink.Protocol.
+func NewProtocol(t *kernel.Task) (netlink.Protocol, *syserr.Error) {
+	return &Protocol{}, nil
+}
+
+// Protocol implements netlink.Protocol.Protocol.
+func (p *Protocol) Protocol() int {
+	return linux.NETLINK_RDMA
+}
+
+// CanSend implements netlink.Protocol.CanSend.
+func (p *Protocol) CanSend() bool {
+	return true
+}
+
+// Receive implements netlink.Protocol.Receive.
+func (p *Protocol) Receive(ctx context.Context, s *netlink.Socket, buf []byte) *syserr.Error {
+	return s.ProcessMessages(ctx, buf)
+}
+
+// ProcessMessage implements netlink.Protocol.ProcessMessage.
+func (p *Protocol) ProcessMessage(ctx context.Context, s *netlink.Socket, msg *nlmsg.Message, ms *nlmsg.MessageSet) *syserr.Error {
+	hdr := msg.Header()
+	if hdr.Type != linux.RDMANLMsgType(linux.RDMA_NL_NLDEV, linux.RDMA_NLDEV_CMD_SYS_GET) {
+		// All other RDMA netlink commands are unimplemented.
+		return syserr.ErrNotSupported
+	}
+	// See drivers/infiniband/core/nldev.c:nldev_sys_get_doit().
+	m := ms.AddMessage(linux.NetlinkMessageHeader{
+		Type: hdr.Type,
+	})
+	m.PutAttr(linux.RDMA_NLDEV_SYS_ATTR_NETNS_MODE, primitive.AllocateUint8(1))
+	m.PutAttr(linux.RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK, primitive.AllocateUint8(1))
+	return nil
+}
+
+// init registers the NETLINK_RDMA provider.
+func init() {
+	netlink.RegisterProvider(linux.NETLINK_RDMA, NewProtocol)
+}

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -105,6 +105,7 @@ go_library(
         "//pkg/sentry/socket/netfilter",
         "//pkg/sentry/socket/netlink",
         "//pkg/sentry/socket/netlink/netfilter",
+        "//pkg/sentry/socket/netlink/rdma",
         "//pkg/sentry/socket/netlink/route",
         "//pkg/sentry/socket/netlink/uevent",
         "//pkg/sentry/socket/netstack",

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -94,6 +94,7 @@ import (
 	// Include other supported socket providers.
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink/netfilter"
+	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink/rdma"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink/route"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/netlink/uevent"
 	_ "gvisor.dev/gvisor/pkg/sentry/socket/unix"


### PR DESCRIPTION
libfabric/rdma-core learn whether the host kernel does copy-on-fork for
pinned pages by querying NETLINK_RDMA's RDMA_NLDEV_CMD_SYS_GET for the
RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK attribute. When it is unset, providers such
as AWS EFA arm an abort-on-fork handler and SIGABRT the process on the first
fork() that has a registered MR (e.g. Megatron's async checkpoint save).

gVisor did not implement NETLINK_RDMA, so the query failed and every such
fork aborted. Add a NETLINK_RDMA provider that answers RDMA_NLDEV_CMD_SYS_GET
with COPY_ON_FORK=1, mirroring drivers/infiniband/core/nldev.c.

This answer is truthful because the sentry implements copy-on-fork for pinned
pages (#14031): rdmaproxy-pinned DMA pages stay stable across fork() while the
host driver keeps DMAing the original.

Depends on #14031; should be merged after it.