### PR TITLE
mm: expand RLIMIT_DATA enforcement to include data segments

### DIFF
--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -764,12 +764,10 @@ func (mm *MemoryManager) Brk(ctx context.Context, addr hostarch.Addr) (hostarch.
 		return addr, linuxerr.EINVAL
 	}
 
-	// TODO(gvisor.dev/issue/156): This enforces RLIMIT_DATA, but is
-	// slightly more permissive than the usual data limit. In particular,
-	// this only limits the size of the heap; a true RLIMIT_DATA limits the
-	// size of heap + data + bss. The segment sizes need to be plumbed from
-	// the loader package to fully enforce RLIMIT_DATA.
-	if uint64(addr-mm.brk.Start) > limits.FromContext(ctx).Get(limits.Data).Cur {
+	// Enforce RLIMIT_DATA which limits the size of heap + data + bss.
+	// mm.dataAS tracks the size of private data segments (including .data and .bss).
+	dataLimit := limits.FromContext(ctx).Get(limits.Data).Cur
+	if uint64(addr-mm.brk.Start)+mm.dataAS > dataLimit {
 		addr = mm.brk.End
 		mm.mappingMu.Unlock()
 		return addr, linuxerr.ENOMEM


### PR DESCRIPTION
Previously, RLIMIT_DATA only enforced the heap size limit. This change expands the enforcement to include private data segments (.data and .bss) by using mm.dataAS which already tracks these segments.

This implements the full RLIMIT_DATA semantics as requested in #156, limiting heap + data + bss instead of just the heap.

Fixes #156.