### PR TITLE
Spawn sandbox subprocesses directly in target cgroup using `clone3(CLONE_INTO_CGROUP)`

### DIFF
--- a/runsc/cgroup/BUILD
+++ b/runsc/cgroup/BUILD
@@ -10,10 +10,12 @@ go_library(
     srcs = [
         "cgroup.go",
         "cgroup_v2.go",
+        "cgroup_v2_unsafe.go",
         "systemd.go",
     ],
     visibility = ["//:sandbox"],
     deps = [
+        "//pkg/abi/linux",
         "//pkg/cleanup",
         "//pkg/log",
         "@com_github_cenkalti_backoff//:go_default_library",

--- a/runsc/cgroup/cgroup.go
+++ b/runsc/cgroup/cgroup.go
@@ -34,6 +34,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
 )
@@ -366,6 +367,7 @@ type Cgroup interface {
 	Update(res *specs.LinuxResources) error
 	Uninstall() error
 	Join() (func(), error)
+	CloneIntoCgroup() (*os.File, error)
 	CPUQuota() (int64, error)
 	CPUPeriod() (int64, error)
 	CPUUsage() (uint64, error)
@@ -729,6 +731,11 @@ func (c *cgroupV1) Join() (func(), error) {
 	return cu.Release(), nil
 }
 
+// CloneIntoCgroup implements Cgroup.CloneIntoCgroup.
+func (c *cgroupV1) CloneIntoCgroup() (*os.File, error) {
+	return nil, errors.New("cgroup v2 required to use CLONE_INTO_CGROUP")
+}
+
 // CPUQuota returns the raw CFS CPU quota in microseconds.
 // A value of -1 means unlimited.
 func (c *cgroupV1) CPUQuota() (int64, error) {
@@ -1071,16 +1078,31 @@ func (*hugeTLB) set(spec *specs.LinuxResources, path string) error {
 	return nil
 }
 
-// RunInCgroup executes fn inside the specified cgroup. If cg is nil, execute
-// it in the current context.
-func RunInCgroup(cg Cgroup, fn func() error) error {
+// RunInCgroup executes `fn` such that every subprocess `fn` creates ends up
+// inside `cg`.
+// `fn` is called with `cloneIntoCgroupFD` that may be nil.
+// If `cloneIntoCgroupFD` is non-nil, `fn` has to use it for
+// `SysProcAttr.CgroupFD` (and set `SysProcAttr.UseCgroupFD = true`).
+// This will use `clone3(CLONE_INTO_CGROUP)` which is fast.
+// If `cloneIntoCgroupFD` is nil, `fn` doesn't need to touch these fields and
+// can simply create a subprocess as normal. It will be created in the correct
+// cgroup by virtue of `RunInCgroup` switching into this cgroup before calling
+// `fn`.
+// If `cg` is nil, `fn` simply runs in the current context.
+func RunInCgroup(cg Cgroup, fn func(cloneIntoCgroupFD *os.File) error) error {
 	if cg == nil {
-		return fn()
+		return fn(nil)
 	}
+	cgroupFD, err := cg.CloneIntoCgroup()
+	if err == nil {
+		defer cgroupFD.Close()
+		return fn(cgroupFD)
+	}
+	log.Warningf("Cannot clone children directly into cgroup %q: %v. Joining it instead. This slows down gVisor startup and checkpoint/restore.", cg.MakePath(""), err)
 	restore, err := cg.Join()
 	if err != nil {
 		return err
 	}
 	defer restore()
-	return fn()
+	return fn(nil)
 }

--- a/runsc/cgroup/cgroup_v2.go
+++ b/runsc/cgroup/cgroup_v2.go
@@ -34,6 +34,7 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
 )
@@ -275,6 +276,14 @@ func (c *cgroupV2) Join() (func(), error) {
 	}
 
 	return cu.Release(), nil
+}
+
+// CloneIntoCgroup implements Cgroup.CloneIntoCgroup.
+func (c *cgroupV2) CloneIntoCgroup() (*os.File, error) {
+	if reason := cannotCloneIntoCgroupReason(); reason != "" {
+		return nil, fmt.Errorf("clone3(CLONE_INTO_CGROUP) is unavailable: %s", reason)
+	}
+	return os.OpenFile(c.MakePath(""), unix.O_DIRECTORY|os.O_RDONLY, 0)
 }
 
 // readCPUQuotaAndPeriod reads and parses cpu.max from the given path.

--- a/runsc/cgroup/cgroup_v2_unsafe.go
+++ b/runsc/cgroup/cgroup_v2_unsafe.go
@@ -1,0 +1,63 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cgroup
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+)
+
+// cannotCloneIntoCgroupReason returns the reason why
+// `clone3(CLONE_INTO_CGROUP)` doesn't work, if any.
+// Returns empty string if it does work.
+var cannotCloneIntoCgroupReason = sync.OnceValue(func() string {
+	// This makes a `clone3` call that always fails, but can fail for
+	// different reasons. See the `switch` below.
+	args := linux.CloneArgs{
+		// We use CLONE_VM here too because otherwise the kernel will copy the
+		// process page table entries before it gets to the cgroup FD check
+		// part, which can be expensive.
+		Flags:      linux.CLONE_INTO_CGROUP | linux.CLONE_VM,
+		ExitSignal: uint64(unix.SIGCHLD),
+		Cgroup:     math.MaxInt32,
+	}
+	_, _, errno := unix.RawSyscall(unix.SYS_CLONE3, uintptr(unsafe.Pointer(&args)), unsafe.Sizeof(args), 0)
+	switch errno {
+	case unix.ENOSYS:
+		// `clone3` doesn't exist, i.e. Linux 5.2 or lower.
+		// This can also happen under Docker's default profile, which injects
+		// ENOSYS as the return code for `clone3`.
+		return "clone3 syscall not implemented (kernel too old, or clone3 denied by container runtime policy)"
+	case unix.EPERM:
+		// Seccomp denial as well, such as Docker's profile before it
+		// explicitly injected `ENOSYS` for `clone3`.
+		return "clone3 syscall denied (perhaps by container runtime policy)"
+	case unix.E2BIG:
+		// The `Cgroup` field is beyond the struct size that `clone3`
+		// expects. So `clone3` exists, but `CLONE_INTO_CGROUP` does not.
+		// Linux 5.3, 5.4, 5.5, or 5.6.
+		return "kernel too old"
+	case unix.EBADF:
+		return "" // Happy case
+	default:
+		return fmt.Sprintf("clone3 probe returned errno %v", errno)
+	}
+})

--- a/runsc/cgroup/systemd.go
+++ b/runsc/cgroup/systemd.go
@@ -29,6 +29,7 @@ import (
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	dbus "github.com/godbus/dbus/v5"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
 )
@@ -143,6 +144,13 @@ func (c *cgroupSystemd) MakePath(string) string {
 	fullSlicePath := expandSlice(c.Parent)
 	path := filepath.Join(c.Mountpoint, fullSlicePath, c.unitName())
 	return path
+}
+
+// CloneIntoCgroup implements Cgroup.CloneIntoCgroup.
+func (c *cgroupSystemd) CloneIntoCgroup() (*os.File, error) {
+	// Can't use CLONE_INTO_CGROUP here because systemd is the thing doing the
+	// process migration, not us.
+	return nil, fmt.Errorf("CLONE_INTO_CGROUP cannot be used with systemd cgroup %q", c.unitName())
 }
 
 // Join implements Cgroup.Join.

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -366,8 +366,8 @@ func (c *Container) createRoot(conf *config.Config, args Args, sandboxID string)
 	if err := nvProxyPreGoferHostSetup(args.Spec, conf); err != nil {
 		return err
 	}
-	if err := cgroup.RunInCgroup(containerCgroup, func() error {
-		ioFiles, goferFilestores, devIOFile, specFile, err := c.createGoferProcess(conf, mountHints, args.Attached)
+	if err := cgroup.RunInCgroup(containerCgroup, func(cloneIntoCgroupFD *os.File) error {
+		ioFiles, goferFilestores, devIOFile, specFile, err := c.createGoferProcess(conf, mountHints, args.Attached, cloneIntoCgroupFD)
 		if err != nil {
 			return fmt.Errorf("cannot create gofer process: %w", err)
 		}
@@ -384,6 +384,7 @@ func (c *Container) createRoot(conf *config.Config, args Args, sandboxID string)
 			DevIOFile:           devIOFile,
 			MountsFile:          specFile,
 			Cgroup:              containerCgroup,
+			CloneIntoCgroupFD:   cloneIntoCgroupFD,
 			Attached:            args.Attached,
 			GoferFilestoreFiles: goferFilestores,
 			GoferMountConfs:     c.GoferMountConfs,
@@ -474,9 +475,9 @@ func (c *Container) startImpl(conf *config.Config, action string, startRoot func
 	} else {
 		// Join cgroup to start gofer process to ensure it's part of the cgroup from
 		// the start (and all their children processes).
-		if err := cgroup.RunInCgroup(c.Sandbox.CgroupJSON.Cgroup, func() error {
+		if err := cgroup.RunInCgroup(c.Sandbox.CgroupJSON.Cgroup, func(cloneIntoCgroupFD *os.File) error {
 			// Create the gofer process.
-			goferFiles, goferFilestores, devIOFile, mountsFile, err := c.createGoferProcess(conf, c.Sandbox.MountHints, false /* attached */)
+			goferFiles, goferFilestores, devIOFile, mountsFile, err := c.createGoferProcess(conf, c.Sandbox.MountHints, false /* attached */, cloneIntoCgroupFD)
 			if err != nil {
 				return err
 			}
@@ -1360,7 +1361,7 @@ func createLisafsSocketPair(sandEnds *[]*os.File, donations *donation.Agency) er
 // a gofer endpoint for the mount points using Gofers. The mounts file is the
 // file to read list of mounts after they have been resolved (direct paths,
 // no symlinks), and will be nil if there is no cleaning required for mounts.
-func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.PodMountHints, attached bool) ([]*os.File, []*os.File, *os.File, *os.File, error) {
+func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.PodMountHints, attached bool, cloneIntoCgroupFD *os.File) ([]*os.File, []*os.File, *os.File, *os.File, error) {
 	rootfsHint, err := boot.NewRootfsHint(c.Spec)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("error creating rootfs hint: %w", err)
@@ -1453,6 +1454,10 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 		// Detach from session. Otherwise, signals sent to the foreground process
 		// will also be forwarded by this process, resulting in duplicate signals.
 		Setsid: true,
+	}
+	if cloneIntoCgroupFD != nil {
+		cmd.SysProcAttr.UseCgroupFD = true
+		cmd.SysProcAttr.CgroupFD = int(cloneIntoCgroupFD.Fd())
 	}
 
 	// Set Args[0] to make easier to spot the gofer process. Otherwise it's

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -297,6 +297,10 @@ type Args struct {
 	// Gcgroup is the cgroup that the sandbox is part of.
 	Cgroup cgroup.Cgroup
 
+	// CloneIntoCgroupFD, when non-nil, is an FD to `Cgroup`'s directory. The
+	// sandbox process is created inside the cgroup via `CLONE_INTO_CGROUP`.
+	CloneIntoCgroupFD *os.File
+
 	// Attached indicates that the sandbox lifecycle is attached with the caller.
 	// If the caller exits, the sandbox should exit too.
 	Attached bool
@@ -962,6 +966,10 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 		// Detach from this session, otherwise cmd will get SIGHUP and SIGCONT
 		// when re-parented.
 		Setsid: true,
+	}
+	if args.CloneIntoCgroupFD != nil {
+		cmd.SysProcAttr.UseCgroupFD = true
+		cmd.SysProcAttr.CgroupFD = int(args.CloneIntoCgroupFD.Fd())
 	}
 
 	// Set Args[0] to make easier to spot the sandbox process.
@@ -1923,7 +1931,7 @@ func (s *Sandbox) maybeStartCheckpointGoferAndGetSocket(conf *config.Config, cg 
 	}
 	defer unix.Close(socketFDs[1])
 	clientSockFile := os.NewFile(uintptr(socketFDs[0]), "checkpointgofer-socket")
-	err = cgroup.RunInCgroup(cg, func() error {
+	err = cgroup.RunInCgroup(cg, func(cloneIntoCgroupFD *os.File) error {
 		argv := append([]string{"runsc-checkpointgofer"}, conf.ToFlags()...)
 		extraFiles := []uintptr{devNullFile.Fd(), devNullFile.Fd(), devNullFile.Fd(), uintptr(socketFDs[1]), gcsOptsFile.Fd()}
 
@@ -1959,15 +1967,20 @@ func (s *Sandbox) maybeStartCheckpointGoferAndGetSocket(conf *config.Config, cg 
 		// particular, containerd-shim-runsc-v1 passes GOMAXPROCS=2 in
 		// v1.service.newCommand()).
 		env := slices.DeleteFunc(os.Environ(), func(env string) bool { return strings.HasPrefix(env, "GOMAXPROCS=") })
+		sysProcAttr := &unix.SysProcAttr{
+			// Detach from this session, otherwise the subprocess will get
+			// SIGHUP and SIGCONT when re-parented.
+			Setsid: true,
+		}
+		if cloneIntoCgroupFD != nil {
+			sysProcAttr.UseCgroupFD = true
+			sysProcAttr.CgroupFD = int(cloneIntoCgroupFD.Fd())
+		}
 		_, err := gvisorbinaries.CheckpointGofer.ForkExec(gvisorbinaries.Options{
-			Argv:  argv,
-			Envv:  env,
-			Files: extraFiles,
-			SysProcAttr: &unix.SysProcAttr{
-				// Detach from this session, otherwise the subprocess will get
-				// SIGHUP and SIGCONT when re-parented.
-				Setsid: true,
-			},
+			Argv:        argv,
+			Envv:        env,
+			Files:       extraFiles,
+			SysProcAttr: sysProcAttr,
 		})
 		return err
 	})


### PR DESCRIPTION
Prior to this change, sandbox subprocesses (`runsc boot` and `runsc gofer`) were spawned into their target cgroup by having the `runsc create` process switch into the target cgroup and fork/exec. This stalls for an RCU grace period (twice actually, one to get into the cgroup and one to get back out). `clone3(CLONE_INTO_CGROUP)` does this in a single operation, and does not stall.

Benchmarks:

```
$ runsc do /bin/true

                 │    before     │                 after                 │
                 │    sec/op     │    sec/op     vs base                 │
RunscDo            100.16m ±  2%   69.03m ±  1%  -31.09% (n=256)

Basic OCI operations:

                 │    before     │                 after                 │
                 │    sec/op     │    sec/op     vs base                 │
OCICreate           55.59m ±  3%   26.46m ±  1%  -52.40% (n=256)
OCIReady            70.44m ±  3%   40.48m ±  1%  -42.53% (n=256)
OCIStart            14.17m ±  2%   13.87m ±  2%   -2.17% (p=0.033 n=256)
OCITotal            77.88m ±  2%   47.99m ±  1%  -38.38% (n=256)
```

`docker run` unaffected as it uses the systemd cgroup controller.