### PR TITLE
checklocks: fix panic on cross-package use of unexported global guards

### DIFF
--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -82,6 +82,11 @@ lock must refer to one of:
 *   A global lock (e.g. globalMu).
 *   A lock resolvable from a global struct (e.g. globalX.mu).
 
+An unexported global lock is enforceable only within the package that declares
+it. Export data does not carry unexported package-level variables, so the lock
+cannot be resolved elsewhere and the annotation is silently skipped at use sites
+in other packages. Export the lock if cross-package enforcement is required.
+
 Like atomic access enforcement, checks may be elided on newly allocated objects.
 
 ### Function Annotations
@@ -101,7 +106,9 @@ The field provided in the `+checklocks` annotation must be resolvable as one of:
 *   A lock resolvable from a global struct (e.g. globalX.mu).
 
 This annotation will ensure that the given lock is held for all calls, and all
-analysis of this function will assume that this is the case.
+analysis of this function will assume that this is the case. The limitation on
+unexported global locks described above applies here also: callers in other
+packages cannot resolve the lock, so the annotation is not enforced for them.
 
 Additional variants of the `+checklocks` annotation are supported for functions:
 

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -248,8 +248,14 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 
 	// Check guards held.
 	for guardName, fgr := range lgf.GuardedBy {
-		guardsFound++
 		r := fgr.resolveField(pc, ls, from)
+		if r.unavailable {
+			// The guard has no object in this package, so it can
+			// neither be enforced nor counted here. This is not an
+			// error; see globalGuard.resolveCommon.
+			continue
+		}
+		guardsFound++
 		if !r.valid() {
 			// See above; this cannot be forced.
 			pc.maybeFail(inst.Pos(), "field %s cannot be resolved", guardName)
@@ -442,8 +448,10 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 		}
 		r := fg.Resolver.resolveCall(pc, ls, call.Common().Args, call.Value())
 		if !r.valid() {
-			// See above: this cannot be forced.
-			pc.maybeFail(call.Pos(), "field %s cannot be resolved", fieldName)
+			if !r.unavailable {
+				// See above: this cannot be forced.
+				pc.maybeFail(call.Pos(), "field %s cannot be resolved", fieldName)
+			}
 			continue
 		}
 		if s, ok := ls.unlockField(r, fg.Exclusive); !ok && !lff.Ignore {
@@ -460,6 +468,10 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 		}
 		// Acquire the lock per the annotation.
 		r := fg.Resolver.resolveCall(pc, ls, call.Common().Args, call.Value())
+		if r.unavailable {
+			// The lock cannot be tracked here; see above.
+			continue
+		}
 		if s, ok := ls.lockField(r, fg.Exclusive); !ok && !lff.Ignore {
 			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 				pc.maybeFail(call.Pos(), "attempt to acquire %s (%s), but already held (locks: %s)", fieldName, s, ls.String())
@@ -507,6 +519,11 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check that excluded locks are not held on entry.
 	for fieldName, fg := range lff.ExcludedOnEntry {
 		r := resolve(fg)
+		if r.unavailable {
+			// The lock has no object in this package, so it cannot
+			// be held here; see globalGuard.resolveCommon.
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); ok {
 			if !forced && !lff.Ignore {
 				if fg.Exclusive {
@@ -521,6 +538,10 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check all guards required are held.
 	for fieldName, fg := range lff.HeldOnEntry {
 		r := resolve(fg)
+		if r.unavailable {
+			// See above; the requirement cannot be checked here.
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); !ok {
 			if !forced && !lff.Ignore {
 				pc.maybeFail(callPos, "must hold %s %s (%s) to call %s, but not held (locks: %s)", fieldName, exclusiveStr(fg.Exclusive), s, fn.Name(), ls.String())

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -112,6 +112,11 @@ type fieldList []fieldEntry
 type resolvedValue struct {
 	value     ssa.Value
 	fieldList fieldList
+
+	// unavailable indicates that the guard object does not exist in this
+	// package, and therefore that the guard cannot be enforced here. This
+	// is distinct from a resolution failure: it is not reported.
+	unavailable bool
 }
 
 // makeResolvedValue makes a new resolvedValue.
@@ -119,6 +124,14 @@ func makeResolvedValue(v ssa.Value, fl fieldList) resolvedValue {
 	return resolvedValue{
 		value:     v,
 		fieldList: fl,
+	}
+}
+
+// makeUnavailableValue makes a resolvedValue for a guard that has no object in
+// this package. See globalGuard.resolveCommon.
+func makeUnavailableValue() resolvedValue {
+	return resolvedValue{
+		unavailable: true,
 	}
 }
 
@@ -205,7 +218,19 @@ func (g *globalGuard) resolveCommon(pc *passContext, ls *lockState) resolvedValu
 	if g.PackageName != "" && g.PackageName != state.Pkg.Pkg.Path() {
 		pkg = state.Pkg.Prog.ImportedPackage(g.PackageName)
 	}
-	v := pkg.Members[g.ObjectName].(ssa.Value)
+	// The object may not exist here. Facts travel across packages, but
+	// export data does not include unexported package-level variables, so
+	// an unexported guard has no object outside the package that declares
+	// it. The guard is simply not enforced at this use. Note that this is
+	// not reported: the annotation is valid, and there is no way for this
+	// package to name the lock in any case.
+	if pkg == nil {
+		return makeUnavailableValue()
+	}
+	v, ok := pkg.Members[g.ObjectName].(ssa.Value)
+	if !ok {
+		return makeUnavailableValue()
+	}
 	return makeResolvedValue(v, g.FieldList)
 }
 

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -25,6 +25,37 @@ var (
 	FooMu sync.Mutex
 )
 
+// CallFoo requires that FooMu is not held.
+//
+// +checklocksexclude:FooMu
+func CallFoo() {}
+
+var (
+	// barMu is deliberately not exported. Export data does not include
+	// unexported package-level variables, so other packages import the
+	// facts below but cannot resolve barMu itself. The guard is enforced
+	// within this package only.
+	barMu sync.Mutex
+
+	// +checklocks:barMu
+	Bar int
+)
+
+// CallBar requires that barMu is not held.
+//
+// +checklocksexclude:barMu
+func CallBar() {}
+
+func testUnexportedGlobalInvalid() {
+	Bar = 1 // +checklocksfail
+}
+
+func testUnexportedGlobalExcludeInvalid() {
+	barMu.Lock()
+	CallBar() // +checklocksfail
+	barMu.Unlock()
+}
+
 // GenericGuard is a generic type with a guarded field. This is used to verify
 // that facts exported by this package are correctly imported when another
 // package instantiates GenericGuard[T].

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -109,3 +109,21 @@ func testCrosspkgGlobalValid() {
 func testCrosspkgGlobalInvalid() {
 	crosspkg.Foo = 1 // +checklocksfail
 }
+
+func testCrosspkgGlobalExcludeValid() {
+	crosspkg.CallFoo()
+}
+
+func testCrosspkgGlobalExcludeInvalid() {
+	crosspkg.FooMu.Lock()
+	crosspkg.CallFoo() // +checklocksfail
+	crosspkg.FooMu.Unlock()
+}
+
+// The guard for the objects below is a package-level variable that crosspkg
+// does not export, so it cannot be resolved here. It is not enforced from this
+// package, and must not crash the analyzer.
+func testCrosspkgUnexportedGlobalValid() {
+	crosspkg.CallBar()
+	crosspkg.Bar = 1
+}


### PR DESCRIPTION
## Problem

Any checklocks annotation whose guard is an **unexported package-level variable** panics the analyzer when the annotated function is called — or the annotated field is accessed — from a different package:

```
panic: interface conversion: interface is nil, not ssa.Value
    gvisor.dev/gvisor/tools/checklocks.(*globalGuard).resolveCommon(...)
        tools/checklocks/facts.go:208
```

Both resolution paths are affected — `resolveCall` (via `checkFunctionCall`) and `resolveField` (via `checkGuards`/`checkFieldAccess`). Minimal repro matrix (two packages: the guard-defining one and a caller):

| guard | call annotation (`+checklocksexclude:` etc.) | field annotation (`+checklocks:`) |
|---|---|---|
| unexported global | panic | panic |
| exported global | works, enforces | works, enforces |

## Root cause

`resolveCommon` does `pkg.Members[g.ObjectName].(ssa.Value)` unchecked. For a cross-package use site, the guard package's SSA is created from export data, which does not include unexported package-level variables — the member lookup returns nil and the type assertion panics. (The interface-conversion, rather than nil-pointer, panic shows the package itself resolved; only the member is missing.)

History: #7721 (2022) fixed the exported cross-package case by adding the `ImportedPackage` lookup, but the tests it added only cover exported guards. The field-path variant of this panic has been latent since then; the call-path variant became commonly reachable when `checklocksexclude{,write}` landed (#12439).

## Fix

Resolution now yields an explicitly *unavailable* `resolvedValue` when the guard object has no member in the resolving package, and the five use sites skip such guards instead of enforcing, reporting, or panicking. `unavailable` is deliberately distinct from the existing invalid state: invalid values are reported as `"field %s cannot be resolved"` in some paths and `panic` in `lockState.isHeld`/`lockField` in others, and neither is right here — the annotation itself is valid and remains fully enforced inside its defining package, so a use site that cannot materialize the object should be silent.

Skipping is sound: a consuming package could only hold the unresolvable guard via an acquire-annotated API whose fact references the same unresolvable object, so the acquisition could never enter its lock state either — the skipped check is vacuously unviolatable. This matches the analyzer's existing elision behavior (newly allocated objects, closures). In `checkGuards`, an unavailable guard is also excluded from `guardsFound` so it cannot silently relax a mixed `+checkatomic` field.

The README now documents the limitation in both places that list global locks as resolvable: an unexported global lock is enforceable only within its declaring package; export the lock if cross-package enforcement is required.

## Tests

`test/crosspkg` + `test/globals.go` gain unexported-global-guard coverage for both paths, with `+checklocksfail` expectations verified load-bearing (removing them makes the analyzer report `missing expected failure`). Before the fix, the new tests reproduce the panic; after it, the analyzer's output over the whole test tree is otherwise identical to the pre-change baseline, and the exported cross-package cases still enforce.

Generated by the Author with assistance from Claude Code