### PR TITLE
netstack: drain all packets from GRO buckets on Flush

### DIFF
--- a/pkg/tcpip/stack/gro/gro.go
+++ b/pkg/tcpip/stack/gro/gro.go
@@ -548,11 +548,13 @@ func (gd *GRO) bucketForPacket6(ipHdr header.IPv6, tcpHdr header.TCP) int {
 // Flush sends all packets up the stack.
 func (gd *GRO) Flush() {
 	for i := range gd.buckets {
-		for groPkt := gd.buckets[i].packets.Front(); groPkt != nil; groPkt = groPkt.Next() {
+		for groPkt := gd.buckets[i].packets.Front(); groPkt != nil; {
+			next := groPkt.Next()
 			pkt := groPkt.pkt
 			gd.buckets[i].removeOne(groPkt)
 			gd.handlePacket(pkt)
 			pkt.DecRef()
+			groPkt = next
 		}
 	}
 }

--- a/pkg/tcpip/stack/gro/gro_test.go
+++ b/pkg/tcpip/stack/gro/gro_test.go
@@ -17,12 +17,51 @@ package gro
 import (
 	"math/bits"
 	"testing"
+
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
+
+type countingDispatcher struct {
+	delivered int
+}
+
+func (d *countingDispatcher) DeliverNetworkPacket(tcpip.NetworkProtocolNumber, *stack.PacketBuffer) {
+	d.delivered++
+}
+
+func (*countingDispatcher) DeliverLinkPacket(tcpip.NetworkProtocolNumber, *stack.PacketBuffer) {
+}
 
 func TestNBuckets(t *testing.T) {
 	// groNBuckets must be a power of 2 so that we can use groNBuckets-1 as
 	// a mask when indexing into the list of buckets.
 	if bits.OnesCount(groNBuckets) != 1 {
 		t.Fatalf("groNBuckets is not a power of two")
+	}
+}
+
+func TestFlushDrainsBucket(t *testing.T) {
+	dispatcher := &countingDispatcher{}
+	gd := GRO{Dispatcher: dispatcher}
+	gd.Init(true)
+	bucket := &gd.buckets[0]
+	for i := 0; i < groBucketSize; i++ {
+		packet := stack.NewPacketBuffer(stack.PacketBufferOptions{})
+		bucket.insert(packet, nil, nil)
+	}
+	t.Cleanup(func() {
+		for bucket.count != 0 {
+			bucket.removeOldest().DecRef()
+		}
+	})
+
+	gd.Flush()
+
+	if got := dispatcher.delivered; got != groBucketSize {
+		t.Errorf("Flush delivered %d packets, want %d", got, groBucketSize)
+	}
+	if got := bucket.count; got != 0 {
+		t.Errorf("Flush left %d packets in bucket, want 0", got)
 	}
 }


### PR DESCRIPTION
GRO.Flush removed the current packet before advancing the list iterator.
groPacketList.Remove clears the removed entry's next and previous links, and
groBucket.removeOne resets the entry. As a result, groPkt.Next() always
returned nil after the first removal, so Flush delivered at most one packet
from each bucket.

Fetch the bucket front after every removal instead. This drains the bucket
without accessing links from a removed entry.

Add a regression test that fills a GRO bucket to capacity and verifies that
Flush delivers every packet and leaves the bucket empty.