### PR TITLE
checklocks: fix checkpoint waiter lock ordering

### DIFF
--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -444,6 +444,7 @@ go_test(
     size = "small",
     srcs = [
         "fd_table_test.go",
+        "kernel_restore_test.go",
         "table_test.go",
         "task_test.go",
         "timekeeper_test.go",

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -402,23 +402,28 @@ type Kernel struct {
 	// It's protected by extMu.
 	containerNames map[string]string
 
-	// checkpointMu is used to protect the checkpointing related fields below.
+	// Lock order: checkpointMu precedes CheckpointWait.mu.
 	checkpointMu sync.Mutex `state:"nosave"`
 
 	// additionalCheckpointState stores additional state that needs
-	// to be checkpointed. It's protected by checkpointMu.
+	// to be checkpointed.
+	//
+	// +checklocks:checkpointMu
 	additionalCheckpointState map[any]any
 
 	// saver implements the Saver interface, which (as of writing) supports
-	// asynchronous checkpointing. It's protected by checkpointMu.
+	// asynchronous checkpointing.
+	//
+	// +checklocks:checkpointMu
 	saver Saver `state:"nosave"`
 
 	// CheckpointWait is used to wait for a checkpoint to complete.
 	CheckpointWait CheckpointWaitable
 
-	// checkpointGen aims to track the number of times the kernel has been
-	// successfully checkpointed. Callers of checkpoint must notify the kernel
-	// when checkpoint/restore are done. It's protected by checkpointMu.
+	// checkpointGen describes the latest checkpoint attempt or restore.
+	// Callers must notify the kernel when checkpoint/restore are done.
+	//
+	// +checklocks:checkpointMu
 	checkpointGen CheckpointGeneration
 
 	// SaveRestoreExecConfig stores configuration options for the save/restore

--- a/pkg/sentry/kernel/kernel_restore.go
+++ b/pkg/sentry/kernel/kernel_restore.go
@@ -41,8 +41,8 @@ type Saver interface {
 //
 // +stateify savable
 type CheckpointGeneration struct {
-	// Count is incremented every time a checkpoint is triggered, even if the
-	// checkpoint failed.
+	// Count is incremented after each checkpoint attempt, including failures,
+	// and on restore.
 	Count uint32
 	// Restore indicates if the current instance resumed after the checkpoint or
 	// it was restored from a checkpoint.
@@ -50,6 +50,9 @@ type CheckpointGeneration struct {
 }
 
 // AddStateToCheckpoint adds a key-value pair to be additionally checkpointed.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) AddStateToCheckpoint(key, v any) {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -61,6 +64,9 @@ func (k *Kernel) AddStateToCheckpoint(key, v any) {
 
 // PopCheckpointState pops a key-value pair from the additional checkpoint
 // state. If the key doesn't exist, nil is returned.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) PopCheckpointState(key any) any {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -73,6 +79,9 @@ func (k *Kernel) PopCheckpointState(key any) any {
 
 // SetSaver sets the kernel's Saver.
 // Thread-compatible.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) SetSaver(s Saver) {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -81,6 +90,9 @@ func (k *Kernel) SetSaver(s Saver) {
 
 // Saver returns the kernel's Saver.
 // Thread-compatible.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) Saver() Saver {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -88,6 +100,9 @@ func (k *Kernel) Saver() Saver {
 }
 
 // CheckpointGen returns the current checkpoint generation.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) CheckpointGen() CheckpointGeneration {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -96,6 +111,9 @@ func (k *Kernel) CheckpointGen() CheckpointGeneration {
 }
 
 // IncCheckpointGenOnRestore increments the checkpoint generation upon restore.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) IncCheckpointGenOnRestore() {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -108,6 +126,9 @@ func (k *Kernel) IncCheckpointGenOnRestore() {
 
 // OnCheckpointAttempt is called when a checkpoint attempt is completed. err is
 // any checkpoint errors that may have occurred.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) OnCheckpointAttempt(err error) {
 	if err == nil {
 		log.Infof("Checkpoint completed successfully.")
@@ -124,7 +145,11 @@ func (k *Kernel) OnCheckpointAttempt(err error) {
 	k.CheckpointWait.signal(k.checkpointGen, err)
 }
 
-// WaitForCheckpoint waits for the Kernel to have been successfully checkpointed.
+// WaitForCheckpoint waits for the next checkpoint generation or an error
+// notification, and returns the reported error.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) WaitForCheckpoint() error {
 	// Send checkpoint result to a channel and wait on it.
 	ch := make(chan error, 1)
@@ -136,6 +161,8 @@ func (k *Kernel) WaitForCheckpoint() error {
 }
 
 // SignalAllCheckpointWaiters signals all checkpoint waiters with err.
+//
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) SignalAllCheckpointWaiters(err error) {
 	k.CheckpointWait.signal(CheckpointGeneration{Count: math.MaxUint32}, err)
 }
@@ -145,6 +172,9 @@ type checkpointWaiter struct {
 	count uint32
 	// callback is the function that will be called when the checkpoint generation
 	// reaches the desired count. It is set to nil after the callback is called.
+	//
+	// It is protected by the owning CheckpointWaitable's mu. The waiter has
+	// no reference to that owner, so checklocks cannot name the mutex here.
 	callback func(CheckpointGeneration, error)
 }
 
@@ -153,21 +183,29 @@ type checkpointWaiter struct {
 //
 // +stateify savable
 type CheckpointWaitable struct {
+	// k is set before the waitable is used and remains unchanged.
 	k *Kernel
 
 	mu sync.Mutex `state:"nosave"`
 
 	// Don't save the waiters, because they are repopulated after restore. It also
 	// allows for external entities to wait for the checkpoint.
+	//
+	// +checklocks:mu
 	waiters map[*checkpointWaiter]struct{} `state:"nosave"`
 }
 
-// Register registers a callback that is notified when the checkpoint generation count is higher
-// than the desired count.
+// Register registers a callback that is notified when the checkpoint generation
+// reaches the desired count.
+//
+// cb runs with mu held and may also run with the kernel's checkpoint mutex
+// held. It must not call methods that acquire either mutex. checklocks cannot
+// attach these owner-lock requirements to the supplied function value.
+//
+// +checklocksexclude:w.mu
+// +checklocksexclude:w.k.checkpointMu
 func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), count uint32) any {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	waiter := &checkpointWaiter{
 		count:    count,
 		callback: cb,
@@ -176,8 +214,17 @@ func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), coun
 		w.waiters = make(map[*checkpointWaiter]struct{})
 	}
 	w.waiters[waiter] = struct{}{}
+	w.mu.Unlock()
 
-	if gen := w.k.CheckpointGen(); count <= gen.Count {
+	// Publish the waiter before reading the generation to avoid missing a
+	// checkpoint. Do not hold mu while acquiring checkpointMu: notification
+	// holds checkpointMu while acquiring mu.
+	gen := w.k.CheckpointGen()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	// Notification may have already delivered the checkpoint's error.
+	if waiter.callback != nil && count <= gen.Count {
 		// The checkpoint has already occurred. Signal immediately.
 		waiter.callback(gen, nil)
 		waiter.callback = nil
@@ -185,8 +232,10 @@ func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), coun
 	return waiter
 }
 
-// Unregister unregisters a waiter. It must be called even if the channel
-// was signalled.
+// Unregister unregisters a waiter. It must be called even if the callback
+// has already run.
+//
+// +checklocksexclude:w.mu
 func (w *CheckpointWaitable) Unregister(key any) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -197,6 +246,9 @@ func (w *CheckpointWaitable) Unregister(key any) {
 	}
 }
 
+// signal notifies waiters whose desired generation has been reached.
+//
+// +checklocksexclude:w.mu
 func (w *CheckpointWaitable) signal(gen CheckpointGeneration, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/pkg/sentry/kernel/kernel_restore_test.go
+++ b/pkg/sentry/kernel/kernel_restore_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestCheckpointRegistrationDuringNotification(t *testing.T) {
+	var k Kernel
+	w := &k.CheckpointWait
+	w.k = &k
+	gen := CheckpointGeneration{Count: 1}
+	wantErr := errors.New("checkpoint failed")
+	type result struct {
+		gen CheckpointGeneration
+		err error
+	}
+	results := make(chan result, 2)
+	registered := make(chan any, 1)
+	notified := make(chan struct{})
+
+	// Hold the generation lock as a checkpoint producer does. Registration
+	// must not hold the waiters lock while waiting to read this generation.
+	k.checkpointMu.Lock()
+	k.checkpointGen = gen
+	go func() {
+		registered <- w.Register(func(gen CheckpointGeneration, err error) {
+			results <- result{gen, err}
+		}, gen.Count)
+	}()
+	go func() {
+		for {
+			w.mu.Lock()
+			pending := len(w.waiters) != 0
+			w.mu.Unlock()
+			if pending {
+				break
+			}
+			runtime.Gosched()
+		}
+		w.signal(gen, wantErr)
+		close(notified)
+	}()
+
+	// Mutex contention is not durably blocking in synctest, so its clock
+	// cannot advance a watchdog when the original lock inversion occurs.
+	// Use a real-time deadline to release both goroutines on that failure.
+	var blocked bool
+	select {
+	case <-notified:
+	case <-time.After(5 * time.Second):
+		blocked = true
+	}
+	// Release the generation lock even on failure, so the original lock
+	// inversion cannot strand either goroutine during test cleanup.
+	k.checkpointMu.Unlock()
+	key := <-registered
+	<-notified
+	w.Unregister(key)
+	if blocked {
+		t.Fatal("checkpoint notification blocked on registration")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d callbacks, want 1", len(results))
+	}
+	if got := <-results; got.gen != gen || got.err != wantErr {
+		t.Fatalf("callback = (%+v, %v), want (%+v, %v)", got.gen, got.err, gen, wantErr)
+	}
+}


### PR DESCRIPTION
Checkpoint waiter registration holds the waiters mutex while reading the kernel generation. Checkpoint completion holds the generation mutex while notifying waiters, creating a lock inversion introduced in fb730ff784.

Publish the waiter before reading the generation, but release the waiters mutex during that read. Recheck whether notification consumed the callback before delivering an immediate result, preserving a concurrent checkpoint error and avoiding duplicate delivery. Keep generation updates and their notifications serialized.

Guard the checkpoint state and waiter map, and document callback ownership. Add a forced-interleaving regression for notification while registration waits on the generation mutex.

Assisted-by: Codex
