### PR TITLE
erofs: make dentry cache configurable via -dcache

### DIFF
--- a/pkg/sentry/fsimpl/erofs/erofs.go
+++ b/pkg/sentry/fsimpl/erofs/erofs.go
@@ -20,7 +20,7 @@
 //	  dentry.dirMu
 //	    inode.dirMu
 //	    inodeBucket.mu
-//	    filesystem.cacheMu
+//	    dentryCache.mu
 package erofs
 
 import (
@@ -38,6 +38,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/erofs"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/checkpoint"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
@@ -53,7 +54,10 @@ const Name = "erofs"
 // Mount option names for EROFS.
 const (
 	moptImageFD = "ifd"
+	moptDcache  = "dcache"
 )
+
+var SupportedMountOptions = []string{moptDcache}
 
 // FilesystemType implements vfs.FilesystemType.
 //
@@ -61,6 +65,28 @@ const (
 type FilesystemType struct{}
 
 const defaultMaxCachedDentries = 1000
+
+// +stateify savable
+type dentryCache struct {
+	maxCachedDentries uint64
+	mu                sync.Mutex `state:"nosave"`
+	dentries          dentryList
+	dentriesLen       uint64
+}
+
+// SetDentryCacheSize sets the size of the global EROFS dentry cache.
+func SetDentryCacheSize(size int) {
+	if size < 0 {
+		return
+	}
+	if globalDentryCache != nil {
+		log.Warningf("Global EROFS dentry cache has already been initialized. Ignoring subsequent attempt.")
+		return
+	}
+	globalDentryCache = &dentryCache{maxCachedDentries: uint64(size)}
+}
+
+var globalDentryCache *dentryCache
 
 // filesystem implements vfs.FilesystemImpl.
 //
@@ -97,13 +123,7 @@ type filesystem struct {
 	// ancestryMu is required by genericfstree.
 	ancestryMu sync.RWMutex `state:"nosave"`
 
-	// cacheMu protects the dentry cache LRU list.
-	cacheMu sync.Mutex `state:"nosave"`
-	// +checklocks:cacheMu
-	cachedDentries dentryList
-	// +checklocks:cacheMu
-	cachedDentriesLen uint64
-	maxCachedDentries uint64
+	dentryCache *dentryCache
 
 	// released is nonzero once filesystem.Release has been called.
 	released atomicbitops.Uint32
@@ -147,6 +167,19 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 	}
 	cu.Add(func() { image.Close() })
 
+	maxCachedDentries := uint64(defaultMaxCachedDentries)
+	if dcacheStr, ok := mopts[moptDcache]; ok {
+		delete(mopts, moptDcache)
+		dcache, err := strconv.ParseInt(dcacheStr, 10, 64)
+		if err != nil {
+			ctx.Warningf("erofs.FilesystemType.GetFilesystem: invalid dcache: %s=%s", moptDcache, dcacheStr)
+			return nil, nil, linuxerr.EINVAL
+		}
+		if dcache >= 0 {
+			maxCachedDentries = uint64(dcache)
+		}
+	}
+
 	iopts, ok := opts.InternalData.(InternalFilesystemOptions)
 	if opts.InternalData != nil && !ok {
 		ctx.Warningf("erofs.FilesystemType.GetFilesystem: GetFilesystemOptions.InternalData has type %T, wanted erofs.InternalFilesystemOptions", opts.InternalData)
@@ -164,16 +197,21 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 	}
 
 	fs := &filesystem{
-		mopts:             opts.Data,
-		iopts:             iopts,
-		image:             image,
-		devMinor:          devMinor,
-		useReadForIO:      useReadForIO,
-		mf:                imageMemmapFile{image: image},
-		maxCachedDentries: defaultMaxCachedDentries,
+		mopts:        opts.Data,
+		iopts:        iopts,
+		image:        image,
+		devMinor:     devMinor,
+		useReadForIO: useReadForIO,
+		mf:           imageMemmapFile{image: image},
 	}
 	fs.vfsfs.Init(vfsObj, &fstype, fs)
 	cu.Add(func() { fs.vfsfs.DecRef(ctx) })
+
+	if globalDentryCache != nil {
+		fs.dentryCache = globalDentryCache
+	} else {
+		fs.dentryCache = &dentryCache{maxCachedDentries: maxCachedDentries}
+	}
 
 	fs.inodeBuckets = make([]inodeBucket, runtime.GOMAXPROCS(0))
 	for i := range fs.inodeBuckets {
@@ -456,7 +494,7 @@ type dentry struct {
 	// cachingMu serializes this dentry's caching and eviction decisions.
 	cachingMu sync.Mutex `state:"nosave"`
 
-	// cached indicates whether this dentry is on fs.cachedDentries. It is
+	// cached indicates whether this dentry is on fs.dentryCache. It is
 	// protected by cachingMu.
 	cached bool
 
@@ -547,7 +585,7 @@ func (d *dentry) LogRefs() bool { return false }
 // Safe to call after either a DecRef or an IncRef; the latter is a hygiene
 // pass that yanks revived dentries off the LRU.
 //
-// Preconditions: the caller holds neither d.cachingMu nor fs.cacheMu.
+// Preconditions: the caller holds neither d.cachingMu nor fs.dentryCache.mu.
 func (d *dentry) checkCaching(ctx context.Context) {
 	d.cachingMu.Lock()
 
@@ -590,22 +628,23 @@ func (d *dentry) checkCaching(ctx context.Context) {
 		return
 	}
 
+	cache := fs.dentryCache
 	if d.cached {
 		// If d is already cached, just move it to the front of the LRU.
-		fs.cacheMu.Lock()
-		fs.cachedDentries.Remove(d)
-		fs.cachedDentries.PushFront(d)
-		fs.cacheMu.Unlock()
+		cache.mu.Lock()
+		cache.dentries.Remove(d)
+		cache.dentries.PushFront(d)
+		cache.mu.Unlock()
 		d.cachingMu.Unlock()
 		return
 	}
 	// Cache the dentry, then evict the least recently used cached dentry if
 	// the cache becomes over-full.
-	fs.cacheMu.Lock()
-	fs.cachedDentries.PushFront(d)
-	fs.cachedDentriesLen++
-	shouldEvict := fs.cachedDentriesLen > fs.maxCachedDentries
-	fs.cacheMu.Unlock()
+	cache.mu.Lock()
+	cache.dentries.PushFront(d)
+	cache.dentriesLen++
+	shouldEvict := cache.dentriesLen > cache.maxCachedDentries
+	cache.mu.Unlock()
 	d.cached = true
 	d.cachingMu.Unlock()
 
@@ -614,27 +653,29 @@ func (d *dentry) checkCaching(ctx context.Context) {
 	}
 }
 
-// removeFromCache ensures d is not on fs.cachedDentries. It is idempotent.
+// removeFromCache removes d from the dentry cache. It is idempotent.
 //
 // +checklocks:d.cachingMu
 func (d *dentry) removeFromCache() {
 	if !d.cached {
 		return
 	}
-	d.inode.fs.cacheMu.Lock()
-	d.inode.fs.cachedDentries.Remove(d)
-	d.inode.fs.cachedDentriesLen--
-	d.inode.fs.cacheMu.Unlock()
+	cache := d.inode.fs.dentryCache
+	cache.mu.Lock()
+	cache.dentries.Remove(d)
+	cache.dentriesLen--
+	cache.mu.Unlock()
 	d.cached = false
 }
 
-// evictCachedDentry removes the least-recently-used dentry from cachedDentries
-// and evicts it. Returns true if a dentry was evicted.
+// evictCachedDentry evicts the LRU dentry. Returns true if a dentry was
+// evicted.
 func (fs *filesystem) evictCachedDentry(ctx context.Context) bool {
+	cache := fs.dentryCache
 	for {
-		fs.cacheMu.Lock()
-		victim := fs.cachedDentries.Back()
-		fs.cacheMu.Unlock()
+		cache.mu.Lock()
+		victim := cache.dentries.Back()
+		cache.mu.Unlock()
 		if victim == nil {
 			return false
 		}
@@ -650,10 +691,29 @@ func (fs *filesystem) evictCachedDentry(ctx context.Context) bool {
 	}
 }
 
-// evictAllCachedDentries drains the LRU. Used during filesystem release;
-// the fs.released flag ensures the cascade doesn't re-populate the LRU.
+// evictAllCachedDentries drains fs's dentries during filesystem release.
+// The fs.released flag ensures the cascade doesn't re-populate the cache.
+// Taking a snapshot avoids repeatedly scanning unrelated entries in a shared
+// cache.
 func (fs *filesystem) evictAllCachedDentries(ctx context.Context) {
-	for fs.evictCachedDentry(ctx) {
+	cache := fs.dentryCache
+	cache.mu.Lock()
+	var victims []*dentry
+	for d := cache.dentries.Back(); d != nil; d = d.Prev() {
+		if d.inode.fs == fs {
+			victims = append(victims, d)
+		}
+	}
+	cache.mu.Unlock()
+
+	for _, victim := range victims {
+		victim.cachingMu.Lock()
+		// victim may have been removed from the cache by a racing eviction.
+		if !victim.cached {
+			victim.cachingMu.Unlock()
+			continue
+		}
+		victim.evictAndUnlockCachingMu(ctx)
 	}
 }
 

--- a/pkg/sentry/fsimpl/erofs/save_restore.go
+++ b/pkg/sentry/fsimpl/erofs/save_restore.go
@@ -15,17 +15,38 @@
 package erofs
 
 import (
-	"context"
+	goContext "context"
 	"fmt"
 	"os"
 
+	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/erofs"
 	"gvisor.dev/gvisor/pkg/refs"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 )
 
+var _ vfs.FilesystemImplSaveRestoreExtension = (*filesystem)(nil)
+
+// PrepareSave implements vfs.FilesystemImplSaveRestoreExtension.PrepareSave.
+func (fs *filesystem) PrepareSave(ctx context.Context) error {
+	for fs.evictCachedDentry(ctx) {
+	}
+	return nil
+}
+
+// BeforeResume implements vfs.FilesystemImplSaveRestoreExtension.BeforeResume.
+func (*filesystem) BeforeResume(context.Context) {}
+
+// CompleteRestore implements vfs.FilesystemImplSaveRestoreExtension.CompleteRestore.
+func (fs *filesystem) CompleteRestore(context.Context, vfs.CompleteRestoreOptions) error {
+	if globalDentryCache != nil {
+		fs.dentryCache = globalDentryCache
+	}
+	return nil
+}
+
 // afterLoad is called by stateify.
-func (fs *filesystem) afterLoad(ctx context.Context) {
+func (fs *filesystem) afterLoad(ctx goContext.Context) {
 	fdmap := vfs.RestoreFilesystemFDMapFromContext(ctx)
 	fd, ok := fdmap[fs.iopts.UniqueID]
 	if !ok {
@@ -49,12 +70,12 @@ func (d *dentry) saveParent() *dentry {
 }
 
 // loadParent is called by stateify.
-func (d *dentry) loadParent(_ context.Context, parent *dentry) {
+func (d *dentry) loadParent(_ goContext.Context, parent *dentry) {
 	d.parent.Store(parent)
 }
 
 // afterLoad is called by stateify.
-func (d *dentry) afterLoad(context.Context) {
+func (d *dentry) afterLoad(goContext.Context) {
 	if d.refs.Load() != -1 {
 		refs.Register(d)
 	}

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -131,6 +131,9 @@ func registerFilesystems(k *kernel.Kernel, info *containerInfo, rdmaSnapshot *rd
 	ctx := k.SupervisorContext()
 	vfsObj := k.VFS()
 
+	// Configure the process-wide EROFS dentry cache.
+	erofs.SetDentryCacheSize(info.conf.DCache)
+
 	vfsObj.MustRegisterFilesystemType(cgroupfs.Name, &cgroupfs.FilesystemType{}, &vfs.RegisterFilesystemTypeOptions{
 		AllowUserMount: true,
 		AllowUserList:  true,
@@ -1160,7 +1163,12 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 		if m.goferFD == nil {
 			return "", nil, fmt.Errorf("EROFS mount requires an image file FD")
 		}
-		data = []string{fmt.Sprintf("ifd=%d", m.goferFD.Release())}
+		var err error
+		mopts, data, err = consumeMountOptions(mopts, erofs.SupportedMountOptions...)
+		if err != nil {
+			return "", nil, err
+		}
+		data = append(data, fmt.Sprintf("ifd=%d", m.goferFD.Release()))
 		internalData = erofs.InternalFilesystemOptions{
 			UniqueID: checkpoint.ResourceID{
 				ContainerName: containerName,

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -343,8 +343,8 @@ type Config struct {
 	// each.
 	FDLimit int `flag:"fdlimit"`
 
-	// DCache sets the global dirent cache size. If negative, per-mount caches are
-	// used.
+	// DCache sets the global dentry cache size. It applies independently to
+	// gofer and EROFS. If negative, per-mount caches are used.
 	DCache int `flag:"dcache"`
 
 	// IOUring enables support for the IO_URING API calls to perform

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -150,7 +150,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 	flagSet.Bool("ignore-cgroups", false, "don't configure cgroups.")
 	flagSet.Var(inSandboxCgroupTypePtr(InSandboxCgroupV1), flagInSandboxCgroup, "cgroup setup to use inside the sandbox: v1 (default), v2.")
 	flagSet.Int("fdlimit", -1, "Specifies a limit on the number of host file descriptors that can be open. Applies separately to the sentry and gofer. Note: each file in the sandbox holds more than one host FD open.")
-	flagSet.Int("dcache", -1, "Set the global dentry cache size. This acts as a coarse-grained control on the number of host FDs simultaneously open by the sentry. If negative, per-mount caches are used.")
+	flagSet.Int("dcache", -1, "Set the global dentry cache size. This acts as a coarse-grained control on the number of host FDs simultaneously open by the sentry; for EROFS, it controls the number of cached dentries. If negative, per-mount caches are used.")
 	flagSet.Bool("iouring", false, "TEST ONLY; Enables io_uring syscalls in the sentry. Support is experimental and very limited.")
 	flagSet.Bool("directfs", true, "directly access the container filesystems from the sentry. Sentry runs with higher privileges.")
 	flagSet.Bool("TESTONLY-nftables", false, "TEST ONLY; Enables nftables support in the sentry.")

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -1254,7 +1254,7 @@ func TestSignalProcessGroup(t *testing.T) {
 // recorded. Then, it is restored in two new containers and the first number
 // printed from these containers is checked. Both should be the next consecutive
 // number after the last number from the checkpointed container.
-func testCheckpointRestore(t *testing.T, conf *config.Config, compression statefile.CompressionLevel, newSpecWithScript func(string) *specs.Spec) {
+func testCheckpointRestore(t *testing.T, conf *config.Config, compression statefile.CompressionLevel, newSpecWithScript func(string) *specs.Spec, afterRestore func(*Container)) {
 	dir, err := os.MkdirTemp(testutil.TmpDir(), "checkpoint-test")
 	if err != nil {
 		t.Fatalf("os.MkdirTemp failed: %v", err)
@@ -1359,6 +1359,9 @@ func testCheckpointRestore(t *testing.T, conf *config.Config, compression statef
 	if lastNum+1 != firstNum {
 		t.Errorf("error numbers not in order, previous: %d, next: %d", lastNum, firstNum)
 	}
+	if afterRestore != nil {
+		afterRestore(cont2)
+	}
 	cont2.Destroy()
 	cont2 = nil
 
@@ -1418,7 +1421,7 @@ func TestCheckpointRestore(t *testing.T) {
 				t.Run(string(compression), func(t *testing.T) {
 					testCheckpointRestore(t, conf, compression, func(script string) *specs.Spec {
 						return testutil.NewSpecWithArgs("bash", "-c", script)
-					})
+					}, nil)
 				})
 			}
 		})
@@ -5121,6 +5124,16 @@ func TestRootfsEROFS(t *testing.T) {
 // TestCheckpointRestoreEROFS does the checkpoint/restore test on each platform using
 // an EROFS image as the rootfs.
 func TestCheckpointRestoreEROFS(t *testing.T) {
+	testCheckpointRestoreEROFS(t, -1)
+}
+
+// TestCheckpointRestoreEROFSDCache checks EROFS checkpoint/restore with a
+// global dentry cache.
+func TestCheckpointRestoreEROFSDCache(t *testing.T) {
+	testCheckpointRestoreEROFS(t, 1)
+}
+
+func testCheckpointRestoreEROFS(t *testing.T, dcache int) {
 	// Skip this test if mkfs.erofs or busybox are not available.
 	skipIfNotAvailable(t, "mkfs.erofs", "busybox")
 
@@ -5138,6 +5151,19 @@ func TestCheckpointRestoreEROFS(t *testing.T) {
 	// Skip overlay because test requires writing to host file.
 	for name, conf := range configs(t, true /* noOverlay */) {
 		t.Run(name, func(t *testing.T) {
+			conf.DCache = dcache
+			var afterRestore func(*Container)
+			if dcache >= 0 {
+				// Add a live EROFS mount after restore to cover global cache reuse.
+				afterRestore = func(c *Container) {
+					if err := c.Sandbox.Mount(c.ID, erofs.Name, rootfsImage, "/data"); err != nil {
+						t.Fatalf("error mounting EROFS image after restore: %v", err)
+					}
+					if out, err := executeCombinedOutput(conf, c, nil, "/busybox", "test", "-f", "/data/busybox"); err != nil {
+						t.Fatalf("failed to access live EROFS mount: %v, output: %s", err, out)
+					}
+				}
+			}
 			testCheckpointRestore(t, conf, statefile.CompressionLevelDefault, func(script string) *specs.Spec {
 				spec := testutil.NewSpecWithArgs("/busybox", "sh", "-c", script)
 				spec.Root = &specs.Root{
@@ -5155,7 +5181,7 @@ func TestCheckpointRestoreEROFS(t *testing.T) {
 				// between host and test container.
 				spec.Annotations[boot.RootfsPrefix+"overlay"] = config.MemoryOverlay.String()
 				return spec
-			})
+			}, afterRestore)
 		})
 	}
 }


### PR DESCRIPTION
Mirrors fsimpl/gofer's configuration model: `-dcache=N` sets up a global cache shared by all erofs mounts; `-dcache=-1` (default) uses per-mount caches with 1000 entries each. Per-mount `dcache=N` option is also supported.

Assisted-by: OpenCode