### PR TITLE
chore: expose checkescape as a vettool

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -153,6 +153,7 @@ go_path(
         "//shim/v1/cli",
         "//webhook/pkg/cli",
         "//tools/checklocks",
+        "//tools/checkescape",
 
         # Packages that are not dependencies of the above.
         "//pkg/sentry/kernel/memevent",

--- a/tools/checkescape/BUILD
+++ b/tools/checkescape/BUILD
@@ -13,7 +13,11 @@ go_library(
         "checkescape_arm64.go",
     ],
     nogo = False,
-    visibility = ["//tools/nogo:__subpackages__"],
+    visibility = [
+        "//:__pkg__",
+        "//tools/checkescape/cmd:__subpackages__",
+        "//tools/nogo:__subpackages__",
+    ],
     deps = [
         "//tools/nogo/flags",
         "@org_golang_x_tools//go/analysis:go_default_library",

--- a/tools/checkescape/cmd/BUILD
+++ b/tools/checkescape/cmd/BUILD
@@ -1,0 +1,13 @@
+load("//tools:defs.bzl", "go_binary")
+
+package(default_applicable_licenses = ["//:license"])
+
+go_binary(
+    name = "checkescape",
+    srcs = ["main.go"],
+    deps = [
+        "//tools/checkescape",
+        "@org_golang_x_tools//go/analysis:go_default_library",
+        "@org_golang_x_tools//go/analysis/singlechecker:go_default_library",
+    ],
+)

--- a/tools/checkescape/cmd/README.md
+++ b/tools/checkescape/cmd/README.md
@@ -1,0 +1,23 @@
+# Checkescape Analyzer
+
+Checkescape allows recursive escape analysis for hot paths.
+
+## Installation and Usage
+
+The analyzer is integrated into the gVisor `nogo` framework. It automatically
+applies to all code in this repository.
+
+For external usage and to iterate quickly, it may be used as part of `go vet` or it can run as a standalone tool.
+You can install the tool separately via:
+
+```sh
+go install gvisor.dev/gvisor/tools/checkescape/cmd/checkescape@go
+```
+
+And run it via:
+
+```sh
+go vet -vettool=$(go env GOBIN)/checkescape ./...
+# or directly
+checkescape ./...
+```

--- a/tools/checkescape/cmd/main.go
+++ b/tools/checkescape/cmd/main.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary checkescape is a `vettool` for `go vet`.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"gvisor.dev/gvisor/tools/checkescape"
+)
+
+// goBuild compiles the pkg under analysis into a standalone binary
+// so that "go tool objdump" (invoked by checkescape) has machine code to disassemble.
+func goBuild(pass *analysis.Pass) (string, error) {
+	tmp, err := os.CreateTemp("", "checkescape-*.bin")
+	if err != nil {
+		return "", err
+	}
+	tmp.Close()
+
+	importPath := pass.Pkg.Path()
+	cmd := exec.Command("go", "build", "-o", tmp.Name(), importPath)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		os.Remove(tmp.Name())
+		return "", fmt.Errorf("cannot build bin from %q: %w", importPath, err)
+	}
+	return tmp.Name(), nil
+}
+
+func main() {
+	// Reset the flags registered by nogo
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	flag.CommandLine.Usage = func() {}
+
+	singlechecker.Main(&analysis.Analyzer{
+		Name:      "checkescape",
+		Doc:       checkescape.Analyzer.Doc,
+		Requires:  checkescape.Analyzer.Requires,
+		FactTypes: checkescape.Analyzer.FactTypes,
+		Run: func(pass *analysis.Pass) (any, error) {
+			binPath, err := goBuild(pass)
+			if err != nil {
+				return nil, err
+			}
+			defer os.Remove(binPath)
+
+			f, err := os.Open(binPath)
+			if err != nil {
+				return nil, err
+			}
+			defer f.Close()
+
+			return checkescape.Analyzer.Run(pass, f)
+		},
+	})
+}

--- a/tools/go_branch.sh
+++ b/tools/go_branch.sh
@@ -116,7 +116,7 @@ EOF
 # There are a few solitary files that can get left behind due to the way bazel
 # constructs the gopath target. Note that we don't find all Go files here
 # because they may correspond to unused templates, etc.
-declare -ar binaries=( "runsc" "shim" "webhook" "tools/checklocks/cmd/checklocks" )
+declare -ar binaries=( "runsc" "shim" "webhook" "tools/checklocks/cmd/checklocks" "tools/checkescape/cmd/checkescape" )
 for target in "${binaries[@]}"; do
   mkdir -p "${target}"
   cp "${repo_orig}/${target}"/*.go "${target}/"


### PR DESCRIPTION
Fixes https://github.com/google/gvisor/issues/14160 as suggested by @milantracy.

### Test

Using a simple file as a target, like the following:
```go
package main

import "fmt"

type Data struct {
	x int
	y int
	z int
}

var sink *Data

// +checkescape
func HeapAllocEscape() {
	d := &Data{1, 2, 3}
	sink = d // d escapes to heap
}

func main() {
	HeapAllocEscape()
	fmt.Println(sink)
}
```

Build and run it as a vettool:
```bash
$ go build -o checkescape main.go
$ mv ./checkescape $(go env GOBIN)
$ go vet -vettool=$(go env GOBIN)/checkescape .
main.go:15:12: heap: explicit allocation → runtime.newobject
```