### PR TITLE
boot: don't dereference a nil ThreadGroup when joining a PID namespace

### DIFF
--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -363,6 +363,19 @@ type execProcess struct {
 	// pidnsPath is the pid namespace path in spec
 	pidnsPath string
 
+	// pidns is the PID namespace that pidnsPath refers to. It is set together
+	// with pidnsPath, before the container's process is created, and holds a
+	// reference that is released when this execProcess is removed from
+	// Loader.processes (or by Loader.Destroy).
+	//
+	// Containers joining a PID namespace look this up instead of deriving it
+	// from tg, which is nil until the container actually starts. Keeping the
+	// namespace here means the mapping stays valid even if the container that
+	// created it never starts, and that the namespace is not leaked.
+	//
+	// Invariant: pidns is non-nil whenever pidnsPath has been set.
+	pidns *kernel.PIDNamespace
+
 	// cgroupnsPath is the cgroup namespace path in spec
 	cgroupnsPath string
 
@@ -370,6 +383,14 @@ type execProcess struct {
 	// TTY file is passed during container create and must be saved until
 	// container start.
 	hostTTY *fd.FD
+}
+
+// releasePIDNamespace drops the PID namespace reference held by ep, if any.
+func (ep *execProcess) releasePIDNamespace(ctx context.Context) {
+	if ep.pidns != nil {
+		ep.pidns.DecRef(ctx)
+		ep.pidns = nil
+	}
 }
 
 // fdMapping maps guest to host file descriptors. Guest file descriptors are
@@ -952,6 +973,11 @@ func (l *Loader) Destroy() {
 	for _, m := range l.sharedMounts {
 		m.DecRef(ctx)
 	}
+	// Release PID namespaces held by containers that were never destroyed
+	// individually, e.g. the root container.
+	for _, ep := range l.processes {
+		ep.releasePIDNamespace(ctx)
+	}
 	if l.cgroup2Mount != nil {
 		l.cgroup2Mount.DecRef(ctx)
 		l.cgroup2Mount = nil
@@ -1215,7 +1241,12 @@ func (l *Loader) run() error {
 
 	ep.tg = l.k.GlobalInit()
 	if ns, ok := specutils.GetNS(specs.PIDNamespace, l.root.spec); ok {
+		// The root container's process always runs in the root PID namespace.
+		// Record it alongside the path so that a subcontainer naming the same
+		// path joins it.
 		ep.pidnsPath = ns.Path
+		ep.pidns = l.k.RootPIDNamespace()
+		ep.pidns.IncRef()
 	}
 
 	// Handle signals by forwarding them to the root container process
@@ -1299,12 +1330,9 @@ func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid st
 		if ns.Path != "" {
 			for _, p := range l.processes {
 				if ns.Path == p.pidnsPath {
-					if p.tg == nil {
-						log.Warningf("PID namespace %q owner has no process, ignoring", ns.Path)
-						continue
-					}
 					log.Debugf("Joining PID namespace named %q", ns.Path)
-					pidns = p.tg.PIDNamespace()
+					pidns = p.pidns
+					pidns.IncRef()
 					break
 				}
 			}
@@ -1313,7 +1341,10 @@ func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid st
 			log.Warningf("PID namespace %q not found, running in new PID namespace", ns.Path)
 			pidns = l.k.RootPIDNamespace().NewChild(l.k.SupervisorContext(), l.k, l.k.RootUserNamespace())
 		}
+		// Publish the namespace, not just the path, so that containers joining it
+		// do not depend on this container ever starting.
 		ep.pidnsPath = ns.Path
+		ep.pidns = pidns
 	} else {
 		pidns = l.k.RootPIDNamespace()
 	}
@@ -1580,8 +1611,9 @@ func (l *Loader) destroySubcontainer(cid string) error {
 	// No more failure from this point on.
 
 	// Remove all container thread groups from the map.
-	for key := range l.processes {
+	for key, ep := range l.processes {
 		if key.cid == cid {
+			ep.releasePIDNamespace(l.k.SupervisorContext())
 			delete(l.processes, key)
 		}
 	}

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -1299,6 +1299,10 @@ func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid st
 		if ns.Path != "" {
 			for _, p := range l.processes {
 				if ns.Path == p.pidnsPath {
+					if p.tg == nil {
+						log.Warningf("PID namespace %q owner has no process, ignoring", ns.Path)
+						continue
+					}
 					log.Debugf("Joining PID namespace named %q", ns.Path)
 					pidns = p.tg.PIDNamespace()
 					break

--- a/runsc/container/multi_container_test.go
+++ b/runsc/container/multi_container_test.go
@@ -4519,3 +4519,83 @@ func TestMultiContainerSharedVolumeCheckpointRestore(t *testing.T) {
 		c.Wait()
 	}
 }
+
+// TestMultiContainerJoinPIDNSOwnerWithoutProcess tests that starting a
+// container which joins a PID namespace whose owning container failed to start
+// does not panic the sandbox.
+//
+// Regression test: a container records ep.pidnsPath early in
+// Loader.startSubcontainer, but its ThreadGroup is only assigned much later
+// (after several error returns). A container whose start fails in between is
+// left registered with pidnsPath set and tg == nil. A second container joining
+// the same path then dereferenced that nil ThreadGroup, panicking the sentry
+// and killing every container in the sandbox.
+func TestMultiContainerJoinPIDNSOwnerWithoutProcess(t *testing.T) {
+	rootDir, cleanup, err := testutil.SetupRootDir()
+	if err != nil {
+		t.Fatalf("error creating root dir: %v", err)
+	}
+	defer cleanup()
+
+	conf := testutil.TestConfig(t)
+	conf.RootDir = rootDir
+
+	const pidnsPath = "/proc/1/ns/pid"
+
+	// specs[0] is the sandbox; specs[1] and specs[2] both join the same PID
+	// namespace path.
+	testSpecs, ids := createSpecs(sleepCmd, sleepCmd, sleepCmd)
+	for _, i := range []int{1, 2} {
+		testSpecs[i].Linux = &specs.Linux{
+			Namespaces: []specs.LinuxNamespace{
+				{Type: "pid", Path: pidnsPath},
+			},
+		}
+	}
+	// Make container 1 fail to start *after* it records pidnsPath but *before*
+	// its ThreadGroup exists: a terminal is requested but no console socket is
+	// provided, so startSubcontainer returns early.
+	testSpecs[1].Process.Terminal = true
+
+	var containers []*Container
+	for i, spec := range testSpecs {
+		bundleDir, cleanupBundle, err := testutil.SetupBundleDir(spec)
+		if err != nil {
+			t.Fatalf("error setting up container %d: %v", i, err)
+		}
+		defer cleanupBundle()
+
+		cont, err := New(conf, Args{ID: ids[i], Spec: spec, BundleDir: bundleDir})
+		if err != nil {
+			t.Fatalf("error creating container %d: %v", i, err)
+		}
+		defer cont.Destroy()
+		containers = append(containers, cont)
+
+		err = cont.Start(conf)
+		switch i {
+		case 1:
+			// Expected to fail; this is what leaves tg == nil.
+			if err == nil {
+				t.Fatalf("container 1 started unexpectedly; the test needs its start to fail so that it is left registered without a process")
+			}
+			t.Logf("container 1 failed to start as intended: %v", err)
+		default:
+			if err != nil {
+				t.Fatalf("error starting container %d: %v", i, err)
+			}
+		}
+	}
+
+	// The sandbox must still be alive: before the fix, starting container 2
+	// panicked the sentry here.
+	expectedPL := []*control.Process{
+		newProcessBuilder().Cmd("sleep").Process(),
+	}
+	if err := waitForProcessList(containers[2], expectedPL); err != nil {
+		t.Errorf("failed to wait for sleep to start in container 2: %v", err)
+	}
+	if err := waitForProcessList(containers[0], expectedPL); err != nil {
+		t.Errorf("sandbox did not survive: root container unusable: %v", err)
+	}
+}


### PR DESCRIPTION
## What this fixes

Fixes #14071 - `Loader.startSubcontainer` calls `p.tg.PIDNamespace()` on a container found by PID-namespace path,
without checking that the container actually has a process. When it doesn't, the sentry takes a
nil-pointer panic and the whole sandbox dies.

A container advertises `pidnsPath` at line 1312 but only gets its `tg` at line 1361, with four
`return` paths in between. Any failure there leaves it registered with `pidnsPath` set and
`tg == nil` — and the next container joining that path panics.


## The change

`execProcess` now records the `*kernel.PIDNamespace` itself alongside `pidnsPath`, and
joining containers read that instead of `p.tg.PIDNamespace()`. Because the two fields are
assigned together, the mapping is valid as soon as it is published and no longer depends on
the container ever starting — the nil dereference becomes unreachable rather than guarded.
`ep` also becomes the namespace's owner: it takes over the reference returned by
`NewChild()` when it creates one and `IncRef`s when it joins one, releasing it in
`destroySubcontainer()` where the entry leaves `l.processes`, with a sweep in
`Loader.Destroy()` for anything still held. That fixes a reference leak which, as far as Ican tell, applied on the success path too and not only on failure — `NewChild()` hands back
a refcount of one owned by the caller, `NewThreadGroup()` takes its own, and
`CreateProcess()` never drops the caller's, but `startSubcontainer` had no matching
`DecRef` (compare `defer pidns.DecRef(t)` in `Task.Clone`).

`Loader.run()` gets the same treatment for the root container. It has the identical
publish-before-assign shape, and `ep.tg = l.k.GlobalInit()` can be nil there when restoring,
since that state creates no process. It now records `l.k.RootPIDNamespace()`, which is where
the root container's process runs and is never nil. Happy to split that into its own commit
if you would rather keep this one narrow.

## Why this shape

Recording the namespace preserves the sharing the spec asked for. Deferring the `pidnsPath`
assignment until `tg` exists also removes the crash, but a container whose owner failed to start would then find no owner and silently create a second namespace, so two containers
that asked to share a PID namespace would end up not sharing it. Keeping the namespace on
`ep` lets the second container join the one that was already created.

## Test coverage

This PR adds `TestMultiContainerJoinPIDNSOwnerWithoutProcess` to
`runsc/container/multi_container_test.go`. It starts a sandbox, then a container that is made to
fail *after* recording `pidnsPath` but *before* its `ThreadGroup` exists (`terminal: true` with no
console socket), then a second container joining the same PID namespace path — and asserts both
that the second container runs and that the sandbox is still alive afterwards.

The failure is deterministic; the test needs no retries or timing tricks.

## Verification

Built and tested with the pinned Bazel (`8.3.1` via bazelisk).

**The test fails without the fix** — the sentry panic shows up as the urpc connection dying
mid-call:

```
--- FAIL: TestMultiContainerJoinPIDNSOwnerWithoutProcess (0.16s)
    container 1 failed to start as intended: starting sub-container [/bin/sleep 1000]:
        terminal enabled but no TTY provided. Did you set --console-socket on create?
    error starting container 2: starting sub-container [/bin/sleep 1000]:
        urpc method "containerManager.StartSubcontainer" failed: EOF
```

and the sandbox is gone, not just that container:

```
destroying container "...": urpc method "containerManager.DestroySubcontainer" failed: connection reset by peer
destroying container "...": connecting to control server at PID 65: connection refused
```

**With the fix applied, the same test passes:**

```
//runsc/container:container_test    PASSED in 0.3s
Executed 1 out of 1 test: 1 test passes.
```

Regressions:

```
//runsc/container:container_test    PASSED in 32.3s   (all 8 shards; contains multi_container_test.go)
//runsc/boot:boot_nogo              PASSED
//runsc/boot:boot_test_nogo         PASSED
//runsc/boot:boot_test              FAILED  <- pre-existing, see below
```

`//runsc/boot:boot_test` fails in our environment on `TestHostnetWithRawSockets`:

```
loader_test.go:296: expected error to contain CAP_NET_RAW but got
    "starting control server: socket operation on non-socket"
```

We confirmed this is **not** caused by this change by stashing the patch and re-running the same
target on unmodified code — identical failure, same test, same message. It needs host networking
capabilities our sandboxed build environment doesn't grant.

`gofmt` is clean on both changed files, and `nogo` passes on the changed package.