### PR TITLE
Suspend GC during Sentry startup.

### DIFF
--- a/pkg/garbage/BUILD
+++ b/pkg/garbage/BUILD
@@ -1,0 +1,21 @@
+load("//tools:defs.bzl", "go_library", "go_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "garbage",
+    srcs = ["garbage.go"],
+    visibility = ["//:sandbox"],
+    deps = [
+        "//pkg/atomicbitops",
+    ],
+)
+
+go_test(
+    name = "garbage_test",
+    srcs = ["garbage_test.go"],
+    library = ":garbage",
+)

--- a/pkg/garbage/garbage.go
+++ b/pkg/garbage/garbage.go
@@ -1,0 +1,52 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package garbage manages the Go garbage collector.
+package garbage
+
+import (
+	gcdebug "runtime/debug"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
+)
+
+var (
+	// suspensions counts `Suspend` calls not yet matched by a `Resume`.
+	suspensions atomicbitops.Int64
+
+	// resumePercent is the collection target percentage in effect before the
+	// first `Suspend`, restored by the last `Resume`.
+	resumePercent int
+)
+
+// Suspend turns garbage collection off until a matching `Resume`.
+// Every `Suspend` must be matched by a `Resume`.
+func Suspend() {
+	if suspensions.Add(1) == 1 {
+		resumePercent = gcdebug.SetGCPercent(-1)
+	}
+}
+
+// Resume releases one `Suspend`.
+// Once all suspensions are released, garbage collection resumes.
+func Resume() {
+	n := suspensions.Add(-1)
+	if n < 0 {
+		suspensions.Add(1)
+		panic("garbage.Resume without a matching Suspend")
+	}
+	if n == 0 {
+		gcdebug.SetGCPercent(resumePercent)
+	}
+}

--- a/pkg/garbage/garbage_test.go
+++ b/pkg/garbage/garbage_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package garbage
+
+import (
+	gcdebug "runtime/debug"
+	"testing"
+)
+
+// gcPercent returns the current garbage collection target percentage.
+func gcPercent() int {
+	p := gcdebug.SetGCPercent(100)
+	gcdebug.SetGCPercent(p)
+	return p
+}
+
+func TestSuspendResume(t *testing.T) {
+	orig := gcdebug.SetGCPercent(37)
+	defer gcdebug.SetGCPercent(orig)
+	Suspend()
+	Resume()
+	if got := gcPercent(); got != 37 {
+		t.Errorf("after Resume: got GC percent %d, want 37", got)
+	}
+}
+
+func TestSuspendNests(t *testing.T) {
+	orig := gcPercent()
+	Suspend()
+	Suspend()
+	Resume()
+	if got := gcPercent(); got != -1 {
+		t.Errorf("after releasing one of two suspensions: got GC percent %d, want -1", got)
+	}
+	Resume()
+	if got := gcPercent(); got != orig {
+		t.Errorf("after releasing all suspensions: got GC percent %d, want %d", got, orig)
+	}
+}
+
+func TestUnmatchedResumePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("Resume without a matching Suspend did not panic")
+		}
+	}()
+	Resume()
+}

