### PR TITLE
runsc: don't fail mount setup on socket mount points

### DIFF
--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -756,8 +756,21 @@ func TPUFunctionalityRequested(spec *specs.Spec, conf *config.Config) bool {
 // flags. procPath is the path to procfs. If it is "", procfs is assumed to be
 // mounted at /proc.
 func SafeSetupAndMount(src, dst, typ string, flags uint32, procPath string) error {
-	// Create the mount point inside. The type must be the same as the source
-	// (file or directory).
+	if err := createMountPoint(src, dst, typ); err != nil {
+		return err
+	}
+
+	// Do the mount.
+	if err := SafeMount(src, dst, typ, uintptr(flags), "", procPath); err != nil {
+		return fmt.Errorf("mount(%q, %q, %d) failed: %v", src, dst, flags, err)
+	}
+	return nil
+}
+
+// createMountPoint creates dst as a suitable mount point for src, creating
+// parent directories as needed. The mount point must agree with the source on
+// directory-ness; any other file type is acceptable.
+func createMountPoint(src, dst, typ string) error {
 	var isDir bool
 	if typ == "proc" {
 		// Special case, as there is no source directory for proc mounts.
@@ -780,16 +793,26 @@ func SafeSetupAndMount(src, dst, typ string, flags uint32, procPath string) erro
 			return fmt.Errorf("mkdir(%q) failed: %v", parent, err)
 		}
 		// Create the destination file if it does not exist.
-		f, err := os.OpenFile(dst, unix.O_CREAT, 0777)
-		if err != nil {
-			return fmt.Errorf("open(%q) failed: %v", dst, err)
+		//
+		// Check for existence with lstat(2) rather than relying on O_CREAT
+		// being a no-op: open(2) on an existing special file fails for some
+		// file types even when the file is a perfectly good mount point. In
+		// particular it returns ENXIO for a unix socket, which is how
+		// nvidia-container-toolkit's bind mount of
+		// /run/nvidia-persistenced/socket used to abort sandbox startup with
+		// an opaque "cannot read client sync file" error. A bind mount only
+		// requires the mount point to agree on directory-ness, not on file
+		// type, so an existing entry of any type is fine here.
+		if _, err := os.Lstat(dst); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("lstat(%q) failed: %v", dst, err)
+			}
+			f, err := os.OpenFile(dst, unix.O_CREAT|unix.O_WRONLY, 0777)
+			if err != nil {
+				return fmt.Errorf("open(%q) failed: %v", dst, err)
+			}
+			f.Close()
 		}
-		f.Close()
-	}
-
-	// Do the mount.
-	if err := SafeMount(src, dst, typ, uintptr(flags), "", procPath); err != nil {
-		return fmt.Errorf("mount(%q, %q, %d) failed: %v", src, dst, flags, err)
 	}
 	return nil
 }

