### PR TITLE
checklocks: guard cgroup controller state

### DIFF
--- a/pkg/sentry/fsimpl/cgroup2fs/cpuset.go
+++ b/pkg/sentry/fsimpl/cgroup2fs/cpuset.go
@@ -31,13 +31,18 @@ import (
 
 // +stateify savable
 type cpuset struct {
-	c        *cgroup
-	parent   *cpuset
+	c      *cgroup
+	parent *cpuset
+
+	// +checkatomic
 	detached atomicbitops.Bool
 
 	mu sync.Mutex `state:"nosave"`
 
+	// +checklocks:mu
 	cpus *bitmap.Bitmap
+
+	// +checklocks:mu
 	mems *bitmap.Bitmap
 }
 

--- a/pkg/sentry/fsimpl/cgroupfs/cpuset.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cpuset.go
@@ -42,7 +42,10 @@ type cpusetController struct {
 
 	mu sync.Mutex `state:"nosave"`
 
+	// +checklocks:mu
 	cpus *bitmap.Bitmap
+
+	// +checklocks:mu
 	mems *bitmap.Bitmap
 }
 

--- a/pkg/sentry/fsimpl/cgroupfs/devices.go
+++ b/pkg/sentry/fsimpl/cgroupfs/devices.go
@@ -132,12 +132,15 @@ type devicesController struct {
 	controllerStateless
 	controllerNoResource
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// Allow or deny the device rules below.
+	//
+	// +checklocks:mu
 	defaultAllow bool
-	deviceRules  map[deviceID]permission
+
+	// +checklocks:mu
+	deviceRules map[deviceID]permission
 }
 
 // +stateify savable
@@ -182,12 +185,14 @@ func (d *controlledDevicesData) Generate(ctx context.Context, buf *bytes.Buffer)
 	return d.c.generate(ctx, buf)
 }
 
+// +checklocks:c.mu
 func (c *devicesController) addRule(id deviceID, newPermission permission) error {
 	existingPermission := c.deviceRules[id]
 	c.deviceRules[id] = existingPermission.union(newPermission)
 	return nil
 }
 
