### PR TITLE
docs: select go branch for Go consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ convenience. This is useful for external packages and libraries that depend on
 gVisor subpackages (e.g. userspace networking via Netstack) to import gVisor Go
 code into their Go projects.
 
+Select this branch explicitly with the `go` branch query. `@latest` resolves
+`master`, which requires Bazel and is not compatible with standard Go tooling:
+
+```sh
+go get gvisor.dev/gvisor/pkg/tcpip/transport/tcp@go
+```
+
 **NOTE**: **`runsc` builds from this branch are not supported**. gVisor and
 `runsc` require several binaries (some of which are not even written in Go) in
 order to function. The `go` branch is supported in a best effort capacity, and

--- a/g3doc/user_guide/sdk/quickstart.md
+++ b/g3doc/user_guide/sdk/quickstart.md
@@ -69,7 +69,7 @@ func main() {
     available):
 
     ```bash
-    go get gvisor.dev/gvisor/sandboxexec/sandbox
+    go get gvisor.dev/gvisor/sandboxexec/sandbox@go
     ```
 
 4.  Run the application:


### PR DESCRIPTION
Fixes #14140.

## Summary

- Document that standard Go consumers must select the synthetic `go` branch with `@go`.
- Update the SDK quickstart to select that branch explicitly.

## Root cause

`master` is the Bazel source tree. It contains the `go_template` input `pkg/refs/refs_template.go`, which declares `package refs_template`, while the other files in that directory declare `package refs`. The Bazel-generated Go archive already excludes that template and includes the generated `package refs` implementation, but `@latest` resolves `master` instead of the synthetic `go` branch.

Removing only the refs template from the raw source tree would not make `master` compatible with standard Go tooling because other Bazel-generated sources would still be absent. Explicitly selecting `@go` follows the existing supported packaging design.

## Validation

- Reproduced the mixed-package failure against the `master` module version.
- Built `pkg/refs` and `pkg/tcpip/transport/tcp` through standard Go tooling using `@go`.
- Tested `pkg/tcpip/transport/tcp` through standard Go tooling.
- Built the SDK quickstart dependency using `@go`.
- Built the relevant Bazel refs and TCP/IP targets and passed their `nogo` tests.
- Built `//:gopath` on Ubuntu 22.04, confirmed that its archive contains `refs_state_autogen.go` and excludes `refs_template.go`, and passed `go build ./...` from the packaged tree.
- Ran `git diff --check`.
