### PR TITLE
checklocks: enforce atomic access contracts

### DIFF
--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -44,6 +44,16 @@ type foo struct {
 This will ensure that all accesses to bar are atomic, with the exception of
 operations on newly allocated objects (when detectable).
 
+For global variables, atomic-use checking applies only when `+checkatomic` is
+present, for example:
+
+```go
+var (
+  // +checkatomic
+  globalValue atomicbitops.Int32
+)
+```
+
 ## Lock Enforcement
 
 Individual struct members may be protected by annotations that indicate locking
@@ -195,13 +205,16 @@ by a mutex. Generally, this imposes the following requirements:
 
 For a read, one of the following must be true:
 
-1.  A lock held be held.
+1.  All guards must be held.
 1.  The access is atomic.
 
 For a write, both of the following must be true:
 
-1.  The lock must be held.
+1.  All guards must be held exclusively.
 1.  The write must be atomic.
+
+Shared RWMutex locks satisfy the lock-held read condition, but not the write
+condition.
 
 In order to annotate a relevant field, simply apply *both* annotations from
 above. For example:
@@ -217,10 +230,15 @@ type foo struct {
 
 This enforces that the preconditions above are upheld.
 
-This also applies to atomic wrapper types (for example, atomic.Int32). In the
-mixed case, lock-free access is limited to read-only atomic operations such as
-Load. Any atomic write operation (for example, Store, Swap, or Add) requires the
-lock to be held.
+This also applies to atomic wrapper types such as `atomic.Int32` and
+`atomic.Pointer[T]`. In the mixed case, lock-free access is limited to read-only
+atomic operations such as Load. Any atomic write operation (for example, Store,
+Swap, or Add) requires the lock to be held exclusively.
+
+The non-atomic `atomicbitops.RacyLoad` method follows the mixed read rule above.
+`RacyStore` and `RacyAdd` do not satisfy the atomic-write requirement, even with
+the lock held, because other readers may access the field atomically without
+locking. The exceptions for newly allocated objects still apply.
 
 ## Ignoring and Forcing
 

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -90,7 +90,7 @@ func (pc *passContext) checkTypeAlignment(pkg *types.Package, typ *types.Named) 
 	}
 }
 
-// atomicRules specify read constraints.
+// atomicRules specifies permitted access modes.
 type atomicRules int
 
 const (
@@ -98,12 +98,14 @@ const (
 	readWriteAtomic
 	readOnlyAtomic
 	mixedAtomic
+	readOnlyMixedAtomic
 )
 
 // checkAtomicCall checks for an atomic access.
 //
 // inst is the instruction analyzed, obj is used only for maybeFail.
 func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, ar atomicRules) {
+	allowNonAtomicRead := ar == mixedAtomic || ar == readOnlyMixedAtomic
 	switch x := inst.(type) {
 	case *ssa.Call:
 		if x.Common().IsInvoke() {
@@ -120,6 +122,10 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 				pc.maybeFail(inst.Pos(), "dispatch to non-static function with atomic-only field")
 			}
 			return
+		}
+		// Generic instantiation wrappers may have no package of their own.
+		if origin := fn.Origin(); origin != nil {
+			fn = origin
 		}
 		pkg := fn.Package()
 		if pkg == nil {
@@ -151,8 +157,20 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic function")
 			}
 		}
-		if !strings.HasPrefix(fn.Name(), "Load") && ar == readOnlyAtomic {
-			// We are not allowing any reads in this context.
+		if pkg.Pkg.Name() == "atomicbitops" && strings.HasPrefix(fn.Name(), "Racy") {
+			// Racy methods are non-atomic. Mixed access permits non-atomic
+			// reads under the lock, but writes must remain atomic for
+			// concurrent lock-free readers.
+			if ar != nonAtomic && (!allowNonAtomicRead || fn.Name() != "RacyLoad") {
+				if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
+					pc.maybeFail(inst.Pos(), "non-atomic operation %s on atomic-only field", fn.Name())
+				}
+			}
+			return
+		}
+		if (ar == readOnlyAtomic || ar == readOnlyMixedAtomic) &&
+			!strings.HasPrefix(fn.Name(), "Load") {
+			// We are not allowing any writes in this context.
 			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic write function, is a lock missing?")
 			}
@@ -166,7 +184,7 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 			return
 		}
 	case *ssa.UnOp:
