### PR TITLE
checklocks: enforce lisafs bookkeeping

### DIFF
--- a/pkg/lisafs/client.go
+++ b/pkg/lisafs/client.go
@@ -41,11 +41,15 @@ type Client struct {
 	sockMu   sync.Mutex
 	sockComm *sockCommunicator
 
-	// channelsMu protects channels and availableChannels.
 	channelsMu sync.Mutex
+
 	// channels tracks all the channels.
+	//
+	// +checklocks:channelsMu
 	channels []*channel
 	// availableChannels is a LIFO (stack) of channels available to be used.
+	//
+	// +checklocks:channelsMu
 	availableChannels []*channel
 	// activeWg represents active channels.
 	activeWg sync.WaitGroup
@@ -61,10 +65,13 @@ type Client struct {
 	// It is initialized on Mount and is immutable.
 	maxMessageSize uint32
 
+	fdsMu sync.Mutex
+
 	// fdsToClose tracks the FDs to close. It caches the FDs no longer being used
 	// by the client and closes them in one shot. It is not preserved across
 	// checkpoint/restore as FDIDs are not preserved.
-	fdsMu      sync.Mutex
+	//
+	// +checklocks:fdsMu
 	fdsToClose []FDID
 }
 

--- a/pkg/lisafs/connection.go
+++ b/pkg/lisafs/connection.go
@@ -69,9 +69,11 @@ type Connection struct {
 	// sockComm is the main socket by which this connections is established.
 	sockComm *sockCommunicator
 
-	// channelsMu protects channels.
 	channelsMu sync.Mutex
+
 	// channels keeps track of all open channels.
+	//
+	// +checklocks:channelsMu
 	channels []*channel
 
 	// activeWg represents active channels.
@@ -84,9 +86,14 @@ type Connection struct {
 	channelAlloc *flipcall.PacketWindowAllocator
 
 	fdsMu sync.RWMutex
-	// fds keeps tracks of open FDs on this server. It is protected by fdsMu.
+
+	// fds tracks this connection's open FDs.
+	//
+	// +checklocks:fdsMu
 	fds map[FDID]genericFD
-	// nextFDID is the next available FDID. It is protected by fdsMu.
+	// nextFDID is the next available FDID.
+	//
+	// +checklocks:fdsMu
 	nextFDID FDID
 }
 
@@ -388,7 +395,7 @@ func (c *Connection) removeControlFDLocked(id FDID) {
 // stopTrackingFD makes c stop tracking the passed FDID. Note that the caller
 // must drop ref on the returned fd (preferably without holding c.fdsMu).
 //
-// Precondition: c.fdsMu is locked.
+// +checklocks:c.fdsMu
 func (c *Connection) stopTrackingFD(id FDID) genericFD {
 	fd := c.fds[id]
 	if fd == nil {

--- a/pkg/lisafs/fd.go
+++ b/pkg/lisafs/fd.go
@@ -61,10 +61,13 @@ type ControlFD struct {
 	// node is the filesystem node this FD is immutably associated with.
 	node *Node
 
+	openFDsMu sync.RWMutex
+
 	// openFDs is a linked list of all FDs opened on this FD. As per reference
 	// model, all open FDs hold a ref on this FD.
-	openFDsMu sync.RWMutex
-	openFDs   openFDList
+	//
+	// +checklocks:openFDsMu
+	openFDs openFDList
 
 	// All the following fields are immutable.
 
@@ -171,10 +174,10 @@ func (fd *ControlFD) Node() *Node {
 
 // RemoveFromConn removes this control FD from its owning connection.
 //
-// Preconditions:
-//   - fd should not have been returned to the client. Otherwise the client can
-//     still refer to it.
-//   - server's rename mutex must at least be read locked.
+// Precondition: fd must not have been returned to the client. Otherwise the
+// client can still refer to it.
+//
+// +checklocksread:fd.conn.server.renameMu
 func (fd *ControlFD) RemoveFromConn() {
 	fd.conn.removeControlFDLocked(fd.id)
 }

--- a/pkg/lisafs/node.go
+++ b/pkg/lisafs/node.go
@@ -66,8 +66,10 @@ type Node struct {
 	// used to deny operations on FDs on this Node after deletion because it is
 	// not safe for FD implementations to do host walks up to this position
 	// anymore. This node may have been replaced with something hazardous.
-	// deleted is protected by opMu. deleted must only be accessed/mutated using
-	// atomics; see markDeletedRecursive for more details.
+	// Accesses must be atomic because markDeletedRecursive also marks
+	// descendants without holding their opMu.
+	//
+	// +checkatomic
 	deleted atomicbitops.Uint32
 
 	// name is the name of the file represented by this Node in parent. If this
@@ -79,12 +81,15 @@ type Node struct {
 	// protected by the backing server's rename mutex.
 	parent *Node
 
+	controlFDsMu sync.Mutex
+
 	// controlFDs is a linked list of all the ControlFDs opened on this node.
 	// Prefer this over a slice to avoid additional allocations. Each ControlFD
 	// is an implicit linked list node so there are no additional allocations
 	// needed to maintain the linked list.
-	controlFDsMu sync.Mutex
-	controlFDs   controlFDList
+	//
+	// +checklocks:controlFDsMu
+	controlFDs controlFDList
 
 	// Here is a performance hack. Past experience has shown that map allocations
 	// on each node for tracking children costs a lot of memory. More small
@@ -125,9 +130,9 @@ func (n *Node) DecRef(context.Context) {
 	}
 }
 
-// InitLocked must be called before first use of fd.
+// InitLocked must be called before first use of n.
 //
-// Precondition: parent.childrenMu is locked.
+// Precondition: parent.childrenMu is locked if parent is non-nil.
 //
 // Postconditions: A ref on n is transferred to the caller.
 func (n *Node) InitLocked(name string, parent *Node) {


### PR DESCRIPTION
Enforce existing mutex contracts for channel collections, descriptor tracking, and per-node and per-control-FD descriptor lists. Require the connection lock when removing a tracked descriptor; callers still drop the returned reference.

Declare atomic access to deletion flags, since recursive deletion marks descendants without their operation locks. Require the rename read lock when removing an unpublished control FD, retaining its lifetime condition and the conditional parent-lock requirement during node initialization.

Assisted-by: Codex
