### PR TITLE
runsc/boot: validate version before loading async pages during restore

### DIFF
--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -625,6 +625,19 @@ func (cm *containerManager) Restore(o *RestoreOpts, _ *struct{}) (retErr error) 
 		timer:      timer,
 	}
 
+	cm.restorer.stateFile, cm.restorer.metadata, err = state.NewStatefileReader(stateFile /* transfers ownership on success */, nil)
+	if err != nil {
+		return fmt.Errorf("creating statefile reader: %w", err)
+	}
+	stateFile = nil
+	timer.Reached("created statefile reader")
+
+	checkpointVersion := cm.restorer.metadata[VersionKey]
+	currentVersion := version.Version()
+	if checkpointVersion != currentVersion {
+		return fmt.Errorf("runsc version does not match across checkpoint restore, checkpoint: %v current: %v", checkpointVersion, currentVersion)
+	}
+
 	// Create the main MemoryFile.
 	cm.restorer.mainMF, err = createMemoryFile(cm.l.root.conf.AppHugePages, cm.l.hostTHP)
 	if err != nil {
@@ -639,13 +652,6 @@ func (cm *containerManager) Restore(o *RestoreOpts, _ *struct{}) (retErr error) 
 		pagesFile = nil
 		timer.Reached("created async MF loader")
 	}
-
-	cm.restorer.stateFile, cm.restorer.metadata, err = state.NewStatefileReader(stateFile /* transfers ownership on success */, nil)
-	if err != nil {
-		return fmt.Errorf("creating statefile reader: %w", err)
-	}
-	stateFile = nil
-	timer.Reached("created statefile reader")
 
 	cm.l.restoreDone = sync.NewCond(&cm.l.mu)
 	cm.l.state = restoringUnstarted
@@ -686,12 +692,6 @@ func (cm *containerManager) Restore(o *RestoreOpts, _ *struct{}) (retErr error) 
 		return err
 	}
 	cm.restorer.checkpointedSpecs = specs
-
-	checkpointVersion := cm.restorer.metadata[VersionKey]
-	currentVersion := version.Version()
-	if checkpointVersion != currentVersion {
-		return fmt.Errorf("runsc version does not match across checkpoint restore, checkpoint: %v current: %v", checkpointVersion, currentVersion)
-	}
 	timer.Reached("restorer initialized")
 	return cm.restorer.restoreContainerInfo(cm.l, &cm.l.root)
 }


### PR DESCRIPTION
### Problem
In `runsc/boot/controller.go`, `Restore()` spawned `kernel.NewAsyncMFLoader` before checking the checkpoint version. When restoring a checkpoint from a different `runsc` build, the background loader started parsing incompatible page headers immediately, causing a panic (`makeslice: len out of range`) instead of returning a clean error.

### My fix
Move statefile reading and the version check before creating `mainMF` and starting `NewAsyncMFLoader`. Incompatible checkpoints now fail fast with a clear version error.

Fixes #14278

