### PR TITLE
checklocks: guard user namespace setgroups

### DIFF
--- a/pkg/sentry/kernel/auth/user_namespace.go
+++ b/pkg/sentry/kernel/auth/user_namespace.go
@@ -59,7 +59,9 @@ type UserNamespace struct {
 	// user_namespace.parent_could_setfcap in Linux.
 	parentHadSetfcap bool
 
-	// setgroupsAllowed mirrors USERNS_SETGROUPS_ALLOWED in Linux. Protected by mu.
+	// setgroupsAllowed mirrors USERNS_SETGROUPS_ALLOWED in Linux.
+	//
+	// +checklocks:mu
 	setgroupsAllowed bool
 
 	// inode is the nsfs inode associated with this namespace. This is stored as


### PR DESCRIPTION
The namespace mutex already protects accesses to setgroupsAllowed after initialization. Replace the prose guard with a checklocks annotation so future accesses must preserve that ownership.

Assisted-by: Codex
