### PR TITLE
tcpip: update Endpoint.Write documentation

### DIFF
--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -769,8 +769,8 @@ type Endpoint interface {
 	//
 	// Unlike io.Writer.Write, Endpoint.Write transfers ownership of any bytes
 	// successfully written to the Endpoint. That is, if a call to
-	// Write(SlicePayload{data}) returns (n, err), it may retain data[:n], and
-	// the caller should not use data[:n] after Write returns.
+	// Write(p, opts) returns (n, err), it may retain the first n bytes read
+	// from p, and the caller should not use those bytes after Write returns.
 	//
 	// Note that unlike io.Writer.Write, it is not an error for Write to
 	// perform a partial write (if n > 0, no error may be returned). Only


### PR DESCRIPTION
## Description

Fixes #6024.

The Write method signature changed from accepting SlicePayload to
accepting Payloader, but the documentation still referenced the old
SlicePayload{data} syntax. Update the documentation to reflect the
current signature and clarify the ownership transfer semantics.

## Testing

- gofmt: Passed (no formatting changes needed)
- git diff --check: Passed (no whitespace issues)
- Documentation review: Updated documentation accurately reflects the current implementation

## Scope

This change is limited to updating documentation only. No code logic or behavior changes are made. The ownership transfer semantics remain the same as documented in the issue comments by maintainers.