### PR TITLE
checklocks: guard shared coordination state

### DIFF
--- a/nogo.yaml
+++ b/nogo.yaml
@@ -261,6 +261,8 @@ analyzers:
         - pkg/sentry/fs/fs.go          # Intentional.
         - pkg/sentry/fs/gofer/inode.go # Intentional.
         - pkg/refs/refcounter_test.go  # Intentional.
+        # Lock-order validator tests intentionally have no protected data.
+        - '^pkg/sync/locking/lockdep_test\.go:'
   SA4016: # Useless bitwise operations.
     internal:
       exclude:

--- a/pkg/compressio/compressio.go
+++ b/pkg/compressio/compressio.go
@@ -209,19 +209,23 @@ func (w *worker) work(compress bool, level int) {
 }
 
 type hashPool struct {
-	// mu protects the hash list.
 	mu sync.Mutex
 
-	// key is the key used to create hash objects.
+	// key is a private copy of the key used to create hash objects. It is
+	// immutable after construction, including during lazy worker setup.
 	key []byte
 
 	// hashes is the hash object free list. Note that this cannot be
 	// globally shared across readers or writers, as it is key-specific.
+	//
+	// +checklocks:mu
 	hashes []hash.Hash
 }
 
 // getHash gets a hash object for the pool. It should only be called when the
