### PR TITLE
checklocks: enforce IPv6 state ownership

### DIFF
--- a/pkg/tcpip/network/ipv6/ipv6.go
+++ b/pkg/tcpip/network/ipv6/ipv6.go
@@ -184,15 +184,21 @@ var _ NDPEndpoint = (*endpoint)(nil)
 type endpointMu struct {
 	sync.RWMutex `state:"nosave"`
 
+	// +checklocks:RWMutex
 	addressableEndpointState stack.AddressableEndpointState
-	ndp                      ndpState
-	mld                      mldState
+
+	// +checklocks:RWMutex
+	ndp ndpState
+
+	// +checklocks:RWMutex
+	mld mldState
 }
 
 // +stateify savable
 type dadMu struct {
 	sync.Mutex `state:"nosave"`
 
+	// +checklocks:Mutex
 	dad ip.DAD
 }
 
@@ -201,6 +207,11 @@ type endpointDAD struct {
 	mu dadMu
 }
 
+// NDP and MLD retain their containing endpoint after NewEndpoint initializes
+// them, so their lock paths refer to the same mutex.
+//
+// +checklocksalias:mu.ndp.ep.mu.RWMutex=mu.RWMutex
+// +checklocksalias:mu.mld.ep.mu.RWMutex=mu.RWMutex
 // +stateify savable
 type endpoint struct {
 	nic        stack.NetworkInterface
@@ -316,7 +327,7 @@ func (e *endpoint) HandleLinkResolutionFailure(pkt *stack.PacketBuffer) {
 
 // onAddressAssignedLocked handles an address being assigned.
 //
-// Precondition: e.mu must be exclusively locked.
+// +checklocks:e.mu.RWMutex
 func (e *endpoint) onAddressAssignedLocked(addr tcpip.Address) {
 	// As per RFC 2710 section 3,
 	//
@@ -586,7 +597,7 @@ func (e *endpoint) Enable() tcpip.Error {
 			addressEndpoint.SetKind(stack.PermanentTentative)
 			fallthrough
 		case stack.PermanentTentative:
-			err = e.mu.ndp.startDuplicateAddressDetection(addr, addressEndpoint)
+			err = e.mu.ndp.startDuplicateAddressDetection(addr, addressEndpoint) // +checklocksforce: ForEachEndpoint calls back synchronously with e.mu held.
 			return err == nil
 		case stack.Temporary, stack.PermanentExpired:
 			return true
@@ -671,6 +682,7 @@ func (e *endpoint) Disable() {
 	e.disableLocked()
 }
 
+// +checklocks:e.mu.RWMutex
 func (e *endpoint) disableLocked() {
 	if !e.isEnabled() {
 		return
@@ -696,7 +708,7 @@ func (e *endpoint) disableLocked() {
 		switch kind := addressEndpoint.GetKind(); kind {
 		case stack.Permanent, stack.PermanentTentative:
 			if header.IsV6UnicastAddress(addrWithPrefix.Address) {
-				e.mu.ndp.stopDuplicateAddressDetection(addrWithPrefix.Address, &stack.DADAborted{})
+				e.mu.ndp.stopDuplicateAddressDetection(addrWithPrefix.Address, &stack.DADAborted{}) // +checklocksforce: ForEachEndpoint calls back synchronously with e.mu held.
 			}
 		case stack.Temporary, stack.PermanentExpired:
 		default:
@@ -1995,7 +2007,7 @@ func (e *endpoint) AddAndAcquirePermanentAddress(addr tcpip.AddressWithPrefix, p
 // addAndAcquirePermanentAddressLocked also joins the passed address's
 // solicited-node multicast group and start duplicate address detection.
 //
-// Precondition: e.mu must be write locked.
+// +checklocks:e.mu.RWMutex
 func (e *endpoint) addAndAcquirePermanentAddressLocked(addr tcpip.AddressWithPrefix, properties stack.AddressProperties) (stack.AddressEndpoint, tcpip.Error) {
 	addressEndpoint, err := e.mu.addressableEndpointState.AddAndAcquireAddress(addr, properties, stack.PermanentTentative)
 	if err != nil {
@@ -2038,7 +2050,7 @@ func (e *endpoint) RemovePermanentAddress(addr tcpip.Address) tcpip.Error {
 // removePermanentEndpointLocked is like removePermanentAddressLocked except
 // it works with a stack.AddressEndpoint.
 //
-// Precondition: e.mu must be write locked.
+// +checklocks:e.mu.RWMutex
 func (e *endpoint) removePermanentEndpointLocked(addressEndpoint stack.AddressEndpoint, allowSLAACInvalidation bool, reason stack.AddressRemovalReason, dadResult stack.DADResult) tcpip.Error {
 	addr := addressEndpoint.AddressWithPrefix()
 	// If we are removing an address generated via SLAAC, cleanup
@@ -2057,7 +2069,7 @@ func (e *endpoint) removePermanentEndpointLocked(addressEndpoint stack.AddressEn
 // removePermanentEndpointInnerLocked is like removePermanentEndpointLocked
 // except it does not cleanup SLAAC address state.
 //
-// Precondition: e.mu must be write locked.
+// +checklocks:e.mu.RWMutex
 func (e *endpoint) removePermanentEndpointInnerLocked(addressEndpoint stack.AddressEndpoint, reason stack.AddressRemovalReason, dadResult stack.DADResult) tcpip.Error {
 	addr := addressEndpoint.AddressWithPrefix()
 	e.mu.ndp.stopDuplicateAddressDetection(addr.Address, dadResult)
@@ -2078,7 +2090,7 @@ func (e *endpoint) removePermanentEndpointInnerLocked(addressEndpoint stack.Addr
 // hasPermanentAddressLocked returns true if the endpoint has a permanent
 // address equal to the passed address.
 //
-// Precondition: e.mu must be read or write locked.
+// +checklocksread:e.mu.RWMutex
 func (e *endpoint) hasPermanentAddressRLocked(addr tcpip.Address) bool {
 	addressEndpoint := e.getAddressRLocked(addr)
 	if addressEndpoint == nil {
@@ -2089,7 +2101,7 @@ func (e *endpoint) hasPermanentAddressRLocked(addr tcpip.Address) bool {
 
 // getAddressRLocked returns the endpoint for the passed address.
 //
-// Precondition: e.mu must be read or write locked.
+// +checklocksread:e.mu.RWMutex
 func (e *endpoint) getAddressRLocked(localAddr tcpip.Address) stack.AddressEndpoint {
 	return e.mu.addressableEndpointState.GetAddress(localAddr)
 }
@@ -2125,7 +2137,7 @@ func (e *endpoint) AcquireAssignedAddress(localAddr tcpip.Address, allowTemp boo
 // acquireAddressOrCreateTempLocked is like AcquireAssignedAddress but with
 // locking requirements.
 //
-// Precondition: e.mu must be write locked.
+// +checklocksread:e.mu.RWMutex
 func (e *endpoint) acquireAddressOrCreateTempLocked(localAddr tcpip.Address, allowTemp bool, tempPEB stack.PrimaryEndpointBehavior, readOnly bool) stack.AddressEndpoint {
 	return e.mu.addressableEndpointState.AcquireAssignedAddress(localAddr, allowTemp, tempPEB, readOnly)
 }
@@ -2142,7 +2154,7 @@ func (e *endpoint) AcquireOutgoingPrimaryAddress(remoteAddr, srcHint tcpip.Addre
 //
 // See stack.PrimaryEndpointBehavior for more details about the primary list.
 //
-// Precondition: e.mu must be read locked.
+// +checklocksread:e.mu.RWMutex
 func (e *endpoint) getLinkLocalAddressRLocked() tcpip.Address {
 	var linkLocalAddr tcpip.Address
 	e.mu.addressableEndpointState.ForEachPrimaryEndpoint(func(addressEndpoint stack.AddressEndpoint) bool {
@@ -2160,7 +2172,7 @@ func (e *endpoint) getLinkLocalAddressRLocked() tcpip.Address {
 // acquireOutgoingPrimaryAddressRLocked is like AcquireOutgoingPrimaryAddress
 // but with locking requirements.
 //
-// Precondition: e.mu must be read locked.
+// +checklocksread:e.mu.RWMutex
 func (e *endpoint) acquireOutgoingPrimaryAddressRLocked(remoteAddr, srcHint tcpip.Address, allowExpired bool) stack.AddressEndpoint {
 	// TODO(b/309216156): Support IPv6 hints.
 
@@ -2306,7 +2318,7 @@ func (e *endpoint) JoinGroup(addr tcpip.Address) tcpip.Error {
 
 // joinGroupLocked is like JoinGroup but with locking requirements.
 //
-// Precondition: e.mu must be locked.
+// +checklocks:e.mu.RWMutex
 func (e *endpoint) joinGroupLocked(addr tcpip.Address) tcpip.Error {
 	if !header.IsV6MulticastAddress(addr) {
 		return &tcpip.ErrBadAddress{}
@@ -2325,7 +2337,7 @@ func (e *endpoint) LeaveGroup(addr tcpip.Address) tcpip.Error {
 
 // leaveGroupLocked is like LeaveGroup but with locking requirements.
 //
-// Precondition: e.mu must be locked.
+// +checklocks:e.mu.RWMutex
 func (e *endpoint) leaveGroupLocked(addr tcpip.Address) tcpip.Error {
 	return e.mu.mld.leaveGroup(addr)
 }
@@ -2353,14 +2365,20 @@ type protocolMu struct {
 
 	// eps is keyed by NICID to allow protocol methods to retrieve an endpoint
 	// when handling a packet, by looking at which NIC handled the packet.
+	//
+	// +checklocks:RWMutex
 	eps map[tcpip.NICID]*endpoint
 
 	// ICMP types for which the stack's global rate limiting must apply.
+	//
+	// +checklocks:RWMutex
 	icmpRateLimitedTypes map[header.ICMPv6Type]struct{}
 
 	// multicastForwardingDisp is the multicast forwarding event dispatcher that
 	// an integrator can provide to receive multicast forwarding events. Note
 	// that multicast packets will only be forwarded if this is non-nil.
+	//
+	// +checklocks:RWMutex
 	multicastForwardingDisp stack.MulticastForwardingEventDispatcher
 }
 

--- a/pkg/tcpip/network/ipv6/ipv6_test.go
+++ b/pkg/tcpip/network/ipv6/ipv6_test.go
@@ -2680,6 +2680,7 @@ func (lm *limitedMatcher) Match(stack.Hook, *stack.PacketBuffer, string, string)
 	return false, false
 }
 
+// +checklocksread:proto.mu.RWMutex
 func knownNICIDs(proto *protocol) []tcpip.NICID {
 	var nicIDs []tcpip.NICID
 

--- a/pkg/tcpip/network/ipv6/mld.go
+++ b/pkg/tcpip/network/ipv6/mld.go
@@ -94,14 +94,14 @@ func (mld *mldState) Enabled() bool {
 
 // SendReport implements ip.MulticastGroupProtocol.
 //
-// Precondition: mld.ep.mu must be read locked.
+// +checklocksread:mld.ep.mu.RWMutex
 func (mld *mldState) SendReport(groupAddress tcpip.Address) (bool, tcpip.Error) {
 	return mld.writePacket(groupAddress, groupAddress, header.ICMPv6MulticastListenerReport)
 }
 
 // SendLeave implements ip.MulticastGroupProtocol.
 //
-// Precondition: mld.ep.mu must be read locked.
+// +checklocksread:mld.ep.mu.RWMutex
 func (mld *mldState) SendLeave(groupAddress tcpip.Address) tcpip.Error {
 	_, err := mld.writePacket(header.IPv6AllRoutersLinkLocalMulticastAddress, groupAddress, header.ICMPv6MulticastListenerDone)
 	return err
@@ -160,6 +160,8 @@ func (b *mldv2ReportBuilder) AddRecord(genericRecordType ip.MulticastGroupProtoc
 }
 
 // Send implements ip.MulticastGroupProtocolV2ReportBuilder.
+//
+// +checklocksread:b.mld.ep.mu.RWMutex
 func (b *mldv2ReportBuilder) Send() (sent bool, err tcpip.Error) {
 	if len(b.records) == 0 {
 		return false, err
@@ -243,14 +245,14 @@ func (mld *mldState) init(ep *endpoint) {
 
 // handleMulticastListenerQuery handles a query message.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) handleMulticastListenerQuery(mldHdr header.MLD) {
 	mld.genericMulticastProtocol.HandleQueryLocked(mldHdr.MulticastAddress(), mldHdr.MaximumResponseDelay())
 }
 
 // handleMulticastListenerQueryV2 handles a V2 query message.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) handleMulticastListenerQueryV2(mldHdr header.MLDv2Query) {
 	sources, ok := mldHdr.Sources()
 	if !ok {
@@ -268,7 +270,7 @@ func (mld *mldState) handleMulticastListenerQueryV2(mldHdr header.MLDv2Query) {
 
 // handleMulticastListenerReport handles a report message.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) handleMulticastListenerReport(mldHdr header.MLD) {
 	mld.genericMulticastProtocol.HandleReportLocked(mldHdr.MulticastAddress())
 }
@@ -278,14 +280,14 @@ func (mld *mldState) handleMulticastListenerReport(mldHdr header.MLD) {
 //
 // If the group is already joined, returns *tcpip.ErrDuplicateAddress.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) joinGroup(groupAddress tcpip.Address) {
 	mld.genericMulticastProtocol.JoinGroupLocked(groupAddress)
 }
 
 // isInGroup returns true if the specified group has been joined locally.
 //
-// Precondition: mld.ep.mu must be read locked.
+// +checklocksread:mld.ep.mu.RWMutex
 func (mld *mldState) isInGroup(groupAddress tcpip.Address) bool {
 	return mld.genericMulticastProtocol.IsLocallyJoinedRLocked(groupAddress)
 }
@@ -294,7 +296,7 @@ func (mld *mldState) isInGroup(groupAddress tcpip.Address) bool {
 // delay timers associated with that group, and sends the Done message, if
 // required.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) leaveGroup(groupAddress tcpip.Address) tcpip.Error {
 	// LeaveGroup returns false only if the group was not joined.
 	if mld.genericMulticastProtocol.LeaveGroupLocked(groupAddress) {
@@ -307,7 +309,7 @@ func (mld *mldState) leaveGroup(groupAddress tcpip.Address) tcpip.Error {
 // softLeaveAll leaves all groups from the perspective of MLD, but remains
 // joined locally.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) softLeaveAll() {
 	mld.genericMulticastProtocol.MakeAllNonMemberLocked()
 }
@@ -315,21 +317,21 @@ func (mld *mldState) softLeaveAll() {
 // initializeAll attempts to initialize the MLD state for each group that has
 // been joined locally.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) initializeAll() {
 	mld.genericMulticastProtocol.InitializeGroupsLocked()
 }
 
 // sendQueuedReports attempts to send any reports that are queued for sending.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) sendQueuedReports() {
 	mld.genericMulticastProtocol.SendQueuedReportsLocked()
 }
 
 // setVersion sets the MLD version.
 //
-// Precondition: mld.ep.mu must be locked.
+// +checklocks:mld.ep.mu.RWMutex
 func (mld *mldState) setVersion(v MLDVersion) MLDVersion {
 	var prev bool
 	switch v {
@@ -353,14 +355,14 @@ func toMLDVersion(v1Generic bool) MLDVersion {
 
 // getVersion returns the MLD version.
 //
-// Precondition: mld.ep.mu must be read locked.
+// +checklocksread:mld.ep.mu.RWMutex
 func (mld *mldState) getVersion() MLDVersion {
 	return toMLDVersion(mld.genericMulticastProtocol.GetV1ModeLocked())
 }
 
 // writePacket assembles and sends an MLD packet.
 //
-// Precondition: mld.ep.mu must be read locked.
+// +checklocksread:mld.ep.mu.RWMutex
 func (mld *mldState) writePacket(destAddress, groupAddress tcpip.Address, mldType header.ICMPv6Type) (bool, tcpip.Error) {
 	sentStats := mld.ep.stats.icmp.packetsSent
 	var mldStat tcpip.MultiCounterStat
@@ -392,6 +394,7 @@ func (mld *mldState) writePacket(destAddress, groupAddress tcpip.Address, mldTyp
 	)
 }
 
+// +checklocksread:mld.ep.mu.RWMutex
 func (mld *mldState) writePacketInner(buf *buffer.View, mldType header.ICMPv6Type, reportStat tcpip.MultiCounterStat, extensionHeaders header.IPv6ExtHdrSerializer, destAddress tcpip.Address) (bool, tcpip.Error) {
 	icmp := header.ICMPv6(buf.AsSlice())
 	icmp.SetType(mldType)

--- a/pkg/tcpip/network/ipv6/ndp.go
+++ b/pkg/tcpip/network/ipv6/ndp.go
@@ -640,7 +640,7 @@ type slaacPrefixState struct {
 // This function must only be called by IPv6 addresses that are currently
 // tentative.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) startDuplicateAddressDetection(addr tcpip.Address, addressEndpoint stack.AddressEndpoint) tcpip.Error {
 	// addr must be a valid unicast IPv6 address.
 	if !header.IsV6UnicastAddress(addr) {
@@ -681,9 +681,9 @@ func (ndp *ndpState) startDuplicateAddressDetection(addr tcpip.Address, addressE
 			if addressEndpoint.ConfigType() == stack.AddressConfigSlaac && !addressEndpoint.Temporary() {
 				// Reset the generation attempts counter as we are starting the
 				// generation of a new address for the SLAAC prefix.
-				ndp.regenerateTempSLAACAddr(addressEndpoint.AddressWithPrefix().Subnet(), true /* resetGenAttempts */)
+				ndp.regenerateTempSLAACAddr(addressEndpoint.AddressWithPrefix().Subnet(), true /* resetGenAttempts */) // +checklocksforce: DAD calls its handlers with ndp.ep.mu held.
 			}
-			ndp.ep.onAddressAssignedLocked(addr)
+			ndp.ep.onAddressAssignedLocked(addr) // +checklocksforce: DAD calls its handlers with ndp.ep.mu held.
 		}
 	})
 
@@ -713,7 +713,7 @@ func (ndp *ndpState) startDuplicateAddressDetection(addr tcpip.Address, addressE
 // (implying another node is attempting to use addr)). It is up to the caller
 // of this function to handle such a scenario.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) stopDuplicateAddressDetection(addr tcpip.Address, reason stack.DADResult) {
 	ndp.dad.StopLocked(addr, reason)
 }
@@ -721,7 +721,7 @@ func (ndp *ndpState) stopDuplicateAddressDetection(addr tcpip.Address, reason st
 // handleRA handles a Router Advertisement message that arrived on the NIC
 // this ndp is for. Does nothing if the NIC is configured to not handle RAs.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) handleRA(ip tcpip.Address, ra header.NDPRouterAdvert) {
 	// Is the IPv6 endpoint configured to handle RAs at all?
 	//
@@ -859,7 +859,7 @@ func (ndp *ndpState) handleRA(ip tcpip.Address, ra header.NDPRouterAdvert) {
 
 // invalidateOffLinkRoute invalidates a discovered off-link route.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) invalidateOffLinkRoute(route offLinkRoute) {
 	state, ok := ndp.offLinkRoutes[route]
 	if !ok {
@@ -877,7 +877,7 @@ func (ndp *ndpState) invalidateOffLinkRoute(route offLinkRoute) {
 
 // handleOffLinkRouteDiscovery handles the discovery of an off-link route.
 //
-// Precondition: ndp.ep.mu must be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) handleOffLinkRouteDiscovery(route offLinkRoute, lifetime time.Duration, prf header.NDPRoutePreference) {
 	ndpDisp := ndp.ep.protocol.options.NDPDisp
 	if ndpDisp == nil {
@@ -898,7 +898,7 @@ func (ndp *ndpState) handleOffLinkRouteDiscovery(route offLinkRoute, lifetime ti
 			state := offLinkRouteState{
 				prf: prf,
 				invalidationJob: tcpip.NewJob(ndp.ep.protocol.stack.Clock(), &ndp.ep.mu, func() {
-					ndp.invalidateOffLinkRoute(route)
+					ndp.invalidateOffLinkRoute(route) // +checklocksforce: NewJob calls back with ndp.ep.mu held.
 				}),
 			}
 
@@ -933,7 +933,7 @@ func (ndp *ndpState) handleOffLinkRouteDiscovery(route offLinkRoute, lifetime ti
 //
 // The prefix identified by prefix MUST NOT already be known.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) rememberOnLinkPrefix(prefix tcpip.Subnet, l time.Duration) {
 	ndpDisp := ndp.ep.protocol.options.NDPDisp
 	if ndpDisp == nil {
@@ -945,7 +945,7 @@ func (ndp *ndpState) rememberOnLinkPrefix(prefix tcpip.Subnet, l time.Duration) 
 
 	state := onLinkPrefixState{
 		invalidationJob: tcpip.NewJob(ndp.ep.protocol.stack.Clock(), &ndp.ep.mu, func() {
-			ndp.invalidateOnLinkPrefix(prefix)
+			ndp.invalidateOnLinkPrefix(prefix) // +checklocksforce: NewJob calls back with ndp.ep.mu held.
 		}),
 	}
 
@@ -958,7 +958,7 @@ func (ndp *ndpState) rememberOnLinkPrefix(prefix tcpip.Subnet, l time.Duration) 
 
 // invalidateOnLinkPrefix invalidates a discovered on-link prefix.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) invalidateOnLinkPrefix(prefix tcpip.Subnet) {
 	s, ok := ndp.onLinkPrefixes[prefix]
 
@@ -983,7 +983,7 @@ func (ndp *ndpState) invalidateOnLinkPrefix(prefix tcpip.Subnet) {
 // handleOnLinkPrefixInformation assumes that the prefix this pi is for is
 // not the link-local prefix and the on-link flag is set.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) handleOnLinkPrefixInformation(pi header.NDPPrefixInformation) {
 	prefix := pi.Subnet()
 	prefixState, ok := ndp.onLinkPrefixes[prefix]
@@ -1036,7 +1036,7 @@ func (ndp *ndpState) handleOnLinkPrefixInformation(pi header.NDPPrefixInformatio
 // handleAutonomousPrefixInformation assumes that the prefix this pi is for is
 // not the link-local prefix and the autonomous flag is set.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) handleAutonomousPrefixInformation(pi header.NDPPrefixInformation) {
 	vl := pi.ValidLifetime()
 	pl := pi.PreferredLifetime()
@@ -1077,7 +1077,7 @@ func (ndp *ndpState) handleAutonomousPrefixInformation(pi header.NDPPrefixInform
 //
 // pl is the new preferred lifetime. vl is the new valid lifetime.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) doSLAAC(prefix tcpip.Subnet, pl, vl time.Duration) {
 	// If we do not already have an address for this prefix and the valid
 	// lifetime is 0, no need to do anything further, as per RFC 4862
@@ -1100,7 +1100,7 @@ func (ndp *ndpState) doSLAAC(prefix tcpip.Subnet, pl, vl time.Duration) {
 				panic(fmt.Sprintf("ndp: must have a slaacPrefixes entry for the deprecated SLAAC prefix %s", prefix))
 			}
 
-			ndp.deprecateSLAACAddress(state.stableAddr.addressEndpoint)
+			ndp.deprecateSLAACAddress(state.stableAddr.addressEndpoint) // +checklocksforce: NewJob calls back with ndp.ep.mu held.
 		}),
 		invalidationJob: tcpip.NewJob(ndp.ep.protocol.stack.Clock(), &ndp.ep.mu, func() {
 			state, ok := ndp.slaacPrefixes[prefix]
@@ -1108,7 +1108,7 @@ func (ndp *ndpState) doSLAAC(prefix tcpip.Subnet, pl, vl time.Duration) {
 				panic(fmt.Sprintf("ndp: must have a slaacPrefixes entry for the invalidated SLAAC prefix %s", prefix))
 			}
 
-			ndp.invalidateSLAACPrefix(prefix, state)
+			ndp.invalidateSLAACPrefix(prefix, state) // +checklocksforce: NewJob calls back with ndp.ep.mu held.
 		}),
 		tempAddrs:             make(map[tcpip.Address]tempSLAACAddrState),
 		maxGenerationAttempts: ndp.configs.AutoGenAddressConflictRetries + 1,
@@ -1158,7 +1158,7 @@ func (ndp *ndpState) doSLAAC(prefix tcpip.Subnet, pl, vl time.Duration) {
 
 // addAndAcquireSLAACAddr adds a SLAAC address to the IPv6 endpoint.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) addAndAcquireSLAACAddr(addr tcpip.AddressWithPrefix, temporary bool, lifetimes stack.AddressLifetimes) stack.AddressEndpoint {
 	addressEndpoint, err := ndp.ep.addAndAcquirePermanentAddressLocked(addr, stack.AddressProperties{
 		PEB:        stack.FirstPrimaryEndpoint,
@@ -1186,7 +1186,7 @@ func (ndp *ndpState) addAndAcquireSLAACAddr(addr tcpip.AddressWithPrefix, tempor
 //
 // Panics if the prefix is not a SLAAC prefix or it already has an address.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) generateSLAACAddr(prefix tcpip.Subnet, state *slaacPrefixState) bool {
 	if addressEndpoint := state.stableAddr.addressEndpoint; addressEndpoint != nil {
 		panic(fmt.Sprintf("ndp: SLAAC prefix %s already has a permanent address %s", prefix, addressEndpoint.AddressWithPrefix()))
@@ -1283,7 +1283,7 @@ func (ndp *ndpState) generateSLAACAddr(prefix tcpip.Subnet, state *slaacPrefixSt
 //
 // If generating a new address for the prefix fails, the prefix is invalidated.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) regenerateSLAACAddr(prefix tcpip.Subnet) {
 	state, ok := ndp.slaacPrefixes[prefix]
 	if !ok {
@@ -1306,6 +1306,8 @@ func (ndp *ndpState) regenerateSLAACAddr(prefix tcpip.Subnet) {
 // If resetGenAttempts is true, the prefix's generation counter is reset.
 //
 // Returns true if a new address was generated.
+//
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) generateTempSLAACAddr(prefix tcpip.Subnet, prefixState *slaacPrefixState, resetGenAttempts bool) bool {
 	// Are we configured to auto-generate new temporary global addresses for the
 	// prefix?
@@ -1403,7 +1405,7 @@ func (ndp *ndpState) generateTempSLAACAddr(prefix tcpip.Subnet, prefixState *sla
 				panic(fmt.Sprintf("ndp: must have a tempAddr entry to deprecate temporary address %s", generatedAddr))
 			}
 
-			ndp.deprecateSLAACAddress(tempAddrState.addressEndpoint)
+			ndp.deprecateSLAACAddress(tempAddrState.addressEndpoint) // +checklocksforce: NewJob calls back with ndp.ep.mu held.
 		}),
 		invalidationJob: tcpip.NewJob(ndp.ep.protocol.stack.Clock(), &ndp.ep.mu, func() {
 			prefixState, ok := ndp.slaacPrefixes[prefix]
@@ -1416,7 +1418,7 @@ func (ndp *ndpState) generateTempSLAACAddr(prefix tcpip.Subnet, prefixState *sla
 				panic(fmt.Sprintf("ndp: must have a tempAddr entry to invalidate temporary address %s", generatedAddr))
 			}
 
-			ndp.invalidateTempSLAACAddr(prefixState.tempAddrs, generatedAddr.Address, tempAddrState)
+			ndp.invalidateTempSLAACAddr(prefixState.tempAddrs, generatedAddr.Address, tempAddrState) // +checklocksforce: NewJob calls back with ndp.ep.mu held.
 		}),
 		regenJob: tcpip.NewJob(ndp.ep.protocol.stack.Clock(), &ndp.ep.mu, func() {
 			prefixState, ok := ndp.slaacPrefixes[prefix]
@@ -1437,7 +1439,7 @@ func (ndp *ndpState) generateTempSLAACAddr(prefix tcpip.Subnet, prefixState *sla
 
 			// Reset the generation attempts counter as we are starting the generation
 			// of a new address for the SLAAC prefix.
-			tempAddrState.regenerated = ndp.generateTempSLAACAddr(prefix, &prefixState, true /* resetGenAttempts */)
+			tempAddrState.regenerated = ndp.generateTempSLAACAddr(prefix, &prefixState, true /* resetGenAttempts */) // +checklocksforce: NewJob calls back with ndp.ep.mu held.
 			prefixState.tempAddrs[generatedAddr.Address] = tempAddrState
 			ndp.slaacPrefixes[prefix] = prefixState
 		}),
@@ -1457,7 +1459,7 @@ func (ndp *ndpState) generateTempSLAACAddr(prefix tcpip.Subnet, prefixState *sla
 
 // regenerateTempSLAACAddr regenerates a temporary address for a SLAAC prefix.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) regenerateTempSLAACAddr(prefix tcpip.Subnet, resetGenAttempts bool) {
 	state, ok := ndp.slaacPrefixes[prefix]
 	if !ok {
@@ -1472,7 +1474,7 @@ func (ndp *ndpState) regenerateTempSLAACAddr(prefix tcpip.Subnet, resetGenAttemp
 //
 // pl is the new preferred lifetime. vl is the new valid lifetime.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) refreshSLAACPrefixLifetimes(prefix tcpip.Subnet, prefixState *slaacPrefixState, pl, vl time.Duration) {
 	// If prefix was preferred for some finite lifetime before, cancel the
 	// deprecation job so it can be reset.
@@ -1658,7 +1660,7 @@ func (ndp *ndpState) refreshSLAACPrefixLifetimes(prefix tcpip.Subnet, prefixStat
 //
 // deprecateSLAACAddress does nothing if the address is already deprecated.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) deprecateSLAACAddress(addressEndpoint stack.AddressEndpoint) {
 	if addressEndpoint.Deprecated() {
 		return
@@ -1672,7 +1674,7 @@ func (ndp *ndpState) deprecateSLAACAddress(addressEndpoint stack.AddressEndpoint
 
 // invalidateSLAACPrefix invalidates a SLAAC prefix.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) invalidateSLAACPrefix(prefix tcpip.Subnet, state slaacPrefixState) {
 	ndp.cleanupSLAACPrefixResources(prefix, state)
 
@@ -1690,7 +1692,7 @@ func (ndp *ndpState) invalidateSLAACPrefix(prefix tcpip.Subnet, state slaacPrefi
 // cleanupSLAACAddrResourcesAndNotify cleans up an invalidated SLAAC address's
 // resources.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) cleanupSLAACAddrResourcesAndNotify(addr tcpip.AddressWithPrefix, invalidatePrefix bool) {
 	if ndpDisp := ndp.ep.protocol.options.NDPDisp; ndpDisp != nil {
 		ndpDisp.OnAutoGenAddressInvalidated(ndp.ep.nic.ID(), addr)
@@ -1718,7 +1720,7 @@ func (ndp *ndpState) cleanupSLAACAddrResourcesAndNotify(addr tcpip.AddressWithPr
 //
 // Panics if the SLAAC prefix is not known.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) cleanupSLAACPrefixResources(prefix tcpip.Subnet, state slaacPrefixState) {
 	// Invalidate all temporary addresses.
 	for tempAddr, tempAddrState := range state.tempAddrs {
@@ -1736,7 +1738,7 @@ func (ndp *ndpState) cleanupSLAACPrefixResources(prefix tcpip.Subnet, state slaa
 
 // invalidateTempSLAACAddr invalidates a temporary SLAAC address.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) invalidateTempSLAACAddr(tempAddrs map[tcpip.Address]tempSLAACAddrState, tempAddr tcpip.Address, tempAddrState tempSLAACAddrState) {
 	ndp.cleanupTempSLAACAddrResourcesAndNotifyInner(tempAddrs, tempAddr, tempAddrState)
 
@@ -1749,7 +1751,7 @@ func (ndp *ndpState) invalidateTempSLAACAddr(tempAddrs map[tcpip.Address]tempSLA
 // SLAAC address's resources from ndp and notifies the NDP dispatcher that the
 // address was invalidated.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) cleanupTempSLAACAddrResourcesAndNotify(addr tcpip.AddressWithPrefix) {
 	prefix := addr.Subnet()
 	state, ok := ndp.slaacPrefixes[prefix]
@@ -1769,7 +1771,7 @@ func (ndp *ndpState) cleanupTempSLAACAddrResourcesAndNotify(addr tcpip.AddressWi
 // cleanupTempSLAACAddrResourcesAndNotify except it does not lookup the
 // temporary address's state in ndp - it assumes the passed state is valid.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) cleanupTempSLAACAddrResourcesAndNotifyInner(tempAddrs map[tcpip.Address]tempSLAACAddrState, tempAddr tcpip.Address, tempAddrState tempSLAACAddrState) {
 	if ndpDisp := ndp.ep.protocol.options.NDPDisp; ndpDisp != nil {
 		ndpDisp.OnAutoGenAddressInvalidated(ndp.ep.nic.ID(), tempAddrState.addressEndpoint.AddressWithPrefix())
@@ -1788,7 +1790,7 @@ func (ndp *ndpState) cleanupTempSLAACAddrResourcesAndNotifyInner(tempAddrs map[t
 // This function invalidates all discovered on-link prefixes, discovered
 // routers, and auto-generated addresses.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) cleanupState() {
 	for prefix, state := range ndp.slaacPrefixes {
 		ndp.invalidateSLAACPrefix(prefix, state)
@@ -1820,7 +1822,7 @@ func (ndp *ndpState) cleanupState() {
 // be solicited as there is no point soliciting routers if we don't handle their
 // advertisements.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) startSolicitingRouters() {
 	if ndp.rtrSolicitTimer.timer != nil {
 		// We are already soliciting routers.
@@ -1937,7 +1939,7 @@ func (ndp *ndpState) startSolicitingRouters() {
 // router solicitation will be stopped if NDP is not configured to handle RAs
 // as a router.
 //
-// Precondition: ndp.ep.mu must be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) forwardingChanged(forwarding bool) {
 	if forwarding {
 		if ndp.configs.HandleRAs.enabled(forwarding) {
@@ -1960,7 +1962,7 @@ func (ndp *ndpState) forwardingChanged(forwarding bool) {
 // stopSolicitingRouters stops soliciting routers. If routers are not currently
 // being solicited, this function does nothing.
 //
-// The IPv6 endpoint that ndp belongs to MUST be locked.
+// +checklocks:ndp.ep.mu.RWMutex
 func (ndp *ndpState) stopSolicitingRouters() {
 	if ndp.rtrSolicitTimer.timer == nil {
 		// Nothing to do.


### PR DESCRIPTION
IPv6 endpoint, DAD, and protocol state lack checked mutex ownership. Annotate the fields and NDP/MLD helper contracts, adapting #7060 to the current named state and embedded mutexes.

Alias the endpoint mutex paths through the initialized NDP and MLD backpointers. Record narrow checklocks exceptions where synchronous iteration preserves the caller's lock or DAD and job callbacks run under the supplied endpoint lock.

Require a read lock for address acquisition, matching its callers and the addressable state implementation that owns exclusive creation.

Assisted-by: Codex