-		if x.Op == token.MUL && ar == mixedAtomic {
+		if x.Op == token.MUL && allowNonAtomicRead {
 			// This is allowed; this is a strict reading.
 			return
 		}
@@ -257,7 +275,8 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 	var (
 		lgf         lockGuardFacts
 		guardsFound int
-		guardsHeld  = make(map[string]struct{}) // Keyed by resolved string.
+		// guardsHeld maps resolved names to exclusive (true) or shared (false).
+		guardsHeld = make(map[string]bool)
 	)
 
 	// Load the facts for the object accessed.
@@ -275,14 +294,15 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		}
 		s, ok := ls.isHeld(r, isWrite)
 		if ok {
-			guardsHeld[s] = struct{}{}
+			_, exclusive := ls.isHeld(r, true)
+			guardsHeld[s] = exclusive
 			continue
 		}
 		if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
 			// Mark this as locked, since it has been forced. All
 			// forces are treated as an exclusive lock.
 			s, _ := ls.lockField(r, true /* exclusive */)
-			guardsHeld[s] = struct{}{}
+			guardsHeld[s] = true
 			continue
 		}
 		// Note that we may allow this if the disposition is atomic,
@@ -307,6 +327,12 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 				ar = readOnlyAtomic
 			} else {
 				ar = mixedAtomic
+				for _, exclusive := range guardsHeld {
+					if !exclusive {
+						ar = readOnlyMixedAtomic
+						break
+					}
+				}
 			}
 		}
 		if refs := inst.Referrers(); refs != nil {
@@ -378,17 +404,30 @@ func (pc *passContext) checkFieldAccess(inst almostInst, structObj ssa.Value, fi
 	pc.checkGuards(inst, structObj, fieldObj, ls, isWrite)
 }
 
-// noReferrers wraps an instruction as an almostInst.
-type noReferrers struct {
+// globalAccess exposes a global's consuming instruction to atomic checks.
+type globalAccess struct {
 	ssa.Instruction
+	checkAtomic bool
 }
 
 // Referrers implements almostInst.Referrers.
-func (noReferrers) Referrers() *[]ssa.Instruction { return nil }
+func (a globalAccess) Referrers() *[]ssa.Instruction {
+	if !a.checkAtomic {
+		return nil
+	}
+	return &[]ssa.Instruction{a.Instruction}
+}
 
 // checkGlobalAccess checks the validity of a global access.
 func (pc *passContext) checkGlobalAccess(inst ssa.Instruction, g *ssa.Global, ls *lockState, isWrite bool) {
-	pc.checkGuards(noReferrers{inst}, g, g.Object(), ls, isWrite)
+	var lgf lockGuardFacts
+	pc.importLockGuardFacts(g.Object(), &lgf)
+	pc.checkGuards(globalAccess{
+		Instruction: inst,
+		// Only explicitly annotated globals opt into atomic-use checking.
+		// Direct writes are diagnosed separately by checkGuards.
+		checkAtomic: !isWrite && lgf.AtomicDisposition == atomicRequired,
+	}, g, g.Object(), ls, isWrite)
 }
 
 func (pc *passContext) checkCall(call callCommon, lff *lockFunctionFacts, ls *lockState) {
@@ -495,10 +534,10 @@ func exclusiveStr(exclusive bool) string {
 }
 
 // checkFunctionCall checks preconditions for function calls, and tracks the
-// lock state by recording relevant calls to sync functions. Note that calls to
-// atomic functions are tracked by checkFieldAccess by looking directly at the
-// referrers (because ordering doesn't matter there, so we need not scan in
-// instruction order).
+// lock state by recording relevant calls to sync functions. Atomic field
+// referrers are checked by checkFieldAccess using the lock state at the field
+// access, not at a later use of a retained field address. Direct global atomic
+// operations are checked at their consuming instructions.
 func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *lockFunctionFacts, ls *lockState) {
 	// Extract the "receiver" properly.
 	var args []ssa.Value
@@ -658,9 +697,8 @@ type callCommon interface {
 // checkInstruction checks the legality the single instruction based on the
 // current lockState.
 func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionFacts, ls *lockState) (*ssa.Return, *lockState) {
-	// Record any observed globals, and check for violations. The global
-	// value is not itself an instruction, but we check all referrers to
-	// see where they are consumed.
+	// Globals are values, not instructions. Check each use with the current
+	// instruction's lock state.
 	var stackLocal [16]*ssa.Value
 	ops := inst.Operands(stackLocal[:])
 	for _, v := range ops {
@@ -668,10 +706,11 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 			continue
 		}
 		g, ok := (*v).(*ssa.Global)
-		if !ok {
+		if !ok || lff.Ignore {
 			continue
 		}
-		_, isWrite := inst.(*ssa.Store)
+		store, ok := inst.(*ssa.Store)
+		isWrite := ok && store.Addr == g
 		pc.checkGlobalAccess(inst, g, ls, isWrite)
 	}
 

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -28,9 +28,12 @@ go_library(
         "rwmutex.go",
         "test.go",
     ],
-    # This ensures that there are no dependencies, since we want to explicitly
-    # control expected failures for analysis.
+    # Disable generated marshal/state sources so they do not add unexpected
+    # diagnostics to this fixture.
     marshal = False,
     stateify = False,
-    deps = ["//tools/checklocks/test/crosspkg"],
+    deps = [
+        "//pkg/atomicbitops",
+        "//tools/checklocks/test/crosspkg",
+    ],
 )

--- a/tools/checklocks/test/atomics.go
+++ b/tools/checklocks/test/atomics.go
@@ -17,6 +17,8 @@ package test
 import (
 	"sync"
 	"sync/atomic"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 )
 
 type atomicStruct struct {
@@ -29,6 +31,13 @@ type atomicStruct struct {
 	ignored int32
 
 	wrapper atomic.Int32 // safe without any annotations
+	bitops  atomicbitops.Int32
+
+	// +checkatomic
+	atomicBitops atomicbitops.Int32
+
+	// +checkatomic
+	pointer atomic.Pointer[int32]
 }
 
 func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -38,6 +47,8 @@ func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
 
 func testAtomicAccess(tc *atomicStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedAtomically)
+	_ = tc.pointer.Load()
+	tc.pointer.Store(nil)
 }
 
 func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
@@ -45,8 +56,13 @@ func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
 }
 
 func testNormalAccessInvalid(tc *atomicStruct, v chan int32, p chan *int32) {
-	v <- tc.accessedAtomically  // +checklocksfail
-	p <- &tc.accessedAtomically // +checklocksfail
+	v <- tc.accessedAtomically              // +checklocksfail
+	p <- &tc.accessedAtomically             // +checklocksfail
+	_ = genericLoad(&tc.accessedAtomically) // +checklocksfail=non-atomic function
+}
+
+func genericLoad[T any](p *T) T {
+	return *p
 }
 
 func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -56,7 +72,7 @@ func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
 }
 
 type atomicMixedStruct struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	// +checkatomic
 	// +checklocks:mu
@@ -65,11 +81,20 @@ type atomicMixedStruct struct {
 	// +checkatomic
 	// +checklocks:mu
 	wrapper atomic.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	bitops atomicbitops.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	pointer atomic.Pointer[int32]
 }
 
 func testAtomicMixedValidRead(tc *atomicMixedStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedMixed)
 	v <- tc.wrapper.Load()
+	_ = tc.pointer.Load()
 }
 
 func testAtomicMixedInvalidRead(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -81,7 +106,23 @@ func testAtomicMixedValidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan
 	tc.mu.Lock()
 	atomic.StoreInt32(&tc.accessedMixed, 1)
 	tc.wrapper.Store(1)
+	tc.pointer.Store(nil)
 	tc.mu.Unlock()
+}
+
+func testAtomicMixedReadLocked(tc *atomicMixedStruct) {
+	tc.mu.RLock()
+	_ = atomic.LoadInt32(&tc.accessedMixed)
+	_ = tc.accessedMixed
+	_ = tc.wrapper.Load()
+	_ = tc.bitops.RacyLoad()
+	_ = tc.pointer.Load()
+	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail=write function
+	tc.wrapper.Store(1)                     // +checklocksfail=write function
+	tc.bitops.Store(1)                      // +checklocksfail=write function
+	tc.bitops.RacyStore(1)                  // +checklocksfail=operation RacyStore
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
+	tc.mu.RUnlock()
 }
 
 func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -93,6 +134,7 @@ func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p ch
 func testAtomicMixedInvalidAtomicWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
 	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail
 	tc.wrapper.Store(1)                     // +checklocksfail
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
 }
 
 func testAtomicMixedInvalidWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -104,4 +146,34 @@ func testAtomicWrapper(tc *atomicStruct, v chan int32) {
 	v <- tc.wrapper.Load()
 	v <- tc.wrapper.Add(33)
 	tc.wrapper.Store(44)
+	v <- tc.bitops.RacyLoad()
+	v <- tc.bitops.RacyAdd(33)
+	tc.bitops.RacyStore(44)
+}
+
+func testAtomicBitops(tc *atomicStruct) {
+	_ = tc.atomicBitops.Load()
+	tc.atomicBitops.Store(1)
+	_ = tc.atomicBitops.Add(1)
+	_ = tc.atomicBitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.atomicBitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.atomicBitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+}
+
+func testAtomicMixedBitops(tc *atomicMixedStruct) {
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)       // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.Add(1)     // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+
+	tc.mu.Lock()
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)
+	_ = tc.bitops.Add(1)
+	_ = tc.bitops.RacyLoad()
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+	tc.mu.Unlock()
 }

