### PR TITLE
fix(runsc): enforce OCI poststart hook failure semantics

### DIFF
--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -516,11 +516,12 @@ func (c *Container) startImpl(conf *config.Config, action string, startRoot func
 		}
 	}
 
-	// "If any poststart hook fails, the runtime MUST log a warning, but
-	// the remaining hooks and lifecycle continue as if the hook had
-	// succeeded" -OCI spec.
+	// "If any poststart hook fails, the runtime MUST generate an error,
+	// stop the container, and continue the lifecycle at step 12" - OCI spec.
 	if c.Spec.Hooks != nil {
-		specutils.ExecuteHooksBestEffort(c.Spec.Hooks.Poststart, c.State())
+		if err := specutils.ExecuteHooks(c.Spec.Hooks.Poststart, c.State()); err != nil {
+			return err
+		}
 	}
 
 	c.changeStatus(Running)

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -512,6 +512,44 @@ func sleepSpecConf(t *testing.T) (*specs.Spec, *config.Config) {
 	return testutil.NewSpecWithArgs("sleep", "1000"), testutil.TestConfig(t)
 }
 
+func TestPostStartHookFailure(t *testing.T) {
+	for name, conf := range configs(t, false /* noOverlay */) {
+		t.Run(name, func(t *testing.T) {
+			spec, _ := sleepSpecConf(t)
+			spec.Hooks = &specs.Hooks{
+				Poststart: []specs.Hook{{
+					Path: "/bin/sh",
+					Args: []string{"/bin/sh", "-c", "exit 1"},
+				}},
+			}
+			_, bundleDir, cleanup, err := testutil.SetupContainer(spec, conf)
+			if err != nil {
+				t.Fatalf("error setting up container: %v", err)
+			}
+			defer cleanup()
+
+			args := Args{
+				ID:        testutil.RandomContainerID(),
+				Spec:      spec,
+				BundleDir: bundleDir,
+			}
+			c, err := New(conf, args)
+			if err != nil {
+				t.Fatalf("error creating container: %v", err)
+			}
+			defer func() {
+				if c != nil {
+					_ = c.Destroy()
+				}
+			}()
+
+			if err := c.Start(conf); err == nil {
+				t.Fatal("container start succeeded with a failing poststart hook")
+			}
+		})
+	}
+}
+
 func TestGetNetworkConfig(t *testing.T) {
 	for name, conf := range configs(t, false /* noOverlay */) {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Description
Fixes #13128.
This change fixes runsc's handling of OCI poststart hooks to match the current runtime lifecycle specification.
Previously, runsc invoked poststart hooks in best-effort mode and ignored failures, allowing the container to continue starting even when a hook exited with an error. This contradicts the OCI lifecycle requirement: if any poststart hook fails, the runtime must generate an error and stop the container.
This patch:
executes poststart hooks with strict error checking;
returns the hook failure from container startup;
adds a regression test covering a failing poststart hook.
Why
Matches the behavior required by the OCI Runtime Specification.
Aligns runsc with the OCI runtime lifecycle contract.
Prevents hook failures during container startup from being silently ignored.
Testing
Added regression coverage in container_test.go for a failing poststart hook.
TestPostStartHookFailure/ptrace passes locally.
KVM variants could not be run locally because /dev/kvm is unavailable in the test environment.
Notes
This is a behavior change: a failing poststart hook now causes container startup to fail instead of the failure being logged as a warning while startup continues.