### PR TITLE
checklocks: guard integer pool state

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -24,9 +24,13 @@ type Pool struct {
 	mu sync.Mutex
 
 	// cache is the set of returned values.
+	//
+	// +checklocks:mu
 	cache []uint64
 
 	// Start is the starting value (if needed).
+	//
+	// +checklocks:mu
 	Start uint64
 
 	// max is the current maximum issued.


### PR DESCRIPTION
Require the pool mutex for returned values and the next fresh value. Construction still initializes Start before publication; Get advances it under the mutex.

Assisted-by: Codex
