### PR TITLE
nvproxy: support PERF_RATED_TDP clock lock controls

### DIFF
--- a/pkg/abi/nvgpu/ctrl.go
+++ b/pkg/abi/nvgpu/ctrl.go
@@ -752,8 +752,10 @@ const (
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080perf.h:
 const (
-	NV2080_CTRL_CMD_PERF_BOOST              = 0x2080200a
-	NV2080_CTRL_CMD_PERF_GET_CURRENT_PSTATE = 0x20802068
+	NV2080_CTRL_CMD_PERF_BOOST                   = 0x2080200a
+	NV2080_CTRL_CMD_PERF_GET_CURRENT_PSTATE      = 0x20802068
+	NV2080_CTRL_CMD_PERF_RATED_TDP_GET_CONTROL   = 0x2080206e
+	NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL   = 0x2080206f
 )
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080rc.h:

--- a/pkg/sentry/devices/nvproxy/nvproxy_test.go
+++ b/pkg/sentry/devices/nvproxy/nvproxy_test.go
@@ -351,3 +351,52 @@ func TestFilterCapabilities(t *testing.T) {
 		})
 	}
 }
+
+// TestPerfRatedTDPControlCmdsRegistered locks that Nsight Compute clock-lock
+// controls are registered. Without these handlers, runsc returns
+// NV_ERR_NOT_SUPPORTED for 0x2080206f and ncu fails with
+// "Failed to lock GPU clock frequencies".
+func TestPerfRatedTDPControlCmdsRegistered(t *testing.T) {
+	Init()
+	cmds := []uint32{
+		nvgpu.NV2080_CTRL_CMD_PERF_RATED_TDP_GET_CONTROL,
+		nvgpu.NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL,
+	}
+	for _, ver := range []nvconf.DriverVersion{
+		nvconf.NewDriverVersion(535, 104, 5),
+		nvconf.NewDriverVersion(580, 95, 5),
+	} {
+		_, _, controlCmds, _, ok := SupportedIoctlsNumbers(ver)
+		if !ok {
+			t.Fatalf("SupportedIoctlsNumbers(%s) returned ok=false", ver)
+		}
+		for _, cmd := range cmds {
+			if _, defined := controlCmds[cmd]; !defined {
+				t.Errorf("control cmd %#x not defined on %s", cmd, ver)
+			}
+		}
+	}
+}
+
+// TestPerfRatedTDPSetControlRequiresProfilingCap checks CapProfiling gating
+// for RATED_TDP clock lock controls used by ncu --clock-control base.
+func TestPerfRatedTDPSetControlRequiresProfilingCap(t *testing.T) {
+	Init()
+	abi := abis[nvconf.NewDriverVersion(580, 95, 5)].cons()
+	handler := abi.controlCmd[nvgpu.NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL]
+	params := &nvgpu.NVOS54_PARAMETERS{}
+
+	utilityOnly := &frontendIoctlState{
+		fd: &frontendFD{dev: &frontendDevice{nvp: &nvproxy{capsEnabled: nvconf.CapUtility}}},
+	}
+	if _, err := handler.handle(utilityOnly, params); err != &errMissingCapability {
+		t.Errorf("without CapProfiling: got err=%v, want errMissingCapability", err)
+	}
+
+	profiling := &frontendIoctlState{
+		fd: &frontendFD{dev: &frontendDevice{nvp: &nvproxy{capsEnabled: nvconf.CapProfiling}}},
+	}
+	if _, err := handler.handle(profiling, params); err == &errMissingCapability || err == &errUndefinedHandler {
+		t.Errorf("with CapProfiling: got err=%v, want capability check to pass", err)
+	}
+}

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -314,6 +314,8 @@ func Init() {
 					nvgpu.NV2080_CTRL_CMD_NVLINK_GET_NVLINK_CAPS:                           ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_NVLINK_GET_NVLINK_STATUS:                         ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_PERF_BOOST:                                       ctrlHandler(rmControlSimple, compUtil),
+					nvgpu.NV2080_CTRL_CMD_PERF_RATED_TDP_GET_CONTROL:                       ctrlHandler(rmControlSimple, nvconf.CapProfiling),
+					nvgpu.NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL:                       ctrlHandler(rmControlSimple, nvconf.CapProfiling),
 					nvgpu.NV2080_CTRL_CMD_RC_GET_WATCHDOG_INFO:                             ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_RC_RELEASE_WATCHDOG_REQUESTS:                     ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_RC_SOFT_DISABLE_WATCHDOG:                         ctrlHandler(rmControlSimple, compUtil),
@@ -629,6 +631,8 @@ func Init() {
 							nvgpu.NV2080_CTRL_CMD_NVLINK_GET_NVLINK_CAPS:                           simpleIoctlInfo("NV2080_CTRL_CMD_NVLINK_GET_NVLINK_CAPS", "NV2080_CTRL_CMD_NVLINK_GET_NVLINK_CAPS_PARAMS"),
 							nvgpu.NV2080_CTRL_CMD_NVLINK_GET_NVLINK_STATUS:                         simpleIoctlInfo("NV2080_CTRL_CMD_NVLINK_GET_NVLINK_STATUS", "NV2080_CTRL_CMD_NVLINK_GET_NVLINK_STATUS_PARAMS"),
 							nvgpu.NV2080_CTRL_CMD_PERF_BOOST:                                       simpleIoctlInfo("NV2080_CTRL_CMD_PERF_BOOST", "NV2080_CTRL_PERF_BOOST_PARAMS"),
+							nvgpu.NV2080_CTRL_CMD_PERF_RATED_TDP_GET_CONTROL:                       simpleIoctlInfo("NV2080_CTRL_CMD_PERF_RATED_TDP_GET_CONTROL", "NV2080_CTRL_PERF_RATED_TDP_CONTROL_PARAMS"),
+							nvgpu.NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL:                       simpleIoctlInfo("NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL", "NV2080_CTRL_PERF_RATED_TDP_CONTROL_PARAMS"),
 							nvgpu.NV2080_CTRL_CMD_RC_GET_WATCHDOG_INFO:                             simpleIoctlInfo("NV2080_CTRL_CMD_RC_GET_WATCHDOG_INFO", "NV2080_CTRL_RC_GET_WATCHDOG_INFO_PARAMS"),
 							nvgpu.NV2080_CTRL_CMD_RC_RELEASE_WATCHDOG_REQUESTS:                     simpleIoctlInfo("NV2080_CTRL_CMD_RC_RELEASE_WATCHDOG_REQUESTS"), // No params.
 							nvgpu.NV2080_CTRL_CMD_RC_SOFT_DISABLE_WATCHDOG:                         simpleIoctlInfo("NV2080_CTRL_CMD_RC_SOFT_DISABLE_WATCHDOG"),     // No params.


### PR DESCRIPTION
## Summary
- Register `NV2080_CTRL_CMD_PERF_RATED_TDP_GET_CONTROL` (`0x2080206e`) and `NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL` (`0x2080206f`) as simple RM controls.
- Gate on `CapProfiling` (same class of privileged power/clock ops as `NV90CC_CTRL_CMD_POWER_*`).
- Without these handlers, nvproxy returns `NV_ERR_NOT_SUPPORTED` for `0x2080206f` and Nsight Compute fails with `Failed to lock GPU clock frequencies` on default `--clock-control base`.

### Evidence
On the same host/driver, LD_PRELOAD RM decode of `NV_ESC_RM_CONTROL` during `ncu --set basic` (default clocks):

| Runtime | `0x2080206f` status | ncu result |
| --- | --- | --- |
| gVisor | `0x56` (`NV_ERR_NOT_SUPPORTED`) | exit 9, clock lock error |
| runc | `0x0` | success |

Other cmds that also return `0x56` on both runtimes (`0x20800407`, `0xb0cc0119`) are not the differentiator.

`NV2080_CTRL_CMD_PERF_RATED_TDP_SET_CONTROL` is documented in NVIDIA open-gpu-kernel-modules (`ctrl2080perf.h`) and supports `FORCE_LOCK`, which matches ncu base-clock locking.

## Test plan
- [x] `make test TARGETS="//pkg/sentry/devices/nvproxy:nvproxy_test" OPTIONS="--test_filter=PerfRatedTDP --test_output=all --test_arg=-test.v"`
- [x] full `//pkg/sentry/devices/nvproxy:nvproxy_test`
- [ ] E2E: rebuild runsc with this change and confirm gVisor `ncu` (default clocks) no longer fails clock lock on H100/A100/etc.