### PR TITLE
ring0: clamp address width without LA57

### DIFF
--- a/pkg/ring0/lib_amd64.go
+++ b/pkg/ring0/lib_amd64.go
@@ -101,6 +101,9 @@ var (
 func Init(fs cpuid.FeatureSet) {
 	// Initialize all sizes.
 	VirtualAddressBits = uintptr(fs.VirtualAddressBits())
+	if !fs.HasFeature(cpuid.X86FeatureLA57) && VirtualAddressBits > 48 {
+		VirtualAddressBits = 48
+	}
 	if PhysicalAddressBits == 0 {
 		PhysicalAddressBits = uintptr(fs.PhysicalAddressBits())
 	}


### PR DESCRIPTION
CPUID may report a 57-bit maximum virtual address width while omitting the LA57 feature required to enable five-level paging. Treat that combination as a 48-bit address space so ring0 uses addresses that are canonical under the selected four-level page-table mode.

This prevents initialization from constructing a 57-bit kernel address layout when CR4.LA57 cannot be enabled.