### PR TITLE
syscalls: prevent overwriting currently executing binary

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_file.go
+++ b/pkg/sentry/syscalls/linux/sys_file.go
@@ -1591,6 +1591,22 @@ func renameat(t *kernel.Task, olddirfd int32, oldpathAddr hostarch.Addr, newdirf
 	}
 	defer oldtpop.Release(t)
 
+	// Prevent renaming the currently executing executable.
+	// This implements partial ETXTBSY behavior as requested in #1005.
+	exe := t.MemoryManager().Executable()
+	if exe != nil {
+		// Check if the source file is the current executable.
+		oldVD, err := t.Kernel().VFS().FindFileDescription(t, oldtpop.pop)
+		if err == nil && oldVD != nil {
+			oldVD.DecRef(t)
+			// Simple check: prevent modification of the executable file itself
+			// This is a basic implementation of ETXTBSY behavior.
+			if oldVD == exe {
+				return linuxerr.ETXTBSY
+			}
+		}
+	}
+
 	newpath, err := copyInPath(t, newpathAddr)
 	if err != nil {
 		return err

--- a/pkg/sentry/syscalls/linux/sys_file.go
+++ b/pkg/sentry/syscalls/linux/sys_file.go
@@ -1596,10 +1596,13 @@ func renameat(t *kernel.Task, olddirfd int32, oldpathAddr hostarch.Addr, newdirf
 	exe := t.MemoryManager().Executable()
 	if exe != nil {
 		// Check if the source file is the current executable.
-		oldVD, err := t.Kernel().VFS().FindFileDescription(t, oldtpop.pop)
+		// Open the file to get its FileDescription and compare with the executable.
+		oldVD, err := t.Kernel().VFS().OpenAt(t, t.Credentials(), &oldtpop.pop, &vfs.OpenOptions{
+			Flags: linux.O_RDONLY,
+		})
 		if err == nil && oldVD != nil {
-			oldVD.DecRef(t)
-			// Simple check: prevent modification of the executable file itself
+			defer oldVD.DecRef(t)
+			// Compare file descriptions by checking if they represent the same file.
 			// This is a basic implementation of ETXTBSY behavior.
 			if oldVD == exe {
 				return linuxerr.ETXTBSY


### PR DESCRIPTION
Add ETXTBSY check in renameat to prevent renaming the currently executing binary. This implements basic Linux behavior where attempting to overwrite a running executable fails with ETXTBSY error.

This is a partial implementation of ETXTBSY behavior as requested in #1005, preventing modification of the executable file itself while it's running.