+// +checklocks:c.mu
 func (c *devicesController) removeRule(id deviceID, p permission) error {
 	// cgroupv1 ignores silently requests to remove a partially-matching wildcard rule,
 	// which are {majorDevice:wildcardDevice}, {wildcardDevice:minorDevice}, and {wildcardDevice:wildcardDevice}
@@ -214,6 +219,7 @@ func (c *devicesController) removeRule(id deviceID, p permission) error {
 	return nil
 }
 
+// +checklocks:c.mu
 func (c *devicesController) applyRule(id deviceID, p permission, allow bool) error {
 	if !id.controllerType.valid() {
 		return linuxerr.EINVAL

--- a/pkg/sentry/fsimpl/cgroupfs/pids.go
+++ b/pkg/sentry/fsimpl/cgroupfs/pids.go
@@ -59,7 +59,6 @@ type pidsController struct {
 	// since cgroupfs doesn't allow cross directory renames.
 	isRoot bool
 
-	// mu protects the fields below.
 	mu pidsControllerMutex `state:"nosave"`
 
 	// pendingTotal and pendingPool tracks the charge for processes starting
@@ -71,15 +70,21 @@ type pidsController struct {
 	// We also track which task owns the pending charge so we can cancel the
 	// charge if a task creation fails after the Charge call.
 	//
-	// pendingTotal and pendingPool are both protected by mu.
+	// +checklocks:mu
 	pendingTotal int64
-	pendingPool  map[*kernel.Task]int64
+
+	// +checklocks:mu
+	pendingPool map[*kernel.Task]int64
 
 	// committed represent charges for tasks that have already started and
-	// called Enter. Protected by mu.
+	// called Enter.
+	//
+	// +checklocks:mu
 	committed int64
 
-	// max is the PID limit for this cgroup. Protected by mu.
+	// max is the PID limit for this cgroup.
+	//
+	// +checklocks:mu
 	max int64
 }
 

--- a/pkg/sentry/usage/memory.go
+++ b/pkg/sentry/usage/memory.go
@@ -76,10 +76,14 @@ const (
 	Mapped
 )
 
-// memoryStats tracks application memory usage in bytes. All fields correspond to the
-// memory category with the same name. This object is thread-safe if accessed
-// through the provided methods. The public fields may be safely accessed
-// directly on a copy of the object obtained from Memory.Copy().
+// memoryStats tracks application memory usage in bytes by category.
+//
+// Its methods require the owning MemoryLocked.mu, both for aggregate counters
+// and for entries in MemCgIDToMemStats. This also makes multi-category totals
+// and copies consistent. memoryStats has no link back to its owner, so
+// checklocks cannot name that mutex for these helpers or counter aliases.
+//
+// MemoryLocked.Copy and CopyPerCg return detached MemoryStats scalar values.
 type memoryStats struct {
 	System    atomicbitops.Uint64
 	Anonymous atomicbitops.Uint64
@@ -91,7 +95,7 @@ type memoryStats struct {
 
 // incLocked adds a usage of 'val' bytes from memory category 'kind'.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) incLocked(val uint64, kind MemoryKind) {
 	switch kind {
 	case System:
@@ -113,7 +117,7 @@ func (ms *memoryStats) incLocked(val uint64, kind MemoryKind) {
 
 // decLocked removes a usage of 'val' bytes from memory category 'kind'.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) decLocked(val uint64, kind MemoryKind) {
 	switch kind {
 	case System:
@@ -135,7 +139,7 @@ func (ms *memoryStats) decLocked(val uint64, kind MemoryKind) {
 
 // totalLocked returns a total usage.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) totalLocked() (total uint64) {
 	total += ms.System.RacyLoad()
 	total += ms.Anonymous.RacyLoad()
@@ -146,9 +150,9 @@ func (ms *memoryStats) totalLocked() (total uint64) {
 	return
 }
 
-// copyLocked returns a copy of the structure.
+// copyLocked returns a detached scalar snapshot of the counters.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) copyLocked() MemoryStats {
 	return MemoryStats{
 		System:    ms.System.RacyLoad(),
@@ -227,17 +231,25 @@ type RTMemoryStats struct {
 	RTMapped atomicbitops.Uint64
 }
 
-// MemoryLocked is Memory with access methods.
+// MemoryLocked serializes aggregate and per-cgroup memory accounting.
 type MemoryLocked struct {
 	mu memoryMutex
-	// memoryStats records the memory stats.
+
+	// memoryStats records the aggregate memory stats.
+	//
+	// +checklocks:mu
 	memoryStats
+
 	// RTMemoryStats records the memory stats that need to be exposed through
 	// shared page.
 	*RTMemoryStats
+
 	// File is the backing file storing the memory stats.
 	File *os.File
+
 	// MemCgIDToMemStats is the map of cgroup ids to memory stats.
+	//
+	// +checklocks:mu
 	MemCgIDToMemStats map[uint32]*memoryStats
 }
 
@@ -286,6 +298,7 @@ func Init() error {
 // resident.
 var MemoryAccounting *MemoryLocked
 
+// +checklocks:m.mu
 func (m *MemoryLocked) incLockedPerCg(val uint64, kind MemoryKind, memCgID uint32) {
 	if _, ok := m.MemCgIDToMemStats[memCgID]; !ok {
 		m.MemCgIDToMemStats[memCgID] = &memoryStats{}
@@ -314,6 +327,7 @@ func (m *MemoryLocked) Inc(val uint64, kind MemoryKind, memCgID uint32) {
 	}
 }
 
+// +checklocks:m.mu
 func (m *MemoryLocked) decLockedPerCg(val uint64, kind MemoryKind, memCgID uint32) {
 	if _, ok := m.MemCgIDToMemStats[memCgID]; !ok {
 		panic(fmt.Sprintf("invalid memory cgroup id: %v", memCgID))


### PR DESCRIPTION
Enforce existing mutex ownership of cpuset bitmaps, device rules, PID accounting, and the shared per-cgroup memory index. Declare the device-rule and memory-accounting helper contracts and preserve the separate source and destination locks during PID migration.

The memory index supplies the cgroup controllers' usage snapshots. Both the index and aggregate counters use the accounting mutex; per-cgroup counter objects retain the same external-owner contract.

Assisted-by: Codex
