### PR TITLE
test: add overlay copy-up tests for FIFOs and sockets

### DIFF
--- a/test/runner/main.go
+++ b/test/runner/main.go
@@ -867,25 +867,30 @@ func setupHostUDSTree(spec *specs.Spec) (cleanup func(), err error) {
 		Type:        "bind",
 	})
 
-	// Individual attach points for each socket to test mounts that attach
-	// directly to the sockets.
-	for _, protocol := range []string{"stream", "seqpacket"} {
-		for _, name := range []string{"echo", "nonlistening"} {
-			spec.Mounts = append(spec.Mounts, specs.Mount{
-				Destination: filepath.Join("/tmp/sockets-attach", protocol, name),
-				Source:      filepath.Join(socketDir, protocol, name),
-				Type:        "bind",
-			})
+	// Individual attach points mount a socket directly as the mount root. Such a
+	// mount cannot itself be wrapped in an overlay, so omit these mounts for
+	// overlay variants. The directory tree above can still be overlaid and
+	// exposes its sockets as lower-layer dentries.
+	if !*overlay {
+		for _, protocol := range []string{"stream", "seqpacket"} {
+			for _, name := range []string{"echo", "nonlistening"} {
+				spec.Mounts = append(spec.Mounts, specs.Mount{
+					Destination: filepath.Join("/tmp/sockets-attach", protocol, name),
+					Source:      filepath.Join(socketDir, protocol, name),
+					Type:        "bind",
+				})
+			}
 		}
+		spec.Mounts = append(spec.Mounts, specs.Mount{
+			Destination: "/tmp/sockets-attach/dgram/null",
+			Source:      filepath.Join(socketDir, "dgram/null"),
+			Type:        "bind",
+		})
+		spec.Process.Env = append(
+			spec.Process.Env, "TEST_UDS_ATTACH_TREE=/tmp/sockets-attach")
 	}
-	spec.Mounts = append(spec.Mounts, specs.Mount{
-		Destination: "/tmp/sockets-attach/dgram/null",
-		Source:      filepath.Join(socketDir, "dgram/null"),
-		Type:        "bind",
-	})
 
 	spec.Process.Env = append(spec.Process.Env, "TEST_UDS_TREE=/tmp/sockets")
-	spec.Process.Env = append(spec.Process.Env, "TEST_UDS_ATTACH_TREE=/tmp/sockets-attach")
 
 	return cleanup, nil
 }
@@ -925,18 +930,22 @@ func setupHostFifoTree(spec *specs.Spec) (cleanup func(), err error) {
 		Type:        "bind",
 	})
 
-	// Individual attach points for each pipe to test mounts that attach
-	// directly to the pipe.
-	for _, name := range []string{"in", "out"} {
-		spec.Mounts = append(spec.Mounts, specs.Mount{
-			Destination: filepath.Join("/tmp/pipes-attach", name),
-			Source:      filepath.Join(fifoDir, name),
-			Type:        "bind",
-		})
+	// Individual attach points mount a FIFO directly as the mount root. Such a
+	// mount cannot itself be wrapped in an overlay, so omit these mounts for
+	// overlay variants. The directory tree above can still be overlaid and exposes
+	// its FIFOs as lower-layer dentries.
+	if !*overlay {
+		for _, name := range []string{"in", "out"} {
+			spec.Mounts = append(spec.Mounts, specs.Mount{
+				Destination: filepath.Join("/tmp/pipes-attach", name),
+				Source:      filepath.Join(fifoDir, name),
+				Type:        "bind",
+			})
+		}
+		spec.Process.Env = append(spec.Process.Env, "TEST_FIFO_ATTACH_TREE=/tmp/pipes-attach")
 	}
 
 	spec.Process.Env = append(spec.Process.Env, "TEST_FIFO_TREE=/tmp/pipes")
-	spec.Process.Env = append(spec.Process.Env, "TEST_FIFO_ATTACH_TREE=/tmp/pipes-attach")
 
 	return cleanup, nil
 }

