### PR TITLE
systrap: fail-stop sentry on stuck context

### DIFF
--- a/pkg/sentry/platform/systrap/BUILD
+++ b/pkg/sentry/platform/systrap/BUILD
@@ -111,9 +111,13 @@ go_library(
 go_test(
     name = "systrap_test",
     size = "small",
-    srcs = ["context_queue_test.go"],
+    srcs = [
+        "context_queue_test.go",
+        "shared_context_test.go",
+    ],
     library = ":systrap",
     deps = [
         "//pkg/hostarch",
+        "//pkg/sentry/platform/systrap/sysmsg",
     ],
 )

--- a/pkg/sentry/platform/systrap/shared_context.go
+++ b/pkg/sentry/platform/systrap/shared_context.go
@@ -121,8 +121,7 @@ func (sc *sharedContext) isActiveInSubprocess(s *subprocess) bool {
 	return sc.subprocess == s
 }
 
-// NotifyInterrupt implements interrupt.Receiver.NotifyInterrupt.
-func (sc *sharedContext) NotifyInterrupt() {
+func (sc *sharedContext) interruptStub() (*thread, error) {
 	// If this context is not being worked on right now we need to mark it as
 	// interrupted so the next executor does not start working on it.
 	atomic.StoreUint32(&sc.shared.Interrupt, 1)
@@ -130,7 +129,7 @@ func (sc *sharedContext) NotifyInterrupt() {
 	// shared memory between reads.
 	threadID := atomic.LoadUint32(&sc.shared.ThreadID)
 	if threadID == invalidThreadID {
-		return
+		return nil, errNoStubThread
 	}
 	s := sc.subprocess
 	s.sysmsgThreadsMu.RLock()
@@ -139,23 +138,39 @@ func (sc *sharedContext) NotifyInterrupt() {
 	if !ok {
 		// This is either an invalidThreadID or another garbage value; either way we
 		// don't know which thread to interrupt; best we can do is mark the context.
-		return
+		return nil, errNoStubThread
 	}
 
 	t := sysmsgThread.thread
-	if e := hostsyscall.RawSyscallErrno(unix.SYS_TGKILL, uintptr(t.tgid), uintptr(t.tid), uintptr(platform.SignalInterrupt)); e != 0 {
-		if e == unix.ESRCH { // Stub thread already killed?
-			s.dead.Store(true)
-			if !sc.shared.State.CompareAndSwap(sysmsg.ContextStateNone, sysmsg.ContextStateUnexpectedDeath) {
-				s.syscallThread.thread.Warningf("failed to set context state to ContextStateUnexpectedDeath; context state was %v", sc.state())
-			}
-			s.syscallThreadMu.Lock()
-			defer s.syscallThreadMu.Unlock()
-			s.syscallThread.thread.Warningf("Cannot interrupt stub thread %sas it no longer exists; killing syscall thread.", *t.loadLogPrefix())
-			s.syscallThread.thread.kill()
-		} else {
-			panic(fmt.Sprintf("failed to interrupt the child process %d: %v", t.tid, e))
-		}
+	errno := hostsyscall.RawSyscallErrno(unix.SYS_TGKILL, uintptr(t.tgid), uintptr(t.tid), uintptr(platform.SignalInterrupt))
+	switch errno {
+	case 0:
+		return t, nil
+	case unix.ESRCH:
+		return t, errStubThreadGone
+	default:
+		panic(fmt.Sprintf("failed to interrupt the child process %d: %v", t.tid, errno))
+	}
+}
+
+// killSubprocess marks the subprocess dead and kills its syscall thread.
+func (sc *sharedContext) killSubprocess() {
+	s := sc.subprocess
+	s.dead.Store(true)
+	if !sc.shared.State.CompareAndSwap(sysmsg.ContextStateNone, sysmsg.ContextStateUnexpectedDeath) {
+		s.syscallThread.thread.Warningf("failed to set context state to ContextStateUnexpectedDeath; context state was %v", sc.state())
+	}
+	s.syscallThreadMu.Lock()
+	defer s.syscallThreadMu.Unlock()
+	s.syscallThread.thread.kill()
+}
+
+// NotifyInterrupt implements interrupt.Receiver.NotifyInterrupt.
+func (sc *sharedContext) NotifyInterrupt() {
+	t, err := sc.interruptStub()
+	if err == errStubThreadGone {
+		sc.subprocess.syscallThread.thread.Warningf("Cannot interrupt stub thread %sas it no longer exists; killing syscall thread.", *t.loadLogPrefix())
+		sc.killSubprocess()
 	}
 }
 
@@ -233,20 +248,37 @@ func (sc *sharedContext) resetLatencyMeasures() {
 }
 
 const (
-	contextPreemptTimeoutNsec = 10 * 1000 * 1000 // 10ms
-	contextCheckupTimeoutSec  = 5
-	stuckContextTimeout       = 30 * time.Second
+	contextPreemptTimeout = 10 * time.Millisecond
+	contextCheckupTimeout = 5 * time.Second
+	stuckContextTimeout   = 30 * time.Second
 )
 
-var errDeadSubprocess = fmt.Errorf("subprocess died")
+var (
+	errDeadSubprocess = fmt.Errorf("subprocess died")
+	errNoStubThread   = fmt.Errorf("no stub thread to interrupt")
+	errStubThreadGone = fmt.Errorf("stub thread does not exist")
+	errStuckContext   = fmt.Errorf("systrap context is stuck")
+)
 
 func (sc *sharedContext) sleepOnState(state sysmsg.ContextState) error {
-	timeout := unix.Timespec{
-		Sec:  0,
-		Nsec: contextPreemptTimeoutNsec,
+	err := sc.sleepOnStateWithTimeout(state, stuckContextTimeout, contextCheckupTimeout)
+	switch err {
+	case errStuckContext:
+		log.TracebackAll(fmt.Sprintf("Systrap context is stuck; killing its subprocess. ThreadContext: %v", sc))
+		sc.killSubprocess()
+		return errDeadSubprocess
+	case errStubThreadGone, errNoStubThread:
+		log.Warningf("Stub thread no longer exists; killing syscall thread. ThreadContext: %v", sc)
+		sc.killSubprocess()
+		return errDeadSubprocess
 	}
-	sentInterruptOnce := false
-	deadline := time.Now().Add(stuckContextTimeout)
+	return err
+}
+
+func (sc *sharedContext) sleepOnStateWithTimeout(state sysmsg.ContextState, stuckTimeout, checkupTimeout time.Duration) error {
+	timeout := unix.NsecToTimespec(contextPreemptTimeout.Nanoseconds())
+	interruptsSent := 0
+	deadline := time.Now().Add(stuckTimeout)
 	for sc.state() == state {
 		errno := sc.shared.SleepOnState(state, &timeout)
 		if errno == 0 {
@@ -258,21 +290,34 @@ func (sc *sharedContext) sleepOnState(state sysmsg.ContextState) error {
 		if !sc.subprocess.alive() {
 			return errDeadSubprocess
 		}
-		if time.Now().After(deadline) {
-			log.Warningf("Systrap task goroutine has been waiting on ThreadContext.State futex too long. ThreadContext: %v", sc)
+		if interruptsSent > 0 && time.Now().After(deadline) {
+			// The context can recover between the futex timeout and here.
+			if sc.state() != state {
+				return nil
+			}
+			return errStuckContext
 		}
-		if sentInterruptOnce {
-			log.Warningf("The context is still running: %v", sc)
-			continue
-		}
-
 		if !sc.isAcked() || sc.subprocess.contextQueue.isEmpty() {
 			continue
 		}
-		sc.NotifyInterrupt()
-		sentInterruptOnce = true
-		timeout.Sec = contextCheckupTimeoutSec
-		timeout.Nsec = 0
+		if _, err := sc.interruptStub(); err != nil {
+			if sc.state() != state {
+				return nil
+			}
+			if err == errNoStubThread {
+				log.TracebackAll(fmt.Sprintf("Systrap context has no stub thread to interrupt. ThreadContext: %v", sc))
+			}
+			return err
+		}
+		if interruptsSent == 0 {
+			// Guarantee a full checkup interval if the first interrupt was
+			// sent close to the deadline.
+			if checkupDeadline := time.Now().Add(checkupTimeout); checkupDeadline.After(deadline) {
+				deadline = checkupDeadline
+			}
+			timeout = unix.NsecToTimespec(checkupTimeout.Nanoseconds())
+		}
+		interruptsSent++
 	}
 	return nil
 }

--- a/pkg/sentry/platform/systrap/shared_context_test.go
+++ b/pkg/sentry/platform/systrap/shared_context_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package systrap
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/sentry/platform/systrap/sysmsg"
+)
+
+func newTestSharedContext(t *testing.T) *sharedContext {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestStuckSubprocessHelper")
+	cmd.Env = append(os.Environ(), "GVISOR_STUCK_SUBPROCESS_HELPER=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start helper subprocess: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+
+	threadID := uint32(1)
+	child := &thread{tgid: int32(cmd.Process.Pid), tid: int32(cmd.Process.Pid)}
+	queue := &contextQueue{}
+	queue.init()
+	atomic.AddUint32(&queue.end, 1)
+	s := &subprocess{
+		contextQueue: queue,
+		syscallThread: &syscallThread{
+			thread: child,
+		},
+		sysmsgThreads: map[uint32]*sysmsgThread{
+			threadID: {thread: child},
+		},
+	}
+	shared := &sysmsg.ThreadContext{}
+	shared.Init(threadID)
+	atomic.StoreUint64(&shared.AckedTime, 1)
+	return &sharedContext{
+		subprocess: s,
+		shared:     shared,
+	}
+}
+
+func TestSleepOnStateStuckContext(t *testing.T) {
+	sc := newTestSharedContext(t)
+
+	err := sc.sleepOnStateWithTimeout(sysmsg.ContextStateNone, 15*time.Millisecond, 10*time.Millisecond)
+	if !errors.Is(err, errStuckContext) {
+		t.Fatalf("sleepOnStateWithTimeout got error %v, want %v", err, errStuckContext)
+	}
+}
+
+func TestSleepOnStateStuckContextWhenStubIsGone(t *testing.T) {
+	sc := newTestSharedContext(t)
+
+	missing := &thread{tgid: 1 << 30, tid: 1 << 30}
+	sc.subprocess.sysmsgThreads[1].thread = missing
+
+	err := sc.sleepOnStateWithTimeout(sysmsg.ContextStateNone, time.Second, 10*time.Millisecond)
+	if !errors.Is(err, errStubThreadGone) {
+		t.Fatalf("sleepOnStateWithTimeout got error %v, want %v", err, errStubThreadGone)
+	}
+}
+
+func TestSleepOnStateRepeatedInterruptsStillStuck(t *testing.T) {
+	sc := newTestSharedContext(t)
+
+	// Interrupts are resent on every checkup wakeup. The resends must not
+	// push the stuck deadline out.
+	start := time.Now()
+	err := sc.sleepOnStateWithTimeout(sysmsg.ContextStateNone, 30*time.Millisecond, 5*time.Millisecond)
+	if !errors.Is(err, errStuckContext) {
+		t.Fatalf("sleepOnStateWithTimeout got error %v, want %v", err, errStuckContext)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("stuck context detection took %v, want under 1s", elapsed)
+	}
+}
+
+func TestSleepOnStateRecoveredContext(t *testing.T) {
+	sc := newTestSharedContext(t)
+
+	stateChanged := make(chan struct{})
+	go func() {
+		for atomic.LoadUint32(&sc.shared.Interrupt) == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		sc.setState(sysmsg.ContextStateSyscall)
+		close(stateChanged)
+	}()
+
+	err := sc.sleepOnStateWithTimeout(sysmsg.ContextStateNone, 5*time.Millisecond, 10*time.Millisecond)
+	<-stateChanged
+	if err != nil {
+		t.Fatalf("sleepOnStateWithTimeout got error %v, want nil", err)
+	}
+}
+
+func TestStuckSubprocessHelper(t *testing.T) {
+	if os.Getenv("GVISOR_STUCK_SUBPROCESS_HELPER") == "" {
+		return
+	}
+	select {}
+}


### PR DESCRIPTION
A systrap task can remain in `sleepOnState` forever when its stub stops responding. The existing path sends a single interrupt and logs repeated warnings, but it has no retry and no escape. Container teardown can then block indefinitely in `WaitExited`, leaving the sandbox and its control RPCs stuck.

We hit this in a production Kubernetes cluster. Multiple gVisor pods remained Terminating for days, on both release-20260427.0 and release-20260714.0. In one affected sandbox, both `runsc kill` and `runsc debug --stacks` hung while the sentry stayed alive. Systrap `[exe]` stubs and node load continued to accumulate even though CPU use remained low. Killing the sentry process tree cleared the pod and returned node load to normal immediately. Full forensics in #14408.

#14405 is an independent production report of the same hang, with the sentry stacks we could not capture: a task goroutine parked 7,818 minutes in `sleepOnState` on the ThreadContext.State futex after one missed SIGUSR1, `Kernel.Pause()` blocked behind it so the URPC handler for `runsc kill --all` never returns. On the shim side 45,646 goroutines piled up on `Init.mu` behind the hung kill, growing containerd and kubelet memory until node OOM.

The fix, staged from least to most disruptive:

1. Because #14405 shows a single interrupt can simply be lost, the interrupt is resent on every checkup wakeup instead of once. A lost signal recovers the workload with no visible damage.
2. If the stub stays unresponsive through repeated interrupts for the full stuck-context deadline (30 seconds), all goroutine stacks are dumped via `log.TracebackAll`. Stacks are unobtainable from outside a wedged sandbox, so the escalation self-documents what #14405 had to capture by hand.
3. Only the stuck subprocess is then killed, through the same path `NotifyInterrupt` already uses when a stub is gone (mark dead, `ContextStateUnexpectedDeath`, kill the syscall thread). Healthy subprocesses in the sandbox are unaffected, and the task goroutine returns instead of blocking `Kernel.Pause()` forever.

`sleepOnStateWithTimeout` returns a typed error and stays side-effect free; `sleepOnState` does the traceback and the kill. A stub that is already gone takes the quiet `NotifyInterrupt` path (warn + kill subprocess, no stack dump). Resent interrupts do not extend the stuck deadline; a regression test covers that.

Tests:

- `bazel test //pkg/sentry/platform/systrap:systrap_test`
- `bazel build //runsc:runsc`
- Stuck, stub-gone, repeated-interrupt, and recovered-context cases covered on the typed error value.

Fixes #14408. Related to #14405 and #12209.

Assisted-by: Claude Code

