### PR TITLE
checklocks: honor global declaration annotations

### DIFF
--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -84,6 +84,26 @@ lock must refer to one of:
 
 Like atomic access enforcement, checks may be elided on newly allocated objects.
 
+### Global Variable Annotations
+
+Global variables also support lock and atomic annotations. Put annotations above
+a standalone declaration or above an individual entry in a `var` block:
+
+```go
+var globalMu sync.Mutex
+
+// +checklocks:globalMu
+var first int
+
+var (
+    // +checklocks:globalMu
+    second, third int
+)
+```
+
+Annotations apply to every named variable in that declaration or block entry.
+Comments above an entire `var` block do not annotate its entries.
+
 ### Function Annotations
 
 The `+checklocks` annotation may apply to functions. For example:

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -95,7 +95,7 @@ func (pc *passContext) observationsFor(obj types.Object) *objectObservations {
 }
 
 // forAllGlobals applies the given function to all globals.
-func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
+func (pc *passContext) forAllGlobals(fn func(vs *ast.ValueSpec, decl *ast.GenDecl)) {
 	for _, f := range pc.pass.Files {
 		for _, decl := range f.Decls {
 			d, ok := decl.(*ast.GenDecl)
@@ -103,7 +103,7 @@ func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
 				continue
 			}
 			for _, gs := range d.Specs {
-				fn(gs.(*ast.ValueSpec))
+				fn(gs.(*ast.ValueSpec), d)
 			}
 		}
 	}
@@ -151,12 +151,12 @@ func run(pass *analysis.Pass) (any, error) {
 	pc.extractLineFailures()
 
 	// Find all struct declarations and export relevant facts.
-	pc.forAllGlobals(func(vs *ast.ValueSpec) {
+	pc.forAllGlobals(func(vs *ast.ValueSpec, decl *ast.GenDecl) {
 		if ss, ok := vs.Type.(*ast.StructType); ok {
 			structType := pc.pass.TypesInfo.TypeOf(vs.Type).Underlying().(*types.Struct)
 			pc.structLockGuardFacts(structType, ss)
 		}
-		pc.globalLockGuardFacts(vs)
+		pc.globalLockGuardFacts(vs, decl)
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec, decl *ast.GenDecl) {
 		if ss, ok := ts.Type.(*ast.StructType); ok {

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -856,10 +856,20 @@ func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.St
 // globalLockGuardFacts finds all relevant guard information for globals.
 //
 // Note that the Type is checked in checklocks.go at the top-level.
-func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec) {
-	var lgf lockGuardFacts
-	globalObj := pc.pass.TypesInfo.ObjectOf(vs.Names[0])
-	pc.fillLockGuardFacts(globalObj, vs.Doc, pc.findGlobalFieldGuard, &lgf)
+func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec, decl *ast.GenDecl) {
+	cg := vs.Doc
+	if !decl.Lparen.IsValid() {
+		// Standalone declarations attach their comments to the GenDecl.
+		cg = decl.Doc
+	}
+	for _, name := range vs.Names {
+		if name.Name == "_" {
+			continue
+		}
+		var lgf lockGuardFacts
+		globalObj := pc.pass.TypesInfo.ObjectOf(name)
+		pc.fillLockGuardFacts(globalObj, cg, pc.findGlobalFieldGuard, &lgf)
+	}
 }
 
 // countFields gives an accurate field count, according for unnamed arguments

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -25,6 +25,11 @@ var (
 	FooMu sync.Mutex
 )
 
+// StandaloneFoo is a guarded global declared outside a var block.
+//
+// +checklocks:FooMu
+var StandaloneFoo int
+
 // GenericGuard is a generic type with a guarded field. This is used to verify
 // that facts exported by this package are correctly imported when another
 // package instantiates GenericGuard[T].

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -25,6 +25,24 @@ var (
 	globalRWMu sync.RWMutex
 )
 
+// +checklocks:globalMu
+var standaloneGlobal int
+
+// +checkatomic
+var standaloneAtomicGlobal int32
+
+var (
+	// +checklocks:globalMu
+	firstGlobal, _, secondGlobal int
+)
+
+// A var block's header does not annotate its entries, even with one spec.
+//
+// +checklocks:globalMu
+var (
+	blockHeaderGlobal int
+)
+
 var globalStruct struct {
 	mu sync.Mutex
 	// +checklocks:mu
@@ -41,7 +59,12 @@ var otherStruct struct {
 }
 
 func testGlobalValid() {
+	blockHeaderGlobal = 1
+
 	globalMu.Lock()
+	standaloneGlobal = 1
+	firstGlobal = 1
+	secondGlobal = 1
 	otherStruct.guardedField1 = 1
 	globalMu.Unlock()
 
@@ -94,6 +117,10 @@ func testGlobalExcludeInvalid() {
 }
 
 func testGlobalInvalid() {
+	standaloneGlobal = 1          // +checklocksfail
+	firstGlobal = 1               // +checklocksfail
+	secondGlobal = 1              // +checklocksfail
+	standaloneAtomicGlobal = 1    // +checklocksfail=non-atomic write
 	globalStruct.guardedField = 1 // +checklocksfail
 	otherStruct.guardedField1 = 1 // +checklocksfail
 	otherStruct.guardedField2 = 1 // +checklocksfail
@@ -103,9 +130,11 @@ func testGlobalInvalid() {
 func testCrosspkgGlobalValid() {
 	crosspkg.FooMu.Lock()
 	crosspkg.Foo = 1
+	crosspkg.StandaloneFoo = 1
 	crosspkg.FooMu.Unlock()
 }
 
 func testCrosspkgGlobalInvalid() {
-	crosspkg.Foo = 1 // +checklocksfail
+	crosspkg.Foo = 1           // +checklocksfail
+	crosspkg.StandaloneFoo = 1 // +checklocksfail
 }


### PR DESCRIPTION
The Go parser places standalone variable documentation on GenDecl, while checklocks only reads ValueSpec.Doc. As a result, standalone global lock and atomic annotations are silently ignored. A multi-name declaration also exports facts only for its first variable.

Keep the enclosing declaration when collecting global facts. Read its documentation for standalone declarations and retain per-entry documentation for var blocks. Export fresh facts for each named variable, skipping blank identifiers.

Extend the existing local and cross-package fixtures to cover these forms, atomic direct writes, and var-block comment boundaries.

Assisted-by: Codex
