### PR TITLE
vfs: rebuild the epoll ready list on restore instead of saving it

### DIFF
--- a/pkg/sentry/vfs/epoll.go
+++ b/pkg/sentry/vfs/epoll.go
@@ -108,10 +108,10 @@ type epollInterest struct {
 	// ready is true if epollInterestEntry is linked into epoll.ready. readySeq
 	// is the value of epoll.readySeq when NotifyEvent() was last called.
 	// ready, epollInterestEntry, and readySeq are protected by epoll.readyMu.
-	// ready and the link are not saved, for the reason on EpollInstance.ready.
+	// None of them are saved, for the reason on EpollInstance.ready.
 	ready              bool `state:"nosave"`
 	epollInterestEntry `state:"nosave"`
-	readySeq           uint32
+	readySeq           uint32 `state:"nosave"`
 
 	// userData is the struct epoll_event::data associated with this
 	// epollInterest. userData is protected by epoll.interestMu.

--- a/pkg/sentry/vfs/epoll.go
+++ b/pkg/sentry/vfs/epoll.go
@@ -61,7 +61,11 @@ type EpollInstance struct {
 	// process fails to notice that additional file descriptors are ready
 	// because it focuses on a set of file descriptors that are already known
 	// to be ready." - epoll_wait(2)
-	ready epollInterestList
+	//
+	// ready is not saved: readyMu does not participate in the save, so a
+	// notification that is not quiesced for it can tear the list mid-encode.
+	// It is rebuilt on restore by epollInterest.afterLoad.
+	ready epollInterestList `state:"nosave"`
 
 	// readySeq is used to detect calls to epollInterest.NotifyEvent() while
 	// Readiness() or ReadEvents() are running with readyMu unlocked. readySeq
@@ -104,9 +108,10 @@ type epollInterest struct {
 	// ready is true if epollInterestEntry is linked into epoll.ready. readySeq
 	// is the value of epoll.readySeq when NotifyEvent() was last called.
 	// ready, epollInterestEntry, and readySeq are protected by epoll.readyMu.
-	ready bool
-	epollInterestEntry
-	readySeq uint32
+	// ready and the link are not saved, for the reason on EpollInstance.ready.
+	ready              bool `state:"nosave"`
+	epollInterestEntry `state:"nosave"`
+	readySeq           uint32
 
 	// userData is the struct epoll_event::data associated with this
 	// epollInterest. userData is protected by epoll.interestMu.


### PR DESCRIPTION
## What breaks

After a checkpoint/restore, an epoll instance registered *before* the checkpoint can stop receiving readiness notifications for one of its file descriptors — permanently. A Go HTTP server whose listening socket is caught this way never wakes its accept loop again: TCP handshakes still complete, but no request ever reaches a handler, and readiness probes time out.

I hit this as a ~2% flake on Full checkpoint/restore in a real workload, and traced it with an instrumented `runsc`.

## The invariant that gets violated

`EpollInstance.ready` is a list, and `epollInterest.ready` is a bool that mirrors membership in it. The code says so explicitly:

```go
// ready is true if epollInterestEntry is linked into epoll.ready. readySeq
// is the value of epoll.readySeq when NotifyEvent() was last called.
// ready, epollInterestEntry, and readySeq are protected by epoll.readyMu.
```

All three are saved. `readyMu` is `state:"nosave"`.

`state.Save` walks the object graph by reflection without taking `readyMu`, and not every notifier is quiesced for the save — `udp`'s `Pause` is a no-op (`pkg/tcpip/transport/udp/protocol.go`), `tcp`'s stops only the dispatcher (`pkg/tcpip/transport/tcp/protocol.go`), and netstack timers are not enumerated by `pauseTimeLocked`. A `Notify` landing inside the encode window is enough: the encoder reads `epi.ready` at one instant and the list links at another, and the saved image ends up self-contradictory — `epi.ready == false` while `epi` is still linked into `ep.ready`.

**Why this is intermittent rather than deterministic.** Nothing is wrong with the state at rest — it only becomes inconsistent if a `Notify` lands between the two reads the encoder makes. That is a narrow target: I measured `Kernel save took` at median 71ms, p99 506ms, max 1095ms under `-parallel=8`, and observed the failure on ~2% of Full restores. It follows that the rate should scale with both encode duration and notifier activity, which is consistent with the reporter of #13920 seeing a much higher rate under different conditions.

## Why that is fatal on restore

`epollInterest.afterLoad` calls `NotifyEvent`, which does:

```go
if !epi.ready {
	epi.ready = true
	epi.epoll.ready.PushBack(epi)
}
```

For the torn interest this branch is taken **even though the entry is already linked**. `PushBack` begins with `linker.SetNext(nil)`, so every interest queued behind it is silently unlinked while keeping `ready == true`. Those interests are then invisible forever: the `if !epi.ready` guard never fires for them again, and `ReadEvents` only ever walks `ep.ready`.

Concretely, with the torn interest `X` at the head of a three-entry list:

```
before:   head -> [X] -> [A] -> [B] -> nil

PushBack(X) begins with linker.SetNext(nil):

          X.next = nil

after:    head -> [X] -> nil
                  [A] -> [B]        <- still allocated, unreachable from head
```

`A` and `B` are never removed and still have `ready == true`; they are simply no longer walkable. Nothing detects this — `Empty()` only tests `head == nil`, and `ilist` has no invariant checking.

The victim is therefore **not** the torn interest — that one ends up self-consistent. It is whichever interests happened to be queued behind it, and their own `afterLoad` has already run and looked fine. That is why per-interest consistency checks do not catch this.

## Measurements

Instrumented `runsc` on `release-20260803.0`, logging at `afterLoad` whether `epi.ready` matches actual list membership, plus the list length.

Torn state appears in the restored image on failing restores only:

| | `ready` inconsistent with list membership |
|---|---|
| healthy restores | **0 / 9704** samples |
| failing restores | **3 / 3** |

The list collapse, from one failing restore (interests in `afterLoad` order):

| order | `ready` on entry | actually linked | list length after |
|---|---|---|---|
| 1 | false | false | 1 → **2** |
| 2 | false | false | 2 → **3** |
| **3** | **false** | **true** ← torn | **3 → 1** |
| 4 | false | false | 1 → 2 |
| 5 | false | false | 2 → 3 |

Every healthy interest adds exactly one. The torn one drops the list from 3 to 1, orphaning two interests that still carry `ready == true`.

Two further data points, both consistent with a save-side race:

- Bypassing epoll entirely (a dedicated thread doing blocking `accept(2)`, same workload, same cluster) never reproduces: **0 failures in 960 lifecycles**, versus **10 in 480** on the epoll path (Fisher p = 1.6e-5).
- Retrying the restore from the same image does **not** help — **0 of 7 rescued**. The tear is in the image and `state.Load` is deterministic, so the same interests are orphaned every time.
- The encode window is long enough to be hit: `Kernel save took` has median 71ms, p99 506ms, max 1095ms under load.

## The fix

Stop saving the ready list, the per-interest link, and the `ready` flag. `epollInterest.afterLoad` already calls `NotifyEvent` for every interest, so starting from an empty list rebuilds it consistently, and `ReadEvents` re-checks real readiness via `FileDescription.Readiness()` immediately after. Nothing is lost: the list is a cache of a conclusion that is recomputed on restore anyway.

This mirrors the fix for the same class of bug in tcp's `epQueue` (#13554, `netstack: rebuild dispatcher queue on restore instead of persisting it`), which was resolved by rebuilding on restore rather than persisting a serialized intrusive list whose mutators are not fully quiesced at save time.

Validation on the same workload:

| | failures | torn state |
|---|---|---|
| baseline `release-20260803.0` | **7 / 360** lifecycles | present |
| with this change | **0 / 240** lifecycles | **not observed (0 / 240)** |

The second column matters more than the first: with the list unsaved, every `afterLoad:entry` reading is `ready=false, not linked` (240/240) — the inconsistent state has no carrier into the restored image, which is the property the change is aiming for rather than a lower probability of hitting it.

## Scope, and what this does not fix

This removes the consequence, not the race. `state.Save` still walks the graph without `readyMu`, and the notifiers above are still not quiesced — other serialized structures protected by `nosave` locks remain exposed to the same pattern. Fixing the quiesce model itself is a much larger change and is not attempted here.

## Relationship to #13920 and #13953

The symptom matches [#13920](https://github.com/google/gvisor/issues/13920) and its three-way signature (`poll` readable, fresh epoll readable, pre-checkpoint epoll never readable) reproduces exactly for me. I am **not** claiming it is provably the same defect: the reporter sees ~87% per restore on an idle listener with an empty accept queue, I see ~2% under parallel load, and the mechanism here requires an interest to be on the ready list at save time.

I ran [#13953](https://github.com/google/gvisor/pull/13953) as a control. Its premise is that the waiter is no longer registered with the file's queue after restore; I measured that membership directly and it is **true throughout**, on healthy and failing restores alike. Applying only its `afterLoad` change reproduced the failure in **round 1 and again in round 2** (2 / 60 lifecycles, versus 7 / 360 at baseline). Its `EventUnregister`/`EventRegister` act on the file's `waiter.Queue` while the damage is to `EpollInstance.ready`, and it keeps the `NotifyEvent` call that performs the damaging `PushBack` — under it the list is still corrupted, there into a self-loop rather than a truncation. **So: #13953 does not fix this failure in my workload, and its premise does not hold there.** It may address something I did not observe, but it should not land as a fix for #13920 on that premise alone. (I did not trace the self-loop through the first `ReadEvents` drain pointer by pointer; the load-bearing evidence is the per-event correspondence, 2 tears and 2 failures.)

No new test: reproducing this needs a concurrent notification during the encode window, which the existing test harness cannot construct. I would rather say that plainly than add a test that manufactures its own precondition.

