### PR TITLE
checklocks: guard PCID allocation state

### DIFF
--- a/pkg/ring0/pagetables/pcids.go
+++ b/pkg/ring0/pagetables/pcids.go
@@ -19,17 +19,17 @@ import (
 )
 
 // PCIDs is a simple PCID database.
-//
-// This is not protected by locks and is thus suitable for use only with a
-// single CPU at a time.
 type PCIDs struct {
-	// mu protects below.
 	mu sync.Mutex
 
 	// cache are the assigned page tables.
+	//
+	// +checklocks:mu
 	cache map[*PageTables]uint16
 
 	// avail are available PCIDs.
+	//
+	// +checklocks:mu
 	avail []uint16
 }
 


### PR DESCRIPTION
Enforce mutex protection of assigned and available PCIDs. Remove the stale claim that PCIDs is unlocked: dbbe9ec91541 added locking because Drop accesses databases belonging to other vCPUs.

Assisted-by: Codex
