### PR TITLE
tcpip: fix IP_MTU_DISCOVER for locally-originated packets

### DIFF
--- a/pkg/tcpip/network/ipv4/ipv4.go
+++ b/pkg/tcpip/network/ipv4/ipv4.go
@@ -687,9 +687,12 @@ func (e *endpoint) writePacketPostRouting(r *stack.Route, pkt *stack.PacketBuffe
 
 	if packetMustBeFragmented(pkt, networkMTU) {
 		h := header.IPv4(pkt.NetworkHeader().Slice())
-		if h.Flags()&header.IPv4FlagDontFragment != 0 && pkt.NetworkPacketInfo.IsForwardedPacket {
-			// TODO(gvisor.dev/issue/5919): Handle error condition in which DontFragment
-			// is set but the packet must be fragmented for the non-forwarding case.
+		if h.Flags()&header.IPv4FlagDontFragment != 0 {
+			// The Don't Fragment bit is set and the packet is too large for the
+			// network MTU. This can happen for both forwarded packets and
+			// locally-originated packets when the socket has IP_MTU_DISCOVER set
+			// to IP_PMTUDISC_DO or IP_PMTUDISC_PROBE. Return ErrMessageTooLong
+			// (EMSGSIZE) in both cases, matching Linux kernel behaviour.
 			return &tcpip.ErrMessageTooLong{}
 		}
 		sent, remain, err := e.handleFragments(r, networkMTU, pkt, func(fragPkt *stack.PacketBuffer) tcpip.Error {

--- a/pkg/tcpip/transport/internal/network/endpoint.go
+++ b/pkg/tcpip/transport/internal/network/endpoint.go
@@ -576,13 +576,11 @@ func (e *Endpoint) AcquireContextForWrite(opts tcpip.WriteOptions) (WriteContext
 		panic(fmt.Sprintf("invalid protocol number = %d", netProto))
 	}
 
-	// Set the DF (Don't Fragment) bit based on the PMTUD strategy,
-	// matching TCP behavior in connect.go.
-	// Note: In gVisor, WANT and DO are treated identically (both set DF).
-	// Linux kernel differentiates them (WANT allows local fragmentation,
-	// DO returns EMSGSIZE), but gVisor's IPv4 layer always allows local
-	// fragmentation for locally-generated packets regardless of DF
-	// (see gvisor.dev/issue/5919).
+	// Set the DF (Don't Fragment) bit based on the PMTUD strategy.
+	// For datagram sockets, Linux sets the DF bit only when PMTU discovery is
+	// explicitly enabled (IP_PMTUDISC_DO or IP_PMTUDISC_PROBE).
+	// Under IP_PMTUDISC_WANT or IP_PMTUDISC_DONT, datagrams exceeding the MTU
+	// are fragmented locally without error.
 	//
 	// PROBE also sets DF, matching Linux ip_dont_fragment(). In Linux,
 	// PROBE differs from DO only in that it ignores incoming ICMP
@@ -590,7 +588,7 @@ func (e *Endpoint) AcquireContextForWrite(opts tcpip.WriteOptions) (WriteContext
 	// route PMTU). Since gVisor does not implement ICMP-based PMTU
 	// feedback for transport sockets, PROBE and DO are functionally
 	// equivalent here.
-	df := e.pmtud == tcpip.PMTUDiscoveryWant || e.pmtud == tcpip.PMTUDiscoveryDo || e.pmtud == tcpip.PMTUDiscoveryProbe
+	df := e.pmtud == tcpip.PMTUDiscoveryDo || e.pmtud == tcpip.PMTUDiscoveryProbe
 
 	return WriteContext{
 		e:     e,

--- a/pkg/tcpip/transport/internal/network/endpoint_test.go
+++ b/pkg/tcpip/transport/internal/network/endpoint_test.go
@@ -359,6 +359,103 @@ func TestBindNICID(t *testing.T) {
 	}
 }
 
+func TestPMTUDiscovery(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy tcpip.PMTUDStrategy
+		wantDF   bool
+	}{
+		{
+			name:     "Want",
+			strategy: tcpip.PMTUDiscoveryWant,
+			wantDF:   false,
+		},
+		{
+			name:     "Dont",
+			strategy: tcpip.PMTUDiscoveryDont,
+			wantDF:   false,
+		},
+		{
+			name:     "Do",
+			strategy: tcpip.PMTUDiscoveryDo,
+			wantDF:   true,
+		},
+		{
+			name:     "Probe",
+			strategy: tcpip.PMTUDiscoveryProbe,
+			wantDF:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := stack.New(stack.Options{
+				NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol},
+				TransportProtocols: []stack.TransportProtocolFactory{udp.NewProtocol},
+				Clock:              &faketime.NullClock{},
+			})
+			defer s.Destroy()
+
+			linkEP := channel.New(1, 1500, "")
+			if err := s.CreateNIC(1, linkEP); err != nil {
+				t.Fatalf("CreateNIC: %s", err)
+			}
+			protocolAddr := tcpip.ProtocolAddress{
+				Protocol:          ipv4.ProtocolNumber,
+				AddressWithPrefix: ipv4NICAddr.WithPrefix(),
+			}
+			if err := s.AddProtocolAddress(1, protocolAddr, stack.AddressProperties{}); err != nil {
+				t.Fatalf("AddProtocolAddress: %s", err)
+			}
+			s.SetRouteTable([]tcpip.Route{
+				{Destination: header.IPv4EmptySubnet, NIC: 1},
+			})
+
+			var ops tcpip.SocketOptions
+			var ep network.Endpoint
+			var wq waiter.Queue
+			ep.Init(s, ipv4.ProtocolNumber, udp.ProtocolNumber, &ops, &wq)
+			defer ep.Close()
+
+			if err := ep.SetSockOptInt(tcpip.MTUDiscoverOption, int(tt.strategy)); err != nil {
+				t.Fatalf("SetSockOptInt: %s", err)
+			}
+
+			writeCtx, err := ep.AcquireContextForWrite(tcpip.WriteOptions{
+				To: &tcpip.FullAddress{Addr: ipv4RemoteAddr},
+			})
+			if err != nil {
+				t.Fatalf("AcquireContextForWrite: %s", err)
+			}
+			defer writeCtx.Release()
+
+			pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
+				ReserveHeaderBytes: int(writeCtx.PacketInfo().MaxHeaderLength),
+				Payload:            buffer.MakeWithData([]byte{1, 2, 3, 4}),
+			})
+			defer pkt.DecRef()
+
+			if err := writeCtx.WritePacket(pkt, false /* headerIncluded */); err != nil {
+				t.Fatalf("WritePacket: %s", err)
+			}
+
+			sentPkt := linkEP.Read()
+			if sentPkt == nil {
+				t.Fatal("expected packet on link, got nil")
+			}
+			defer sentPkt.DecRef()
+
+			v := stack.PayloadSince(sentPkt.NetworkHeader())
+			defer v.Release()
+			h := header.IPv4(v.AsSlice())
+			hasDF := h.Flags()&header.IPv4FlagDontFragment != 0
+			if hasDF != tt.wantDF {
+				t.Errorf("got DF = %v, want %v", hasDF, tt.wantDF)
+			}
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	refs.SetLeakMode(refs.LeaksPanic)
 	code := m.Run()

--- a/pkg/tcpip/transport/udp/endpoint.go
+++ b/pkg/tcpip/transport/udp/endpoint.go
@@ -562,6 +562,35 @@ func (e *endpoint) write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcp
 	}
 	if err := udpInfo.ctx.WritePacket(pkt, false /* headerIncluded */); err != nil {
 		e.stack.Stats().UDP.PacketSendErrors.Increment()
+		if _, ok := err.(*tcpip.ErrMessageTooLong); ok {
+			// When IP_MTU_DISCOVER is set to IP_PMTUDISC_DO or IP_PMTUDISC_PROBE
+			// and the packet exceeds the path MTU, Linux queues an EMSGSIZE error
+			// on the socket's error queue (MSG_ERRQUEUE) if IP_RECVERR is enabled.
+			// See net/ipv4/udp.c:udp_send_skb().
+			netProto := udpInfo.ctx.PacketInfo().NetProto
+			so := e.SocketOptions()
+			var recvErr bool
+			switch netProto {
+			case header.IPv4ProtocolNumber:
+				recvErr = so.GetIPv4RecvError()
+			case header.IPv6ProtocolNumber:
+				recvErr = so.GetIPv6RecvError()
+			default:
+				panic(fmt.Sprintf("unhandled network protocol number = %d", netProto))
+			}
+			if recvErr {
+				so.QueueLocalErr(
+					err,
+					netProto,
+					udpInfo.ctx.MTU(),
+					tcpip.FullAddress{
+						Addr: udpInfo.ctx.PacketInfo().RemoteAddress,
+						Port: udpInfo.remotePort,
+					},
+					nil,
+				)
+			}
+		}
 		return 0, err
 	}
 

--- a/pkg/tcpip/transport/udp/udp_test.go
+++ b/pkg/tcpip/transport/udp/udp_test.go
@@ -2421,6 +2421,544 @@ func TestSetExperimentOptionIPv6(t *testing.T) {
 	checker.IPv6WithExtHdr(t, v, checker.IPv6ExtHdr(checker.IPv6ExperimentHeader(expval)))
 }
 
+func TestPMTUDiscovery(t *testing.T) {
+	const mtu = 1500
+	const payloadSize = 2000
+
+	tests := []struct {
+		name          string
+		strategy      tcpip.PMTUDStrategy
+		v4RecvErr     bool
+		v6RecvErr     bool
+		wantWriteErr  tcpip.Error
+		wantQueuedErr bool
+		wantPackets   int // number of fragment packets expected on LinkEP
+	}{
+		{
+			name:          "DefaultWantFragments",
+			strategy:      tcpip.PMTUDiscoveryWant,
+			wantWriteErr:  nil,
+			wantQueuedErr: false,
+			wantPackets:   2,
+		},
+		{
+			name:          "DontFragments",
+			strategy:      tcpip.PMTUDiscoveryDont,
+			wantWriteErr:  nil,
+			wantQueuedErr: false,
+			wantPackets:   2,
+		},
+		{
+			name:          "DoFailsAndQueuesErrorWithIPv4RecvError",
+			strategy:      tcpip.PMTUDiscoveryDo,
+			v4RecvErr:     true,
+			wantWriteErr:  &tcpip.ErrMessageTooLong{},
+			wantQueuedErr: true,
+			wantPackets:   0,
+		},
+		{
+			name:          "DoFailsWithoutQueueingWhenRecvErrorDisabled",
+			strategy:      tcpip.PMTUDiscoveryDo,
+			v4RecvErr:     false,
+			wantWriteErr:  &tcpip.ErrMessageTooLong{},
+			wantQueuedErr: false,
+			wantPackets:   0,
+		},
+		{
+			name:          "DoFailsWithoutQueueingWhenOnlyIPv6RecvErrorEnabledOnIPv4",
+			strategy:      tcpip.PMTUDiscoveryDo,
+			v4RecvErr:     false,
+			v6RecvErr:     true,
+			wantWriteErr:  &tcpip.ErrMessageTooLong{},
+			wantQueuedErr: false,
+			wantPackets:   0,
+		},
+		{
+			name:          "ProbeFailsAndQueuesErrorWithIPv4RecvError",
+			strategy:      tcpip.PMTUDiscoveryProbe,
+			v4RecvErr:     true,
+			wantWriteErr:  &tcpip.ErrMessageTooLong{},
+			wantQueuedErr: true,
+			wantPackets:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := context.Options{
+				MTU:         mtu,
+				HandleLocal: true,
+			}
+			c := context.NewWithOptions(t, []stack.TransportProtocolFactory{udp.NewProtocol}, opts)
+			defer c.Cleanup()
+
+			c.CreateEndpoint(ipv4.ProtocolNumber, udp.ProtocolNumber)
+
+			target := tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort}
+			if err := c.EP.Connect(target); err != nil {
+				t.Fatalf("Connect failed: %s", err)
+			}
+
+			if err := c.EP.SetSockOptInt(tcpip.MTUDiscoverOption, int(tt.strategy)); err != nil {
+				t.Fatalf("SetSockOptInt(MTUDiscoverOption, %d) failed: %s", tt.strategy, err)
+			}
+
+			c.EP.SocketOptions().SetIPv4RecvError(tt.v4RecvErr)
+			c.EP.SocketOptions().SetIPv6RecvError(tt.v6RecvErr)
+
+			payload := newRandomPayload(payloadSize)
+			var r bytes.Reader
+			r.Reset(payload)
+			n, err := c.EP.Write(&r, tcpip.WriteOptions{})
+			if (err == nil && tt.wantWriteErr != nil) || (err != nil && tt.wantWriteErr == nil) || (err != nil && tt.wantWriteErr != nil && err != tt.wantWriteErr) {
+				t.Fatalf("Write got error %v, want %v", err, tt.wantWriteErr)
+			}
+			if tt.wantWriteErr == nil && n != int64(payloadSize) {
+				t.Fatalf("got Write bytes = %d, want = %d", n, payloadSize)
+			}
+
+			if tt.wantQueuedErr {
+				sockErr := c.EP.SocketOptions().DequeueErr()
+				if sockErr == nil {
+					t.Fatal("expected queued error, got nil")
+				}
+				if _, ok := sockErr.Err.(*tcpip.ErrMessageTooLong); !ok {
+					t.Errorf("unexpected sockErr.Err: got %v, want ErrMessageTooLong", sockErr.Err)
+				}
+				if sockErr.NetProto != header.IPv4ProtocolNumber {
+					t.Errorf("got sockErr.NetProto = %d, want %d", sockErr.NetProto, header.IPv4ProtocolNumber)
+				}
+				if sockErr.Dst != target {
+					t.Errorf("got sockErr.Dst = %+v, want %+v", sockErr.Dst, target)
+				}
+				wantMTU := uint32(mtu - header.IPv4MinimumSize)
+				if sockErr.Cause == nil || sockErr.Cause.Info() != wantMTU {
+					t.Errorf("got sockErr.Cause.Info() = %v, want %d", sockErr.Cause, wantMTU)
+				}
+			} else {
+				if sockErr := c.EP.SocketOptions().DequeueErr(); sockErr != nil {
+					t.Fatalf("unexpected queued error: %+v", sockErr)
+				}
+			}
+
+			var pktsRead int
+			for {
+				pkt := c.LinkEP.Read()
+				if pkt == nil {
+					break
+				}
+				pkt.DecRef()
+				pktsRead++
+			}
+			if pktsRead != tt.wantPackets {
+				t.Errorf("got %d packets on LinkEP, want %d", pktsRead, tt.wantPackets)
+			}
+		})
+	}
+}
+
+func TestPMTUDiscoveryMTUBoundaries(t *testing.T) {
+	const mtu = 1500
+	// 1500 MTU - 20 (IPv4 header) - 8 (UDP header) = 1472 bytes max unfragmented payload.
+	const exactMTUPayload = 1472
+	const overMTUPayload = 1473
+	const smallPayload = 1
+
+	tests := []struct {
+		name         string
+		strategy     tcpip.PMTUDStrategy
+		payloadSize  int
+		wantWriteErr tcpip.Error
+		wantPackets  int
+		wantDF       bool
+	}{
+		{
+			name:         "ExactMTU_Want",
+			strategy:     tcpip.PMTUDiscoveryWant,
+			payloadSize:  exactMTUPayload,
+			wantWriteErr: nil,
+			wantPackets:  1,
+			wantDF:       false,
+		},
+		{
+			name:         "ExactMTU_Do",
+			strategy:     tcpip.PMTUDiscoveryDo,
+			payloadSize:  exactMTUPayload,
+			wantWriteErr: nil,
+			wantPackets:  1,
+			wantDF:       true,
+		},
+		{
+			name:         "ExactMTU_Dont",
+			strategy:     tcpip.PMTUDiscoveryDont,
+			payloadSize:  exactMTUPayload,
+			wantWriteErr: nil,
+			wantPackets:  1,
+			wantDF:       false,
+		},
+		{
+			name:         "OverMTU_Want",
+			strategy:     tcpip.PMTUDiscoveryWant,
+			payloadSize:  overMTUPayload,
+			wantWriteErr: nil,
+			wantPackets:  2,
+			wantDF:       false,
+		},
+		{
+			name:         "OverMTU_Dont",
+			strategy:     tcpip.PMTUDiscoveryDont,
+			payloadSize:  overMTUPayload,
+			wantWriteErr: nil,
+			wantPackets:  2,
+			wantDF:       false,
+		},
+		{
+			name:         "OverMTU_Do",
+			strategy:     tcpip.PMTUDiscoveryDo,
+			payloadSize:  overMTUPayload,
+			wantWriteErr: &tcpip.ErrMessageTooLong{},
+			wantPackets:  0,
+		},
+		{
+			name:         "OverMTU_Probe",
+			strategy:     tcpip.PMTUDiscoveryProbe,
+			payloadSize:  overMTUPayload,
+			wantWriteErr: &tcpip.ErrMessageTooLong{},
+			wantPackets:  0,
+		},
+		{
+			name:         "Small_Do",
+			strategy:     tcpip.PMTUDiscoveryDo,
+			payloadSize:  smallPayload,
+			wantWriteErr: nil,
+			wantPackets:  1,
+			wantDF:       true,
+		},
+		{
+			name:         "Small_Want",
+			strategy:     tcpip.PMTUDiscoveryWant,
+			payloadSize:  smallPayload,
+			wantWriteErr: nil,
+			wantPackets:  1,
+			wantDF:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := context.Options{
+				MTU:         mtu,
+				HandleLocal: true,
+			}
+			c := context.NewWithOptions(t, []stack.TransportProtocolFactory{udp.NewProtocol}, opts)
+			defer c.Cleanup()
+
+			c.CreateEndpoint(ipv4.ProtocolNumber, udp.ProtocolNumber)
+
+			target := tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort}
+			if err := c.EP.Connect(target); err != nil {
+				t.Fatalf("Connect failed: %s", err)
+			}
+
+			if err := c.EP.SetSockOptInt(tcpip.MTUDiscoverOption, int(tt.strategy)); err != nil {
+				t.Fatalf("SetSockOptInt(MTUDiscoverOption, %d) failed: %s", tt.strategy, err)
+			}
+
+			payload := newRandomPayload(tt.payloadSize)
+			var r bytes.Reader
+			r.Reset(payload)
+			n, err := c.EP.Write(&r, tcpip.WriteOptions{})
+			if (err == nil && tt.wantWriteErr != nil) || (err != nil && tt.wantWriteErr == nil) || (err != nil && tt.wantWriteErr != nil && err != tt.wantWriteErr) {
+				t.Fatalf("Write got error %v, want %v", err, tt.wantWriteErr)
+			}
+			if tt.wantWriteErr == nil && n != int64(tt.payloadSize) {
+				t.Fatalf("got Write bytes = %d, want = %d", n, tt.payloadSize)
+			}
+
+			var pktsRead int
+			for {
+				pkt := c.LinkEP.Read()
+				if pkt == nil {
+					break
+				}
+				defer pkt.DecRef()
+				pktsRead++
+
+				if tt.wantPackets == 1 {
+					v := stack.PayloadSince(pkt.NetworkHeader())
+					defer v.Release()
+					h := header.IPv4(v.AsSlice())
+					hasDF := h.Flags()&header.IPv4FlagDontFragment != 0
+					if hasDF != tt.wantDF {
+						t.Errorf("got DF flag = %v, want %v", hasDF, tt.wantDF)
+					}
+				}
+			}
+			if pktsRead != tt.wantPackets {
+				t.Errorf("got %d packets on LinkEP, want %d", pktsRead, tt.wantPackets)
+			}
+		})
+	}
+}
+
+func TestPMTUDiscoveryDynamicStrategyChange(t *testing.T) {
+	const mtu = 1500
+	const largePayload = 2000
+	const smallPayload = 500
+
+	opts := context.Options{
+		MTU:         mtu,
+		HandleLocal: true,
+	}
+	c := context.NewWithOptions(t, []stack.TransportProtocolFactory{udp.NewProtocol}, opts)
+	defer c.Cleanup()
+
+	c.CreateEndpoint(ipv4.ProtocolNumber, udp.ProtocolNumber)
+
+	target := tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort}
+	if err := c.EP.Connect(target); err != nil {
+		t.Fatalf("Connect failed: %s", err)
+	}
+
+	drainPackets := func() int {
+		var count int
+		for {
+			pkt := c.LinkEP.Read()
+			if pkt == nil {
+				break
+			}
+			pkt.DecRef()
+			count++
+		}
+		return count
+	}
+
+	// 1. Initial state is PMTUDiscoveryWant: large write should succeed and fragment.
+	var r bytes.Reader
+	r.Reset(newRandomPayload(largePayload))
+	if _, err := c.EP.Write(&r, tcpip.WriteOptions{}); err != nil {
+		t.Fatalf("Step 1 (Want): Write failed unexpectedly: %s", err)
+	}
+	if pkts := drainPackets(); pkts != 2 {
+		t.Fatalf("Step 1 (Want): expected 2 fragment packets, got %d", pkts)
+	}
+
+	// 2. Switch to PMTUDiscoveryDo: large write should fail with ErrMessageTooLong.
+	if err := c.EP.SetSockOptInt(tcpip.MTUDiscoverOption, int(tcpip.PMTUDiscoveryDo)); err != nil {
+		t.Fatalf("SetSockOptInt(PMTUDiscoveryDo) failed: %s", err)
+	}
+	r.Reset(newRandomPayload(largePayload))
+	if _, err := c.EP.Write(&r, tcpip.WriteOptions{}); err == nil {
+		t.Fatal("Step 2 (Do): Write expected error, got nil")
+	} else if _, ok := err.(*tcpip.ErrMessageTooLong); !ok {
+		t.Fatalf("Step 2 (Do): Write got %v, want ErrMessageTooLong", err)
+	}
+	if pkts := drainPackets(); pkts != 0 {
+		t.Fatalf("Step 2 (Do): expected 0 packets, got %d", pkts)
+	}
+
+	// 3. Under PMTUDiscoveryDo, small write within MTU should succeed with DF=1.
+	r.Reset(newRandomPayload(smallPayload))
+	if _, err := c.EP.Write(&r, tcpip.WriteOptions{}); err != nil {
+		t.Fatalf("Step 3 (Do small): Write failed: %s", err)
+	}
+	pkt := c.LinkEP.Read()
+	if pkt == nil {
+		t.Fatal("Step 3 (Do small): expected 1 packet, got nil")
+	}
+	v := stack.PayloadSince(pkt.NetworkHeader())
+	h := header.IPv4(v.AsSlice())
+	if h.Flags()&header.IPv4FlagDontFragment == 0 {
+		t.Errorf("Step 3 (Do small): expected DF bit set, got %v", h.Flags())
+	}
+	v.Release()
+	pkt.DecRef()
+
+	// 4. Switch to PMTUDiscoveryDont: large write should succeed and fragment with DF=0.
+	if err := c.EP.SetSockOptInt(tcpip.MTUDiscoverOption, int(tcpip.PMTUDiscoveryDont)); err != nil {
+		t.Fatalf("SetSockOptInt(PMTUDiscoveryDont) failed: %s", err)
+	}
+	r.Reset(newRandomPayload(largePayload))
+	if _, err := c.EP.Write(&r, tcpip.WriteOptions{}); err != nil {
+		t.Fatalf("Step 4 (Dont): Write failed: %s", err)
+	}
+	if pkts := drainPackets(); pkts != 2 {
+		t.Fatalf("Step 4 (Dont): expected 2 fragment packets, got %d", pkts)
+	}
+
+	// 5. Switch to PMTUDiscoveryProbe: large write should fail with ErrMessageTooLong.
+	if err := c.EP.SetSockOptInt(tcpip.MTUDiscoverOption, int(tcpip.PMTUDiscoveryProbe)); err != nil {
+		t.Fatalf("SetSockOptInt(PMTUDiscoveryProbe) failed: %s", err)
+	}
+	r.Reset(newRandomPayload(largePayload))
+	if _, err := c.EP.Write(&r, tcpip.WriteOptions{}); err == nil {
+		t.Fatal("Step 5 (Probe): Write expected error, got nil")
+	} else if _, ok := err.(*tcpip.ErrMessageTooLong); !ok {
+		t.Fatalf("Step 5 (Probe): Write got %v, want ErrMessageTooLong", err)
+	}
+	if pkts := drainPackets(); pkts != 0 {
+		t.Fatalf("Step 5 (Probe): expected 0 packets, got %d", pkts)
+	}
+}
+
+func TestPMTUDiscoveryFragmentInspection(t *testing.T) {
+	const mtu = 1500
+	const payloadSize = 2500
+
+	opts := context.Options{
+		MTU:         mtu,
+		HandleLocal: true,
+	}
+	c := context.NewWithOptions(t, []stack.TransportProtocolFactory{udp.NewProtocol}, opts)
+	defer c.Cleanup()
+
+	c.CreateEndpoint(ipv4.ProtocolNumber, udp.ProtocolNumber)
+
+	target := tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort}
+	if err := c.EP.Connect(target); err != nil {
+		t.Fatalf("Connect failed: %s", err)
+	}
+
+	payload := newRandomPayload(payloadSize)
+	var r bytes.Reader
+	r.Reset(payload)
+	n, err := c.EP.Write(&r, tcpip.WriteOptions{})
+	if err != nil {
+		t.Fatalf("Write failed: %s", err)
+	}
+	if n != int64(payloadSize) {
+		t.Fatalf("Write returned %d bytes, want %d", n, payloadSize)
+	}
+
+	// Read Fragment 1.
+	pkt1 := c.LinkEP.Read()
+	if pkt1 == nil {
+		t.Fatal("expected fragment 1, got nil")
+	}
+	defer pkt1.DecRef()
+
+	v1 := stack.PayloadSince(pkt1.NetworkHeader())
+	defer v1.Release()
+	h1 := header.IPv4(v1.AsSlice())
+	if h1.Flags()&header.IPv4FlagMoreFragments == 0 {
+		t.Error("fragment 1: expected MoreFragments bit set")
+	}
+	if h1.Flags()&header.IPv4FlagDontFragment != 0 {
+		t.Error("fragment 1: expected DontFragment bit cleared")
+	}
+	if h1.FragmentOffset() != 0 {
+		t.Errorf("fragment 1: got FragmentOffset = %d, want 0", h1.FragmentOffset())
+	}
+	if h1.TotalLength() != mtu {
+		t.Errorf("fragment 1: got TotalLength = %d, want %d", h1.TotalLength(), mtu)
+	}
+
+	// Read Fragment 2.
+	pkt2 := c.LinkEP.Read()
+	if pkt2 == nil {
+		t.Fatal("expected fragment 2, got nil")
+	}
+	defer pkt2.DecRef()
+
+	v2 := stack.PayloadSince(pkt2.NetworkHeader())
+	defer v2.Release()
+	h2 := header.IPv4(v2.AsSlice())
+	if h2.Flags()&header.IPv4FlagMoreFragments != 0 {
+		t.Error("fragment 2: expected MoreFragments bit cleared")
+	}
+	if h2.Flags()&header.IPv4FlagDontFragment != 0 {
+		t.Error("fragment 2: expected DontFragment bit cleared")
+	}
+	const expectedOffset = mtu - header.IPv4MinimumSize
+	if h2.FragmentOffset() != expectedOffset {
+		t.Errorf("fragment 2: got FragmentOffset = %d, want %d", h2.FragmentOffset(), expectedOffset)
+	}
+	if h2.ID() != h1.ID() {
+		t.Errorf("fragment IDs mismatch: fragment 1 ID = %d, fragment 2 ID = %d", h1.ID(), h2.ID())
+	}
+}
+
+func TestPMTUDiscoveryEndToEndReassembly(t *testing.T) {
+	const mtu = 1500
+	const payloadSize = 3000
+
+	opts := context.Options{
+		MTU:         mtu,
+		HandleLocal: true,
+	}
+	c := context.NewWithOptions(t, []stack.TransportProtocolFactory{udp.NewProtocol}, opts)
+	defer c.Cleanup()
+
+	// Server endpoint bound to context.StackAddr:context.TestPort.
+	serverEP, err := c.Stack.NewEndpoint(udp.ProtocolNumber, ipv4.ProtocolNumber, &c.WQ)
+	if err != nil {
+		t.Fatalf("NewEndpoint(server) failed: %s", err)
+	}
+	defer serverEP.Close()
+	if err := serverEP.Bind(tcpip.FullAddress{Addr: context.StackAddr, Port: context.TestPort}); err != nil {
+		t.Fatalf("server Bind failed: %s", err)
+	}
+
+	// Client endpoint.
+	c.CreateEndpoint(ipv4.ProtocolNumber, udp.ProtocolNumber)
+	if err := c.EP.Connect(tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort}); err != nil {
+		t.Fatalf("client Connect failed: %s", err)
+	}
+
+	payload := newRandomPayload(payloadSize)
+	var r bytes.Reader
+	r.Reset(payload)
+	n, err := c.EP.Write(&r, tcpip.WriteOptions{})
+	if err != nil {
+		t.Fatalf("client Write failed: %s", err)
+	}
+	if n != int64(payloadSize) {
+		t.Fatalf("client Write returned %d bytes, want %d", n, payloadSize)
+	}
+
+	// Inject all produced fragments back into the stack link layer to simulate reception.
+	var fragments []*stack.PacketBuffer
+	for {
+		pkt := c.LinkEP.Read()
+		if pkt == nil {
+			break
+		}
+		fragments = append(fragments, pkt)
+	}
+	if len(fragments) < 2 {
+		t.Fatalf("expected at least 2 fragments, got %d", len(fragments))
+	}
+
+	for _, frag := range fragments {
+		v := stack.PayloadSince(frag.NetworkHeader())
+		slice := append([]byte(nil), v.AsSlice()...)
+		v.Release()
+		frag.DecRef()
+
+		// Swap src and dst addresses so the incoming packet is addressed to Server (StackAddr).
+		h := header.IPv4(slice)
+		h.SetSourceAddress(context.TestAddr)
+		h.SetDestinationAddress(context.StackAddr)
+		h.SetChecksum(0)
+		h.SetChecksum(^h.CalculateChecksum())
+
+		c.InjectPacket(ipv4.ProtocolNumber, slice)
+	}
+
+	// Read from server endpoint and verify complete reassembled payload.
+	var buf bytes.Buffer
+	res, err := serverEP.Read(&buf, tcpip.ReadOptions{NeedRemoteAddr: true})
+	if err != nil {
+		t.Fatalf("server Read failed: %s", err)
+	}
+	if res.Count != payloadSize {
+		t.Fatalf("server Read count = %d, want %d", res.Count, payloadSize)
+	}
+	if !bytes.Equal(buf.Bytes(), payload) {
+		t.Fatal("server Read payload content does not match sent payload")
+	}
+}
+
 func TestMain(m *testing.M) {
 	refs.SetLeakMode(refs.LeaksPanic)
 	code := m.Run()

--- a/test/packetimpact/tests/ipv4_id_uniqueness_test.go
+++ b/test/packetimpact/tests/ipv4_id_uniqueness_test.go
@@ -79,14 +79,9 @@ func TestIPv4RetransmitIdentificationUniqueness(t *testing.T) {
 
 			dut.SetSockOptInt(t, remoteFD, unix.IPPROTO_TCP, unix.TCP_NODELAY, 1)
 
-			// TODO(b/129291778) The following socket option clears the DF bit on
-			// IP packets sent over the socket, and is currently not supported by
-			// gVisor. gVisor by default sends packets with DF=0 anyway, so the
-			// socket option being not supported does not affect the operation of
-			// this test. Once the socket option is supported, the following call
-			// can be changed to simply assert success.
+			// Set IP_PMTUDISC_DONT to clear the DF bit on IP packets.
+			// Fuchsia will return ENOPROTOOPT errno.
 			ret, errno := dut.SetSockOptIntWithErrno(context.Background(), t, remoteFD, unix.IPPROTO_IP, linux.IP_MTU_DISCOVER, linux.IP_PMTUDISC_DONT)
-			// Fuchsia will return ENOPROTOPT errno.
 			if ret == -1 && errno != unix.ENOPROTOOPT {
 				t.Fatalf("failed to set IP_MTU_DISCOVER socket option to IP_PMTUDISC_DONT: %s", errno)
 			}


### PR DESCRIPTION
Fixes #12319

### Problem
`tracepath` fails with `tracepath: IP_MTU_DISCOVER: Operation not supported` because `setsockopt(IP_MTU_DISCOVER, IP_PMTUDISC_DO)` and `IP_PMTUDISC_PROBE` returned `ENOTSUP`.
A previous attempt to support this in PR #12366 was rolled back because large UDP datagrams failed with `EMSGSIZE` (#12479).

### Solution
1. **`pkg/tcpip/network/ipv4/ipv4.go`**:
   Remove the `IsForwardedPacket` guard from the `DontFragment` check. When the Don't Fragment (DF) bit is set and the packet exceeds the MTU, return `ErrMessageTooLong` (`EMSGSIZE`), matching Linux kernel semantics.

2. **`pkg/tcpip/transport/internal/network/endpoint.go`**:
   Set `DF=true` for datagram endpoints only when `PMTUDiscoveryDo` or `PMTUDiscoveryProbe` is set. Under default `PMTUDiscoveryWant` and `PMTUDiscoveryDont`, `DF` remains `false`, allowing local fragmentation for large datagrams without error and preventing regressions for workloads sending datagrams larger than MTU (#12479).

3. **`pkg/tcpip/transport/udp/endpoint.go`**:
   When UDP `WritePacket` fails with `ErrMessageTooLong`, check `GetIPv4RecvError()` vs `GetIPv6RecvError()` based on the packet's `NetProto` and queue a local error on the socket error queue (`MSG_ERRQUEUE`).

4. **`pkg/tcpip/transport/udp/udp_test.go`, `pkg/tcpip/transport/internal/network/endpoint_test.go`**:
   Add tests for PMTUD strategies (`WANT`, `DONT`, `DO`, `PROBE`), MTU boundary conditions (exact, +1B, small), dynamic socket option changes, wire fragment inspection, and end-to-end multi-fragment delivery/reassembly.

5. **`test/packetimpact/tests/ipv4_id_uniqueness_test.go`**:
   Update comment now that `IP_PMTUDISC_DONT` is supported.

### Verification
All unit tests, integration tests, and static checks passed:
- `//pkg/tcpip/network/ipv4:ipv4_test`
- `//pkg/tcpip/network/ipv4:ipv4_unit_test`
- `//pkg/tcpip/network/ipv4:stats_test`
- `//pkg/tcpip/transport/udp:udp_x_test`
- `//pkg/tcpip/transport/internal/network:network_test`
- `//pkg/tcpip/transport/tcp:tcp_test`
- `//pkg/tcpip/tests/integration:all`
- `nogo` static analysis for all modified packages