### PR TITLE
checklocks: enforce link endpoint ownership

### DIFF
--- a/pkg/tcpip/link/nested/nested.go
+++ b/pkg/tcpip/link/nested/nested.go
@@ -34,8 +34,9 @@ type Endpoint struct {
 	child    stack.LinkEndpoint
 	embedder stack.NetworkDispatcher
 
-	// mu protects dispatcher.
-	mu         sync.RWMutex `state:"nosave"`
+	mu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:mu
 	dispatcher stack.NetworkDispatcher
 }
 

--- a/pkg/tcpip/link/tun/device.go
+++ b/pkg/tcpip/link/tun/device.go
@@ -45,10 +45,16 @@ var zeroMAC [6]byte
 type Device struct {
 	waiter.Queue
 
-	mu           deviceRWMutex `state:"nosave"`
-	endpoint     *tunEndpoint
+	mu deviceRWMutex `state:"nosave"`
+	// +checklocks:mu
+	endpoint *tunEndpoint
+	// +checklocks:mu
 	notifyHandle *channel.NotificationHandle
-	flags        Flags
+
+	// flags is set by SetIff under mu and immutable for that association.
+	// After capturing a non-nil endpoint under mu, file operations may read
+	// flags without mu. File lifetime excludes final Release from these operations.
+	flags Flags
 }
 
 // Flags set properties of a Device
@@ -371,10 +377,13 @@ type tunEndpoint struct {
 	name  string
 	isTap bool
 
-	mu            endpointMutex `state:"nosave"`
-	onCloseAction func()        `state:"nosave"`
-	persistent    bool
-	closed        bool
+	mu endpointMutex `state:"nosave"`
+	// +checklocks:mu
+	onCloseAction func() `state:"nosave"`
+	// +checklocks:mu
+	persistent bool
+	// +checklocks:mu
+	closed bool
 }
 
 func (e *tunEndpoint) setPersistent(v bool) {

--- a/pkg/tcpip/link/veth/veth.go
+++ b/pkg/tcpip/link/veth/veth.go
@@ -29,11 +29,17 @@ var _ stack.GSOEndpoint = (*Endpoint)(nil)
 
 // +stateify savable
 type veth struct {
-	mu           vethRWMutex `state:"nosave"`
-	closed       bool
+	mu vethRWMutex `state:"nosave"`
+
+	// +checklocks:mu
+	closed bool
+
 	backlogQueue chan vethPacket `state:"nosave"`
-	mtu          uint32
-	endpoints    [2]Endpoint
+
+	// +checklocks:mu
+	mtu uint32
+
+	endpoints [2]Endpoint
 }
 
 func (v *veth) close() {


### PR DESCRIPTION
Enforce existing mutex ownership of TUN endpoint associations and lifecycle state, shared veth state, and the nested endpoint dispatcher. TUN flags remain immutable for an association; readers capture the association under the device mutex before accessing flags without it. Final release remains a file-lifetime boundary.

Assisted-by: Codex