--- a/runsc/specutils/specutils_test.go
+++ b/runsc/specutils/specutils_test.go
@@ -16,7 +16,10 @@ package specutils
 
 import (
 	"fmt"
+	"net"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -840,4 +843,93 @@ func TestTPUProxyEnabled(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCreateMountPoint verifies that mount points are created for every source
+// file type. The unix-socket case is a regression test: open(2) on an existing
+// socket returns ENXIO, which used to make createMountPoint fail for
+// nvidia-container-toolkit's bind mount of /run/nvidia-persistenced/socket and
+// take down the whole sandbox with an unrelated-looking error.
+func TestCreateMountPoint(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		makeSrc func(t *testing.T, path string)
+		makeDst func(t *testing.T, path string)
+		wantDir bool
+	}{
+		{
+			name:    "regular file, destination absent",
+			makeSrc: func(t *testing.T, p string) { mustWriteFile(t, p) },
+		},
+		{
+			name:    "directory, destination absent",
+			makeSrc: func(t *testing.T, p string) { mustMkdir(t, p) },
+			wantDir: true,
+		},
+		{
+			name:    "regular file, destination already exists",
+			makeSrc: func(t *testing.T, p string) { mustWriteFile(t, p) },
+			makeDst: func(t *testing.T, p string) { mustWriteFile(t, p) },
+		},
+		{
+			name:    "unix socket source, destination absent",
+			makeSrc: func(t *testing.T, p string) { mustMakeSocket(t, p) },
+		},
+		{
+			name:    "unix socket source, destination is a socket",
+			makeSrc: func(t *testing.T, p string) { mustMakeSocket(t, p) },
+			makeDst: func(t *testing.T, p string) { mustMakeSocket(t, p) },
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			src := filepath.Join(dir, "src")
+			// Nested, so parent-directory creation is exercised too.
+			dst := filepath.Join(dir, "sub", "dst")
+			test.makeSrc(t, src)
+			if test.makeDst != nil {
+				if err := os.MkdirAll(filepath.Dir(dst), 0777); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				test.makeDst(t, dst)
+			}
+
+			if err := createMountPoint(src, dst, "bind"); err != nil {
+				t.Fatalf("createMountPoint(%q, %q) = %v, want nil", src, dst, err)
+			}
+
+			fi, err := os.Lstat(dst)
+			if err != nil {
+				t.Fatalf("mount point was not created: %v", err)
+			}
+			if got := fi.IsDir(); got != test.wantDir {
+				t.Errorf("mount point IsDir() = %t, want %t", got, test.wantDir)
+			}
+		})
+	}
+}
+
+func mustWriteFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, nil, 0666); err != nil {
+		t.Fatalf("WriteFile(%q): %v", path, err)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Mkdir(path, 0777); err != nil {
+		t.Fatalf("Mkdir(%q): %v", path, err)
+	}
+}
+
+func mustMakeSocket(t *testing.T, path string) {
+	t.Helper()
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen(unix, %q): %v", path, err)
+	}
+	// Close the listener but keep the socket file: the file, not the
+	// listener, is what createMountPoint has to cope with.
+	t.Cleanup(func() { l.Close() })
 }


### PR DESCRIPTION
### AI assistance

This change was prepared with AI assistance (Claude Code) and is labelled `Assisted-by: Claude Code` in the commit message, per CONTRIBUTING.md. I have reviewed the change and am able to discuss and justify it.

### Problem

`SafeSetupAndMount` created a non-directory mount point with an unconditional
`open(dst, O_CREAT)`. `open(2)` on an existing unix socket returns `ENXIO`, so a bind
mount whose destination already exists as a socket aborts mount setup, even though a
perfectly usable mount point is already present.

This is reachable in practice. When `nvidia-persistenced` is running,
`nvidia-cdi-refresh` bakes a bind mount of `/run/nvidia-persistenced/socket` into the
generated CDI spec, and Docker replays it for every GPU container. The gofer dies
before writing the mounts file, and the sentry then fails with:

```
cannot create sandbox: cannot read client sync file: waiting for sandbox to start: EOF
```

which names nothing related to the actual cause. **On hosts running that daemon --
which includes AWS Deep Learning AMIs by default -- no GPU container starts under
runsc at all.** The same CDI spec carries `nvidia-fabricmanager/socket` and
`/tmp/nvidia-mps` entries on hosts running those, and they would fail identically.

Tracing that EOF back to the gofer took several rounds, so the opacity of the error
may be worth improving separately.

### Fix

Check for an existing mount point with `lstat(2)` first. A bind mount only requires
the mount point to agree with the source on directory-ness, not on file type, so an
existing entry of any type is fine.

Mount point creation is extracted into `createMountPoint` so that it can be tested
without root. `TestCreateMountPoint` covers socket sources and socket destinations
alongside the regular-file and directory cases.

### Verification

`runsc/specutils:specutils_test`, a `runsc` build, and `nogo` all pass on a clean
checkout with only this change applied.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
