### PR TITLE
checklocks: synchronize key permissions

### DIFF
--- a/pkg/sentry/kernel/auth/BUILD
+++ b/pkg/sentry/kernel/auth/BUILD
@@ -94,6 +94,7 @@ go_library(
     ],
     deps = [
         "//pkg/abi/linux",
+        "//pkg/atomicbitops",
         "//pkg/bits",
         "//pkg/context",
         "//pkg/errors/linuxerr",
@@ -109,7 +110,10 @@ go_library(
 
 go_test(
     name = "auth_test",
-    srcs = ["capability_set_test.go"],
+    srcs = [
+        "capability_set_test.go",
+        "key_test.go",
+    ],
     library = ":auth",
     deps = [
         "//pkg/abi/linux",

--- a/pkg/sentry/kernel/auth/key.go
+++ b/pkg/sentry/kernel/auth/key.go
@@ -15,10 +15,12 @@
 package auth
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"strings"
 
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/rand"
 )
@@ -93,16 +95,34 @@ type Key struct {
 	Description string
 
 	// kuid is the owner of the key in the root namespace.
-	// kuid is only mutable in KeySet transactions.
+	// It is immutable.
 	kuid KUID
 
 	// kgid is the group of the key in the root namespace.
-	// kgid is only mutable in KeySet transactions.
+	// It is immutable.
 	kgid KGID
 
 	// perms is a bitfield of key permissions.
-	// perms is only mutable in KeySet transactions.
-	perms KeyPermissions
+	//
+	// After initialization or restore, writes occur only in KeySet
+	// transactions. Readers may access shared keys outside a transaction.
+	//
+	// A task can retain a session key across a user-namespace switch and
+	// update it through the new namespace's KeySet. Writers therefore need
+	// not hold the same transaction mutex.
+	//
+	// +checkatomic
+	perms atomicbitops.Uint64 `state:".(KeyPermissions)"`
+}
+
+// savePerms is invoked by stateify.
+func (k *Key) savePerms() KeyPermissions {
+	return k.Permissions()
+}
+
+// loadPerms is invoked by stateify.
+func (k *Key) loadPerms(_ context.Context, perms KeyPermissions) {
+	k.perms.Store(uint64(perms))
 }
 
 // Type returns the type of this key.
@@ -117,13 +137,13 @@ func (k *Key) KUID() KUID { return k.kuid }
 func (k *Key) KGID() KGID { return k.kgid }
 
 // Permissions returns the permission bits of the key.
-func (k *Key) Permissions() KeyPermissions { return k.perms }
+func (k *Key) Permissions() KeyPermissions { return KeyPermissions(k.perms.Load()) }
 
 // String is a human-friendly representation of the key.
 // Notably, this is *not* the string returned to userspace when requested
 // using `KEYCTL_DESCRIBE`.
 func (k *Key) String() string {
-	return fmt.Sprintf("id=%d,perms=0x%x,desc=%q", k.ID, k.perms, k.Description)
+	return fmt.Sprintf("id=%d,perms=0x%x,desc=%q", k.ID, k.Permissions(), k.Description)
 }
 
 // Bitmasks for permission checks.
@@ -232,7 +252,7 @@ func (c *Credentials) PossessedKeys(sessionKeyring, processKeyring, threadKeyrin
 			continue
 		}
 		// The possessor still needs "search" permission in order to actually possess anything.
-		if ((k.perms&keyPossessorPermissionsMask)>>keyPossessorPermissionsShift)&keyPermissionSearch != 0 {
+		if ((k.Permissions()&keyPossessorPermissionsMask)>>keyPossessorPermissionsShift)&keyPermissionSearch != 0 {
 			possessed.possessed[k.ID] = struct{}{}
 		}
 	}
@@ -247,15 +267,16 @@ func (c *Credentials) PossessedKeys(sessionKeyring, processKeyring, threadKeyrin
 //
 //go:nosplit
 func (c *Credentials) HasKeyPermission(k *Key, possessed *PossessedKeys, permission KeyPermission) bool {
-	perms := k.perms & keyOtherPermissionsMask
+	keyPerms := k.Permissions()
+	perms := keyPerms & keyOtherPermissionsMask
 	if _, ok := possessed.possessed[k.ID]; ok {
-		perms |= (k.perms & keyPossessorPermissionsMask) >> keyPossessorPermissionsShift
+		perms |= (keyPerms & keyPossessorPermissionsMask) >> keyPossessorPermissionsShift
 	}
 	if c.EffectiveKUID == k.kuid {
-		perms |= (k.perms & keyOwnerPermissionsMask) >> keyOwnerPermissionsShift
+		perms |= (keyPerms & keyOwnerPermissionsMask) >> keyOwnerPermissionsShift
 	}
 	if c.EffectiveKGID == k.kgid {
-		perms |= (k.perms & keyGroupPermissionsMask) >> keyGroupPermissionsShift
+		perms |= (keyPerms & keyGroupPermissionsMask) >> keyGroupPermissionsShift
 	}
 	switch permission {
 	case KeyView:
@@ -279,9 +300,8 @@ func (c *Credentials) HasKeyPermission(k *Key, possessed *PossessedKeys, permiss
 //
 // +stateify savable
 type KeySet struct {
-	// txnMu is used for transactionality of key changes.
-	// This blocks multiple tasks for concurrently changing the keyset or the
-	// permissions of any keys.
+	// txnMu serializes transactions on this KeySet. A transaction may update
+	// a key retained from another namespace.
 	txnMu keysetTransactionMutex `state:"nosave"`
 
 	// mu protects the fields below.
@@ -297,6 +317,12 @@ type KeySet struct {
 
 // LockedKeySet is a KeySet in a transaction.
 // It exposes functions that can mutate the KeySet or its keys.
+//
+// KeySet.Do holds the transaction mutex while its callback runs. A
+// LockedKeySet must not be retained after the callback returns.
+//
+// checklocks cannot propagate Do's held txnMu through its callback argument.
+// Calls to the guarded methods inside these callbacks carry local exceptions.
 type LockedKeySet struct {
 	*KeySet
 }
@@ -361,6 +387,8 @@ func getNewID() (KeySerial, error) {
 }
 
 // Add adds a new Key to the KeySet.
+//
+// +checklocks:s.txnMu
 func (s *LockedKeySet) Add(description string, creds *Credentials, perms KeyPermissions, keySizeLimit int) (*Key, error) {
 	if len(description) >= MaxKeyDescSize {
 		return nil, linuxerr.EINVAL
@@ -385,7 +413,7 @@ func (s *LockedKeySet) Add(description string, creds *Credentials, perms KeyPerm
 		Description: description,
 		kuid:        creds.EffectiveKUID,
 		kgid:        creds.EffectiveKGID,
-		perms:       perms,
+		perms:       atomicbitops.FromUint64(uint64(perms)),
 	}
 	s.keys[newID] = k
 	return k, nil
@@ -393,6 +421,8 @@ func (s *LockedKeySet) Add(description string, creds *Credentials, perms KeyPerm
 
 // SetPerms sets the permissions on a given key.
 // The caller must have SetAttr permission on the key.
+//
+// +checklocks:s.txnMu
 func (s *LockedKeySet) SetPerms(key *Key, newPerms KeyPermissions) {
-	key.perms = newPerms
+	key.perms.Store(uint64(newPerms))
 }

--- a/pkg/sentry/kernel/auth/key_test.go
+++ b/pkg/sentry/kernel/auth/key_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestKeyPermissionsConcurrentUpdate(t *testing.T) {
+	const (
+		initialPerms KeyPermissions = (keyPermissionRead | keyPermissionSetAttr) << keyOwnerPermissionsShift
+		newPerms     KeyPermissions = keyPermissionSetAttr<<keyOwnerPermissionsShift | keyPermissionRead<<keyOtherPermissionsShift
+	)
+	ns := NewRootUserNamespace()
+	creds := NewRootCredentials(ns)
+	var key *Key
+	if err := ns.Keys.Do(func(keys *LockedKeySet) error {
+		var err error
+		// Do holds keys.txnMu during this synchronous callback, but
+		// checklocks cannot propagate that fact through its argument.
+		key, err = keys.Add("permissions", creds, initialPerms, MaxSetSize) // +checklocksignore
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both permission sets allow reading, but through different classes.
+	// The permission check must use a single snapshot of the key's bits.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		if err := ns.Keys.Do(func(keys *LockedKeySet) error {
+			// Do holds keys.txnMu during this synchronous callback, but
+			// checklocks cannot propagate that fact through its argument.
+			keys.SetPerms(key, newPerms) // +checklocksignore
+			return nil
+		}); err != nil {
+			t.Error(err)
+		}
+	})
+	if !creds.HasKeyPermission(key, creds.PossessedKeys(nil, nil, nil), KeyRead) {
+		t.Error("permission check denied reading during an update")
+	}
+	wg.Wait()
+	if got := key.Permissions(); got != newPerms {
+		t.Errorf("Permissions() = %v, want %v", got, newPerms)
+	}
+}

--- a/pkg/sentry/kernel/task_key.go
+++ b/pkg/sentry/kernel/task_key.go
@@ -47,8 +47,11 @@ func (t *Task) joinNewSessionKeyringLocked(newKeyDesc string, newKeyPerms auth.K
 	var sessionKeyring *auth.Key
 	err := t.UserNamespace().Keys.Do(func(keySet *auth.LockedKeySet) error {
 		creds := t.Credentials()
+		maxKeys := int(t.Kernel().MaxKeySetSize.Load())
 		var err error
-		sessionKeyring, err = keySet.Add(newKeyDesc, creds, newKeyPerms, int(t.Kernel().MaxKeySetSize.Load()))
+		// Do holds keySet.txnMu during this synchronous callback, but
+		// checklocks cannot propagate that fact through its argument.
+		sessionKeyring, err = keySet.Add(newKeyDesc, creds, newKeyPerms, maxKeys) // +checklocksignore
 		return err
 	})
 	if err != nil {
@@ -116,7 +119,9 @@ func (t *Task) SetPermsOnKey(key *auth.Key, perms auth.KeyPermissions) error {
 		if !creds.HasKeyPermission(key, possessed, auth.KeySetAttr) {
 			return linuxerr.EACCES
 		}
-		keySet.SetPerms(key, perms)
+		// Do holds keySet.txnMu during this synchronous callback, but
+		// checklocks cannot propagate that fact through its argument.
+		keySet.SetPerms(key, perms) // +checklocksignore
 		return nil
 	})
 }


### PR DESCRIPTION
Since 02f70b5df083, keys may be shared by tasks with different task mutexes. KeySet transactions serialize permission writes, but readers do not take that mutex, so permission updates race with readers.

Use an atomic permission word and one snapshot for each permission check. Enforce atomic access with checklocks and retain the typed checkpoint representation through stateify hooks.

Cover concurrent permission checks and transaction updates with a regression that preserves read access while moving it between classes.

Assisted-by: Codex