--- a/runsc/boot/BUILD
+++ b/runsc/boot/BUILD
@@ -51,6 +51,7 @@ go_library(
         "//pkg/flipcall",
         "//pkg/fspath",
         "//pkg/fsutil",
+        "//pkg/garbage",
         "//pkg/gomaxprocs",
         "//pkg/hostarch",
         "//pkg/log",

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -34,6 +34,7 @@ import (
 	"gvisor.dev/gvisor/pkg/coverage"
 	"gvisor.dev/gvisor/pkg/cpuid"
 	"gvisor.dev/gvisor/pkg/fd"
+	"gvisor.dev/gvisor/pkg/garbage"
 	"gvisor.dev/gvisor/pkg/gomaxprocs"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/memutil"
@@ -1310,6 +1311,12 @@ func (l *Loader) run() error {
 	l.startupTimer.Reached("kernel started")
 	l.root.procArgs.StartupTimeline.End()
 	l.root.procArgs.StartupTimeline = nil
+
+	// LINT.IfChange
+	// Resume garbage collection now that process has started.
+	garbage.Resume()
+	// LINT.ThenChange(../cmd/sentry/sentrycmd/boot.go)
+
 	switch l.state {
 	case created:
 		l.state = started

--- a/runsc/cmd/sentry/sentrycmd/BUILD
+++ b/runsc/cmd/sentry/sentrycmd/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/coretag",
         "//pkg/cpuid",
         "//pkg/fd",
+        "//pkg/garbage",
         "//pkg/hostarch",
         "//pkg/log",
         "//pkg/metric",

--- a/runsc/cmd/sentry/sentrycmd/boot.go
+++ b/runsc/cmd/sentry/sentrycmd/boot.go
@@ -34,6 +34,7 @@ import (
 	"gvisor.dev/gvisor/pkg/coretag"
 	"gvisor.dev/gvisor/pkg/cpuid"
 	"gvisor.dev/gvisor/pkg/fd"
+	"gvisor.dev/gvisor/pkg/garbage"
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/metric"
@@ -325,16 +326,25 @@ func (b *Boot) willReexec() bool {
 // Execute implements subcommands.Command.Execute.  It starts a sandbox in a
 // waiting state.
 func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcommands.ExitStatus {
+	timer := starttime.Timer("runsc boot")
+	timer.ReachedAt("Go code running", starttime.GoStartTime())
+	timer.Reached("boot subcommand dispatched")
+
+	// LINT.IfChange
+	// Garbage collection is not worth its cost until the container is up.
+	// Go forces every GC every ~doubling of memory (from 4MiB onwards).
+	// But during Sentry startup, we will allocate more than that, and there
+	// will essentially be no garbage to clean. So all of these GC runs will
+	// be futile. Suspend GC until startup finishes.
+	garbage.Suspend()
+	// LINT.ThenChange(../../../boot/loader.go)
+
 	if b.specFD == -1 || b.controllerFD == -1 || b.startSyncFD == -1 || f.NArg() != 1 {
 		f.Usage()
 		return subcommands.ExitUsageError
 	}
 
 	conf := args[0].(*config.Config)
-
-	timer := starttime.Timer("runsc boot")
-	timer.ReachedAt("Go code running", starttime.GoStartTime())
-	timer.Reached("boot subcommand dispatched")
 
 	if hostPageSize := unix.Getpagesize(); hostPageSize != hostarch.PageSize {
 		util.Fatalf("host page size (%d) does not match compiled page size (%d)", hostPageSize, hostarch.PageSize)


### PR DESCRIPTION
The Go garbage collector runs every doubling of process RSS starting at 4 MiB. But for the Sentry, which uses more than 4 MiB and for which all objects allocated during its startup will never be freed, these GC passes are useless because they will never free any meaningful amount of memory. But what they will definitely do is slow down startup.

So suspend GC during startup. Shaves a tiny bit of time at low complexity cost.

Laid this out as a separate `//pkg/garbage` package because it's a funny name and because I suspect we may want to use this to coordinate GC management in other parts of the Sentry's lifecycle in the near future.

Benchmarks:

```
                 │   before    │                after                 │
                 │   sec/op    │   sec/op     vs base                 │
RunscDo            314.5m ± 0%   312.6m ± 0%  -0.59% (p=0.006 n=8448)
DockerRunStartup   402.3m ± 0%   400.0m ± 0%  -0.58% (p=0.004 n=2560)
OCICreate          25.47m ± 0%   23.75m ± 0%  -6.76% (n=2304)
OCIDelete          6.456m ± 0%   6.342m ± 0%  -1.76% (p=0.000 n=2304)
OCIStart           13.17m ± 1%   13.31m ± 0%  +1.04% (p=0.000 n=2304)
OCIReady           38.68m ± 0%   37.02m ± 0%  -4.30% (n=2304)
OCITotal           79.24m ± 1%   78.73m ± 1%  -0.64% (p=0.003 n=2304)
```

(No, I don't know why Delete would be faster either, but the finding is very statistically significant somehow.)