### PR TITLE
nvproxy: support MAXWELL_PROFILER_CONTEXT allocation class

### DIFF
--- a/pkg/abi/nvgpu/classes.go
+++ b/pkg/abi/nvgpu/classes.go
@@ -78,6 +78,7 @@ const (
 	GF100_ZBC_CLEAR                  = 0x00009096
 	GF100_SUBDEVICE_INFOROM          = 0x000090e7
 	GF100_PROFILER                   = 0x000090cc
+	MAXWELL_PROFILER_CONTEXT         = 0x0000b1cc
 	MAXWELL_PROFILER_DEVICE          = 0x0000b2cc
 	NV_COUNTER_COLLECTION_UNIT       = 0x0000cbca
 	GF100_SUBDEVICE_MASTER           = 0x000090e6
@@ -843,6 +844,15 @@ type NV_OFA_ALLOCATION_PARAMETERS_V545 struct {
 	_ structs.HostLayout
 	NV_OFA_ALLOCATION_PARAMETERS
 	EngineInstance uint32
+}
+
+// NVB1CC_ALLOC_PARAMETERS is the alloc params type for MAXWELL_PROFILER_CONTEXT,
+// from src/common/sdk/nvidia/inc/class/clb1cc.h.
+//
+// +marshal
+type NVB1CC_ALLOC_PARAMETERS struct {
+	_          structs.HostLayout
+	HSubDevice Handle
 }
 
 // NVB2CC_ALLOC_PARAMETERS is the alloc params type for MAXWELL_PROFILER_DEVICE,

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -984,10 +984,12 @@ func Init() {
 		v565_57_01 := addUnsupportedDriverABI(565, 57, 01, func() *driverABI {
 			abi := v560_28_03()
 			abi.controlCmd[nvgpu.NV2080_CTRL_CMD_GPU_GET_RECOVERY_ACTION] = ctrlHandler(rmControlSimple, nvconf.CapGraphics)
+			abi.allocationClass[nvgpu.MAXWELL_PROFILER_CONTEXT] = allocHandler(rmAllocSimple[nvgpu.NVB1CC_ALLOC_PARAMETERS], nvconf.CapProfiling)
 			prevGetInfo := abi.getInfo
 			abi.getInfo = func() *DriverABIInfo {
 				info := prevGetInfo()
 				info.ControlInfos[nvgpu.NV2080_CTRL_CMD_GPU_GET_RECOVERY_ACTION] = simpleIoctlInfo("NV2080_CTRL_CMD_GPU_GET_RECOVERY_ACTION", "NV2080_CTRL_GPU_GET_RECOVERY_ACTION_PARAMS")
+				info.AllocationInfos[nvgpu.MAXWELL_PROFILER_CONTEXT] = ioctlInfo("MAXWELL_PROFILER_CONTEXT", nvgpu.NVB1CC_ALLOC_PARAMETERS{})
 				return info
 			}
 			return abi


### PR DESCRIPTION
Allowlist allocation class `MAXWELL_PROFILER_CONTEXT` (`0xb1cc`) under `CapProfiling`.

NVIDIA headers introduce this class at driver `565.57.01`; register it on that ABI node next to the existing Maxwell profiler device allocation. This unblocks Nsight Compute paths that allocate a Maxwell profiler context object under gVisor nvproxy.

## Test plan
- [x] `make test TARGETS="//pkg/sentry/devices/nvproxy:nvproxy_test"`
- [ ] Re-run Nsight Compute under gVisor after this lands in a runsc build that includes the change