### PR TITLE
checklocks: guard cgroup CPU accounting

### DIFF
--- a/pkg/sentry/fsimpl/cgroupfs/cpuacct.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cpuacct.go
@@ -49,13 +49,15 @@ type cpuacctController struct {
 	mu sync.Mutex `state:"nosave"`
 
 	// taskCommittedCharges tracks charges for a task already attributed to this
-	// cgroup. This is used to avoid double counting usage for live
-	// tasks. Protected by mu.
+	// cgroup. This is used to avoid double counting usage for live tasks.
+	//
+	// +checklocks:mu
 	taskCommittedCharges map[*kernel.Task]usage.CPUStats
 
 	// usage is the cumulative CPU time used by past tasks in this cgroup. Note
-	// that this doesn't include usage by live tasks currently in the
-	// cgroup. Protected by mu.
+	// that this doesn't include usage by live tasks currently in the cgroup.
+	//
+	// +checklocks:mu
 	usage usage.CPUStats
 }
 


### PR DESCRIPTION
CPU accounting protects committed task charges and accumulated usage with the controller mutex during task exit, migration, and statistics collection. Add field guards so checklocks enforces those existing contracts, replacing the protection comments.

Assisted-by: Codex