--- a/test/syscalls/BUILD
+++ b/test/syscalls/BUILD
@@ -166,6 +166,17 @@ syscall_test(
 
 syscall_test(
     add_host_fifo = True,
+    add_host_uds = True,
+    add_overlay = True,
+    allow_native = False,
+    one_sandbox = False,
+    save = False,
+    test = "//test/syscalls/linux:copy_up_test",
+    use_tmpfs = True,
+)
+
+syscall_test(
+    add_host_fifo = True,
     one_sandbox = False,
     # Takes too long to run with S/R.
     save = False,

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -647,6 +647,19 @@ cc_binary(
 )
 
 cc_binary(
+    name = "copy_up_test",
+    testonly = 1,
+    srcs = ["copy_up.cc"],
+    linkstatic = 1,
+    malloc = "//test/util:errno_safe_allocator",
+    deps = select_gtest() + [
+        "//test/util:fs_util",
+        "//test/util:test_main",
+        "//test/util:test_util",
+    ],
+)
+
+cc_binary(
     name = "pipe_external_test",
     testonly = 1,
     srcs = ["pipe_external.cc"],

--- a/test/syscalls/linux/copy_up.cc
+++ b/test/syscalls/linux/copy_up.cc
@@ -1,0 +1,96 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "test/util/fs_util.h"
+#include "test/util/test_util.h"
+
+namespace gvisor {
+namespace testing {
+namespace {
+
+// A host-backed FIFO exists before runsc applies the overlay, so in the
+// overlay variant it is a lower-layer dentry that cannot be copied up.
+TEST(CopyUpTest, LowerFIFOAccessForWriteFails) {
+  const char* fifo_root = getenv("TEST_FIFO_TREE");
+  ASSERT_NE(fifo_root, nullptr);
+
+  const std::string path = JoinPath(fifo_root, "out");
+
+  const struct stat st = ASSERT_NO_ERRNO_AND_VALUE(Lstat(path));
+  ASSERT_TRUE(S_ISFIFO(st.st_mode));
+
+  // This test specifically exercises overlay copy-up behavior. Other generated
+  // syscall-test variants don't have the relevant lower/upper relationship.
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(path)));
+
+  EXPECT_THAT(access(path.c_str(), W_OK), SyscallFailsWithErrno(EACCES));
+}
+
+TEST(CopyUpTest, LowerFIFOOpenForWriteFails) {
+  const char* fifo_root = getenv("TEST_FIFO_TREE");
+  ASSERT_NE(fifo_root, nullptr);
+
+  // "out" has a host-side reader, so opening the FIFO for writing does not
+  // block waiting for a reader.
+  const std::string path = JoinPath(fifo_root, "out");
+
+  const struct stat st = ASSERT_NO_ERRNO_AND_VALUE(Lstat(path));
+  ASSERT_TRUE(S_ISFIFO(st.st_mode));
+
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(path)));
+
+  EXPECT_THAT(open(path.c_str(), O_WRONLY), SyscallFailsWithErrno(EPERM));
+}
+
+TEST(CopyUpTest, LowerSocketAccessForWriteFails) {
+  const char* socket_root = getenv("TEST_UDS_TREE");
+  ASSERT_NE(socket_root, nullptr);
+
+  const std::string path = JoinPath(socket_root, "stream", "echo");
+
+  const struct stat st = ASSERT_NO_ERRNO_AND_VALUE(Lstat(path));
+  ASSERT_TRUE(S_ISSOCK(st.st_mode));
+
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(path)));
+
+  EXPECT_THAT(access(path.c_str(), W_OK), SyscallFailsWithErrno(EACCES));
+}
+
+TEST(CopyUpTest, LowerSocketOpenForWriteFails) {
+  const char* socket_root = getenv("TEST_UDS_TREE");
+  ASSERT_NE(socket_root, nullptr);
+
+  const std::string path = JoinPath(socket_root, "stream", "echo");
+
+  const struct stat st = ASSERT_NO_ERRNO_AND_VALUE(Lstat(path));
+  ASSERT_TRUE(S_ISSOCK(st.st_mode));
+
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(path)));
+
+  EXPECT_THAT(open(path.c_str(), O_WRONLY),
+              SyscallFailsWithErrno(EPERM));
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace gvisor


### PR DESCRIPTION
## Description

Add `CopyUpTest` coverage for non-copy-upable lower-layer FIFOs and Unix domain sockets under overlayfs.

The tests verify that:

* `access(..., W_OK)` fails with `EACCES` for lower-layer FIFOs and sockets.
* `open(O_WRONLY)` fails with `EPERM` instead of proceeding through an invalid copy-up path.

The host FIFO and UDS test fixtures are also adjusted for overlay variants. Individual special-file bind mounts are omitted because a FIFO or socket cannot itself be used as an overlay lower root, while the directory-backed mounts remain available to expose these files as lower-layer dentries.

This covers the non-copy-upable FIFO/socket cases from #13998. The remaining copy-up trigger, permission, and read-only mount cases can be covered separately.

Updates #13998

## Testing

* `make syscall-tests OPTIONS="--nocache_test_results" TARGETS="//test/syscalls:copy_up_test_runsc_systrap_overlay"`
* `make syscall-tests OPTIONS="--nocache_test_results" TARGETS="//test/syscalls:copy_up_test_runsc_systrap_directfs"`
* `make syscall-tests OPTIONS="--nocache_test_results" TARGETS="//test/syscalls:pipe_external_test_runsc_systrap_directfs"`
* `make syscall-tests OPTIONS="--nocache_test_results" TARGETS="//test/syscalls:connect_external_test_runsc_systrap_directfs"`
* `make test TARGETS="//test/runner:runner_nogo"`

Also verified the regression coverage by locally restoring the writable-open ordering that previously bypassed the non-copy-upable lower-layer check: `LowerFIFOOpenForWriteFails` failed with `EROFS` instead of the expected `EPERM`. Restoring the current implementation makes the test pass.
