### PR TITLE
mm: enforce RLIMIT_DATA considering total data segment size (heap + data + bss)

### DIFF
--- a/pkg/sentry/mm/mm_test.go
+++ b/pkg/sentry/mm/mm_test.go
@@ -148,6 +148,47 @@ func TestBrkDataLimitUpdates(t *testing.T) {
 	}
 }
 
+func TestBrkDataLimitIncludesPrivateData(t *testing.T) {
+	// Set RLIMIT_DATA to 2 pages.
+	limitSet := limits.NewLimitSet()
+	limitSet.Set(limits.Data, limits.Limit{Cur: 2 * uint64(hostarch.PageSize), Max: limits.Infinity}, true /* privileged */)
+
+	ctx := contexttest.WithLimitSet(contexttest.Context(t), limitSet)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	// Set up a valid, page-aligned heap start address above MinUserAddress.
+	mm.BrkSetup(ctx, 0x10000)
+
+	// Map a private, writable segment of 1 page (simulating .data/.bss).
+	_, err := mm.MMap(ctx, memmap.MMapOpts{
+		Length:   hostarch.PageSize,
+		Private:  true,
+		Perms:    hostarch.ReadWrite,
+		MaxPerms: hostarch.AnyAccess,
+	})
+	if err != nil {
+		t.Fatalf("MMap failed: %v", err)
+	}
+
+	oldBrk, _ := mm.Brk(ctx, 0)
+	if oldBrk != 0x10000 {
+		t.Fatalf("unexpected initial brk: got %#x, want 0x10000", oldBrk)
+	}
+
+	// Extending brk by 2 pages would bring total data to 3 pages (> RLIMIT_DATA of 2 pages),
+	// which must fail.
+	if newBrk, _ := mm.Brk(ctx, oldBrk+2*hostarch.PageSize); newBrk != oldBrk {
+		t.Errorf("brk() increased total data segment above RLIMIT_DATA (old brk = %#x, new brk = %#x)", oldBrk, newBrk)
+	}
+
+	// Extending brk by 1 page brings total data to 2 pages (<= RLIMIT_DATA of 2 pages),
+	// which must succeed.
+	if newBrk, _ := mm.Brk(ctx, oldBrk+hostarch.PageSize); newBrk != oldBrk+hostarch.PageSize {
+		t.Errorf("brk() failed to increase data segment within RLIMIT_DATA (old brk = %#x, wanted brk = %#x, got brk = %#x)", oldBrk, oldBrk+hostarch.PageSize, newBrk)
+	}
+}
+
 // TestIOAfterUnmap ensures that IO fails after unmap.
 func TestIOAfterUnmap(t *testing.T) {
 	ctx := contexttest.Context(t)

--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -768,15 +768,16 @@ func (mm *MemoryManager) Brk(ctx context.Context, addr hostarch.Addr) (hostarch.
 		return addr, linuxerr.EINVAL
 	}
 
-	// TODO(gvisor.dev/issue/156): This enforces RLIMIT_DATA, but is
-	// slightly more permissive than the usual data limit. In particular,
-	// this only limits the size of the heap; a true RLIMIT_DATA limits the
-	// size of heap + data + bss. The segment sizes need to be plumbed from
-	// the loader package to fully enforce RLIMIT_DATA.
-	if uint64(addr-mm.brk.Start) > limits.FromContext(ctx).Get(limits.Data).Cur {
-		addr = mm.brk.End
-		mm.mappingMu.Unlock()
-		return addr, linuxerr.ENOMEM
+	// RLIMIT_DATA limits the total size of private data segments (heap + data
+	// + bss + private writable mappings), tracked by mm.dataAS.
+	if addr > mm.brk.End {
+		add := uint64(addr - mm.brk.End)
+		rlimitData := limits.FromContext(ctx).Get(limits.Data).Cur
+		if mm.dataAS+add < mm.dataAS || mm.dataAS+add > rlimitData {
+			addr = mm.brk.End
+			mm.mappingMu.Unlock()
+			return addr, linuxerr.ENOMEM
+		}
 	}
 
 	oldbrkpg, _ := mm.brk.End.RoundUp()


### PR DESCRIPTION
Currently, MemoryManager.Brk only enforces RLIMIT_DATA for the heap because it only checks `uint64(addr - mm.brk.Start)` against the limit, ignoring the size of other private writable segments (like .data and .bss) which are mapped by the loader and tracked by `mm.dataAS`.

Fix this by checking the total size of private writable data segments (heap + data + bss + private writable mappings) against RLIMIT_DATA.

Fixes #156.
Assisted-by: Gemini CLI