-// pool key is non-nil.
+// pool key is non-empty.
+//
+// +checklocksexclude:p.mu
 func (p *hashPool) getHash() hash.Hash {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -235,6 +239,9 @@ func (p *hashPool) getHash() hash.Hash {
 	return h
 }
 
+// putHash resets h and returns it to the free list.
+//
+// +checklocksexclude:p.mu
 func (p *hashPool) putHash(h hash.Hash) {
 	h.Reset()
 
@@ -246,42 +253,63 @@ func (p *hashPool) putHash(h hash.Hash) {
 
 // pool is common functionality for reader/writers.
 type pool struct {
+	// mu serializes construction, Reader.Read, Writer.Write, Writer.Close,
+	// and finalizer cleanup, including synchronous completion callbacks.
+	mu sync.Mutex
+
 	// workers are the compression/decompression workers.
+	//
+	// +checklocks:mu
 	workers []worker
 
 	// chunkSize is the chunk size. This is the first four bytes in the
-	// stream and is shared across both the reader and writer.
+	// stream and is shared across both the reader and writer. It is immutable
+	// after construction.
 	chunkSize uint32
 
-	// mu protects below; it is generally the responsibility of users to
-	// acquire this mutex before calling any methods on the pool.
-	mu sync.Mutex
-
 	// nextInput is the next worker for input (scheduling).
+	//
+	// +checklocks:mu
 	nextInput int
 
 	// nextOutput is the next worker for output (result).
+	//
+	// +checklocks:mu
 	nextOutput int
 
 	// buf is the current active buffer; the exact semantics of this buffer
-	// depending on whether this is a reader or a writer.
+	// depend on whether this is a reader or a writer.
+	//
+	// +checklocks:mu
 	buf *bytes.Buffer
 
-	// lasSum records the hash of the last chunk processed.
+	// err is the first terminal Read or Write error. Workers are stopped before
+	// returning it, so later calls must not schedule more work.
+	//
+	// +checklocks:mu
+	err error
+
+	// lastSum records the hash of the last chunk processed.
+	//
+	// +checklocks:mu
 	lastSum []byte
 
 	// hashPool is the hash object pool. It cannot be embedded into pool
 	// itself as worker refers to it and that would stop pool from being
 	// GCed.
+	//
+	// +checklocks:mu
 	hashPool *hashPool
 }
 
 // init initializes the worker pool.
 //
 // This should only be called once.
+//
+// +checklocks:p.mu
 func (p *pool) init(key []byte, workers int, compress bool, level int) {
 	if len(key) > 0 {
-		p.hashPool = &hashPool{key: key}
+		p.hashPool = &hashPool{key: bytes.Clone(key)}
 	}
 	p.workers = make([]worker, workers)
 	for i := 0; i < len(p.workers); i++ {
@@ -292,19 +320,27 @@ func (p *pool) init(key []byte, workers int, compress bool, level int) {
 		}
 		go p.workers[i].work(compress, level) // S/R-SAFE: In save path only.
 	}
-	runtime.SetFinalizer(p, (*pool).stop)
+	runtime.SetFinalizer(p, func(p *pool) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.stop()
+	})
 }
 
 // stop stops all workers.
+//
+// +checklocks:p.mu
 func (p *pool) stop() {
 	for i := 0; i < len(p.workers); i++ {
 		close(p.workers[i].input)
 	}
-	// Wait for all workers to finish since p.schedule(c=nil) may have returned
+	// Drain outstanding results since p.schedule(c=nil) may have returned
 	// early if any worker emitted an error.
 	if len(p.workers) != 0 {
 		for p.nextOutput < p.nextInput {
-			handleResult(<-p.workers[(p.nextOutput+1)%len(p.workers)].output, func(*chunk) error {
+			// Reclaim completed chunks even if their work failed. No results
+			// are delivered to the caller during cleanup.
+			_ = handleResult(<-p.workers[(p.nextOutput+1)%len(p.workers)].output, func(*chunk) error {
 				return nil
 			})
 			p.nextOutput++
@@ -334,6 +370,10 @@ func handleResult(r result, callback func(*chunk) error) error {
 //
 // If no callback function is provided, then the output channel will be
 // ignored.  You must be sure that the input is schedulable in this case.
+//
+// callback is invoked synchronously with p.mu held.
+//
+// +checklocks:p.mu
 func (p *pool) schedule(c *chunk, callback func(*chunk) error) error {
 	for {
 		var (
@@ -372,12 +412,14 @@ type Reader struct {
 
 	// scratch is a temporary buffer used for marshalling. This is declared
 	// unfront here to avoid reallocation.
+	//
+	// +checklocks:mu
 	scratch [4]byte
 }
 
 var _ io.Reader = (*Reader)(nil)
 
-// NewReader returns a new compressed reader. If key is non-nil, the data stream
+// NewReader returns a new compressed reader. If key is non-empty, the data stream
 // is assumed to contain expected hash values, which will be compared against
 // hash values computed from the compressed bytes. See package comments for
 // details.
@@ -385,6 +427,10 @@ func NewReader(in io.ReadCloser, key []byte) (*Reader, error) {
 	r := &Reader{
 		in: in,
 	}
+	// init registers a finalizer. Order subsequent initialization before
+	// finalizer cleanup, including when a header read fails.
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	// Use double buffering for read.
 	r.init(key, 2*runtime.GOMAXPROCS(0), false, 0)
@@ -422,13 +468,24 @@ var errNewBuffer = errors.New("buffer ready")
 var ErrHashMismatch = errors.New("hash mismatch")
 
 // Read implements io.Reader.Read.
-func (r *Reader) Read(p []byte) (int, error) {
+//
+// +checklocksexclude:r.mu
+func (r *Reader) Read(p []byte) (done int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Total bytes completed; this is declared up front because it must be
-	// adjustable by the callback below.
-	done := 0
+	if r.err != nil {
+		return 0, r.err
+	}
+	defer func() {
+		if err != nil {
+			r.err = err
+			// Workers may still be writing directly into p, even when an
+			// input read or an earlier worker failed.
+			r.stop()
+			r.buf = nil
+		}
+	}()
 
 	// Total bytes pending in the asynchronous workers for buffers. This is
 	// used to process the proper regions of the input as inline buffers.
@@ -450,11 +507,13 @@ func (r *Reader) Read(p []byte) (int, error) {
 		// return errNewBuffer to ensure that we aren't called a second
 		// time. This error code is handled specially below.
 		//
-		// c.buf will be freed and return to the pool when it is done.
+		// Read returns c.uncompressed to bufPool after consuming it.
 		if pendingPre > 0 {
 			pendingPre--
 		}
-		r.buf = c.uncompressed
+		// schedule invokes this callback with r.mu held, but checklocks does
+		// not propagate the lock state through the callback parameter.
+		r.buf = c.uncompressed // +checklocksignore
 		return errNewBuffer
 	}
 
@@ -471,7 +530,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 				r.buf = nil
 			} else if err != nil {
 				// Should never happen.
-				defer r.stop()
 				return done, err
 			}
 			continue
@@ -489,7 +547,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 			if err := r.schedule(nil, callback); err == nil {
 				// We've actually finished all buffers; this is
 				// the normal EOF exit path.
-				defer r.stop()
 				return done, io.EOF
 			} else if err == errNewBuffer {
 				// A new buffer is now available.
@@ -497,7 +554,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 			} else {
 				// Some other error occurred; we cannot
 				// process any further.
-				defer r.stop()
 				return done, err
 			}
 		}
@@ -547,10 +603,9 @@ func (r *Reader) Read(p []byte) (int, error) {
 			//
 			// It is safe to pass nil as an output function here,
 			// because we know that we just freed up a slot above.
-			r.schedule(c, nil)
+			_ = r.schedule(c, nil)
 		} else if err != nil {
 			// Some other error occurred; see above.
-			defer r.stop()
 			return done, err
 		}
 	}
@@ -563,8 +618,8 @@ func (r *Reader) Read(p []byte) (int, error) {
 				return err
 			}
 			// The nil case means that an inline buffer has
-			// completed. The callback will have already removed
-			// the inline buffer from the map, so we just return an
+			// completed. The callback has already decremented
+			// pendingInline, so we just return an
 			// error to check the top of the loop again.
 			return errNewBuffer
 		}); err != errNewBuffer {
@@ -591,16 +646,20 @@ type Writer struct {
 	out io.Writer
 
 	// closed indicates whether the file has been closed.
+	//
+	// +checklocks:mu
 	closed bool
 
 	// scratch is a temporary buffer used for marshalling. This is declared
 	// unfront here to avoid reallocation.
+	//
+	// +checklocks:mu
 	scratch [4]byte
 }
 
 var _ io.Writer = (*Writer)(nil)
 
-// NewWriter returns a new compressed writer. If key is non-nil, hash values are
+// NewWriter returns a new compressed writer. If key is non-empty, hash values are
 // generated and written out for compressed bytes. See package comments for
 // details.
 //
@@ -615,6 +674,10 @@ func NewWriter(out io.Writer, key []byte, chunkSize uint32, level int) (*Writer,
 		},
 		out: out,
 	}
+	// init registers a finalizer. Order subsequent initialization before
+	// finalizer cleanup, including when a header write fails.
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.init(key, 1+runtime.GOMAXPROCS(0), true, level)
 
 	binary.BigEndian.PutUint32(w.scratch[:], chunkSize)
@@ -637,6 +700,8 @@ func NewWriter(out io.Writer, key []byte, chunkSize uint32, level int) (*Writer,
 }
 
 // flush writes a single buffer.
+//
+// +checklocks:w.mu
 func (w *Writer) flush(c *chunk) error {
 	// Prefix each chunk with a length; this allows the reader to safely
 	// limit reads while buffering.
@@ -667,7 +732,9 @@ func (w *Writer) flush(c *chunk) error {
 }
 
 // Write implements io.Writer.Write.
-func (w *Writer) Write(p []byte) (int, error) {
+//
+// +checklocksexclude:w.mu
+func (w *Writer) Write(p []byte) (done int, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -675,6 +742,19 @@ func (w *Writer) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, io.ErrUnexpectedEOF
 	}
+	if w.err != nil {
+		return 0, w.err
+	}
+	defer func() {
+		if err != nil {
+			w.err = err
+			// Finish all reads from p before the caller can reuse it.
+			w.stop()
+			// buf may be an unsubmitted inline slice of p. Do not return
+			// caller-owned storage to bufPool or submit it on a later call.
+			w.buf = nil
+		}
+	}()
 
 	// See above; we need to track in the same way.
 	var (
@@ -682,29 +762,29 @@ func (w *Writer) Write(p []byte) (int, error) {
 		pendingInline = 0
 	)
 	callback := func(c *chunk) error {
+		// schedule invokes this callback with w.mu held, but checklocks does
+		// not propagate the lock state through the callback parameter.
 		if pendingPre > 0 {
 			pendingPre--
-			err := w.flush(c)
+			err := w.flush(c) // +checklocksignore
 			c.uncompressed.Reset()
 			bufPool.Put(c.uncompressed)
 			return err
 		}
 		if pendingInline > 0 {
 			pendingInline--
-			return w.flush(c)
+			return w.flush(c) // +checklocksignore
 		}
 		panic("both pendingPre and pendingInline exhausted")
 	}
 
-	for done := 0; done < len(p); {
+	for done < len(p) {
 		// Construct an inline buffer if we're doing an inline
 		// encoding; see above regarding the bytes.MinRead constraint.
 		inline := false
 		if w.buf.Len() == 0 && len(p) >= done+int(w.chunkSize) && len(p) >= done+bytes.MinRead {
 			bufPool.Put(w.buf) // Return to the pool; never scheduled.
 			w.buf = bytes.NewBuffer(p[done : done+int(w.chunkSize)])
-			done += int(w.chunkSize)
-			pendingInline++
 			inline = true
 		}
 
@@ -715,7 +795,10 @@ func (w *Writer) Write(p []byte) (int, error) {
 			if err := w.schedule(newChunk(nil, nil, nil, w.buf), callback); err != nil {
 				return done, err
 			}
-			if !inline {
+			if inline {
+				done += int(w.chunkSize)
+				pendingInline++
+			} else {
 				pendingPre++
 			}
 			// Reset the buffer, since this has now been scheduled
@@ -758,7 +841,9 @@ func (w *Writer) Write(p []byte) (int, error) {
 }
 
 // Close implements io.Closer.Close.
-func (w *Writer) Close() error {
+//
+// +checklocksexclude:w.mu
+func (w *Writer) Close() (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -768,7 +853,19 @@ func (w *Writer) Close() error {
 		return io.ErrUnexpectedEOF
 	}
 	w.closed = true
-	defer w.stop()
+	defer func() {
+		w.stop()
+		// Close the destination even if Write or the final flush failed,
+		// but preserve the earlier error.
+		if closer, ok := w.out.(io.Closer); ok {
+			if closeErr := closer.Close(); err == nil {
+				err = closeErr
+			}
+		}
+	}()
+	if w.err != nil {
+		return w.err
+	}
 
 	// Schedule any remaining partial buffer; we pass w.flush directly here
 	// because the final buffer is guaranteed to not be an inline buffer.
@@ -783,9 +880,5 @@ func (w *Writer) Close() error {
 		return err
 	}
 
-	// Close the underlying writer (if necessary).
-	if closer, ok := w.out.(io.Closer); ok {
-		return closer.Close()
-	}
 	return nil
 }

--- a/pkg/compressio/compressio_test.go
+++ b/pkg/compressio/compressio_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -203,6 +204,150 @@ func TestCompress(t *testing.T) {
 			NewReader: func(b *bytes.Buffer) (io.Reader, error) {
 				return flate.NewReader(b), nil
 			},
+		})
+	}
+}
+
+func TestReaderOwnsKey(t *testing.T) {
+	doTest(t, testOpts{
+		Name: "reader owns key",
+		Data: bytes.Repeat([]byte{'a'}, 2*bytes.MinRead),
+		NewWriter: func(b *bytes.Buffer) (io.WriteCloser, error) {
+			return NewWriter(b, hashKey, bytes.MinRead, flate.BestSpeed)
+		},
+		NewReader: func(b *bytes.Buffer) (io.Reader, error) {
+			key := bytes.Clone(hashKey)
+			r, err := NewReader(io.NopCloser(b), key)
+			// Lazy worker HMACs must use the same key as the stream header,
+			// even if the caller reuses the constructor's key buffer.
+			clear(key)
+			return r, err
+		},
+	})
+}
+
+func TestReadErrorReleasesBuffer(t *testing.T) {
+	for _, key := range [][]byte{nil, hashKey} {
+		t.Run(fmt.Sprintf("hash=%t", key != nil), func(t *testing.T) {
+			var compressed bytes.Buffer
+			w, err := NewWriter(&compressed, key, bytes.MinRead, flate.BestSpeed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data := bytes.Repeat([]byte{'a'}, 2*bytes.MinRead)
+			if _, err := w.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			// The first chunk can be decoding directly into data when reading
+			// the second chunk's body (or hash) fails.
+			compressed.Truncate(compressed.Len() - 1)
+			r, err := NewReader(io.NopCloser(&compressed), key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				r.mu.Lock()
+				defer r.mu.Unlock()
+				r.stop()
+			})
+			if _, err := r.Read(data); err != io.ErrUnexpectedEOF {
+				t.Fatalf("Read: got %v, want %v", err, io.ErrUnexpectedEOF)
+			}
+			// A Reader must release the caller's buffer even on error. Do not
+			// synchronize with workers before reusing it: that hides the race.
+			// Use instrumented byte accesses; clear is not race-instrumented.
+			for i := range data {
+				data[i]++
+			}
+			if n, err := r.Read(data); n != 0 || err != io.ErrUnexpectedEOF {
+				t.Fatalf("Read after error: got (%d, %v), want (0, %v)", n, err, io.ErrUnexpectedEOF)
+			}
+		})
+	}
+}
+
+type failingWriteCloser struct {
+	err      error
+	closeErr error
+	writes   int
+	closes   int
+}
+
+func (w *failingWriteCloser) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == 1 {
+		return len(p), nil // Accept the stream header.
+	}
+	return 0, w.err
+}
+
+func (w *failingWriteCloser) Close() error {
+	w.closes++
+	return w.closeErr
+}
+
+func TestWriteErrorReleasesBuffer(t *testing.T) {
+	out := &failingWriteCloser{
+		err:      errors.New("write failed"),
+		closeErr: errors.New("close failed"),
+	}
+	w, err := NewWriter(out, nil, bytes.MinRead, flate.BestSpeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.stop()
+	})
+	data := bytes.Repeat([]byte{'a'}, 2*bytes.MinRead)
+	if _, err := w.Write(data); err != out.err {
+		t.Fatalf("Write: got %v, want %v", err, out.err)
+	}
+	// As with Read, an error must not leave workers using the caller's slice.
+	// Use instrumented byte accesses; clear is not race-instrumented.
+	for i := range data {
+		data[i]++
+	}
+	if n, err := w.Write(nil); n != 0 || err != out.err {
+		t.Errorf("Write after error: got (%d, %v), want (0, %v)", n, err, out.err)
+	}
+	if err := w.Close(); err != out.err {
+		t.Errorf("Close: got %v, want original write error %v", err, out.err)
+	}
+	if out.closes != 1 {
+		t.Errorf("underlying Close called %d times, want 1", out.closes)
+	}
+}
+
+func TestCloseErrorClosesWriter(t *testing.T) {
+	for _, data := range [][]byte{nil, {'a'}} {
+		t.Run(fmt.Sprintf("buffered=%t", len(data) != 0), func(t *testing.T) {
+			out := &failingWriteCloser{
+				err:      errors.New("write failed"),
+				closeErr: errors.New("close failed"),
+			}
+			w, err := NewWriter(out, nil, bytes.MinRead, flate.BestSpeed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A partial chunk is buffered, so the first flush is in Close.
+			if _, err := w.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			want := out.closeErr
+			if len(data) != 0 {
+				want = out.err
+			}
+			if err := w.Close(); err != want {
+				t.Errorf("Close: got %v, want %v", err, want)
+			}
+			if out.closes != 1 {
+				t.Errorf("underlying Close called %d times, want 1", out.closes)
+			}
 		})
 	}
 }

--- a/pkg/compressio/nocompressio.go
+++ b/pkg/compressio/nocompressio.go
@@ -76,7 +76,7 @@ const (
 	defaultBufSize = 256 * 1024
 )
 
-// NewSimpleReader returns a new (uncompressed) reader. If key is non-nil, the
+// NewSimpleReader returns a new (uncompressed) reader. If key is non-empty, the
 // data stream is assumed to contain expected hash values. See package comments
 // for details.
 func NewSimpleReader(in io.ReadCloser, key []byte) *SimpleReader {
@@ -199,8 +199,8 @@ type SimpleWriter struct {
 var _ io.Writer = (*SimpleWriter)(nil)
 var _ io.Closer = (*SimpleWriter)(nil)
 
-// NewSimpleWriter returns a new non-compressing writer. If key is non-nil,
-// hash values are generated and written out for compressed bytes. See package
+// NewSimpleWriter returns a new non-compressing writer. If key is non-empty,
+// hash values are generated and written out for data. See package
 // comments for details. chunkSize is the buffer size used for buffering. Large
 // writes are not buffered and written out directly as a single chunk.
 func NewSimpleWriter(out io.Writer, key []byte, chunkSize uint32) *SimpleWriter {

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -24,19 +24,22 @@ type Pool struct {
 	mu sync.Mutex
 
 	// cache is the set of returned values.
+	//
+	// +checklocks:mu
 	cache []uint64
 
-	// Start is the starting value (if needed).
+	// Start is the next fresh value. Initialize it before publishing the pool.
+	//
+	// +checklocks:mu
 	Start uint64
 
-	// max is the current maximum issued.
-	max uint64
-
-	// Limit is the upper limit.
+	// Limit is the exclusive upper limit, fixed before publishing the pool.
 	Limit uint64
 }
 
 // Get gets a value from the pool.
+//
+// +checklocksexclude:p.mu
 func (p *Pool) Get() (uint64, bool) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -60,6 +63,8 @@ func (p *Pool) Get() (uint64, bool) {
 }
 
 // Put returns a value to the pool.
+//
+// +checklocksexclude:p.mu
 func (p *Pool) Put(v uint64) {
 	p.mu.Lock()
 	p.cache = append(p.cache, v)

--- a/pkg/rand/rand_linux.go
+++ b/pkg/rand/rand_linux.go
@@ -25,7 +25,10 @@ import (
 
 // reader implements an io.Reader that returns pseudorandom bytes.
 type reader struct {
-	once         sync.Once
+	once sync.Once
+
+	// useGetrandom is initialized by once.Do; every read follows Do's return.
+	// checklocks does not model publication through sync.Once.
 	useGetrandom bool
 }
 
@@ -47,22 +50,22 @@ func (r *reader) Read(p []byte) (int, error) {
 // bufferedReader implements a threadsafe buffered io.Reader.
 type bufferedReader struct {
 	mu sync.Mutex
-	r  *bufio.Reader
+
+	// +checklocks:mu
+	r *bufio.Reader
 }
 
 // Read implements io.Reader.Read.
+//
+// +checklocksexclude:b.mu
 func (b *bufferedReader) Read(p []byte) (int, error) {
 	// In Linux, reads of up to page size bytes will always complete fully.
 	// See drivers/char/random.c:get_random_bytes_user().
 	// NOTE(gvisor.dev/issue/9445): Some applications rely on this behavior.
 	const pageSize = 4096
-	min := len(p)
-	if min > pageSize {
-		min = pageSize
-	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return io.ReadAtLeast(b.r, p, min)
+	return io.ReadAtLeast(b.r, p, min(len(p), pageSize))
 }
 
 // Reader is the default reader.

--- a/pkg/sentry/platform/interrupt/BUILD
+++ b/pkg/sentry/platform/interrupt/BUILD
@@ -19,4 +19,5 @@ go_test(
     size = "small",
     srcs = ["interrupt_test.go"],
     library = ":interrupt",
+    deps = ["//pkg/sync"],
 )

--- a/pkg/sentry/platform/interrupt/interrupt.go
+++ b/pkg/sentry/platform/interrupt/interrupt.go
@@ -15,15 +15,16 @@
 // Package interrupt provides an interrupt helper.
 package interrupt
 
-import (
-	"fmt"
-
-	"gvisor.dev/gvisor/pkg/sync"
-)
+import "gvisor.dev/gvisor/pkg/sync"
 
 // Receiver receives interrupt notifications from a Forwarder.
 type Receiver interface {
 	// NotifyInterrupt is called when the Receiver receives an interrupt.
+	//
+	// Forwarder calls this synchronously with its mutex held. It must not
+	// synchronously call back into that Forwarder. This interface does not
+	// identify the calling Forwarder, so checklocks cannot express the
+	// nonreentry requirement here.
 	NotifyInterrupt()
 }
 
@@ -31,13 +32,17 @@ type Receiver interface {
 //
 // This helps platform implementations with Interrupt semantics.
 type Forwarder struct {
-	// mu protects the below.
 	mu sync.Mutex
 
-	// dst is the function to be called when NotifyInterrupt() is called. If
-	// dst is nil, pending will be set instead, causing the next call to
-	// Enable() to return false.
-	dst     Receiver
+	// dst receives forwarded interrupts. It is nil while forwarding is disabled.
+	//
+	// +checklocks:mu
+	dst Receiver
+
+	// pending records an interrupt received while forwarding was disabled.
+	// The next Enable consumes it and returns false.
+	//
+	// +checklocks:mu
 	pending bool
 }
 
@@ -58,6 +63,8 @@ type Forwarder struct {
 // Preconditions:
 //   - r must not be nil.
 //   - f must not already be forwarding interrupts to a Receiver.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) Enable(r Receiver) bool {
 	if r == nil {
 		panic("nil Receiver")
@@ -65,7 +72,7 @@ func (f *Forwarder) Enable(r Receiver) bool {
 	f.mu.Lock()
 	if f.dst != nil {
 		f.mu.Unlock()
-		panic(fmt.Sprintf("already forwarding interrupts to %+v", f.dst))
+		panic("already forwarding interrupts")
 	}
 	if f.pending {
 		f.pending = false
@@ -79,6 +86,8 @@ func (f *Forwarder) Enable(r Receiver) bool {
 
 // Disable stops interrupt forwarding. If interrupt forwarding is already
 // disabled, Disable is a no-op.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) Disable() {
 	f.mu.Lock()
 	f.dst = nil
@@ -88,6 +97,8 @@ func (f *Forwarder) Disable() {
 // NotifyInterrupt implements Receiver.NotifyInterrupt. If interrupt forwarding
 // is enabled, the configured Receiver will be notified. Otherwise the
 // interrupt will be delivered to the next call to Enable.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) NotifyInterrupt() {
 	f.mu.Lock()
 	if f.dst != nil {
@@ -101,6 +112,8 @@ func (f *Forwarder) NotifyInterrupt() {
 // Preempt preempts the running context. Preempt is a weaker version of
 // NotifyInterrupt, it doesn't set the pending flag which is set when a context
 // isn't actually running at this moment.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) Preempt() {
 	f.mu.Lock()
 	if f.dst != nil {

--- a/pkg/sentry/platform/interrupt/interrupt_test.go
+++ b/pkg/sentry/platform/interrupt/interrupt_test.go
@@ -16,6 +16,8 @@ package interrupt
 
 import (
 	"testing"
+
+	"gvisor.dev/gvisor/pkg/sync"
 )
 
 type countingReceiver struct {
@@ -96,4 +98,26 @@ func TestMultipleInterruptsAfterEnable(t *testing.T) {
 	if r.interrupts != 2 {
 		t.Errorf("interrupts: got %d, wanted 2", r.interrupts)
 	}
+}
+
+func TestEnableAlreadyForwarding(t *testing.T) {
+	var f Forwarder
+	var r countingReceiver
+	if !f.Enable(&r) {
+		t.Fatal("initial Enable failed")
+	}
+	defer f.Disable()
+
+	// A receiver's fields can change while forwarding is enabled. The
+	// Forwarder's mutex does not protect that receiver-owned state.
+	var wg sync.WaitGroup
+	wg.Go(func() { r.interrupts++ })
+	// Join only after Enable so this write remains unordered with its panic.
+	defer wg.Wait()
+	defer func() {
+		if recover() == nil {
+			t.Error("duplicate Enable did not panic")
+		}
+	}()
+	_ = f.Enable(&r)
 }

--- a/pkg/sync/gate_test.go
+++ b/pkg/sync/gate_test.go
@@ -37,6 +37,18 @@ func TestGateBasic(t *testing.T) {
 	}
 }
 
+func TestRaceUncheckedAtomicCompareAndSwapUintptr(t *testing.T) {
+	// Gate's park callback needs distinct old and new operands even when the
+	// primitive uses race-detector-free assembly.
+	value := uintptr(1)
+	if swapped := RaceUncheckedAtomicCompareAndSwapUintptr(&value, 1, 2); !swapped || value != 2 {
+		t.Fatalf("CAS(1, 2) = %t, value = %d; want true, 2", swapped, value)
+	}
+	if swapped := RaceUncheckedAtomicCompareAndSwapUintptr(&value, 1, 3); swapped || value != 2 {
+		t.Fatalf("CAS(1, 3) = %t, value = %d; want false, 2", swapped, value)
+	}
+}
+
 func TestGateConcurrent(t *testing.T) {
 	// Each call to testGateConcurrentOnce tests behavior around a single call
 	// to Gate.Close, so run many short tests to increase the probability of

--- a/pkg/sync/locking/generic_mutex.go
+++ b/pkg/sync/locking/generic_mutex.go
@@ -44,28 +44,28 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *Mutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // Unlock unlocks m.
 // +checklocksignore
 func (m *Mutex) Unlock() {
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Unlock()
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedUnlock(i lockNameIndex) {
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Unlock()
 }
 

--- a/pkg/sync/locking/generic_rwmutex.go
+++ b/pkg/sync/locking/generic_rwmutex.go
@@ -42,14 +42,14 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *RWMutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
@@ -57,20 +57,20 @@ func (m *RWMutex) NestedLock(i lockNameIndex) {
 // +checklocksignore
 func (m *RWMutex) Unlock() {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedUnlock(i lockNameIndex) {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 }
 
 // RLock locks m for reading.
 // +checklocksignore
 func (m *RWMutex) RLock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.RLock()
 }
 
@@ -78,7 +78,7 @@ func (m *RWMutex) RLock() {
 // +checklocksignore
 func (m *RWMutex) RUnlock() {
 	m.mu.RUnlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // RLockBypass locks m for reading without executing the validator.

--- a/pkg/sync/locking/locking.go
+++ b/pkg/sync/locking/locking.go
@@ -25,4 +25,8 @@
 // taken before the target one. For each goroutine, we have the list of
 // currently locked mutexes. And finally, all lock methods check that
 // ancestors of currently locked mutexes don't contain the target one.
+//
+// Lockdep bookkeeping may allocate maps and stack traces. Generated mutexes
+// exempt calls to this optional instrumentation from checkescape contracts;
+// the underlying mutex operations and their callers remain checked.
 package locking

--- a/pkg/sync/race_arm64.s
+++ b/pkg/sync/race_arm64.s
@@ -21,7 +21,7 @@
 TEXT ·RaceUncheckedAtomicCompareAndSwapUintptr(SB),NOSPLIT,$0-25
 	MOVD ptr+0(FP), R0
 	MOVD old+8(FP), R1
-	MOVD new+16(FP), R1
+	MOVD new+16(FP), R2
 again:
 	LDAXR (R0), R3
 	CMP R1, R3

--- a/pkg/syncevent/broadcaster.go
+++ b/pkg/syncevent/broadcaster.go
@@ -34,18 +34,25 @@ type Broadcaster struct {
 	// efficiently, which matters since the cost of Broadcast is linear in the
 	// size of the table.
 
-	// mu protects the following fields.
 	mu sync.Mutex
 
 	// Invariants: len(table) is 0 or a power of 2.
+	//
+	// +checklocks:mu
 	table []broadcasterSlot
 
 	// load is the number of entries in table with receiver != nil.
+	//
+	// +checklocks:mu
 	load int
 
+	// +checklocks:mu
 	lastID SubscriptionID
 }
 
+// broadcasterSlot fields in a published table are protected by the owning
+// Broadcaster's mu. A slot has no link back to that Broadcaster, so checklocks
+// cannot resolve the owner's mutex from the slot.
 type broadcasterSlot struct {
 	// Invariants: If receiver == nil, then filter == NoEvents and id == 0.
 	// Otherwise, id != 0.
@@ -62,6 +69,8 @@ const (
 )
 
 // SubscribeEvents implements Source.SubscribeEvents.
+//
+// +checklocksexclude:b.mu
 func (b *Broadcaster) SubscribeEvents(r *Receiver, filter Set) SubscriptionID {
 	b.mu.Lock()
 
@@ -111,9 +120,16 @@ func (b *Broadcaster) SubscribeEvents(r *Receiver, filter Set) SubscriptionID {
 	return id
 }
 
+// broadcasterTableInsert inserts a subscription into table.
+//
+// A table slice has no link to its owning Broadcaster, so checklocks cannot
+// resolve that mutex for writes through the slice.
+//
 // Preconditions:
 //   - table must not be full.
 //   - len(table) is a power of 2.
+//   - The caller holds the owning Broadcaster's mu or exclusively owns the
+//     backing storage of an unpublished table.
 func broadcasterTableInsert(table []broadcasterSlot, id SubscriptionID, r *Receiver, filter Set) {
 	entry := broadcasterSlot{
 		receiver: r,
@@ -142,6 +158,8 @@ func broadcasterTableInsert(table []broadcasterSlot, id SubscriptionID, r *Recei
 }
 
 // UnsubscribeEvents implements Source.UnsubscribeEvents.
+//
+// +checklocksexclude:b.mu
 func (b *Broadcaster) UnsubscribeEvents(id SubscriptionID) {
 	b.mu.Lock()
 
@@ -195,6 +213,11 @@ func (b *Broadcaster) UnsubscribeEvents(id SubscriptionID) {
 // Broadcast notifies all Receivers subscribed to the Broadcaster of the subset
 // of events to which they subscribed. The order in which Receivers are
 // notified is unspecified.
+//
+// Receiver callbacks run synchronously with b.mu held and must not reenter b.
+// checklocks cannot recover b's identity through ReceiverCallback.
+//
+// +checklocksexclude:b.mu
 func (b *Broadcaster) Broadcast(events Set) {
 	b.mu.Lock()
 	for i := range b.table {
@@ -209,6 +232,8 @@ func (b *Broadcaster) Broadcast(events Set) {
 
 // FilteredEvents returns the set of events for which Broadcast will notify at
 // least one Receiver, i.e. the union of filters for all subscribed Receivers.
+//
+// +checklocksexclude:b.mu
 func (b *Broadcaster) FilteredEvents() Set {
 	var es Set
 	b.mu.Lock()

--- a/tools/bazeldefs/go.bzl
+++ b/tools/bazeldefs/go.bzl
@@ -3,7 +3,7 @@
 load("@bazel_gazelle//:def.bzl", _gazelle = "gazelle")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@io_bazel_rules_go//go:def.bzl", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "GoArchive", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", _go_grpc_library = "go_grpc_library", _go_proto_library = "go_proto_library")
 load("//tools/bazeldefs:defs.bzl", "select_arch", "select_system")
 
@@ -88,6 +88,10 @@ def go_importpath(target):
     """Returns the importpath for the target."""
     return target[GoLibrary].importpath
 
+def go_binary_archive(target):
+    """Returns compiled Go archive metadata for a binary target."""
+    return target[GoArchive].data
+
 def go_library(name, bazel_cgo = False, bazel_cdeps = [], bazel_clinkopts = [], bazel_copts = [], **kwargs):
     """Wrapper for `go_library` rule.
 
@@ -159,13 +163,14 @@ def go_embed_libraries(target):
         return target.attr.embed
     return []
 
-def go_context(ctx, goos = None, goarch = None):
+def go_context(ctx, goos = None, goarch = None, attr = None):
     """Extracts a standard Go context struct.
 
     Args:
       ctx: the starlark context (required).
       goos: the GOOS value.
       goarch: the GOARCH value.
+      attr: the analyzed rule's attributes for aspect callers.
 
     Returns:
       A context Go struct with pointers to Go toolchain components.
@@ -174,7 +179,7 @@ def go_context(ctx, goos = None, goarch = None):
     # We don't change anything for the standard library analysis. All Go files
     # are available in all instances. Note that this includes the standard
     # library sources, which are analyzed by nogo.
-    go_ctx = _go_context(ctx)
+    go_ctx = _go_context(ctx, attr = attr)
 
     nogo_args = []
     if go_ctx.mode.race:

--- a/tools/checkescape/test3/BUILD
+++ b/tools/checkescape/test3/BUILD
@@ -1,0 +1,17 @@
+load("//tools:defs.bzl", "go_binary")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_binary(
+    name = "test3",
+    srcs = [
+        "main.go",
+        "tagged.go",
+    ],
+    gotags = ["checkescape_binary"],
+    pure = True,
+    testonly = True,
+)

--- a/tools/checkescape/test3/main.go
+++ b/tools/checkescape/test3/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Binary test3 checks build-tag and archive selection for nogo.
 package main
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
-
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+func main() {
+	// Analysis must use the binary's build tags to resolve this constant.
+	_ = taggedValue
 }

--- a/tools/checkescape/test3/tagged.go
+++ b/tools/checkescape/test3/tagged.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build checkescape_binary
+
 package main
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
+const taggedValue = true
 
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+// unusedAllocation remains in the Go archive but is removed by the linker.
+// The stack check rejects checkescape's conservative fallback if objdump fails.
+//
+// +mustescape:local,heap
+// +checkescape:stack
+//
+//go:noinline
+//go:nosplit
+func unusedAllocation() *int {
+	return new(int)
 }

--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -44,6 +44,20 @@ type foo struct {
 This will ensure that all accesses to bar are atomic, with the exception of
 operations on newly allocated objects (when detectable).
 
+An atomic call must use the annotated address as its receiver or atomic
+location. Storing that address as the payload of another atomic value does not
+make accesses through the stored pointer atomic.
+
+For global variables, atomic-use checking applies only when `+checkatomic` is
+present, for example:
+
+```go
+var (
+  // +checkatomic
+  globalValue atomicbitops.Int32
+)
+```
+
 ## Lock Enforcement
 
 Individual struct members may be protected by annotations that indicate locking
@@ -73,6 +87,8 @@ These semantics are enforceable on `sync.Mutex`, `sync.RWMutex` and
 `sync.Locker` fields. Semantics with respect to reading and writing are
 automatically detected and enforced. If an access is read-only, then the lock
 need only be held as a read lock, in the case of an `sync.RWMutex`.
+Annotations on a field declaration with multiple names apply to every named
+field in that declaration.
 
 The locks must be resolvable within the scope of the declaration. This means the
 lock must refer to one of:
@@ -82,7 +98,57 @@ lock must refer to one of:
 *   A global lock (e.g. globalMu).
 *   A lock resolvable from a global struct (e.g. globalX.mu).
 
+A field with multiple guards can additionally use `+checklocksreadany` when
+reads require **any one** guard, but writes require **all** guards exclusively:
+
+```go
+type example struct {
+    mu sync.Mutex
+    otherMu sync.RWMutex
+
+    // +checklocks:mu
+    // +checklocks:otherMu
+    // +checklocksreadany
+    value int
+}
+```
+
+A reader may hold `mu`, or hold `otherMu` for reading or writing. A writer must
+hold both mutexes for writing, so it excludes readers using either guard.
+The modifier applies only to fields, requires at least one `+checklocks` guard,
+and takes no arguments. Only value reads and immediately following loads
+qualify. Retaining an address or passing it to a function requires all guards
+exclusively, as with other guarded address uses; the modifier does not add
+alias lifetime tracking.
+With `+checkatomic`, atomic reads remain allowed without any guard. Holding
+any guard additionally permits an immediate non-atomic load, including a direct
+`atomicbitops.RacyLoad` call. This permission requires the field address's sole
+use to immediately follow it in the same basic block; retained addresses,
+casts, and deferred calls do not qualify. Atomic writes still require all
+guards exclusively, and non-atomic writes remain forbidden even with all
+guards held. The modifier cannot be combined with a field's `+checklocksignore`.
+
 Like atomic access enforcement, checks may be elided on newly allocated objects.
+
+### Global Variable Annotations
+
+Global variables also support lock and atomic annotations. Put annotations above
+a standalone declaration or above an individual entry in a `var` block:
+
+```go
+var globalMu sync.Mutex
+
+// +checklocks:globalMu
+var first int
+
+var (
+    // +checklocks:globalMu
+    second, third int
+)
+```
+
+Annotations apply to every named variable in that declaration or block entry.
+Comments above an entire `var` block do not annotate its entries.
 
 ### Function Annotations
 
@@ -195,13 +261,16 @@ by a mutex. Generally, this imposes the following requirements:
 
 For a read, one of the following must be true:
 
-1.  A lock held be held.
+1.  All guards must be held.
 1.  The access is atomic.
 
 For a write, both of the following must be true:
 
-1.  The lock must be held.
+1.  All guards must be held exclusively.
 1.  The write must be atomic.
+
+Shared RWMutex locks satisfy the lock-held read condition, but not the write
+condition.
 
 In order to annotate a relevant field, simply apply *both* annotations from
 above. For example:
@@ -217,10 +286,19 @@ type foo struct {
 
 This enforces that the preconditions above are upheld.
 
-This also applies to atomic wrapper types (for example, atomic.Int32). In the
-mixed case, lock-free access is limited to read-only atomic operations such as
-Load. Any atomic write operation (for example, Store, Swap, or Add) requires the
-lock to be held.
+This also applies to atomic wrapper types such as `atomic.Int32` and
+`atomic.Pointer[T]`. In the mixed case, lock-free access is limited to read-only
+atomic operations such as Load. Any atomic write operation (for example, Store,
+Swap, or Add) requires the lock to be held exclusively.
+
+The non-atomic `atomicbitops.RacyLoad` method follows the mixed read rule above.
+`RacyStore` and `RacyAdd` do not satisfy the atomic-write requirement, even with
+the lock held, because other readers may access the field atomically without
+locking. The exceptions for newly allocated objects still apply.
+
+Deferred atomic calls are supported for pure atomic fields and globals. Deferred
+calls on values with both atomic and mutex requirements remain unsupported: their
+locks would need to be checked when the calls execute, not when they are deferred.
 
 ## Ignoring and Forcing
 

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -17,6 +17,8 @@ package checklocks
 import (
 	"go/token"
 	"go/types"
+	"maps"
+	"slices"
 	"strings"
 
 	"golang.org/x/tools/go/ssa"
@@ -90,7 +92,7 @@ func (pc *passContext) checkTypeAlignment(pkg *types.Package, typ *types.Named) 
 	}
 }
 
-// atomicRules specify read constraints.
+// atomicRules specifies permitted access modes.
 type atomicRules int
 
 const (
@@ -98,22 +100,54 @@ const (
 	readWriteAtomic
 	readOnlyAtomic
 	mixedAtomic
+	readOnlyMixedAtomic
 )
 
-// checkAtomicCall checks for an atomic access.
-//
-// inst is the instruction analyzed, obj is used only for maybeFail.
-func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, ar atomicRules) {
+// functionPackage also resolves methods from indirectly imported packages,
+// which buildssa may represent using type information without an SSA package.
+func functionPackage(fn *ssa.Function) *types.Package {
+	if pkg := fn.Package(); pkg != nil {
+		return pkg.Pkg
+	}
+	obj, ok := fn.Object().(*types.Func)
+	if !ok || fn.Signature.Recv() == nil {
+		return nil
+	}
+	recv := obj.Type().(*types.Signature).Recv()
+	// Wrappers may retain the original method object but change or remove
+	// its receiver. They must not inherit the method's atomic privileges.
+	if recv == nil || !types.Identical(fn.Signature.Recv().Type(), recv.Type()) {
+		return nil
+	}
+	return obj.Pkg()
+}
+
+// checkAtomicCall checks whether inst accesses the value atomically.
+func (pc *passContext) checkAtomicCall(inst ssa.Instruction, value ssa.Value, ar atomicRules) {
+	allowNonAtomicRead := ar == mixedAtomic || ar == readOnlyMixedAtomic
 	switch x := inst.(type) {
-	case *ssa.Call:
-		if x.Common().IsInvoke() {
+	case *ssa.Call, *ssa.Defer:
+		if _, deferred := x.(*ssa.Defer); deferred {
+			// Pure atomic access does not depend on lock state. Guarded
+			// deferred accesses would need their locks checked at execution,
+			// not registration, so keep rejecting those conservatively.
+			if ar != readWriteAtomic {
+				break
+			}
+			// Deferred uses previously reached the force-aware fallback.
+			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
+				return
+			}
+		}
+		call := x.(ssa.CallInstruction).Common()
+		if call.IsInvoke() {
 			if ar != nonAtomic {
 				// This is an illegal interface dispatch.
 				pc.maybeFail(inst.Pos(), "dynamic dispatch with atomic-only field")
 			}
 			return
 		}
-		fn, ok := x.Common().Value.(*ssa.Function)
+		fn, ok := call.Value.(*ssa.Function)
 		if !ok {
 			if ar != nonAtomic {
 				// This is an illegal call to a non-static function.
@@ -121,7 +155,11 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 			}
 			return
 		}
-		pkg := fn.Package()
+		// Generic instantiation wrappers may have no package of their own.
+		if origin := fn.Origin(); origin != nil {
+			fn = origin
+		}
+		pkg := functionPackage(fn)
 		if pkg == nil {
 			if ar != nonAtomic {
 				// This is a call to some shared wrapper function.
@@ -133,12 +171,18 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 		if obj := fn.Object(); obj != nil && pc.pass.ImportObjectFact(obj, &lff) && lff.Ignore {
 			return
 		}
-		if name := pkg.Pkg.Name(); name != "atomic" && name != "atomicbitops" {
+		if name := pkg.Name(); name != "atomic" && name != "atomicbitops" {
 			if ar != nonAtomic {
 				// This is an illegal call to a non-atomic package function.
 				pc.maybeFail(inst.Pos(), "dispatch to non-atomic function with atomic-only field")
 			}
 			return
+		}
+		// Only the receiver (or first argument to a free function) is the
+		// atomic location. Storing the field's address as a pointer payload
+		// would let later accesses bypass its atomic requirement.
+		if len(call.Args) == 0 || call.Args[0] != value {
+			break
 		}
 		if ar == nonAtomic {
 			if fn.Signature.Recv() != nil {
@@ -151,8 +195,20 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic function")
 			}
 		}
-		if !strings.HasPrefix(fn.Name(), "Load") && ar == readOnlyAtomic {
-			// We are not allowing any reads in this context.
+		if pkg.Name() == "atomicbitops" && strings.HasPrefix(fn.Name(), "Racy") {
+			// Racy methods are non-atomic. Mixed access permits non-atomic
+			// reads under the lock, but writes must remain atomic for
+			// concurrent lock-free readers.
+			if ar != nonAtomic && (!allowNonAtomicRead || fn.Name() != "RacyLoad") {
+				if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
+					pc.maybeFail(inst.Pos(), "non-atomic operation %s on atomic-only field", fn.Name())
+				}
+			}
+			return
+		}
+		if (ar == readOnlyAtomic || ar == readOnlyMixedAtomic) &&
+			!strings.HasPrefix(fn.Name(), "Load") {
+			// We are not allowing any writes in this context.
 			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic write function, is a lock missing?")
 			}
@@ -162,11 +218,11 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 	case *ssa.ChangeType:
 		// Allow casts for atomic values, but nothing else.
 		if refs := x.Referrers(); refs != nil && len(*refs) == 1 {
-			pc.checkAtomicCall((*refs)[0], obj, ar)
+			pc.checkAtomicCall((*refs)[0], x, ar)
 			return
 		}
 	case *ssa.UnOp:
-		if x.Op == token.MUL && ar == mixedAtomic {
+		if x.Op == token.MUL && allowNonAtomicRead {
 			// This is allowed; this is a strict reading.
 			return
 		}
@@ -245,6 +301,45 @@ type almostInst interface {
 	Referrers() *[]ssa.Instruction
 }
 
+// isImmediateFieldRead reports whether inst reads a value without retaining
+// its address. allowRacyLoad also accepts atomicbitops.RacyLoad.
+func isImmediateFieldRead(inst almostInst, allowRacyLoad bool) bool {
+	switch x := inst.(type) {
+	case *ssa.Field:
+		return true
+	case *ssa.FieldAddr:
+		refs := x.Referrers()
+		if refs == nil || len(*refs) != 1 || x.Block() == nil {
+			return false
+		}
+		// Use instruction order, not source positions: a retained address
+		// may be loaded after an unlock, including on another control path.
+		use := (*refs)[0]
+		instrs := x.Block().Instrs
+		i := slices.Index(instrs, ssa.Instruction(x))
+		if i < 0 || i+1 >= len(instrs) || instrs[i+1] != use {
+			return false
+		}
+		switch use := use.(type) {
+		case *ssa.UnOp:
+			return use.Op == token.MUL && use.X == x
+		case *ssa.Call:
+			call := use.Common()
+			fn := call.StaticCallee()
+			if !allowRacyLoad || fn == nil || len(call.Args) != 1 || call.Args[0] != x {
+				return false
+			}
+			if origin := fn.Origin(); origin != nil {
+				fn = origin
+			}
+			pkg := functionPackage(fn)
+			return pkg != nil && pkg.Path() == "gvisor.dev/gvisor/pkg/atomicbitops" &&
+				fn.Signature.Recv() != nil && fn.Name() == "RacyLoad"
+		}
+	}
+	return false
+}
+
 // checkGuards checks the guards held.
 //
 // This also enforces atomicity constraints for fields that must be accessed
@@ -253,15 +348,21 @@ type almostInst interface {
 //
 // Note that this function is not called if lff.Ignore is true, since it cannot
 // discover any local anonymous functions or closures.
-func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj types.Object, ls *lockState, isWrite bool) {
+func (pc *passContext) checkGuards(inst almostInst, value, from ssa.Value, accessObj types.Object, ls *lockState, isWrite bool) {
 	var (
 		lgf         lockGuardFacts
 		guardsFound int
-		guardsHeld  = make(map[string]struct{}) // Keyed by resolved string.
+		// guardsHeld maps resolved names to exclusive (true) or shared (false).
+		guardsHeld = make(map[string]bool)
 	)
 
 	// Load the facts for the object accessed.
 	pc.importLockGuardFacts(accessObj, &lgf)
+	if lgf.ReadAny && lgf.AtomicDisposition == atomicDisallow {
+		// Unlike the optimistic isWrite check, alternative reader guards
+		// must not admit an address used for mutation or escaping aliases.
+		isWrite = isWrite || !isImmediateFieldRead(inst, false /* allowRacyLoad */)
+	}
 	pc.applyTypeAliases(ls, from)
 
 	// Check guards held.
@@ -275,14 +376,15 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		}
 		s, ok := ls.isHeld(r, isWrite)
 		if ok {
-			guardsHeld[s] = struct{}{}
+			_, exclusive := ls.isHeld(r, true)
+			guardsHeld[s] = exclusive
 			continue
 		}
 		if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
 			// Mark this as locked, since it has been forced. All
 			// forces are treated as an exclusive lock.
 			s, _ := ls.lockField(r, true /* exclusive */)
-			guardsHeld[s] = struct{}{}
+			guardsHeld[s] = true
 			continue
 		}
 		// Note that we may allow this if the disposition is atomic,
@@ -291,10 +393,15 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		// access is atomic. Further, len(guardsHeld) < guardsFound
 		// will be true for this case, so we require it to be
 		// read-only.
-		if lgf.AtomicDisposition != atomicRequired {
+		if lgf.AtomicDisposition != atomicRequired && (!lgf.ReadAny || isWrite) {
 			// There is no force key, no atomic access and no lock held.
 			pc.maybeFail(inst.Pos(), "invalid field access, %s (%s) must be locked when accessing %s (locks: %s)", guardName, s, accessObj.Name(), ls.String())
 		}
+	}
+
+	if lgf.ReadAny && lgf.AtomicDisposition == atomicDisallow && !isWrite && len(guardsHeld) == 0 {
+		guards := strings.Join(slices.Sorted(maps.Keys(lgf.GuardedBy)), ", ")
+		pc.maybeFail(inst.Pos(), "invalid field access, at least one of %s must be locked when reading %s (locks: %s)", guards, accessObj.Name(), ls.String())
 	}
 
 	// Check the atomic access for this field.
@@ -307,11 +414,22 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 				ar = readOnlyAtomic
 			} else {
 				ar = mixedAtomic
+				for _, exclusive := range guardsHeld {
+					if !exclusive {
+						ar = readOnlyMixedAtomic
+						break
+					}
+				}
 			}
+		}
+		if ar == readOnlyAtomic && lgf.ReadAny && len(guardsHeld) > 0 && isImmediateFieldRead(inst, true /* allowRacyLoad */) {
+			// Permit only an immediate non-atomic read under an alternative
+			// guard. Writes still need every guard held exclusively.
+			ar = readOnlyMixedAtomic
 		}
 		if refs := inst.Referrers(); refs != nil {
 			for _, otherInst := range *refs {
-				pc.checkAtomicCall(otherInst, accessObj, ar)
+				pc.checkAtomicCall(otherInst, value, ar)
 			}
 		}
 		// Check that this is not otherwise written non-atomically,
@@ -327,7 +445,7 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		// Check that this is *not* used atomically.
 		if refs := inst.Referrers(); refs != nil {
 			for _, otherInst := range *refs {
-				pc.checkAtomicCall(otherInst, accessObj, nonAtomic)
+				pc.checkAtomicCall(otherInst, value, nonAtomic)
 			}
 		}
 	}
@@ -373,22 +491,35 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 }
 
 // checkFieldAccess checks the validity of a field access.
-func (pc *passContext) checkFieldAccess(inst almostInst, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
+func (pc *passContext) checkFieldAccess(inst ssa.Value, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
 	fieldObj, _ := findField(structObj.Type(), field)
-	pc.checkGuards(inst, structObj, fieldObj, ls, isWrite)
+	pc.checkGuards(inst, inst, structObj, fieldObj, ls, isWrite)
 }
 
-// noReferrers wraps an instruction as an almostInst.
-type noReferrers struct {
+// globalAccess exposes a global's consuming instruction to atomic checks.
+type globalAccess struct {
 	ssa.Instruction
+	checkAtomic bool
 }
 
 // Referrers implements almostInst.Referrers.
-func (noReferrers) Referrers() *[]ssa.Instruction { return nil }
+func (a globalAccess) Referrers() *[]ssa.Instruction {
+	if !a.checkAtomic {
+		return nil
+	}
+	return &[]ssa.Instruction{a.Instruction}
+}
 
 // checkGlobalAccess checks the validity of a global access.
 func (pc *passContext) checkGlobalAccess(inst ssa.Instruction, g *ssa.Global, ls *lockState, isWrite bool) {
-	pc.checkGuards(noReferrers{inst}, g, g.Object(), ls, isWrite)
+	var lgf lockGuardFacts
+	pc.importLockGuardFacts(g.Object(), &lgf)
+	pc.checkGuards(globalAccess{
+		Instruction: inst,
+		// Only explicitly annotated globals opt into atomic-use checking.
+		// Direct writes are diagnosed separately by checkGuards.
+		checkAtomic: !isWrite && lgf.AtomicDisposition == atomicRequired,
+	}, g, g, g.Object(), ls, isWrite)
 }
 
 func (pc *passContext) checkCall(call callCommon, lff *lockFunctionFacts, ls *lockState) {
@@ -478,6 +609,10 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 		}
 		// Acquire the lock per the annotation.
 		r := fg.Resolver.resolveCall(pc, ls, call.Common().Args, call.Value())
+		if !r.valid() {
+			pc.maybeFail(call.Pos(), "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.lockField(r, fg.Exclusive); !ok && !lff.Ignore {
 			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 				pc.maybeFail(call.Pos(), "attempt to acquire %s (%s), but already held (locks: %s)", fieldName, s, ls.String())
@@ -495,10 +630,10 @@ func exclusiveStr(exclusive bool) string {
 }
 
 // checkFunctionCall checks preconditions for function calls, and tracks the
-// lock state by recording relevant calls to sync functions. Note that calls to
-// atomic functions are tracked by checkFieldAccess by looking directly at the
-// referrers (because ordering doesn't matter there, so we need not scan in
-// instruction order).
+// lock state by recording relevant calls to sync functions. Atomic field
+// referrers are checked by checkFieldAccess using the lock state at the field
+// access, not at a later use of a retained field address. Direct global atomic
+// operations are checked at their consuming instructions.
 func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *lockFunctionFacts, ls *lockState) {
 	// Extract the "receiver" properly.
 	var args []ssa.Value
@@ -525,6 +660,10 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check that excluded locks are not held on entry.
 	for fieldName, fg := range lff.ExcludedOnEntry {
 		r := resolve(fg)
+		if !r.valid() {
+			pc.maybeFail(callPos, "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); ok {
 			if !forced && !lff.Ignore {
 				if fg.Exclusive {
@@ -539,6 +678,10 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check all guards required are held.
 	for fieldName, fg := range lff.HeldOnEntry {
 		r := resolve(fg)
+		if !r.valid() {
+			pc.maybeFail(callPos, "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); !ok {
 			if !forced && !lff.Ignore {
 				pc.maybeFail(callPos, "must hold %s %s (%s) to call %s, but not held (locks: %s)", fieldName, exclusiveStr(fg.Exclusive), s, fn.Name(), ls.String())
@@ -658,9 +801,8 @@ type callCommon interface {
 // checkInstruction checks the legality the single instruction based on the
 // current lockState.
 func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionFacts, ls *lockState) (*ssa.Return, *lockState) {
-	// Record any observed globals, and check for violations. The global
-	// value is not itself an instruction, but we check all referrers to
-	// see where they are consumed.
+	// Globals are values, not instructions. Check each use with the current
+	// instruction's lock state.
 	var stackLocal [16]*ssa.Value
 	ops := inst.Operands(stackLocal[:])
 	for _, v := range ops {
@@ -668,10 +810,11 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 			continue
 		}
 		g, ok := (*v).(*ssa.Global)
-		if !ok {
+		if !ok || lff.Ignore {
 			continue
 		}
-		_, isWrite := inst.(*ssa.Store)
+		store, ok := inst.(*ssa.Store)
+		isWrite := ok && store.Addr == g
 		pc.checkGlobalAccess(inst, g, ls, isWrite)
 	}
 
@@ -710,20 +853,22 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 				nonCalls int
 			)
 			for _, ref := range *refs {
-				switch ref.(type) {
-				case *ssa.Call, *ssa.Defer:
-					// Analysis will be done on the call
-					// itself subsequently, including the
-					// lock state at the time of the call.
-					calls++
-				default:
-					// We need to analyze separately. Per
-					// below, this means that we'll analyze
-					// at closure construction time no zero
-					// assumptions about when it will be
-					// called.
-					nonCalls++
+				// Only direct calls are analyzed later with the lock
+				// state at invocation. Passing the closure as an argument
+				// gives no guarantee about when it will be called.
+				switch ref := ref.(type) {
+				case *ssa.Call:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
+				case *ssa.Defer:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
 				}
+				nonCalls++
 			}
 			if calls > 0 && nonCalls == 0 {
 				return nil, nil

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -25,6 +25,7 @@ import (
 const (
 	checkLocksAnnotation     = "// +checklocks:"
 	checkLocksAnnotationRead = "// +checklocksread:"
+	checkLocksReadAny        = "// +checklocksreadany"
 	checkLocksAcquires       = "// +checklocksacquire:"
 	checkLocksAcquiresRead   = "// +checklocksacquireread:"
 	checkLocksReleases       = "// +checklocksrelease:"

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -95,7 +95,7 @@ func (pc *passContext) observationsFor(obj types.Object) *objectObservations {
 }
 
 // forAllGlobals applies the given function to all globals.
-func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
+func (pc *passContext) forAllGlobals(fn func(vs *ast.ValueSpec, decl *ast.GenDecl)) {
 	for _, f := range pc.pass.Files {
 		for _, decl := range f.Decls {
 			d, ok := decl.(*ast.GenDecl)
@@ -103,7 +103,7 @@ func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
 				continue
 			}
 			for _, gs := range d.Specs {
-				fn(gs.(*ast.ValueSpec))
+				fn(gs.(*ast.ValueSpec), d)
 			}
 		}
 	}
@@ -151,12 +151,12 @@ func run(pass *analysis.Pass) (any, error) {
 	pc.extractLineFailures()
 
 	// Find all struct declarations and export relevant facts.
-	pc.forAllGlobals(func(vs *ast.ValueSpec) {
+	pc.forAllGlobals(func(vs *ast.ValueSpec, decl *ast.GenDecl) {
 		if ss, ok := vs.Type.(*ast.StructType); ok {
 			structType := pc.pass.TypesInfo.TypeOf(vs.Type).Underlying().(*types.Struct)
 			pc.structLockGuardFacts(structType, ss)
 		}
-		pc.globalLockGuardFacts(vs)
+		pc.globalLockGuardFacts(vs, decl)
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec, decl *ast.GenDecl) {
 		if ss, ok := ts.Type.(*ast.StructType); ok {

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -106,12 +106,14 @@ func fieldEntryEqual(left, right fieldEntry) bool {
 // fieldList is a simple list of fields, used in two types below.
 type fieldList []fieldEntry
 
-// resolvedValue is an ssa.Value with additional fields.
-//
-// This can be resolved to a string as part of a lock state.
+// resolvedValue identifies a lock through SSA or an exported global identity.
 type resolvedValue struct {
 	value     ssa.Value
 	fieldList fieldList
+
+	// key identifies an imported global whose declaration or package is absent
+	// from SSA. It is synthesized where the declaration's type is available.
+	key string
 }
 
 // makeResolvedValue makes a new resolvedValue.
@@ -124,15 +126,17 @@ func makeResolvedValue(v ssa.Value, fl fieldList) resolvedValue {
 
 // valid indicates whether this is a valid resolvedValue.
 func (rv *resolvedValue) valid() bool {
-	return rv.value != nil
+	return rv.value != nil || rv.key != ""
 }
 
 // valueAndObject returns a string and object.
 //
-// This uses the lockState valueAndObject in order to produce a string and
-// object for the base ssa.Value, then synthesizes a string representation
-// based on the fieldList.
+// An imported identity may have no source object. Otherwise, resolve the base
+// SSA value through lockState and synthesize its field path.
 func (rv *resolvedValue) valueAndObject(ls *lockState) (string, types.Object) {
+	if rv.key != "" {
+		return rv.key, nil
+	}
 	// N.B. obj.Type() and typ should be equal, but a check is omitted
 	// since, 1) we automatically chase through pointers during field
 	// resolution, and 2) obj may be nil if there is no source object.
@@ -172,6 +176,10 @@ type lockGuardFacts struct {
 	// traversal path.
 	GuardedBy map[string]fieldGuardResolver
 
+	// ReadAny allows immediate non-atomic reads with any guard held.
+	// Writes still require all guards exclusively.
+	ReadAny bool
+
 	// AtomicDisposition is the disposition for this field. Note that this
 	// can affect the interpretation of the GuardedBy field above, see the
 	// relevant comment.
@@ -191,6 +199,14 @@ type globalGuard struct {
 
 	// FieldList is the traversal path from object.
 	FieldList fieldList
+
+	// Key preserves the complete lock identity when export data omits the
+	// private global or the caller does not directly import its package.
+	Key string
+}
+
+func globalLockKey(pkgPath, name string) string {
+	return fmt.Sprintf("{global:%s.%s}", pkgPath, name)
 }
 
 // ssaPackager returns the ssa package.
@@ -205,8 +221,12 @@ func (g *globalGuard) resolveCommon(pc *passContext, ls *lockState) resolvedValu
 	if g.PackageName != "" && g.PackageName != state.Pkg.Pkg.Path() {
 		pkg = state.Pkg.Prog.ImportedPackage(g.PackageName)
 	}
-	v := pkg.Members[g.ObjectName].(ssa.Value)
-	return makeResolvedValue(v, g.FieldList)
+	if pkg != nil {
+		if v, ok := pkg.Members[g.ObjectName].(ssa.Value); ok {
+			return makeResolvedValue(v, g.FieldList)
+		}
+	}
+	return resolvedValue{key: g.Key}
 }
 
 // resolveStatic implements functionGuardResolver.resolveStatic.
@@ -730,6 +750,20 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 	}
 	for _, l := range cg.List {
 		pc.extractAnnotations(l.Text, map[string]func(string){
+			checkLocksReadAny: func(p string) {
+				if field, ok := obj.(*types.Var); !ok || !field.IsField() {
+					pc.maybeFail(obj.Pos(), "checklocksreadany is only valid on fields")
+					return
+				}
+				if p != "" {
+					pc.maybeFail(obj.Pos(), "checklocksreadany does not take arguments")
+					return
+				}
+				if lgf.ReadAny {
+					pc.maybeFail(obj.Pos(), "checklocksreadany specified more than once")
+				}
+				lgf.ReadAny = true
+			},
 			checkAtomicAnnotation: func(string) {
 				switch lgf.AtomicDisposition {
 				case atomicRequired:
@@ -773,6 +807,21 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 			},
 		})
 	}
+}
+
+// exportLockGuardFacts validates and exports accumulated lock guard facts.
+// For fields, both the doc comment and trailing comment must have been read.
+func (pc *passContext) exportLockGuardFacts(obj types.Object, lgf *lockGuardFacts) {
+	if lgf.ReadAny {
+		if len(lgf.GuardedBy) == 0 {
+			pc.maybeFail(obj.Pos(), "checklocksreadany requires at least one checklocks guard")
+			lgf.ReadAny = false
+		}
+		if lgf.AtomicDisposition == atomicIgnore {
+			pc.maybeFail(obj.Pos(), "checklocksreadany cannot be combined with checklocksignore")
+			lgf.ReadAny = false
+		}
+	}
 	// Save only if there is something meaningful.
 	if len(lgf.GuardedBy) > 0 || lgf.AtomicDisposition != atomicDisallow {
 		pc.pass.ExportObjectFact(obj, lgf)
@@ -783,9 +832,9 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 func (pc *passContext) findGlobalGuard(pos token.Pos, guardName string) (*globalGuard, types.Object, bool) {
 	// Attempt to resolve the object.
 	parts := strings.Split(guardName, ".")
-	globalObj := pc.pass.Pkg.Scope().Lookup(parts[0])
-	if globalObj == nil {
-		// No global object.
+	globalObj, ok := pc.pass.Pkg.Scope().Lookup(parts[0]).(*types.Var)
+	if !ok {
+		// A type or constant cannot identify a global lock.
 		return nil, nil, false
 	}
 	fl, lockObj, ok := pc.maybeFindFieldListObj(pos, globalObj, parts[1:])
@@ -796,10 +845,18 @@ func (pc *passContext) findGlobalGuard(pos token.Pos, guardName string) (*global
 	if pc.lockKind(pos, lockObj) == nil {
 		return nil, nil, false
 	}
+	key := globalLockKey(pc.pass.Pkg.Path(), globalObj.Name())
+	typ := globalObj.Type()
+	for _, entry := range fl {
+		var obj types.Object
+		key, obj = entry.synthesize(key, typ)
+		typ = obj.Type()
+	}
 	return &globalGuard{
 		ObjectName:  parts[0],
 		PackageName: pc.pass.Pkg.Path(),
 		FieldList:   fl,
+		Key:         key,
 	}, lockObj, true
 }
 
@@ -817,7 +874,6 @@ func (pc *passContext) findGlobalFunctionGuard(pos token.Pos, guardName string) 
 
 // structLockGuardFacts finds all relevant guard information for structures.
 func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.StructType) {
-	var fieldObj *types.Var
 	findLocal := func(pos token.Pos, guardName string) (fieldGuardResolver, bool) {
 		// Try to resolve from the local structure first.
 		if fl, _, objs, ok := pc.resolveFieldListParts(pos, structType, strings.Split(guardName, ".")); ok {
@@ -834,20 +890,28 @@ func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.St
 		// Attempt a global resolution.
 		return pc.findGlobalFieldGuard(pos, guardName)
 	}
-	for i, field := range ss.Fields.List {
-		var lgf lockGuardFacts
-		fieldObj = structType.Field(i) // N.B. Captured above.
-		if field.Doc != nil {
-			pc.fillLockGuardFacts(fieldObj, field.Doc, findLocal, &lgf)
-		}
-		if field.Comment != nil {
-			pc.fillLockGuardFacts(fieldObj, field.Comment, findLocal, &lgf)
-		}
+	fieldIndex := 0
+	for _, field := range ss.Fields.List {
+		// A declaration may name several fields; an embedded field has no
+		// names but still occupies one position in the expanded struct type.
+		for range max(1, len(field.Names)) {
+			fieldObj := structType.Field(fieldIndex)
+			fieldIndex++
+			var lgf lockGuardFacts
+			if field.Doc != nil {
+				pc.fillLockGuardFacts(fieldObj, field.Doc, findLocal, &lgf)
+			}
+			if field.Comment != nil {
+				pc.fillLockGuardFacts(fieldObj, field.Comment, findLocal, &lgf)
+			}
 
-		// See above, for anonymous structure fields.
-		if ss, ok := field.Type.(*ast.StructType); ok {
-			if st, ok := types.Unalias(fieldObj.Type()).(*types.Struct); ok {
-				pc.structLockGuardFacts(st, ss)
+			pc.exportLockGuardFacts(fieldObj, &lgf)
+
+			// See above, for anonymous structure fields.
+			if ss, ok := field.Type.(*ast.StructType); ok {
+				if st, ok := types.Unalias(fieldObj.Type()).(*types.Struct); ok {
+					pc.structLockGuardFacts(st, ss)
+				}
 			}
 		}
 	}
@@ -856,10 +920,21 @@ func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.St
 // globalLockGuardFacts finds all relevant guard information for globals.
 //
 // Note that the Type is checked in checklocks.go at the top-level.
-func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec) {
-	var lgf lockGuardFacts
-	globalObj := pc.pass.TypesInfo.ObjectOf(vs.Names[0])
-	pc.fillLockGuardFacts(globalObj, vs.Doc, pc.findGlobalFieldGuard, &lgf)
+func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec, decl *ast.GenDecl) {
+	cg := vs.Doc
+	if !decl.Lparen.IsValid() {
+		// Standalone declarations attach their comments to the GenDecl.
+		cg = decl.Doc
+	}
+	for _, name := range vs.Names {
+		if name.Name == "_" {
+			continue
+		}
+		var lgf lockGuardFacts
+		globalObj := pc.pass.TypesInfo.ObjectOf(name)
+		pc.fillLockGuardFacts(globalObj, cg, pc.findGlobalFieldGuard, &lgf)
+		pc.exportLockGuardFacts(globalObj, &lgf)
+	}
 }
 
 // countFields gives an accurate field count, according for unnamed arguments
@@ -984,6 +1059,7 @@ func (pc *passContext) functionFacts(d *ast.FuncDecl) {
 				// extremely rare.
 				lff.Ignore = true
 			},
+			checkLocksReadAny:        func(string) { pc.maybeFail(d.Pos(), "checklocksreadany is only valid on fields") },
 			checkLocksAnnotation:     func(guardName string) { lff.addGuardedBy(pc, d, guardName, true /* exclusive */) },
 			checkLocksAnnotationRead: func(guardName string) { lff.addGuardedBy(pc, d, guardName, false /* exclusive */) },
 			checkLocksAcquires:       func(guardName string) { lff.addAcquires(pc, d, guardName, true /* exclusive */) },
@@ -1011,6 +1087,7 @@ func (pc *passContext) typeAliasFacts(ts *ast.TypeSpec, decl *ast.GenDecl) {
 		}
 		for _, l := range cg.List {
 			pc.extractAnnotations(l.Text, map[string]func(string){
+				checkLocksReadAny: func(string) { pc.maybeFail(ts.Pos(), "checklocksreadany is only valid on fields") },
 				checkLocksAlias: func(guardName string) {
 					if !ok {
 						pc.maybeFail(ts.Pos(), "annotation %s is only valid on struct types", guardName)

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -287,12 +287,18 @@ func (l *lockState) valueAndObject(v ssa.Value) (string, types.Object) {
 		}
 		return fmt.Sprintf("{param:%s}", x.Name()), x.Object()
 	case *ssa.Global:
-		return fmt.Sprintf("{global:%s}", x.Name()), x.Object()
+		return globalLockKey(x.Pkg.Pkg.Path(), x.Name()), x.Object()
 	case *ssa.FreeVar:
 		// Attempt to resolve this, in case we are being invoked in a
 		// scope where all the variables are bound.
 		v, ok := l.stored[x]
 		if ok {
+			// Nested closures capture the enclosing FreeVar. Follow that
+			// binding before dereferencing the captured location. A Store
+			// can instead place an address here, with a different type.
+			if fv, ok := v.(*ssa.FreeVar); ok && types.Identical(fv.Type(), x.Type()) {
+				return l.valueAndObject(fv)
+			}
 			// The FreeVar is typically bound to a location, so we
 			// check what's been stored there. Note that the second
 			// may map to the same FreeVar, which we can check.

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -28,9 +28,12 @@ go_library(
         "rwmutex.go",
         "test.go",
     ],
-    # This ensures that there are no dependencies, since we want to explicitly
-    # control expected failures for analysis.
+    # Disable generated marshal/state sources so they do not add unexpected
+    # diagnostics to this fixture.
     marshal = False,
     stateify = False,
-    deps = ["//tools/checklocks/test/crosspkg"],
+    deps = [
+        "//pkg/atomicbitops",
+        "//tools/checklocks/test/crosspkg",
+    ],
 )

--- a/tools/checklocks/test/atomicfields/BUILD
+++ b/tools/checklocks/test/atomicfields/BUILD
@@ -6,11 +6,10 @@ package(
 )
 
 go_library(
-    name = "crosspkg",
-    srcs = ["crosspkg.go"],
-    # See next level up.
+    name = "atomicfields",
+    srcs = ["atomicfields.go"],
     marshal = False,
     stateify = False,
-    visibility = ["//tools/checklocks/test:__pkg__"],
-    deps = ["//tools/checklocks/test/atomicfields"],
+    visibility = ["//tools/checklocks/test/crosspkg:__pkg__"],
+    deps = ["//pkg/atomicbitops"],
 )

--- a/tools/checklocks/test/atomicfields/atomicfields.go
+++ b/tools/checklocks/test/atomicfields/atomicfields.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package atomicfields exposes atomic fields to a consumer that does not
+// directly import their types' packages.
+package atomicfields
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
+)
+
+type Values struct {
+	// +checkatomic
+	Standard atomic.Pointer[int]
+	// +checkatomic
+	Bitops atomicbitops.Uint64
+	// +checkatomic
+	Promoted WrappedAtomic
+
+	Mu      sync.Mutex
+	OtherMu sync.Mutex
+	// +checklocks:Mu
+	// +checklocks:OtherMu
+	// +checklocksreadany
+	// +checkatomic
+	Mixed atomicbitops.Uint64
+}
+
+type WrappedAtomic struct {
+	atomicbitops.Uint64
+}

--- a/tools/checklocks/test/atomicfields/atomicfields.go
+++ b/tools/checklocks/test/atomicfields/atomicfields.go
@@ -43,3 +43,15 @@ type Values struct {
 type WrappedAtomic struct {
 	atomicbitops.Uint64
 }
+
+var globalMu sync.Mutex
+
+// RequirePrivate requires a lock in this indirectly imported package.
+//
+// +checklocks:globalMu
+func (*Values) RequirePrivate() {}
+
+// ExcludePrivate excludes a lock in this indirectly imported package.
+//
+// +checklocksexclude:globalMu
+func (*Values) ExcludePrivate() {}

--- a/tools/checklocks/test/atomics.go
+++ b/tools/checklocks/test/atomics.go
@@ -17,6 +17,8 @@ package test
 import (
 	"sync"
 	"sync/atomic"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 )
 
 type atomicStruct struct {
@@ -29,6 +31,13 @@ type atomicStruct struct {
 	ignored int32
 
 	wrapper atomic.Int32 // safe without any annotations
+	bitops  atomicbitops.Int32
+
+	// +checkatomic
+	atomicBitops atomicbitops.Int32
+
+	// +checkatomic
+	pointer atomic.Pointer[int32]
 }
 
 func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -38,6 +47,11 @@ func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
 
 func testAtomicAccess(tc *atomicStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedAtomically)
+	_ = tc.pointer.Load()
+	tc.pointer.Store(nil)
+	defer tc.pointer.Store(nil)
+	defer atomic.StoreInt32(&tc.accessedAtomically, 1)
+	go tc.pointer.Store(nil) // +checklocksfail=illegal use
 }
 
 func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
@@ -45,8 +59,21 @@ func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
 }
 
 func testNormalAccessInvalid(tc *atomicStruct, v chan int32, p chan *int32) {
-	v <- tc.accessedAtomically  // +checklocksfail
-	p <- &tc.accessedAtomically // +checklocksfail
+	v <- tc.accessedAtomically              // +checklocksfail
+	p <- &tc.accessedAtomically             // +checklocksfail
+	_ = genericLoad(&tc.accessedAtomically) // +checklocksfail=non-atomic function
+	// Keep this return-valued call directly deferred: a wrapper discarding
+	// its result would test a closure instead of the operation's SSA Defer.
+	defer genericLoad(&tc.accessedAtomically) // +checklocksforce
+	// An atomic pointer payload is not the atomic location being accessed.
+	var sink atomic.Pointer[int32]
+	sink.Store(&tc.accessedAtomically)       // +checklocksfail=illegal use
+	defer sink.Store(&tc.accessedAtomically) // +checklocksfail=illegal use
+	*sink.Load() = 1
+}
+
+func genericLoad[T any](p *T) T {
+	return *p
 }
 
 func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -56,7 +83,7 @@ func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
 }
 
 type atomicMixedStruct struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	// +checkatomic
 	// +checklocks:mu
@@ -65,11 +92,20 @@ type atomicMixedStruct struct {
 	// +checkatomic
 	// +checklocks:mu
 	wrapper atomic.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	bitops atomicbitops.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	pointer atomic.Pointer[int32]
 }
 
 func testAtomicMixedValidRead(tc *atomicMixedStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedMixed)
 	v <- tc.wrapper.Load()
+	_ = tc.pointer.Load()
 }
 
 func testAtomicMixedInvalidRead(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -81,7 +117,36 @@ func testAtomicMixedValidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan
 	tc.mu.Lock()
 	atomic.StoreInt32(&tc.accessedMixed, 1)
 	tc.wrapper.Store(1)
+	tc.pointer.Store(nil)
 	tc.mu.Unlock()
+}
+
+func testAtomicMixedReadLocked(tc *atomicMixedStruct) {
+	tc.mu.RLock()
+	defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+	_ = atomic.LoadInt32(&tc.accessedMixed)
+	_ = tc.accessedMixed
+	_ = tc.wrapper.Load()
+	_ = tc.bitops.RacyLoad()
+	_ = tc.pointer.Load()
+	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail=write function
+	tc.wrapper.Store(1)                     // +checklocksfail=write function
+	tc.bitops.Store(1)                      // +checklocksfail=write function
+	tc.bitops.RacyStore(1)                  // +checklocksfail=operation RacyStore
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
+	tc.mu.RUnlock()
+}
+
+// Mixed deferred accesses are unsupported even when execution order is safe.
+func testAtomicMixedDeferred(tc *atomicMixedStruct, unlockFirst bool) {
+	tc.mu.Lock()
+	if unlockFirst {
+		defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+		defer tc.mu.Unlock()
+	} else {
+		defer tc.mu.Unlock()
+		defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+	}
 }
 
 func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -93,6 +158,7 @@ func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p ch
 func testAtomicMixedInvalidAtomicWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
 	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail
 	tc.wrapper.Store(1)                     // +checklocksfail
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
 }
 
 func testAtomicMixedInvalidWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -104,4 +170,105 @@ func testAtomicWrapper(tc *atomicStruct, v chan int32) {
 	v <- tc.wrapper.Load()
 	v <- tc.wrapper.Add(33)
 	tc.wrapper.Store(44)
+	v <- tc.bitops.RacyLoad()
+	v <- tc.bitops.RacyAdd(33)
+	tc.bitops.RacyStore(44)
+}
+
+func testAtomicBitops(tc *atomicStruct) {
+	// Keep direct defers, including the unused result, to check the SSA Defer
+	// path rather than a closure that invokes the operation later.
+	defer tc.atomicBitops.RacyLoad()   // +checklocksfail=non-atomic operation
+	defer tc.atomicBitops.RacyStore(1) // +checklocksfail=non-atomic operation
+	_ = tc.atomicBitops.Load()
+	tc.atomicBitops.Store(1)
+	_ = tc.atomicBitops.Add(1)
+	_ = tc.atomicBitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.atomicBitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.atomicBitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+}
+
+func testAtomicMixedBitops(tc *atomicMixedStruct) {
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)       // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.Add(1)     // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+
+	tc.mu.Lock()
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)
+	_ = tc.bitops.Add(1)
+	_ = tc.bitops.RacyLoad()
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+	tc.mu.Unlock()
+}
+
+// atomicReadAnyStruct permits unlocked atomic reads and non-atomic reads
+// under either lock. Writes need both locks.
+type atomicReadAnyStruct struct {
+	mu      sync.Mutex
+	otherMu sync.RWMutex
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	// +checkatomic
+	wrapper atomicbitops.Int32
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	// +checkatomic
+	value int32
+}
+
+func testAtomicReadAny(tc *atomicReadAnyStruct) {
+	_ = tc.wrapper.Load()
+	_ = tc.wrapper.RacyLoad() // +checklocksfail=non-atomic operation
+	_ = tc.value              // +checklocksfail=illegal use
+
+	tc.mu.Lock()
+	_ = tc.wrapper.RacyLoad()
+	_ = tc.value
+	tc.wrapper.Store(1)    // +checklocksfail=write function
+	_ = tc.wrapper.Swap(1) // +checklocksfail=write function
+	tc.mu.Unlock()
+
+	tc.otherMu.RLock()
+	_ = tc.wrapper.RacyLoad()
+	_ = tc.value
+	_ = tc.wrapper.Add(1) // +checklocksfail=write function
+	tc.mu.Lock()
+	tc.wrapper.Store(1) // +checklocksfail=write function
+	tc.otherMu.RUnlock()
+	tc.otherMu.Lock()
+	tc.wrapper.Store(1)
+	_ = tc.wrapper.Add(1)
+	tc.wrapper.RacyStore(1) // +checklocksfail=non-atomic operation
+	tc.otherMu.Unlock()
+	tc.mu.Unlock()
+}
+
+func testAtomicReadAnyRetained(tc *atomicReadAnyStruct, read bool) {
+	tc.mu.Lock()
+	p := &tc.wrapper
+	tc.mu.Unlock()
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+
+	tc.mu.Lock()
+	p = &tc.wrapper
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.mu.Unlock()
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+
+	// Even when the lock remains held, only immediate uses are supported.
+	tc.mu.Lock()
+	p = &tc.wrapper
+	if read {
+		_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+	}
+	tc.mu.Unlock()
 }

--- a/tools/checklocks/test/closures.go
+++ b/tools/checklocks/test/closures.go
@@ -49,6 +49,9 @@ func testClosureInline(tc *oneGuardStruct) {
 	tc.mu.Lock()
 	func() {
 		tc.guardedField = 1
+		func() {
+			tc.guardedField = 2
+		}()
 	}()
 	tc.mu.Unlock()
 }
@@ -58,8 +61,17 @@ func testClosureIgnore(tc *oneGuardStruct) {
 	// Inherit the checklocksignore.
 	x := func() {
 		tc.guardedField = 1
+		atomicGlobal.RacyStore(1)
 	}
 	x()
+
+	// Passing a closure as an argument is not an inline invocation.
+	callClosure(func() {
+		callPreconditions(tc)
+	})
+	defer callClosure(func() {
+		callPreconditions(tc)
+	})
 }
 
 func testAnonymousInvalid(tc *oneGuardStruct) {

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -110,3 +110,6 @@ func RequirePrivate() {}
 // +checklocksexclude:globalMu
 // +checklocksexclude:globalStruct.mu
 func ExcludePrivate() {}
+
+// IndirectValues exposes methods without importing their defining package.
+type IndirectValues = atomicfields.Values

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -17,6 +17,8 @@ package crosspkg
 
 import (
 	"sync"
+
+	"gvisor.dev/gvisor/tools/checklocks/test/atomicfields"
 )
 
 var (
@@ -24,6 +26,11 @@ var (
 	Foo   int
 	FooMu sync.Mutex
 )
+
+// StandaloneFoo is a guarded global declared outside a var block.
+//
+// +checklocks:FooMu
+var StandaloneFoo int
 
 // GenericGuard is a generic type with a guarded field. This is used to verify
 // that facts exported by this package are correctly imported when another
@@ -33,3 +40,73 @@ type GenericGuard[T any] struct {
 	// +checklocks:Mu
 	Value T
 }
+
+// ReadAnyGuard allows readers to hold either mutex; writers need both.
+type ReadAnyGuard[T any] struct {
+	Mu      sync.Mutex
+	OtherMu sync.RWMutex
+
+	// +checklocks:Mu
+	// +checklocks:OtherMu
+	Value T // +checklocksreadany
+}
+
+// Do not import atomic or atomicbitops here: these methods must be resolved
+// from type information for a transitive dependency, not a direct SSA import.
+func readIndirectAtomics(v *atomicfields.Values) {
+	_ = v.Standard.Load()
+	_ = v.Bitops.Load()
+	v.Standard.Store(nil)
+	v.Bitops.Store(1)
+	_ = v.Bitops.RacyLoad() // +checklocksfail=non-atomic operation
+	// A method expression forces an SSA wrapper instead of selecting the
+	// embedded field directly, as an ordinary promoted call would.
+	_ = (*atomicfields.WrappedAtomic).Load(&v.Promoted) // +checklocksfail=shared function or wrapper
+
+	v.Mu.Lock()
+	_ = v.Mixed.RacyLoad()
+	v.Mu.Unlock()
+}
+
+// Keep the lock/unlock functions out of line so importers do not need these
+// private globals for inlined calls. Their guards still cross the package
+// boundary.
+var globalMu sync.Mutex
+
+var globalStruct struct {
+	mu sync.Mutex
+}
+
+// LockPrivate acquires both private locks.
+//
+// +checklocksacquire:globalMu
+// +checklocksacquire:globalStruct.mu
+//
+//go:noinline
+func LockPrivate() {
+	globalMu.Lock()
+	globalStruct.mu.Lock()
+}
+
+// UnlockPrivate releases both private locks.
+//
+// +checklocksrelease:globalMu
+// +checklocksrelease:globalStruct.mu
+//
+//go:noinline
+func UnlockPrivate() {
+	globalStruct.mu.Unlock()
+	globalMu.Unlock()
+}
+
+// RequirePrivate requires both private locks.
+//
+// +checklocks:globalMu
+// +checklocks:globalStruct.mu
+func RequirePrivate() {}
+
+// ExcludePrivate excludes both private locks.
+//
+// +checklocksexclude:globalMu
+// +checklocksexclude:globalStruct.mu
+func ExcludePrivate() {}

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -16,13 +16,46 @@ package test
 
 import (
 	"sync"
+	"sync/atomic"
 
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
 )
 
 var (
 	globalMu   sync.Mutex
 	globalRWMu sync.RWMutex
+
+	// +checkatomic
+	atomicGlobal = atomicbitops.FromInt32(1)
+
+	// +checkatomic
+	// +checklocks:globalRWMu
+	mixedAtomicGlobal atomicbitops.Int32
+
+	unannotatedAtomicGlobal atomicbitops.Int32
+	unannotatedRawGlobal    int32
+
+	// +checklocks:globalRWMu
+	guardedRawGlobal int32
+)
+
+// +checklocks:globalMu
+var standaloneGlobal int
+
+// +checkatomic
+var standaloneAtomicGlobal int32
+
+var (
+	// +checklocks:globalMu
+	firstGlobal, _, secondGlobal int
+)
+
+// A var block's header does not annotate its entries, even with one spec.
+//
+// +checklocks:globalMu
+var (
+	blockHeaderGlobal int
 )
 
 var globalStruct struct {
@@ -41,7 +74,12 @@ var otherStruct struct {
 }
 
 func testGlobalValid() {
+	blockHeaderGlobal = 1
+
 	globalMu.Lock()
+	standaloneGlobal = 1
+	firstGlobal = 1
+	secondGlobal = 1
 	otherStruct.guardedField1 = 1
 	globalMu.Unlock()
 
@@ -94,18 +132,102 @@ func testGlobalExcludeInvalid() {
 }
 
 func testGlobalInvalid() {
+	standaloneGlobal = 1          // +checklocksfail
+	firstGlobal = 1               // +checklocksfail
+	secondGlobal = 1              // +checklocksfail
+	standaloneAtomicGlobal = 1    // +checklocksfail=non-atomic write
 	globalStruct.guardedField = 1 // +checklocksfail
 	otherStruct.guardedField1 = 1 // +checklocksfail
 	otherStruct.guardedField2 = 1 // +checklocksfail
 	otherStruct.guardedField3 = 1 // +checklocksfail
+	var sink atomic.Pointer[int32]
+	sink.Store(&standaloneAtomicGlobal) // +checklocksfail=illegal use
 }
 
 func testCrosspkgGlobalValid() {
 	crosspkg.FooMu.Lock()
 	crosspkg.Foo = 1
+	crosspkg.StandaloneFoo = 1
 	crosspkg.FooMu.Unlock()
 }
 
 func testCrosspkgGlobalInvalid() {
-	crosspkg.Foo = 1 // +checklocksfail
+	crosspkg.Foo = 1           // +checklocksfail
+	crosspkg.StandaloneFoo = 1 // +checklocksfail
 }
+
+func testAtomicGlobal() {
+	defer atomicGlobal.Store(1)
+	_ = atomicGlobal.Load()
+	atomicGlobal.Store(1)
+	_ = atomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+	atomicGlobal.RacyStore(1)   // +checklocksfail=non-atomic operation
+
+	atomicGlobal = atomicbitops.FromInt32(0) // +checklocksfail=non-atomic write
+}
+
+func testMixedAtomicGlobal() {
+	_ = mixedAtomicGlobal.Load()
+	mixedAtomicGlobal.Store(1)       // +checklocksfail=atomic write function
+	_ = mixedAtomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+
+	globalRWMu.Lock()
+	mixedAtomicGlobal.Store(1)
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.RacyStore(1) // +checklocksfail=non-atomic operation
+	globalRWMu.Unlock()
+
+	globalRWMu.RLock()
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.Store(1) // +checklocksfail=atomic write function
+	globalRWMu.RUnlock()
+}
+
+func testUnannotatedGlobalAtomics(out **int32) {
+	_ = unannotatedAtomicGlobal.RacyLoad()
+	unannotatedAtomicGlobal.RacyStore(1)
+	_ = atomic.LoadInt32(&unannotatedRawGlobal)
+
+	globalRWMu.RLock()
+	_ = atomic.LoadInt32(&guardedRawGlobal)
+	*out = &guardedRawGlobal
+	globalRWMu.RUnlock()
+}
+
+// +checklocksignore
+func testAtomicGlobalIgnore() {
+	atomicGlobal.RacyStore(1)
+	atomicGlobal = atomicbitops.FromInt32(0)
+}
+
+func testCrosspkgPrivateGuards() {
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+	crosspkg.LockPrivate()
+	crosspkg.RequirePrivate()
+	crosspkg.ExcludePrivate() // +checklocksfail=must not hold globalMu|must not hold globalStruct.mu
+	crosspkg.UnlockPrivate()
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+
+	// Same-named globals in this package are different locks.
+	globalMu.Lock()
+	globalStruct.mu.Lock()
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+	globalStruct.mu.Unlock()
+	globalMu.Unlock()
+}
+
+var FooMu sync.Mutex
+
+func testCrosspkgGlobalNameCollision() {
+	FooMu.Lock()
+	crosspkg.Foo = 1 // +checklocksfail=invalid field access, FooMu
+	FooMu.Unlock()
+}
+
+type invalidGlobalMutex = sync.Mutex
+
+// +checklocks:invalidGlobalMutex
+func testGlobalTypeGuard() {} // +checklocksfail=does not have a match

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -227,6 +227,11 @@ func testCrosspkgGlobalNameCollision() {
 	FooMu.Unlock()
 }
 
+func testIndirectGlobalGuards(v *crosspkg.IndirectValues) {
+	v.RequirePrivate() // +checklocksfail=must hold
+	v.ExcludePrivate()
+}
+
 type invalidGlobalMutex = sync.Mutex
 
 // +checklocks:invalidGlobalMutex

--- a/tools/checklocks/test/rwmutex.go
+++ b/tools/checklocks/test/rwmutex.go
@@ -16,6 +16,8 @@ package test
 
 import (
 	"sync"
+
+	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
 )
 
 // oneReadGuardStruct has one read-guarded field.
@@ -64,5 +66,130 @@ func testRWExcludeWriteSatisfied(tc *oneReadGuardStruct) {
 func testRWExcludeWriteViolated(tc *oneReadGuardStruct) {
 	tc.mu.Lock()
 	testRWExcludeWrite(tc) // +checklocksfail
+	tc.mu.Unlock()
+}
+
+func testReadAnyGuards(tc *crosspkg.ReadAnyGuard[int]) {
+	_ = tc.Value // +checklocksfail=at least one
+	tc.Mu.Lock()
+	_ = tc.Value
+	tc.Value = 1 // +checklocksfail=OtherMu
+	tc.Mu.Unlock()
+
+	tc.OtherMu.RLock()
+	_ = tc.Value
+	tc.Value = 2 // +checklocksfail=access, Mu|access, OtherMu
+	tc.OtherMu.RUnlock()
+
+	tc.Mu.Lock()
+	tc.OtherMu.RLock()
+	tc.Value = 3 // +checklocksfail=OtherMu
+	tc.OtherMu.RUnlock()
+	tc.OtherMu.Lock()
+	tc.Value = 4
+	tc.OtherMu.Unlock()
+	tc.Mu.Unlock()
+}
+
+type invalidReadAnyGuards struct {
+	mu sync.Mutex
+
+	// +checklocksreadany
+	unguarded int // +checklocksfail=requires at least one
+
+	// +checklocks:mu
+	// +checklocksreadany
+	// +checklocksreadany
+	duplicate int // +checklocksfail=specified more than once
+
+	// +checklocks:mu
+	// +checklocksreadany:mu
+	argument int // +checklocksfail=does not take arguments
+
+	// +checklocks:mu
+	// +checklocksreadany
+	// +checklocksignore
+	ignored int // +checklocksfail=cannot be combined
+}
+
+// +checklocksreadany
+func invalidReadAnyFunction() {} // +checklocksfail=only valid on fields
+
+var (
+	// +checklocksreadany
+	invalidReadAnyGlobal int // +checklocksfail=only valid on fields
+)
+
+func testReadAnyIndirectWrites(tc *crosspkg.ReadAnyGuard[struct{ member int }]) {
+	tc.Mu.Lock()
+	tc.Value.member = 1             // +checklocksfail=OtherMu
+	mutateReadAny(&tc.Value.member) // +checklocksfail=OtherMu
+	tc.OtherMu.RLock()
+	tc.Value.member = 2 // +checklocksfail=OtherMu
+	tc.OtherMu.RUnlock()
+	tc.Mu.Unlock()
+}
+
+func mutateReadAny(p *int) {
+	*p = 1
+}
+
+// +checklocksreadany
+type invalidReadAnyType int // +checklocksfail=only valid on fields
+
+// A modifier may precede a guard in the field's trailing comment.
+type readAnyTrailingGuard struct {
+	mu sync.Mutex
+
+	// +checklocksreadany
+	value int // +checklocks:mu
+}
+
+// +checklocksreadany
+var invalidStandaloneReadAny int // +checklocksfail=only valid on fields
+
+func testReadAnyRetainedAddress(tc *crosspkg.ReadAnyGuard[int]) {
+	tc.Mu.Lock()
+	p := &tc.Value // +checklocksfail=OtherMu
+	tc.Mu.Unlock()
+	_ = *p
+
+	// An immediate first load must not authorize a later unlocked load.
+	tc.Mu.Lock()
+	p = &tc.Value // +checklocksfail=OtherMu
+	_ = *p
+	tc.Mu.Unlock()
+	_ = *p
+}
+
+// +checklocksread:tc.OtherMu
+func testReadAnyPrecondition(tc *crosspkg.ReadAnyGuard[int]) int {
+	return tc.Value
+}
+
+type groupedReadAnyGuards struct {
+	mu, otherMu sync.Mutex
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	first, second int
+
+	// +checklocks:mu
+	last int
+}
+
+func testGroupedReadAnyGuards(tc *groupedReadAnyGuards) {
+	tc.first = 1  // +checklocksfail=access, mu|access, otherMu
+	tc.second = 2 // +checklocksfail=access, mu|access, otherMu
+	tc.last = 3   // +checklocksfail=access, mu
+	tc.mu.Lock()
+	_ = tc.first
+	_ = tc.second
+	tc.last = 3
+	tc.otherMu.Lock()
+	tc.first = 1
+	tc.second = 2
+	tc.otherMu.Unlock()
 	tc.mu.Unlock()
 }

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -90,22 +90,11 @@ def go_binary(name, nogo = True, pure = False, static = False, x_defs = None, **
         **kwargs
     )
     if nogo:
-        # Note that the nogo rule applies only for go_library and go_test
-        # targets, therefore we construct a library from the binary sources.
-        # This is done because the binary may not be in a form that objdump
-        # supports (i.e. a pure Go binary).
-        _go_library(
-            name = name + "_nogo_library",
-            srcs = kwargs.get("srcs", []),
-            deps = kwargs.get("deps", []),
-            embedsrcs = kwargs.get("embedsrcs", []),
-            testonly = 1,
-        )
         nogo_test(
             name = name + "_nogo",
             config = "//:nogo_config",
             srcs = kwargs.get("srcs", []),
-            deps = [":" + name + "_nogo_library"],
+            deps = [":" + name],
             tags = ["nogo"],
         )
 

--- a/tools/go_generics/go_merge/main.go
+++ b/tools/go_generics/go_merge/main.go
@@ -21,9 +21,12 @@ import (
 	"go/ast"
 	"go/format"
 	"go/parser"
+	"go/printer"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 
 	"gvisor.dev/gvisor/tools/constraintutil"
@@ -52,13 +55,17 @@ func main() {
 
 	// Load all files.
 	files := make(map[string]*ast.File)
+	comments := make(ast.CommentMap)
 	fset := token.NewFileSet()
 	var name string
-	for _, fname := range flag.Args() {
+	// Match MergePackageFiles' declaration order when assigning token positions.
+	srcs := slices.Sorted(slices.Values(flag.Args()))
+	for _, fname := range srcs {
 		f, err := parser.ParseFile(fset, fname, nil, parser.ParseComments|parser.DeclarationErrors|parser.SpuriousErrors)
 		if err != nil {
 			fatalf("%v\n", err)
 		}
+		maps.Copy(comments, ast.NewCommentMap(fset, f, f.Comments))
 
 		files[fname] = f
 		if name == "" {
@@ -75,13 +82,13 @@ func main() {
 	}
 	f := ast.MergePackageFiles(pkg, ast.FilterUnassociatedComments|ast.FilterFuncDuplicates|ast.FilterImportDuplicates)
 
-	// Create a new declaration slice with all imports at the top, merging any
-	// redundant imports.
+	// Put imports first and remove redundant specs. Keep the original import
+	// declarations so their comments retain valid positions within each file.
 	imports := make(map[string]*ast.ImportSpec)
-	var importNames []string // Keep imports in the original order to get deterministic output.
-	var anonImports []*ast.ImportSpec
+	newDecls := make([]ast.Decl, 0, len(f.Decls))
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); ok && g.Tok == token.IMPORT {
+			specs := g.Specs[:0]
 			for _, s := range g.Specs {
 				i := s.(*ast.ImportSpec)
 				p, _ := strconv.Unquote(i.Path.Value)
@@ -92,7 +99,7 @@ func main() {
 					n = i.Name.Name
 				}
 				if n == "_" {
-					anonImports = append(anonImports, i)
+					specs = append(specs, i)
 				} else {
 					if i2, ok := imports[n]; ok {
 						if first, second := i.Path.Value, i2.Path.Value; first != second {
@@ -100,28 +107,15 @@ func main() {
 						}
 					} else {
 						imports[n] = i
-						importNames = append(importNames, n)
+						specs = append(specs, i)
 					}
 				}
 			}
+			if len(specs) > 0 {
+				g.Specs = specs
+				newDecls = append(newDecls, g)
+			}
 		}
-	}
-	newDecls := make([]ast.Decl, 0, len(f.Decls))
-	if l := len(imports) + len(anonImports); l > 0 {
-		// Non-NoPos Lparen is needed for Go to recognize more than one spec in
-		// ast.GenDecl.Specs.
-		d := &ast.GenDecl{
-			Tok:    token.IMPORT,
-			Lparen: token.NoPos + 1,
-			Specs:  make([]ast.Spec, 0, l),
-		}
-		for _, i := range importNames {
-			d.Specs = append(d.Specs, imports[i])
-		}
-		for _, i := range anonImports {
-			d.Specs = append(d.Specs, i)
-		}
-		newDecls = append(newDecls, d)
 	}
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); !ok || g.Tok != token.IMPORT {
@@ -136,10 +130,24 @@ func main() {
 		fatalf("Failed to read build constraints: %v\n", err)
 	}
 
-	// Write the output file.
+	// Print each declaration with only its own comments. Imports moved from
+	// later files must not pull earlier declarations' inline annotations forward.
+	// Template instances omit package documentation; build constraints are
+	// reconstructed separately below.
 	var buf bytes.Buffer
-	if err := format.Node(&buf, fset, f); err != nil {
-		fatalf("formatting: %v\n", err)
+	_, _ = fmt.Fprintf(&buf, "package %s\n\n", name)
+	for _, decl := range f.Decls {
+		if err := format.Node(&buf, fset, &printer.CommentedNode{
+			Node:     decl,
+			Comments: comments.Filter(decl).Comments(),
+		}); err != nil {
+			fatalf("formatting: %v\n", err)
+		}
+		_, _ = buf.WriteString("\n\n")
+	}
+	source, err := format.Source(buf.Bytes())
+	if err != nil {
+		fatalf("formatting merged source: %v\n", err)
 	}
 	outf, err := os.OpenFile(*output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -147,7 +155,7 @@ func main() {
 	}
 	defer outf.Close()
 	outf.WriteString(constraintutil.Lines(bcexpr))
-	if _, err := outf.Write(buf.Bytes()); err != nil {
+	if _, err := outf.Write(source); err != nil {
 		fatalf("write: %v\n", err)
 	}
 }

--- a/tools/go_generics/tests/simple/BUILD
+++ b/tools/go_generics/tests/simple/BUILD
@@ -4,7 +4,11 @@ package(default_applicable_licenses = ["//:license"])
 
 go_generics_test(
     name = "simple",
-    inputs = ["input.go"],
+    # Reverse source order to exercise comment positions across merged files.
+    inputs = [
+        "second.go",
+        "input.go",
+    ],
     output = "output.go",
     suffix = "New",
     types = {
@@ -16,4 +20,5 @@ go_generics_test(
 glaze_ignore = [
     "input.go",
     "output.go",
+    "second.go",
 ]

--- a/tools/go_generics/tests/simple/input.go
+++ b/tools/go_generics/tests/simple/input.go
@@ -14,6 +14,8 @@
 
 package tests
 
+import _ "os" // Earlier blank import.
+
 type T int
 
 var global T
@@ -27,6 +29,7 @@ func g(a T, b int) {
 
 	d := (*T)(nil)
 	_ = d
+	_ = new(T) // escapes: test annotation.
 }
 
 type R struct {

--- a/tools/go_generics/tests/simple/output.go
+++ b/tools/go_generics/tests/simple/output.go
@@ -14,6 +14,10 @@
 
 package main
 
+import _ "os" // Earlier blank import.
+
+import "fmt" // Later named import.
+
 var globalNew Q
 
 func fNew(_ Q, a int) {
@@ -25,6 +29,7 @@ func gNew(a Q, b int) {
 
 	d := (*Q)(nil)
 	_ = d
+	_ = new(Q) // escapes: test annotation.
 }
 
 type RNew struct {
@@ -41,3 +46,7 @@ const (
 )
 
 type YNew Q
+
+func hNew(a Q) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
+}

--- a/tools/go_generics/tests/simple/second.go
+++ b/tools/go_generics/tests/simple/second.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tests
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
+import "fmt" // Later named import.
 
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+func h(a T) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
 }

--- a/tools/nogo/check/BUILD
+++ b/tools/nogo/check/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -57,5 +57,16 @@ go_library(
         "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_default_library",
         "@org_golang_x_tools//go/gcexportdata:go_default_library",
+    ],
+)
+
+go_test(
+    name = "check_test",
+    size = "small",
+    srcs = ["check_test.go"],
+    library = ":check",
+    deps = [
+        "//tools/nogo/flags",
+        "@org_golang_x_tools//go/analysis:go_default_library",
     ],
 )

--- a/tools/nogo/check/check.go
+++ b/tools/nogo/check/check.go
@@ -55,14 +55,8 @@ var (
 	releaseTagsErr error
 )
 
-// Hack! factFacts only provides facts loaded from directly imported packages
-// for efficiency (see importer.cache). In general, if you need a fact from a
-// package that isn't otherwise imported, the expectation is that you will add
-// a dummy import/use of the desired package to ensure it is a dependency.
-//
-// Unfortunately, some packages need facts from internal packages. Since
-// internal packages cannot be imported we explicitly import in this tool to
-// ensure the facts are available to ImportPackageFact.
+// Preload type information needed to decode facts from internal packages that
+// analyzed packages cannot import directly.
 var internalPackages = []string{
 	// Required by pkg/sync for internal/abi.MapType.
 	"internal/abi",
@@ -145,12 +139,25 @@ type importer struct {
 
 	analyzers map[*analysis.Analyzer]analyzer
 
-	// mu protects cache & bundles (see below).
-	mu    sync.Mutex
-	cache map[string]*importerEntry // key is package path (see sources above).
+	// mu protects cache, bundles, and factsErr (see below).
+	mu sync.Mutex
 
-	// bundles is protected by mu, but once set is immutable.
+	// cache is keyed by package path (see sources above).
+	//
+	// +checklocks:mu
+	cache map[string]*importerEntry
+
+	// bundles and each bundle's decoded-package cache are protected by mu.
+	// A bundle has no link to this importer, so checklocks cannot express
+	// that protection for the bundle's internal cache.
+	//
+	// +checklocks:mu
 	bundles []*facts.Bundle
+
+	// factsErr is the first error loading package facts.
+	//
+	// +checklocks:mu
+	factsErr error
 
 	// importsMu protects imports.
 	importsMu sync.Mutex
@@ -159,8 +166,7 @@ type importer struct {
 
 // loadBundles loads all bundle files.
 //
-// This should only be called from loadFacts, below. After calling this
-// function, i.bundles may be read freely without holding a lock.
+// This should only be called from loadFacts, below.
 func (i *importer) loadBundles() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -187,9 +193,8 @@ func (i *importer) loadBundles() error {
 
 // loadFacts returns all package facts for the given name.
 //
-// This should be called only from importPackage, as this may deserialize a
-// facts file (which is an expensive operation). Callers should generally rely
-// on fastFacts to access facts for packages that have already been imported.
+// This may deserialize a facts file. Callers should generally use fastFacts
+// to cache the result.
 func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 	// Attempt to load from the fact map.
 	filename, ok := flags.FactMap[pkg.Path()]
@@ -211,7 +216,10 @@ func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 		return nil, fmt.Errorf("error loading bundles: %w", err)
 	}
 
-	// Try to import from the bundle.
+	// Bundle.Package memoizes decoded packages, including across concurrent
+	// requests for facts from different packages.
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	for _, bundleFacts := range i.bundles {
 		localFacts, err := bundleFacts.Package(pkg)
 		if err != nil {
@@ -233,10 +241,14 @@ func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 func (i *importer) fastFacts(pkg *types.Package) *facts.Package {
 	i.mu.Lock()
 	e, ok := i.cache[pkg.Path()]
-	i.mu.Unlock()
 	if !ok {
-		return nil
+		// Export data can introduce a package without importPackage. Cache
+		// its facts, but leave pkg nil so a later import still loads types
+		// or analyzes source instead of treating this as a completed import.
+		e = new(importerEntry)
+		i.cache[pkg.Path()] = e
 	}
+	i.mu.Unlock()
 
 	e.factsMu.Lock()
 	defer e.factsMu.Unlock()
@@ -249,9 +261,12 @@ func (i *importer) fastFacts(pkg *types.Package) *facts.Package {
 	// Load the facts.
 	facts, err := i.loadFacts(pkg)
 	if err != nil {
-		// There are no facts available, but no good way to propagate
-		// this minor error. It may be intentional that no analysis was
-		// performed on some part of the standard library, for example.
+		// Optional fact absence is not an error; unreadable inputs are.
+		i.mu.Lock()
+		if i.factsErr == nil {
+			i.factsErr = fmt.Errorf("loading facts for %q: %w", pkg.Path(), err)
+		}
+		i.mu.Unlock()
 		return nil
 	}
 	e.facts = facts // Cache the result.
@@ -717,6 +732,12 @@ func (i *importer) checkPackage(path string, srcs []string) (*types.Package, Fin
 		// Wait for completion.
 		wg.Wait()
 	}
+	i.mu.Lock()
+	factsErr := i.factsErr
+	i.mu.Unlock()
+	if factsErr != nil {
+		return astPackage, findings, astFacts, factsErr
+	}
 	for a := range ready {
 		// Check the error. If we generate an error here, we report
 		// this as a finding that can be suppressed. Some analyzers
@@ -778,7 +799,12 @@ func Package(path string, srcs []string) (FindingSet, facts.Serializer, error) {
 	return findings, facts, nil
 }
 
-// allFactsAndFindings returns all factsAndFindings from an importer.
+// allFactsAndFindings returns the collected findings and package facts.
+//
+// Imports and analysis must have completed: mu does not protect the cached
+// entries' findings and facts.
+//
+// +checklocks:i.mu
 func (i *importer) allFactsAndFindings() (FindingSet, *facts.Bundle) {
 	var (
 		findings = make(FindingSet, 0)
@@ -814,7 +840,8 @@ func TemplateFuncs(path string, srcs []string) (map[string]any, any, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	_, allFacts := i.allFactsAndFindings()
+	// checkPackage joined all analyzers; this private importer is quiescent.
+	_, allFacts := i.allFactsAndFindings() // +checklocksignore
 	funcMap, err := facts.ResolveFuncs(pkg, localFacts, allFacts)
 	if err != nil {
 		return nil, nil, err
@@ -926,6 +953,7 @@ func Bundle(sources map[string][]string, roots []string) (FindingSet, facts.Seri
 		}
 	}
 
-	findings, facts := i.allFactsAndFindings()
+	// All imports and their analyzers completed; this importer is quiescent.
+	findings, facts := i.allFactsAndFindings() // +checklocksignore
 	return findings, facts, nil
 }

--- a/tools/nogo/check/check_test.go
+++ b/tools/nogo/check/check_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"go/token"
+	"go/types"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+	"gvisor.dev/gvisor/tools/nogo/flags"
+)
+
+type factsLoadTestFact struct{}
+
+func (*factsLoadTestFact) AFact() {}
+
+func TestDeclaredFactsErrors(t *testing.T) {
+	savedFactMap, savedBundles := flags.FactMap, flags.Bundles
+	t.Cleanup(func() {
+		flags.FactMap, flags.Bundles = savedFactMap, savedBundles
+	})
+	var malformed bytes.Buffer
+	if err := gob.NewEncoder(&malformed).Encode([]struct {
+		Key   string
+		Value any
+	}{{Value: "bad"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		supplied bool
+		create   bool
+		contents []byte
+		bundles  [][]byte // A nil entry omits the package from that bundle.
+		wantErr  error
+		wantText string
+	}{
+		{name: "absent"},
+		{name: "missing", supplied: true, wantErr: os.ErrNotExist},
+		{name: "empty", supplied: true, create: true, wantErr: io.EOF},
+		{name: "wrong_type", supplied: true, create: true, contents: malformed.Bytes(), wantText: "invalid fact payload"},
+		{name: "bundle_absent", bundles: [][]byte{nil}},
+		{name: "bundle_empty", bundles: [][]byte{{}}, wantErr: io.EOF},
+		{name: "later_bundle_wrong_type", bundles: [][]byte{nil, malformed.Bytes()}, wantText: "invalid fact payload"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dep := types.NewPackage("indirect", "indirect")
+			flags.FactMap = make(map[string]string)
+			flags.Bundles = nil
+			if tc.supplied {
+				filename := filepath.Join(t.TempDir(), "facts")
+				flags.FactMap[dep.Path()] = filename
+				if tc.create {
+					if err := os.WriteFile(filename, tc.contents, 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			for _, contents := range tc.bundles {
+				var buf bytes.Buffer
+				zw := zip.NewWriter(&buf)
+				if contents != nil {
+					w, err := zw.Create(dep.Path())
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := w.Write(contents); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := zw.Close(); err != nil {
+					t.Fatal(err)
+				}
+				filename := filepath.Join(t.TempDir(), "bundle.zip")
+				if err := os.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+					t.Fatal(err)
+				}
+				flags.Bundles = append(flags.Bundles, filename)
+			}
+			a := &analysis.Analyzer{
+				Name:      "importfact",
+				FactTypes: []analysis.Fact{new(factsLoadTestFact)},
+				Run: func(p *analysis.Pass) (any, error) {
+					// Fact absence is allowed; input errors must fail the driver.
+					_ = p.ImportPackageFact(dep, new(factsLoadTestFact))
+					return nil, nil
+				},
+			}
+			i := &importer{
+				fset:      token.NewFileSet(),
+				cache:     make(map[string]*importerEntry),
+				analyzers: map[*analysis.Analyzer]analyzer{a: &plainAnalyzer{a}},
+			}
+			// An empty package exercises fact loading without SDK imports.
+			_, findings, _, err := i.checkPackage("test", nil)
+			if tc.wantText != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+					t.Fatalf("checkPackage() error = %v, want %q (findings: %v)", err, tc.wantText, findings)
+				}
+			} else if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("checkPackage() error = %v, want %v", err, tc.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), dep.Path()) {
+				t.Errorf("checkPackage() error = %v, want package path %q", err, dep.Path())
+			}
+		})
+	}
+}

--- a/tools/nogo/cli/BUILD
+++ b/tools/nogo/cli/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -19,4 +19,12 @@ go_library(
         "@in_gopkg_yaml_v2//:go_default_library",
         "@org_golang_x_term//:go_default_library",
     ],
+)
+
+go_test(
+    name = "cli_test",
+    size = "small",
+    srcs = ["cli_test.go"],
+    library = ":cli",
+    deps = ["//tools/nogo/flags"],
 )

--- a/tools/nogo/cli/cli.go
+++ b/tools/nogo/cli/cli.go
@@ -65,7 +65,7 @@ func closeOutput(w io.Writer) {
 	}
 }
 
-// failure exits with the given failure message.
+// failure prints the given failure message and returns a failure status.
 func failure(fmtStr string, v ...any) subcommands.ExitStatus {
 	fmt.Fprintf(os.Stderr, fmtStr+"\n", v...)
 	return subcommands.ExitFailure
@@ -514,7 +514,7 @@ func (r *Render) Execute(ctx context.Context, fs *flag.FlagSet, args ...any) sub
 }
 
 // goVersionRe matches a `go VERSION` line in go.mod, capturing VERSION.
-var goVersionRe = regexp.MustCompile(`^go\s+(\S+)`)
+var goVersionRe = regexp.MustCompile(`(?m)^go[ \t]+(\S+)`)
 
 // resolveGOVERSION sets flags.GOVERSION from flags.GOVERSIONModFile, if necessary.
 func resolveGOVERSION() error {
@@ -535,7 +535,7 @@ func resolveGOVERSION() error {
 	if len(m) != 2 {
 		return fmt.Errorf("go line not found in go.mod:\n%s", string(b))
 	}
-	flags.GOVERSION = m[1]
+	flags.GOVERSION = "go" + m[1]
 	return nil
 }
 
@@ -549,7 +549,7 @@ func Main() {
 	subcommands.Register(subcommands.FlagsCommand(), "")
 	flag.CommandLine.Parse(os.Args[1:])
 	if err := resolveGOVERSION(); err != nil {
-		failure("error resolving GOVERSION: %v", err)
+		os.Exit(int(failure("error resolving GOVERSION: %v", err)))
 	}
 	os.Exit(int(subcommands.Execute(context.Background())))
 }

--- a/tools/nogo/cli/cli_test.go
+++ b/tools/nogo/cli/cli_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gvisor.dev/gvisor/tools/nogo/flags"
+)
+
+func TestResolveGOVERSION(t *testing.T) {
+	oldVersion, oldModFile := flags.GOVERSION, flags.GOVERSIONModFile
+	t.Cleanup(func() {
+		flags.GOVERSION, flags.GOVERSIONModFile = oldVersion, oldModFile
+	})
+	for _, tc := range []struct {
+		name, contents, want string
+	}{
+		{"stdlib", "module std\n\ngo 1.26\n", "go1.26"},
+		{"comments-and-crlf", "// Header.\r\nmodule std\r\ngo\t1.26\r\n", "go1.26"},
+		{"missing", "module std\n", ""},
+		{"split-directive", "module std\ngo\n1.26\n", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			modFile := filepath.Join(t.TempDir(), "go.mod")
+			if err := os.WriteFile(modFile, []byte(tc.contents), 0644); err != nil {
+				t.Fatal(err)
+			}
+			flags.GOVERSION = ""
+			flags.GOVERSIONModFile = modFile
+			if err := resolveGOVERSION(); err != nil {
+				if tc.want != "" {
+					t.Fatalf("resolveGOVERSION: %v", err)
+				}
+				return
+			}
+			if tc.want == "" {
+				t.Fatal("resolveGOVERSION succeeded without a valid go directive")
+			}
+			if got := flags.GOVERSION; got != tc.want {
+				t.Errorf("GOVERSION = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/nogo/defs.bzl
+++ b/tools/nogo/defs.bzl
@@ -1,7 +1,7 @@
 """Nogo rules."""
 
 load("//tools:arch.bzl", "arch_transition")
-load("//tools/bazeldefs:go.bzl", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
+load("//tools/bazeldefs:go.bzl", "go_binary_archive", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
 
 NogoConfigInfo = provider(
     "information about a nogo configuration",
@@ -70,7 +70,7 @@ def _nogo_stdlib_impl(ctx):
     go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps = [])
 
     # GOVERSION of std is set by the std go.mod.
-    args.append("-GOVERSION-mod-file=%s" % go_ctx.stdlib_mod)
+    args.append("-GOVERSION-mod-file=%s" % go_ctx.stdlib_mod.path)
 
     # Build the analyzer command.
     facts_file = ctx.actions.declare_file(ctx.label.name + ".facts")
@@ -135,6 +135,7 @@ NogoInfo = provider(
     "information for nogo analysis",
     fields = {
         "facts": "serialized package facts",
+        "transitive_facts": "depset of (import path, facts file) pairs",
         "raw_findings": "raw package findings (if relevant)",
         "importpath": "package import path",
         "binaries": "package binary files",
@@ -161,14 +162,14 @@ def _select_objfile(files):
         a_files = x_files
     return a_files[0], x_files[0]
 
-def _nogo_config(ctx, deps):
+def _nogo_config(ctx, deps, attr = None):
     # Build a configuration for the given set of deps. This is most basic
     # configuration and is used by the stdlib. For a more complete config, the
     # _nogo_package_config function may be used.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
     nogo_target_info = ctx.attr._target[NogoTargetInfo]
-    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch)
+    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch, attr = attr)
     args = go_ctx.nogo_args + [
         "-go=%s" % go_ctx.go.path,
         "-GOOS=%s" % go_ctx.goos,
@@ -177,6 +178,7 @@ def _nogo_config(ctx, deps):
     ]
     inputs = []
     raw_findings = []
+    fact_sets = []
     for dep in deps:
         extras = nogo_extra_proto_deps(dep)
         for importpath, a_file, x_file in extras:
@@ -198,7 +200,7 @@ def _nogo_config(ctx, deps):
         a_file, x_file = _select_objfile(info.binaries)
         args.append("-archive=%s=%s" % (info.importpath, a_file.path))
         args.append("-import=%s=%s" % (info.importpath, x_file.path))
-        args.append("-facts=%s=%s" % (info.importpath, info.facts.path))
+        fact_sets.append(info.transitive_facts)
 
         # Collect all findings; duplicates are resolved at the end.
         raw_findings.extend(info.raw_findings)
@@ -206,27 +208,26 @@ def _nogo_config(ctx, deps):
         # Ensure the above are available as inputs.
         inputs.append(a_file)
         inputs.append(x_file)
-        inputs.append(info.facts)
+
+    # Export data can expose types and methods from indirect imports. Their
+    # facts must be available even without a direct source import.
+    for importpath, facts_file in depset(transitive = fact_sets).to_list():
+        args.append("-facts=%s=%s" % (importpath, facts_file.path))
+        inputs.append(facts_file)
 
     return (go_ctx, args, inputs, raw_findings)
 
-def _nogo_package_config(ctx, deps, importpath = None, target = None):
+def _nogo_package_config(ctx, deps, importpath = None, objfiles = (None, None), attr = None):
     # See _nogo_config. This includes package details.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
-    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps)
+    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps, attr = attr)
 
     # GOVERSION of packages are set by the project language version.
     args.append("-GOVERSION=%s" % go_ctx.lang_version)
 
-    # Add the module itself, for the type sanity check. This applies only to
-    # the libraries, and not binaries or tests.
-    binaries = []
-    if target != None:
-        binaries.extend(target.files.to_list())
-        if hasattr(target.output_groups, "compilation_outputs"):
-            binaries.extend(target.output_groups.compilation_outputs.to_list())
-    target_afile, target_xfile = _select_objfile(binaries)
+    # Add the compiled package itself for analyzers that inspect object code.
+    target_afile, target_xfile = objfiles
     if target_xfile != None:
         args.append("-archive=%s=%s" % (importpath, target_afile.path))
         args.append("-import=%s=%s" % (importpath, target_xfile.path))
@@ -263,7 +264,8 @@ def _nogo_aspect_impl(target, ctx):
     # since there is guaranteed to be no conflict. However for consistency,
     # we should not introduce new go_tool_library dependencies unless strictly
     # necessary.
-    if ctx.rule.kind in ("go_library", "go_tool_library", "go_binary", "go_test"):
+    is_binary = ctx.rule.kind in ("go_binary", "go_non_executable_binary")
+    if is_binary or ctx.rule.kind in ("go_library", "go_tool_library", "go_test"):
         srcs = ctx.rule.files.srcs
         deps = ctx.rule.attr.deps
     elif ctx.rule.kind in ("go_proto_library", "go_wrap_cc"):
@@ -287,14 +289,24 @@ def _nogo_aspect_impl(target, ctx):
         if hasattr(info, "deps"):
             deps = deps + info.deps
 
-    # Extract the importpath for this package.
-    if ctx.rule.kind == "go_test":
-        importpath = "test"
+    # Binary analysis needs the compiled Go archive, not the linked executable:
+    # the linker can remove functions that checkescape still needs to inspect.
+    if is_binary:
+        archive = go_binary_archive(target)
+        importpath = archive.importpath
+        objfiles = (archive.file, archive.export_file)
+        binaries = list(objfiles)
     else:
-        importpath = go_importpath(target)
+        importpath = "test" if ctx.rule.kind == "go_test" else go_importpath(target)
+        binaries = target.files.to_list()
+        compilation_outputs = binaries
+        if hasattr(target.output_groups, "compilation_outputs"):
+            compilation_outputs = compilation_outputs + target.output_groups.compilation_outputs.to_list()
+        objfiles = _select_objfile(compilation_outputs)
 
-    # Build a complete configuration, referring to the library rule.
-    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, target = target)
+    # Use the analyzed rule's transitioned Go configuration, including its build
+    # tags, rather than the aspect's own attributes.
+    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, objfiles = objfiles, attr = ctx.rule.attr)
 
     # Build the argument file, and the runner.
     facts_file = ctx.actions.declare_file(ctx.label.name + ".facts")
@@ -322,9 +334,17 @@ def _nogo_aspect_impl(target, ctx):
     return [
         NogoInfo(
             facts = facts_file,
+            transitive_facts = depset(
+                [(importpath, facts_file)],
+                transitive = [
+                    dep[NogoInfo].transitive_facts
+                    for dep in deps
+                    if hasattr(dep[NogoInfo], "transitive_facts")
+                ],
+            ),
             raw_findings = raw_findings + [findings_file],
             importpath = importpath,
-            binaries = target.files.to_list(),
+            binaries = binaries,
             srcs = srcs,
             deps = deps,
         ),
@@ -463,9 +483,8 @@ nogo_aspect_tricorder = aspect(
 def _nogo_facts_render_impl(ctx):
     """Extract nogo facts."""
 
-    # Build a complete configuration. Note that we don't care about the import
-    # path, since this will generate facts only. We use ctx as the target here,
-    # since this will refer to ctx.files (which contains no binaries).
+    # Rendering dependency facts needs neither an import path nor an archive
+    # for the package containing the template.
     go_ctx, args, inputs, _ = _nogo_package_config(ctx, ctx.attr.deps)
 
     # Build the runner.

--- a/tools/nogo/facts/facts.go
+++ b/tools/nogo/facts/facts.go
@@ -118,6 +118,10 @@ func (p *Package) ReadFrom(pkg *types.Package, r io.Reader) error {
 		return err
 	}
 	for _, fi := range is {
+		objectFacts, ok := fi.Value.([]analysis.Fact)
+		if !ok {
+			return fmt.Errorf("invalid fact payload for %q: %T", fi.Key, fi.Value)
+		}
 		var (
 			obj types.Object
 			err error
@@ -130,7 +134,7 @@ func (p *Package) ReadFrom(pkg *types.Package, r io.Reader) error {
 			// object. We just suppress this error and ignore it.
 			continue
 		}
-		p.Objects[obj] = fi.Value.([]analysis.Fact)
+		p.Objects[obj] = objectFacts
 	}
 	return nil
 }
@@ -229,7 +233,8 @@ func (b *Bundle) Add(path string, facts *Package) {
 	b.decoded[path] = facts
 }
 
-// Package looks up the given package in the bundle.
+// Package looks up the given package in the bundle. It returns nil without an
+// error if the package is absent, or an error if its facts cannot be read.
 func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 	// Already decoded?
 	if facts, ok := b.decoded[pkg.Path()]; ok {
@@ -240,7 +245,7 @@ func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 		// Nothing available.
 		//
 		// N.B. some bundles contain only cached packages.
-		return nil, fmt.Errorf("no facts available for package %q", pkg.Path())
+		return nil, nil
 	}
 
 	// Find based on the reader.
@@ -266,7 +271,7 @@ func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 	}
 
 	// Nothing available.
-	return nil, fmt.Errorf("no facts available for package %q", pkg.Path())
+	return nil, nil
 }
 
 func resolveConstants(pkg *types.Package, localPkg *types.Package, localFacts *Package, allFacts *Bundle) (checkconst.Constants, error) {
@@ -278,10 +283,10 @@ func resolveConstants(pkg *types.Package, localPkg *types.Package, localFacts *P
 	} else {
 		importFacts, err := allFacts.Package(pkg)
 		if err != nil {
-			return c, fmt.Errorf("no facts available for package %q", pkg.Path())
+			return c, fmt.Errorf("loading facts for package %q: %w", pkg.Path(), err)
 		}
 		if importFacts == nil {
-			panic("nil importFacts")
+			return c, fmt.Errorf("no facts available for package %q", pkg.Path())
 		}
 		factSource = importFacts
 	}

--- a/tools/nogo/sanity/sanity_test.sh
+++ b/tools/nogo/sanity/sanity_test.sh
@@ -28,7 +28,7 @@ if [[ "${rc}" -eq "0" ]]; then
   echo "Expected failure; got success."
   exit 1
 fi
-if [[ "${output}" =~ ^sanity.go:[0-9]+:[0-9]+:.*%d.*string.*$ ]]; then
+if [[ "${output}" != *'fmt.Fprintf format %d has arg "hello world!" of wrong type string'* ]]; then
   echo "Expected format error; not found."
   exit 1
 fi


### PR DESCRIPTION
Serialize compression-pool construction and finalizer cleanup with the mutex used by readers and writers. Finalizer registration alone does not order subsequent constructor writes.

Drain compression workers before failed Read or Write calls return so workers cannot retain caller buffers. Close the destination after prior write or final-flush failure while preserving the first stream error. Copy the hash key so lazy workers cannot observe later caller changes.

Fix the race-only ARM64 compare-and-swap operand registers used by Sleeper parking and Gate.Close. Exercise successful replacement and rejection of a mismatched expected value through the existing Gate fixture.

Enforce ownership contracts for shared pools, buffered random reads and event broadcasters. Remove unlocked receiver-state formatting from the interrupt forwarder's duplicate-Enable panic and clarify integer-pool state.

Depends on #14237. These subsystem changes are based on its checker and nogo commits through 193b2056501b. Rebase onto master after that prerequisite lands to remove those commits from this PR's comparison.

Assisted-by: Codex