### PR TITLE
checklocks: store virtual ownership atomically

### DIFF
--- a/pkg/sentry/fsimpl/host/BUILD
+++ b/pkg/sentry/fsimpl/host/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(default_applicable_licenses = ["//:license"])
@@ -64,5 +64,19 @@ go_library(
         "//pkg/usermem",
         "//pkg/waiter",
         "@org_golang_x_sys//unix:go_default_library",
+    ],
+)
+
+go_test(
+    name = "host_test",
+    size = "small",
+    srcs = ["host_test.go"],
+    library = ":host",
+    deps = [
+        "//pkg/abi/linux",
+        "//pkg/fd",
+        "//pkg/memutil",
+        "//pkg/sentry/contexttest",
+        "//pkg/sentry/vfs",
     ],
 )

--- a/pkg/sentry/fsimpl/host/host.go
+++ b/pkg/sentry/fsimpl/host/host.go
@@ -55,13 +55,19 @@ type virtualOwner struct {
 	// This field is initialized at creation time and is immutable.
 	enabled bool
 
-	// mu protects the fields below and they can be accessed using atomic memory
-	// operations.
-	mu  sync.Mutex `state:"nosave"`
+	// mu serializes ownership updates and their permission checks. SetStat
+	// acquires it only for requested virtual-owner changes. Readers access the
+	// fields below atomically without holding mu.
+	mu sync.Mutex `state:"nosave"`
+
+	// +checkatomic
 	uid atomicbitops.Uint32
+	// +checkatomic
 	gid atomicbitops.Uint32
 	// mode is also stored, otherwise setting the host file to `0000` could remove
 	// access to the file.
+	//
+	// +checkatomic
 	mode atomicbitops.Uint32
 }
 
@@ -327,10 +333,12 @@ func NewFD(ctx context.Context, mnt *vfs.Mount, hostFD int, opts *NewFDOptions) 
 		return nil, err
 	}
 	if opts.VirtualOwner {
-		i.virtualOwner.enabled = true
-		i.virtualOwner.uid = atomicbitops.FromUint32(uint32(opts.UID))
-		i.virtualOwner.gid = atomicbitops.FromUint32(uint32(opts.GID))
-		i.virtualOwner.mode = atomicbitops.FromUint32(stat.Mode)
+		i.virtualOwner = virtualOwner{
+			enabled: true,
+			uid:     atomicbitops.FromUint32(uint32(opts.UID)),
+			gid:     atomicbitops.FromUint32(uint32(opts.GID)),
+			mode:    atomicbitops.FromUint32(stat.Mode),
+		}
 	}
 	i.restorable = opts.Restorable
 
@@ -576,8 +584,6 @@ func (i *inode) stat(stat *unix.Stat_t) error {
 }
 
 // SetStat implements kernfs.Inode.SetStat.
