### PR TITLE
nvproxy: remove stale device files when restoring onto different GPUs 

### DIFF
--- a/runsc/boot/nvproxy.go
+++ b/runsc/boot/nvproxy.go
@@ -183,19 +183,37 @@ func collectContainerNvidiaRegularDevices(ctx context.Context, spec *specs.Spec,
 	return gotAny, nil
 }
 
-func (l *Loader) createRemappedNvproxyDeviceFiles(ctx context.Context) {
+// remapNvproxyDeviceFiles rewrites the Nvidia device special files in every
+// dev filesystem mount to match the GPUs the sandbox owns after restore,
+// creating /dev/nvidia# for newly present device minors and removing it for
+// minors that are no longer present.
+//
+// Applications derive the /dev/nvidia# paths they open from identity the
+// driver reports and nvproxy passes through (most directly
+// nv_ioctl_card_info_t::minor_number from NV_ESC_CARD_INFO), so /dev must
+// agree with the driver: a stale file resolves to a GPU this sandbox no
+// longer owns -- possibly another sandbox's -- with no error anywhere.
+// Removing it turns that into ENOENT.
+func (l *Loader) remapNvproxyDeviceFiles(ctx context.Context) {
 	dr := nvproxy.DeviceRemappingFromContext(ctx)
 	if dr == nil {
 		return
 	}
-	newMinors := make(map[uint32]struct{})
+	newMinors := make(map[uint32]struct{}, len(dr.NewDeviceByOld))
 	for _, newID := range dr.NewDeviceByOld {
 		newMinors[newID.Minor] = struct{}{}
 	}
+	// If the restored device minors are the same set as the saved ones, every
+	// /dev/nvidia# file is still valid, even if devices were permuted within
+	// the set.
+	sameMinors := true
 	for oldMinor := range dr.OldDeviceByMinor {
-		delete(newMinors, oldMinor)
+		if _, ok := newMinors[oldMinor]; !ok {
+			sameMinors = false
+			break
+		}
 	}
-	if len(newMinors) == 0 {
+	if sameMinors {
 		return
 	}
 	vfsObj := l.k.VFS()
@@ -227,24 +245,42 @@ func (l *Loader) createRemappedNvproxyDeviceFiles(ctx context.Context) {
 				continue
 			}
 			if ftype := stat.Mode & linux.S_IFMT; ftype != linux.S_IFCHR || stat.RdevMajor != nvgpu.NV_MAJOR_DEVICE_NUMBER || stat.RdevMinor != oldMinor {
-				log.Infof("Not creating remapped device file for %s, which has type %v and rdev numbers (%d, %d)", oldBasename, ftype, stat.RdevMajor, stat.RdevMinor)
+				log.Infof("Not remapping device file %s, which has type %v and rdev numbers (%d, %d)", oldBasename, ftype, stat.RdevMajor, stat.RdevMinor)
 				continue
 			}
 			newID := dr.NewDeviceByOld[oldID]
-			newBasename := fmt.Sprintf("nvidia%d", newID.Minor)
-			if err := vfsObj.MknodAt(ctx, creds, &vfs.PathOperation{
-				Root:  rootVD,
-				Start: rootVD,
-				Path:  fspath.Parse(newBasename),
-			}, &vfs.MknodOptions{
-				Mode:     linux.FileMode(linux.S_IFCHR | 0o666),
-				DevMajor: nvgpu.NV_MAJOR_DEVICE_NUMBER,
-				DevMinor: newID.Minor,
-			}); err != nil {
-				if err == linuxerr.EEXIST {
-					log.Debugf("Remapped device file %s already exists", newBasename)
+			if newID.Minor != oldMinor {
+				newBasename := fmt.Sprintf("nvidia%d", newID.Minor)
+				if err := vfsObj.MknodAt(ctx, creds, &vfs.PathOperation{
+					Root:  rootVD,
+					Start: rootVD,
+					Path:  fspath.Parse(newBasename),
+				}, &vfs.MknodOptions{
+					Mode:     linux.FileMode(linux.S_IFCHR | 0o666),
+					DevMajor: nvgpu.NV_MAJOR_DEVICE_NUMBER,
+					DevMinor: newID.Minor,
+				}); err != nil {
+					if err == linuxerr.EEXIST {
+						log.Debugf("Remapped device file %s already exists", newBasename)
+					} else {
+						log.Warningf("Failed to create remapped device file %s: %v", newBasename, err)
+					}
+				}
+			}
+			// The stat above established that oldBasename is the saved device's
+			// file (character device with rdev (NV_MAJOR, oldMinor)), so this
+			// cannot delete an unrelated file sharing the name. It runs even if
+			// the mknod above failed: ENOENT is strictly better than resolving
+			// to a GPU this sandbox does not own.
+			if _, stillPresent := newMinors[oldMinor]; !stillPresent {
+				if err := vfsObj.UnlinkAt(ctx, creds, &vfs.PathOperation{
+					Root:  rootVD,
+					Start: rootVD,
+					Path:  fspath.Parse(oldBasename),
+				}); err != nil {
+					log.Warningf("Failed to remove stale device file %s: %v", oldBasename, err)
 				} else {
-					log.Warningf("Failed to create remapped device file %s: %v", newBasename, err)
+					log.Infof("Removed stale device file %s: GPU not owned by this sandbox after restore", oldBasename)
 				}
 			}
 		}

--- a/runsc/boot/restore.go
+++ b/runsc/boot/restore.go
@@ -573,7 +573,7 @@ func (r *restorer) restore(l *Loader) error {
 
 	l.k.RestoreContainerMapping(l.containerIDs)
 	l.k.SetSaver(l)
-	l.createRemappedNvproxyDeviceFiles(ctx)
+	l.remapNvproxyDeviceFiles(ctx)
 
 	// Refresh the control server with the newly created kernel.
 	l.ctrl.refreshHandlers()


### PR DESCRIPTION
Applications derive the `/dev/nvidia#` paths they open from identity the driver reports, so a restored sandbox's device files must agree with the driver. Restore already creates `/dev/nvidia#` for newly present minors, but the checkpoint-time GPUs' files lingered, and an application stumbling upon one opened a GPU the sandbox no longer owns. This is wrong and can cause applications to fail upon restore.

I am now extending the existing remapping fix to delete `/dev/nvidia/<old>` for every saved minor not among the restored minors.

The existing stat check gates the unlink, so an unrelated file sharing the name is left alone. Restored frontendFDs are unaffected, since `nvproxy.afterLoad()` already rebinds them and unlink does not affect open FDs and access for stale devices now fails with ENOENT.

This program illustrates how this affects a restored program:

```c
// Host has GPUs 0-3; a sandbox holding two of them is checkpointed
// on {0,1} and restored onto {2,3}.

#define NV_IOCTL_MAGIC   'F'  // kernel-open/common/inc/nv-ioctl-numbers.h
#define NV_ESC_CARD_INFO 200
#define NV_MAX_DEVICES   32

struct nv_ioctl_card_info {   // kernel-open/common/inc/nv-ioctl.h
    NvBool valid;
    /* pci_info, gpu_id, ... */
    NvU32  minor_number;      // host minor; not rewritten by nvproxy
    /* ... */
};

int usable_gpus(int fds[]) {
    int ctl = open("/dev/nvidiactl", O_RDWR);
    struct nv_ioctl_card_info ci[NV_MAX_DEVICES] = {0};
    ioctl(ctl, _IOWR(NV_IOCTL_MAGIC, NV_ESC_CARD_INFO, ci), ci);
    int n = 0;
    for (int i = 0; i < NV_MAX_DEVICES; i++) {
        if (!ci[i].valid) continue;
        char path[32];
        sprintf(path, "/dev/nvidia%u", ci[i].minor_number);
        int fd = open(path, O_RDWR);
        if (fd >= 0) fds[n++] = fd;
    }
    return n;
}

int main(void) {
    int fds[NV_MAX_DEVICES];
    int n = usable_gpus(fds);   // n == 2: host GPUs 0 and 1

    /* ==== runsc checkpoint; runsc restore onto GPUs {2,3} ==== */

    // FDs held across the checkpoint are rebound by nvproxy.afterLoad();
    // fds[] now drive host GPUs 2 and 3. But any re-discovery -- a fresh
    // process, or libcuda re-initializing after the cuda-checkpoint toggle:
    n = usable_gpus(fds);
    
    // BEFORE this change: n == 4. The driver reports minors {0,1,2,3}, the
    // restore created nvidia2 and nvidia3, and nvidia0 and nvidia1 linger
    // from the checkpoint -- so the app also "successfully" opens GPUs 0,1,
    // which it no longer owns.
    //
    // AFTER this change: n == 2, host GPUs 2 and 3. remapNvproxyDeviceFiles()
    // deleted the stale files; open("/dev/nvidia0") is ENOENT.
}

```