### PR TITLE
runsc: keep writable-layer filestores out of the checkpoint image

### DIFF
--- a/pkg/sentry/checkpoint/BUILD
+++ b/pkg/sentry/checkpoint/BUILD
@@ -6,6 +6,9 @@ licenses(["notice"])
 
 go_library(
     name = "checkpoint",
-    srcs = ["checkpoint.go"],
+    srcs = [
+        "checkpoint.go",
+        "filestore_snapshot.go",
+    ],
     visibility = ["//pkg/sentry:internal"],
 )

--- a/pkg/sentry/checkpoint/filestore_snapshot.go
+++ b/pkg/sentry/checkpoint/filestore_snapshot.go
@@ -1,0 +1,120 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+// FilestoreSnapshot identifies a private MemoryFile (by ResourceID) and the
+// destination host file its backing file is FICLONE'd (reflink-cloned) to
+// during a state checkpoint's freeze window. Taking the snapshot inside the
+// window makes the filestore snapshot and the saved memory-state metadata
+// describe the same instant, which is what allows the combination to remain
+// correct with leave-running checkpoints.
+//
+// It is defined here (rather than in pkg/sentry/state) so that both
+// pkg/sentry/kernel and pkg/sentry/state can use it without an import cycle.
+type FilestoreSnapshot struct {
+	// ID identifies the private MemoryFile to snapshot.
+	ID ResourceID
+	// Name is the artifact file name the destination will get in the
+	// snapshot directory (e.g. "filestore-0"); it is recorded in the
+	// filestores.json sidecar manifest.
+	Name string
+	// Dest is the (pre-created, empty) destination file for the reflink
+	// clone. It lives on the same filesystem as the snapshot directory.
+	Dest *os.File
+}
+
+// FilestoreSidecarEntry is one entry of the filestores.json artifact manifest
+// written next to in-window filestore snapshots (`runsc checkpoint
+// --filestore-snapshot-dir`) and verified at adoption time (`runsc restore
+// --filestore-adopt-dir`). It is defined here so that the writer (the sentry,
+// inside the save freeze window) and the verifier (runsc/container, host-side,
+// before the sandbox starts) share one schema.
+type FilestoreSidecarEntry struct {
+	// File is the artifact file name, relative to the snapshot/adopt dir.
+	File string `json:"file"`
+	// ResourceContainer and ResourcePath identify the mount this artifact
+	// backs (ResourceID fields).
+	ResourceContainer string `json:"resource_container"`
+	ResourcePath      string `json:"resource_path"`
+	// SizeBytes is the exact stat size of the artifact.
+	SizeBytes uint64 `json:"size_bytes"`
+	// ChunkCount is the number of pgalloc chunks in the filestore.
+	ChunkCount uint64 `json:"chunk_count"`
+	// Fingerprint is the sampled SHA-256 (FingerprintFile) of the artifact.
+	Fingerprint string `json:"fingerprint"`
+}
+
+// FilestoreSidecar is the top-level filestores.json document.
+type FilestoreSidecar struct {
+	Filestores []FilestoreSidecarEntry `json:"filestores"`
+}
+
+// WriteFilestoreSidecar writes the filestores.json manifest to w.
+func WriteFilestoreSidecar(w io.Writer, entries []FilestoreSidecarEntry) error {
+	data, err := json.Marshal(FilestoreSidecar{Filestores: entries})
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(append(data, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// fingerprintChunkSize is the amount of data sampled from each end of a file
+// for FilestoreSidecarEntry.Fingerprint.
+const fingerprintChunkSize = 4096
+
+// FingerprintFile returns an O(1)-cost sampled fingerprint of file: the hex
+// SHA-256 of the first and last fingerprintChunkSize bytes of the file. It is
+// used to detect "same size, different contents" mistakes when a host file is
+// used as externally-saved MemoryFile content (checkpoint metadata records the
+// fingerprint at save time; adoption verifies it).
+func FingerprintFile(file *os.File) (string, error) {
+	fi, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	size := fi.Size()
+	var buf [fingerprintChunkSize]byte
+	readAt := func(off int64) error {
+		n, err := file.ReadAt(buf[:], off)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		h.Write(buf[:n])
+		return nil
+	}
+	if size > 0 {
+		if err := readAt(0); err != nil {
+			return "", err
+		}
+		if size > fingerprintChunkSize {
+			if err := readAt(size - fingerprintChunkSize); err != nil {
+				return "", err
+			}
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/sentry/control/BUILD
+++ b/pkg/sentry/control/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//pkg/metric",
         "//pkg/metric:metric_go_proto",
         "//pkg/prometheus",
+        "//pkg/sentry/checkpoint",
         "//pkg/sentry/devices/memdev",
         "//pkg/sentry/devices/nvproxy",
         "//pkg/sentry/devices/tpuproxy/vfio",

--- a/pkg/sentry/control/state.go
+++ b/pkg/sentry/control/state.go
@@ -79,6 +79,13 @@ type SaveOpts struct {
 	// file.
 	AppMFExcludeCommittedZeroPages bool `json:"app_mf_exclude_committed_zero_pages"`
 
+	// PrivateMFExternalContent is the value of
+	// pgalloc.SaveOpts.ExternalContent for private (disk-backed) MemoryFiles.
+	// If true, their page contents are not saved into the checkpoint; the
+	// backing host files (gofer filestore files) must be captured out-of-band
+	// and provided for adoption on restore.
+	PrivateMFExternalContent bool `json:"private_mf_external_content"`
+
 	// HavePagesFile indicates whether the pages file and its corresponding
 	// metadata file is provided.
 	HavePagesFile bool `json:"have_pages_file"`
@@ -131,6 +138,7 @@ func ConvertToStateSaveOpts(o *SaveOpts) (*state.SaveOpts, error) {
 		Key:                            o.Key,
 		Metadata:                       o.Metadata,
 		AppMFExcludeCommittedZeroPages: o.AppMFExcludeCommittedZeroPages,
+		PrivateMFExternalContent:       o.PrivateMFExternalContent,
 		Resume:                         o.Resume,
 		CudaCheckpointPath:             o.CudaCheckpointPath,
 		CudaCheckpointSequential:       o.CudaCheckpointSequential,

--- a/pkg/sentry/control/state.go
+++ b/pkg/sentry/control/state.go
@@ -24,6 +24,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/checkpoint"
 	"gvisor.dev/gvisor/pkg/sentry/fdcollector"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/pipefs"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
@@ -66,6 +67,17 @@ type State struct {
 	Watchdog *watchdog.Watchdog
 }
 
+// FilestoreSnapshotTarget identifies one filestore snapshot destination for
+// the Save RPC's FilePayload.
+type FilestoreSnapshotTarget struct {
+	ResourceID checkpoint.ResourceID `json:"resource_id"`
+	// Name is the artifact file name the destination will get in the
+	// snapshot directory (e.g. "filestore-0"); it is recorded in the
+	// filestores.json sidecar.
+	Name    string `json:"name"`
+	FDIndex int    `json:"fd_index"`
+}
+
 // SaveOpts contains options for the Save RPC call.
 type SaveOpts struct {
 	// Key is used to enable state integrity check.
@@ -85,6 +97,18 @@ type SaveOpts struct {
 	// backing host files (gofer filestore files) must be captured out-of-band
 	// and provided for adoption on restore.
 	PrivateMFExternalContent bool `json:"private_mf_external_content"`
+
+	// FilestoreSnapshot specifies in-freeze-window filestore snapshots: each
+	// private MemoryFile matching a target's ResourceID is FICLONE'd to the
+	// target's donated destination FD after the kernel pauses and before
+	// memory-file metadata is serialized, so the snapshot and the saved
+	// metadata describe the same instant (valid with Resume/leave-running).
+	FilestoreSnapshot []FilestoreSnapshotTarget `json:"filestore_snapshot,omitempty"`
+
+	// FilestoreSidecarFDIndex is the index into FilePayload.Files of the
+	// donated file that receives the filestores.json artifact manifest
+	// during the save window. Only meaningful with FilestoreSnapshot.
+	FilestoreSidecarFDIndex int `json:"filestore_sidecar_fd_index,omitempty"`
 
 	// HavePagesFile indicates whether the pages file and its corresponding
 	// metadata file is provided.
@@ -162,6 +186,11 @@ func setSaveOptsForLocalCheckpointFiles(o *SaveOpts, saveOpts *state.SaveOpts) e
 	if o.HavePagesFile {
 		wantFiles += 2
 	}
+	// In-window filestore snapshot destinations and the sidecar manifest file.
+	wantFiles += len(o.FilestoreSnapshot)
+	if len(o.FilestoreSnapshot) > 0 {
+		wantFiles++ // sidecar
+	}
 	if gotFiles := len(o.FilePayload.Files); gotFiles != wantFiles {
 		return fmt.Errorf("got %d files, wanted %d", gotFiles, wantFiles)
 	}
@@ -190,6 +219,25 @@ func setSaveOptsForLocalCheckpointFiles(o *SaveOpts, saveOpts *state.SaveOpts) e
 			return err
 		}
 		saveOpts.PagesFile = stateio.NewPagesFileFDWriterDefault(int32(pagesFileFD))
+	}
+	for i := range o.FilestoreSnapshot {
+		t := &o.FilestoreSnapshot[i]
+		dest, err := o.ReleaseFD(t.FDIndex)
+		if err != nil {
+			return err
+		}
+		saveOpts.FilestoreSnapshots = append(saveOpts.FilestoreSnapshots, checkpoint.FilestoreSnapshot{
+			ID:   t.ResourceID,
+			Name: t.Name,
+			Dest: dest.ReleaseToFile("filestore snapshot dest"),
+		})
+	}
+	if len(o.FilestoreSnapshot) > 0 {
+		sidecar, err := o.ReleaseFD(o.FilestoreSidecarFDIndex)
+		if err != nil {
+			return err
+		}
+		saveOpts.FilestoreSidecar = sidecar.ReleaseToFile("filestore sidecar")
 	}
 	return nil
 }

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -272,6 +272,7 @@ go_library(
         "fs_context_mutex.go",
         "fs_context_refs.go",
         "fs_save_mutex.go",
+        "filestore_snapshot.go",
         "fscheckpoint.go",
         "ipc_namespace.go",
         "kcov.go",

--- a/pkg/sentry/kernel/filestore_snapshot.go
+++ b/pkg/sentry/kernel/filestore_snapshot.go
@@ -1,0 +1,67 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"fmt"
+	"sort"
+
+	"gvisor.dev/gvisor/pkg/sentry/checkpoint"
+	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
+)
+
+// snapshotFilestores reflink-clones every private MemoryFile's backing file
+// to its snapshot destination, recording the snapshot's exact size and
+// sampled fingerprint both on the MemoryFile (so its ExternalContent save
+// embeds snapshot-describing values) and in the returned sidecar entries.
+//
+// Precondition: the kernel is paused (this runs inside Kernel.SaveTo's
+// quiesce window, after mfsToSave has been collected).
+func (k *Kernel) snapshotFilestores(mfsToSave map[checkpoint.ResourceID]*pgalloc.MemoryFile, snapshots []checkpoint.FilestoreSnapshot) ([]checkpoint.FilestoreSidecarEntry, error) {
+	// Every private MemoryFile must be snapshotted: the checkpoint does not
+	// carry its contents, so a missed one would make the checkpoint
+	// unrestorable. Fail loudly rather than produce a half-usable artifact.
+	targeted := make(map[checkpoint.ResourceID]bool, len(snapshots))
+	for _, s := range snapshots {
+		targeted[s.ID] = true
+	}
+	for rid := range mfsToSave {
+		if !targeted[rid] {
+			return nil, fmt.Errorf("filestore snapshot targets do not cover private memory file %+v (checkpoint would be unrestorable); the caller's mount enumeration is inconsistent with the sandbox's", rid)
+		}
+	}
+	entries := make([]checkpoint.FilestoreSidecarEntry, 0, len(snapshots))
+	for _, s := range snapshots {
+		mf := mfsToSave[s.ID]
+		if mf == nil {
+			return nil, fmt.Errorf("filestore snapshot target %+v has no matching private memory file; the caller's mount enumeration is inconsistent with the sandbox's", s.ID)
+		}
+		size, fp, err := mf.SnapshotToFd(s.Dest)
+		if err != nil {
+			return nil, fmt.Errorf("snapshotting filestore %+v failed: %w", s.ID, err)
+		}
+		entries = append(entries, checkpoint.FilestoreSidecarEntry{
+			File:              s.Name,
+			ResourceContainer: s.ID.ContainerName,
+			ResourcePath:      s.ID.Path,
+			SizeBytes:         size,
+			ChunkCount:        uint64(mf.ChunkCount()),
+			Fingerprint:       fp,
+		})
+	}
+	// Deterministic output regardless of caller target order.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].File < entries[j].File })
+	return entries, nil
+}

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -710,11 +710,30 @@ func savePrivateMFs(ctx context.Context, w io.Writer, mfsToSave map[checkpoint.R
 	return nil
 }
 
+// SaveOpts contains options for Kernel.SaveTo().
+type SaveOpts struct {
+	// AppMFExcludeCommittedZeroPages is the value of
+	// pgalloc.SaveOpts.ExcludeCommittedZeroPages for the application
+	// MemoryFile. It is expected to reflect application memory usage
+	// behavior, but not necessarily usage of private MemoryFiles.
+	AppMFExcludeCommittedZeroPages bool
+
+	// PrivateMFExternalContent is the value of
+	// pgalloc.SaveOpts.ExternalContent for private (disk-backed) MemoryFiles.
+	// If true, they only save segment metadata; their contents are expected
+	// to be captured out-of-band (the backing host files are preserved or
+	// snapshotted separately) and adopted on restore.
+	PrivateMFExternalContent bool
+
+	// Resume indicates if the statefile is used for save-resume.
+	Resume bool
+}
+
 // SaveTo saves the state of k to stateFile. It takes ownership of stateFile,
 // pagesMetadata, and pagesFile, even if it returns a non-nil error.
 //
 // Preconditions: The kernel must be paused throughout the call to SaveTo.
-func (k *Kernel) SaveTo(ctx context.Context, stateFile, pagesMetadata io.WriteCloser, pagesFile stateio.AsyncWriter, appMFExcludeCommittedZeroPages, resume bool) error {
+func (k *Kernel) SaveTo(ctx context.Context, stateFile, pagesMetadata io.WriteCloser, pagesFile stateio.AsyncWriter, opts *SaveOpts) error {
 	if hostarch.PageSize != 4096 {
 		return fmt.Errorf("save is not supported with %dK page size", hostarch.PageSize/1024)
 	}
@@ -763,7 +782,7 @@ func (k *Kernel) SaveTo(ctx context.Context, stateFile, pagesMetadata io.WriteCl
 			mfSaveWg.Add(1)
 			go func() {
 				defer mfSaveWg.Done()
-				mfSaveErr = k.saveMemoryFiles(ctx, nil, pagesMetadata, pagesFile, mfsToSave, appMFExcludeCommittedZeroPages) // transfers ownership
+				mfSaveErr = k.saveMemoryFiles(ctx, nil, pagesMetadata, pagesFile, mfsToSave, opts) // transfers ownership
 			}()
 			pagesCleanup.Release()
 			// Defer a Wait() so we wait for k.saveMemoryFiles() to complete even if we
@@ -788,7 +807,7 @@ func (k *Kernel) SaveTo(ctx context.Context, stateFile, pagesMetadata io.WriteCl
 			// Pause the network stack.
 			netstackPauseStart := time.Now()
 			// Stack.removeConf should be true when resume=false and vice versa.
-			k.rootNetworkNamespace.Stack().SetRemoveConf(!resume)
+			k.rootNetworkNamespace.Stack().SetRemoveConf(!opts.Resume)
 			log.Infof("Pausing root network namespace")
 			k.rootNetworkNamespace.Stack().Pause()
 			defer k.rootNetworkNamespace.Stack().Resume()
@@ -817,7 +836,7 @@ func (k *Kernel) SaveTo(ctx context.Context, stateFile, pagesMetadata io.WriteCl
 				return mfSaveErr
 			}
 		} else {
-			mfSaveErr = k.saveMemoryFiles(ctx, stateFile, nil, nil, mfsToSave, appMFExcludeCommittedZeroPages)
+			mfSaveErr = k.saveMemoryFiles(ctx, stateFile, nil, nil, mfsToSave, opts)
 			if mfSaveErr != nil {
 				return mfSaveErr
 			}
@@ -846,7 +865,7 @@ func (k *Kernel) BeforeResume(ctx context.Context) {
 // pagesFile must be non-nil, saveMemoryFiles takes ownership of both
 // pagesMetadata and pagesFile (even if it returns a non-nil error), and
 // MemoryFile state will be saved to pagesMetadata and pagesFile.
-func (k *Kernel) saveMemoryFiles(ctx context.Context, w io.Writer, pagesMetadata io.WriteCloser, pagesFile stateio.AsyncWriter, mfsToSave map[checkpoint.ResourceID]*pgalloc.MemoryFile, appMFExcludeCommittedZeroPages bool) error {
+func (k *Kernel) saveMemoryFiles(ctx context.Context, w io.Writer, pagesMetadata io.WriteCloser, pagesFile stateio.AsyncWriter, mfsToSave map[checkpoint.ResourceID]*pgalloc.MemoryFile, opts *SaveOpts) error {
 	memoryStart := time.Now()
 
 	pmw := w
@@ -858,7 +877,7 @@ func (k *Kernel) saveMemoryFiles(ctx context.Context, w io.Writer, pagesMetadata
 	defer pmwCleanup.Clean()
 
 	mfOpts := pgalloc.SaveOpts{
-		ExcludeCommittedZeroPages: appMFExcludeCommittedZeroPages,
+		ExcludeCommittedZeroPages: opts.AppMFExcludeCommittedZeroPages,
 	}
 	var (
 		asyncPageSaveWg      sync.WaitGroup
@@ -885,9 +904,13 @@ func (k *Kernel) saveMemoryFiles(ctx context.Context, w io.Writer, pagesMetadata
 	if err := k.mf.SaveTo(ctx, pmw, &mfOpts); err != nil {
 		return err
 	}
-	// appMFExcludeCommittedZeroPages is expected to reflect application memory
+	// AppMFExcludeCommittedZeroPages is expected to reflect application memory
 	// usage behavior, but not necessarily usage of private MemoryFiles.
 	mfOpts.ExcludeCommittedZeroPages = false
+	// If PrivateMFExternalContent is set, private MemoryFiles only save
+	// segment metadata; their contents are expected to be captured out-of-band
+	// (the backing host files are preserved or snapshotted separately).
+	mfOpts.ExternalContent = opts.PrivateMFExternalContent
 	if err := savePrivateMFs(ctx, pmw, mfsToSave, &mfOpts); err != nil {
 		return err
 	}

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -725,6 +725,19 @@ type SaveOpts struct {
 	// snapshotted separately) and adopted on restore.
 	PrivateMFExternalContent bool
 
+	// FilestoreSnapshots, if non-empty, requests in-freeze-window snapshots
+	// of the private MemoryFiles: after the kernel pauses and before
+	// memory-file metadata is serialized, each MemoryFile identified by ID
+	// has its backing file FICLONE'd (reflink-cloned) to Dest, so the
+	// snapshot and the saved metadata describe the same instant (valid with
+	// Resume/leave-running).
+	FilestoreSnapshots []checkpoint.FilestoreSnapshot
+
+	// FilestoreSidecar, if non-nil, receives a JSON manifest describing the
+	// FilestoreSnapshots artifacts (names, resource IDs, sizes, sampled
+	// fingerprints) written during the freeze window.
+	FilestoreSidecar io.Writer
+
 	// Resume indicates if the statefile is used for save-resume.
 	Resume bool
 }
@@ -771,6 +784,34 @@ func (k *Kernel) SaveTo(ctx context.Context, stateFile, pagesMetadata io.WriteCl
 		k.mf.MarkSavable()
 		for _, mf := range mfsToSave {
 			mf.MarkSavable()
+		}
+
+		// Start a fresh save window on every private MemoryFile: snapshot
+		// credentials stashed by a previous window's SnapshotToFd() must not
+		// leak into this save's ExternalContent metadata (a plain
+		// --skip-filestore-pages save following a --filestore-snapshot-dir
+		// one must describe the backing file's current contents).
+		for _, mf := range mfsToSave {
+			mf.BeginSaveWindow()
+		}
+
+		// Take in-window filestore snapshots (--filestore-snapshot-dir): the
+		// kernel is paused, so there are no writers to the backing files; the
+		// snapshot therefore describes exactly the instant the metadata
+		// below will describe. Snapshots are recorded (size + sampled
+		// fingerprint) on the MemoryFiles so that their ExternalContent save
+		// embeds values describing the snapshot rather than the original
+		// file, which may diverge after the window (leave-running).
+		if len(opts.FilestoreSnapshots) > 0 {
+			entries, err := k.snapshotFilestores(mfsToSave, opts.FilestoreSnapshots)
+			if err != nil {
+				return err
+			}
+			if opts.FilestoreSidecar != nil {
+				if err := checkpoint.WriteFilestoreSidecar(opts.FilestoreSidecar, entries); err != nil {
+					return fmt.Errorf("failed to write filestores.json sidecar: %w", err)
+				}
+			}
 		}
 
 		var (

--- a/pkg/sentry/pgalloc/BUILD
+++ b/pkg/sentry/pgalloc/BUILD
@@ -214,6 +214,7 @@ go_test(
     library = ":pgalloc",
     deps = [
         "//pkg/hostarch",
+        "//pkg/sentry/checkpoint",
         "//pkg/sentry/memmap",
         "//pkg/sentry/usage",
     ],

--- a/pkg/sentry/pgalloc/BUILD
+++ b/pkg/sentry/pgalloc/BUILD
@@ -209,11 +209,13 @@ go_test(
     srcs = [
         "pgalloc_64k_test.go",
         "pgalloc_test.go",
+        "save_restore_external_test.go",
     ],
     library = ":pgalloc",
     deps = [
         "//pkg/hostarch",
         "//pkg/sentry/memmap",
+        "//pkg/sentry/usage",
     ],
 )
 

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -194,6 +194,15 @@ type MemoryFile struct {
 	// release all MemoryFile resources and exit. destroyed is protected by mu.
 	destroyed bool
 
+	// contentExternal is set when SaveTo() has been called with
+	// ExternalContent, i.e. page contents were intentionally left in the
+	// backing host file (captured out-of-band) instead of being serialized
+	// into the checkpoint. Destroy must not decommit such a file: an external
+	// holder (e.g. a fd-holding orchestrator or a host-side snapshot) may
+	// still reference the same inode and the checkpoint is unusable without
+	// its contents. contentExternal is protected by mu.
+	contentExternal bool
+
 	// stopNotifyPressure stops memory cgroup pressure level
 	// notifications used to drive eviction. stopNotifyPressure is
 	// immutable.
@@ -545,7 +554,7 @@ func (f *MemoryFile) releaserDestroyLocked() {
 		panic("destroyed is no longer set")
 	}
 
-	if f.opts.DecommitOnDestroy {
+	if f.opts.DecommitOnDestroy && !f.contentExternal {
 		if chunks := f.chunksLoad(); len(chunks) != 0 {
 			if err := f.decommitFile(memmap.FileRange{0, uint64(len(chunks)) * chunkSize}); err != nil {
 				panic(fmt.Sprintf("failed to decommit entire memory file during destruction: %v", err))

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -203,6 +203,14 @@ type MemoryFile struct {
 	// its contents. contentExternal is protected by mu.
 	contentExternal bool
 
+	// externalSavedSize/externalSavedFingerprint record the exact size and
+	// sampled fingerprint of the snapshot taken by SnapshotToFd() during the
+	// current save window (empty fingerprint = no snapshot taken; the backing
+	// file itself is then fingerprinted by SaveTo inside the window). They
+	// are only written and read while the kernel is paused during a save.
+	externalSavedSize        uint64
+	externalSavedFingerprint string
+
 	// stopNotifyPressure stops memory cgroup pressure level
 	// notifications used to drive eviction. stopNotifyPressure is
 	// immutable.

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -388,6 +388,13 @@ type MemoryFileOpts struct {
 	// If DisableMemoryAccounting is true, memory usage observed by the
 	// MemoryFile will not be reported in usage.MemoryAccounting.
 	DisableMemoryAccounting bool
+
+	// If AdoptExistingFile is true, NewMemoryFile() will not truncate the
+	// backing file, allowing an existing file with meaningful contents to be
+	// adopted. The caller is responsible for the file's contents being valid
+	// for the restored MemoryFile (e.g. via MemoryFile.LoadFrom() of a
+	// checkpoint whose metadata was saved with ExternalContent).
+	AdoptExistingFile bool
 }
 
 // DelayedEvictionType is the type of MemoryFileOpts.DelayedEviction.
@@ -436,9 +443,11 @@ func NewMemoryFile(file *os.File, opts MemoryFileOpts) (*MemoryFile, error) {
 		return nil, fmt.Errorf("invalid MemoryFileOpts.DelayedEviction: %v", opts.DelayedEviction)
 	}
 
-	// Truncate the file to 0 bytes first to ensure that it's empty.
-	if err := file.Truncate(0); err != nil {
-		return nil, err
+	if !opts.AdoptExistingFile {
+		// Truncate the file to 0 bytes first to ensure that it's empty.
+		if err := file.Truncate(0); err != nil {
+			return nil, err
+		}
 	}
 	f := &MemoryFile{
 		opts: opts,

--- a/pkg/sentry/pgalloc/pgalloc.proto
+++ b/pkg/sentry/pgalloc/pgalloc.proto
@@ -48,4 +48,11 @@ message MemoryFileMetadataProto {
   repeated FileRangeProto unwaste_small = 6;
   repeated FileRangeProto unwaste_huge = 7;
   map<uint64, uint64> subreleased = 8;
+
+  // ContentExternal is true if page contents were not saved to the
+  // checkpoint. LoadFrom() requires the backing file to already contain the
+  // correct contents at the offsets described by the saved segment table
+  // (i.e. the MemoryFile must adopt the host file that the original
+  // MemoryFile was backed by when it was saved).
+  bool content_external = 9;
 }

--- a/pkg/sentry/pgalloc/pgalloc.proto
+++ b/pkg/sentry/pgalloc/pgalloc.proto
@@ -55,4 +55,19 @@ message MemoryFileMetadataProto {
   // (i.e. the MemoryFile must adopt the host file that the original
   // MemoryFile was backed by when it was saved).
   bool content_external = 9;
+
+  // ContentExternalFileSize is the exact stat size of the backing host file
+  // at save time, when content_external is true. LoadFrom() requires the
+  // adopted file to match it exactly (not merely be large enough), so that a
+  // mismatched artifact is rejected instead of silently restoring with tail
+  // garbage or holes.
+  uint64 content_external_file_size = 10;
+
+  // ContentExternalFingerprint is an O(1) sampled fingerprint (SHA-256 of
+  // the first and last 4KiB) of the backing host file at save time, when
+  // content_external is true. It catches "same size, different contents"
+  // mistakes, e.g. adopting the original filestore after it diverged
+  // following a leave-running checkpoint (divergence changes contents but
+  // not necessarily size).
+  string content_external_fingerprint = 11;
 }

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -17,9 +17,7 @@ package pgalloc
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"math"
@@ -196,43 +194,6 @@ type SaveOpts struct {
 	ExternalContent bool
 }
 
-// fingerprintChunkSize is the amount of data sampled from each end of a file
-// for ContentExternalFingerprint.
-const fingerprintChunkSize = 4096
-
-// fingerprintFile returns an O(1)-cost sampled fingerprint of file: the hex
-// SHA-256 of the first and last fingerprintChunkSize bytes of the file. It is
-// used to detect "same size, different contents" mistakes when adopting a
-// host file as a MemoryFile's externally-saved content.
-func fingerprintFile(file *os.File) (string, error) {
-	fi, err := file.Stat()
-	if err != nil {
-		return "", err
-	}
-	h := sha256.New()
-	size := fi.Size()
-	var buf [fingerprintChunkSize]byte
-	readAt := func(off int64) error {
-		n, err := file.ReadAt(buf[:], off)
-		if err != nil && err != io.EOF {
-			return err
-		}
-		h.Write(buf[:n])
-		return nil
-	}
-	if size > 0 {
-		if err := readAt(0); err != nil {
-			return "", err
-		}
-		if size > fingerprintChunkSize {
-			if err := readAt(size - fingerprintChunkSize); err != nil {
-				return "", err
-			}
-		}
-	}
-	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
 // externalContentInfoLocked returns the exact size and sampled fingerprint to
 // record for an ExternalContent save. If SnapshotToFd() captured an in-window
 // snapshot during the current save, the snapshot's values are used (reflink
@@ -252,7 +213,7 @@ func (f *MemoryFile) externalContentInfoLocked() (uint64, string, error) {
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to stat backing file: %w", err)
 	}
-	fp, err := fingerprintFile(f.file)
+	fp, err := checkpoint.FingerprintFile(f.file)
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to fingerprint backing file: %w", err)
 	}
@@ -301,7 +262,7 @@ func (f *MemoryFile) SnapshotToFd(dst *os.File) (size uint64, fingerprint string
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to stat filestore snapshot: %w", err)
 	}
-	fp, err := fingerprintFile(dst)
+	fp, err := checkpoint.FingerprintFile(dst)
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to fingerprint filestore snapshot: %w", err)
 	}
@@ -1249,7 +1210,7 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 			return fmt.Errorf("adopted MemoryFile file size %d is smaller than required %d (state checkpoint and filestore artifact mismatch?)", fi.Size(), fileSize)
 		}
 		if pb.ContentExternalFingerprint != "" {
-			fp, err := fingerprintFile(f.file)
+			fp, err := checkpoint.FingerprintFile(f.file)
 			if err != nil {
 				return fmt.Errorf("failed to fingerprint adopted MemoryFile file: %w", err)
 			}

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -17,10 +17,13 @@ package pgalloc
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"runtime"
 	"sync/atomic"
 	"time"
@@ -193,6 +196,128 @@ type SaveOpts struct {
 	ExternalContent bool
 }
 
+// fingerprintChunkSize is the amount of data sampled from each end of a file
+// for ContentExternalFingerprint.
+const fingerprintChunkSize = 4096
+
+// fingerprintFile returns an O(1)-cost sampled fingerprint of file: the hex
+// SHA-256 of the first and last fingerprintChunkSize bytes of the file. It is
+// used to detect "same size, different contents" mistakes when adopting a
+// host file as a MemoryFile's externally-saved content.
+func fingerprintFile(file *os.File) (string, error) {
+	fi, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	size := fi.Size()
+	var buf [fingerprintChunkSize]byte
+	readAt := func(off int64) error {
+		n, err := file.ReadAt(buf[:], off)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		h.Write(buf[:n])
+		return nil
+	}
+	if size > 0 {
+		if err := readAt(0); err != nil {
+			return "", err
+		}
+		if size > fingerprintChunkSize {
+			if err := readAt(size - fingerprintChunkSize); err != nil {
+				return "", err
+			}
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// externalContentInfoLocked returns the exact size and sampled fingerprint to
+// record for an ExternalContent save. If SnapshotToFd() captured an in-window
+// snapshot during the current save, the snapshot's values are used (reflink
+// guarantees they stay stable even if the original file diverges after the
+// window, e.g. with leave-running); otherwise the backing file's current
+// values are sampled (valid because the kernel is paused throughout the save).
+//
+// Precondition: f.mu is locked.
+func (f *MemoryFile) externalContentInfoLocked() (uint64, string, error) {
+	if f.externalSavedFingerprint != "" {
+		return f.externalSavedSize, f.externalSavedFingerprint, nil
+	}
+	if f.file == nil {
+		return 0, "", fmt.Errorf("MemoryFile %p has no backing file to fingerprint", f)
+	}
+	fi, err := f.file.Stat()
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to stat backing file: %w", err)
+	}
+	fp, err := fingerprintFile(f.file)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to fingerprint backing file: %w", err)
+	}
+	return uint64(fi.Size()), fp, nil
+}
+
+// BeginSaveWindow clears the snapshot credentials stashed by a previous
+// window's SnapshotToFd(). It must be called at the start of every save
+// window, before any SnapshotToFd()/SaveTo(ExternalContent) calls: without
+// it, a later ExternalContent save on the same live MemoryFile (e.g. a
+// plain --skip-filestore-pages checkpoint following a
+// --filestore-snapshot-dir one) would embed the stale size and fingerprint
+// of the old snapshot instead of describing the backing file's current
+// contents.
+func (f *MemoryFile) BeginSaveWindow() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.externalSavedSize = 0
+	f.externalSavedFingerprint = ""
+}
+
+// SnapshotToFd reflink-clones (FICLONE) the backing file's current contents to
+// dst, and records the snapshot's size and sampled fingerprint for the ongoing
+// save, so that SaveTo(ExternalContent) embeds values describing the snapshot
+// rather than the original (which may diverge after the save window).
+//
+// It is used to internalize the filestore snapshot into the checkpoint's
+// freeze window (runsc checkpoint --filestore-snapshot-dir), making the
+// snapshot and the saved memory-state metadata describe the same instant.
+//
+// Precondition: the kernel is paused (no writers to the backing file), and
+// SaveTo(ExternalContent) is called on the same MemoryFile afterwards. Both
+// the backing file and dst must be on a filesystem supporting reflink
+// (e.g. XFS/btrfs); otherwise this fails loudly (EOPNOTSUPP/EXDEV).
+func (f *MemoryFile) SnapshotToFd(dst *os.File) (size uint64, fingerprint string, err error) {
+	if f.file == nil {
+		return 0, "", fmt.Errorf("MemoryFile %p has no backing file to snapshot", f)
+	}
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, dst.Fd(), unix.FICLONE, f.file.Fd()); errno != 0 {
+		return 0, "", fmt.Errorf("FICLONE of filestore backing file to snapshot failed (%w); --filestore-snapshot-dir requires a reflink-capable filesystem (e.g. XFS) for both the backing filestore and the snapshot directory", errno)
+	}
+	if err := dst.Sync(); err != nil {
+		return 0, "", fmt.Errorf("failed to fsync filestore snapshot: %w", err)
+	}
+	fi, err := dst.Stat()
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to stat filestore snapshot: %w", err)
+	}
+	fp, err := fingerprintFile(dst)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to fingerprint filestore snapshot: %w", err)
+	}
+	f.externalSavedSize = uint64(fi.Size())
+	f.externalSavedFingerprint = fp
+	return f.externalSavedSize, f.externalSavedFingerprint, nil
+}
+
+// ChunkCount returns the number of chunks currently tracked by f. It is used
+// by in-checkpoint snapshotting to record artifact chunk counts.
+func (f *MemoryFile) ChunkCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.chunksLoad())
+}
+
 // SaveTo writes f's state to the given stream.
 func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) error {
 	if err := f.AwaitLoadAll(); err != nil {
@@ -225,9 +350,21 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 		// file's contents, which may outlive this MemoryFile via an
 		// externally-held fd referencing the same inode.
 		f.contentExternal = true
+		// Record the exact size and a sampled fingerprint of the content
+		// source so that LoadFrom() can reject a wrong or diverged adopted
+		// file. If an in-checkpoint snapshot (SnapshotToFd) already captured
+		// the contents during this save window, its recorded values are used:
+		// the snapshot file is reflink-stable while the original may diverge
+		// after the window (leave-running).
+		extSize, extFP, err := f.externalContentInfoLocked()
+		if err != nil {
+			return err
+		}
 		timeMetadataStart := gohacks.Nanotime()
 		pb := f.exportMetadataProto()
 		pb.ContentExternal = true
+		pb.ContentExternalFileSize = extSize
+		pb.ContentExternalFingerprint = extFP
 		data, err := proto.Marshal(pb)
 		if err != nil {
 			return fmt.Errorf("failed to marshal metadata: %w", err)
@@ -1100,8 +1237,25 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 		if err != nil {
 			return fmt.Errorf("failed to stat adopted MemoryFile file: %w", err)
 		}
-		if uint64(fi.Size()) < fileSize {
+		if pb.ContentExternalFileSize != 0 {
+			// Exact size match: an artifact with a different size cannot be
+			// the file that was checkpointed, even if it is large enough.
+			if uint64(fi.Size()) != pb.ContentExternalFileSize {
+				return fmt.Errorf("adopted MemoryFile file size %d != checkpointed filestore size %d (wrong or diverged filestore artifact)", fi.Size(), pb.ContentExternalFileSize)
+			}
+		} else if uint64(fi.Size()) < fileSize {
+			// Legacy checkpoint (saved before size/fingerprint recording):
+			// keep the weaker lower-bound check.
 			return fmt.Errorf("adopted MemoryFile file size %d is smaller than required %d (state checkpoint and filestore artifact mismatch?)", fi.Size(), fileSize)
+		}
+		if pb.ContentExternalFingerprint != "" {
+			fp, err := fingerprintFile(f.file)
+			if err != nil {
+				return fmt.Errorf("failed to fingerprint adopted MemoryFile file: %w", err)
+			}
+			if fp != pb.ContentExternalFingerprint {
+				return fmt.Errorf("adopted MemoryFile file fingerprint mismatch: got %s, checkpoint expects %s (artifact contents differ from the checkpointed filestore, e.g. the original filestore diverged after a leave-running checkpoint)", fp[:16], pb.ContentExternalFingerprint[:16])
+			}
 		}
 	}
 	if err := f.file.Truncate(int64(fileSize)); err != nil {

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -219,6 +219,12 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 		// snapshotted separately). Skip async page file registration, zero
 		// page scanning (which would otherwise decommit pages, mutating the
 		// backing file), and page serialization entirely.
+		//
+		// Also arm contentExternal so that Destroy does not decommit the
+		// file: the checkpoint is only usable together with the backing
+		// file's contents, which may outlive this MemoryFile via an
+		// externally-held fd referencing the same inode.
+		f.contentExternal = true
 		timeMetadataStart := gohacks.Nanotime()
 		pb := f.exportMetadataProto()
 		pb.ContentExternal = true

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -182,6 +182,15 @@ type SaveOpts struct {
 	// but may instead improve SaveTo() and LoadFrom() time, and checkpoint
 	// size, if the application has many committed zero pages.
 	ExcludeCommittedZeroPages bool
+
+	// If ExternalContent is true, SaveTo() will not scan for zero pages and
+	// will not save page contents; it only saves segment metadata, marked
+	// with ContentExternal so that LoadFrom() expects contents to be provided
+	// externally by the backing file itself. This is appropriate for private
+	// (disk-backed) MemoryFiles whose host file contents are captured
+	// out-of-band (e.g. by snapshotting the host file) instead of being
+	// serialized into the checkpoint.
+	ExternalContent bool
 }
 
 // SaveTo writes f's state to the given stream.
@@ -202,6 +211,31 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 	// Ensure that there are no pending evictions.
 	if len(f.evictable) != 0 {
 		panic(fmt.Sprintf("evictions still pending for %d users; call StartEvictions and WaitForEvictions before SaveTo", len(f.evictable)))
+	}
+
+	if opts.ExternalContent {
+		// Only save segment metadata; page contents are expected to be
+		// captured out-of-band (the backing host file is preserved or
+		// snapshotted separately). Skip async page file registration, zero
+		// page scanning (which would otherwise decommit pages, mutating the
+		// backing file), and page serialization entirely.
+		timeMetadataStart := gohacks.Nanotime()
+		pb := f.exportMetadataProto()
+		pb.ContentExternal = true
+		data, err := proto.Marshal(pb)
+		if err != nil {
+			return fmt.Errorf("failed to marshal metadata: %w", err)
+		}
+		var lengthBuf [8]byte
+		binary.LittleEndian.PutUint64(lengthBuf[:], uint64(len(data)))
+		if _, err := w.Write(lengthBuf[:]); err != nil {
+			return fmt.Errorf("failed to write metadata length: %w", err)
+		}
+		if _, err := w.Write(data); err != nil {
+			return fmt.Errorf("failed to write metadata: %w", err)
+		}
+		log.Infof("MemoryFile(%p): saved external-content metadata in %s", f, time.Duration(gohacks.Nanotime()-timeMetadataStart))
+		return nil
 	}
 
 	// Register this MemoryFile with async page saving if a pages file has been
@@ -1047,6 +1081,23 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 	log.Infof("MemoryFile(%p): loaded metadata in %s", f, time.Duration(gohacks.Nanotime()-timeMetadataStart))
 
 	fileSize := uint64(len(chunks)) * chunkSize
+	if pb.ContentExternal {
+		// Contents are expected to already be present in the backing file.
+		// Require that the MemoryFile adopted an existing host file (i.e.
+		// was not created empty) and that the file is at least as large as
+		// the saved chunk table requires; otherwise restore would silently
+		// produce zero-filled holes instead of the original contents.
+		if !f.opts.AdoptExistingFile {
+			return fmt.Errorf("cannot restore externally-contented MemoryFile: backing file was not adopted")
+		}
+		fi, err := f.file.Stat()
+		if err != nil {
+			return fmt.Errorf("failed to stat adopted MemoryFile file: %w", err)
+		}
+		if uint64(fi.Size()) < fileSize {
+			return fmt.Errorf("adopted MemoryFile file size %d is smaller than required %d (state checkpoint and filestore artifact mismatch?)", fi.Size(), fileSize)
+		}
+	}
 	if err := f.file.Truncate(int64(fileSize)); err != nil {
 		return fmt.Errorf("failed to truncate MemoryFile: %w", err)
 	}
@@ -1091,9 +1142,10 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 	defer madviseWG.Wait()
 
 	// Register this MemoryFile with async page loading if a pages file has
-	// been provided.
+	// been provided. This is skipped for externally-contented MemoryFiles:
+	// no pages are read from the pages file, so there is nothing to load.
 	var amfl *asyncMemoryFileLoad
-	if opts.PagesFile != nil {
+	if opts.PagesFile != nil && !pb.ContentExternal {
 		var df stateio.DestinationFile
 		if opts.PagesFile.ar.NeedRegisterDestinationFD() {
 			var err error
@@ -1153,9 +1205,11 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 		}
 		maFR := maseg.Range()
 		amount := maFR.Length()
-		// Wait for all chunks spanned by this segment to be madvised.
-		for madviseEnd.Load() < maFR.End {
-			<-madviseChan
+		if !pb.ContentExternal {
+			// Wait for all chunks spanned by this segment to be madvised.
+			for madviseEnd.Load() < maFR.End {
+				<-madviseChan
+			}
 		}
 		if amfl != nil {
 			// Record where to read data.
@@ -1170,7 +1224,7 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 			amfl.pf.mu.Unlock()
 			opts.PagesFileOffset += amount
 			amfl.pf.lfStatus.Notify(aplLFPending)
-		} else {
+		} else if !pb.ContentExternal {
 			// Verify header.
 			length, object, err := state.ReadHeader(&wr)
 			if err != nil {

--- a/pkg/sentry/pgalloc/save_restore_external_test.go
+++ b/pkg/sentry/pgalloc/save_restore_external_test.go
@@ -201,6 +201,89 @@ func TestExternalContentRejectsUndersizedAdoption(t *testing.T) {
 	}
 }
 
+// TestExternalContentRejectsSizeMismatch verifies that adopting a file whose
+// size differs from the checkpointed filestore size fails exactly (a larger
+// artifact is no longer accepted either).
+func TestExternalContentRejectsSizeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "filestore")
+
+	orig := newTestMemoryFile(t, path, false)
+	fr, err := orig.Allocate(hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	writeTestRange(t, orig, fr, 0x33)
+
+	var buf bytes.Buffer
+	if err := orig.SaveTo(context.Background(), &buf, &SaveOpts{ExternalContent: true}); err != nil {
+		t.Fatalf("SaveTo(ExternalContent): %v", err)
+	}
+	metadataImage := buf.Bytes()
+
+	// Grow the host file beyond the saved size: large enough per the legacy
+	// lower-bound check, but not the exact recorded size.
+	if err := os.Truncate(path, 4*hostarch.PageSize); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	adopted := newTestMemoryFile(t, path, true)
+	if err := adopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err == nil {
+		t.Fatal("LoadFrom(ContentExternal) with oversized adopted file unexpectedly succeeded")
+	}
+}
+
+// TestExternalContentRejectsDivergedContents verifies the sampled
+// fingerprint: an adopted file with the SAME size but DIFFERENT contents
+// (e.g. the original filestore kept running after a leave-running
+// checkpoint) must be rejected instead of silently restoring foreign data.
+func TestExternalContentRejectsDivergedContents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "filestore")
+
+	orig := newTestMemoryFile(t, path, false)
+	// Ensure the file is larger than the 4KiB fingerprint sampling chunk so
+	// the mutation lands inside a sampled region (first chunk).
+	const nPages = 3
+	var frs []memmap.FileRange
+	for i := 0; i < nPages; i++ {
+		fr, err := orig.Allocate(hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
+		if err != nil {
+			t.Fatalf("Allocate: %v", err)
+		}
+		writeTestRange(t, orig, fr, 0x44)
+		frs = append(frs, fr)
+	}
+
+	var buf bytes.Buffer
+	if err := orig.SaveTo(context.Background(), &buf, &SaveOpts{ExternalContent: true}); err != nil {
+		t.Fatalf("SaveTo(ExternalContent): %v", err)
+	}
+	metadataImage := buf.Bytes()
+
+	// Diverge the contents at the same size (post-leave-running divergence).
+	func() {
+		f, err := os.OpenFile(path, os.O_RDWR, 0)
+		if err != nil {
+			t.Fatalf("open for mutation: %v", err)
+		}
+		defer f.Close()
+		mutation := make([]byte, hostarch.PageSize)
+		for i := range mutation {
+			mutation[i] = 0x99
+		}
+		if _, err := f.WriteAt(mutation, 0); err != nil {
+			t.Fatalf("WriteAt: %v", err)
+		}
+	}()
+
+	adopted := newTestMemoryFile(t, path, true)
+	if err := adopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err == nil {
+		t.Fatal("LoadFrom(ContentExternal) with diverged same-size contents unexpectedly succeeded")
+	}
+	_ = frs
+}
+
 // newTestMemoryFileDecommit is newTestMemoryFile with a DecommitOnDestroy
 // override, mimicking runsc's createPrivateMemoryFile (upstream default:
 // DecommitOnDestroy true for disk-backed private memory files).
@@ -302,5 +385,83 @@ func TestDefaultSaveStillDecommitsOnDestroy(t *testing.T) {
 			t.Fatalf("host file contents survived Destroy after a default (non-external) save; DecommitOnDestroy regression")
 		}
 		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestExternalContentSnapshotCredentialsResetPerSaveWindow verifies that the
+// snapshot credentials stashed by SnapshotToFd() during one save window do
+// not leak into a subsequent window's ExternalContent metadata. Simulates a
+// --filestore-snapshot-dir checkpoint followed (on the same live MemoryFile)
+// by a plain --skip-filestore-pages checkpoint after the original diverged:
+// the second save must describe the backing file's current contents.
+func TestExternalContentSnapshotCredentialsResetPerSaveWindow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "filestore")
+	stalePath := filepath.Join(dir, "filestore-stale-snapshot")
+
+	orig := newTestMemoryFile(t, path, false)
+	const nPages = 3
+	for i := 0; i < nPages; i++ {
+		fr, err := orig.Allocate(hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
+		if err != nil {
+			t.Fatalf("Allocate: %v", err)
+		}
+		writeTestRange(t, orig, fr, 0x44)
+	}
+
+	// The "stale snapshot artifact": same size, different contents in the
+	// fingerprint-sampled region (what the file looked like at window 1).
+	staleData := make([]byte, nPages*hostarch.PageSize)
+	for i := range staleData {
+		staleData[i] = 0x77
+	}
+	if err := os.WriteFile(stalePath, staleData, 0600); err != nil {
+		t.Fatalf("WriteFile(stale): %v", err)
+	}
+
+	// Emulate the state left behind by a completed window-1 SnapshotToFd()
+	// (FICLONE is not available on all test filesystems, so stash the
+	// credentials the snapshot would have recorded directly).
+	func() {
+		sf, err := os.Open(stalePath)
+		if err != nil {
+			t.Fatalf("open stale: %v", err)
+		}
+		defer sf.Close()
+		fp, err := fingerprintFile(sf)
+		if err != nil {
+			t.Fatalf("fingerprintFile(stale): %v", err)
+		}
+		fi, err := sf.Stat()
+		if err != nil {
+			t.Fatalf("stat stale: %v", err)
+		}
+		orig.mu.Lock()
+		defer orig.mu.Unlock()
+		orig.externalSavedSize = uint64(fi.Size())
+		orig.externalSavedFingerprint = fp
+	}()
+
+	// Window 2 (plain ExternalContent save): BeginSaveWindow must discard
+	// the stale credentials so the metadata describes the current file.
+	orig.BeginSaveWindow()
+	var buf bytes.Buffer
+	if err := orig.SaveTo(context.Background(), &buf, &SaveOpts{ExternalContent: true}); err != nil {
+		t.Fatalf("SaveTo(ExternalContent): %v", err)
+	}
+	metadataImage := buf.Bytes()
+
+	// Adopting the CURRENT backing file must succeed; without the reset it
+	// would be rejected against the stale window-1 fingerprint.
+	adopted := newTestMemoryFile(t, path, true)
+	if err := adopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err != nil {
+		t.Fatalf("LoadFrom(ContentExternal) against current file failed (stale window-1 credentials leaked): %v", err)
+	}
+
+	// Adopting the stale snapshot artifact for window-2 metadata must fail:
+	// it no longer describes the backing file's contents.
+	staleAdopted := newTestMemoryFile(t, stalePath, true)
+	if err := staleAdopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err == nil {
+		t.Fatal("LoadFrom(ContentExternal) against stale snapshot artifact unexpectedly succeeded")
 	}
 }

--- a/pkg/sentry/pgalloc/save_restore_external_test.go
+++ b/pkg/sentry/pgalloc/save_restore_external_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
@@ -197,5 +198,109 @@ func TestExternalContentRejectsUndersizedAdoption(t *testing.T) {
 	adopted := newTestMemoryFile(t, path, true)
 	if err := adopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err == nil {
 		t.Fatal("LoadFrom(ContentExternal) with undersized adopted file unexpectedly succeeded")
+	}
+}
+
+// newTestMemoryFileDecommit is newTestMemoryFile with a DecommitOnDestroy
+// override, mimicking runsc's createPrivateMemoryFile (upstream default:
+// DecommitOnDestroy true for disk-backed private memory files).
+func newTestMemoryFileDecommit(t *testing.T, path string, decommit bool) *MemoryFile {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		t.Fatalf("opening %q: %v", path, err)
+	}
+	mf, err := NewMemoryFile(f, MemoryFileOpts{
+		DelayedEviction:         DelayedEvictionManual,
+		DisableIMAWorkAround:    true,
+		DisableMemoryAccounting: true,
+		DecommitOnDestroy:       decommit,
+	})
+	if err != nil {
+		t.Fatalf("NewMemoryFile(%q): %v", path, err)
+	}
+	return mf
+}
+
+func hostFilePatternOk(t *testing.T, path string, fill byte, length uint64) bool {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading host file %q: %v", path, err)
+	}
+	if uint64(len(got)) < length {
+		t.Fatalf("host file %q is %d bytes, want >= %d", path, len(got), length)
+	}
+	for i := uint64(0); i < length; i++ {
+		if got[i] != fill {
+			return false
+		}
+	}
+	return true
+}
+
+// TestExternalContentSurvivesDestroy verifies the fd-hold invariant: after
+// SaveTo(ExternalContent), destroying the MemoryFile must NOT decommit the
+// backing host file - an external fd holder or snapshot references the same
+// inode, and the checkpoint is useless without the file's contents.
+func TestExternalContentSurvivesDestroy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "filestore")
+	const size = 1 << 20
+	const fill = 0x5a
+
+	mf := newTestMemoryFileDecommit(t, path, true /* decommit */)
+	fr, err := mf.Allocate(size, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	writeTestRange(t, mf, fr, fill)
+	if err := mf.SaveTo(context.Background(), &bytes.Buffer{}, &SaveOpts{ExternalContent: true}); err != nil {
+		t.Fatalf("SaveTo(ExternalContent): %v", err)
+	}
+	mf.Destroy()
+
+	// Destroy is asynchronous (releaser goroutine). Poll: the contents must
+	// remain intact; the pre-fix behavior would punch holes (read as zeros).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if !hostFilePatternOk(t, path, fill, size) {
+			t.Fatalf("host file contents were destroyed despite ExternalContent save (decommitted on destroy)")
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestDefaultSaveStillDecommitsOnDestroy is the control for the above: the
+// default save path does not arm contentExternal, so DecommitOnDestroy must
+// still release the host file's disk space.
+func TestDefaultSaveStillDecommitsOnDestroy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "filestore")
+	const size = 1 << 20
+	const fill = 0xa5
+
+	mf := newTestMemoryFileDecommit(t, path, true /* decommit */)
+	fr, err := mf.Allocate(size, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	writeTestRange(t, mf, fr, fill)
+	if err := mf.SaveTo(context.Background(), &bytes.Buffer{}, &SaveOpts{}); err != nil {
+		t.Fatalf("SaveTo: %v", err)
+	}
+	mf.Destroy()
+
+	// Poll until the releaser decommits (contents become holes/zeros).
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if !hostFilePatternOk(t, path, fill, size) {
+			return // decommitted as expected
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("host file contents survived Destroy after a default (non-external) save; DecommitOnDestroy regression")
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/pkg/sentry/pgalloc/save_restore_external_test.go
+++ b/pkg/sentry/pgalloc/save_restore_external_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/sentry/checkpoint"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
 	"gvisor.dev/gvisor/pkg/sentry/usage"
 )
@@ -245,14 +246,12 @@ func TestExternalContentRejectsDivergedContents(t *testing.T) {
 	// Ensure the file is larger than the 4KiB fingerprint sampling chunk so
 	// the mutation lands inside a sampled region (first chunk).
 	const nPages = 3
-	var frs []memmap.FileRange
 	for i := 0; i < nPages; i++ {
 		fr, err := orig.Allocate(hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
 		if err != nil {
 			t.Fatalf("Allocate: %v", err)
 		}
 		writeTestRange(t, orig, fr, 0x44)
-		frs = append(frs, fr)
 	}
 
 	var buf bytes.Buffer
@@ -281,7 +280,6 @@ func TestExternalContentRejectsDivergedContents(t *testing.T) {
 	if err := adopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err == nil {
 		t.Fatal("LoadFrom(ContentExternal) with diverged same-size contents unexpectedly succeeded")
 	}
-	_ = frs
 }
 
 // newTestMemoryFileDecommit is newTestMemoryFile with a DecommitOnDestroy
@@ -428,9 +426,9 @@ func TestExternalContentSnapshotCredentialsResetPerSaveWindow(t *testing.T) {
 			t.Fatalf("open stale: %v", err)
 		}
 		defer sf.Close()
-		fp, err := fingerprintFile(sf)
+		fp, err := checkpoint.FingerprintFile(sf)
 		if err != nil {
-			t.Fatalf("fingerprintFile(stale): %v", err)
+			t.Fatalf("checkpoint.FingerprintFile(stale): %v", err)
 		}
 		fi, err := sf.Stat()
 		if err != nil {

--- a/pkg/sentry/pgalloc/save_restore_external_test.go
+++ b/pkg/sentry/pgalloc/save_restore_external_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pgalloc
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
+)
+
+func newTestMemoryFile(t *testing.T, path string, adopt bool) *MemoryFile {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		t.Fatalf("opening %q: %v", path, err)
+	}
+	mf, err := NewMemoryFile(f, MemoryFileOpts{
+		DelayedEviction:         DelayedEvictionManual,
+		DisableIMAWorkAround:    true,
+		DisableMemoryAccounting: true,
+		DecommitOnDestroy:       false,
+		AdoptExistingFile:       adopt,
+	})
+	if err != nil {
+		t.Fatalf("NewMemoryFile(%q): %v", path, err)
+	}
+	return mf
+}
+
+func writeTestRange(t *testing.T, mf *MemoryFile, fr memmap.FileRange, fill byte) {
+	t.Helper()
+	bs, err := mf.MapInternal(fr, hostarch.ReadWrite)
+	if err != nil {
+		t.Fatalf("MapInternal(%v): %v", fr, err)
+	}
+	for !bs.IsEmpty() {
+		s := bs.Head().ToSlice()
+		for i := range s {
+			s[i] = fill
+		}
+		bs = bs.Tail()
+	}
+}
+
+func readTestRange(t *testing.T, mf *MemoryFile, fr memmap.FileRange) []byte {
+	t.Helper()
+	bs, err := mf.MapInternal(fr, hostarch.Read)
+	if err != nil {
+		t.Fatalf("MapInternal(%v): %v", fr, err)
+	}
+	var out []byte
+	for !bs.IsEmpty() {
+		out = append(out, bs.Head().ToSlice()...)
+		bs = bs.Tail()
+	}
+	if uint64(len(out)) != fr.Length() {
+		t.Fatalf("read %d bytes, want %d", len(out), fr.Length())
+	}
+	return out
+}
+
+// TestExternalContentRoundtrip verifies that a MemoryFile saved with
+// SaveOpts.ExternalContent only emits segment metadata, and that the metadata
+// can be restored over the SAME host file with AdoptExistingFile without any
+// page contents being serialized.
+func TestExternalContentRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "filestore")
+
+	// Build an original MemoryFile with two allocated segments with distinct
+	// contents and a hole in between.
+	orig := newTestMemoryFile(t, path, false)
+	fr1, err := orig.Allocate(2*hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	writeTestRange(t, orig, fr1, 0xab)
+	fr2, err := orig.Allocate(hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	writeTestRange(t, orig, fr2, 0xcd)
+
+	// Save metadata-only.
+	var buf bytes.Buffer
+	saveOpts := &SaveOpts{ExternalContent: true}
+	if err := orig.SaveTo(context.Background(), &buf, saveOpts); err != nil {
+		t.Fatalf("SaveTo(ExternalContent): %v", err)
+	}
+	// The saved image must be tiny compared to the allocated data
+	// (segment tables only, no pages).
+	if maxMeta := 64 << 10; buf.Len() > maxMeta {
+		t.Errorf("metadata-only save emitted %d bytes, want <= %d", buf.Len(), maxMeta)
+	}
+	metadataImage := buf.Bytes()
+
+	// The host file must not have been truncated to zero by adoption.
+	if fi, err := os.Stat(path); err != nil || fi.Size() == 0 {
+		t.Fatalf("host file after save: size=%d err=%v (contents must be preserved)", fi.Size(), err)
+	}
+
+	// Restore over the same host file with AdoptExistingFile.
+	adopted := newTestMemoryFile(t, path, true)
+	if fi, err := os.Stat(path); err != nil || fi.Size() == 0 {
+		t.Fatalf("host file truncated by NewMemoryFile(AdoptExistingFile): size=%d err=%v", fi.Size(), err)
+	}
+	if err := adopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err != nil {
+		t.Fatalf("LoadFrom(ContentExternal): %v", err)
+	}
+
+	// Contents must be identical, served from the adopted file itself.
+	got1 := readTestRange(t, adopted, fr1)
+	for i, b := range got1 {
+		if b != 0xab {
+			t.Fatalf("fr1 byte %d = %#x, want 0xab", i, b)
+		}
+	}
+	got2 := readTestRange(t, adopted, fr2)
+	for i, b := range got2 {
+		if b != 0xcd {
+			t.Fatalf("fr2 byte %d = %#x, want 0xcd", i, b)
+		}
+	}
+}
+
+// TestExternalContentRequiresAdoption verifies that ContentExternal metadata
+// is rejected when the backing file was not adopted (i.e. was truncated empty
+// at creation), which would otherwise silently restore zero pages.
+func TestExternalContentRequiresAdoption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "filestore")
+
+	orig := newTestMemoryFile(t, path, false)
+	fr, err := orig.Allocate(hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	writeTestRange(t, orig, fr, 0x11)
+
+	var buf bytes.Buffer
+	if err := orig.SaveTo(context.Background(), &buf, &SaveOpts{ExternalContent: true}); err != nil {
+		t.Fatalf("SaveTo(ExternalContent): %v", err)
+	}
+	metadataImage := buf.Bytes()
+
+	// A fresh (non-adopted) MemoryFile is created empty; loading
+	// ContentExternal metadata into it must fail loudly.
+	fresh := newTestMemoryFile(t, filepath.Join(dir, "fresh"), false)
+	if err := fresh.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err == nil {
+		t.Fatal("LoadFrom(ContentExternal) on non-adopted empty file unexpectedly succeeded")
+	}
+}
+
+// TestExternalContentRejectsUndersizedAdoption verifies that adopting a file
+// smaller than the saved chunk table requires fails instead of silently
+// restoring holes.
+func TestExternalContentRejectsUndersizedAdoption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "filestore")
+
+	orig := newTestMemoryFile(t, path, false)
+	fr, err := orig.Allocate(hostarch.PageSize, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatalf("Allocate: %v", err)
+	}
+	writeTestRange(t, orig, fr, 0x22)
+
+	var buf bytes.Buffer
+	if err := orig.SaveTo(context.Background(), &buf, &SaveOpts{ExternalContent: true}); err != nil {
+		t.Fatalf("SaveTo(ExternalContent): %v", err)
+	}
+	metadataImage := buf.Bytes()
+
+	// Shrink the host file below the chunk-table requirement.
+	if err := os.Truncate(path, hostarch.PageSize); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	adopted := newTestMemoryFile(t, path, true)
+	if err := adopted.LoadFrom(context.Background(), bytes.NewReader(metadataImage), &LoadOpts{}); err == nil {
+		t.Fatal("LoadFrom(ContentExternal) with undersized adopted file unexpectedly succeeded")
+	}
+}

--- a/pkg/sentry/state/BUILD
+++ b/pkg/sentry/state/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/log",
+        "//pkg/sentry/checkpoint",
         "//pkg/sentry/kernel",
         "//pkg/sentry/state/stateio",
         "//pkg/sentry/time",

--- a/pkg/sentry/state/state.go
+++ b/pkg/sentry/state/state.go
@@ -24,6 +24,7 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/checkpoint"
 	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/state/stateio"
 	"gvisor.dev/gvisor/pkg/sentry/watchdog"
@@ -70,6 +71,21 @@ type SaveOpts struct {
 	// If true, their page contents are not saved; the backing host files must
 	// be captured out-of-band and adopted on restore.
 	PrivateMFExternalContent bool
+
+	// FilestoreSnapshots, if non-empty, requests in-window snapshots of the
+	// private MemoryFiles: inside the save freeze window (after Pause, before
+	// memory-file metadata serialization), each MemoryFile identified by ID
+	// has its backing file FICLONE'd to Dest. This makes the snapshot and the
+	// saved metadata describe the same instant, so it is correct even with
+	// Resume (leave-running). Name is the artifact file name recorded in the
+	// sidecar. The type lives in pkg/sentry/checkpoint to avoid an import
+	// cycle with pkg/sentry/kernel.
+	FilestoreSnapshots []checkpoint.FilestoreSnapshot
+
+	// FilestoreSidecar, if non-nil, receives a JSON manifest describing the
+	// FilestoreSnapshots artifacts (names, resource IDs, sizes, sampled
+	// fingerprints) written during the freeze window.
+	FilestoreSidecar io.Writer
 
 	// Resume indicates if the statefile is used for save-resume.
 	Resume bool
@@ -166,6 +182,8 @@ func (opts *SaveOpts) Save(ctx context.Context, k *kernel.Kernel, w *watchdog.Wa
 		err = k.SaveTo(ctx, wc, opts.PagesMetadata, opts.PagesFile, &kernel.SaveOpts{
 			AppMFExcludeCommittedZeroPages: opts.AppMFExcludeCommittedZeroPages,
 			PrivateMFExternalContent:       opts.PrivateMFExternalContent,
+			FilestoreSnapshots:             opts.FilestoreSnapshots,
+			FilestoreSidecar:               opts.FilestoreSidecar,
 			Resume:                         opts.Resume,
 		}) // transfers ownership of wc, opts.PagesMetadata, opts.PagesFile
 		opts.PagesMetadata = nil

--- a/pkg/sentry/state/state.go
+++ b/pkg/sentry/state/state.go
@@ -65,6 +65,12 @@ type SaveOpts struct {
 	// file.
 	AppMFExcludeCommittedZeroPages bool
 
+	// PrivateMFExternalContent is the value of
+	// pgalloc.SaveOpts.ExternalContent for private (disk-backed) MemoryFiles.
+	// If true, their page contents are not saved; the backing host files must
+	// be captured out-of-band and adopted on restore.
+	PrivateMFExternalContent bool
+
 	// Resume indicates if the statefile is used for save-resume.
 	Resume bool
 
@@ -157,7 +163,11 @@ func (opts *SaveOpts) Save(ctx context.Context, k *kernel.Kernel, w *watchdog.Wa
 	} else {
 		opts.Destination = nil
 		// Save the kernel.
-		err = k.SaveTo(ctx, wc, opts.PagesMetadata, opts.PagesFile, opts.AppMFExcludeCommittedZeroPages, opts.Resume) // transfers ownership of wc, opts.PagesMetadata, opts.PagesFile
+		err = k.SaveTo(ctx, wc, opts.PagesMetadata, opts.PagesFile, &kernel.SaveOpts{
+			AppMFExcludeCommittedZeroPages: opts.AppMFExcludeCommittedZeroPages,
+			PrivateMFExternalContent:       opts.PrivateMFExternalContent,
+			Resume:                         opts.Resume,
+		}) // transfers ownership of wc, opts.PagesMetadata, opts.PagesFile
 		opts.PagesMetadata = nil
 		opts.PagesFile = nil
 	}

--- a/runsc/boot/filter/config/config_main.go
+++ b/runsc/boot/filter/config/config_main.go
@@ -124,6 +124,14 @@ var allowedSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
 			seccomp.EqualTo(linux.FIONREAD),
 			seccomp.AnyValue{}, /* int* */
 		},
+		// Needed to take reflink snapshots of the writable-layer filestore
+		// backing files inside the checkpoint's freeze window
+		// (--filestore-snapshot-dir).
+		seccomp.PerArg{
+			seccomp.NonNegativeFD{},         /* fd (snapshot destination) */
+			seccomp.EqualTo(linux.FICLONE),
+			seccomp.NonNegativeFD{}, /* fd (filestore source) */
+		},
 		// These commands are needed for terminal support, but we only allow
 		// setting/getting termios and winsize.
 		seccomp.PerArg{

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -563,6 +563,13 @@ func getMountAccessType(conf *config.Config, hint *MountHint) config.FileAccessT
 func (c *containerMounter) mountAll(rootCtx context.Context, rootCreds *auth.Credentials, spec *specs.Spec, conf *config.Config, rootProcArgs *kernel.CreateProcessArgs) (*vfs.MountNamespace, error) {
 	log.Infof("Configuring container's file system")
 
+	if conf.FilestoreAdoptDir != "" {
+		// The donated filestore FDs are adopted host files whose contents are
+		// only valid for a state checkpoint restore. A fresh mount would
+		// truncate and overwrite them.
+		return nil, fmt.Errorf("cannot mount fresh filesystem with filestore adoption enabled; filestore-adopt-dir requires state checkpoint restore")
+	}
+
 	mns, err := c.createMountNamespace(rootCtx, spec, conf, rootCreds)
 	if err != nil {
 		return nil, fmt.Errorf("creating mount namespace: %w", err)
@@ -766,7 +773,7 @@ func (c *containerMounter) configureOverlay(ctx context.Context, conf *config.Co
 	if filestoreFD != nil {
 		// Create memory file for disk-backed overlays.
 		resourceID := checkpoint.ResourceID{ContainerName: c.containerName, Path: dst}
-		mf, err := createPrivateMemoryFile(filestoreFD.ReleaseToFile("overlay-filestore"), resourceID, c.containerID, c.l.fsRestore)
+		mf, err := createPrivateMemoryFile(filestoreFD.ReleaseToFile("overlay-filestore"), resourceID, c.containerID, c.l.fsRestore, false /* adopt */)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create memory file for overlay: %v", err)
 		}
@@ -1103,7 +1110,7 @@ func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo,
 		}
 		if m.filestoreFD != nil {
 			resourceID := checkpoint.ResourceID{ContainerName: containerName, Path: m.mount.Destination}
-			mf, err := createPrivateMemoryFile(m.filestoreFD.ReleaseToFile("tmpfs-filestore"), resourceID, containerID, fsr)
+			mf, err := createPrivateMemoryFile(m.filestoreFD.ReleaseToFile("tmpfs-filestore"), resourceID, containerID, fsr, false /* adopt */)
 			if err != nil {
 				return "", nil, fmt.Errorf("failed to create memory file for tmpfs: %w", err)
 			}
@@ -1215,7 +1222,7 @@ func parseKeyValue(s string) (string, string, bool) {
 	return strings.TrimSpace(tokens[0]), strings.TrimSpace(tokens[1]), true
 }
 
-func createPrivateMemoryFile(file *os.File, resourceID checkpoint.ResourceID, cid string, fsr *fsRestore) (*pgalloc.MemoryFile, error) {
+func createPrivateMemoryFile(file *os.File, resourceID checkpoint.ResourceID, cid string, fsr *fsRestore, adopt bool) (*pgalloc.MemoryFile, error) {
 	pagesMetadataReader, pagesFileOffset, onLoadEnd, err := fsr.memoryFileLoadArgs(resourceID, cid)
 	if err != nil {
 		return nil, err
@@ -1224,14 +1231,19 @@ func createPrivateMemoryFile(file *os.File, resourceID checkpoint.ResourceID, ci
 		// Private memory files are usually backed by files on disk. Ideally we
 		// would confirm with fstatfs(2) but that is prohibited by seccomp.
 		DiskBackedFile: true,
-		// Disk backed files need to be decommited on destroy to release disk space.
-		DecommitOnDestroy: true,
+		// Disk backed files need to be decommitted on destroy to release disk space.
+		// Adopted files are not decommitted: their contents may still be
+		// referenced by other clones of the same checkpoint artifact.
+		DecommitOnDestroy: !adopt,
 		// sentry's seccomp filters don't allow the mmap(2) syscalls that
 		// pgalloc.IMAWorkAroundForMemFile() uses. Users of private memory files
 		// are expected to have performed the work around outside the sandbox.
 		DisableIMAWorkAround: true,
 		// Private memory files need to be restored correctly using this ID.
 		ResourceID: resourceID,
+		// Adopted files already contain the restored contents; they must not
+		// be truncated by NewMemoryFile().
+		AdoptExistingFile: adopt,
 	}
 	mf, err := pgalloc.NewMemoryFile(file, mfOpts)
 	if err != nil {
@@ -1790,7 +1802,7 @@ func (c *containerMounter) configureRestore(restoreMnts *restoreMounts) error {
 	restoreMnts.fdmap[rootKey] = c.goferFDs.remove()
 
 	if rootfsConf := c.goferMountConfs[0]; rootfsConf.IsFilestorePresent() {
-		mf, err := createPrivateMemoryFile(c.goferFilestoreFDs.removeAsFD().ReleaseToFile("overlay-filestore"), rootKey, c.containerID, c.l.fsRestore)
+		mf, err := createPrivateMemoryFile(c.goferFilestoreFDs.removeAsFD().ReleaseToFile("overlay-filestore"), rootKey, c.containerID, c.l.fsRestore, c.l.root.conf.FilestoreAdoptDir != "")
 		if err != nil {
 			return fmt.Errorf("failed to create private memory file for mount rootfs: %w", err)
 		}
@@ -1826,7 +1838,7 @@ func (c *containerMounter) configureRestore(restoreMnts *restoreMounts) error {
 		}
 		if submount.filestoreFD != nil {
 			key := checkpoint.ResourceID{ContainerName: c.containerName, Path: submount.mount.Destination}
-			mf, err := createPrivateMemoryFile(submount.filestoreFD.ReleaseToFile("overlay-filestore"), key, c.containerID, c.l.fsRestore)
+			mf, err := createPrivateMemoryFile(submount.filestoreFD.ReleaseToFile("overlay-filestore"), key, c.containerID, c.l.fsRestore, c.l.root.conf.FilestoreAdoptDir != "")
 			if err != nil {
 				return fmt.Errorf("failed to create private memory file for mount %q: %w", submount.mount.Destination, err)
 			}

--- a/runsc/cmd/checkpoint.go
+++ b/runsc/cmd/checkpoint.go
@@ -39,6 +39,7 @@ type Checkpoint struct {
 	compression               CheckpointCompression
 	excludeCommittedZeroPages bool
 	skipFilestorePages        bool
+	filestoreSnapshotDir      string
 	cudaCheckpointPath        string
 	cudaCheckpointSequential  bool
 	saveRestoreExecArgv       string
@@ -74,6 +75,7 @@ func (c *Checkpoint) SetFlags(f *flag.FlagSet) {
 	f.Var(newCheckpointCompressionValue(statefile.CompressionLevelDefault, &c.compression), "compression", "compress checkpoint image on disk. Values: none|flate-best-speed.")
 	f.BoolVar(&c.excludeCommittedZeroPages, "exclude-committed-zero-pages", false, "exclude committed zero-filled pages from checkpoint")
 	f.BoolVar(&c.skipFilestorePages, "skip-filestore-pages", false, "skip saving page contents of private (disk-backed) MemoryFiles; only segment metadata is saved and the backing host filestore files must be captured out-of-band and adopted on restore (experimental)")
+	f.StringVar(&c.filestoreSnapshotDir, "filestore-snapshot-dir", "", "directory in which reflink (FICLONE) snapshots of the writable-layer filestores are written inside the checkpoint's freeze window, together with a filestores.json artifact manifest. Requires --skip-filestore-pages, a fresh (empty) directory, and a reflink-capable filesystem (e.g. XFS); valid with --leave-running (snapshots and metadata describe the same instant). Restores adopt the directory via --filestore-adopt-dir (experimental)")
 	f.BoolVar(&c.direct, "direct", false, "use O_DIRECT for writing checkpoint pages file")
 	f.StringVar(&c.cudaCheckpointPath, "cuda-checkpoint-path", "", "path to the cuda-checkpoint binary in the container")
 	f.BoolVar(&c.cudaCheckpointSequential, "cuda-checkpoint-sequential", false, "run cuda-checkpoint sequentially in the container")
@@ -122,6 +124,7 @@ func (c *Checkpoint) Execute(_ context.Context, f *flag.FlagSet, args ...any) su
 		Direct:                     c.direct,
 		ExcludeCommittedZeroPages:  c.excludeCommittedZeroPages,
 		SkipFilestorePages:         c.skipFilestorePages,
+		FilestoreSnapshotDir:       c.filestoreSnapshotDir,
 		CudaCheckpointPath:         c.cudaCheckpointPath,
 		CudaCheckpointSequential:   c.cudaCheckpointSequential,
 		SaveRestoreExecArgv:        c.saveRestoreExecArgv,

--- a/runsc/cmd/checkpoint.go
+++ b/runsc/cmd/checkpoint.go
@@ -38,6 +38,7 @@ type Checkpoint struct {
 	leaveRunning              bool
 	compression               CheckpointCompression
 	excludeCommittedZeroPages bool
+	skipFilestorePages        bool
 	cudaCheckpointPath        string
 	cudaCheckpointSequential  bool
 	saveRestoreExecArgv       string
@@ -72,6 +73,7 @@ func (c *Checkpoint) SetFlags(f *flag.FlagSet) {
 	f.BoolVar(&c.leaveRunning, "leave-running", false, "restart the container after checkpointing")
 	f.Var(newCheckpointCompressionValue(statefile.CompressionLevelDefault, &c.compression), "compression", "compress checkpoint image on disk. Values: none|flate-best-speed.")
 	f.BoolVar(&c.excludeCommittedZeroPages, "exclude-committed-zero-pages", false, "exclude committed zero-filled pages from checkpoint")
+	f.BoolVar(&c.skipFilestorePages, "skip-filestore-pages", false, "skip saving page contents of private (disk-backed) MemoryFiles; only segment metadata is saved and the backing host filestore files must be captured out-of-band and adopted on restore (experimental)")
 	f.BoolVar(&c.direct, "direct", false, "use O_DIRECT for writing checkpoint pages file")
 	f.StringVar(&c.cudaCheckpointPath, "cuda-checkpoint-path", "", "path to the cuda-checkpoint binary in the container")
 	f.BoolVar(&c.cudaCheckpointSequential, "cuda-checkpoint-sequential", false, "run cuda-checkpoint sequentially in the container")
@@ -119,6 +121,7 @@ func (c *Checkpoint) Execute(_ context.Context, f *flag.FlagSet, args ...any) su
 		Resume:                     c.leaveRunning,
 		Direct:                     c.direct,
 		ExcludeCommittedZeroPages:  c.excludeCommittedZeroPages,
+		SkipFilestorePages:         c.skipFilestorePages,
 		CudaCheckpointPath:         c.cudaCheckpointPath,
 		CudaCheckpointSequential:   c.cudaCheckpointSequential,
 		SaveRestoreExecArgv:        c.saveRestoreExecArgv,

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -111,6 +111,15 @@ type Config struct {
 	// the private MemoryFile contents that the checkpoint does not carry.
 	FilestoreAdoptDir string `flag:"filestore-adopt-dir"`
 
+	// FilestoreCloneOnAdopt makes restore adopt a reflink (FICLONE) private
+	// copy of each filestore artifact instead of the artifact itself. This
+	// keeps the artifact an immutable template: multiple restores from the
+	// same directory get write-isolated copies at O(1) cost, and the restored
+	// sandbox's truncation/mutation never touches the template. It requires a
+	// reflink-capable filesystem; set it to false for a consuming restore that
+	// mutates the artifacts in place (e.g. fd-hold fallbacks on ext4).
+	FilestoreCloneOnAdopt bool `flag:"filestore-clone-on-adopt"`
+
 	// FSGoferHostUDS is deprecated: use host-uds=all.
 	FSGoferHostUDS bool `flag:"fsgofer-host-uds"`
 

--- a/runsc/config/config.go
+++ b/runsc/config/config.go
@@ -104,6 +104,13 @@ type Config struct {
 	// DO NOT call it directly, use GetOverlay2() instead.
 	Overlay2 Overlay2 `flag:"overlay2"`
 
+	// FilestoreAdoptDir is the directory containing host filestore files to
+	// adopt as the sandbox's writable-layer backing files, instead of creating
+	// new anonymous ones. It is used together with state checkpoint restore of
+	// a checkpoint saved with --skip-filestore-pages: the adopted files provide
+	// the private MemoryFile contents that the checkpoint does not carry.
+	FilestoreAdoptDir string `flag:"filestore-adopt-dir"`
+
 	// FSGoferHostUDS is deprecated: use host-uds=all.
 	FSGoferHostUDS bool `flag:"fsgofer-host-uds"`
 

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -41,6 +41,7 @@ const (
 	flagReproduceNFTables       = "reproduce-nftables"
 	flagOCISeccomp              = "oci-seccomp"
 	flagOverlay2                = "overlay2"
+	flagFilestoreAdoptDir       = "filestore-adopt-dir"
 	flagAllowFlagOverride       = "allow-flag-override"
 	flagPauseExternalNetworking = "pause-external-networking"
 	flagAllowConnectedOnSave    = "allow-connected-on-save"
@@ -142,6 +143,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 		"    'medium' can be 'memory', 'self' or 'dir=/abs/dir/path' in which filestore will be created\n"+
 		"    'size' optional parameter overrides default overlay upper layer size\n")
 	flagSet.Var(hostUDSPtr(HostUDSNone), flagHostUDS, "controls permission to access host Unix-domain sockets. Values: none|open|create|all, default: none")
+	flagSet.String(flagFilestoreAdoptDir, "", "directory containing host filestore files to adopt as the sandbox's writable-layer backing files, instead of creating new anonymous ones. Files are named 'filestore-<n>' in mount order (root first). Requires restoring a state checkpoint saved with --skip-filestore-pages (experimental)")
 	flagSet.Var(hostFifoPtr(HostFifoNone), "host-fifo", "controls permission to access host FIFOs (or named pipes). Values: none|open, default: none")
 	flagSet.Var(charDevicePolicyPtr(CharDevEmulatedOnly), "character-device-policy", "controls how character device files on gofer mounts (rootfs and bind mounts) are handled. 'emulated-only' serves devices implemented by the sentry and fails opens of other devices with ENXIO (default and more secure); 'prefer-emulated' serves sentry-implemented devices from the sentry and opens the rest through the host; 'passthrough' opens all of them through the host. Values: emulated-only|prefer-emulated|passthrough, default: emulated-only")
 	flagSet.Bool("gvisor-marker-file", false, "enable the presence of the /proc/gvisor/kernel_is_gvisor file that can be used by applications to detect that gVisor is in use")

--- a/runsc/config/flags.go
+++ b/runsc/config/flags.go
@@ -42,6 +42,7 @@ const (
 	flagOCISeccomp              = "oci-seccomp"
 	flagOverlay2                = "overlay2"
 	flagFilestoreAdoptDir       = "filestore-adopt-dir"
+	flagFilestoreCloneOnAdopt   = "filestore-clone-on-adopt"
 	flagAllowFlagOverride       = "allow-flag-override"
 	flagPauseExternalNetworking = "pause-external-networking"
 	flagAllowConnectedOnSave    = "allow-connected-on-save"
@@ -144,6 +145,7 @@ func RegisterFlags(flagSet *flag.FlagSet) {
 		"    'size' optional parameter overrides default overlay upper layer size\n")
 	flagSet.Var(hostUDSPtr(HostUDSNone), flagHostUDS, "controls permission to access host Unix-domain sockets. Values: none|open|create|all, default: none")
 	flagSet.String(flagFilestoreAdoptDir, "", "directory containing host filestore files to adopt as the sandbox's writable-layer backing files, instead of creating new anonymous ones. Files are named 'filestore-<n>' in mount order (root first). Requires restoring a state checkpoint saved with --skip-filestore-pages (experimental)")
+	flagSet.Bool(flagFilestoreCloneOnAdopt, true, "when adopting filestore artifacts (--filestore-adopt-dir), reflink-clone (FICLONE) a private copy of each artifact instead of consuming the artifact itself, keeping it a reusable read-only template. Requires a reflink-capable filesystem (e.g. XFS); false performs a consuming restore that mutates the artifacts in place (experimental)")
 	flagSet.Var(hostFifoPtr(HostFifoNone), "host-fifo", "controls permission to access host FIFOs (or named pipes). Values: none|open, default: none")
 	flagSet.Var(charDevicePolicyPtr(CharDevEmulatedOnly), "character-device-policy", "controls how character device files on gofer mounts (rootfs and bind mounts) are handled. 'emulated-only' serves devices implemented by the sentry and fails opens of other devices with ENXIO (default and more secure); 'prefer-emulated' serves sentry-implemented devices from the sentry and opens the rest through the host; 'passthrough' opens all of them through the host. Values: emulated-only|prefer-emulated|passthrough, default: emulated-only")
 	flagSet.Bool("gvisor-marker-file", false, "enable the presence of the /proc/gvisor/kernel_is_gvisor file that can be used by applications to detect that gVisor is in use")

--- a/runsc/container/BUILD
+++ b/runsc/container/BUILD
@@ -9,6 +9,7 @@ go_library(
     name = "container",
     srcs = [
         "container.go",
+        "filestore_snapshot.go",
         "gofer_to_host_rpc.go",
         "null_netns.go",
         "state_file.go",
@@ -23,6 +24,7 @@ go_library(
         "//pkg/cleanup",
         "//pkg/log",
         "//pkg/pinring",
+        "//pkg/sentry/checkpoint",
         "//pkg/sentry/control",
         "//pkg/sentry/fsimpl/erofs",
         "//pkg/sentry/fsimpl/tmpfs",

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -851,6 +851,15 @@ func (c *Container) Checkpoint(conf *config.Config, imagePath string, opts sandb
 	if err := c.requireStatus("checkpoint", Created, Running, Paused); err != nil {
 		return err
 	}
+	if opts.FilestoreSnapshotDir != "" {
+		targets, destFiles, sidecar, err := c.prepareFilestoreSnapshot(opts.FilestoreSnapshotDir)
+		if err != nil {
+			return err
+		}
+		opts.FilestoreSnapshotTargets = targets
+		opts.FilestoreSnapshotFiles = destFiles
+		opts.FilestoreSidecarFile = sidecar
+	}
 	return c.Sandbox.Checkpoint(conf, c.ID, imagePath, opts)
 }
 
@@ -1158,13 +1167,21 @@ func (c *Container) createGoferFilestores(conf *config.Config, ovlConf config.Ov
 
 	// If set, adopt pre-existing host files (from a checkpoint artifact) as
 	// the filestores instead of creating new anonymous ones, in mount order
-	// (root first).
-	adoptDir := conf.FilestoreAdoptDir
-	adoptIdx := 0
+	// (root first). Artifacts are selected by sidecar resource identity when
+	// a runsc-issued filestores.json is present, and reflink-cloned when
+	// --filestore-clone-on-adopt is enabled (default).
+	var adopter *filestoreAdopter
+	if conf.FilestoreAdoptDir != "" {
+		var aerr error
+		adopter, aerr = newFilestoreAdopter(conf, c)
+		if aerr != nil {
+			return nil, aerr
+		}
+	}
 
 	// Handle rootfs first.
 	rootfsConf := c.GoferMountConfs[0]
-	filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, rootfsConf, c.Spec.Root.Path, mountHints, adoptDir, &adoptIdx)
+	filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, rootfsConf, c.Spec.Root.Path, "/", mountHints, adopter)
 	if err != nil {
 		return nil, err
 	}
@@ -1180,7 +1197,7 @@ func (c *Container) createGoferFilestores(conf *config.Config, ovlConf config.Ov
 		}
 		mountConf := c.GoferMountConfs[mountIdx]
 		mountIdx++
-		filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, mountConf, m.Source, mountHints, adoptDir, &adoptIdx)
+		filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, mountConf, m.Source, m.Destination, mountHints, adopter)
 		if err != nil {
 			return nil, err
 		}
@@ -1196,21 +1213,23 @@ func (c *Container) createGoferFilestores(conf *config.Config, ovlConf config.Ov
 	return goferFilestores, nil
 }
 
-func (c *Container) createGoferFilestore(goferRootfs string, ovlConf config.Overlay2, goferConf specutils.GoferMountConf, mountSrc string, mountHints *boot.PodMountHints, adoptDir string, adoptIdx *int) (*os.File, error) {
+func (c *Container) createGoferFilestore(goferRootfs string, ovlConf config.Overlay2, goferConf specutils.GoferMountConf, mountSrc string, mountDest string, mountHints *boot.PodMountHints, adopter *filestoreAdopter) (*os.File, error) {
 	if !goferConf.IsFilestorePresent() {
 		return nil, nil
+	}
+	if adopter != nil && goferConf.Upper == specutils.SelfOverlay {
+		// Adoption only supports anonymous filestores (overlay2 dir= medium).
+		// A self-overlay filestore is a named file inside the mount source;
+		// adopting it would make two restores (e.g. fan-out from the same
+		// checkpoint) silently share one writable file. Fail loudly instead.
+		return nil, fmt.Errorf("--filestore-adopt-dir supports anonymous filestores only (overlay2 'dir=' medium); mount %q uses the self overlay medium and its named filestore cannot be adopted", mountSrc)
 	}
 	switch goferConf.Upper {
 	case specutils.SelfOverlay:
 		return c.createGoferFilestoreInSelf(goferRootfs, mountSrc, mountHints)
 	case specutils.AnonOverlay:
-		if adoptDir != "" {
-			filestore, err := c.adoptGoferFilestoreInDir(adoptDir, *adoptIdx)
-			if err != nil {
-				return nil, err
-			}
-			*adoptIdx++
-			return filestore, nil
+		if adopter != nil {
+			return adopter.adopt(c, mountDest)
 		}
 		return c.createGoferFilestoreInDir(goferRootfs, ovlConf.Medium().HostFileDir())
 	default:
@@ -1268,34 +1287,6 @@ func (c *Container) createGoferFilestoreInDir(goferRootfs string, filestoreDir s
 		return nil, fmt.Errorf("failed to unlink temporary file %q: %v", filestoreFile.Name(), err)
 	}
 	log.Debugf("Created an unnamed filestore file at %q", filestoreDir)
-	return filestoreFile, nil
-}
-
-// adoptGoferFilestoreInDir opens a pre-existing host file from a checkpoint
-// artifact directory to adopt as a filestore, instead of creating a new
-// anonymous one. The file is NOT unlinked and NOT truncated here: its
-// contents must remain intact for the sandbox's private MemoryFile to adopt
-// during state checkpoint restore.
-func (c *Container) adoptGoferFilestoreInDir(adoptDir string, idx int) (*os.File, error) {
-	if !path.IsAbs(adoptDir) {
-		return nil, fmt.Errorf("filestore adopt directory %q must be an absolute path", adoptDir)
-	}
-	filestorePath := path.Join(adoptDir, fmt.Sprintf("filestore-%d", idx))
-	fileInfo, err := os.Stat(filestorePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to stat filestore artifact %q: %v", filestorePath, err)
-	}
-	if !fileInfo.Mode().IsRegular() {
-		return nil, fmt.Errorf("filestore artifact %q is not a regular file", filestorePath)
-	}
-	if fileInfo.Size() == 0 {
-		return nil, fmt.Errorf("filestore artifact %q is empty; it must contain the adopted writable-layer contents", filestorePath)
-	}
-	filestoreFile, err := os.OpenFile(filestorePath, unix.O_RDWR|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open filestore artifact %q: %v", filestorePath, err)
-	}
-	log.Debugf("Adopting filestore file at %q", filestorePath)
 	return filestoreFile, nil
 }
 

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -1148,7 +1148,7 @@ func (c *Container) initGoferConfs(ovlConf config.Overlay2, mountHints *boot.Pod
 // tmpfs/overlayfs mounts that will overlay some gofer mounts.
 //
 // Precondition: gofer process must be running.
-func (c *Container) createGoferFilestores(ovlConf config.Overlay2, mountHints *boot.PodMountHints) ([]*os.File, error) {
+func (c *Container) createGoferFilestores(conf *config.Config, ovlConf config.Overlay2, mountHints *boot.PodMountHints) ([]*os.File, error) {
 	var goferFilestores []*os.File
 	// NOTE(gvisor.dev/issue/9834): Create the filestores in the gofer mount
 	// namespace, so that they don't prevent the host mount points from being
@@ -1156,9 +1156,15 @@ func (c *Container) createGoferFilestores(ovlConf config.Overlay2, mountHints *b
 	// to access gofer's mount namespace. See proc_pid_root(5).
 	goferRootfs := fmt.Sprintf("/proc/%d/root", c.GoferPid.Load())
 
+	// If set, adopt pre-existing host files (from a checkpoint artifact) as
+	// the filestores instead of creating new anonymous ones, in mount order
+	// (root first).
+	adoptDir := conf.FilestoreAdoptDir
+	adoptIdx := 0
+
 	// Handle rootfs first.
 	rootfsConf := c.GoferMountConfs[0]
-	filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, rootfsConf, c.Spec.Root.Path, mountHints)
+	filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, rootfsConf, c.Spec.Root.Path, mountHints, adoptDir, &adoptIdx)
 	if err != nil {
 		return nil, err
 	}
@@ -1174,7 +1180,7 @@ func (c *Container) createGoferFilestores(ovlConf config.Overlay2, mountHints *b
 		}
 		mountConf := c.GoferMountConfs[mountIdx]
 		mountIdx++
-		filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, mountConf, m.Source, mountHints)
+		filestore, err := c.createGoferFilestore(goferRootfs, ovlConf, mountConf, m.Source, mountHints, adoptDir, &adoptIdx)
 		if err != nil {
 			return nil, err
 		}
@@ -1190,7 +1196,7 @@ func (c *Container) createGoferFilestores(ovlConf config.Overlay2, mountHints *b
 	return goferFilestores, nil
 }
 
-func (c *Container) createGoferFilestore(goferRootfs string, ovlConf config.Overlay2, goferConf specutils.GoferMountConf, mountSrc string, mountHints *boot.PodMountHints) (*os.File, error) {
+func (c *Container) createGoferFilestore(goferRootfs string, ovlConf config.Overlay2, goferConf specutils.GoferMountConf, mountSrc string, mountHints *boot.PodMountHints, adoptDir string, adoptIdx *int) (*os.File, error) {
 	if !goferConf.IsFilestorePresent() {
 		return nil, nil
 	}
@@ -1198,6 +1204,14 @@ func (c *Container) createGoferFilestore(goferRootfs string, ovlConf config.Over
 	case specutils.SelfOverlay:
 		return c.createGoferFilestoreInSelf(goferRootfs, mountSrc, mountHints)
 	case specutils.AnonOverlay:
+		if adoptDir != "" {
+			filestore, err := c.adoptGoferFilestoreInDir(adoptDir, *adoptIdx)
+			if err != nil {
+				return nil, err
+			}
+			*adoptIdx++
+			return filestore, nil
+		}
 		return c.createGoferFilestoreInDir(goferRootfs, ovlConf.Medium().HostFileDir())
 	default:
 		return nil, fmt.Errorf("unexpected upper layer with filestore %s", goferConf)
@@ -1254,6 +1268,34 @@ func (c *Container) createGoferFilestoreInDir(goferRootfs string, filestoreDir s
 		return nil, fmt.Errorf("failed to unlink temporary file %q: %v", filestoreFile.Name(), err)
 	}
 	log.Debugf("Created an unnamed filestore file at %q", filestoreDir)
+	return filestoreFile, nil
+}
+
+// adoptGoferFilestoreInDir opens a pre-existing host file from a checkpoint
+// artifact directory to adopt as a filestore, instead of creating a new
+// anonymous one. The file is NOT unlinked and NOT truncated here: its
+// contents must remain intact for the sandbox's private MemoryFile to adopt
+// during state checkpoint restore.
+func (c *Container) adoptGoferFilestoreInDir(adoptDir string, idx int) (*os.File, error) {
+	if !path.IsAbs(adoptDir) {
+		return nil, fmt.Errorf("filestore adopt directory %q must be an absolute path", adoptDir)
+	}
+	filestorePath := path.Join(adoptDir, fmt.Sprintf("filestore-%d", idx))
+	fileInfo, err := os.Stat(filestorePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat filestore artifact %q: %v", filestorePath, err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("filestore artifact %q is not a regular file", filestorePath)
+	}
+	if fileInfo.Size() == 0 {
+		return nil, fmt.Errorf("filestore artifact %q is empty; it must contain the adopted writable-layer contents", filestorePath)
+	}
+	filestoreFile, err := os.OpenFile(filestorePath, unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open filestore artifact %q: %v", filestorePath, err)
+	}
+	log.Debugf("Adopting filestore file at %q", filestorePath)
 	return filestoreFile, nil
 }
 
@@ -1717,7 +1759,7 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 
 	// Create gofer filestore files with the Gofer's mount namespaces while
 	// chrootSyncSandEnd is still open.
-	goferFilestores, err := c.createGoferFilestores(conf.GetOverlay2(), mountHints)
+	goferFilestores, err := c.createGoferFilestores(conf, conf.GetOverlay2(), mountHints)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("creating gofer filestore files: %w", err)
 	}

--- a/runsc/container/filestore_snapshot.go
+++ b/runsc/container/filestore_snapshot.go
@@ -1,0 +1,272 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/checkpoint"
+	"gvisor.dev/gvisor/runsc/config"
+	"gvisor.dev/gvisor/runsc/specutils"
+)
+
+// filestoresSidecarName is the name of the artifact manifest written by
+// `runsc checkpoint --filestore-snapshot-dir` into the snapshot directory.
+// Its presence on restore switches adoption from the legacy index-based
+// convention to runsc-issued, verified artifact credentials.
+const filestoresSidecarName = "filestores.json"
+
+// filestoreResourceID returns the checkpoint resource ID that identifies the
+// filestore backing the mount at destination dest ("/" for the rootfs). It
+// mirrors how the sentry names private MemoryFiles (boot/vfs.go
+// configureRestore), so that sidecar entries can be matched to mounts by
+// identity rather than by position.
+//
+// NOTE: for specs without an explicit container name, the sentry falls back
+// to creation-order names ("__no_name_<n>"); only the first container of a
+// sandbox is supported by this helper.
+func (c *Container) filestoreResourceID(dest string) checkpoint.ResourceID {
+	name := specutils.ContainerName(c.Spec)
+	if len(name) == 0 {
+		name = "__no_name_0"
+	}
+	return checkpoint.ResourceID{ContainerName: name, Path: dest}
+}
+
+// filestoreAdopter adopts checkpoint-artifact filestores on restore, with
+// sidecar verification and clone-on-adopt.
+type filestoreAdopter struct {
+	dir     string
+	clone   bool
+	entries map[checkpoint.ResourceID]*checkpoint.FilestoreSidecarEntry
+	legacy  bool // no sidecar present: use index-based convention
+	nextIdx int
+}
+
+func newFilestoreAdopter(conf *config.Config, c *Container) (*filestoreAdopter, error) {
+	a := &filestoreAdopter{
+		dir:   conf.FilestoreAdoptDir,
+		clone: conf.FilestoreCloneOnAdopt,
+	}
+	if !path.IsAbs(a.dir) {
+		return nil, fmt.Errorf("filestore adopt directory %q must be an absolute path", a.dir)
+	}
+	data, err := os.ReadFile(path.Join(a.dir, filestoresSidecarName))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to read filestore sidecar in %q: %w", a.dir, err)
+		}
+		// No sidecar: artifacts come from an external orchestrator (e.g. a
+		// park daemon); fall back to the index-based convention. The
+		// pgalloc-level exact-size and fingerprint checks in the checkpoint
+		// still apply once the sandbox starts.
+		a.legacy = true
+		log.Debugf("No filestores.json in adopt dir %q; using legacy index-based adoption", a.dir)
+		return a, nil
+	}
+	var sc checkpoint.FilestoreSidecar
+	if err := json.Unmarshal(data, &sc); err != nil {
+		return nil, fmt.Errorf("failed to parse filestore sidecar %q: %w", path.Join(a.dir, filestoresSidecarName), err)
+	}
+	a.entries = make(map[checkpoint.ResourceID]*checkpoint.FilestoreSidecarEntry, len(sc.Filestores))
+	for i := range sc.Filestores {
+		e := &sc.Filestores[i]
+		rid := checkpoint.ResourceID{ContainerName: e.ResourceContainer, Path: e.ResourcePath}
+		if _, dup := a.entries[rid]; dup {
+			return nil, fmt.Errorf("filestore sidecar in %q has duplicate entry for resource %+v", a.dir, rid)
+		}
+		a.entries[rid] = e
+	}
+	return a, nil
+}
+
+// adopt opens the filestore artifact for the mount at destination dest. With
+// a sidecar, the artifact is selected and verified by resource identity
+// (exact size + sampled fingerprint); without, by legacy index. With
+// clone-on-adopt, a reflink private copy is adopted instead of the artifact
+// itself, keeping the artifact an immutable template.
+func (a *filestoreAdopter) adopt(c *Container, dest string) (*os.File, error) {
+	var (
+		artifactPath string
+		expSize      uint64
+		expFP        string
+	)
+	if a.legacy {
+		artifactPath = path.Join(a.dir, fmt.Sprintf("filestore-%d", a.nextIdx))
+		a.nextIdx++
+	} else {
+		rid := c.filestoreResourceID(dest)
+		e := a.entries[rid]
+		if e == nil {
+			return nil, fmt.Errorf("filestore sidecar in %q has no artifact for mount %q (resource %+v); the checkpoint and the adopt directory do not match", a.dir, dest, rid)
+		}
+		artifactPath = path.Join(a.dir, e.File)
+		expSize, expFP = e.SizeBytes, e.Fingerprint
+	}
+	fileInfo, err := os.Stat(artifactPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat filestore artifact %q: %w", artifactPath, err)
+	}
+	if !fileInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("filestore artifact %q is not a regular file", artifactPath)
+	}
+	if fileInfo.Size() == 0 {
+		return nil, fmt.Errorf("filestore artifact %q is empty; it must contain the adopted writable-layer contents", artifactPath)
+	}
+	if !a.legacy {
+		// Sidecar credentials: exact size + sampled fingerprint, checked
+		// before the sandbox is started so a swapped or diverged artifact
+		// fails fast with the offending artifact named.
+		if uint64(fileInfo.Size()) != expSize {
+			return nil, fmt.Errorf("filestore artifact %q has size %d, sidecar records %d; artifact and sidecar do not match", artifactPath, fileInfo.Size(), expSize)
+		}
+		if expFP != "" {
+			if err := func() error {
+				f, err := os.Open(artifactPath)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				fp, err := checkpoint.FingerprintFile(f)
+				if err != nil {
+					return err
+				}
+				if fp != expFP {
+					return fmt.Errorf("fingerprint mismatch: got %s, sidecar records %s; artifact contents differ from what was checkpointed", fp[:16], expFP[:16])
+				}
+				return nil
+			}(); err != nil {
+				return nil, fmt.Errorf("failed to verify filestore artifact %q against sidecar: %w", artifactPath, err)
+			}
+		}
+	}
+	src, err := os.OpenFile(artifactPath, unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open filestore artifact %q: %w", artifactPath, err)
+	}
+	if !a.clone {
+		// Consuming adoption: the restored sandbox mutates the artifact
+		// in place (legacy unpark semantics, and the only option on
+		// filesystems without reflink).
+		log.Debugf("Adopting filestore file at %q (consuming)", artifactPath)
+		return src, nil
+	}
+	// Clone-on-adopt: reflink a private CoW copy in the same directory (same
+	// filesystem), unlinked immediately so it is anonymous exactly like a
+	// freshly created filestore. The artifact itself is never truncated or
+	// mutated (pgalloc's LoadFrom truncate lands on the copy), so it stays a
+	// reusable read-only template and multiple restores from one directory
+	// cannot share writable state.
+	clone, err := os.CreateTemp(a.dir, "runsc-filestore-adopt-")
+	if err != nil {
+		src.Close()
+		return nil, fmt.Errorf("failed to create clone for filestore artifact %q: %w", artifactPath, err)
+	}
+	cloneName := clone.Name()
+	ok := false
+	defer func() {
+		if !ok {
+			clone.Close()
+			os.Remove(cloneName)
+		}
+	}()
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, clone.Fd(), unix.FICLONE, src.Fd()); errno != 0 {
+		return nil, fmt.Errorf("--filestore-clone-on-adopt: FICLONE of %q failed (%w); the filesystem may not support reflink (e.g. ext4), use --filestore-clone-on-adopt=false for a consuming restore", artifactPath, errno)
+	}
+	if err := unix.Unlink(cloneName); err != nil {
+		return nil, fmt.Errorf("failed to unlink filestore clone %q: %w", cloneName, err)
+	}
+	src.Close()
+	ok = true
+	log.Debugf("Adopting reflink clone of filestore file at %q", artifactPath)
+	return clone, nil
+}
+
+// prepareFilestoreSnapshot creates the snapshot artifact files for
+// `runsc checkpoint --filestore-snapshot-dir` and records the
+// (resource ID -> destination FD) targets that the sentry will FICLONE into
+// inside the checkpoint's freeze window. The sidecar temp file is appended
+// last; it is renamed to filestores.json by the caller on success.
+func (c *Container) prepareFilestoreSnapshot(snapDir string) (targets []checkpoint.ResourceID, destFiles []*os.File, sidecar *os.File, err error) {
+	if !path.IsAbs(snapDir) {
+		return nil, nil, nil, fmt.Errorf("--filestore-snapshot-dir %q must be an absolute path", snapDir)
+	}
+	_, statErr := os.Stat(snapDir)
+	createdDir := os.IsNotExist(statErr)
+	if err := os.MkdirAll(snapDir, 0700); err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create filestore snapshot directory %q: %w", snapDir, err)
+	}
+	cleanup := func(cause error) ([]checkpoint.ResourceID, []*os.File, *os.File, error) {
+		for _, f := range destFiles {
+			f.Close()
+			os.Remove(f.Name())
+		}
+		if sidecar != nil {
+			sidecar.Close()
+			os.Remove(sidecar.Name())
+		}
+		if createdDir {
+			// Don't leave behind an empty directory we created if the
+			// checkpoint is rejected (e.g. self-overlay mounts).
+			os.Remove(snapDir)
+		}
+		return nil, nil, nil, cause
+	}
+	// Enumerate filestore mounts in the same order as createGoferFilestores
+	// (root first, then spec mount order). Self-overlay filestores are a
+	// named file inside the mount source, not an anonymous artifact; they
+	// can be neither snapshotted as an artifact nor adopted, so reject at
+	// checkpoint time (mirroring the restore-side guard) instead of
+	// producing a snapshot directory that can never be restored.
+	dests := []string{"/"}
+	if rootfsConf := c.GoferMountConfs[0]; !rootfsConf.IsFilestorePresent() {
+		dests = nil
+	} else if rootfsConf.IsSelfBacked() {
+		return cleanup(fmt.Errorf("--filestore-snapshot-dir supports anonymous filestores only (overlay2 'dir=' medium); the root mount uses the self overlay medium and its named filestore cannot be snapshotted for adoption"))
+	}
+	mountIdx := 1 // first one is the root
+	for _, m := range c.Spec.Mounts {
+		if !specutils.HasMountConfig(m) {
+			continue
+		}
+		if c.GoferMountConfs[mountIdx].IsFilestorePresent() {
+			if c.GoferMountConfs[mountIdx].IsSelfBacked() {
+				return cleanup(fmt.Errorf("--filestore-snapshot-dir supports anonymous filestores only (overlay2 'dir=' medium); mount %q uses the self overlay medium and its named filestore cannot be snapshotted for adoption", m.Destination))
+			}
+			dests = append(dests, m.Destination)
+		}
+		mountIdx++
+	}
+	for i, dest := range dests {
+		name := path.Join(snapDir, "filestore-"+strconv.Itoa(i))
+		f, err := os.OpenFile(name, os.O_RDWR|unix.O_CREAT|os.O_EXCL|unix.O_CLOEXEC, 0600)
+		if err != nil {
+			return cleanup(fmt.Errorf("failed to create filestore snapshot artifact %q (use a fresh --filestore-snapshot-dir for each checkpoint): %w", name, err))
+		}
+		destFiles = append(destFiles, f)
+		targets = append(targets, c.filestoreResourceID(dest))
+	}
+	sc, err := os.OpenFile(path.Join(snapDir, filestoresSidecarName+".tmp"), os.O_WRONLY|unix.O_CREAT|os.O_EXCL|unix.O_CLOEXEC, 0600)
+	if err != nil {
+		return cleanup(fmt.Errorf("failed to create filestore sidecar temp file in %q: %w", snapDir, err))
+	}
+	return targets, destFiles, sc, nil
+}

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -1657,6 +1657,11 @@ type CheckpointOpts struct {
 	CudaCheckpointPath        string
 	CudaCheckpointSequential  bool
 
+	// SkipFilestorePages causes private (disk-backed) MemoryFiles to save
+	// only segment metadata; their backing host files (gofer filestore files)
+	// must be captured out-of-band and adopted on restore.
+	SkipFilestorePages bool
+
 	// Save/restore exec options.
 	SaveRestoreExecArgv        string
 	SaveRestoreExecTimeout     time.Duration
@@ -1671,6 +1676,7 @@ func (s *Sandbox) Checkpoint(conf *config.Config, cid string, imagePath string, 
 	opt := control.SaveOpts{
 		Metadata:                       opts.Compression.ToMetadata(),
 		AppMFExcludeCommittedZeroPages: opts.ExcludeCommittedZeroPages,
+		PrivateMFExternalContent:       opts.SkipFilestorePages,
 		Resume:                         opts.Resume,
 		CudaCheckpointPath:             opts.CudaCheckpointPath,
 		CudaCheckpointSequential:       opts.CudaCheckpointSequential,

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -1662,6 +1662,17 @@ type CheckpointOpts struct {
 	// must be captured out-of-band and adopted on restore.
 	SkipFilestorePages bool
 
+	// FilestoreSnapshotDir internalizes the filestore capture: inside the
+	// checkpoint's freeze window, each private MemoryFile's backing file is
+	// reflink-cloned to FilestoreSnapshotFiles[i] (created by the container
+	// process under this directory), and the filestores.json manifest is
+	// written to FilestoreSidecarFile and renamed into place on success.
+	// Requires SkipFilestorePages.
+	FilestoreSnapshotDir     string
+	FilestoreSnapshotTargets []checkpoint.ResourceID
+	FilestoreSnapshotFiles   []*os.File
+	FilestoreSidecarFile     *os.File
+
 	// Save/restore exec options.
 	SaveRestoreExecArgv        string
 	SaveRestoreExecTimeout     time.Duration
@@ -1695,8 +1706,75 @@ func (s *Sandbox) Checkpoint(conf *config.Config, cid string, imagePath string, 
 		return err
 	}
 
+	if opts.FilestoreSnapshotDir != "" {
+		if !opts.SkipFilestorePages {
+			return fmt.Errorf("--filestore-snapshot-dir requires --skip-filestore-pages")
+		}
+		if opt.UseCheckpointGofer {
+			return fmt.Errorf("--filestore-snapshot-dir is not supported with the checkpoint gofer")
+		}
+		// The snapshot destination FDs (and the sidecar temp file, last) are
+		// donated after the save files; the sentry FICLONEs into them inside
+		// the save freeze window.
+		base := len(opt.FilePayload.Files)
+		for i, dest := range opts.FilestoreSnapshotFiles {
+			opt.FilestoreSnapshot = append(opt.FilestoreSnapshot, control.FilestoreSnapshotTarget{
+				ResourceID: opts.FilestoreSnapshotTargets[i],
+				Name:       fmt.Sprintf("filestore-%d", i),
+				FDIndex:    base + i,
+			})
+			opt.FilePayload.Files = append(opt.FilePayload.Files, dest)
+		}
+		opt.FilestoreSidecarFDIndex = base + len(opts.FilestoreSnapshotFiles)
+		opt.FilePayload.Files = append(opt.FilePayload.Files, opts.FilestoreSidecarFile)
+	}
+
 	if err := s.call(boot.ContMgrCheckpoint, &opt, nil); err != nil {
+		// Remove the partial snapshot artifacts: without the sidecar rename,
+		// the directory is not a valid adoption target anyway.
+		if opts.FilestoreSnapshotDir != "" {
+			for _, f := range opts.FilestoreSnapshotFiles {
+				f.Close()
+				os.Remove(f.Name())
+			}
+			opts.FilestoreSidecarFile.Close()
+			os.Remove(opts.FilestoreSidecarFile.Name())
+		}
 		return fmt.Errorf("checkpointing container %q: %w", cid, err)
+	}
+	if opts.FilestoreSnapshotDir != "" {
+		// The sentry wrote the sidecar manifest during the freeze window;
+		// make it durable and visible atomically (tmp+rename). With zero
+		// filestore mounts the sentry writes nothing; emit an empty (but
+		// valid) manifest ourselves.
+		if len(opts.FilestoreSnapshotFiles) == 0 {
+			if err := checkpoint.WriteFilestoreSidecar(opts.FilestoreSidecarFile, nil); err != nil {
+				return fmt.Errorf("failed to write empty filestores.json: %w", err)
+			}
+		}
+		if err := opts.FilestoreSidecarFile.Sync(); err != nil {
+			return fmt.Errorf("failed to fsync filestores.json: %w", err)
+		}
+		if err := opts.FilestoreSidecarFile.Close(); err != nil {
+			return fmt.Errorf("failed to close filestores.json.tmp: %w", err)
+		}
+		final := filepath.Join(opts.FilestoreSnapshotDir, "filestores.json")
+		if err := os.Rename(opts.FilestoreSidecarFile.Name(), final); err != nil {
+			return fmt.Errorf("failed to rename filestores.json into place: %w", err)
+		}
+		// fsync the snapshot directory itself so the rename is durable too;
+		// the artifact files were already fsynced inside the freeze window.
+		snapDir, err := os.Open(opts.FilestoreSnapshotDir)
+		if err != nil {
+			return fmt.Errorf("failed to open filestore snapshot dir %q for fsync: %w", opts.FilestoreSnapshotDir, err)
+		}
+		if err := snapDir.Sync(); err != nil {
+			snapDir.Close()
+			return fmt.Errorf("failed to fsync filestore snapshot dir %q: %w", opts.FilestoreSnapshotDir, err)
+		}
+		if err := snapDir.Close(); err != nil {
+			return fmt.Errorf("failed to close filestore snapshot dir %q: %w", opts.FilestoreSnapshotDir, err)
+		}
 	}
 	s.Checkpointed = true
 	return nil


### PR DESCRIPTION
## Motivation

`runsc checkpoint/restore` currently round-trips the writable layer through the sentry's memory: filestore pages of private (disk-backed) MemoryFiles are serialized into the image on checkpoint and read back into a fresh filestore on restore. Both costs scale linearly with the writable layer S, and the checkpoint side is serialization-CPU-bound (tmpfs-backed images do not speed it up at all in our measurements). Under a memory cgroup limit near S it gets substantially worse: the full serialization pass faults every page through the sandbox's memcg and sustained reclaim churn dominates — at a 512M quota with a 2G layer, cold restore on current main measures **8.9–9.6s vs a 0.9s unlimited baseline (~9x)**, with ~9k `memory.events:max` during the window. The O(S) image also has a robustness edge: near ENOSPC we measured checkpoint silently truncating the pages file (exit 0) with the corruption surfacing later as a restore panic.

For GB-scale, long-lived sandboxes (our use case is a park/unpark scheduler that pauses batch workloads for resource-scheduling reasons and resumes them once resources free up), this makes C/R unusable as a scheduling quantum.

The writable layer already *is* a host file — an unlinked sparse filestore held alive by a gofer fd. This PR keeps it that way across C/R: checkpoint binds its **lifecycle** to the state image instead of serializing its **contents**.

## What this PR adds

New, opt-in checkpoint/restore flow for `--overlay2=all:dir=...` anonymous filestores (all flags experimental, default-off, stock behavior unchanged):

- **`runsc checkpoint --skip-filestore-pages`** — private MemoryFiles save segment metadata only; the image becomes a pure memory-state template (opened strictly read-only on restore, therefore reusable across restores).
- **`runsc checkpoint --filestore-snapshot-dir=<fresh dir>`** — reflink (FICLONE) snapshots of the writable-layer filestores are taken **inside the checkpoint's freeze window** by the sentry, together with a `filestores.json` manifest (resource ID, exact size, chunk count, sampled SHA-256 fingerprint per artifact). Requires `--skip-filestore-pages`; valid with `--leave-running` (snapshot and metadata describe the same instant). This replaces the orchestrator-side out-of-band capture (fd-hold / `open_by_handle_at`) and makes `--skip-filestore-pages` correct without orchestrator call-ordering conventions.
- **`runsc restore --filestore-adopt-dir=<dir>`** — adopts the externally kept filestore snapshots as the writable layer. With the sidecar manifest present, artifacts are matched to mounts by resource identity and verified (exact size + sampled fingerprint) **before the sandbox starts**, so a swapped or diverged artifact fails loudly and named. Without a sidecar (external orchestrator captures), a legacy index-based convention applies with the same in-sentry checks.
- **`runsc restore --filestore-clone-on-adopt` (default true)** — each restore takes a private FICLONE copy of each artifact instead of consuming it, keeping the artifact an immutable, reusable template: one image + snapshot pair resumes into N write-isolated sandboxes. `false` performs a consuming restore (for filesystems without reflink).
- **Correctness guards**: fresh (non-restore) starts with adoption enabled are refused loudly (they would truncate the artifacts); self-overlay filestores are rejected at checkpoint time for snapshot/adoption (mirroring the restore-side guard); destroy no longer punches holes into a filestore saved with external content (upstream teardown zeroes every written page on graceful exit — measured 16385 → 0 nonzero 4K pages with stat size unchanged — while SIGKILL leaves it intact; with the guard the artifact survives both paths).
- **Seccomp**: the sentry is permitted to issue exactly `ioctl(dest_fd, FICLONE, src_fd)` for the in-window snapshot and clone-on-adopt.

## Commits

(rebased onto current master `3c5eee17d`; history reworked 2026-08-24 per
reviewer guidance — minimal diff, upstream style; all commits signed off per DCO)

1. `76df95b98` pgalloc/runsc: adopt host filestore files on restore; skip private MF page contents on checkpoint
2. `61548ad43` pgalloc: don't decommit host file after ExternalContent save
3. `592165208` pgalloc: verify adopted filestore contents; reset snapshot latch per save window
4. `b980323e6` checkpoint: in-window filestore snapshots with runsc-issued artifact manifest
5. `8d2e4f4e6` runsc: verified artifact adoption with clone-on-adopt
6. `e3a7e9eba` runsc: permit FICLONE in the sandbox seccomp filter

Note on the rebase: upstream replaced the `memoryFileSaved` state-serialized struct with a length-prefixed `MemoryFileMetadataProto` (protobuf) metadata format. Our ExternalContent fields (`content_external`, `content_external_file_size`, `content_external_fingerprint`) are now proto fields 9–11 of `pgalloc.proto`; the wire format follows upstream's new convention. The rebase was re-verified end-to-end (see below).

Re-verification after rebase: `//pkg/sentry/pgalloc:pgalloc_test` PASSED (includes the ExternalContent roundtrip/adoption-guard/latch-reset tests), and the bare-metal gate `bm_native.sh` passed 6/6 with the rebased binary (in-window snapshot timing, sidecar-verified adoption, clone-on-adopt write isolation, same-size swap rejection, leave-running + classic-park mixed window reset, SelfOverlay rejection).

Re-verification after the 2026-08-24 history rework (same gates, rebuilt binary): `bazel build //runsc:runsc` OK, `pgalloc_test` PASSED, `bm_native.sh` 6/6 PASSED; perf spot-check (systrap, S=1G/4G): park critical path 49–51ms flat (first snapshot after fresh writes additionally pays the host dirty-writeback of the layer, which the orchestration strips asynchronously — second ckpt back to ~50ms), restore 112–116ms, image 1MB flat, md5 verified.

## Performance (bare metal, 104 cores / 187G / kernel 6.8 / cgroup v2, md5-verified on every cell)

Same workload (urandom-filled writable layer), this branch vs upstream main. Baseline note: the "main" binary in these tables was built from the master snapshot at measurement time (`5d1328306`, 2026-08-20); the branch itself has since been rebased onto newer master (currently `3c5eee17d`) — the delta is additive upstream changes outside the checkpoint paths, so the comparison is unaffected, but the perf baseline ref is intentionally not the rebase base.

| writable layer | main park | main restore | main image | PR park | PR restore | PR image |
|---|---|---|---|---|---|---|
| 64M | 75–91ms | 226–326ms | 65MB | 87–104ms | 163–196ms | ~1MB |
| 1G | 709–798ms | 5.7–8.4s | 1025MB | 87–104ms | 163–196ms | ~1MB |
| 4G | 2.7–4.0s | 23–28s | 4097MB | 87–104ms | 163–196ms | ~1MB |

| memcg quota (2G layer) | main restore (max events) | PR restore (max events) |
|---|---|---|
| unlimited | 0.9–1.0s (0) | 0.24–0.29s (0) |
| 1G | 2.6–2.7s (6.1–6.6k) | 0.24–0.29s (0) |
| 512M | **8.9–9.6s (8.7–9.8k)** | 0.24–0.29s (0) |

The PR's checkpoint pause window itself is 63–68ms flat (FICLONE included) and insensitive to quota (`memory.events:max` ≤ 12); the working set lives in the host page cache, not anon memory inside the sandbox memcg (zero oom_kill, zero pgscan under 0.5x quotas).

Fork semantics: per-instance marginal cost 220–290ms flat over N (1→64) and S (64M→1G); disk delta 0 for read-only instances (N×S "virtual copies" are free CoW).

Robustness: 72-cell platform×size×quota matrix (systrap/kvm/ptrace), 64-sandbox concurrent park/restore, 3-generation fork lineage, 100-round soak, and orchestrator-kill fault injection at every phase — all green, with the (image, artifact) pairing always converging to "no manifest ⇒ refuse and safe to erase" or "manifest ⇒ snapshot complete and usable".

## Tests

- `pkg/sentry/pgalloc/save_restore_external_test.go`: metadata-only roundtrip over the same host file, loud failures for the non-adopted and undersized-artifact cases, per-save-window latch reset (negative + positive control).

## Limitations / discussion

- Reflink path requires XFS/btrfs; ext4 degrades (external orchestrator fd-hold fallback, no fork) — we consider that a backup design and are not proposing it as the interface here.
- New unit tests cover the pgalloc layer; runsc-level integration tests for the flag matrix are on our list and feedback on where they should live (e.g. `runsc/cmd` or integration harness conventions) is welcome.
- We're opening a separate design discussion on the semantics (lifecycle binding vs content serialization, fork, memcg accounting) — linking it here once posted.