--- a/tools/checklocks/test/closures.go
+++ b/tools/checklocks/test/closures.go
@@ -58,6 +58,7 @@ func testClosureIgnore(tc *oneGuardStruct) {
 	// Inherit the checklocksignore.
 	x := func() {
 		tc.guardedField = 1
+		atomicGlobal.RacyStore(1)
 	}
 	x()
 }

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -16,13 +16,28 @@ package test
 
 import (
 	"sync"
+	"sync/atomic"
 
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
 )
 
 var (
 	globalMu   sync.Mutex
 	globalRWMu sync.RWMutex
+
+	// +checkatomic
+	atomicGlobal = atomicbitops.FromInt32(1)
+
+	// +checkatomic
+	// +checklocks:globalRWMu
+	mixedAtomicGlobal atomicbitops.Int32
+
+	unannotatedAtomicGlobal atomicbitops.Int32
+	unannotatedRawGlobal    int32
+
+	// +checklocks:globalRWMu
+	guardedRawGlobal int32
 )
 
 var globalStruct struct {
@@ -108,4 +123,47 @@ func testCrosspkgGlobalValid() {
 
 func testCrosspkgGlobalInvalid() {
 	crosspkg.Foo = 1 // +checklocksfail
+}
+
+func testAtomicGlobal() {
+	_ = atomicGlobal.Load()
+	atomicGlobal.Store(1)
+	_ = atomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+	atomicGlobal.RacyStore(1)   // +checklocksfail=non-atomic operation
+
+	atomicGlobal = atomicbitops.FromInt32(0) // +checklocksfail=non-atomic write
+}
+
+func testMixedAtomicGlobal() {
+	_ = mixedAtomicGlobal.Load()
+	mixedAtomicGlobal.Store(1)       // +checklocksfail=atomic write function
+	_ = mixedAtomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+
+	globalRWMu.Lock()
+	mixedAtomicGlobal.Store(1)
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.RacyStore(1) // +checklocksfail=non-atomic operation
+	globalRWMu.Unlock()
+
+	globalRWMu.RLock()
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.Store(1) // +checklocksfail=atomic write function
+	globalRWMu.RUnlock()
+}
+
+func testUnannotatedGlobalAtomics(out **int32) {
+	_ = unannotatedAtomicGlobal.RacyLoad()
+	unannotatedAtomicGlobal.RacyStore(1)
+	_ = atomic.LoadInt32(&unannotatedRawGlobal)
+
+	globalRWMu.RLock()
+	_ = atomic.LoadInt32(&guardedRawGlobal)
+	*out = &guardedRawGlobal
+	globalRWMu.RUnlock()
+}
+
+// +checklocksignore
+func testAtomicGlobalIgnore() {
+	atomicGlobal.RacyStore(1)
+	atomicGlobal = atomicbitops.FromInt32(0)
 }


### PR DESCRIPTION
Recognize atomicbitops Racy methods as non-atomic operations. Permit mixed-mode RacyLoad only when all guards are held, and require atomic writes with all guards held exclusively. Distinguish shared-lock reads from lock-free atomic reads so an RLock cannot authorize writes.

Check atomic uses of annotated globals at the consuming instruction instead of discarding that instruction. Keep unannotated-global behavior unchanged, preserve function and closure ignores, and distinguish writes to a global from stores of its address.

Resolve generic instantiations to their original declarations before classifying atomic operations. This recognizes atomic.Pointer methods without bypassing package or mixed-access checks for generic calls.

Assisted-by: Codex
