### PR TITLE
checklocks: analyze generated and tagged code

### DIFF
--- a/pkg/sync/locking/generic_mutex.go
+++ b/pkg/sync/locking/generic_mutex.go
@@ -44,28 +44,28 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *Mutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // Unlock unlocks m.
 // +checklocksignore
 func (m *Mutex) Unlock() {
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Unlock()
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedUnlock(i lockNameIndex) {
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Unlock()
 }
 

--- a/pkg/sync/locking/generic_rwmutex.go
+++ b/pkg/sync/locking/generic_rwmutex.go
@@ -42,14 +42,14 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *RWMutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
@@ -57,20 +57,20 @@ func (m *RWMutex) NestedLock(i lockNameIndex) {
 // +checklocksignore
 func (m *RWMutex) Unlock() {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedUnlock(i lockNameIndex) {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 }
 
 // RLock locks m for reading.
 // +checklocksignore
 func (m *RWMutex) RLock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.RLock()
 }
 
@@ -78,7 +78,7 @@ func (m *RWMutex) RLock() {
 // +checklocksignore
 func (m *RWMutex) RUnlock() {
 	m.mu.RUnlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // RLockBypass locks m for reading without executing the validator.

--- a/pkg/sync/locking/locking.go
+++ b/pkg/sync/locking/locking.go
@@ -25,4 +25,8 @@
 // taken before the target one. For each goroutine, we have the list of
 // currently locked mutexes. And finally, all lock methods check that
 // ancestors of currently locked mutexes don't contain the target one.
+//
+// Lockdep bookkeeping may allocate maps and stack traces. Generated mutexes
+// exempt only calls to this optional instrumentation from checkescape contracts;
+// the underlying mutex operations and their callers remain checked.
 package locking

--- a/tools/bazeldefs/go.bzl
+++ b/tools/bazeldefs/go.bzl
@@ -3,7 +3,7 @@
 load("@bazel_gazelle//:def.bzl", _gazelle = "gazelle")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@io_bazel_rules_go//go:def.bzl", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "GoArchive", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", _go_grpc_library = "go_grpc_library", _go_proto_library = "go_proto_library")
 load("//tools/bazeldefs:defs.bzl", "select_arch", "select_system")
 
@@ -88,6 +88,10 @@ def go_importpath(target):
     """Returns the importpath for the target."""
     return target[GoLibrary].importpath
 
+def go_binary_archive(target):
+    """Returns compiled Go archive metadata for a binary target."""
+    return target[GoArchive].data
+
 def go_library(name, bazel_cgo = False, bazel_cdeps = [], bazel_clinkopts = [], bazel_copts = [], **kwargs):
     """Wrapper for `go_library` rule.
 
@@ -159,13 +163,14 @@ def go_embed_libraries(target):
         return target.attr.embed
     return []
 
-def go_context(ctx, goos = None, goarch = None):
+def go_context(ctx, goos = None, goarch = None, attr = None):
     """Extracts a standard Go context struct.
 
     Args:
       ctx: the starlark context (required).
       goos: the GOOS value.
       goarch: the GOARCH value.
+      attr: the analyzed rule's attributes for aspect callers.
 
     Returns:
       A context Go struct with pointers to Go toolchain components.
@@ -174,7 +179,7 @@ def go_context(ctx, goos = None, goarch = None):
     # We don't change anything for the standard library analysis. All Go files
     # are available in all instances. Note that this includes the standard
     # library sources, which are analyzed by nogo.
-    go_ctx = _go_context(ctx)
+    go_ctx = _go_context(ctx, attr = attr)
 
     nogo_args = []
     if go_ctx.mode.race:

--- a/tools/checkescape/test3/BUILD
+++ b/tools/checkescape/test3/BUILD
@@ -1,0 +1,17 @@
+load("//tools:defs.bzl", "go_binary")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_binary(
+    name = "test3",
+    srcs = [
+        "main.go",
+        "tagged.go",
+    ],
+    gotags = ["checkescape_binary"],
+    pure = True,
+    testonly = True,
+)

--- a/tools/checkescape/test3/main.go
+++ b/tools/checkescape/test3/main.go
@@ -1,0 +1,21 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Binary test3 checks build-tag and archive selection for nogo.
+package main
+
+func main() {
+	// Analysis must use the binary's build tags to resolve this constant.
+	_ = taggedValue
+}

--- a/tools/checkescape/test3/tagged.go
+++ b/tools/checkescape/test3/tagged.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build checkescape_binary
+
+package main
+
+const taggedValue = true
+
+// unusedAllocation remains in the Go archive but is removed by the linker.
+// The stack check rejects checkescape's conservative fallback if objdump fails.
+//
+// +mustescape:local,heap
+// +checkescape:stack
+//
+//go:noinline
+//go:nosplit
+func unusedAllocation() *int {
+	return new(int)
+}

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -90,22 +90,11 @@ def go_binary(name, nogo = True, pure = False, static = False, x_defs = None, **
         **kwargs
     )
     if nogo:
-        # Note that the nogo rule applies only for go_library and go_test
-        # targets, therefore we construct a library from the binary sources.
-        # This is done because the binary may not be in a form that objdump
-        # supports (i.e. a pure Go binary).
-        _go_library(
-            name = name + "_nogo_library",
-            srcs = kwargs.get("srcs", []),
-            deps = kwargs.get("deps", []),
-            embedsrcs = kwargs.get("embedsrcs", []),
-            testonly = 1,
-        )
         nogo_test(
             name = name + "_nogo",
             config = "//:nogo_config",
             srcs = kwargs.get("srcs", []),
-            deps = [":" + name + "_nogo_library"],
+            deps = [":" + name],
             tags = ["nogo"],
         )
 

--- a/tools/go_generics/go_merge/main.go
+++ b/tools/go_generics/go_merge/main.go
@@ -21,9 +21,12 @@ import (
 	"go/ast"
 	"go/format"
 	"go/parser"
+	"go/printer"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 
 	"gvisor.dev/gvisor/tools/constraintutil"
@@ -52,13 +55,17 @@ func main() {
 
 	// Load all files.
 	files := make(map[string]*ast.File)
+	comments := make(ast.CommentMap)
 	fset := token.NewFileSet()
 	var name string
-	for _, fname := range flag.Args() {
+	// Match MergePackageFiles' declaration order when assigning token positions.
+	srcs := slices.Sorted(slices.Values(flag.Args()))
+	for _, fname := range srcs {
 		f, err := parser.ParseFile(fset, fname, nil, parser.ParseComments|parser.DeclarationErrors|parser.SpuriousErrors)
 		if err != nil {
 			fatalf("%v\n", err)
 		}
+		maps.Copy(comments, ast.NewCommentMap(fset, f, f.Comments))
 
 		files[fname] = f
 		if name == "" {
@@ -75,13 +82,13 @@ func main() {
 	}
 	f := ast.MergePackageFiles(pkg, ast.FilterUnassociatedComments|ast.FilterFuncDuplicates|ast.FilterImportDuplicates)
 
-	// Create a new declaration slice with all imports at the top, merging any
-	// redundant imports.
+	// Put imports first and remove redundant specs. Keep the original import
+	// declarations so their comments retain valid positions within each file.
 	imports := make(map[string]*ast.ImportSpec)
-	var importNames []string // Keep imports in the original order to get deterministic output.
-	var anonImports []*ast.ImportSpec
+	newDecls := make([]ast.Decl, 0, len(f.Decls))
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); ok && g.Tok == token.IMPORT {
+			specs := g.Specs[:0]
 			for _, s := range g.Specs {
 				i := s.(*ast.ImportSpec)
 				p, _ := strconv.Unquote(i.Path.Value)
@@ -92,7 +99,7 @@ func main() {
 					n = i.Name.Name
 				}
 				if n == "_" {
-					anonImports = append(anonImports, i)
+					specs = append(specs, i)
 				} else {
 					if i2, ok := imports[n]; ok {
 						if first, second := i.Path.Value, i2.Path.Value; first != second {
@@ -100,28 +107,15 @@ func main() {
 						}
 					} else {
 						imports[n] = i
-						importNames = append(importNames, n)
+						specs = append(specs, i)
 					}
 				}
 			}
+			if len(specs) > 0 {
+				g.Specs = specs
+				newDecls = append(newDecls, g)
+			}
 		}
-	}
-	newDecls := make([]ast.Decl, 0, len(f.Decls))
-	if l := len(imports) + len(anonImports); l > 0 {
-		// Non-NoPos Lparen is needed for Go to recognize more than one spec in
-		// ast.GenDecl.Specs.
-		d := &ast.GenDecl{
-			Tok:    token.IMPORT,
-			Lparen: token.NoPos + 1,
-			Specs:  make([]ast.Spec, 0, l),
-		}
-		for _, i := range importNames {
-			d.Specs = append(d.Specs, imports[i])
-		}
-		for _, i := range anonImports {
-			d.Specs = append(d.Specs, i)
-		}
-		newDecls = append(newDecls, d)
 	}
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); !ok || g.Tok != token.IMPORT {
@@ -136,10 +130,24 @@ func main() {
 		fatalf("Failed to read build constraints: %v\n", err)
 	}
 
-	// Write the output file.
+	// Print each declaration with only its own comments. Imports moved from
+	// later files must not pull earlier declarations' inline annotations forward.
+	// Template instances omit package documentation; build constraints are
+	// reconstructed separately below.
 	var buf bytes.Buffer
-	if err := format.Node(&buf, fset, f); err != nil {
-		fatalf("formatting: %v\n", err)
+	_, _ = fmt.Fprintf(&buf, "package %s\n\n", name)
+	for _, decl := range f.Decls {
+		if err := format.Node(&buf, fset, &printer.CommentedNode{
+			Node:     decl,
+			Comments: comments.Filter(decl).Comments(),
+		}); err != nil {
+			fatalf("formatting: %v\n", err)
+		}
+		_, _ = buf.WriteString("\n\n")
+	}
+	source, err := format.Source(buf.Bytes())
+	if err != nil {
+		fatalf("formatting merged source: %v\n", err)
 	}
 	outf, err := os.OpenFile(*output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -147,7 +155,7 @@ func main() {
 	}
 	defer outf.Close()
 	outf.WriteString(constraintutil.Lines(bcexpr))
-	if _, err := outf.Write(buf.Bytes()); err != nil {
+	if _, err := outf.Write(source); err != nil {
 		fatalf("write: %v\n", err)
 	}
 }

--- a/tools/go_generics/tests/simple/BUILD
+++ b/tools/go_generics/tests/simple/BUILD
@@ -4,7 +4,11 @@ package(default_applicable_licenses = ["//:license"])
 
 go_generics_test(
     name = "simple",
-    inputs = ["input.go"],
+    # Reverse source order to exercise comment positions across merged files.
+    inputs = [
+        "second.go",
+        "input.go",
+    ],
     output = "output.go",
     suffix = "New",
     types = {
@@ -16,4 +20,5 @@ go_generics_test(
 glaze_ignore = [
     "input.go",
     "output.go",
+    "second.go",
 ]

--- a/tools/go_generics/tests/simple/input.go
+++ b/tools/go_generics/tests/simple/input.go
@@ -14,6 +14,8 @@
 
 package tests
 
+import _ "os" // Earlier blank import.
+
 type T int
 
 var global T
@@ -27,6 +29,7 @@ func g(a T, b int) {
 
 	d := (*T)(nil)
 	_ = d
+	_ = new(T) // escapes: test annotation.
 }
 
 type R struct {

--- a/tools/go_generics/tests/simple/output.go
+++ b/tools/go_generics/tests/simple/output.go
@@ -14,6 +14,10 @@
 
 package main
 
+import _ "os" // Earlier blank import.
+
+import "fmt" // Later named import.
+
 var globalNew Q
 
 func fNew(_ Q, a int) {
@@ -25,6 +29,7 @@ func gNew(a Q, b int) {
 
 	d := (*Q)(nil)
 	_ = d
+	_ = new(Q) // escapes: test annotation.
 }
 
 type RNew struct {
@@ -41,3 +46,7 @@ const (
 )
 
 type YNew Q
+
+func hNew(a Q) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
+}

--- a/tools/go_generics/tests/simple/second.go
+++ b/tools/go_generics/tests/simple/second.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tests
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
+import "fmt" // Later named import.
 
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+func h(a T) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
 }

--- a/tools/nogo/defs.bzl
+++ b/tools/nogo/defs.bzl
@@ -1,7 +1,7 @@
 """Nogo rules."""
 
 load("//tools:arch.bzl", "arch_transition")
-load("//tools/bazeldefs:go.bzl", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
+load("//tools/bazeldefs:go.bzl", "go_binary_archive", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
 
 NogoConfigInfo = provider(
     "information about a nogo configuration",
@@ -161,14 +161,14 @@ def _select_objfile(files):
         a_files = x_files
     return a_files[0], x_files[0]
 
-def _nogo_config(ctx, deps):
+def _nogo_config(ctx, deps, attr = None):
     # Build a configuration for the given set of deps. This is most basic
     # configuration and is used by the stdlib. For a more complete config, the
     # _nogo_package_config function may be used.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
     nogo_target_info = ctx.attr._target[NogoTargetInfo]
-    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch)
+    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch, attr = attr)
     args = go_ctx.nogo_args + [
         "-go=%s" % go_ctx.go.path,
         "-GOOS=%s" % go_ctx.goos,
@@ -210,23 +210,17 @@ def _nogo_config(ctx, deps):
 
     return (go_ctx, args, inputs, raw_findings)
 
-def _nogo_package_config(ctx, deps, importpath = None, target = None):
+def _nogo_package_config(ctx, deps, importpath = None, objfiles = (None, None), attr = None):
     # See _nogo_config. This includes package details.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
-    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps)
+    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps, attr = attr)
 
     # GOVERSION of packages are set by the project language version.
     args.append("-GOVERSION=%s" % go_ctx.lang_version)
 
-    # Add the module itself, for the type sanity check. This applies only to
-    # the libraries, and not binaries or tests.
-    binaries = []
-    if target != None:
-        binaries.extend(target.files.to_list())
-        if hasattr(target.output_groups, "compilation_outputs"):
-            binaries.extend(target.output_groups.compilation_outputs.to_list())
-    target_afile, target_xfile = _select_objfile(binaries)
+    # Add the compiled package itself for analyzers that inspect object code.
+    target_afile, target_xfile = objfiles
     if target_xfile != None:
         args.append("-archive=%s=%s" % (importpath, target_afile.path))
         args.append("-import=%s=%s" % (importpath, target_xfile.path))
@@ -263,7 +257,8 @@ def _nogo_aspect_impl(target, ctx):
     # since there is guaranteed to be no conflict. However for consistency,
     # we should not introduce new go_tool_library dependencies unless strictly
     # necessary.
-    if ctx.rule.kind in ("go_library", "go_tool_library", "go_binary", "go_test"):
+    is_binary = ctx.rule.kind in ("go_binary", "go_non_executable_binary")
+    if is_binary or ctx.rule.kind in ("go_library", "go_tool_library", "go_test"):
         srcs = ctx.rule.files.srcs
         deps = ctx.rule.attr.deps
     elif ctx.rule.kind in ("go_proto_library", "go_wrap_cc"):
@@ -287,14 +282,24 @@ def _nogo_aspect_impl(target, ctx):
         if hasattr(info, "deps"):
             deps = deps + info.deps
 
-    # Extract the importpath for this package.
-    if ctx.rule.kind == "go_test":
-        importpath = "test"
+    # Binary analysis needs the compiled Go archive, not the linked executable:
+    # the linker can remove functions that checkescape still needs to inspect.
+    if is_binary:
+        archive = go_binary_archive(target)
+        importpath = archive.importpath
+        objfiles = (archive.file, archive.export_file)
+        binaries = list(objfiles)
     else:
-        importpath = go_importpath(target)
+        importpath = "test" if ctx.rule.kind == "go_test" else go_importpath(target)
+        binaries = target.files.to_list()
+        compilation_outputs = binaries
+        if hasattr(target.output_groups, "compilation_outputs"):
+            compilation_outputs = compilation_outputs + target.output_groups.compilation_outputs.to_list()
+        objfiles = _select_objfile(compilation_outputs)
 
-    # Build a complete configuration, referring to the library rule.
-    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, target = target)
+    # Use the analyzed rule's transitioned Go configuration, including its build
+    # tags, rather than the aspect's own attributes.
+    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, objfiles = objfiles, attr = ctx.rule.attr)
 
     # Build the argument file, and the runner.
     facts_file = ctx.actions.declare_file(ctx.label.name + ".facts")
@@ -324,7 +329,7 @@ def _nogo_aspect_impl(target, ctx):
             facts = facts_file,
             raw_findings = raw_findings + [findings_file],
             importpath = importpath,
-            binaries = target.files.to_list(),
+            binaries = binaries,
             srcs = srcs,
             deps = deps,
         ),
@@ -463,9 +468,8 @@ nogo_aspect_tricorder = aspect(
 def _nogo_facts_render_impl(ctx):
     """Extract nogo facts."""
 
-    # Build a complete configuration. Note that we don't care about the import
-    # path, since this will generate facts only. We use ctx as the target here,
-    # since this will refer to ctx.files (which contains no binaries).
+    # Rendering dependency facts needs neither an import path nor an archive
+    # for the package containing the template.
     go_ctx, args, inputs, _ = _nogo_package_config(ctx, ctx.attr.deps)
 
     # Build the runner.


### PR DESCRIPTION
Generated and configured source can currently lose analyzer coverage: template merging discards inline annotations, while nogo reads ambient build tags and recreates binaries as libraries instead of analyzing the compiler's actual configuration.

Preserve comments on surviving template nodes and original import declarations, then analyze each target through its transitioned Go context and compiled archive. Keep internal test-package archives separate from generated test mains. Extend the existing fixtures for inline annotations, import/source ordering, and tagged binary functions.

Correctly analyzing lockdep builds exposes validator map and stack-trace allocations below recursive checkescape contracts. The middle commit deliberately excludes optional AddGLock and DelGLock bookkeeping from those contracts while retaining checks on underlying mutex operations and application allocations. This is a proposed analysis-policy boundary requiring explicit maintainer review, not a claim that lockdep execution is allocation-free.

Assisted-by: Codex
