### PR TITLE
sentry: return ETXTBSY for writes to files being executed

### DIFF
--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -1088,6 +1088,11 @@ func (d *dentry) open(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.Open
 	if err := d.checkPermissions(rp.Credentials(), ats); err != nil {
 		return nil, err
 	}
+	if ats.MayWrite() {
+		if err := rp.VirtualFilesystem().CheckWriteAccess(&d.vfsd); err != nil {
+			return nil, err
+		}
+	}
 	if !d.inode.isSynthetic() {
 		// renameMu is locked here because it is required by d.openHandle(), which
 		// is called by d.ensureSharedHandle() and d.openSpecialFile() below. It is

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -1295,6 +1295,11 @@ func (d *dentry) setStat(ctx context.Context, creds *auth.Credentials, opts *vfs
 	if err := vfs.CheckSetStat(ctx, creds, opts, mode, nil, auth.KUID(d.inode.uid.Load()), auth.KGID(d.inode.gid.Load())); err != nil {
 		return err
 	}
+	if stat.Mask&linux.STATX_SIZE != 0 {
+		if err := mnt.Filesystem().VirtualFilesystem().CheckWriteAccess(&d.vfsd); err != nil {
+			return err
+		}
+	}
 	if err := mnt.CheckBeginWrite(); err != nil {
 		return err
 	}

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -935,6 +935,12 @@ func (d *dentry) ensureOpenableLocked(ctx context.Context, rp *vfs.ResolvingPath
 func (d *dentry) openCopiedUp(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.OpenOptions) (*vfs.FileDescription, error) {
 	mnt := rp.Mount()
 
+	if vfs.AccessTypesForOpenFlags(opts).MayWrite() {
+		if err := rp.VirtualFilesystem().CheckWriteAccess(&d.vfsd); err != nil {
+			return nil, err
+		}
+	}
+
 	// Directory FDs open FDs from each layer when directory entries are read,
 	// so they don't require opening an FD from d.topLayer() up front.
 	ftype := d.mode.Load() & linux.S_IFMT
@@ -1524,6 +1530,11 @@ func (d *dentry) setStatLocked(ctx context.Context, rp *vfs.ResolvingPath, opts 
 	mode := linux.FileMode(d.mode.Load())
 	if err := vfs.CheckSetStat(ctx, rp.Credentials(), &opts, mode, d.accessACL.Load(), auth.KUID(d.uid.Load()), auth.KGID(d.gid.Load())); err != nil {
 		return err
+	}
+	if opts.Stat.Mask&linux.STATX_SIZE != 0 {
+		if err := rp.VirtualFilesystem().CheckWriteAccess(&d.vfsd); err != nil {
+			return err
+		}
 	}
 	mnt := rp.Mount()
 	if err := mnt.CheckBeginWrite(); err != nil {

--- a/pkg/sentry/fsimpl/overlay/regular_file.go
+++ b/pkg/sentry/fsimpl/overlay/regular_file.go
@@ -170,6 +170,11 @@ func (fd *regularFileFD) SetStat(ctx context.Context, opts vfs.SetStatOptions) e
 	if err := vfs.CheckSetStat(ctx, auth.CredentialsFromContext(ctx), &opts, mode, d.accessACL.Load(), auth.KUID(d.uid.Load()), auth.KGID(d.gid.Load())); err != nil {
 		return err
 	}
+	if opts.Stat.Mask&linux.STATX_SIZE != 0 {
+		if err := fd.vfsfd.CheckWriteAccess(); err != nil {
+			return err
+		}
+	}
 	mnt := fd.vfsfd.Mount()
 	if err := mnt.CheckBeginWrite(); err != nil {
 		return err

--- a/pkg/sentry/fsimpl/tmpfs/filesystem.go
+++ b/pkg/sentry/fsimpl/tmpfs/filesystem.go
@@ -467,6 +467,11 @@ func (d *dentry) open(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.Open
 		if err := d.inode.checkPermissions(rp.Credentials(), ats); err != nil {
 			return nil, err
 		}
+		if ats.MayWrite() {
+			if err := rp.VirtualFilesystem().CheckWriteAccess(&d.vfsd); err != nil {
+				return nil, err
+			}
+		}
 	}
 	switch impl := d.inode.impl.(type) {
 	case *regularFile:
@@ -772,6 +777,12 @@ func (fs *filesystem) SetStatAt(ctx context.Context, rp *vfs.ResolvingPath, opts
 	if err != nil {
 		fs.mu.RUnlock()
 		return err
+	}
+	if opts.Stat.Mask&linux.STATX_SIZE != 0 {
+		if err := rp.VirtualFilesystem().CheckWriteAccess(&d.vfsd); err != nil {
+			fs.mu.RUnlock()
+			return err
+		}
 	}
 	err = d.inode.setStat(ctx, rp.Credentials(), &opts)
 	fs.mu.RUnlock()

--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -1238,6 +1238,11 @@ func (fd *fileDescription) Stat(ctx context.Context, opts vfs.StatOptions) (linu
 
 // SetStat implements vfs.FileDescriptionImpl.SetStat.
 func (fd *fileDescription) SetStat(ctx context.Context, opts vfs.SetStatOptions) error {
+	if opts.Stat.Mask&linux.STATX_SIZE != 0 {
+		if err := fd.vfsfd.CheckWriteAccess(); err != nil {
+			return err
+		}
+	}
 	return fd.dentry().inode.setStat(ctx, auth.CredentialsFromContext(ctx), &opts)
 }
 

--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -299,6 +299,7 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 
 	if mm2.executable != nil {
 		mm2.executable.IncRef()
+		denyExecutableWrite(mm2.executable)
 	}
 	return mm2, nil
 }
@@ -377,6 +378,7 @@ func (mm *MemoryManager) DecUsers(ctx context.Context) {
 	mm.executable = nil
 	mm.metadataMu.Unlock()
 	if exe != nil {
+		allowExecutableWrite(exe)
 		exe.DecRef(ctx)
 	}
 

--- a/pkg/sentry/mm/metadata.go
+++ b/pkg/sentry/mm/metadata.go
@@ -156,11 +156,14 @@ func (mm *MemoryManager) SetExecutable(ctx context.Context, fd *vfs.FileDescript
 
 	mm.metadataMu.Unlock()
 
+	denyExecutableWrite(fd)
+
 	// Release the old reference.
 	//
 	// Do this without holding the lock, since it may wind up doing some
 	// I/O to sync the dirent, etc.
 	if orig != nil {
+		allowExecutableWrite(orig)
 		orig.DecRef(ctx)
 	}
 }
@@ -177,4 +180,15 @@ func (mm *MemoryManager) SetVDSOSigReturn(addr uint64) {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
 	mm.vdsoSigReturnAddr = addr
+}
+
+// denyExecutableWrite denies writes to the file backing fd, which is being
+// executed.
+func denyExecutableWrite(fd *vfs.FileDescription) {
+	fd.Mount().Filesystem().VirtualFilesystem().DenyWriteAccess(fd.Dentry())
+}
+
+// allowExecutableWrite undoes a previous call to denyExecutableWrite.
+func allowExecutableWrite(fd *vfs.FileDescription) {
+	fd.Mount().Filesystem().VirtualFilesystem().AllowWriteAccess(fd.Dentry())
 }

--- a/pkg/sentry/vfs/permissions.go
+++ b/pkg/sentry/vfs/permissions.go
@@ -359,3 +359,38 @@ func ClearSUIDAndSGID(mode uint32) uint32 {
 	}
 	return mode
 }
+
+// DenyWriteAccess marks d as being executed, causing subsequent attempts to
+// open it for writing or truncate it to fail with ETXTBSY.
+func (vfs *VirtualFilesystem) DenyWriteAccess(d *Dentry) {
+	vfs.execDentriesMu.Lock()
+	defer vfs.execDentriesMu.Unlock()
+	vfs.execDentries[d]++
+}
+
+// AllowWriteAccess undoes a previous call to DenyWriteAccess.
+func (vfs *VirtualFilesystem) AllowWriteAccess(d *Dentry) {
+	vfs.execDentriesMu.Lock()
+	defer vfs.execDentriesMu.Unlock()
+	if n := vfs.execDentries[d]; n > 1 {
+		vfs.execDentries[d] = n - 1
+	} else {
+		delete(vfs.execDentries, d)
+	}
+}
+
+// CheckWriteAccess returns ETXTBSY if d is currently being executed.
+func (vfs *VirtualFilesystem) CheckWriteAccess(d *Dentry) error {
+	vfs.execDentriesMu.RLock()
+	defer vfs.execDentriesMu.RUnlock()
+	if _, ok := vfs.execDentries[d]; ok {
+		return linuxerr.ETXTBSY
+	}
+	return nil
+}
+
+// CheckWriteAccess returns ETXTBSY if the file described by fd is currently
+// being executed.
+func (fd *FileDescription) CheckWriteAccess() error {
+	return fd.Mount().Filesystem().VirtualFilesystem().CheckWriteAccess(fd.Dentry())
+}

--- a/pkg/sentry/vfs/vfs.go
+++ b/pkg/sentry/vfs/vfs.go
@@ -118,6 +118,14 @@ type VirtualFilesystem struct {
 	dynCharDevMajorMu   sync.Mutex `state:"nosave"`
 	dynCharDevMajorUsed map[uint32]struct{}
 
+	// execDentries maps Dentries that are currently being executed to the
+	// number of MemoryManagers executing them. Such files may not be opened
+	// for writing or truncated. execDentries is protected by execDentriesMu.
+	//
+	// execDentries is analogous to a negative Linux inode.i_writecount.
+	execDentriesMu sync.RWMutex `state:"nosave"`
+	execDentries   map[*Dentry]uint32
+
 	// anonBlockDevMinor contains all allocated anonymous block device minor
 	// numbers. anonBlockDevMinorNext is a lower bound for the smallest
 	// unallocated anonymous block device number. anonBlockDevMinorNext and
@@ -158,6 +166,7 @@ func (vfs *VirtualFilesystem) Init(ctx context.Context) error {
 	vfs.mountpoints = make(map[*Dentry]map[*Mount]struct{})
 	vfs.devices = make(map[devTuple]*registeredDevice)
 	vfs.dynCharDevMajorUsed = make(map[uint32]struct{})
+	vfs.execDentries = make(map[*Dentry]uint32)
 	vfs.anonBlockDevMinorNext = 1
 	vfs.anonBlockDevMinor = make(map[uint32]struct{})
 	vfs.fsTypes = make(map[string]*registeredFilesystemType)

--- a/test/syscalls/linux/exec.cc
+++ b/test/syscalls/linux/exec.cc
@@ -86,6 +86,7 @@ constexpr char kExecWithThread[] = "--exec_exec_with_thread";
 constexpr char kExecFromThread[] = "--exec_exec_from_thread";
 constexpr char kExecInParent[] = "--exec_exec_in_parent";
 constexpr char kWriteAndWaitForPid[] = "--exec_write_and_wait_for_pid";
+constexpr char kSignalAndPause[] = "--exec_signal_and_pause";
 
 // Runs file specified by dirfd and pathname with argv and checks that the exit
 // status is expect_status and that stderr contains expect_stderr.
@@ -1155,6 +1156,49 @@ TEST(ExecTest, ReadProcMemAfterExecFromChild) {
             W_EXITCODE(42, 0), "");
 }
 
+// Signals readiness on pipe_fd, then blocks so that the caller can operate on
+// this process' executable while it is still running.
+void signalAndPause(int pipe_fd) {
+  char c = 'x';
+  TEST_PCHECK(WriteFd(pipe_fd, &c, 1) == 1);
+  TEST_PCHECK(close(pipe_fd) == 0);
+  pause();
+  _exit(1);
+}
+
+TEST(ExecTest, WriteExecutedBinaryFails) {
+  // Execute a writable copy of this binary, so that write permission does not
+  // mask ETXTBSY.
+  const std::string exe = ASSERT_NO_ERRNO_AND_VALUE(ProcessExePath(getpid()));
+  const std::string contents = ASSERT_NO_ERRNO_AND_VALUE(GetContents(exe));
+  const TempPath binary = ASSERT_NO_ERRNO_AND_VALUE(
+      TempPath::CreateFileWith(GetShortTestTmpdir(), contents, 0755));
+
+  int pipe_fds[2];
+  ASSERT_THAT(pipe(pipe_fds), SyscallSucceeds());
+  FileDescriptor read_fd(pipe_fds[0]);
+  FileDescriptor write_fd(pipe_fds[1]);
+
+  pid_t child;
+  int execve_errno;
+  const Cleanup kill = ASSERT_NO_ERRNO_AND_VALUE(ForkAndExec(
+      binary.path(),
+      {binary.path(), kSignalAndPause, absl::StrCat(pipe_fds[1])}, {}, &child,
+      &execve_errno));
+  ASSERT_EQ(0, execve_errno);
+  write_fd.reset();
+
+  char c;
+  ASSERT_THAT(ReadFd(read_fd.get(), &c, 1), SyscallSucceedsWithValue(1));
+
+  EXPECT_THAT(open(binary.path().c_str(), O_WRONLY),
+              SyscallFailsWithErrno(ETXTBSY));
+  EXPECT_THAT(open(binary.path().c_str(), O_RDONLY | O_TRUNC),
+              SyscallFailsWithErrno(ETXTBSY));
+  EXPECT_THAT(truncate(binary.path().c_str(), 0),
+              SyscallFailsWithErrno(ETXTBSY));
+}
+
 /*
 This function, along with writeAndWaitForPid, sets up the test case to verify
 that a /proc/self/mem file descriptor is not leaked across an execve similar to
@@ -1343,6 +1387,14 @@ int main(int argc, char** argv) {
     }
     if (arg == gvisor::testing::kExecInParent) {
       gvisor::testing::execInParent();
+      return 1;
+    }
+    if (arg == gvisor::testing::kSignalAndPause) {
+      int fd;
+      if (!absl::SimpleAtoi(argv[i + 1], &fd)) {
+        return 1;
+      }
+      gvisor::testing::signalAndPause(fd);
       return 1;
     }
     if (arg == gvisor::testing::kWriteAndWaitForPid) {


### PR DESCRIPTION
Fixes #1005.

## Summary

- Track Dentries in use as a `MemoryManager`'s executable in the `VirtualFilesystem`.
- Return `ETXTBSY` when such a file is opened for writing, opened with `O_TRUNC`, or truncated.
- Add a regression test covering the reported repro.

## Root cause

Linux denies write access to a regular file while it is in use as a process' executable, via `inode.i_writecount` and `deny_write_access()` in `fs/exec.c`. The sentry tracked no equivalent state. `linuxerr.ETXTBSY` was already defined in the errno tables but was never returned anywhere, so overwriting a running binary corrupted the running image instead of failing.

## Implementation

The marker lives in `VirtualFilesystem` as a refcounted set of Dentries, since one binary may be executed by several processes. It is taken in `MemoryManager.SetExecutable` and on fork, and released when the `MemoryManager` is torn down or its executable is replaced — the analogue of Linux tying this to `mm->exe_file`.

Filesystems consult the marker after their existing permission check and before truncating. That ordering matches Linux (`may_open` before `get_write_access`), so a file the caller cannot write still fails with `EACCES` rather than `ETXTBSY`. `vfs.OpenAt` was not a usable choke point: it has no inode identity for the target before calling into the filesystem, and `O_TRUNC` is applied inside each `OpenAt` implementation, so a check there would truncate the binary before returning the error.

Covered: gofer, overlay, tmpfs. erofs is read-only; kernfs and host are not exec-then-write targets.

## Limitations

Keyed on Dentry rather than inode, so a hardlink to a running binary under a different name is not covered. Linux catches that case. Extending this to inode identity would require write-count tracking in each filesystem implementation, which seemed disproportionate here.

## Testing

I was not able to build or run this locally — I don't currently have a Linux/Bazel environment available, and `test/syscalls` needs one. **This change has not been compiled or executed.** I'm relying on CI for the first real signal, and I'll fix up whatever it finds.

Static checks I did run: `git diff --check`, and manual verification that every referenced symbol and import exists.

Relevant targets:

```
make test TARGETS="//test/syscalls:exec_test_runsc_ptrace"
make test TARGETS="//test/syscalls:exec_binary_test_runsc_ptrace"
make test TARGETS="//test/syscalls:open_create_test_runsc_ptrace"
```

Assisted-by: Claude Code
