### PR TITLE
runsc: allow readv for direct TAP links

### DIFF
--- a/runsc/boot/filter/config/config_main.go
+++ b/runsc/boot/filter/config/config_main.go
@@ -267,6 +267,7 @@ var allowedSyscalls = seccomp.MakeSyscallRules(map[uintptr]seccomp.SyscallRule{
 	unix.SYS_PWRITEV:  seccomp.MatchAll{},
 	unix.SYS_PWRITEV2: seccomp.MatchAll{},
 	unix.SYS_READ:     seccomp.MatchAll{},
+	unix.SYS_READV:    seccomp.MatchAll{}, // Used by TAP/TUN fdbased links.
 	unix.SYS_RECVMSG: seccomp.Or{
 		seccomp.PerArg{
 			seccomp.AnyValue{},


### PR DESCRIPTION
Allow the sentry to use readv when an fdbased endpoint receives a non-socket file descriptor such as a TAP or TUN device. The dispatcher already selects readv for these supported descriptors, but the common seccomp policy previously terminated the sentry on its first packet.

This keeps the seccomp policy aligned with the existing fdbased receive path used by direct TAP links.