### PR TITLE
checklocks: guard KCOV and deferred task work

### DIFF
--- a/pkg/sentry/kernel/kcov.go
+++ b/pkg/sentry/kernel/kcov.go
@@ -44,30 +44,38 @@ type Kcov struct {
 	// mf stores application memory. It is immutable after creation.
 	mf *pgalloc.MemoryFile
 
-	// mu protects all of the fields below.
 	mu sync.RWMutex
 
 	// mode is the current kcov mode.
+	//
+	// +checklocks:mu
 	mode uint8
 
 	// size is the size of the mapping through which the kernel conveys coverage
 	// information to userspace.
+	//
+	// +checklocks:mu
 	size uint64
 
 	// owningTask is the task that currently owns coverage data on the system. The
 	// interface for kcov essentially requires that coverage is only going to a
 	// single task. Note that kcov should only generate coverage data for the
 	// owning task, but we currently generate global coverage.
+	//
+	// +checklocks:mu
 	owningTask *Task
 
 	// count is a locally cached version of the first uint64 in the kcov data,
 	// which is the number of subsequent entries representing PCs.
 	//
-	// It is used with kcovInode.countBlock(), to copy in/out the first element of
+	// It is used with Kcov.countBlock(), to copy in/out the first element of
 	// the actual data in an efficient manner, avoid boilerplate, and prevent
 	// accidental garbage escapes by the temporary counts.
+	//
+	// +checklocks:mu
 	count uint64
 
+	// +checklocks:mu
 	mappable *mm.SpecialMappable
 }
 

--- a/pkg/sentry/kernel/kcov_unsafe.go
+++ b/pkg/sentry/kernel/kcov_unsafe.go
@@ -22,7 +22,13 @@ import (
 
 // countBlock provides a safemem.BlockSeq for kcov.count.
 //
-// Like k.count, the block returned is protected by k.mu.
+// The returned block aliases kcov.count and must only be accessed while
+// kcov.mu is held.
+//
+// The entry annotation cannot enforce that requirement on accesses through
+// the returned BlockSeq.
+//
+// +checklocks:kcov.mu
 func (kcov *Kcov) countBlock() safemem.BlockSeq {
 	return safemem.BlockSeqOf(safemem.BlockFromSafePointer(unsafe.Pointer(&kcov.count), int(unsafe.Sizeof(kcov.count))))
 }

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -81,15 +81,17 @@ type Task struct {
 
 	// taskWorkCount represents the current size of the task work queue. It is
 	// used to avoid acquiring taskWorkMu when the queue is empty.
+	//
+	// +checkatomic
+	// +checklocks:taskWorkMu
 	taskWorkCount atomicbitops.Int32
 
-	// taskWorkMu protects taskWork.
 	taskWorkMu taskWorkMutex `state:"nosave"`
 
 	// taskWork is a queue of work to be executed before resuming user execution.
 	// It is similar to the task_work mechanism in Linux.
 	//
-	// taskWork is exclusive to the task goroutine.
+	// +checklocks:taskWorkMu
 	taskWork []TaskWorker
 
 	// haveSyscallReturn is true if image.Arch().Return() represents a value


### PR DESCRIPTION
Enforce existing KCOV state and deferred-task-work mutex contracts. Preserve countBlock's borrowed-memory lifetime requirement and the unlocked callback phase that lets task work register additional work.

Assisted-by: Codex
