### PR TITLE
checklocks: guard directory state

### DIFF
--- a/pkg/sentry/fsimpl/devpts/devpts.go
+++ b/pkg/sentry/fsimpl/devpts/devpts.go
@@ -237,13 +237,14 @@ type rootInode struct {
 	// master is the master pty inode. Immutable.
 	master *masterInode
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// replicas maps pty ids to replica inodes.
+	// +checklocks:mu
 	replicas map[uint32]*replicaInode
 
-	// nextIdx is the next pty index to use. Must be accessed atomically.
+	// nextIdx is the next pty index to use.
+	// +checklocks:mu
 	nextIdx uint32
 }
 

--- a/pkg/sentry/fsimpl/kernfs/fd_impl_util.go
+++ b/pkg/sentry/fsimpl/kernfs/fd_impl_util.go
@@ -72,10 +72,10 @@ type GenericDirectoryFD struct {
 	vfsfd    vfs.FileDescription
 	children *OrderedChildren
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
-	// off is the current directory offset. Protected by "mu".
+	// off is the current directory offset.
+	// +checklocks:mu
 	off int64
 }
 
@@ -153,7 +153,7 @@ func (fd *GenericDirectoryFD) inode() Inode {
 }
 
 // IterDirents implements vfs.FileDescriptionImpl.IterDirents. IterDirents holds
-// o.mu when calling cb.
+// fd.mu when calling cb.
 func (fd *GenericDirectoryFD) IterDirents(ctx context.Context, cb vfs.IterDirentsCallback) error {
 	fd.mu.Lock()
 	defer fd.mu.Unlock()


### PR DESCRIPTION
Enforce existing mutex ownership of kernfs directory offsets and the devpts replica registry and allocation counter.

Assisted-by: Codex
