### PR TITLE
checklocks: guard VFS dynamic device majors

### DIFF
--- a/pkg/sentry/vfs/device.go
+++ b/pkg/sentry/vfs/device.go
@@ -156,7 +156,10 @@ func (vfs *VirtualFilesystem) GetDynamicCharDevMajor() (uint32, error) {
 	return vfs.getDynamicCharDevMajorLocked()
 }
 
-// Preconditions: vfs.dynCharDevMajorMu must be locked.
+// getDynamicCharDevMajorLocked is equivalent to GetDynamicCharDevMajor with
+// vfs.dynCharDevMajorMu already held.
+//
+// +checklocks:vfs.dynCharDevMajorMu
 func (vfs *VirtualFilesystem) getDynamicCharDevMajorLocked() (uint32, error) {
 	// Compare Linux's fs/char_dev.c:find_dynamic_major().
 	for major := uint32(254); major >= 234; major-- {

--- a/pkg/sentry/vfs/save_restore.go
+++ b/pkg/sentry/vfs/save_restore.go
@@ -192,6 +192,8 @@ func (epi *epollInterest) afterLoad(goContext.Context) {
 
 // afterLoad is called by stateify.
 func (vfs *VirtualFilesystem) afterLoad(goContext.Context) {
+	vfs.dynCharDevMajorMu.Lock()
+	defer vfs.dynCharDevMajorMu.Unlock()
 	if vfs.dynCharDevMajorShared == nil {
 		vfs.dynCharDevMajorShared = make(map[SharedDynamicCharDevMajorKey]uint32)
 	}

--- a/pkg/sentry/vfs/vfs.go
+++ b/pkg/sentry/vfs/vfs.go
@@ -113,14 +113,19 @@ type VirtualFilesystem struct {
 	devicesMu sync.RWMutex `state:"nosave"`
 	devices   map[devTuple]*registeredDevice
 
+	dynCharDevMajorMu sync.Mutex `state:"nosave"`
+
 	// dynCharDevMajorUsed contains all allocated dynamic character device
-	// major numbers. dynCharDevMajor is protected by dynCharDevMajorMu.
+	// major numbers.
 	//
+	// +checklocks:dynCharDevMajorMu
+	dynCharDevMajorUsed map[uint32]struct{}
+
 	// dynCharDevMajorShared maps keys passed to
 	// GetSharedDynamicCharDevMajor() to the major number allocated for that
-	// key. dynCharDevMajorShared is protected by dynCharDevMajorMu.
-	dynCharDevMajorMu     sync.Mutex `state:"nosave"`
-	dynCharDevMajorUsed   map[uint32]struct{}
+	// key.
+	//
+	// +checklocks:dynCharDevMajorMu
 	dynCharDevMajorShared map[SharedDynamicCharDevMajorKey]uint32
 
 	// anonBlockDevMinor contains all allocated anonymous block device minor
@@ -162,8 +167,10 @@ func (vfs *VirtualFilesystem) Init(ctx context.Context) error {
 	}
 	vfs.mountpoints = make(map[*Dentry]map[*Mount]struct{})
 	vfs.devices = make(map[devTuple]*registeredDevice)
+	vfs.dynCharDevMajorMu.Lock()
 	vfs.dynCharDevMajorUsed = make(map[uint32]struct{})
 	vfs.dynCharDevMajorShared = make(map[SharedDynamicCharDevMajorKey]uint32)
+	vfs.dynCharDevMajorMu.Unlock()
 	vfs.anonBlockDevMinorNext = 1
 	vfs.anonBlockDevMinor = make(map[uint32]struct{})
 	vfs.fsTypes = make(map[string]*registeredFilesystemType)


### PR DESCRIPTION
Dynamic character-device allocation protects its used-major map and shared-key cache with dynCharDevMajorMu, but the contract is only documented in prose. Add guards for both maps and the locked allocation helper.

Hold the mutex while initializing the maps and repairing a nil shared cache after load so these lifecycle paths follow the same contract.

Assisted-by: Codex
