### PR TITLE
devpts: return ESPIPE for positional I/O on PTYs

### DIFF
--- a/pkg/sentry/fsimpl/devpts/master.go
+++ b/pkg/sentry/fsimpl/devpts/master.go
@@ -67,6 +67,8 @@ func (mi *masterInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernf
 	fd.LockFD.Init(&mi.locks)
 	if err := fd.vfsfd.Init(fd, opts.Flags, rp.Credentials(), rp.Mount(), d.VFSDentry(), &vfs.FileDescriptionOptions{
 		SpecialFile: true,
+		DenyPRead:   true,
+		DenyPWrite:  true,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/sentry/fsimpl/devpts/terminal.go
+++ b/pkg/sentry/fsimpl/devpts/terminal.go
@@ -75,6 +75,8 @@ func (t *Terminal) OpenTTY(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry
 	fd.LockFD.Init(&ri.locks)
 	if err := fd.vfsfd.Init(fd, opts.Flags, tsk.Credentials(), mnt, vfsd, &vfs.FileDescriptionOptions{
 		SpecialFile: true,
+		DenyPRead:   true,
+		DenyPWrite:  true,
 	}); err != nil {
 		return nil, err
 	}

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -2166,6 +2166,7 @@ cc_binary(
     deps = select_gtest() + [
         "//test/util:file_descriptor",
         "//test/util:posix_error",
+        "//test/util:pty_util",
         "//test/util:temp_path",
         "//test/util:test_main",
         "//test/util:test_util",
@@ -2403,6 +2404,7 @@ cc_binary(
         ":file_base",
         "//test/util:file_descriptor",
         "//test/util:posix_error",
+        "//test/util:pty_util",
         "//test/util:temp_path",
         "//test/util:test_main",
         "//test/util:test_util",

--- a/test/syscalls/linux/preadv2.cc
+++ b/test/syscalls/linux/preadv2.cc
@@ -25,6 +25,7 @@
 #include "absl/memory/memory.h"
 #include "test/syscalls/linux/file_base.h"
 #include "test/util/file_descriptor.h"
+#include "test/util/pty_util.h"
 #include "test/util/temp_path.h"
 #include "test/util/test_util.h"
 
@@ -290,6 +291,44 @@ TEST(Preadv2Test, TestUnseekableFileValid) {
 
   EXPECT_THAT(close(pipe_fds[0]), SyscallSucceeds());
   EXPECT_THAT(close(pipe_fds[1]), SyscallSucceeds());
+}
+
+TEST(Preadv2Test, PtyWithOffset) {
+  SKIP_IF(preadv2(-1, nullptr, 0, 0, 0) < 0 && errno == ENOSYS);
+
+  const FileDescriptor master =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/ptmx", O_RDWR | O_NOCTTY));
+  const FileDescriptor replica = ASSERT_NO_ERRNO_AND_VALUE(OpenReplica(master));
+  char buf[2] = {};
+  struct iovec iov = {buf, sizeof(buf)};
+
+  const auto check_endpoint = [&](int fd) {
+    EXPECT_THAT(preadv(fd, &iov, /*iovcnt=*/1, /*offset=*/0),
+                SyscallFailsWithErrno(ESPIPE));
+    EXPECT_THAT(preadv2(fd, &iov, /*iovcnt=*/1, /*offset=*/0, /*flags=*/0),
+                SyscallFailsWithErrno(ESPIPE));
+  };
+  check_endpoint(master.get());
+  check_endpoint(replica.get());
+
+  const char replica_output = 'x';
+  ASSERT_THAT(write(replica.get(), &replica_output, sizeof(replica_output)),
+              SyscallSucceedsWithValue(sizeof(replica_output)));
+  iov.iov_len = sizeof(replica_output);
+  EXPECT_THAT(preadv2(master.get(), &iov, /*iovcnt=*/1,
+                      /*offset=*/static_cast<off_t>(-1), /*flags=*/0),
+              SyscallSucceedsWithValue(sizeof(replica_output)));
+  EXPECT_EQ(buf[0], replica_output);
+
+  const char master_input[] = {'y', '\n'};
+  ASSERT_THAT(write(master.get(), master_input, sizeof(master_input)),
+              SyscallSucceedsWithValue(sizeof(master_input)));
+  iov.iov_len = sizeof(master_input);
+  EXPECT_THAT(preadv2(replica.get(), &iov, /*iovcnt=*/1,
+                      /*offset=*/static_cast<off_t>(-1), /*flags=*/0),
+              SyscallSucceedsWithValue(sizeof(master_input)));
+  EXPECT_EQ(std::string(buf, sizeof(buf)),
+            std::string(master_input, sizeof(master_input)));
 }
 
 }  // namespace

--- a/test/syscalls/linux/pwritev2.cc
+++ b/test/syscalls/linux/pwritev2.cc
@@ -23,6 +23,7 @@
 #include "gtest/gtest.h"
 #include "test/syscalls/linux/file_base.h"
 #include "test/util/file_descriptor.h"
+#include "test/util/pty_util.h"
 #include "test/util/temp_path.h"
 #include "test/util/test_util.h"
 
@@ -263,6 +264,28 @@ TEST(Pwritev2Test, UnseekableFileInvalid) {
 
   EXPECT_THAT(close(pipe_fds[0]), SyscallSucceeds());
   EXPECT_THAT(close(pipe_fds[1]), SyscallSucceeds());
+}
+
+TEST(Pwritev2Test, PtyWithOffset) {
+  SKIP_IF(pwritev2(-1, nullptr, 0, 0, 0) < 0 && errno == ENOSYS);
+
+  const FileDescriptor master =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/dev/ptmx", O_RDWR | O_NOCTTY));
+  const FileDescriptor replica = ASSERT_NO_ERRNO_AND_VALUE(OpenReplica(master));
+  char buf = 'x';
+  struct iovec iov = {&buf, sizeof(buf)};
+
+  const auto check_endpoint = [&](int fd) {
+    EXPECT_THAT(pwritev(fd, &iov, /*iovcnt=*/1, /*offset=*/0),
+                SyscallFailsWithErrno(ESPIPE));
+    EXPECT_THAT(pwritev2(fd, &iov, /*iovcnt=*/1, /*offset=*/0, /*flags=*/0),
+                SyscallFailsWithErrno(ESPIPE));
+    EXPECT_THAT(pwritev2(fd, &iov, /*iovcnt=*/1,
+                         /*offset=*/static_cast<off_t>(-1), /*flags=*/0),
+                SyscallSucceedsWithValue(sizeof(buf)));
+  };
+  check_endpoint(master.get());
+  check_endpoint(replica.get());
 }
 
 TEST(Pwritev2Test, ReadOnlyFile) {


### PR DESCRIPTION
Description

PTY master and replica file descriptions currently fall through to the default
PRead and PWrite implementations, which return EINVAL. Mark both endpoints as
denying positional reads and writes so VFS returns ESPIPE before dispatching the
operation.

This matches Linux for preadv, preadv2, pwritev, and pwritev2 with explicit
offsets while preserving preadv2 and pwritev2 with offset -1 as streaming I/O.
It also lets callers such as Zig file writers recognize PTYs as unseekable and
fall back to normal streaming writes.

Fixes #13737.

Tests

- //test/syscalls:preadv2_test_runsc_systrap_directfs
- //test/syscalls:preadv2_test_runsc_ptrace
- bazel-bin/test/syscalls/linux/preadv2_test --gtest_filter=Preadv2Test.PtyWithOffset (native Linux)
- //test/syscalls:pwritev2_test_runsc_systrap_directfs
- //test/syscalls:pwritev2_test_runsc_ptrace
- //test/syscalls:pwritev2_test_native (focused PTY regression)
- //pkg/sentry/fsimpl/devpts:devpts_test
- //pkg/sentry/fsimpl/devpts:devpts_nogo
- //pkg/sentry/fsimpl/devpts:devpts_test_nogo

Assisted-by: Codex