### PR TITLE
`runsc gofer`: Remove `/proc` unmounter and unmount in-process instead.

### DIFF
--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -90,13 +90,10 @@ type goferSyncFDs struct {
 	// procMountFD is a file descriptor that has to be closed when the
 	// procfs mount isn't needed anymore. It is read by the procfs unmounter
 	// process.
+	// It is only set when re-execing is necessary.
 	// If this is set, this FD is the last that the Gofer interacts with and
 	// closes.
 	procMountFD int
-
-	// procMountFile holds the *os.File for procMountFD when this process
-	// continues without re-exec'ing itself. Keeps the FD alive.
-	procMountFile *os.File
 }
 
 // Gofer implements subcommands.Command for the "gofer" command, which starts a
@@ -218,11 +215,9 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 		if err := sandboxsetup.SetupRootFS(spec, conf, g.mountConfs, g.devIoFD, makeRPCMountOpener(goferToHostRPC), containerID, g.bundleDir); err != nil {
 			util.Fatalf("Error setting up root FS: %v", err)
 		}
-		if !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
-			cleanupUnmounter := g.syncFDs.spawnProcUnmounter(willReexec)
-			if willReexec {
-				defer cleanupUnmounter()
-			}
+		if willReexec && !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
+			cleanupUnmounter := g.syncFDs.spawnProcUnmounter()
+			defer cleanupUnmounter()
 		}
 	}
 	extensionPrepare, err := extension.PrepareGofer(extension.GoferPrepareContext{
@@ -233,31 +228,27 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	if err != nil {
 		util.Fatalf("preparing gofer extensions: %v", err)
 	}
-	if g.applyCaps {
-		capsToApply := goferCaps
-		if conf.GetHostUDS().AllowOpen() {
-			capsToApply = specutils.MergeCapabilities(capsToApply, goferUdsOpenCaps)
-		}
-		if willReexec {
-			if config.CgoEnabled {
-				log.Warningf("Need to re-exec in order to drop capabilities, due to cgo build. This slows down gVisor startup. Use a pure-Go gVisor build for faster startup.")
-			} else {
-				log.Infof("Re-execing. FYI, this step isn't necessary when running with root. gVisor will start up faster (and is just as secure) when started as root, as it has to do fewer hoops to get to its as-sandboxed-as-possible state.")
-			}
-			overrides := g.syncFDs.flags()
-			overrides["apply-caps"] = "false"
-			overrides["setup-root"] = "false"
-			for key, value := range extensionPrepare.FlagOverrides {
-				overrides[key] = value
-			}
-			args := sandboxsetup.PrepareArgs(g.Name(), f, overrides)
-			util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, capsToApply, sandboxsetup.SetCapsAndCallSelf(args, capsToApply))
-			panic("unreachable")
-		}
-		if err := sandboxsetup.ApplyCapsAllThreads(capsToApply, nil); err != nil {
-			util.Fatalf("applying caps to all threads: %v", err)
-		}
+	capsToApply := goferCaps
+	if conf.GetHostUDS().AllowOpen() {
+		capsToApply = specutils.MergeCapabilities(capsToApply, goferUdsOpenCaps)
 	}
+	if g.applyCaps && willReexec {
+		if config.CgoEnabled {
+			log.Warningf("Need to re-exec in order to drop capabilities, due to cgo build. This slows down gVisor startup. Use a pure-Go gVisor build for faster startup.")
+		} else {
+			log.Infof("Re-execing. FYI, this step isn't necessary when running with root. gVisor will start up faster (and is just as secure) when started as root, as it has to do fewer hoops to get to its as-sandboxed-as-possible state.")
+		}
+		overrides := g.syncFDs.flags()
+		overrides["apply-caps"] = "false"
+		overrides["setup-root"] = "false"
+		for key, value := range extensionPrepare.FlagOverrides {
+			overrides[key] = value
+		}
+		args := sandboxsetup.PrepareArgs(g.Name(), f, overrides)
+		util.Fatalf("setCapsAndCallSelf(%v, %v): %v", args, capsToApply, sandboxsetup.SetCapsAndCallSelf(args, capsToApply))
+		panic("unreachable")
+	}
+	// No re-exec from here on out.
 
 	// This can't happen until after setCapsAndCallSelf(), since otherwise the
 	// re-executed gofer may reuse goferToHostRPCFD's file descriptor for an
@@ -265,25 +256,9 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	goferToHostRPC.Close()
 
 	// Start profiling. This will be a noop if no profiling arguments were passed.
+	// This *must* happen while procfs is still mounted (need `/proc/self/maps`).
 	profileOpts := profile.MakeOpts(&g.profileFDs, conf.ProfileGCInterval)
 	g.stopProfiling = profile.Start(profileOpts)
-
-	// At this point we won't re-execute, so it's safe to limit via rlimits. Any
-	// limit >= 0 works. If the limit is lower than the current number of open
-	// files, then Setrlimit will succeed, and the next open will fail.
-	if conf.FDLimit > -1 {
-		rlimit := unix.Rlimit{
-			Cur: uint64(conf.FDLimit),
-			Max: uint64(conf.FDLimit),
-		}
-		switch err := unix.Setrlimit(unix.RLIMIT_NOFILE, &rlimit); err {
-		case nil:
-		case unix.EPERM:
-			log.Warningf("FD limit %d is higher than the current hard limit or system-wide maximum", conf.FDLimit)
-		default:
-			util.Fatalf("Failed to set RLIMIT_NOFILE: %v", err)
-		}
-	}
 
 	// Find what path is going to be served by this gofer.
 	root := spec.Root.Path
@@ -313,6 +288,7 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 	// modes exactly as sent by the sandbox, which will have applied its own umask.
 	unix.Umask(0)
 
+	// Open `/proc/self/fd` (needs procfs).
 	procFDPath := sandboxsetup.ProcFDBindMount
 	if conf.TestOnlyAllowRunAsCurrentUserWithoutChroot {
 		procFDPath = "/proc/self/fd"
@@ -321,8 +297,45 @@ func (g *Gofer) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomm
 		util.Fatalf("failed to open /proc/self/fd: %v", err)
 	}
 
-	// procfs isn't needed anymore.
-	g.syncFDs.unmountProcfs()
+	// Look up our own caps (needs procfs).
+	var resolvedCaps *sandboxsetup.ResolvedThreadCaps
+	if g.applyCaps {
+		var err error
+		resolvedCaps, err = sandboxsetup.ResolveThreadCaps(capsToApply, nil)
+		if err != nil {
+			util.Fatalf("resolving capabilities: %v", err)
+		}
+	}
+
+	// Unmount procfs.
+	if g.setUpRoot && !conf.TestOnlyAllowRunAsCurrentUserWithoutChroot && g.syncFDs.procMountFD < 0 {
+		sandboxsetup.UmountProcInProcess()
+	} else {
+		g.syncFDs.unmountProcfs()
+	}
+
+	if g.applyCaps {
+		if err := resolvedCaps.Apply(nil); err != nil {
+			util.Fatalf("applying caps to all threads: %v", err)
+		}
+	}
+
+	// At this point we won't re-execute, so it's safe to limit via rlimits. Any
+	// limit >= 0 works. If the limit is lower than the current number of open
+	// files, then Setrlimit will succeed, and the next open will fail.
+	if conf.FDLimit > -1 {
+		rlimit := unix.Rlimit{
+			Cur: uint64(conf.FDLimit),
+			Max: uint64(conf.FDLimit),
+		}
+		switch err := unix.Setrlimit(unix.RLIMIT_NOFILE, &rlimit); err {
+		case nil:
+		case unix.EPERM:
+			log.Warningf("FD limit %d is higher than the current hard limit or system-wide maximum", conf.FDLimit)
+		default:
+			util.Fatalf("Failed to set RLIMIT_NOFILE: %v", err)
+		}
+	}
 
 	if err := unix.Chroot(root); err != nil {
 		util.Fatalf("failed to chroot to %q: %v", root, err)
@@ -531,50 +544,34 @@ func (g *goferSyncFDs) flags() map[string]string {
 	}
 }
 
-// spawnProcMounter executes the /proc unmounter process.
-// It returns a function to wait on the proc unmounter process, which
-// should be called (via defer) in case of errors in order to clean up the
-// unmounter process properly, but only when `willReexec` is true; otherwise
-// the unmounter is reaped by `unmountProcfs`.
-// When procfs is no longer needed, `unmountProcfs` should be called.
-func (g *goferSyncFDs) spawnProcUnmounter(willReexec bool) func() {
+// spawnProcUnmounter executes the /proc unmounter process, for gofers that
+// will re-exec and would lose the capability to umount /proc on their own.
+// It returns a function to clean up the unmounter process, which
+// should be called (via defer) in case of errors.
+func (g *goferSyncFDs) spawnProcUnmounter() func() {
 	if g.procMountFD != -1 {
 		util.Fatalf("procMountFD is set")
 	}
-	// /proc is umounted from a forked process, because the
-	// current one is going to drop capabilities and won't be
-	// able to umount it.
 	cmd, w := sandboxsetup.ExecProcUmounter()
-	// Clear FD_CLOEXEC in case this process re-executes itself.
-	// procMountFD should remain open.
+	// Clear FD_CLOEXEC so procMountFD survives re-exec.
 	if _, _, errno := unix.RawSyscall(unix.SYS_FCNTL, w.Fd(), unix.F_SETFD, 0); errno != 0 {
 		util.Fatalf("error clearing CLOEXEC: %v", errno)
 	}
 	g.procMountFD = int(w.Fd())
-	if !willReexec {
-		// Keep `w` alive until UmountProcFile uses it.
-		g.procMountFile = w
-	}
 	return func() {
 		g.procMountFD = -1
-		g.procMountFile = nil
 		w.Close()
 		cmd.Wait()
 	}
 }
 
 // unmountProcfs signals the proc unmounter process that procfs is no longer
-// needed.
+// needed. No-op when no unmounter process was spawned.
 func (g *goferSyncFDs) unmountProcfs() {
 	if g.procMountFD < 0 {
 		return
 	}
-	if g.procMountFile != nil {
-		sandboxsetup.UmountProcFile(g.procMountFile)
-		g.procMountFile = nil
-	} else {
-		sandboxsetup.UmountProc(g.procMountFD)
-	}
+	sandboxsetup.UmountProc(g.procMountFD)
 	g.procMountFD = -1
 }
 

--- a/runsc/cmd/sandboxsetup/caps_unsafe.go
+++ b/runsc/cmd/sandboxsetup/caps_unsafe.go
@@ -65,38 +65,60 @@ func allThreadsPrctl(option, arg2, arg3 uintptr) error {
 	return nil
 }
 
-// ApplyCapsAllThreads applies the capabilities in the spec to every thread of
-// the current process. Fails with ENOTSUP in cgo builds.
-func ApplyCapsAllThreads(caps *specs.LinuxCapabilities, timer *timing.Timer) error {
+// ResolvedThreadCaps is a set of capability masks resolved against the
+// current process's capabilities.
+type ResolvedThreadCaps struct {
+	bounding, effective, permitted, inheritable, ambient uint64
+
+	// lastCap is the highest capability number supported by the host kernel.
+	lastCap capability.Cap
+
+	// haveSetPCap is whether the effective set had `CAP_SETPCAP` at
+	// resolution time. (`PR_CAPBSET_DROP` requires it.)
+	haveSetPCap bool
+}
+
+// ResolveThreadCaps resolves the capability sets in the spec against the
+// current process's capabilities.
+//
+// Precondition: procfs is mounted at `/proc`.
+// This reads `/proc/self/status` and `/proc/sys/kernel/cap_last_cap`.
+func ResolveThreadCaps(caps *specs.LinuxCapabilities, timer *timing.Timer) (*ResolvedThreadCaps, error) {
 	curCaps, err := capability.NewPid2(0)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if err := curCaps.Load(); err != nil {
-		return err
+		return nil, err
 	}
 	timer.Reached("current capabilities read")
-	var bounding, effective, permitted, inheritable, ambient uint64
-	for i, mask := range [5]*uint64{&bounding, &effective, &permitted, &inheritable, &ambient} {
+	var r ResolvedThreadCaps
+	for i, mask := range [5]*uint64{&r.bounding, &r.effective, &r.permitted, &r.inheritable, &r.ambient} {
 		set, err := TrimCaps(GetCaps(AllCapTypes[i], caps), curCaps)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, c := range set {
 			*mask |= uint64(1) << uint(c)
 		}
 	}
-	last, err := capability.LastCap()
-	if err != nil {
-		return err
+	if r.lastCap, err = capability.LastCap(); err != nil {
+		return nil, err
 	}
+	r.haveSetPCap = curCaps.Get(capability.EFFECTIVE, capability.CAP_SETPCAP)
+	return &r, nil
+}
 
+// Apply applies `r` to every thread of the current process.
+// May be run without procfs available.
+// Fails with `ENOTSUP` in cgo builds.
+func (r *ResolvedThreadCaps) Apply(timer *timing.Timer) error {
 	// 1. Trim the bounding set on every thread. This must happen before
 	// capset drops CAP_SETPCAP from the effective set (PR_CAPBSET_DROP
 	// requires it).
-	if curCaps.Get(capability.EFFECTIVE, capability.CAP_SETPCAP) {
-		for c := capability.Cap(0); c <= last; c++ {
-			if bounding&(uint64(1)<<uint(c)) != 0 {
+	if r.haveSetPCap {
+		for c := capability.Cap(0); c <= r.lastCap; c++ {
+			if r.bounding&(uint64(1)<<uint(c)) != 0 {
 				continue
 			}
 			if err := allThreadsPrctl(unix.PR_CAPBSET_DROP, uintptr(c), 0); err != nil {
@@ -114,12 +136,12 @@ func ApplyCapsAllThreads(caps *specs.LinuxCapabilities, timer *timing.Timer) err
 		// in turn mean each Go runtime thread.
 		pid: 0,
 	}
-	capsetData[0].effective = uint32(effective)
-	capsetData[1].effective = uint32(effective >> 32)
-	capsetData[0].permitted = uint32(permitted)
-	capsetData[1].permitted = uint32(permitted >> 32)
-	capsetData[0].inheritable = uint32(inheritable)
-	capsetData[1].inheritable = uint32(inheritable >> 32)
+	capsetData[0].effective = uint32(r.effective)
+	capsetData[1].effective = uint32(r.effective >> 32)
+	capsetData[0].permitted = uint32(r.permitted)
+	capsetData[1].permitted = uint32(r.permitted >> 32)
+	capsetData[0].inheritable = uint32(r.inheritable)
+	capsetData[1].inheritable = uint32(r.inheritable >> 32)
 	if _, _, errno := syscall.AllThreadsSyscall6(unix.SYS_CAPSET, uintptr(unsafe.Pointer(&capsetHdr)), uintptr(unsafe.Pointer(&capsetData[0])), 0, 0, 0, 0); errno != 0 {
 		return fmt.Errorf("capset on all threads: %w", errno)
 	}
@@ -129,8 +151,8 @@ func ApplyCapsAllThreads(caps *specs.LinuxCapabilities, timer *timing.Timer) err
 	if err := allThreadsPrctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_CLEAR_ALL, 0); err != nil {
 		return fmt.Errorf("clearing ambient capabilities on all threads: %w", err)
 	}
-	for c := capability.Cap(0); c <= last; c++ {
-		if ambient&(uint64(1)<<uint(c)) == 0 {
+	for c := capability.Cap(0); c <= r.lastCap; c++ {
+		if r.ambient&(uint64(1)<<uint(c)) == 0 {
 			continue
 		}
 		if err := allThreadsPrctl(unix.PR_CAP_AMBIENT, unix.PR_CAP_AMBIENT_RAISE, uintptr(c)); err != nil {
@@ -139,6 +161,18 @@ func ApplyCapsAllThreads(caps *specs.LinuxCapabilities, timer *timing.Timer) err
 	}
 
 	log.Infof("Capabilities applied to all threads: bounding=%#x effective=%#x permitted=%#x inheritable=%#x ambient=%#x",
-		bounding, effective, permitted, inheritable, ambient)
+		r.bounding, r.effective, r.permitted, r.inheritable, r.ambient)
 	return nil
+}
+
+// ApplyCapsAllThreads applies the capabilities in the spec to every thread of
+// the current process. Fails with `ENOTSUP` in cgo builds.
+// Requires procfs to be mounted at `/proc`; see `ResolveThreadCaps` if you
+// need to decouple these operations.
+func ApplyCapsAllThreads(caps *specs.LinuxCapabilities, timer *timing.Timer) error {
+	r, err := ResolveThreadCaps(caps, timer)
+	if err != nil {
+		return err
+	}
+	return r.Apply(timer)
 }

--- a/runsc/cmd/sandboxsetup/process.go
+++ b/runsc/cmd/sandboxsetup/process.go
@@ -181,3 +181,14 @@ func UmountProcFile(syncFile *os.File) {
 		util.Fatalf("/proc is still accessible")
 	}
 }
+
+// UmountProcInProcess umounts /proc directly from the calling process.
+// The caller must still hold CAP_SYS_ADMIN.
+func UmountProcInProcess() {
+	if err := unix.Unmount("/proc", unix.MNT_DETACH); err != nil {
+		util.Fatalf("error umounting /proc: %v", err)
+	}
+	if err := unix.Access("/proc/self", unix.F_OK); err != unix.ENOENT {
+		util.Fatalf("/proc is still accessible")
+	}
+}


### PR DESCRIPTION
Saves about 3ms on the gofer hot path.

Benchmarks:

```
                 │     base     │                  new                  │
                 │    sec/op    │    sec/op     vs base                 │
  RunscDo           75.78m ± 3%   73.06m ±  2%   -3.59% (p=0.012 n=200)
  GoferInit        10.403m ± 5%   7.364m ± 13%  -29.21% (p=0.000 n=25)
```