### PR TITLE
nvproxy: complete Blackwell allocation class coverage

### DIFF
--- a/g3doc/user_guide/gpu.md
+++ b/g3doc/user_guide/gpu.md
@@ -170,6 +170,39 @@ microarchitectures as the above will likely work as well. This includes
 consumer-oriented GPUs such as **RTX 3090** (Ampere) and **RTX 4090** (Ada
 Lovelace).
 
+#### Blackwell {#blackwell}
+
+Blackwell GPUs are **not yet officially supported**, because gVisor's
+continuous tests do not currently run on Blackwell hardware. `nvproxy` does
+however implement the Blackwell ABI, and CUDA workloads have been verified to
+run on a **RTX PRO 6000 Blackwell Server Edition** (GB202, compute capability
+12.0) with driver 610.57.04: `nvidia-smi`, the CUDA vector-add and smoke
+samples, and vLLM inference all pass under `runsc`, and the
+[ioctl sniffer](#debugging) reports no unimplemented `ioctl`s. Treat this as
+"expected to work, not qualified": please report problems, but do not rely on
+Blackwell in production the way you can rely on the GPUs listed above.
+
+`nvproxy` implements allocation classes for both Blackwell chip families: the
+datacenter parts (GB100/GB102/GB110/GB112, i.e. B100/B200/GB200/GB300) and the
+consumer and workstation parts (GB202-GB207, i.e. GeForce RTX 50 series and
+RTX PRO Blackwell). Blackwell requires a supported driver version of
+**570.124.06 or newer**; older supported drivers predate the Blackwell
+allocation classes. The Blackwell SoCs (GB10, as in DGX Spark, and GB20x, as in
+Jetson Thor) additionally need their video engine classes, which are present in
+supported drivers 580.65.06 and newer. Device-level GPU tracing uses the
+driver's `trace-device` capability, which exists in driver versions 610.43.02
+and newer and requires the `profiling` driver capability; see
+[Supported Driver Capabilities](#driver-capabilities).
+
+Note that a workload also needs kernels compiled for the GPU's compute
+capability. Frameworks that predate Blackwell fail with `no kernel image is
+available for execution on the device` regardless of the container runtime;
+this is a property of the workload, not of gVisor. For PyTorch, Blackwell
+kernels first shipped in **2.7.0**, and only in the CUDA 12.8 (`cu128`) builds,
+so a `cu126`-or-older wheel will fail on Blackwell even at a recent PyTorch
+version. `torch.cuda.get_arch_list()` shows what a given build actually
+contains.
+
 Therefore, if you encounter an incompatible workload on a GPU on one of the
 above microarchitectures, even if on an unsupported GPU, chances are that this
 workload is also incompatible in the same manner on one of the officially
@@ -233,6 +266,21 @@ capabilities to allow. Allowing additional capabilities broadens the host driver
 surface exposed to the sandbox, so provision this flag conservatively. Passing
 "all" will allow all supported capabilities. If `NVIDIA_DRIVER_CAPABILITIES=all`
 then all allowed capabilities will be used.
+
+`nvproxy` additionally understands the following *privileged* capabilities,
+which correspond to capabilities in the driver's
+`src/nvidia/inc/kernel/os/capability.h` rather than to capabilities defined by
+`nvidia-container-toolkit`. These are not included in "all" and must be
+requested explicitly via `--nvproxy-allowed-driver-capabilities`, because each
+one exposes a substantially larger part of the host driver to the sandbox:
+
+*   `profiling`: GPU hardware performance counter and tracing access, as used by
+    Nsight Compute and Nsight Systems. On Blackwell GPUs with driver 610.43.02
+    or newer this also exposes the driver's `trace-device` capability, which
+    `TRACE_DEVICE_EVENT` requires.
+*   `fabric-imex-mgmt`: NVLink fabric IMEX management, as used for multi-node
+    NVLink (for example on GB200 NVL72).
+*   `rdma`: GPUDirect RDMA, i.e. exporting GPU memory to a dma-buf FD.
 
 ### Supported Device Files {#device-files}
 

--- a/pkg/abi/nvgpu/classes.go
+++ b/pkg/abi/nvgpu/classes.go
@@ -130,12 +130,14 @@ const (
 	BLACKWELL_A                      = 0x0000cd97
 	NVCDB0_VIDEO_DECODER             = 0x0000cdb0
 	BLACKWELL_COMPUTE_A              = 0x0000cdc0
+	TRACE_DEVICE_EVENT               = 0x0000cdcd
 	NVCDD1_VIDEO_NVJPG               = 0x0000cdd1
 	NVCDFA_VIDEO_OFA                 = 0x0000cdfa
 	BLACKWELL_B                      = 0x0000ce97
 	NVCEB0_VIDEO_DECODER             = 0x0000ceb0
 	NVCEB7_VIDEO_ENCODER             = 0x0000ceb7
 	BLACKWELL_COMPUTE_B              = 0x0000cec0
+	NVCED0_VIDEO_NVJPG               = 0x0000ced0
 	NVCEFA_VIDEO_OFA                 = 0x0000cefa
 	NVCFB0_VIDEO_DECODER             = 0x0000cfb0
 	NVCFB7_VIDEO_ENCODER             = 0x0000cfb7
@@ -863,4 +865,18 @@ type NVB2CC_ALLOC_PARAMETERS struct {
 	_              structs.HostLayout
 	HClientTarget  Handle
 	HContextTarget Handle
+}
+
+// NVCDCD_ALLOC_PARAMETERS is the alloc params type for TRACE_DEVICE_EVENT,
+// from src/common/sdk/nvidia/inc/class/clcdcd.h.
+//
+// +marshal
+type NVCDCD_ALLOC_PARAMETERS struct {
+	_ structs.HostLayout
+	// Despite being NvU64-typed by the driver, capDescriptor is a file
+	// descriptor for the nv-caps device file corresponding to
+	// NV_RM_CAP_SYS_TRACE_DEVICE. See
+	// src/nvidia/src/kernel/gpu/hwpm/trace_device_event.c:traceDeviceEventConstruct_IMPL()
+	// => src/nvidia/arch/nvalloc/unix/src/os.c:osRmCapAcquire().
+	CapDescriptor uint64
 }

--- a/pkg/sentry/devices/nvproxy/BUILD
+++ b/pkg/sentry/devices/nvproxy/BUILD
@@ -102,7 +102,10 @@ go_library(
 
 go_test(
     name = "nvproxy_test",
-    srcs = ["nvproxy_test.go"],
+    srcs = [
+        "nvproxy_blackwell_test.go",
+        "nvproxy_test.go",
+    ],
     library = ":nvproxy",
     deps = [
         "//pkg/abi/nvgpu",

--- a/pkg/sentry/devices/nvproxy/README.md
+++ b/pkg/sentry/devices/nvproxy/README.md
@@ -173,3 +173,40 @@ If an `ioctl` data structure contains neither pointers nor FDs and has no
 special `mmap` semantics, it requires no translation and is considered "simple".
 Helper utilities exist in nvproxy to proxy these simple ioctls directly, which
 you should use whenever possible. Majority of ioctls proxied today are simple.
+
+## Adding Support for New GPU Architectures
+
+Driver version support and GPU architecture support are separate concerns. A
+driver version can be fully modelled in the version tree while `nvproxy` still
+fails to run workloads on a newly released GPU, because each GPU generation
+brings its own allocation classes (compute, DMA copy, GPFIFO channel, usermode,
+and video engine classes) that must be registered explicitly.
+
+The driver's generated sources state authoritatively which classes each chip
+exposes, so architecture coverage can be checked mechanically rather than
+discovered by a failing workload:
+
+*   `src/nvidia/generated/g_gpu_class_list.c` contains
+    `gpuGetEngClassDescriptorList_<CHIP>()` and `gpuGetNoEngClassList_<CHIP>()`
+    for every chip the driver supports. The union of both lists is the set of
+    classes that chip can allocate.
+*   `src/nvidia/generated/g_allclasses.h` maps every class name to its ID, and
+    is the source of truth for the constants in
+    [`pkg/abi/nvgpu/classes.go`](../../../abi/nvgpu/classes.go).
+*   `src/nvidia/src/kernel/rmapi/resource_list.h` gives each class's alloc param
+    struct, its valid parents, and whether allocation is privileged.
+
+To audit a new architecture, diff the union of its chips' class lists against
+the union for the previous architectures. Classes that are new to the
+architecture are the ones at risk of being missed. Not every new class needs
+proxying: display (`NV*70`/`NV*7D`/`NV*7E` and friends), vGPU, MIG/SMC, and
+classes that only the kernel driver itself allocates are all deliberately out of
+scope. Compute, memory, channel, and video engine classes are in scope.
+
+Register each in-scope class at the version tree node for the driver release
+that introduced it, then add it to `blackwellClasses` (or the equivalent table
+for a newer architecture) in
+[nvproxy_blackwell_test.go](nvproxy_blackwell_test.go), which asserts that
+every driver ABI at or after that release registers the class. That test is
+what keeps a new driver branch from silently dropping support for an
+architecture.

--- a/pkg/sentry/devices/nvproxy/frontend.go
+++ b/pkg/sentry/devices/nvproxy/frontend.go
@@ -1515,6 +1515,51 @@ func rmAllocIMEXSession(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS64_PARAME
 	return n, nil
 }
 
+// rmAllocTraceDeviceEvent handles allocation of TRACE_DEVICE_EVENT, which
+// exists on Blackwell and later GPUs since driver version 610.43.02. Its alloc
+// params contain a file descriptor for the trace-device capability file in
+// /dev/nvidia-caps/, which must be translated to the corresponding host FD. See
+// src/nvidia/src/kernel/gpu/hwpm/trace_device_event.c:traceDeviceEventConstruct_IMPL().
+func rmAllocTraceDeviceEvent(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS64_PARAMETERS, isNVOS64 bool) (uintptr, error) {
+	var allocParams nvgpu.NVCDCD_ALLOC_PARAMETERS
+	// As in rmAllocSimpleParams(), the driver ignores ioctlParams.ParamsSize and
+	// derives the param size from the class, so it is not validated here.
+	if _, err := allocParams.CopyIn(fi.t, addrFromP64(ioctlParams.PAllocParms)); err != nil {
+		return 0, err
+	}
+
+	origCapDescriptor := allocParams.CapDescriptor
+	capsFileGeneric, _ := fi.t.FDTable().Get(int32(allocParams.CapDescriptor))
+	if capsFileGeneric == nil {
+		return 0, linuxerr.EINVAL
+	}
+	defer capsFileGeneric.DecRef(fi.ctx)
+	capsFile, ok := capsFileGeneric.Impl().(*openOnlyFD)
+	if !ok {
+		fi.ctx.Warningf("nvproxy: rmAllocTraceDeviceEvent got capDescriptor file of incompatible type %T", capsFileGeneric.Impl())
+		return 0, linuxerr.EINVAL
+	}
+	allocParams.CapDescriptor = uint64(capsFile.hostFD)
+
+	// As in rmAllocIMEXSession(), don't capture allocParams in the tracked
+	// object: they hold a host FD, which is meaningless after restore, so
+	// replaying the allocation with them would be incorrect. This makes the
+	// object non-restorable, so checkpointing a sandbox with a live
+	// TRACE_DEVICE_EVENT fails rather than restoring a broken one.
+	n, err := rmAllocInvoke(fi, ioctlParams, &allocParams, isNVOS64, func(fi *frontendIoctlState, client *rootClient, ioctlParams *nvgpu.NVOS64_PARAMETERS, rightsRequested nvgpu.RS_ACCESS_MASK, allocParams *nvgpu.NVCDCD_ALLOC_PARAMETERS) {
+		fi.fd.dev.nvp.objAdd(fi.ctx, client, ioctlParams.HObjectNew, ioctlParams.HClass, &miscObject{}, ioctlParams.HObjectParent)
+	})
+	if err != nil {
+		return n, err
+	}
+
+	allocParams.CapDescriptor = origCapDescriptor
+	if _, err := allocParams.CopyOut(fi.t, addrFromP64(ioctlParams.PAllocParms)); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
 func rmAllocMulticastFabric[Params any, PtrParams hasPOsEventPtr[Params]](fi *frontendIoctlState, ioctlParams *nvgpu.NVOS64_PARAMETERS, isNVOS64 bool) (uintptr, error) {
 	var allocParamsValue Params
 	allocParams := PtrParams(&allocParamsValue)

--- a/pkg/sentry/devices/nvproxy/nvconf/hostsettings.go
+++ b/pkg/sentry/devices/nvproxy/nvconf/hostsettings.go
@@ -34,6 +34,14 @@ type HostSettings struct {
 	// /proc/driver/nvidia/capabilities/fabric-imex-mgmt.
 	HaveFabricIMEXManagement     bool
 	FabricIMEXManagementDevMinor uint32
+
+	// If HaveTraceDevice is true, TraceDeviceDevMinor is the device minor
+	// number advertised in /proc/driver/nvidia/capabilities/trace-device.
+	// This capability gates allocation of TRACE_DEVICE_EVENT, which only
+	// exists in driver versions >= 610.43.02, so hosts running older drivers
+	// legitimately lack it.
+	HaveTraceDevice     bool
+	TraceDeviceDevMinor uint32
 }
 
 // HostSettingsOptions holds arguments to GetHostSettings.
@@ -42,6 +50,13 @@ type HostSettingsOptions struct {
 	// HaveFabricIMEXManagement and FabricIMEXManagementDevMinor are set in the
 	// returned HostSettings.
 	WantFabricIMEXManagement bool
+
+	// If WantTraceDevice is true, set HaveTraceDevice and TraceDeviceDevMinor
+	// in the returned HostSettings if the host driver advertises the
+	// trace-device capability. Unlike WantFabricIMEXManagement, the capability
+	// being unavailable is not an error, since it does not exist in driver
+	// versions < 610.43.02.
+	WantTraceDevice bool
 }
 
 // GetHostSettings returns HostSettings.
@@ -55,23 +70,54 @@ func GetHostSettings(opts HostSettingsOptions) (*HostSettings, error) {
 	settings.ProcDriverNvidiaParams = string(params)
 
 	if opts.WantFabricIMEXManagement {
-		fabricImexMgmt, err := os.ReadFile("/proc/driver/nvidia/capabilities/fabric-imex-mgmt")
+		minor, err := capabilityDevMinor("fabric-imex-mgmt")
 		if err != nil {
-			return nil, fmt.Errorf("failed to read /proc/driver/nvidia/capabilities/fabric-imex-mgmt: %w", err)
-		}
-		m := regexp.MustCompile(`DeviceFileMinor: (\d+)`).FindSubmatch(fabricImexMgmt)
-		if m == nil {
-			return nil, fmt.Errorf("failed to find DeviceFileMinor in /proc/driver/nvidia/capabilities/fabric-imex-mgmt")
-		}
-		minor, err := strconv.ParseUint(string(m[1]), 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse DeviceFileMinor %s: %w", string(m[1]), err)
+			return nil, err
 		}
 		settings.HaveFabricIMEXManagement = true
-		settings.FabricIMEXManagementDevMinor = uint32(minor)
+		settings.FabricIMEXManagementDevMinor = minor
+	}
+
+	if opts.WantTraceDevice {
+		minor, err := capabilityDevMinor("trace-device")
+		if err != nil {
+			// The trace-device capability was added in driver version
+			// 610.43.02; older drivers do not have it. Applications that
+			// require it will fail when allocating TRACE_DEVICE_EVENT, which
+			// is the same behavior as on the host.
+			log.Infof("nvproxy: trace-device capability is unavailable: %v", err)
+		} else {
+			settings.HaveTraceDevice = true
+			settings.TraceDeviceDevMinor = minor
+		}
 	}
 
 	return settings, nil
+}
+
+// deviceFileMinorRE matches the DeviceFileMinor line in files under
+// /proc/driver/nvidia/capabilities/, as written by
+// kernel-open/nvidia/nv-caps.c:nv_cap_procfs_read().
+var deviceFileMinorRE = regexp.MustCompile(`DeviceFileMinor: (\d+)`)
+
+// capabilityDevMinor returns the device minor number in /dev/nvidia-caps/ that
+// corresponds to the capability named by the given file in
+// /proc/driver/nvidia/capabilities/.
+func capabilityDevMinor(name string) (uint32, error) {
+	path := "/proc/driver/nvidia/capabilities/" + name
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read %s: %w", path, err)
+	}
+	m := deviceFileMinorRE.FindSubmatch(contents)
+	if m == nil {
+		return 0, fmt.Errorf("failed to find DeviceFileMinor in %s", path)
+	}
+	minor, err := strconv.ParseUint(string(m[1]), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse DeviceFileMinor %s in %s: %w", string(m[1]), path, err)
+	}
+	return uint32(minor), nil
 }
 
 // IMEXChannelCount returns the number of IMEX channels indicated by

--- a/pkg/sentry/devices/nvproxy/nvproxy.go
+++ b/pkg/sentry/devices/nvproxy/nvproxy.go
@@ -127,25 +127,53 @@ func Register(vfsObj *vfs.VirtualFilesystem, opts *Options) (*DeviceInfo, error)
 		return nil, err
 	}
 
-	if opts.DriverCaps&nvconf.CapFabricIMEXManagement != 0 {
-		if !opts.HostSettings.HaveFabricIMEXManagement {
-			return nil, fmt.Errorf("driver capability %s is enabled, but fabric-imex-mgmt device minor number is unavailable", nvconf.CapFabricIMEXManagement)
-		}
+	// Register the capability files in /dev/nvidia-caps/ that nvproxy supports.
+	// All files in /dev/nvidia-caps/ share a single device major number.
+	wantFabricIMEXManagement := opts.DriverCaps&nvconf.CapFabricIMEXManagement != 0
+	if wantFabricIMEXManagement && !opts.HostSettings.HaveFabricIMEXManagement {
+		return nil, fmt.Errorf("driver capability %s is enabled, but fabric-imex-mgmt device minor number is unavailable", nvconf.CapFabricIMEXManagement)
+	}
+	// TRACE_DEVICE_EVENT, which exists on Blackwell and later GPUs in driver
+	// versions >= 610.43.02, requires a file descriptor for the trace-device
+	// capability. Unlike fabric-imex-mgmt, the capability being unavailable is
+	// not an error: older drivers simply do not have it, and applications that
+	// need it fail at allocation time exactly as they would on the host.
+	wantTraceDevice := opts.DriverCaps&nvconf.CapProfiling != 0 && opts.HostSettings.HaveTraceDevice
+	if wantFabricIMEXManagement || wantTraceDevice {
 		capsDevMajor, err := vfsObj.GetDynamicCharDevMajor()
 		if err != nil {
 			return nil, fmt.Errorf("allocating device major number for nvidia-caps: %w", err)
 		}
 		nvp.devInfo.CapsDevMajor = capsDevMajor
-		if err := vfsObj.RegisterDevice(vfs.CharDevice, capsDevMajor, opts.HostSettings.FabricIMEXManagementDevMinor, &openOnlyDevice{
-			nvp:     nvp,
-			relpath: fmt.Sprintf("nvidia-caps/nvidia-cap%d", opts.HostSettings.FabricIMEXManagementDevMinor),
-		}, &vfs.RegisterDeviceOptions{
-			GroupName: "nvidia-caps",
-		}); err != nil {
-			return nil, err
+		// The host driver assigns a distinct minor number to each capability,
+		// but dedupe defensively since a duplicate registration would fail.
+		registeredCaps := make(map[uint32]struct{}, 2)
+		registerCap := func(devMinor uint32) error {
+			if _, ok := registeredCaps[devMinor]; ok {
+				return nil
+			}
+			registeredCaps[devMinor] = struct{}{}
+			return vfsObj.RegisterDevice(vfs.CharDevice, capsDevMajor, devMinor, &openOnlyDevice{
+				nvp:     nvp,
+				relpath: fmt.Sprintf("nvidia-caps/nvidia-cap%d", devMinor),
+			}, &vfs.RegisterDeviceOptions{
+				GroupName: "nvidia-caps",
+			})
 		}
-		nvp.devInfo.HaveFabricIMEXManagement = true
-		nvp.devInfo.FabricIMEXManagementDevMinor = opts.HostSettings.FabricIMEXManagementDevMinor
+		if wantFabricIMEXManagement {
+			if err := registerCap(opts.HostSettings.FabricIMEXManagementDevMinor); err != nil {
+				return nil, err
+			}
+			nvp.devInfo.HaveFabricIMEXManagement = true
+			nvp.devInfo.FabricIMEXManagementDevMinor = opts.HostSettings.FabricIMEXManagementDevMinor
+		}
+		if wantTraceDevice {
+			if err := registerCap(opts.HostSettings.TraceDeviceDevMinor); err != nil {
+				return nil, err
+			}
+			nvp.devInfo.HaveTraceDevice = true
+			nvp.devInfo.TraceDeviceDevMinor = opts.HostSettings.TraceDeviceDevMinor
+		}
 	}
 
 	if imexChannelCount := opts.HostSettings.IMEXChannelCount(); imexChannelCount != 0 {
@@ -183,6 +211,13 @@ type DeviceInfo struct {
 	// be non-zero and might not match the host's value.)
 	HaveFabricIMEXManagement     bool
 	FabricIMEXManagementDevMinor uint32
+
+	// If HaveTraceDevice is true, TraceDeviceDevMinor is the trace-device
+	// capability's device minor number, which matches the value on the host.
+	// (Its device major number is CapsDevMajor, which must be non-zero and
+	// might not match the host's value.)
+	HaveTraceDevice     bool
+	TraceDeviceDevMinor uint32
 
 	// CapsIMEXChannelsDevMajor is nvidia-caps-imex-channels's device major
 	// number. If CapsIMEXChannelsDevMajor is 0, nvidia-caps-imex-channels is

--- a/pkg/sentry/devices/nvproxy/nvproxy_blackwell_test.go
+++ b/pkg/sentry/devices/nvproxy/nvproxy_blackwell_test.go
@@ -1,0 +1,195 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+	"gvisor.dev/gvisor/pkg/sentry/devices/nvproxy/nvconf"
+)
+
+// blackwellClass describes an allocation class that NVIDIA's kernel driver
+// exposes on Blackwell GPUs, and which nvproxy must therefore support in order
+// for the corresponding workloads to run on those GPUs.
+//
+// The contents of this table are derived from the driver's own generated
+// sources, which are the authoritative statement of what each chip supports:
+//
+//   - class is the value in src/nvidia/generated/g_allclasses.h.
+//   - chips lists the Blackwell chips whose class list contains the class, per
+//     gpuGetEngClassDescriptorList_*() and gpuGetNoEngClassList_*() in
+//     src/nvidia/generated/g_gpu_class_list.c.
+//   - introducedIn is the earliest driver release in which the class appears in
+//     g_allclasses.h and src/nvidia/src/kernel/rmapi/resource_list.h.
+type blackwellClass struct {
+	name         string
+	class        nvgpu.ClassID
+	chips        string
+	introducedIn nvconf.DriverVersion
+	wantCaps     nvconf.DriverCaps
+}
+
+// blackwellClasses is the complete set of Blackwell-specific allocation classes
+// that nvproxy supports. Chip codenames map to products as follows:
+// GB100/GB102/GB110/GB112 are datacenter Blackwell (B100/B200/GB200/GB300),
+// GB202-GB207 are consumer and workstation Blackwell (GeForce RTX 50 series,
+// RTX PRO Blackwell), GB10B is the GB10 superchip (DGX Spark), and GB20B/GB20C
+// are Blackwell SoCs (Jetson Thor).
+//
+// Classes are keyed by the driver version that introduced them, not by the
+// nvproxy version tree node that happens to add them: an ABI change must be
+// attached to the exact driver release that made it so that later branches
+// inherit it correctly. See the "Handling Intermediate Versions" section of
+// README.md.
+var blackwellClasses = []blackwellClass{
+	// Introduced in 560.28.03, along with the first Blackwell chips.
+	{"BLACKWELL_A", nvgpu.BLACKWELL_A, "GB100 GB102 GB110 GB112 GB10B", nvconf.NewDriverVersion(560, 28, 3), nvconf.CapGraphics},
+	{"BLACKWELL_COMPUTE_A", nvgpu.BLACKWELL_COMPUTE_A, "GB100 GB102 GB110 GB112 GB10B", nvconf.NewDriverVersion(560, 28, 3), compUtil},
+	{"BLACKWELL_CHANNEL_GPFIFO_A", nvgpu.BLACKWELL_CHANNEL_GPFIFO_A, "all Blackwell", nvconf.NewDriverVersion(560, 28, 3), compUtil},
+	{"BLACKWELL_DMA_COPY_A", nvgpu.BLACKWELL_DMA_COPY_A, "GB100 GB102 GB110 GB112 GB10B GB20B GB20C", nvconf.NewDriverVersion(560, 28, 3), compUtil},
+	{"BLACKWELL_INLINE_TO_MEMORY_A", nvgpu.BLACKWELL_INLINE_TO_MEMORY_A, "all Blackwell", nvconf.NewDriverVersion(560, 28, 3), nvconf.CapGraphics},
+	{"NVCDB0_VIDEO_DECODER", nvgpu.NVCDB0_VIDEO_DECODER, "GB100 GB102 GB110 GB112", nvconf.NewDriverVersion(560, 28, 3), nvconf.CapVideo},
+	{"NVCDD1_VIDEO_NVJPG", nvgpu.NVCDD1_VIDEO_NVJPG, "GB100 GB102 GB110 GB112", nvconf.NewDriverVersion(560, 28, 3), nvconf.CapVideo},
+	{"NVCDFA_VIDEO_OFA", nvgpu.NVCDFA_VIDEO_OFA, "GB100 GB102 GB110 GB112", nvconf.NewDriverVersion(560, 28, 3), nvconf.CapVideo},
+
+	// Introduced in 570.86.15, along with the GB20x chips.
+	{"BLACKWELL_B", nvgpu.BLACKWELL_B, "GB202 GB203 GB205 GB206 GB207 GB20B GB20C", nvconf.NewDriverVersion(570, 86, 15), nvconf.CapGraphics},
+	{"BLACKWELL_COMPUTE_B", nvgpu.BLACKWELL_COMPUTE_B, "GB202 GB203 GB205 GB206 GB207 GB20B GB20C", nvconf.NewDriverVersion(570, 86, 15), compUtil},
+	{"BLACKWELL_CHANNEL_GPFIFO_B", nvgpu.BLACKWELL_CHANNEL_GPFIFO_B, "GB202 GB203 GB205 GB206 GB207 GB20B GB20C", nvconf.NewDriverVersion(570, 86, 15), compUtil},
+	{"BLACKWELL_DMA_COPY_B", nvgpu.BLACKWELL_DMA_COPY_B, "GB202 GB203 GB205 GB206 GB207 GB20B GB20C", nvconf.NewDriverVersion(570, 86, 15), compUtil},
+	{"BLACKWELL_USERMODE_A", nvgpu.BLACKWELL_USERMODE_A, "GB202 GB203 GB205 GB206 GB207 GB20B GB20C", nvconf.NewDriverVersion(570, 86, 15), compUtil},
+	{"NVCFB0_VIDEO_DECODER", nvgpu.NVCFB0_VIDEO_DECODER, "GB202 GB203 GB205 GB206 GB207", nvconf.NewDriverVersion(570, 86, 15), nvconf.CapVideo},
+	{"NVCFB7_VIDEO_ENCODER", nvgpu.NVCFB7_VIDEO_ENCODER, "GB202 GB203 GB205 GB206 GB207", nvconf.NewDriverVersion(570, 86, 15), nvconf.CapVideo},
+	{"NVCFD1_VIDEO_NVJPG", nvgpu.NVCFD1_VIDEO_NVJPG, "GB202 GB203 GB205 GB206", nvconf.NewDriverVersion(570, 86, 15), nvconf.CapVideo},
+	{"NVCFFA_VIDEO_OFA", nvgpu.NVCFFA_VIDEO_OFA, "GB202 GB203 GB205 GB206 GB207", nvconf.NewDriverVersion(570, 86, 15), nvconf.CapVideo},
+
+	// Introduced in 580.65.06, along with the Blackwell SoC video engines.
+	// NVCED0_VIDEO_NVJPG is the only NVJPG class that GB10B, GB20B and GB20C
+	// support, so JPEG decode on those chips depends on it.
+	{"NVCEB0_VIDEO_DECODER", nvgpu.NVCEB0_VIDEO_DECODER, "GB10B", nvconf.NewDriverVersion(580, 65, 6), nvconf.CapVideo},
+	{"NVCEB7_VIDEO_ENCODER", nvgpu.NVCEB7_VIDEO_ENCODER, "GB10B", nvconf.NewDriverVersion(580, 65, 6), nvconf.CapVideo},
+	{"NVCED0_VIDEO_NVJPG", nvgpu.NVCED0_VIDEO_NVJPG, "GB10B GB20B GB20C", nvconf.NewDriverVersion(580, 65, 6), nvconf.CapVideo},
+	{"NVCEFA_VIDEO_OFA", nvgpu.NVCEFA_VIDEO_OFA, "GB10B", nvconf.NewDriverVersion(580, 65, 6), nvconf.CapVideo},
+	{"NVD1B0_VIDEO_DECODER", nvgpu.NVD1B0_VIDEO_DECODER, "GB20B GB20C", nvconf.NewDriverVersion(580, 65, 6), nvconf.CapVideo},
+	{"NVD1B7_VIDEO_ENCODER", nvgpu.NVD1B7_VIDEO_ENCODER, "GB20B GB20C", nvconf.NewDriverVersion(580, 65, 6), nvconf.CapVideo},
+	{"NVD1FA_VIDEO_OFA", nvgpu.NVD1FA_VIDEO_OFA, "GB20B GB20C", nvconf.NewDriverVersion(580, 65, 6), nvconf.CapVideo},
+
+	// Introduced in 610.43.02. TRACE_DEVICE_EVENT is supported by every
+	// Blackwell chip and is used for device-level GPU tracing.
+	{"TRACE_DEVICE_EVENT", nvgpu.TRACE_DEVICE_EVENT, "all Blackwell", nvconf.NewDriverVersion(610, 43, 2), nvconf.CapProfiling},
+}
+
+// TestBlackwellClassIDs verifies that nvproxy's Blackwell class IDs match the
+// values in the driver's src/nvidia/generated/g_allclasses.h. These are checked
+// against literals rather than against the nvgpu constants they come from, so
+// that a typo in classes.go is caught here rather than at runtime on a Blackwell
+// GPU.
+func TestBlackwellClassIDs(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		got  nvgpu.ClassID
+		want nvgpu.ClassID
+	}{
+		{"BLACKWELL_USERMODE_A", nvgpu.BLACKWELL_USERMODE_A, 0x0000c761},
+		{"BLACKWELL_CHANNEL_GPFIFO_A", nvgpu.BLACKWELL_CHANNEL_GPFIFO_A, 0x0000c96f},
+		{"BLACKWELL_DMA_COPY_A", nvgpu.BLACKWELL_DMA_COPY_A, 0x0000c9b5},
+		{"BLACKWELL_CHANNEL_GPFIFO_B", nvgpu.BLACKWELL_CHANNEL_GPFIFO_B, 0x0000ca6f},
+		{"BLACKWELL_DMA_COPY_B", nvgpu.BLACKWELL_DMA_COPY_B, 0x0000cab5},
+		{"BLACKWELL_INLINE_TO_MEMORY_A", nvgpu.BLACKWELL_INLINE_TO_MEMORY_A, 0x0000cd40},
+		{"BLACKWELL_A", nvgpu.BLACKWELL_A, 0x0000cd97},
+		{"BLACKWELL_COMPUTE_A", nvgpu.BLACKWELL_COMPUTE_A, 0x0000cdc0},
+		{"TRACE_DEVICE_EVENT", nvgpu.TRACE_DEVICE_EVENT, 0x0000cdcd},
+		{"BLACKWELL_B", nvgpu.BLACKWELL_B, 0x0000ce97},
+		{"BLACKWELL_COMPUTE_B", nvgpu.BLACKWELL_COMPUTE_B, 0x0000cec0},
+		{"NVCDB0_VIDEO_DECODER", nvgpu.NVCDB0_VIDEO_DECODER, 0x0000cdb0},
+		{"NVCDD1_VIDEO_NVJPG", nvgpu.NVCDD1_VIDEO_NVJPG, 0x0000cdd1},
+		{"NVCDFA_VIDEO_OFA", nvgpu.NVCDFA_VIDEO_OFA, 0x0000cdfa},
+		{"NVCEB0_VIDEO_DECODER", nvgpu.NVCEB0_VIDEO_DECODER, 0x0000ceb0},
+		{"NVCEB7_VIDEO_ENCODER", nvgpu.NVCEB7_VIDEO_ENCODER, 0x0000ceb7},
+		{"NVCED0_VIDEO_NVJPG", nvgpu.NVCED0_VIDEO_NVJPG, 0x0000ced0},
+		{"NVCEFA_VIDEO_OFA", nvgpu.NVCEFA_VIDEO_OFA, 0x0000cefa},
+		{"NVCFB0_VIDEO_DECODER", nvgpu.NVCFB0_VIDEO_DECODER, 0x0000cfb0},
+		{"NVCFB7_VIDEO_ENCODER", nvgpu.NVCFB7_VIDEO_ENCODER, 0x0000cfb7},
+		{"NVCFD1_VIDEO_NVJPG", nvgpu.NVCFD1_VIDEO_NVJPG, 0x0000cfd1},
+		{"NVCFFA_VIDEO_OFA", nvgpu.NVCFFA_VIDEO_OFA, 0x0000cffa},
+		{"NVD1B0_VIDEO_DECODER", nvgpu.NVD1B0_VIDEO_DECODER, 0x0000d1b0},
+		{"NVD1B7_VIDEO_ENCODER", nvgpu.NVD1B7_VIDEO_ENCODER, 0x0000d1b7},
+		{"NVD1FA_VIDEO_OFA", nvgpu.NVD1FA_VIDEO_OFA, 0x0000d1fa},
+	} {
+		if test.got != test.want {
+			t.Errorf("%s = %v, want %v (see src/nvidia/generated/g_allclasses.h)", test.name, test.got, test.want)
+		}
+	}
+}
+
+// TestBlackwellClassCoverage verifies that every driver ABI at or after the
+// driver version that introduced a Blackwell class registers a handler for that
+// class, and that ABIs before it do not. This guarantees that a newly added
+// driver version cannot silently lose Blackwell support by branching from a
+// pre-Blackwell node, and that a Blackwell ABI change is never back-dated to a
+// driver release that did not contain it.
+//
+// The check uses driver version ordering as a proxy for ancestry in nvproxy's
+// version tree, which holds for every branch in the tree today. If a future
+// driver branch makes the two disagree, this table needs a more precise notion
+// of "applies to" rather than a looser assertion.
+func TestBlackwellClassCoverage(t *testing.T) {
+	Init()
+	for version, abiEntry := range abis {
+		t.Run(version.String(), func(t *testing.T) {
+			abi := abiEntry.cons()
+			for _, bc := range blackwellClasses {
+				handler, ok := abi.allocationClass[bc.class]
+				wantSupported := version.IsGreaterThan(bc.introducedIn)
+				switch {
+				case wantSupported && !ok:
+					t.Errorf("driver %s does not support %s (%v), which the driver exposes on %s since %s", version, bc.name, bc.class, bc.chips, bc.introducedIn)
+				case !wantSupported && ok:
+					t.Errorf("driver %s supports %s (%v), but the driver only added it in %s", version, bc.name, bc.class, bc.introducedIn)
+				case ok && handler.capSet != bc.wantCaps:
+					t.Errorf("%s (%v) in driver %s is gated on capabilities %q, want %q", bc.name, bc.class, version, handler.capSet, bc.wantCaps)
+				}
+			}
+		})
+	}
+}
+
+// TestBlackwellSupportedOnLatestDriver verifies that the newest supported driver
+// version supports every Blackwell class, i.e. that Blackwell support is not
+// stranded on an older branch of the version tree.
+func TestBlackwellSupportedOnLatestDriver(t *testing.T) {
+	Init()
+	var latest nvconf.DriverVersion
+	found := false
+	for version, abiEntry := range abis {
+		if !abiEntry.supported {
+			continue
+		}
+		if !found || version.IsGreaterThan(latest) {
+			latest = version
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("no supported driver versions")
+	}
+	abi := abis[latest].cons()
+	for _, bc := range blackwellClasses {
+		if _, ok := abi.allocationClass[bc.class]; !ok {
+			t.Errorf("latest supported driver %s does not support %s (%v)", latest, bc.name, bc.class)
+		}
+	}
+}

--- a/pkg/sentry/devices/nvproxy/procfs.go
+++ b/pkg/sentry/devices/nvproxy/procfs.go
@@ -43,6 +43,9 @@ func ProcfsInfoFromVFS(vfsObj *vfs.VirtualFilesystem) *ProcfsInfo {
 	if nvp.devInfo.HaveFabricIMEXManagement {
 		procfsInfo.StaticFiles["capabilities/fabric-imex-mgmt"] = procfsCapability(nvp.devInfo.FabricIMEXManagementDevMinor, 0o400)
 	}
+	if nvp.devInfo.HaveTraceDevice {
+		procfsInfo.StaticFiles["capabilities/trace-device"] = procfsCapability(nvp.devInfo.TraceDeviceDevMinor, 0o400)
+	}
 	return procfsInfo
 }
 

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -1090,6 +1090,7 @@ func Init() {
 			abi.allocationClass[nvgpu.NVD1B7_VIDEO_ENCODER] = allocHandler(rmAllocSimple[nvgpu.NV_MSENC_ALLOCATION_PARAMETERS], nvconf.CapVideo)
 			abi.allocationClass[nvgpu.NVCEB0_VIDEO_DECODER] = allocHandler(rmAllocSimple[nvgpu.NV_BSP_ALLOCATION_PARAMETERS], nvconf.CapVideo)
 			abi.allocationClass[nvgpu.NVD1B0_VIDEO_DECODER] = allocHandler(rmAllocSimple[nvgpu.NV_BSP_ALLOCATION_PARAMETERS], nvconf.CapVideo)
+			abi.allocationClass[nvgpu.NVCED0_VIDEO_NVJPG] = allocHandler(rmAllocSimple[nvgpu.NV_NVJPG_ALLOCATION_PARAMETERS], nvconf.CapVideo)
 			abi.allocationClass[nvgpu.NVCEFA_VIDEO_OFA] = allocHandler(rmAllocSimple[nvgpu.NV_OFA_ALLOCATION_PARAMETERS_V545], nvconf.CapVideo)
 			abi.allocationClass[nvgpu.NVD1FA_VIDEO_OFA] = allocHandler(rmAllocSimple[nvgpu.NV_OFA_ALLOCATION_PARAMETERS_V545], nvconf.CapVideo)
 			abi.controlCmd[nvgpu.NV2080_CTRL_CMD_GPU_GET_SKYLINE_INFO] = ctrlHandler(rmControlSimple, compUtil|nvconf.CapGraphics)
@@ -1107,6 +1108,7 @@ func Init() {
 				info.AllocationInfos[nvgpu.NVD1B7_VIDEO_ENCODER] = ioctlInfo("NVD1B7_VIDEO_ENCODER", nvgpu.NV_MSENC_ALLOCATION_PARAMETERS{})
 				info.AllocationInfos[nvgpu.NVCEB0_VIDEO_DECODER] = ioctlInfo("NVCEB0_VIDEO_DECODER", nvgpu.NV_BSP_ALLOCATION_PARAMETERS{})
 				info.AllocationInfos[nvgpu.NVD1B0_VIDEO_DECODER] = ioctlInfo("NVD1B0_VIDEO_DECODER", nvgpu.NV_BSP_ALLOCATION_PARAMETERS{})
+				info.AllocationInfos[nvgpu.NVCED0_VIDEO_NVJPG] = ioctlInfo("NVCED0_VIDEO_NVJPG", nvgpu.NV_NVJPG_ALLOCATION_PARAMETERS{})
 				info.AllocationInfos[nvgpu.NVCEFA_VIDEO_OFA] = ioctlInfoWithStructName("NVCEFA_VIDEO_OFA", nvgpu.NV_OFA_ALLOCATION_PARAMETERS_V545{}, "NV_OFA_ALLOCATION_PARAMETERS")
 				info.AllocationInfos[nvgpu.NVD1FA_VIDEO_OFA] = ioctlInfoWithStructName("NVD1FA_VIDEO_OFA", nvgpu.NV_OFA_ALLOCATION_PARAMETERS_V545{}, "NV_OFA_ALLOCATION_PARAMETERS")
 				info.ControlInfos[nvgpu.NV2080_CTRL_CMD_GPU_GET_SKYLINE_INFO] = simpleIoctlInfo("NV2080_CTRL_CMD_GPU_GET_SKYLINE_INFO", "NV2080_CTRL_GPU_GET_SKYLINE_INFO_PARAMS")
@@ -1166,6 +1168,10 @@ func Init() {
 			abi.allocationClass[nvgpu.NVD2B0_VIDEO_DECODER] = allocHandler(rmAllocSimple[nvgpu.NV_BSP_ALLOCATION_PARAMETERS], nvconf.CapVideo)
 			abi.allocationClass[nvgpu.NVD2D1_VIDEO_NVJPG] = allocHandler(rmAllocSimple[nvgpu.NV_NVJPG_ALLOCATION_PARAMETERS], nvconf.CapVideo)
 			abi.allocationClass[nvgpu.NVD2FA_VIDEO_OFA] = allocHandler(rmAllocSimple[nvgpu.NV_OFA_ALLOCATION_PARAMETERS_V545], nvconf.CapVideo)
+			// TRACE_DEVICE_EVENT is supported by all Blackwell and later chips;
+			// see gpuGetNoEngClassList_GB100() in
+			// src/nvidia/generated/g_gpu_class_list.c.
+			abi.allocationClass[nvgpu.TRACE_DEVICE_EVENT] = allocHandler(rmAllocTraceDeviceEvent, nvconf.CapProfiling)
 
 			prevGetInfo := abi.getInfo
 			abi.getInfo = func() *DriverABIInfo {
@@ -1182,6 +1188,7 @@ func Init() {
 				info.AllocationInfos[nvgpu.BLACKWELL_CHANNEL_GPFIFO_B] = ioctlInfoWithStructName("BLACKWELL_CHANNEL_GPFIFO_B", nvgpu.NV_CHANNEL_ALLOC_PARAMS_V610{}, "NV_CHANNEL_ALLOC_PARAMS")
 				info.AllocationInfos[nvgpu.NVD2D1_VIDEO_NVJPG] = ioctlInfo("NVD2D1_VIDEO_NVJPG", nvgpu.NV_NVJPG_ALLOCATION_PARAMETERS{})
 				info.AllocationInfos[nvgpu.NVD2FA_VIDEO_OFA] = ioctlInfoWithStructName("NVD2FA_VIDEO_OFA", nvgpu.NV_OFA_ALLOCATION_PARAMETERS_V545{}, "NV_OFA_ALLOCATION_PARAMETERS")
+				info.AllocationInfos[nvgpu.TRACE_DEVICE_EVENT] = ioctlInfo("TRACE_DEVICE_EVENT", nvgpu.NVCDCD_ALLOC_PARAMETERS{})
 
 				// BSP/MSENC structs were renamed to NVDEC/NVENC in 610.43.02.
 

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -1879,8 +1879,10 @@ func createDeviceFiles(ctx context.Context, creds *auth.Credentials, info *conta
 			{Path: "/dev/nvidiactl", Type: "c", Major: nvgpu.NV_MAJOR_DEVICE_NUMBER, Minor: nvgpu.NV_MINOR_DEVICE_NUMBER_CONTROL_DEVICE},
 			{Path: "/dev/nvidia-uvm", Type: "c", Major: int64(info.nvproxyDevInfo.UVMDevMajor), Minor: nvgpu.NVIDIA_UVM_PRIMARY_MINOR_NUMBER},
 		}
-		// There is no nvidia-container-cli flag to enable fabric-imex-mgmt, so
-		// we never create a /dev/nvidia-caps/nvidia-cap# file for it here.
+		// There is no nvidia-container-cli flag to enable fabric-imex-mgmt or
+		// trace-device, so we never create a /dev/nvidia-caps/nvidia-cap# file
+		// for either of them here. Workloads that need one must have the device
+		// injected via the OCI spec or a CDI spec instead.
 		devClient := devutil.GoferClientFromContext(ctx)
 		if devClient == nil {
 			return fmt.Errorf("dev gofer client not found in context")

--- a/runsc/cmd/sentry/sentrycmd/boot.go
+++ b/runsc/cmd/sentry/sentrycmd/boot.go
@@ -219,6 +219,7 @@ type Boot struct {
 	// particular is uint32 and there is no flag.Uint32Var().
 	procDriverNvidiaParams             string
 	nvidiaFabricIMEXManagementDevMinor int64
+	nvidiaTraceDeviceDevMinor          int64
 
 	// uid and gid are the user and group IDs to switch to after setting up the
 	// user namespace.
@@ -303,6 +304,7 @@ func (b *Boot) SetFlags(f *flag.FlagSet) {
 	f.StringVar(&b.nvidiaDriverVersion, "nvidia-driver-version", "", "Nvidia driver version on the host")
 	f.StringVar(&b.procDriverNvidiaParams, "nvidia-host-params", "", "value of /proc/driver/nvidia/params on the host")
 	f.Int64Var(&b.nvidiaFabricIMEXManagementDevMinor, "nvidia-fabric-imex-mgmt-minor", -1, "DeviceFileMinor in /proc/driver/nvidia/capabilities/fabric-imex-mgmt on the host")
+	f.Int64Var(&b.nvidiaTraceDeviceDevMinor, "nvidia-trace-device-minor", -1, "DeviceFileMinor in /proc/driver/nvidia/capabilities/trace-device on the host")
 }
 
 // willReexec returns true if this boot process will re-execute itself to
@@ -415,6 +417,7 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 		driverCaps, driverCapsErr := specutils.NVProxyDriverCapsAllowed(conf)
 		nvhs, err := nvconf.GetHostSettings(nvconf.HostSettingsOptions{
 			WantFabricIMEXManagement: driverCapsErr == nil && driverCaps&nvconf.CapFabricIMEXManagement != 0,
+			WantTraceDevice:          driverCapsErr == nil && driverCaps&nvconf.CapProfiling != 0,
 		})
 		if err != nil {
 			log.Warningf("Failed to get nvconf.HostSettings: %v", err)
@@ -424,6 +427,10 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 			if nvhs.HaveFabricIMEXManagement {
 				b.nvidiaFabricIMEXManagementDevMinor = int64(nvhs.FabricIMEXManagementDevMinor)
 				argOverride["nvidia-fabric-imex-mgmt-minor"] = strconv.FormatUint(uint64(nvhs.FabricIMEXManagementDevMinor), 10)
+			}
+			if nvhs.HaveTraceDevice {
+				b.nvidiaTraceDeviceDevMinor = int64(nvhs.TraceDeviceDevMinor)
+				argOverride["nvidia-trace-device-minor"] = strconv.FormatUint(uint64(nvhs.TraceDeviceDevMinor), 10)
 			}
 		}
 	}
@@ -686,6 +693,8 @@ func (b *Boot) Execute(_ context.Context, f *flag.FlagSet, args ...any) subcomma
 			ProcDriverNvidiaParams:       b.procDriverNvidiaParams,
 			HaveFabricIMEXManagement:     b.nvidiaFabricIMEXManagementDevMinor >= 0,
 			FabricIMEXManagementDevMinor: uint32(b.nvidiaFabricIMEXManagementDevMinor),
+			HaveTraceDevice:              b.nvidiaTraceDeviceDevMinor >= 0,
+			TraceDeviceDevMinor:          uint32(b.nvidiaTraceDeviceDevMinor),
 		},
 		HostTHP:                  b.hostTHP,
 		SaveFDs:                  b.saveFDs.GetFDs(),


### PR DESCRIPTION
### AI assistance

This change was prepared with AI assistance (Claude Code) and is labelled `Assisted-by: Claude Code` in the commit message, per CONTRIBUTING.md. I have reviewed the change and am able to discuss and justify it.

### What

Two allocation classes that the driver exposes on Blackwell chips are missing from
nvproxy. I found them by diffing the per-chip class lists in the driver's generated
`src/nvidia/generated/g_gpu_class_list.c` against nvproxy's version tree, across every
Blackwell chip (GB100/102/110/112, GB202-207, GB10B, GB20B/20C).

- **`NVCED0_VIDEO_NVJPG` (0xced0)**, introduced in 580.65.06 alongside the other
  Blackwell SoC video engines. It is the *only* NVJPG class that GB10B, GB20B and
  GB20C expose, so JPEG decode is unreachable on GB10 (DGX Spark) and Jetson Thor.
  The sibling classes added in that same driver release (`NVCEB0`, `NVCEB7`,
  `NVCEFA`, `NVD1B0`, `NVD1B7`, `NVD1FA`) are already registered; this one appears
  to have been missed.
- **`TRACE_DEVICE_EVENT` (0xcdcd)**, introduced in 610.43.02 and present on every
  Blackwell chip. `NVCDCD_ALLOC_PARAMETERS` carries a file descriptor for the
  `NV_RM_CAP_SYS_TRACE_DEVICE` capability, so it needs an FD-translating alloc
  handler plus plumbing for the `trace-device` capability file, mirroring the
  existing `fabric-imex-mgmt` path. It is gated on `CapProfiling`; the capability
  being absent is not an error, since drivers older than 610.43.02 lack it.

### Regression test

`nvproxy_blackwell_test.go` tables all 25 Blackwell classes against the driver
release that introduced each, and asserts that every ABI at or after that release
registers the class and that no earlier ABI does. The intent is to stop a future
driver branch from silently losing Blackwell support by branching from a
pre-Blackwell node. Each introducing version was checked against the driver headers
across six release tags, and all 25 class IDs were verified against
`g_allclasses.h`.

### Verification

On an NVIDIA RTX PRO 6000 Blackwell Server Edition (GB202, compute capability 12.0)
with driver **610.57.04** -- a qualified version, with no
`--nvproxy-allow-unsupported-driver`:

- `test/gpu:smoke_test` under `runsc`: 5/5 pass (`nvidia-smi`, CUDA vector-add on
  12.x and 12.8, CUDA smoke samples)
- `test/gpu:sniffer_test`: pass, reporting **no unimplemented ioctls**
- vLLM served a model and answered a completion request under `runsc`
- With `profiling` enabled, the `trace-device` caps device and the synthesised
  `/proc/driver/nvidia/capabilities/trace-device` both appear correctly inside the
  sandbox, and the smoke suite still passes 5/5

`pkg/sentry/devices/nvproxy:nvproxy_test`, a `runsc` build, and `nogo` all pass on a
clean checkout with only this change applied.

### Not verified

- `NVCED0_VIDEO_NVJPG` exists only on GB10B/GB20B/GB20C, which I do not have access
  to. Its evidence is the driver's own class lists plus registration symmetry with
  its siblings.
- No profiler allocated `TRACE_DEVICE_EVENT` during testing (Nsight Systems is not
  present in the CUDA test image), so the capability plumbing is verified end to end
  but the `rmAlloc` handler itself has not been exercised by a real workload.
- Only GB202 was tested; not the datacenter parts, and not the SoCs.

Happy to move either class to a different node in the version tree if maintainers
read the driver history differently.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
