### PR TITLE
Add an empty `/proc/modules` to procfs.

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks.go
+++ b/pkg/sentry/fsimpl/proc/tasks.go
@@ -88,6 +88,7 @@ func (fs *filesystem) newTasksInode(ctx context.Context, k *kernel.Kernel, pidns
 		"fs":             fs.newStaticDir(ctx, root, map[string]kernfs.Inode{}),
 		"irq":            fs.newStaticDir(ctx, root, map[string]kernfs.Inode{}),
 		"meminfo":        fs.newInode(ctx, root, 0444, &meminfoData{}),
+		"modules":        fs.newInode(ctx, root, 0444, newStaticFile("")),
 		"mounts":         kernfs.NewStaticSymlink(ctx, root, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), "self/mounts"),
 		"net":            kernfs.NewStaticSymlink(ctx, root, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), "self/net"),
 		"sentry-meminfo": fs.newInode(ctx, root, 0444, &sentryMeminfoData{}),

--- a/pkg/sentry/fsimpl/proc/tasks_test.go
+++ b/pkg/sentry/fsimpl/proc/tasks_test.go
@@ -59,6 +59,7 @@ var (
 		"irq":            linux.DT_DIR,
 		"loadavg":        linux.DT_REG,
 		"meminfo":        linux.DT_REG,
+		"modules":        linux.DT_REG,
 		"mounts":         linux.DT_LNK,
 		"net":            linux.DT_LNK,
 		"self":           linux.DT_LNK,


### PR DESCRIPTION
It's my understanding that Linux exposes `/proc/modules` empty in most configurations (it's possible to not expose modules but that seems rare; only if the kernel is compile with that configuration).

Some applications like NVIDIA's GPUDirect Storage libraries (libcufile) will scan `/proc/modules`. However, if `/proc/modules` isn't available, applications will hang forever.

This PR adds `/proc/modules` as an empty file to all Sandboxes. This was already possible with `--override-procs=module`, but I think that having it be available everywhere is more reasonable than optionally adding it in some configurations. 