### PR TITLE
checklocks: enforce memory-manager ownership

### DIFF
--- a/pkg/sentry/mm/address_space.go
+++ b/pkg/sentry/mm/address_space.go
@@ -35,10 +35,11 @@ func (mm *MemoryManager) AddressSpace() platform.AddressSpace {
 // mapASLocked maps addresses in ar into mm.as.
 //
 // Preconditions:
-//   - mm.activeMu must be locked.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
 //   - pseg == mm.pmas.LowerBoundSegment(ar.Start).
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) mapASLocked(ctx context.Context, pseg pmaIterator, ar hostarch.AddrRange, platformEffect memmap.MMapPlatformEffect) error {
 	if platformEffect == memmap.PlatformEffectCommit && ar.Length() > (1<<30) {
 		// FIXME(b/445932215, b/445939339): Don't precommit very large ranges
@@ -121,7 +122,7 @@ func (mm *MemoryManager) mapASLocked(ctx context.Context, pseg pmaIterator, ar h
 
 // unmapASLocked removes all AddressSpace mappings for addresses in ar.
 //
-// Preconditions: mm.activeMu must be locked.
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) unmapASLocked(ar hostarch.AddrRange) {
 	if ar.Length() == 0 {
 		return

--- a/pkg/sentry/mm/aio_context.go
+++ b/pkg/sentry/mm/aio_context.go
@@ -29,10 +29,11 @@ import (
 //
 // +stateify savable
 type aioManager struct {
-	// mu protects below.
 	mu aioManagerMutex `state:"nosave"`
 
-	// aioContexts is the set of asynchronous I/O contexts.
+	// contexts is the set of asynchronous I/O contexts.
+	//
+	// +checklocks:mu
 	contexts map[uint64]*AIOContext
 }
 
@@ -69,7 +70,7 @@ func (a *aioManager) newAIOContext(events uint32, id uint64) bool {
 //
 // Nil is returned if the context does not exist.
 //
-// Precondition: mm.aioManager.mu is locked.
+// +checklocks:mm.aioManager.mu
 func (mm *MemoryManager) destroyAIOContextLocked(ctx context.Context, id uint64) *AIOContext {
 	aioCtx, ok := mm.aioManager.contexts[id]
 	if !ok {
@@ -104,12 +105,15 @@ type ioResult struct {
 // +stateify savable
 type AIOContext struct {
 	// requestReady is the notification channel used for all requests.
+	//
+	// +checklocks:mu
 	requestReady chan struct{} `state:"nosave"`
 
-	// mu protects below.
 	mu aioContextMutex `state:"nosave"`
 
 	// results is the set of completed requests.
+	//
+	// +checklocks:mu
 	results ioList
 
 	// maxOutstanding is the maximum number of outstanding entries; this value
@@ -119,9 +123,13 @@ type AIOContext struct {
 	// outstanding is the number of requests outstanding; this will effectively
 	// be the number of entries in the result list or that are expected to be
 	// added to the result list.
+	//
+	// +checklocks:mu
 	outstanding uint32
 
 	// dead is set when the context is destroyed.
+	//
+	// +checklocks:mu
 	dead bool `state:"zerovalue"`
 }
 
@@ -133,7 +141,7 @@ func (aio *AIOContext) destroy() {
 	aio.checkForDone()
 }
 
-// Preconditions: ctx.mu must be held by caller.
+// +checklocks:aio.mu
 func (aio *AIOContext) checkForDone() {
 	if aio.dead && aio.outstanding == 0 {
 		close(aio.requestReady)

--- a/pkg/sentry/mm/aio_context_state.go
+++ b/pkg/sentry/mm/aio_context_state.go
@@ -20,7 +20,9 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
 )
 
-// afterLoad is invoked by stateify.
+// afterLoad is invoked by stateify before the restored context is in use.
+//
+// +checklocks:aio.mu
 func (aio *AIOContext) afterLoad(context.Context) {
 	aio.requestReady = make(chan struct{}, 1)
 }

--- a/pkg/sentry/mm/debug.go
+++ b/pkg/sentry/mm/debug.go
@@ -59,7 +59,11 @@ func (mm *MemoryManager) DebugString(ctx context.Context) string {
 	return b.String()
 }
 
-// Preconditions: mm.activeMu must be locked.
+// debugStringEntryLocked formats pseg for DebugString. The generated iterator
+// has no MemoryManager reference, so checklocks cannot name the owning mutex.
+//
+// Preconditions: the owning MemoryManager's activeMu is held at least for
+// reading.
 func (pseg pmaIterator) debugStringEntryLocked() []byte {
 	var b bytes.Buffer
 

--- a/pkg/sentry/mm/io.go
+++ b/pkg/sentry/mm/io.go
@@ -715,12 +715,13 @@ func (mm *MemoryManager) withVecInternalMappings(ctx context.Context, ars hostar
 // called.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - pseg.Range().Contains(ar.Start).
 //   - pmas must exist for all addresses in ar.
 //   - ar.Length() != 0.
 //
 // Postconditions: getIOMappingsLocked does not invalidate iterators into mm.pmas.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getIOMappingsLocked(pseg pmaIterator, ar hostarch.AddrRange, at hostarch.AccessType) (safemem.BlockSeq, *ioBufTracker, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -759,12 +760,12 @@ slowPath:
 // are valid until either mm.activeMu is unlocked or ioBufTracker.flush() is
 // called.
 //
-// Preconditions:
-//   - mm.activeMu must be locked for writing.
-//   - pmas must exist for all addresses in ar.
+// Preconditions: pmas must exist for all addresses in ars.
 //
 // Postconditions: getVecIOMappingsLocked does not invalidate iterators into
 // mm.pmas
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getVecIOMappingsLocked(ars hostarch.AddrRangeSeq, at hostarch.AccessType) (safemem.BlockSeq, *ioBufTracker, error) {
 	if ars.NumRanges() == 1 {
 		ar := ars.Head()
@@ -807,13 +808,14 @@ func (mm *MemoryManager) getVecIOMappingsLocked(ars hostarch.AddrRangeSeq, at ho
 // ioBufTracker.flush() is called.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - pseg.Range().Contains(ar.Start).
 //   - pmas must exist for all addresses in ar.
 //   - ar.Length() != 0.
 //
 // Postconditions: getIOMappingsTrackedLocked does not invalidate iterators
 // into mm.pmas.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getIOMappingsTrackedLocked(pseg pmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, ims []safemem.Block, t *ioBufTracker, unbufBytes uint64) ([]safemem.Block, *ioBufTracker, uint64, error) {
 	for {
 		pmaAR := ar.Intersect(pseg.Range())

--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -129,7 +129,10 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 		// Inform the Mappable, if any, of the new mapping.
 		if vma.mappable != nil {
 			if err := vma.mappable.AddMapping(ctx, mm2, vmaAR, vma.off, vma.canWriteMappableLocked()); err != nil {
-				_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs)
+				// Fork still exclusively owns mm2's VMA and mapping-accounting
+				// state. AddMapping only exposes its activeMu-protected
+				// invalidation state.
+				_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs) // +checklocksignore
 				as.Release()
 				return nil, err
 			}
@@ -233,7 +236,10 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 							pseg.ValuePtr().file.DecRef(pseg.fileRange())
 						}
 						mm2.pmas.RemoveAll()
-						_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs)
+						// Fork still exclusively owns mm2's VMA and mapping-accounting
+						// state. AddMapping only exposes its activeMu-protected
+						// invalidation state.
+						_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs) // +checklocksignore
 						as.Release()
 						return nil, err
 					}
@@ -309,11 +315,12 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 // may be pinned for DMA. It returns the gap after the inserted pma.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
-//   - mm2.activeMu must be locked for writing.
 //   - srcpseg.ValuePtr().private == true.
 //   - dstpgap must be the gap in mm2.pmas at which the new pma should be
 //     inserted.
+//
+// +checklocks:mm.activeMu
+// +checklocks:mm2.activeMu
 func (mm *MemoryManager) forkCopyPMALocked(mm2 *MemoryManager, srcpseg pmaIterator, dstpgap pmaGapIterator, memCgID uint32) (pmaGapIterator, error) {
 	if err := srcpseg.getInternalMappingsLocked(); err != nil {
 		return dstpgap, err

--- a/pkg/sentry/mm/mm.go
+++ b/pkg/sentry/mm/mm.go
@@ -79,6 +79,8 @@ type MemoryManager struct {
 	// users is the number of dependencies on the mappings in the MemoryManager.
 	// When the number of references in users reaches zero, all mappings are
 	// unmapped.
+	//
+	// +checkatomic
 	users atomicbitops.Int32
 
 	// mappingMu is analogous to Linux's struct mm_struct::mmap_sem.
@@ -90,37 +92,37 @@ type MemoryManager struct {
 	//
 	// Invariants: vmas are always page-aligned.
 	//
-	// vmas is protected by mappingMu.
+	// +checklocks:mappingMu
 	vmas vmaSet
 
 	// brk is the mm's brk, which is manipulated using the brk(2) system call.
 	// The brk is initially set up by the loader which maps an executable
 	// binary into the mm.
 	//
-	// brk is protected by mappingMu.
+	// +checklocks:mappingMu
 	brk hostarch.AddrRange
 
 	// usageAS is vmas.Span(), cached to accelerate RLIMIT_AS checks.
 	//
-	// usageAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	usageAS uint64
 
 	// lockedAS is the combined size in bytes of all vmas with vma.mlockMode !=
 	// memmap.MLockNone.
 	//
-	// lockedAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	lockedAS uint64
 
 	// dataAS is the size of private data segments, like mm_struct->data_vm.
 	// It means the vma which is private, writable, not stack.
 	//
-	// dataAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	dataAS uint64
 
 	// New VMAs created by MMap use whichever of memmap.MMapOpts.MLockMode or
 	// defMLockMode is greater.
 	//
-	// defMLockMode is protected by mappingMu.
+	// +checklocks:mappingMu
 	defMLockMode memmap.MLockMode
 
 	// activeMu is loosely analogous to Linux's struct
@@ -133,36 +135,36 @@ type MemoryManager struct {
 	// a copy.
 	//
 	// Inserting or removing segments from pmas should happen along with a
-	// call to mm.insertRSS or mm.removeRSS.
+	// call to mm.addRSSLocked or mm.removeRSSLocked.
 	//
 	// Invariants: pmas are always page-aligned. If a pma exists for a given
 	// address, a vma must also exist for that address.
 	//
-	// pmas is protected by activeMu.
+	// +checklocks:activeMu
 	pmas pmaSet
 
 	// curRSS is pmas.Span(), cached to accelerate updates to maxRSS. It is
 	// reported as the MemoryManager's RSS.
 	//
-	// maxRSS should be modified only via insertRSS and removeRSS, not
+	// curRSS should be modified only via addRSSLocked and removeRSSLocked, not
 	// directly.
 	//
-	// maxRSS is protected by activeMu.
+	// +checklocks:activeMu
 	curRSS uint64
 
 	// maxRSS is the maximum resident set size in bytes of a MemoryManager.
 	// It is tracked as the application adds and removes mappings to pmas.
 	//
-	// maxRSS should be modified only via insertRSS, not directly.
+	// maxRSS should be modified only via addRSSLocked, not directly.
 	//
-	// maxRSS is protected by activeMu.
+	// +checklocks:activeMu
 	maxRSS uint64
 
 	// hasPinned is true if pages in this MemoryManager have ever been pinned
 	// by Pin. It is never cleared, even if all pinned pages are unpinned;
 	// compare Linux's MMF_HAS_PINNED.
 	//
-	// hasPinned is protected by activeMu.
+	// +checklocks:activeMu
 	hasPinned bool
 
 	// as is the platform.AddressSpace that pmas are mapped into. as is immutable
@@ -174,15 +176,20 @@ type MemoryManager struct {
 	// This is to avoid a race condition in MM.Fork(); see that function for
 	// details.
 	//
-	// Both captureInvalidations and capturedInvalidations are protected by
-	// activeMu. Neither need to be saved since captureInvalidations is only
+	// Neither field needs to be saved since captureInvalidations is only
 	// enabled during MM.Fork(), during which saving can't occur.
-	captureInvalidations  bool             `state:"zerovalue"`
+	//
+	// +checklocks:activeMu
+	captureInvalidations bool `state:"zerovalue"`
+
+	// +checklocks:activeMu
 	capturedInvalidations []invalidateArgs `state:"nosave"`
 
 	// dumpability describes if and how this MemoryManager may be dumped to
 	// userspace. This is read under kernel.TaskSet.mu, so it can't be protected
 	// by metadataMu.
+	//
+	// +checkatomic
 	dumpability atomicbitops.Int32
 
 	metadataMu metadataMutex `state:"nosave"`
@@ -191,25 +198,25 @@ type MemoryManager struct {
 	// modified by prctl(PR_SET_MM_ARG_START/PR_SET_MM_ARG_END). No
 	// requirements apply to argv; we do not require that argv.WellFormed().
 	//
-	// argv is protected by metadataMu.
+	// +checklocks:metadataMu
 	argv hostarch.AddrRange
 
 	// envv is the application envv. This is set up by the loader and may be
 	// modified by prctl(PR_SET_MM_ENV_START/PR_SET_MM_ENV_END). No
 	// requirements apply to envv; we do not require that envv.WellFormed().
 	//
-	// envv is protected by metadataMu.
+	// +checklocks:metadataMu
 	envv hostarch.AddrRange
 
 	// auxv is the ELF's auxiliary vector.
 	//
-	// auxv is protected by metadataMu.
+	// +checklocks:metadataMu
 	auxv arch.Auxv
 
 	// executable is the executable for this MemoryManager. If executable
-	// is not nil, it holds a reference on the Dirent.
+	// is not nil, it holds a reference on the FileDescription.
 	//
-	// executable is protected by metadataMu.
+	// +checklocks:metadataMu
 	executable *vfs.FileDescription
 
 	// aioManager keeps track of AIOContexts used for async IOs. AIOManager
@@ -217,22 +224,34 @@ type MemoryManager struct {
 	aioManager aioManager
 
 	// vdsoSigReturnAddr is the address of 'vdso_sigreturn'.
+	//
+	// +checklocks:metadataMu
 	vdsoSigReturnAddr uint64
 
 	// membarrierPrivateEnabled is non-zero if EnableMembarrierPrivate has
 	// previously been called. Since, as of this writing,
 	// MEMBARRIER_CMD_PRIVATE_EXPEDITED is implemented as a global memory
 	// barrier, membarrierPrivateEnabled has no other effect.
+	//
+	// +checkatomic
 	membarrierPrivateEnabled atomicbitops.Uint32
 
 	// membarrierRSeqEnabled is non-zero if EnableMembarrierRSeq has previously
 	// been called.
+	//
+	// +checkatomic
 	membarrierRSeqEnabled atomicbitops.Uint32
 }
 
 // vma represents a virtual memory area.
 //
-// Note: new fields added to this struct must be added to vma.Copy and
+// After MemoryManager construction, fields in stored VMAs are protected by its
+// mappingMu, except as noted below. Detached copies are exclusively owned.
+//
+// Neither vma nor its generated iterators have a MemoryManager backpointer,
+// so checklocks cannot name the owner mutex for their fields and methods.
+//
+// Note: new fields added to this struct must be added to vma.copy and
 // vmaSetFunctions.Merge.
 //
 // +stateify savable
@@ -304,8 +323,12 @@ type vma struct {
 	// lastFault records the last address that was paged faulted. It hints at
 	// which direction addresses in this vma are being accessed.
 	//
-	// This field can be read atomically, and written with mm.activeMu locked for
-	// writing and mm.mapping locked.
+	// Accesses to this field in stored VMAs are atomic. Fault updates hold
+	// mappingMu at least for reading and activeMu for writing. After
+	// construction, VMA-set mutations hold mappingMu for writing, excluding
+	// fault updates. Detached copies may use ordinary reads and writes.
+	//
+	// +checkatomic
 	lastFault uintptr
 }
 
@@ -331,6 +354,11 @@ func (v *vma) copy() vma {
 }
 
 // pma represents a platform mapping area.
+//
+// Stored PMA metadata is protected by the owning MemoryManager.activeMu.
+// Detached copies of the metadata can be used under exclusive ownership.
+// Neither pma nor its generated iterators have a MemoryManager backpointer,
+// so checklocks cannot name the owner mutex for their fields and methods.
 //
 // +stateify savable
 type pma struct {

--- a/pkg/sentry/mm/mm_test.go
+++ b/pkg/sentry/mm/mm_test.go
@@ -52,6 +52,8 @@ func testMemoryManager(ctx context.Context, t *testing.T) *MemoryManager {
 }
 
 func (mm *MemoryManager) realUsageAS() uint64 {
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
 	return uint64(mm.vmas.Span())
 }
 
@@ -68,18 +70,20 @@ func TestUsageASUpdates(t *testing.T) {
 		t.Fatalf("MMap got err %v want nil", err)
 	}
 	realUsage := mm.realUsageAS()
-	if mm.usageAS != realUsage {
-		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", mm.usageAS, realUsage)
+	if got := mm.VirtualMemorySize(); got != realUsage {
+		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", got, realUsage)
 	}
 
 	mm.MUnmap(ctx, addr, hostarch.PageSize)
 	realUsage = mm.realUsageAS()
-	if mm.usageAS != realUsage {
-		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", mm.usageAS, realUsage)
+	if got := mm.VirtualMemorySize(); got != realUsage {
+		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", got, realUsage)
 	}
 }
 
 func (mm *MemoryManager) realDataAS() uint64 {
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
 	var sz uint64
 	for seg := mm.vmas.FirstSegment(); seg.Ok(); seg = seg.NextSegment() {
 		vma := seg.ValuePtr()
@@ -104,32 +108,32 @@ func TestDataASUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MMap got err %v want nil", err)
 	}
-	if mm.dataAS == 0 {
+	if mm.VirtualDataSize() == 0 {
 		t.Fatalf("dataAS is 0, wanted not 0")
 	}
 	realDataAS := mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MUnmap(ctx, addr, hostarch.PageSize)
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MProtect(addr+hostarch.PageSize, hostarch.PageSize, hostarch.Read, false)
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MRemap(ctx, addr+2*hostarch.PageSize, hostarch.PageSize, 2*hostarch.PageSize, MRemapOpts{
 		Move: MRemapMayMove,
 	})
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 }
 

--- a/pkg/sentry/mm/pma.go
+++ b/pkg/sentry/mm/pma.go
@@ -35,9 +35,9 @@ import (
 // iterator to the pma containing ar.Start. Otherwise it returns a terminal
 // iterator.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - ar.Length() != 0.
+// Preconditions: ar.Length() != 0.
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) existingPMAsLocked(ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool, needInternalMappings bool) pmaIterator {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -73,7 +73,7 @@ func (mm *MemoryManager) existingPMAsLocked(ar hostarch.AddrRange, at hostarch.A
 // existingVecPMAsLocked returns true if pmas exist for all addresses in ars,
 // and support access of type (at, ignorePermissions).
 //
-// Preconditions: mm.activeMu must be locked.
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) existingVecPMAsLocked(ars hostarch.AddrRangeSeq, at hostarch.AccessType, ignorePermissions bool, needInternalMappings bool) bool {
 	for ; !ars.IsEmpty(); ars = ars.Tail() {
 		if ar := ars.Head(); ar.Length() != 0 && !mm.existingPMAsLocked(ar, at, ignorePermissions, needInternalMappings).Ok() {
@@ -105,12 +105,13 @@ func (mm *MemoryManager) existingVecPMAsLocked(ars hostarch.AddrRangeSeq, at hos
 // mm/internal.h:gup_must_unshare(FOLL_PIN|FOLL_LONGTERM).
 //
 // Preconditions:
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - vseg.Range().Contains(ar.Start).
 //   - vmas must exist for all addresses in ar, and support accesses of type at
 //     (i.e. permission checks must have been performed against vmas).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getPMAsLocked(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, callerIndirectCommit, forPin bool) (pmaIterator, pmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -153,11 +154,11 @@ func (mm *MemoryManager) getPMAsLocked(ctx context.Context, vseg vmaIterator, ar
 // exist. If this is not equal to ars, it returns a non-nil error explaining
 // why.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
-//   - vmas must exist for all addresses in ars, and support accesses of type at
-//     (i.e. permission checks must have been performed against vmas).
+// Preconditions: vmas must exist for all addresses in ars, and support accesses
+// of type at (i.e. permission checks must have been performed against vmas).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getVecPMAsLocked(ctx context.Context, ars hostarch.AddrRangeSeq, at hostarch.AccessType, callerIndirectCommit bool) (hostarch.AddrRangeSeq, error) {
 	for arsit := ars; !arsit.IsEmpty(); arsit = arsit.Tail() {
 		ar := arsit.Head()
@@ -230,6 +231,9 @@ func (mm *MemoryManager) getAllocationDirection(ar hostarch.AddrRange, vma *vma)
 //   - getPMAsInternalLocked additionally requires that ar is page-aligned.
 //     getPMAsInternalLocked is an implementation helper for getPMAsLocked and
 //     getVecPMAsLocked; other clients should call one of those instead.
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getPMAsInternalLocked(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, callerIndirectCommit, forPin bool) (pmaIterator, pmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -628,10 +632,10 @@ func hugepageAligned(ar hostarch.AddrRange) hostarch.AddrRange {
 // the memory it maps, isPMACopyOnWriteLocked will take ownership of the memory
 // and update the pma to indicate that it does not require copy-on-write.
 //
-// Preconditions:
-//   - vseg.Range().IsSupersetOf(pseg.Range()).
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
+// Preconditions: vseg.Range().IsSupersetOf(pseg.Range()).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) isPMACopyOnWriteLocked(vseg vmaIterator, pseg pmaIterator) bool {
 	pma := pseg.ValuePtr()
 	if !pma.needCOW {
@@ -676,9 +680,10 @@ func (mm *MemoryManager) Invalidate(ar hostarch.AddrRange, opts memmap.Invalidat
 // addresses in ar.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) invalidateLocked(ar hostarch.AddrRange, invalidatePrivate, invalidateShared bool) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -827,12 +832,13 @@ func Unpin(prs []PinnedRange) {
 // movePMAsLocked moves all pmas in oldAR to newAR.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - oldAR.Length() != 0.
 //   - oldAR.Length() <= newAR.Length().
 //   - !oldAR.Overlaps(newAR).
 //   - mm.pmas.IsEmptyRange(newAR).
 //   - oldAR and newAR must be page-aligned.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) movePMAsLocked(oldAR, newAR hostarch.AddrRange) {
 	if checkInvariants {
 		if !oldAR.WellFormed() || oldAR.Length() == 0 || !oldAR.IsPageAligned() {
@@ -881,12 +887,13 @@ func (mm *MemoryManager) movePMAsLocked(oldAR, newAR hostarch.AddrRange) {
 // internalMappingsLocked returns cached internal mappings for addresses in ar.
 //
 // Preconditions:
-//   - mm.activeMu must be locked.
 //   - While mm.activeMu was locked, a call to
 //     existingPMAsLocked(needInternalMappings=true) succeeded for all
 //     addresses in ar.
 //   - ar.Length() != 0.
 //   - pseg.Range().Contains(ar.Start).
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) internalMappingsLocked(pseg pmaIterator, ar hostarch.AddrRange) safemem.BlockSeq {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -921,11 +928,11 @@ func (mm *MemoryManager) internalMappingsLocked(pseg pmaIterator, ar hostarch.Ad
 // vecInternalMappingsLocked returns cached internal mappings for addresses in
 // ars.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - While mm.activeMu was locked, a call to
-//     existingVecPMAsLocked(needInternalMappings=true) succeeded for all
-//     addresses in ars.
+// Preconditions: While mm.activeMu was locked, a call to
+// existingVecPMAsLocked(needInternalMappings=true) succeeded for all addresses
+// in ars.
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) vecInternalMappingsLocked(ars hostarch.AddrRangeSeq) safemem.BlockSeq {
 	var ims []safemem.Block
 	for ; !ars.IsEmpty(); ars = ars.Tail() {
@@ -943,7 +950,7 @@ func (mm *MemoryManager) vecInternalMappingsLocked(ars hostarch.AddrRangeSeq) sa
 // addRSSLocked updates the current and maximum resident set size of a
 // MemoryManager to reflect the insertion of a pma at ar.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) addRSSLocked(ar hostarch.AddrRange) {
 	mm.curRSS += uint64(ar.Length())
 	if mm.curRSS > mm.maxRSS {
@@ -954,7 +961,7 @@ func (mm *MemoryManager) addRSSLocked(ar hostarch.AddrRange) {
 // removeRSSLocked updates the current resident set size of a MemoryManager to
 // reflect the removal of a pma at ar.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) removeRSSLocked(ar hostarch.AddrRange) {
 	mm.curRSS -= uint64(ar.Length())
 }
@@ -1008,9 +1015,9 @@ func (pmaSetFunctions) Split(ar hostarch.AddrRange, p pma, split hostarch.Addr) 
 // findOrSeekPrevUpperBoundPMA returns mm.pmas.UpperBoundSegment(addr), but may do
 // so by scanning linearly backward from pgap.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - addr <= pgap.Start().
+// Preconditions: addr <= pgap.Start().
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) findOrSeekPrevUpperBoundPMA(addr hostarch.Addr, pgap pmaGapIterator) pmaIterator {
 	if checkInvariants {
 		if !pgap.Ok() {
@@ -1030,9 +1037,10 @@ func (mm *MemoryManager) findOrSeekPrevUpperBoundPMA(addr hostarch.Addr, pgap pm
 }
 
 // getInternalMappingsLocked ensures that pseg.ValuePtr().internalMappings is
-// non-empty.
+// non-empty. The generated iterator identifies a set node and index, not its
+// MemoryManager, so checklocks cannot name the owning mutex.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// Preconditions: the owning MemoryManager's activeMu is held for writing.
 func (pseg pmaIterator) getInternalMappingsLocked() error {
 	pma := pseg.ValuePtr()
 	if pma.internalMappings.IsEmpty() {

--- a/pkg/sentry/mm/procfs.go
+++ b/pkg/sentry/mm/procfs.go
@@ -98,14 +98,14 @@ func (mm *MemoryManager) ReadMapsDataInto(ctx context.Context, fn MapsCallbackFu
 // vmaMapsEntryLocked returns a /proc/[pid]/maps entry for the vma iterated by
 // vseg, including the trailing newline.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) vmaMapsEntryLocked(ctx context.Context, vseg vmaIterator) []byte {
 	var b bytes.Buffer
 	mm.appendVMAMapsEntryLocked(ctx, vseg, mm.MapsCallbackFuncForBuffer(&b))
 	return b.Bytes()
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) appendVMAMapsEntryLocked(ctx context.Context, vseg vmaIterator, fn MapsCallbackFunc) {
 	vma := vseg.ValuePtr()
 	private := "p"
@@ -149,13 +149,14 @@ func (mm *MemoryManager) ReadSmapsDataInto(ctx context.Context, buf *bytes.Buffe
 // vmaSmapsEntryLocked returns a /proc/[pid]/smaps entry for the vma iterated
 // by vseg, including the trailing newline.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) vmaSmapsEntryLocked(ctx context.Context, vseg vmaIterator) []byte {
 	var b bytes.Buffer
 	mm.vmaSmapsEntryIntoLocked(ctx, vseg, &b)
 	return b.Bytes()
 }
 
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) vmaSmapsEntryIntoLocked(ctx context.Context, vseg vmaIterator, b *bytes.Buffer) {
 	mm.appendVMAMapsEntryLocked(ctx, vseg, mm.MapsCallbackFuncForBuffer(b))
 	vma := vseg.ValuePtr()

--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -174,9 +174,9 @@ func (mm *MemoryManager) MMap(ctx context.Context, opts memmap.MMapOpts) (hostar
 // populateVMA obtains pmas for addresses in ar in the given vma, and maps them
 // into mm.as if it is active.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked.
-//   - vseg.Range().IsSupersetOf(ar).
+// Preconditions: vseg.Range().IsSupersetOf(ar).
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) populateVMA(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, platformEffect memmap.MMapPlatformEffect) error {
 	if !vseg.ValuePtr().effectivePerms.Any() {
 		// mm.mapASLocked() will no-op due to platform.AddressSpace.MapFile()

--- a/pkg/sentry/mm/vma.go
+++ b/pkg/sentry/mm/vma.go
@@ -34,9 +34,9 @@ import (
 // calls to functions that drop mapping identities within a scope should reuse
 // the same slice.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked for writing.
-//   - opts must be valid as defined by the checks in MMap.
+// Preconditions: opts must be valid as defined by the checks in MMap.
+//
+// +checklocks:mm.mappingMu
 func (mm *MemoryManager) createVMALocked(ctx context.Context, opts memmap.MMapOpts, droppedIDs []memmap.MappingIdentity) (vmaIterator, hostarch.AddrRange, []memmap.MappingIdentity, error) {
 	if opts.MaxPerms != opts.MaxPerms.Effective() {
 		panic(fmt.Sprintf("Non-effective MaxPerms %s cannot be enforced", opts.MaxPerms))
@@ -172,7 +172,7 @@ const (
 
 // findAvailableLocked finds an allocatable range.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findAvailableLocked(length uint64, opts findAvailableOpts) (hostarch.Addr, error) {
 	if opts.Fixed {
 		opts.Map32Bit = false
@@ -231,7 +231,7 @@ func (mm *MemoryManager) applicationAddrRange() hostarch.AddrRange {
 	return hostarch.AddrRange{mm.layout.MinAddr, mm.layout.MaxAddr}
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findLowestAvailableLocked(length, alignment uint64, bounds hostarch.AddrRange) (hostarch.Addr, error) {
 	for gap := mm.vmas.LowerBoundGap(bounds.Start); gap.Ok() && gap.Start() < bounds.End; gap = gap.NextLargeEnoughGap(hostarch.Addr(length)) {
 		if gr := gap.availableRange().Intersect(bounds); uint64(gr.Length()) >= length {
@@ -250,7 +250,7 @@ func (mm *MemoryManager) findLowestAvailableLocked(length, alignment uint64, bou
 	return 0, linuxerr.ENOMEM
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findHighestAvailableLocked(length, alignment uint64, bounds hostarch.AddrRange) (hostarch.Addr, error) {
 	for gap := mm.vmas.UpperBoundGap(bounds.End); gap.Ok() && gap.End() > bounds.Start; gap = gap.PrevLargeEnoughGap(hostarch.Addr(length)) {
 		if gr := gap.availableRange().Intersect(bounds); uint64(gr.Length()) >= length {
@@ -270,7 +270,7 @@ func (mm *MemoryManager) findHighestAvailableLocked(length, alignment uint64, bo
 	return 0, linuxerr.ENOMEM
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) mlockedBytesRangeLocked(ar hostarch.AddrRange) uint64 {
 	var total uint64
 	for vseg := mm.vmas.LowerBoundSegment(ar.Start); vseg.Ok() && vseg.Start() < ar.End; vseg = vseg.NextSegment() {
@@ -296,6 +296,8 @@ func (mm *MemoryManager) mlockedBytesRangeLocked(ar hostarch.AddrRange) uint64 {
 // Preconditions:
 //   - mm.mappingMu must be locked for reading; it may be temporarily unlocked.
 //   - ar.Length() != 0.
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) getVMAsLocked(ctx context.Context, ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool) (vmaIterator, vmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -352,6 +354,8 @@ func (mm *MemoryManager) getVMAsLocked(ctx context.Context, ar hostarch.AddrRang
 // temporarily unlocked.
 //
 // Postconditions: ars is not mutated.
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) getVecVMAsLocked(ctx context.Context, ars hostarch.AddrRangeSeq, at hostarch.AccessType, ignorePermissions bool) (hostarch.AddrRangeSeq, error) {
 	for arsit := ars; !arsit.IsEmpty(); arsit = arsit.Tail() {
 		ar := arsit.Head()
@@ -383,9 +387,10 @@ const guardBytes = 256 * hostarch.PageSize
 // the same slice.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.mappingMu
 func (mm *MemoryManager) unmapLocked(ctx context.Context, ar hostarch.AddrRange, droppedIDs []memmap.MappingIdentity) (vmaGapIterator, []memmap.MappingIdentity) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -409,15 +414,19 @@ func (mm *MemoryManager) unmapLocked(ctx context.Context, ar hostarch.AddrRange,
 // the same slice.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.mappingMu
 func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrRange, droppedIDs []memmap.MappingIdentity) (vmaGapIterator, []memmap.MappingIdentity) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
 			panic(fmt.Sprintf("invalid ar: %v", ar))
 		}
 	}
+	// RemoveRangeWith invokes this callback synchronously, so this method's
+	// entry ownership contract covers its updates. checklocks does not
+	// propagate that contract into a passed callback.
 	vgap := mm.vmas.RemoveRangeWith(ar, func(vseg vmaIterator) {
 		vmaAR := vseg.Range()
 		vma := vseg.ValuePtr()
@@ -427,12 +436,12 @@ func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrR
 		if vma.id != nil {
 			droppedIDs = append(droppedIDs, vma.id)
 		}
-		mm.usageAS -= uint64(vmaAR.Length())
+		mm.usageAS -= uint64(vmaAR.Length()) // +checklocksignore
 		if vma.isPrivateDataLocked() {
-			mm.dataAS -= uint64(vmaAR.Length())
+			mm.dataAS -= uint64(vmaAR.Length()) // +checklocksignore
 		}
 		if vma.mlockMode != memmap.MLockNone {
-			mm.lockedAS -= uint64(vmaAR.Length())
+			mm.lockedAS -= uint64(vmaAR.Length()) // +checklocksignore
 		}
 	})
 	return vgap, droppedIDs
@@ -446,14 +455,23 @@ func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrR
 //
 // canWriteMappableLocked is equivalent to Linux's VM_SHARED.
 //
-// Preconditions: mm.mappingMu must be locked.
+// Preconditions: the owning MemoryManager's mappingMu is held at least for
+// reading, or v is exclusively owned (a detached copy or construction-owned
+// VMA).
+//
+// The vma type describes the missing owner link for checklocks.
 func (v *vma) canWriteMappableLocked() bool {
 	return !v.private && v.maxPerms.Write
 }
 
-// isPrivateDataLocked identify the data segments - private, writable, not stack
+// isPrivateDataLocked reports whether v is a private, writable, non-stack
+// data segment.
 //
-// Preconditions: mm.mappingMu must be locked.
+// Preconditions: the owning MemoryManager's mappingMu is held at least for
+// reading, or v is exclusively owned (a detached copy or construction-owned
+// VMA).
+//
+// The vma type describes the missing owner link for checklocks.
 func (v *vma) isPrivateDataLocked() bool {
 	return v.realPerms.Write && v.private && !v.growsDown
 }
@@ -598,10 +616,11 @@ func (vseg vmaIterator) addrRangeOf(mr memmap.MappableRange) hostarch.AddrRange 
 }
 
 // seekNextLowerBound returns mm.vmas.LowerBoundSegment(addr), but does so by
-// scanning linearly forward from vseg.
+// scanning linearly forward from vseg. The generated iterator has no
+// MemoryManager reference, so checklocks cannot name the owning mutex.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked.
+//   - The owning MemoryManager's mappingMu is held at least for reading.
 //   - addr >= vseg.Start().
 func (vseg vmaIterator) seekNextLowerBound(addr hostarch.Addr) vmaIterator {
 	if checkInvariants {

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -710,20 +710,22 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 				nonCalls int
 			)
 			for _, ref := range *refs {
-				switch ref.(type) {
-				case *ssa.Call, *ssa.Defer:
-					// Analysis will be done on the call
-					// itself subsequently, including the
-					// lock state at the time of the call.
-					calls++
-				default:
-					// We need to analyze separately. Per
-					// below, this means that we'll analyze
-					// at closure construction time no zero
-					// assumptions about when it will be
-					// called.
-					nonCalls++
+				// Only direct calls are analyzed later with the lock
+				// state at invocation. Passing the closure as an argument
+				// gives no guarantee about when it will be called.
+				switch ref := ref.(type) {
+				case *ssa.Call:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
+				case *ssa.Defer:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
 				}
+				nonCalls++
 			}
 			if calls > 0 && nonCalls == 0 {
 				return nil, nil

--- a/tools/checklocks/test/closures.go
+++ b/tools/checklocks/test/closures.go
@@ -60,6 +60,14 @@ func testClosureIgnore(tc *oneGuardStruct) {
 		tc.guardedField = 1
 	}
 	x()
+
+	// Passing a closure as an argument is not an inline invocation.
+	callClosure(func() {
+		callPreconditions(tc)
+	})
+	defer callClosure(func() {
+		callPreconditions(tc)
+	})
 }
 
 func testAnonymousInvalid(tc *oneGuardStruct) {


### PR DESCRIPTION
Enforce activeMu for PMAs, resident-set accounting, pin state, and invalidation capture. Annotate the read/write lock contracts of mapping, I/O, fork, and procfs helpers, along with metadata and AIO state.

Require atomic access to reference counts, dumpability, membarrier state, and VMA fault hints. Keep private-copy and mapping lifetime rules explicit, and use locked reads in the existing accounting tests.

Document constructor-owned VMA state and restore-time AIO initialization that uniform mutex annotations cannot express. Preserve these lifecycles without adding synchronization or suppressions.

Assisted-by: Codex