-//
-// +checklocksignore
 func (i *inode) SetStat(ctx context.Context, fs *vfs.Filesystem, creds *auth.Credentials, opts vfs.SetStatOptions) error {
 	if i.readonly {
 		return linuxerr.EPERM
@@ -614,7 +620,7 @@ func (i *inode) SetStat(ctx context.Context, fs *vfs.Filesystem, creds *auth.Cre
 	if m&linux.STATX_MODE != 0 {
 		if i.virtualOwner.enabled {
 			// We hold i.virtualOwner.mu.
-			i.virtualOwner.mode = atomicbitops.FromUint32(uint32(opts.Stat.Mode))
+			i.virtualOwner.mode.Store(uint32(opts.Stat.Mode))
 		} else {
 			log.Warningf("sentry seccomp filters don't allow making fchmod(2) syscall")
 			return unix.EPERM
@@ -655,11 +661,11 @@ func (i *inode) SetStat(ctx context.Context, fs *vfs.Filesystem, creds *auth.Cre
 	if i.virtualOwner.enabled {
 		if m&linux.STATX_UID != 0 {
 			// We hold i.virtualOwner.mu.
-			i.virtualOwner.uid = atomicbitops.FromUint32(opts.Stat.UID)
+			i.virtualOwner.uid.Store(opts.Stat.UID)
 		}
 		if m&linux.STATX_GID != 0 {
 			// We hold i.virtualOwner.mu.
-			i.virtualOwner.gid = atomicbitops.FromUint32(opts.Stat.GID)
+			i.virtualOwner.gid.Store(opts.Stat.GID)
 		}
 	}
 	return nil

--- a/pkg/sentry/fsimpl/host/host_test.go
+++ b/pkg/sentry/fsimpl/host/host_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package host
+
+import (
+	"sync"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/fd"
+	"gvisor.dev/gvisor/pkg/memutil"
+	"gvisor.dev/gvisor/pkg/sentry/contexttest"
+	"gvisor.dev/gvisor/pkg/sentry/vfs"
+)
+
+func TestVirtualOwnerConcurrentStat(t *testing.T) {
+	ctx := contexttest.RootContext(t)
+	vfsObj := &vfs.VirtualFilesystem{}
+	if err := vfsObj.Init(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer vfsObj.Release(ctx)
+	fs, err := NewFilesystem(vfsObj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fs.DecRef(ctx)
+	mnt := vfsObj.NewDisconnectedMount(fs, nil, &vfs.MountOptions{})
+	defer mnt.DecRef(ctx)
+
+	rawFD, err := memutil.CreateMemFD("virtual-owner-test", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostFD := fd.New(rawFD)
+	defer func() { _ = hostFD.Close() }()
+	file, err := NewFD(ctx, mnt, hostFD.FD(), &NewFDOptions{
+		VirtualOwner: true,
+		UID:          100,
+		GID:          200,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = hostFD.Release()
+	defer file.DecRef(ctx)
+
+	statOpts := vfs.StatOptions{Mask: linux.STATX_TYPE | virtualOwnerModes}
+	initial, err := file.Stat(ctx, statOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initial.UID != 100 || initial.GID != 200 ||
+		initial.Mode&linux.S_IFMT != linux.S_IFREG {
+		t.Fatalf("initial metadata = %+v, want UID 100, GID 200, regular file", initial)
+	}
+
+	want := linux.Statx{
+		Mask: virtualOwnerModes,
+		Mode: 0o640,
+		UID:  1001,
+		GID:  1002,
+	}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		<-start
+		if err := file.SetStat(ctx, vfs.SetStatOptions{Stat: want}); err != nil {
+			t.Errorf("SetStat: %v", err)
+		}
+	})
+	wg.Go(func() {
+		<-start
+		if _, err := file.Stat(ctx, statOpts); err != nil {
+			t.Errorf("Stat: %v", err)
+		}
+	})
+	close(start)
+	wg.Wait()
+
+	got, err := file.Stat(ctx, statOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Mode&^linux.S_IFMT != want.Mode {
+		t.Errorf("mode = %#o, want %#o", got.Mode, want.Mode)
+	}
+	if got.UID != want.UID {
+		t.Errorf("UID = %d, want %d", got.UID, want.UID)
+	}
+	if got.GID != want.GID {
+		t.Errorf("GID = %d, want %d", got.GID, want.GID)
+	}
+}


### PR DESCRIPTION
Virtual ownership introduced in f51e0486d4 pairs atomic readers with ordinary writes in SetStat. The writer mutex does not protect Stat's unlocked readers. Use atomic stores for mode, UID and GID while retaining the existing permission-check critical section and error ordering.

Initialize a fresh virtual-owner value before publication. Declare all three atomic field contracts and remove SetStat's blanket suppression. Its conditionally held writer-lock contract remains documented in prose; checklocks cannot correlate the repeated enabled and mask tests.

Cover concurrent Stat and SetStat through an imported host file, as well as the constructor's initial virtual ownership.

Assisted-by: Codex
