### PR TITLE
checklocks: propagate async loader startup errors

### DIFF
--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -443,6 +443,7 @@ go_test(
     name = "kernel_test",
     size = "small",
     srcs = [
+        "async_loader_test.go",
         "fd_table_test.go",
         "table_test.go",
         "task_test.go",
@@ -460,6 +461,7 @@ go_test(
         "//pkg/sentry/kernel/sched",
         "//pkg/sentry/limits",
         "//pkg/sentry/pgalloc",
+        "//pkg/sentry/state/stateio",
         "//pkg/sentry/time",
         "//pkg/sentry/usage",
         "//pkg/sentry/vfs",

--- a/pkg/sentry/kernel/async_loader_test.go
+++ b/pkg/sentry/kernel/async_loader_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"testing/synctest"
+
+	"gvisor.dev/gvisor/pkg/sentry/state/stateio"
+)
+
+func TestAsyncMFLoaderStartupError(t *testing.T) {
+	// The bubble detects a missing mainMFStartWg completion as a deadlock,
+	// without a timeout. This test does not depend on virtual time.
+	synctest.Test(t, func(t *testing.T) {
+		// A sub-page read limit fails before metadata or mainMF is loaded.
+		pages := stateio.NewIOReader(bytes.NewReader(nil), 1, 1, 1)
+		metadata := io.NopCloser(bytes.NewReader(nil))
+		loader := NewAsyncMFLoader(metadata, pages, nil, nil)
+
+		const want = "stateio.AsyncReader.MaxReadBytes() (1) must be at least one page)"
+		startErr := loader.WaitMainMFStart()
+		if startErr == nil || startErr.Error() != want {
+			t.Fatalf("WaitMainMFStart() = %v, want %q", startErr, want)
+		}
+		if err := loader.WaitMetadata(); err != startErr {
+			t.Errorf("WaitMetadata() = %v, want %v", err, startErr)
+		}
+		if err := loader.Wait(); err != startErr {
+			t.Errorf("Wait() = %v, want %v", err, startErr)
+		}
+	})
+}

--- a/pkg/sentry/kernel/kernel_restore.go
+++ b/pkg/sentry/kernel/kernel_restore.go
@@ -262,6 +262,10 @@ type AsyncMFLoader struct {
 	// MemoryFiles, once they are known. This channel is written to exactly once.
 	privateMFsChan chan map[checkpoint.ResourceID]*pgalloc.MemoryFile
 
+	// Error fields are published by WaitGroup completion rather than a mutex:
+	// mainMFStartWg publishes mainMetadataErr, metadataWg publishes metadataErr,
+	// and loadWg publishes loadErr. Readers wait for the corresponding group.
+	// checklocks cannot express these completion-based publication boundaries.
 	mainMFStartWg   sync.WaitGroup
 	mainMetadataErr error
 
@@ -306,6 +310,9 @@ func (mfl *AsyncMFLoader) backgroundGoroutine(pagesMetadata io.ReadCloser, pages
 	}, timeline) // transfers ownership of pagesFile
 	if err != nil {
 		mfl.loadWg.Done()
+		mfl.mainMetadataErr = err
+		mfl.metadataErr = err
+		mfl.mainMFStartWg.Done()
 		log.Warningf("Failed to start async page loading: %v", err)
 		return
 	}


### PR DESCRIPTION
When pgalloc rejects an asynchronous pages reader during startup, AsyncMFLoader leaves its main-start wait group pending and does not record the error. WaitMainMFStart blocks indefinitely, while WaitMetadata and Wait can report success. This error path was introduced in dd4881af83ed.

Publish the startup error to both metadata phases and complete the main-start wait group. Keep the existing callback-count compensation and transferred reader cleanup. A synctest regression uses a sub-page reader limit to check completion and error propagation through all three wait methods without a wall-clock timeout.

Assisted-by: Codex
