### PR TITLE
checklocks: guard networking test helpers

### DIFF
--- a/pkg/tcpip/faketime/faketime.go
+++ b/pkg/tcpip/faketime/faketime.go
@@ -61,6 +61,7 @@ type notificationChannels struct {
 	mu struct {
 		sync.Mutex
 
+		// +checklocks:Mutex
 		ch []<-chan struct{}
 	}
 }
@@ -96,12 +97,18 @@ type manualClockMutex struct {
 	sync.RWMutex
 
 	// now is the current (fake) time of the clock.
+	//
+	// +checklocks:RWMutex
 	now time.Time
 
 	// times is min-heap of times.
+	//
+	// +checklocks:RWMutex
 	times timeHeap
 
 	// timers holds the timers scheduled for each time.
+	//
+	// +checklocks:RWMutex
 	timers map[time.Time]map[*manualTimer]struct{}
 }
 
@@ -167,7 +174,8 @@ func (mc *ManualClock) AfterFunc(d time.Duration, f func()) tcpip.Timer {
 
 // resetTimerLocked schedules a timer to be fired after the given duration.
 //
-// Precondition: mc.mu and mt.mu must be locked.
+// +checklocks:mc.mu.RWMutex
+// +checklocks:mt.mu.Mutex
 func (mc *ManualClock) resetTimerLocked(mt *manualTimer, d time.Duration) {
 	if !mt.mu.firesAt.IsZero() {
 		panic("tried to reset an active timer")
@@ -207,7 +215,8 @@ func (mc *ManualClock) resetTimerLocked(mt *manualTimer, d time.Duration) {
 
 // stopTimerLocked stops a timer from firing.
 //
-// Precondition: mc.mu and mt.mu must be locked.
+// +checklocks:mc.mu.RWMutex
+// +checklocks:mt.mu.Mutex
 func (mc *ManualClock) stopTimerLocked(mt *manualTimer) {
 	t := mt.mu.firesAt
 	mt.mu.firesAt = time.Time{}
@@ -335,6 +344,8 @@ type manualTimerMu struct {
 	// firesAt is the time when the timer will fire.
 	//
 	// Zero only when the timer is not active.
+	//
+	// +checklocks:Mutex
 	firesAt time.Time
 }
 

--- a/pkg/tcpip/network/internal/ip/duplicate_address_detection_test.go
+++ b/pkg/tcpip/network/internal/ip/duplicate_address_detection_test.go
@@ -33,7 +33,10 @@ type mockDADProtocol struct {
 	mu struct {
 		sync.Mutex
 
-		dad        ip.DAD
+		// +checklocks:Mutex
+		dad ip.DAD
+
+		// +checklocks:Mutex
 		sentNonces map[tcpip.Address][][]byte
 	}
 }
@@ -48,6 +51,7 @@ func (m *mockDADProtocol) init(t *testing.T, c stack.DADConfigurations, opts ip.
 	m.initLocked()
 }
 
+// +checklocks:m.mu.Mutex
 func (m *mockDADProtocol) initLocked() {
 	m.mu.sentNonces = make(map[tcpip.Address][][]byte)
 }

--- a/pkg/tcpip/network/ip_test.go
+++ b/pkg/tcpip/network/ip_test.go
@@ -328,6 +328,8 @@ type testInterface struct {
 
 	mu struct {
 		sync.RWMutex
+
+		// +checklocks:RWMutex
 		disabled bool
 	}
 }

--- a/pkg/tcpip/stack/forwarding_test.go
+++ b/pkg/tcpip/stack/forwarding_test.go
@@ -58,6 +58,8 @@ type fwdTestNetworkEndpoint struct {
 
 	mu struct {
 		sync.RWMutex
+
+		// +checklocks:RWMutex
 		forwarding bool
 	}
 }

--- a/pkg/tcpip/stack/neighbor_entry_test.go
+++ b/pkg/tcpip/stack/neighbor_entry_test.go
@@ -121,6 +121,8 @@ func (e testEntryEventInfo) String() string {
 type testNUDDispatcher struct {
 	mu struct {
 		sync.Mutex
+
+		// +checklocks:Mutex
 		events []testEntryEventInfo
 	}
 }
@@ -160,6 +162,8 @@ func (d *testNUDDispatcher) OnNeighborRemoved(nicID tcpip.NICID, entry NeighborE
 type entryTestLinkResolver struct {
 	mu struct {
 		sync.Mutex
+
+		// +checklocks:Mutex
 		probes []entryTestProbeInfo
 	}
 }

--- a/pkg/tcpip/stack/stack_test.go
+++ b/pkg/tcpip/stack/stack_test.go
@@ -84,8 +84,13 @@ type fakeNetworkEndpoint struct {
 	mu struct {
 		sync.RWMutex
 
-		enabled             bool
-		forwarding          bool
+		// +checklocks:RWMutex
+		enabled bool
+
+		// +checklocks:RWMutex
+		forwarding bool
+
+		// +checklocks:RWMutex
 		multicastForwarding bool
 	}
 


### PR DESCRIPTION
The fake clock and networking helpers protect mutable state with mutexes without exposing those contracts to checklocks. Annotate the clock, timers, notifications, and helper state, including the existing locked clock and DAD initialization helpers.

Adapt the helper annotations from #7053 to current source, including multicast forwarding state added since that proposal.

Assisted-by: Codex
