### PR TITLE
checklocks: enforce checkpoint state ownership

### DIFF
--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -438,9 +438,11 @@ type Kernel struct {
 	// MaxKeySetSize is the maximum number of keys in a key set.
 	MaxKeySetSize atomicbitops.Int32
 
-	// fsSaveWaiters holds waiters for Kernel.WaitForFSSave. fsSaveWaiters is
-	// protected by fsSaveMu.
-	fsSaveMu      fsSaveMutex  `state:"nosave"`
+	fsSaveMu fsSaveMutex `state:"nosave"`
+
+	// fsSaveWaiters holds waiters for Kernel.WaitForFSSave.
+	//
+	// +checklocks:fsSaveMu
 	fsSaveWaiters []chan error `state:"nosave"`
 
 	// HostNamePoller is notified when the system hostname changes in *any*

--- a/runsc/boot/fscheckpoint.go
+++ b/runsc/boot/fscheckpoint.go
@@ -266,7 +266,8 @@ type fsRestore struct {
 	mfs         map[checkpoint.ResourceID]*fscheckpoint.MemoryFile
 	tmpfs       map[checkpoint.ResourceID]*fscheckpoint.Tmpfs
 
-	waitMu  sync.Mutex
+	waitMu sync.Mutex
+	// +checklocks:waitMu
 	waitMap map[string]*fsRestoreContainer // key is container ID
 }
 

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -338,9 +338,13 @@ type Loader struct {
 
 	// networkArgs contains the routes and links which were scraped from the
 	// host network namespace during sandbox creation.
+	//
+	// +checklocks:mu
 	networkArgs *CreateLinksAndRoutesArgs
 
 	// fsSaveFDs are FDs used for user-triggered filesystem checkpoint saving.
+	//
+	// +checklocks:mu
 	fsSaveFDs []*fd.FD
 
 	// fsSaveCheckpointGofer is true if fsSaveFDs contains only one FD, which
@@ -924,6 +928,10 @@ func New(args Args) (*Loader, error) {
 }
 
 // ConfigureNetwork implements inet.NetworkArgs.ConfigureNetwork.
+// Restore calls this synchronously through Kernel.LoadFrom while retaining
+// l.mu. That interface call cannot convey this concrete lock contract.
+//
+// +checklocks:l.mu
 func (l *Loader) ConfigureNetwork(s inet.Stack) error {
 	if h, ok := s.(*hostinet.Stack); ok {
 		h.SetFiles(l.hostinetNetDevFile, l.hostinetNetSNMPFile)


### PR DESCRIPTION
Enforce the existing mutexes for one-shot filesystem-save FD handoff, save waiters and per-container restore completion tracking. The input slice is detached under the loader mutex before saving; each completion registry remains protected by its own mutex.

Guard the loader's network arguments and require its mutex during configuration. Restore retains that lock across the synchronous Kernel.LoadFrom callback, preserving duplicated-FD consumption and cleanup. Document the interface boundary where checklocks cannot enforce the concrete loader contract.

Assisted-by: Codex
