### PR TITLE
checklocks: activate address-state guards

### DIFF
--- a/pkg/tcpip/stack/addressable_endpoint_state.go
+++ b/pkg/tcpip/stack/addressable_endpoint_state.go
@@ -750,9 +750,9 @@ type addressState struct {
 	//   addressState.mu
 	mu   addressStateRWMutex
 	refs addressStateRefs
-	// checklocks:mu
+	// +checklocks:mu
 	kind AddressKind
-	// checklocks:mu
+	// +checklocks:mu
 	configType AddressConfigType
 	// lifetimes holds this address' lifetimes.
 	//
@@ -760,12 +760,12 @@ type addressState struct {
 	// must be the zero value. Note that the converse does not need to be
 	// upheld!
 	//
-	// checklocks:mu
+	// +checklocks:mu
 	lifetimes AddressLifetimes
 	// The enclosing mutex must be write-locked before calling methods on the
 	// dispatcher.
 	//
-	// checklocks:mu
+	// +checklocks:mu
 	disp AddressDispatcher
 }
 


### PR DESCRIPTION
Four addressState guard comments omit the annotation prefix, so checklocks does not enforce their existing mutex ownership. Add the missing prefix to cover kind, configuration, lifetimes, and dispatcher accesses.

Assisted-by: Codex
