### PR TITLE
images/gpu: update test images for Blackwell (sm_100/sm_120)

### DIFF
--- a/images/gpu/nccl-tests/Dockerfile
+++ b/images/gpu/nccl-tests/Dockerfile
@@ -1,4 +1,6 @@
-FROM nvidia/cuda:12.5.0-devel-ubuntu22.04
+# CUDA 12.8 is the first toolkit whose nvcc knows the Blackwell arches
+# (sm_100/sm_120); nccl-tests derives its gencode list from the toolkit.
+FROM nvidia/cuda:12.8.1-devel-ubuntu22.04
 
 RUN apt-get update && apt-get install git -y
 

--- a/images/gpu/pytorch/Dockerfile.x86_64
+++ b/images/gpu/pytorch/Dockerfile.x86_64
@@ -1,7 +1,12 @@
-FROM nvidia/cuda:12.4.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.8.1-devel-ubuntu22.04
 
 # Used for determining the correct pip index URL below.
-ENV CUDA_VERSION=12.4
+# 12.8 is the floor for Blackwell: the cu128 wheels are the first PyTorch
+# builds (torch 2.7.0 onwards) to ship sm_100/sm_120 kernels. Below this the
+# image installs a torch that fails on Blackwell with "no kernel image is
+# available for execution on the device". CUDA_VERSION also selects the pip
+# index URL below, so both move together.
+ENV CUDA_VERSION=12.8
 
 ENV PYTORCH_DATASETS_DIR=/pytorch-data
 ENV TORCH_HOME=/pytorch-home

--- a/images/gpu/vllm/Dockerfile.x86_64
+++ b/images/gpu/vllm/Dockerfile.x86_64
@@ -8,10 +8,15 @@ RUN apk add git-lfs && \
     rm /opt-125m/tf_model.h5
 # post checkout hook. checks that command git lfs is available.
 RUN GIT_CLONE_PROTECTION_ACTIVE=false git clone https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered /dataset
-RUN git clone https://github.com/vllm-project/vllm.git /vllm && cd /vllm && git checkout v0.4.2
+RUN git clone https://github.com/vllm-project/vllm.git /vllm && cd /vllm && git checkout v0.27.1
 
-# v0.4.2
-FROM vllm/vllm-openai@sha256:c63bd9e99c6d5914032b396be38a80fd9640693da62b64b907434d38bf38a8e9
+# v0.27.1. Do not downgrade below this without checking torch's compiled
+# arch list: releases before this shipped torch 2.3.0+cu121, whose kernels
+# stop at sm_90, so every CUDA op fails on Blackwell (sm_100/sm_120) with
+# "no kernel image is available for execution on the device" under any
+# runtime. v0.27.1 ships torch 2.13.0+cu130 built for
+# ['sm_75','sm_80','sm_86','sm_90','sm_100','sm_120'].
+FROM vllm/vllm-openai@sha256:0a51ea5b4ae2dc5d81890e5173f54203d2a3ae0cfffe51b8fd2afd4391bfd967
 COPY --from=downloader /vllm/examples/template_chatml.jinja /vllm/examples/template_chatml.jinja
 COPY --from=downloader /vllm/benchmarks /vllm/benchmarks
 COPY --from=downloader /opt-125m /model


### PR DESCRIPTION
### AI assistance

This change was prepared with AI assistance (Claude Code) and is labelled `Assisted-by: Claude Code` in the commit message, per CONTRIBUTING.md. I have reviewed the change and am able to discuss and justify it.

### Problem

Several GPU test images pin CUDA and PyTorch versions that predate Blackwell, so they
fail on sm_100/sm_120 with `no kernel image is available for execution on the device`
-- under `runc` exactly as much as under `runsc`. These tests therefore cannot pass on
Blackwell regardless of nvproxy.

PyTorch first shipped Blackwell kernels in **2.7.0**, and only in the CUDA 12.8
(`cu128`) wheels, so 12.8 is the floor for anything torch-based.

### Changes

- **vllm**: pinned v0.4.2, whose torch 2.3.0+cu121 compiles for `sm_50..sm_90`.
  Bumped to v0.27.1 (torch 2.13.0+cu130, built for `sm_75..sm_90`, `sm_100`,
  `sm_120`), pinned by digest.
- **pytorch**: `CUDA_VERSION` drives both the base image and the pip index URL, and
  torch is unpinned, so moving 12.4 to 12.8 selects the `cu128` wheels.
- **nccl-tests**: CUDA 12.8 is the first toolkit whose nvcc knows the Blackwell
  arches, and nccl-tests derives its gencode list from the toolkit.

The CUDA sample images (`cuda-tests`, `cuda-tests-12-8`) already work on Blackwell
unchanged, because the samples embed PTX and the driver JIT-compiles it forward.
PyTorch ships cubins with no forward-compatible PTX, which is why it hard-fails
instead.

`stable-diffusion-xl` is deliberately left alone: it installs torch transitively from
the default PyPI index rather than a CUDA-specific one, so it needs an explicit
`cu128` index plus a compatible `xformers` pin. That is more than a version bump and
wants a build test.

### Verification

On an NVIDIA RTX PRO 6000 Blackwell Server Edition (GB202), the upstream vLLM v0.27.1
image serves `facebook/opt-125m` and answers completion requests under both `runc`
and `runsc`.

### Not verified

**I have not built the pytorch or nccl-tests images.** Those are reasoned version
bumps; in particular, a torch bump may disturb the pinned `pytorch/benchmark` model
installs in the pytorch image. Please exercise those image builds in CI before
merging.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
