### PR TITLE
checklocks: guard pending packet queues

### DIFF
--- a/pkg/tcpip/stack/pending_packets.go
+++ b/pkg/tcpip/stack/pending_packets.go
@@ -39,12 +39,16 @@ type packetsPendingLinkResolutionMu struct {
 	// The packets to send once the resolver completes.
 	//
 	// The link resolution channel is used as the key for this map.
+	//
+	// +checklocks:packetsPendingLinkResolutionMutex
 	packets map[<-chan struct{}][]pendingPacket
 
 	// FIFO of channels used to cancel the oldest goroutine waiting for
 	// link-address resolution.
 	//
 	// cancelChans holds the same channels that are used as keys to packets.
+	//
+	// +checklocks:packetsPendingLinkResolutionMutex
 	cancelChans []<-chan struct{}
 }
 
@@ -183,6 +187,8 @@ func (f *packetsPendingLinkResolution) enqueue(r *Route, pkt *PacketBuffer) tcpi
 // newCancelChannelLocked appends the link resolution channel to a FIFO. If the
 // maximum number of pending resolutions is reached, the oldest channel will be
 // removed and its associated pending packets will be returned.
+//
+// +checklocks:f.mu.packetsPendingLinkResolutionMutex
 func (f *packetsPendingLinkResolution) newCancelChannelLocked(newCH <-chan struct{}) []pendingPacket {
 	f.mu.cancelChans = append(f.mu.cancelChans, newCH)
 	if len(f.mu.cancelChans) <= maxPendingResolutions {


### PR DESCRIPTION
The pending-packet map and cancellation FIFO share one mutex, but their ownership is only implicit. Annotate both fields and the helper that updates them so checklocks enforces the existing queue contract.

Revive the missing coverage from #7061 using the current generated lockdep mutex and named queue state.

Assisted-by: Codex
