### PR TITLE
kernel: avoid self-deadlock in setsid() with shared signal handlers

### DIFF
--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -443,6 +443,7 @@ go_test(
     size = "small",
     srcs = [
         "fd_table_test.go",
+        "sessions_test.go",
         "table_test.go",
         "task_test.go",
         "timekeeper_test.go",

--- a/pkg/sentry/kernel/sessions.go
+++ b/pkg/sentry/kernel/sessions.go
@@ -149,8 +149,14 @@ func (pg *ProcessGroup) incRefWithParent(parentPG *ProcessGroup) {
 //
 // parentPG is per incRefWithParent.
 //
+// heldSH, if non-nil, is a *SignalHandlers instance that the caller already
+// holds locked. handleOrphan must not (Nested)Lock it again, because a thread
+// group in an orphaned process group may share that same instance (e.g. a
+// process created via clone(CLONE_SIGHAND) without CLONE_THREAD). Locking an
+// already-held signal mutex would self-deadlock the goroutine.
+//
 // Precondition: callers must hold TaskSet.mu for writing.
-func (pg *ProcessGroup) decRefWithParent(parentPG *ProcessGroup) {
+func (pg *ProcessGroup) decRefWithParent(parentPG *ProcessGroup, heldSH *SignalHandlers) {
 	// See incRefWithParent regarding parent == nil.
 	if pg != parentPG && (parentPG == nil || pg.session == parentPG.session) {
 		pg.ancestors--
@@ -172,7 +178,7 @@ func (pg *ProcessGroup) decRefWithParent(parentPG *ProcessGroup) {
 		pg.session.DecRef()
 	})
 	if alive {
-		pg.handleOrphan()
+		pg.handleOrphan(heldSH)
 	}
 }
 
@@ -190,8 +196,12 @@ func (tg *ThreadGroup) parentPG() *ProcessGroup {
 // stopped jobs. If yes, then appropriate signals are delivered to each thread
 // group within the process group.
 //
+// heldSH, if non-nil, is a *SignalHandlers instance that the caller already
+// holds locked; thread groups sharing it are operated on without re-locking
+// (see decRefWithParent).
+//
 // Precondition: callers must hold TaskSet.mu for writing.
-func (pg *ProcessGroup) handleOrphan() {
+func (pg *ProcessGroup) handleOrphan(heldSH *SignalHandlers) {
 	// Check if this process is an orphan.
 	if pg.ancestors != 0 {
 		return
@@ -203,11 +213,18 @@ func (pg *ProcessGroup) handleOrphan() {
 		if tg.processGroup != pg {
 			return
 		}
-		tg.signalHandlers.mu.NestedLock(signalHandlersLockTg)
+		// tg.signalHandlers may be the same instance the caller already holds
+		// locked; NestedLock on an already-held mutex would deadlock.
+		lock := tg.signalHandlers != heldSH
+		if lock {
+			tg.signalHandlers.mu.NestedLock(signalHandlersLockTg)
+		}
 		if tg.groupStopComplete {
 			hasStopped = true
 		}
-		tg.signalHandlers.mu.NestedUnlock(signalHandlersLockTg)
+		if lock {
+			tg.signalHandlers.mu.NestedUnlock(signalHandlersLockTg)
+		}
 	})
 	if !hasStopped {
 		return
@@ -218,10 +235,15 @@ func (pg *ProcessGroup) handleOrphan() {
 		if tg.processGroup != pg {
 			return
 		}
-		tg.signalHandlers.mu.NestedLock(signalHandlersLockTg)
+		lock := tg.signalHandlers != heldSH
+		if lock {
+			tg.signalHandlers.mu.NestedLock(signalHandlersLockTg)
+		}
 		tgLeader.sendSignalLocked(SignalInfoPriv(linux.SIGHUP), true /* group */)
 		tgLeader.sendSignalLocked(SignalInfoPriv(linux.SIGCONT), true /* group */)
-		tg.signalHandlers.mu.NestedUnlock(signalHandlersLockTg)
+		if lock {
+			tg.signalHandlers.mu.NestedUnlock(signalHandlersLockTg)
+		}
 	})
 
 }
@@ -327,7 +349,7 @@ func (tg *ThreadGroup) createSession() (SessionID, *TTY, error) {
 		oldParentPG := tg.parentPG()
 		tg.forEachChildThreadGroupLocked(func(childTG *ThreadGroup) {
 			childTG.processGroup.incRefWithParent(pg)
-			childTG.processGroup.decRefWithParent(oldParentPG)
+			childTG.processGroup.decRefWithParent(oldParentPG, tg.signalHandlers)
 		})
 		// If tg.processGroup is an orphan, decRefWithParent will lock
 		// the signal mutex of each thread group in tg.processGroup.
@@ -336,7 +358,7 @@ func (tg *ThreadGroup) createSession() (SessionID, *TTY, error) {
 		// decRefWithParent to avoid locking tg's signal mutex twice.
 		oldPG := tg.processGroup
 		tg.processGroup = pg
-		oldPG.decRefWithParent(oldParentPG)
+		oldPG.decRefWithParent(oldParentPG, tg.signalHandlers)
 	} else {
 		// The current process group may be nil only in the case of an
 		// unparented thread group (i.e. the init process). This would
@@ -419,9 +441,9 @@ func (tg *ThreadGroup) CreateProcessGroup() error {
 	oldParentPG := tg.parentPG()
 	tg.forEachChildThreadGroupLocked(func(childTG *ThreadGroup) {
 		childTG.processGroup.incRefWithParent(&pg)
-		childTG.processGroup.decRefWithParent(oldParentPG)
+		childTG.processGroup.decRefWithParent(oldParentPG, nil)
 	})
-	tg.processGroup.decRefWithParent(oldParentPG)
+	tg.processGroup.decRefWithParent(oldParentPG, nil)
 	tg.processGroup = &pg
 
 	// Add the new process group to the session.
@@ -466,9 +488,9 @@ func (tg *ThreadGroup) JoinProcessGroup(pidns *PIDNamespace, pgid ProcessGroupID
 	pg.incRefWithParent(parentPG)
 	tg.forEachChildThreadGroupLocked(func(childTG *ThreadGroup) {
 		childTG.processGroup.incRefWithParent(pg)
-		childTG.processGroup.decRefWithParent(tg.processGroup)
+		childTG.processGroup.decRefWithParent(tg.processGroup, nil)
 	})
-	tg.processGroup.decRefWithParent(parentPG)
+	tg.processGroup.decRefWithParent(parentPG, nil)
 	tg.processGroup = pg
 
 	return nil

--- a/pkg/sentry/kernel/sessions_test.go
+++ b/pkg/sentry/kernel/sessions_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"testing"
+	"time"
+)
+
+// These tests exercise handleOrphan's locking of thread-group signal handlers
+// directly, because the kernel package has no lightweight harness for building
+// real Tasks/ThreadGroups. They cover the first (stopped-job detection) loop of
+// handleOrphan, which is where the production self-deadlock occurred. The full
+// setsid()->CreateSession()->handleOrphan() call chain is covered end-to-end by
+// the SetsidWithSharedSignalHandlers syscall test. The second (SIGHUP/SIGCONT
+// delivery) loop uses the same "skip the already-held instance" guard as the
+// first, but reaching it requires a stopped job and a real thread-group leader,
+// so it is not separately unit-tested here.
+
+// orphanTestSetup builds a minimal TaskSet containing thread groups that all
+// belong to a single orphaned process group (ancestors == 0). Each thread
+// group uses the SignalHandlers instance provided in shs[i]; passing the same
+// pointer for multiple entries models thread groups that share signal handlers
+// (e.g. clone(CLONE_SIGHAND) without CLONE_THREAD).
+//
+// It returns the process group so tests can invoke handleOrphan directly.
+func orphanTestSetup(shs []*SignalHandlers) *ProcessGroup {
+	ts := &TaskSet{}
+	ns := &PIDNamespace{
+		owner: ts,
+		tgids: make(map[*ThreadGroup]ThreadID),
+	}
+	ts.Root = ns
+
+	pg := &ProcessGroup{ancestors: 0}
+	for i, sh := range shs {
+		tg := &ThreadGroup{signalHandlers: sh}
+		tg.pidns = ns
+		tg.processGroup = pg
+		ns.tgids[tg] = ThreadID(i + 1)
+		if pg.originator == nil {
+			pg.originator = tg
+		}
+	}
+	return pg
+}
+
+// TestHandleOrphanSharedSignalHandlersNoDeadlock is a regression test for a
+// self-deadlock in CreateSession: the caller holds a thread group's
+// signalHandlers.mu, and handleOrphan would NestedLock the same instance again
+// for another thread group that shares it. NestedLock is not recursive, so the
+// goroutine deadlocked on itself. handleOrphan must skip re-locking the
+// instance the caller already holds (passed as heldSH).
+//
+// The held locks, the handleOrphan call, and the unlocks all run on the same
+// goroutine, faithfully reproducing the production condition: a single
+// goroutine holds the shared signal mutex and then re-enters handleOrphan.
+func TestHandleOrphanSharedSignalHandlersNoDeadlock(t *testing.T) {
+	shared := &SignalHandlers{}
+	// Two distinct thread groups sharing one SignalHandlers instance, both in
+	// the orphaned process group.
+	pg := orphanTestSetup([]*SignalHandlers{shared, shared})
+
+	done := make(chan struct{})
+	go func() {
+		// Model CreateSession's held locks on this goroutine: TaskSet.mu
+		// (write) and the originator's signal mutex. Then re-enter handleOrphan,
+		// which must not try to lock the shared instance again.
+		pg.originator.pidns.owner.mu.Lock()
+		shared.mu.Lock()
+		pg.handleOrphan(shared)
+		shared.mu.Unlock()
+		pg.originator.pidns.owner.mu.Unlock()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good.
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleOrphan deadlocked re-locking a shared signalHandlers instance already held by the caller")
+	}
+}
+
+// TestHandleOrphanLocksUnsharedSignalHandlers verifies that the normal path
+// really does (Nested)Lock thread-group signal handlers the caller does not
+// already hold, and that the lock participates in synchronization. It holds one
+// thread group's signal mutex from a helper goroutine and confirms handleOrphan
+// blocks until that mutex is released, rather than silently skipping the lock.
+func TestHandleOrphanLocksUnsharedSignalHandlers(t *testing.T) {
+	sh1 := &SignalHandlers{}
+	sh2 := &SignalHandlers{}
+	pg := orphanTestSetup([]*SignalHandlers{sh1, sh2})
+
+	// Hold sh2 from a helper goroutine so handleOrphan must block when it
+	// reaches sh2's thread group.
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		sh2.mu.Lock()
+		close(held)
+		<-release
+		sh2.mu.Unlock()
+	}()
+	<-held
+
+	// Run handleOrphan on its own goroutine (holding TaskSet.mu, as required).
+	// With heldSH == nil it must attempt to lock every thread group's signal
+	// mutex, so it should block on the held sh2.
+	done := make(chan struct{})
+	go func() {
+		pg.originator.pidns.owner.mu.Lock()
+		pg.handleOrphan(nil)
+		pg.originator.pidns.owner.mu.Unlock()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("handleOrphan completed without blocking on the held sh2 mutex; it is not locking the normal path")
+	case <-time.After(500 * time.Millisecond):
+		// Good: blocked waiting for sh2, proving it takes the lock.
+	}
+
+	close(release)
+	select {
+	case <-done:
+		// Good: completed once sh2 became available.
+	case <-time.After(10 * time.Second):
+		t.Fatal("handleOrphan did not complete after sh2 was released")
+	}
+}

--- a/pkg/sentry/kernel/task_exit.go
+++ b/pkg/sentry/kernel/task_exit.go
@@ -791,7 +791,7 @@ func (t *Task) exitNotifyLocked(fromPtraceDetach bool) {
 			}
 		} else if tc == 0 {
 			t.tg.pidWithinNS.Store(0)
-			t.tg.processGroup.decRefWithParent(t.tg.parentPG())
+			t.tg.processGroup.decRefWithParent(t.tg.parentPG(), nil)
 			t.notifyPIDFDsOnDeathLocked()
 		}
 		if t.parent != nil {

--- a/test/syscalls/linux/processes.cc
+++ b/test/syscalls/linux/processes.cc
@@ -119,6 +119,56 @@ TEST(Processes, SetPGIDOfZombie) {
   EXPECT_EQ(status, 0);
 }
 
+// Stack and pipe fd for the CLONE_VM child below. The child shares our address
+// space, so these are visible to it; it must otherwise use only raw syscalls.
+static char sharedSighandChildStack[65536] __attribute__((aligned(16)));
+static int sharedSighandPipeWriteFd;
+
+int sharedSighandChild(void* arg) {
+  syscall(SYS_setpgid, 0, 0);  // Move into our own process group.
+  char c = 1;
+  syscall(SYS_write, sharedSighandPipeWriteFd, &c, 1);
+  for (;;) {
+    syscall(SYS_ppoll, 0, 0, 0, 0, 0);  // Block until killed.
+  }
+  return 0;
+}
+
+// Regression test for a sentry self-deadlock in setsid()/CreateSession: when the
+// calling thread group shares its signal handlers with another thread group in
+// an about-to-be-orphaned process group, orphan handling tried to re-lock the
+// signal mutex the caller already held (a non-recursive nested lock). A
+// regression deadlocks setsid() forever, so this test hangs until it times out.
+TEST(Processes, SetsidWithSharedSignalHandlers) {
+  const DisableSave ds;  // The helper child blocks until killed.
+
+  // Run in a child so the process calling setsid() is not a session leader.
+  pid_t t = fork();
+  if (t == 0) {
+    int p[2];
+    TEST_PCHECK(pipe(p) == 0);
+    sharedSighandPipeWriteFd = p[1];
+    // A separate thread group (no CLONE_THREAD) that shares our signal handlers
+    // (CLONE_SIGHAND, which requires CLONE_VM).
+    pid_t c = clone(sharedSighandChild,
+                    sharedSighandChildStack + sizeof(sharedSighandChildStack),
+                    CLONE_VM | CLONE_SIGHAND | SIGCHLD, nullptr);
+    TEST_PCHECK(c > 0);
+    char b;
+    TEST_PCHECK(ReadFd(p[0], &b, sizeof(b)) == sizeof(b));
+    // The child is in its own process group; leaving our session orphans it,
+    // driving the orphan handling that used to deadlock.
+    TEST_PCHECK(setsid() >= 0);
+    TEST_PCHECK(kill(c, SIGKILL) == 0);
+    _exit(0);
+  }
+  ASSERT_THAT(t, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(RetryEINTR(waitpid)(t, &status, 0), SyscallSucceedsWithValue(t));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "setsid() child exited abnormally, status=" << status;
+}
+
 void WritePIDToPipe(int* pipe_fds) {
   pid_t child_pid;
   TEST_PCHECK(child_pid = getpid());


### PR DESCRIPTION
setsid() deadlocks when the calling thread group shares signal handlers with another thread group (CLONE_SIGHAND without CLONE_THREAD).

createSession holds:
  TaskSet.mu (write) + caller->signalHandlers.mu

It then reparents children, which calls handleOrphan. handleOrphan NestedLocks signalHandlers.mu of every thread group in the orphaned process group. If one of them shares the caller's signalHandlers, NestedLock deadlocks (it is non-recursive).

This permanently holds TaskSet.mu, starving all readers and hanging every runsc control-plane RPC.

The existing guard (reassigning tg.processGroup before decRef) only covers the caller's own group by identity, missing shared instances.

Fix: pass the already-held *SignalHandlers down through decRefWithParent into handleOrphan. Skip locking when the instance is already held. Only createSession call sites opt into this; all other callers unchanged.

assisted-by: GLM
fix #14275 