### PR TITLE
checklocks: guard netlink port allocation

### DIFF
--- a/pkg/sentry/socket/netlink/port/port.go
+++ b/pkg/sentry/socket/netlink/port/port.go
@@ -36,10 +36,11 @@ const maxPorts = 10000
 //
 // +stateify savable
 type Manager struct {
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// ports contains a map of allocated ports for each protocol.
+	//
+	// +checklocks:mu
 	ports map[int]map[int32]struct{}
 }
 


### PR DESCRIPTION
The port manager serializes allocation and release with mu, including access to each protocol map. Annotate the ports field so checklocks enforces the existing contract, replacing the protection comment.

Assisted-by: Codex
