### PR TITLE
checklocks: lock parent-death signal resets

### DIFF
--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -451,6 +451,7 @@ go_test(
     library = ":kernel",
     deps = [
         "//pkg/abi",
+        "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/errors/linuxerr",
         "//pkg/hostarch",
@@ -459,6 +460,7 @@ go_test(
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/kernel/sched",
         "//pkg/sentry/limits",
+        "//pkg/sentry/mm",
         "//pkg/sentry/pgalloc",
         "//pkg/sentry/time",
         "//pkg/sentry/usage",

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -494,7 +494,7 @@ type Task struct {
 
 	// parentDeathSignal is sent to this task's thread group when its parent exits.
 	//
-	// parentDeathSignal is protected by mu.
+	// +checklocks:mu
 	parentDeathSignal linux.Signal
 
 	// seccomp contains all seccomp-bpf syscall filters applicable to the task.

--- a/pkg/sentry/kernel/task_exec.go
+++ b/pkg/sentry/kernel/task_exec.go
@@ -359,7 +359,7 @@ func (r *runExecveAfterSiblingExitStop) execute(t *Task) taskRunState {
 
 	// Parent should not signal the now privileged task, undocumented Linux behavior.
 	if r.secureExec {
-		t.parentDeathSignal = 0
+		t.SetParentDeathSignal(0)
 	}
 
 	// Update dumpability using just the old creds, see fs/exec.c:begin_new_exec().
@@ -377,7 +377,7 @@ func (r *runExecveAfterSiblingExitStop) execute(t *Task) taskRunState {
 		r.newCreds.EffectiveKGID != oldCreds.EffectiveKGID ||
 		!r.newCreds.PermittedCaps.IsSubsetOf(oldCreds.PermittedCaps) {
 		r.image.MemoryManager.SetDumpability(mm.NotDumpable) // suid_dumpable is not implemented
-		t.parentDeathSignal = 0
+		t.SetParentDeathSignal(0)
 	}
 
 	// Switch to the new process.

--- a/pkg/sentry/kernel/task_identity.go
+++ b/pkg/sentry/kernel/task_identity.go
@@ -220,7 +220,7 @@ func (t *Task) setKUIDsUnchecked(newR, newE, newS auth.KUID) {
 		t.MemoryManager().SetDumpability(mm.NotDumpable)
 
 		// Not documented, but compare Linux's kernel/cred.c:commit_creds().
-		t.parentDeathSignal = 0
+		t.SetParentDeathSignal(0)
 	}
 	t.creds.Store(creds)
 }
@@ -334,7 +334,7 @@ func (t *Task) setKGIDsUnchecked(newR, newE, newS auth.KGID) {
 
 		// Not documented, but compare Linux's
 		// kernel/cred.c:commit_creds().
-		t.parentDeathSignal = 0
+		t.SetParentDeathSignal(0)
 	}
 	t.creds.Store(creds)
 }

--- a/pkg/sentry/kernel/task_test.go
+++ b/pkg/sentry/kernel/task_test.go
@@ -15,10 +15,55 @@
 package kernel
 
 import (
+	"sync"
 	"testing"
 
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/sched"
+	"gvisor.dev/gvisor/pkg/sentry/mm"
 )
+
+func TestParentDeathSignalClearedOnCredentialChange(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		change func(*Task)
+	}{
+		{
+			name: "uid",
+			change: func(task *Task) {
+				task.setKUIDsUnchecked(0, 1, 0)
+			},
+		},
+		{
+			name: "gid",
+			change: func(task *Task) {
+				task.setKGIDsUnchecked(0, 1, 0)
+			},
+		},
+	} {
+		_ = t.Run(test.name, func(t *testing.T) {
+			task := &Task{
+				image: TaskImage{MemoryManager: new(mm.MemoryManager)},
+			}
+			task.creds.Store(auth.NewRootCredentials(auth.NewRootUserNamespace()))
+			task.SetParentDeathSignal(linux.SIGUSR1)
+
+			var wg sync.WaitGroup
+			wg.Go(func() { test.change(task) })
+			// Read before Wait so the reset and read are not ordered by the
+			// wait group. Under -race, this checks that the reset takes Task.mu.
+			observed := task.ParentDeathSignal()
+			wg.Wait()
+			if observed != 0 && observed != linux.SIGUSR1 {
+				t.Errorf("concurrent ParentDeathSignal() = %d, want 0 or %d", observed, linux.SIGUSR1)
+			}
+			if got := task.ParentDeathSignal(); got != 0 {
+				t.Errorf("ParentDeathSignal() after credential change = %d, want 0", got)
+			}
+		})
+	}
+}
 
 func TestTaskCPU(t *testing.T) {
 	for _, test := range []struct {


### PR DESCRIPTION
Task.mu protects parentDeathSignal, but credential and exec paths reset it without that lock while an exiting parent can read it. Use the existing setter without changing the reset predicates or credential publication order.

Annotate the field and extend the task tests to cover a concurrent signal read during effective UID/GID changes under the race detector.

Assisted-by: Codex
