### PR TITLE
metric: reject NaN bucketer parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ nogo-tests:
 #
 # FIXME(gvisor.dev/issue/10045): Need to fix broken tests.
 unit-tests: ## Local package unit tests in pkg/..., tools/.., etc.
-	@$(call test,--test_tag_filters=-nogo$(COMMA)-requires-kvm --build_tag_filters=-network_plugins --test_env=CGROUPV2=$(CGROUPV2) -- //:all pkg/... tools/... runsc/... vdso/... sandboxexec/... test/trace/... -//pkg/metric:metric_test -//pkg/coretag:coretag_test -//tools/tracereplay:tracereplay_test -//test/trace:trace_test)
+	@$(call test,--test_tag_filters=-nogo$(COMMA)-requires-kvm --build_tag_filters=-network_plugins --test_env=CGROUPV2=$(CGROUPV2) -- //:all pkg/... tools/... runsc/... vdso/... sandboxexec/... test/trace/... -//pkg/coretag:coretag_test -//tools/tracereplay:tracereplay_test -//test/trace:trace_test)
 .PHONY: unit-tests
 
 # See unit-tests: this includes runsc/container.

--- a/pkg/metric/BUILD
+++ b/pkg/metric/BUILD
@@ -47,7 +47,6 @@ go_test(
         "utils_test.go",
     ],
     library = ":metric",
-    tags = ["not_run:arm"],
     deps = [
         ":metric_go_proto",
         "//pkg/eventchannel",

--- a/pkg/metric/metric.go
+++ b/pkg/metric/metric.go
@@ -779,7 +779,7 @@ func NewExponentialBucketer(numFiniteBuckets int, width uint64, scale, growth fl
 	if numFiniteBuckets < exponentialMinBuckets || numFiniteBuckets > exponentialMaxBuckets {
 		panic(fmt.Sprintf("number of finite buckets must be in [%d, %d]", exponentialMinBuckets, exponentialMaxBuckets))
 	}
-	if scale < 0 || growth < 0 {
+	if scale < 0 || growth < 0 || math.IsNaN(scale) || math.IsNaN(growth) {
 		panic(fmt.Sprintf("scale and growth for exponential buckets must be >0, got scale=%f and growth=%f", scale, growth))
 	}
 	b := &ExponentialBucketer{

--- a/pkg/metric/metric_test.go
+++ b/pkg/metric/metric_test.go
@@ -841,7 +841,7 @@ func TestBucketerPanics(t *testing.T) {
 		"NewDurationBucketer @ 2": func() {
 			NewDurationBucketer(2, time.Second, time.Minute)
 		},
-		"NewDurationBucketer @ 80": func() {
+		"NewDurationBucketer with invalid range": func() {
 			NewDurationBucketer(80, time.Microsecond, 50*time.Microsecond)
 		},
 	} {


### PR DESCRIPTION
Updates #10045.

## Summary

- Reject NaN exponential bucketer parameters.
- Clarify that the duration bucketer regression case has an invalid range.
- Re-enable `//pkg/metric:metric_test` in unit and ARM testing.

## Root cause

The invalid duration range produces a NaN growth factor. NaN comparisons and
float-to-integer conversions allowed the constructor to return without panicking
on ARM64, while other architectures reached the existing overflow panic.

## Tests

- `//pkg/metric:metric_test` on Linux AArch64, focused and complete
- `//pkg/metric:condmetric_test` on Linux AArch64
- `git diff --check`

Assisted-by: OpenAI Codex
