### PR TITLE
checklocks: enforce user namespace lock ownership

### DIFF
--- a/pkg/sentry/kernel/auth/id_map.go
+++ b/pkg/sentry/kernel/auth/id_map.go
@@ -25,7 +25,9 @@ func (ns *UserNamespace) MapFromKUID(kuid KUID) UID {
 	if ns.parent == nil {
 		return UID(kuid)
 	}
-	return UID(ns.mapID(&ns.uidMapFromParent, uint32(ns.parent.MapFromKUID(kuid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.uidMapFromParent // +checklocksignore
+	return UID(ns.mapID(m, uint32(ns.parent.MapFromKUID(kuid))))
 }
 
 // MapFromKGID translates kgid, a GID in the root namespace, to a GID in ns.
@@ -33,7 +35,9 @@ func (ns *UserNamespace) MapFromKGID(kgid KGID) GID {
 	if ns.parent == nil {
 		return GID(kgid)
 	}
-	return GID(ns.mapID(&ns.gidMapFromParent, uint32(ns.parent.MapFromKGID(kgid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.gidMapFromParent // +checklocksignore
+	return GID(ns.mapID(m, uint32(ns.parent.MapFromKGID(kgid))))
 }
 
 // MapToKUID translates uid, a UID in ns, to a UID in the root namespace.
@@ -41,7 +45,9 @@ func (ns *UserNamespace) MapToKUID(uid UID) KUID {
 	if ns.parent == nil {
 		return KUID(uid)
 	}
-	return ns.parent.MapToKUID(UID(ns.mapID(&ns.uidMapToParent, uint32(uid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.uidMapToParent // +checklocksignore
+	return ns.parent.MapToKUID(UID(ns.mapID(m, uint32(uid))))
 }
 
 // MapToKGID translates gid, a GID in ns, to a GID in the root namespace.
@@ -49,9 +55,16 @@ func (ns *UserNamespace) MapToKGID(gid GID) KGID {
 	if ns.parent == nil {
 		return KGID(gid)
 	}
-	return ns.parent.MapToKGID(GID(ns.mapID(&ns.gidMapToParent, uint32(gid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.gidMapToParent // +checklocksignore
+	return ns.parent.MapToKGID(GID(ns.mapID(m, uint32(gid))))
 }
 
+// mapID translates id through m, which must be one of ns's ID maps.
+//
+// checklocks cannot express this owner relationship for a map argument.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) mapID(m *idMapSet, id uint32) uint32 {
 	if id == NoID {
 		return NoID
@@ -67,7 +80,10 @@ func (ns *UserNamespace) mapID(m *idMapSet, id uint32) uint32 {
 // allIDsMapped returns true if all IDs in the range [start, end) are mapped in
 // m.
 //
-// Preconditions: end >= start.
+// Preconditions: end >= start. m is one of ns's ID maps; checklocks cannot
+// express this owner relationship for a map argument.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) allIDsMapped(m *idMapSet, start, end uint32) bool {
 	ns.mu.NestedLock(userNamespaceLockNs)
 	defer ns.mu.NestedUnlock(userNamespaceLockNs)
@@ -192,6 +208,10 @@ func (ns *UserNamespace) verifyRootUserMapping(c *Credentials, entries []IDMapEn
 	return c.HasCapabilityIn(linux.CAP_SETFCAP, ns.parent)
 }
 
+// trySetUIDMap installs the UID mappings. On error, it may leave partial
+// mappings that the caller must remove before releasing ns.mu.
+//
+// +checklocks:ns.mu
 func (ns *UserNamespace) trySetUIDMap(entries []IDMapEntry) error {
 	for _, e := range entries {
 		// Determine upper bounds and check for overflow. This implicitly
@@ -209,7 +229,10 @@ func (ns *UserNamespace) trySetUIDMap(entries []IDMapEntry) error {
 		// Only the root namespace has a nil parent, and root is assigned
 		// mappings when it's created, so SetUIDMap would have returned EPERM
 		// without reaching this point if ns is root.
-		if !ns.parent.allIDsMapped(&ns.parent.uidMapToParent, e.FirstParentID, lastParentID) {
+		//
+		// allIDsMapped locks the parent; checklocks checks the address first.
+		m := &ns.parent.uidMapToParent // +checklocksignore
+		if !ns.parent.allIDsMapped(m, e.FirstParentID, lastParentID) {
 			return linuxerr.EPERM
 		}
 		// If either of these Adds fail, we have an overlapping range.
@@ -264,6 +287,10 @@ func (ns *UserNamespace) SetGIDMap(ctx context.Context, entries []IDMapEntry) er
 	return nil
 }
 
+// trySetGIDMap installs the GID mappings. On error, it may leave partial
+// mappings that the caller must remove before releasing ns.mu.
+//
+// +checklocks:ns.mu
 func (ns *UserNamespace) trySetGIDMap(entries []IDMapEntry) error {
 	for _, e := range entries {
 		lastID := e.FirstID + e.Length
@@ -274,7 +301,9 @@ func (ns *UserNamespace) trySetGIDMap(entries []IDMapEntry) error {
 		if lastParentID <= e.FirstParentID {
 			return linuxerr.EINVAL
 		}
-		if !ns.parent.allIDsMapped(&ns.parent.gidMapToParent, e.FirstParentID, lastParentID) {
+		// allIDsMapped locks the parent; checklocks checks the address first.
+		m := &ns.parent.gidMapToParent // +checklocksignore
+		if !ns.parent.allIDsMapped(m, e.FirstParentID, lastParentID) {
 			return linuxerr.EPERM
 		}
 		if !ns.gidMapFromParent.TryInsertRange(idMapRange{e.FirstParentID, lastParentID}, e.FirstID).Ok() {
@@ -290,15 +319,24 @@ func (ns *UserNamespace) trySetGIDMap(entries []IDMapEntry) error {
 // UIDMap returns the user ID mappings configured for ns. If no mappings
 // have been configured, UIDMap returns nil.
 func (ns *UserNamespace) UIDMap() []IDMapEntry {
-	return ns.getIDMap(&ns.uidMapToParent)
+	// getIDMap locks ns.mu; checklocks checks the map address before the call.
+	m := &ns.uidMapToParent // +checklocksignore
+	return ns.getIDMap(m)
 }
 
 // GIDMap returns the group ID mappings configured for ns. If no mappings
 // have been configured, GIDMap returns nil.
 func (ns *UserNamespace) GIDMap() []IDMapEntry {
-	return ns.getIDMap(&ns.gidMapToParent)
+	// getIDMap locks ns.mu; checklocks checks the map address before the call.
+	m := &ns.gidMapToParent // +checklocksignore
+	return ns.getIDMap(m)
 }
 
+// getIDMap copies the entries in m, which must be one of ns's ID maps.
+//
+// checklocks cannot express this owner relationship for a map argument.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) getIDMap(m *idMapSet) []IDMapEntry {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()

--- a/pkg/sentry/kernel/auth/key.go
+++ b/pkg/sentry/kernel/auth/key.go
@@ -292,6 +292,8 @@ type KeySet struct {
 	// keys maps key IDs to the underlying Key struct.
 	// It is initially nil to save on heap space.
 	// It is only initialized when doing mutable transactions on it using `Do`.
+	//
+	// +checklocks:mu
 	keys map[KeySerial]*Key
 }
 
@@ -310,9 +312,9 @@ func (s *KeySet) Do(fn func(*LockedKeySet) error) error {
 	defer s.txnMu.Unlock()
 	ls := &LockedKeySet{s}
 	ls.mu.Lock()
-	if s.keys == nil {
+	if ls.keys == nil {
 		// Initialize the map from its zero value, if it hasn't been done yet.
-		s.keys = make(map[KeySerial]*Key)
+		ls.keys = make(map[KeySerial]*Key)
 	}
 	ls.mu.Unlock()
 	return fn(ls)

--- a/pkg/sentry/kernel/auth/user_namespace.go
+++ b/pkg/sentry/kernel/auth/user_namespace.go
@@ -39,7 +39,7 @@ type UserNamespace struct {
 	// Keys is the set of keys in this namespace.
 	Keys KeySet
 
-	// mu protects the following fields.
+	// mu protects the ID maps, setgroupsAllowed, and inode.
 	//
 	// If mu will be locked in multiple UserNamespaces, it must be locked in
 	// descendant namespaces before ancestors.
@@ -49,13 +49,21 @@ type UserNamespace struct {
 	//
 	// All ID maps, once set, cannot be changed. This means that successful
 	// UID/GID translations cannot be racy.
+	//
+	// +checklocks:mu
 	uidMapFromParent idMapSet
-	uidMapToParent   idMapSet
-	gidMapFromParent idMapSet
-	gidMapToParent   idMapSet
 
-	// parentHadSetfcap is true if the parent namespace had the CAP_SETFCAP
-	// capability when this namespace was created. Similar to
+	// +checklocks:mu
+	uidMapToParent idMapSet
+
+	// +checklocks:mu
+	gidMapFromParent idMapSet
+
+	// +checklocks:mu
+	gidMapToParent idMapSet
+
+	// parentHadSetfcap is true if the creator had CAP_SETFCAP in the parent
+	// namespace when this namespace was created. It is immutable, like
 	// user_namespace.parent_could_setfcap in Linux.
 	parentHadSetfcap bool
 
@@ -64,6 +72,8 @@ type UserNamespace struct {
 
 	// inode is the nsfs inode associated with this namespace. This is stored as
 	// refs.TryRefCounter instead of *nsfs.Inode because nsfs imports auth.
+	//
+	// +checklocks:mu
 	inode refs.TryRefCounter
 }
 


### PR DESCRIPTION
Enforce the existing mutexes for user namespace inode references, setgroups permission, and key registries. Initialize the key map through the locked transaction view instead of the untracked outer receiver.

Declare the namespace lock required by UID/GID map installation helpers, whose callers retain it through rollback. Distinguish the immutable creation-time capability snapshot from mutable namespace state.

Assisted-by: Codex
