### PR TITLE
Handle SECCOMP_RET_KILL_PROCESS in the sentry

### DIFF
--- a/pkg/sentry/kernel/seccomp.go
+++ b/pkg/sentry/kernel/seccomp.go
@@ -95,7 +95,10 @@ func seccompSiginfo(t *Task, errno, sysno int32, ip hostarch.Addr) *linux.Signal
 // Preconditions: The caller must be running on the task goroutine.
 func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip hostarch.Addr) linux.BPFAction {
 	result := linux.BPFAction(t.evaluateSyscallFilters(sysno, args, ip))
-	action := result & linux.SECCOMP_RET_ACTION
+	// Extract the action using SECCOMP_RET_ACTION_FULL rather than
+	// SECCOMP_RET_ACTION: SECCOMP_RET_ACTION (0x7fff0000) would truncate
+	// SECCOMP_RET_KILL_PROCESS (0x80000000) to SECCOMP_RET_KILL_THREAD.
+	action := result & linux.SECCOMP_RET_ACTION_FULL
 	switch action {
 	case linux.SECCOMP_RET_TRAP:
 		// "Results in the kernel sending a SIGSYS signal to the triggering
@@ -126,6 +129,11 @@ func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip h
 
 	case linux.SECCOMP_RET_ALLOW:
 		// "Results in the system call being executed."
+
+	case linux.SECCOMP_RET_KILL_PROCESS:
+		// "Results in the entire process being killed immediately without
+		// executing the system call. The exit status of the process will be
+		// SIGSYS, not SIGKILL." - Documentation/prctl/seccomp_filter.txt
 
 	case linux.SECCOMP_RET_KILL_THREAD:
 		// "Results in the task exiting immediately without executing the
@@ -186,7 +194,14 @@ func (t *Task) evaluateSyscallFilters(sysno int32, args arch.SyscallArguments, i
 		// "The ordering ensures that a min_t() over composed return values
 		// always selects the least permissive choice." -
 		// include/uapi/linux/seccomp.h
-		if (thisRet & linux.SECCOMP_RET_ACTION) < (ret & linux.SECCOMP_RET_ACTION) {
+		//
+		// Like Linux's seccomp_run_filters() (ACTION_ONLY()), compare the
+		// SECCOMP_RET_ACTION_FULL-masked actions as signed integers. This is
+		// required so that SECCOMP_RET_KILL_PROCESS (0x80000000) sorts before
+		// SECCOMP_RET_KILL_THREAD (0x0) and takes precedence; masking with
+		// SECCOMP_RET_ACTION (0x7fff0000) would truncate KILL_PROCESS to
+		// KILL_THREAD.
+		if int32(thisRet&linux.SECCOMP_RET_ACTION_FULL) < int32(ret&linux.SECCOMP_RET_ACTION_FULL) {
 			ret = thisRet
 		}
 	}
@@ -252,7 +267,10 @@ func (ts *taskSeccomp) populateCache(t *Task) {
 				sysnoIsCacheable = false
 				break
 			}
-			if (linux.BPFAction(result) & linux.SECCOMP_RET_ACTION) < (ret & linux.SECCOMP_RET_ACTION) {
+			// See the note in `evaluateSyscallFilters`: compare
+			// SECCOMP_RET_ACTION_FULL-masked actions as signed integers so
+			// that SECCOMP_RET_KILL_PROCESS takes precedence.
+			if int32(linux.BPFAction(result)&linux.SECCOMP_RET_ACTION_FULL) < int32(ret&linux.SECCOMP_RET_ACTION_FULL) {
 				ret = linux.BPFAction(result)
 			}
 		}

--- a/pkg/sentry/kernel/task_syscall.go
+++ b/pkg/sentry/kernel/task_syscall.go
@@ -242,6 +242,10 @@ func (t *Task) doSyscall() taskRunState {
 			return (*runSyscallExit)(nil)
 		case linux.SECCOMP_RET_ALLOW:
 			// ok
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("Syscall %d: killed by seccomp (process)", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
 		case linux.SECCOMP_RET_KILL_THREAD:
 			t.Debugf("Syscall %d: killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
@@ -399,6 +403,10 @@ func (t *Task) doVsyscall(addr hostarch.Addr, sysno uintptr) taskRunState {
 		case linux.SECCOMP_RET_TRACE:
 			t.Debugf("vsyscall %d, caller %x: stopping for PTRACE_EVENT_SECCOMP", sysno, t.Arch().Value(caller))
 			return &runVsyscallAfterPtraceEventSeccomp{addr, sysno, caller}
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("vsyscall %d: killed by seccomp (process)", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
 		case linux.SECCOMP_RET_KILL_THREAD:
 			t.Debugf("vsyscall %d: killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))

--- a/test/syscalls/linux/seccomp.cc
+++ b/test/syscalls/linux/seccomp.cc
@@ -47,6 +47,10 @@
 #define SYS_SECCOMP 1
 #endif
 
+#ifndef SECCOMP_RET_KILL_PROCESS
+#define SECCOMP_RET_KILL_PROCESS 0x80000000U
+#endif
+
 namespace gvisor {
 namespace testing {
 
@@ -215,6 +219,42 @@ TEST(SeccompTest, RetKillOnlyKillsOneThread) {
   int status;
   ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
   EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "status " << status;
+}
+
+TEST(SeccompTest, RetKillProcessKillsWholeThreadGroup) {
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE));
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    // Register a signal handler for SIGSYS that we don't expect to be invoked.
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL_PROCESS);
+    // Pass CLONE_VFORK to block the original thread in the child process until
+    // the clone thread exits. Unlike SECCOMP_RET_KILL, which only kills the
+    // offending thread, SECCOMP_RET_KILL_PROCESS must terminate the whole
+    // thread group, so the CLONE_VFORK-blocked original thread dies too.
+    //
+    // N.B. clone(2) is not officially async-signal-safe, but at minimum glibc's
+    // x86_64 implementation is safe. See glibc
+    // sysdeps/unix/sysv/linux/x86_64/clone.S.
+    clone(
+        +[](void* arg) {
+          syscall(kFilteredSyscall);  // should kill the whole thread group
+          _exit(1);                   // should be unreachable
+          return 2;  // should be very unreachable, shut up the compiler
+        },
+        stack.endptr(),
+        CLONE_FILES | CLONE_FS | CLONE_SIGHAND | CLONE_THREAD | CLONE_VM |
+            CLONE_VFORK,
+        nullptr);
+    _exit(0);  // Should be unreachable: the group exit killed this thread.
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
       << "status " << status;
 }
 


### PR DESCRIPTION
Fixes #13819

**Bug.** `Task.checkSeccompSyscall` extracts the filter action with `SECCOMP_RET_ACTION` (0x7fff0000). Because `SECCOMP_RET_KILL_PROCESS` is 0x80000000, masking truncates it to 0x00000000 = `SECCOMP_RET_KILL_THREAD`: a filter that returns `SECCOMP_RET_KILL_PROCESS` only kills the offending thread instead of the entire thread group, diverging from Linux (which exits the whole process with SIGSYS). The same masking is used for the multi-filter precedence comparison and for the seccomp cache, which also ties `KILL_PROCESS` to `KILL_THREAD`.

**Fix.**
- Extract the action with `SECCOMP_RET_ACTION_FULL` in `checkSeccompSyscall` and dispatch a new `SECCOMP_RET_KILL_PROCESS` case to `PrepareGroupExit(WaitStatusTerminationSignal(SIGSYS))`, mirroring Linux's `do_group_exit(SIGSYS)`.
- Compare combined filter actions the way Linux's `seccomp_run_filters()` does (`ACTION_ONLY`: `(s32)(ret & SECCOMP_RET_ACTION_FULL)`), so `KILL_PROCESS` (0x80000000, negative as s32) sorts ahead of `KILL_THREAD` and takes precedence. Update `populateCache` to match.
- Add `SECCOMP_RET_KILL_PROCESS` handling to both seccomp dispatch sites (`doSyscall` and `doVsyscall`).

**Test.** Added `RetKillProcessKillsWholeThreadGroup` to `test/syscalls/linux/seccomp.cc`: a `CLONE_VFORK` sibling triggers a `SECCOMP_RET_KILL_PROCESS` filter while the original thread is blocked, and the test asserts the whole thread group dies by SIGSYS (the mirror of the existing `RetKillOnlyKillsOneThread`).

Verified the signed `SECCOMP_RET_ACTION_FULL` comparison reproduces the kernel's `ACTION_ONLY` ordering for all action pairs, while the previous `SECCOMP_RET_ACTION` comparison diverged exactly on `KILL_PROCESS` vs `KILL_THREAD`.