### PR TITLE
checklocks: synchronize plugin readiness

### DIFF
--- a/pkg/sentry/socket/plugin/BUILD
+++ b/pkg/sentry/socket/plugin/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/atomicbitops",
         "//pkg/seccomp",
         "//pkg/sentry/inet",
         "//pkg/waiter",

--- a/pkg/sentry/socket/plugin/plugin.go
+++ b/pkg/sentry/socket/plugin/plugin.go
@@ -18,6 +18,7 @@
 package plugin
 
 import (
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
 	"gvisor.dev/gvisor/pkg/waiter"
 )
@@ -68,17 +69,23 @@ func GetPluginStack() PluginStack {
 	return pluginStack
 }
 
-// EventInfo is a struct that holds information necessary to a socket
-// notification mechanisms.
+// EventInfo holds a socket's notification queue and readiness cache.
+//
+// Mask and Waiting are protected by the owning notifier's mutex. EventInfo
+// does not retain that notifier, so checklocks cannot express these guards.
 type EventInfo struct {
-	// Queue is the socket corresponding event queue.
+	// Wq is the socket's event queue, initialized before registration.
+	// The pointer is immutable; the queue synchronizes its own entries.
 	Wq *waiter.Queue
 
 	// Mask represents events this socket registered.
 	Mask waiter.EventMask
 
-	// Ready represents events has been currently reported.
-	Ready waiter.EventMask
+	// Ready caches reported events. The notifier updates it concurrently with
+	// socket readiness checks, which consume cached IN/OUT events.
+	//
+	// +checkatomic
+	Ready atomicbitops.Uint64
 
 	// Waiting represents whether there is any waiting event.
 	Waiting bool

--- a/pkg/sentry/socket/plugin/stack/BUILD
+++ b/pkg/sentry/socket/plugin/stack/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/abi/linux",
         "//pkg/abi/linux/errno",
+        "//pkg/atomicbitops",
         "//pkg/binary",
         "//pkg/context",
         "//pkg/errors/linuxerr",
@@ -44,4 +45,12 @@ go_library(
         "//pkg/waiter",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_test(
+    name = "stack_test",
+    size = "small",
+    srcs = ["socket_test.go"],
+    library = ":stack",
+    deps = ["//pkg/waiter"],
 )

--- a/pkg/sentry/socket/plugin/stack/notifier.go
+++ b/pkg/sentry/socket/plugin/stack/notifier.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/sentry/socket/plugin"
 	"gvisor.dev/gvisor/pkg/sentry/socket/plugin/cgo"
 	"gvisor.dev/gvisor/pkg/waiter"
@@ -29,14 +30,16 @@ import (
 // Notifier holds all the state necessary to issue notifications when
 // IO events occur on the observed FDs in plugin stack.
 type Notifier struct {
-	// the epoll FD used to register for io notifications.
+	// epFD is the epoll FD used for event registration. It is initialized by
+	// waitAndNotify before signaling ioInit and is immutable afterward.
 	epFD int32
 
-	// mu protects eventMap.
 	mu sync.Mutex
 
 	// eventMap maps file descriptors to their notification queues
 	// and waiting status.
+	//
+	// +checklocks:mu
 	eventMap map[uint32]*plugin.EventInfo
 }
 
@@ -131,7 +134,7 @@ func (n *Notifier) waitAndNotify(ioInit chan int32) error {
 			}
 
 			ev := waiter.EventMask(events[i].Events)
-			eventInfo.Ready |= ev & (eventInfo.Mask | waiter.EventErr | waiter.EventHUp)
+			atomicbitops.OrUint64(&eventInfo.Ready, uint64(ev&(eventInfo.Mask|waiter.EventErr|waiter.EventHUp)))
 			// When an error occurred, invoke all events
 			if ev&(waiter.EventErr|waiter.EventHUp) != 0 {
 				ev |= waiter.EventIn | waiter.EventOut
@@ -142,6 +145,7 @@ func (n *Notifier) waitAndNotify(ioInit chan int32) error {
 	}
 }
 
+// +checklocks:n.mu
 func (n *Notifier) waitFD(fd uint32, eventInfo *plugin.EventInfo) {
 	mask := eventInfo.Wq.Events()
 
@@ -156,10 +160,10 @@ func (n *Notifier) waitFD(fd uint32, eventInfo *plugin.EventInfo) {
 		eventInfo.Waiting = true
 	case eventInfo.Waiting && mask == 0:
 		cgo.EpollCtl(n.epFD, syscall.EPOLL_CTL_DEL, fd, uint32(mask))
-		eventInfo.Ready = 0
+		eventInfo.Ready.Store(0)
 		eventInfo.Waiting = false
 	case eventInfo.Waiting && mask != 0:
 		cgo.EpollCtl(n.epFD, syscall.EPOLL_CTL_MOD, fd, uint32(mask))
-		eventInfo.Ready &= mask
+		atomicbitops.AndUint64(&eventInfo.Ready, uint64(mask))
 	}
 }

--- a/pkg/sentry/socket/plugin/stack/socket.go
+++ b/pkg/sentry/socket/plugin/stack/socket.go
@@ -263,24 +263,21 @@ func (s *socketOperations) EventUnregister(e *waiter.Entry) {
 
 // Readiness implements socket.Socket.Readiness.
 func (s *socketOperations) Readiness(mask waiter.EventMask) waiter.EventMask {
-	var events waiter.EventMask
-
-	evInfo := &s.eventInfo
-	iomask := mask & (waiter.EventIn | waiter.EventOut)
-
-	// Fast path condition:
-	// 1. The event needed has been reported by plugin stack io-thread; or
-	// 2. POLLIN or POLLOUT event has been reported by io-thread.
-	// Directly report current event without invoking cgo Readiness again.
-	if evInfo.Ready&iomask == iomask {
-		events = evInfo.Ready & mask
-		// Clear plugin stack eventInfo record after consuming IN/OUT event.
-		evInfo.Ready &= ^iomask
-	} else {
-		events = waiter.EventMask(cgo.Readiness(s.fd, uint64(mask)))
+	iomask := uint64(mask & (waiter.EventIn | waiter.EventOut))
+	// Notification callbacks can check readiness while holding the notifier
+	// mutex, so accessing the cache must not acquire that mutex.
+	for {
+		ready := s.eventInfo.Ready.Load()
+		// Use the cache only if all requested IN/OUT events are present.
+		if ready&iomask != iomask {
+			return waiter.EventMask(cgo.Readiness(s.fd, uint64(mask)))
+		}
+		// Consume only the requested I/O bits without overwriting concurrent
+		// updates. A failed CAS must recheck whether the cache still suffices.
+		if iomask == 0 || s.eventInfo.Ready.CompareAndSwap(ready, ready&^iomask) {
+			return waiter.EventMask(ready) & mask
+		}
 	}
-
-	return events
 }
 
 // Epollable implements socket.Socket.Epollable.

--- a/pkg/sentry/socket/plugin/stack/socket_test.go
+++ b/pkg/sentry/socket/plugin/stack/socket_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"sync"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+func TestConcurrentReadiness(t *testing.T) {
+	const common = waiter.EventErr | waiter.EventHUp | waiter.EventMask(1<<40)
+	const initial = waiter.EventIn | waiter.EventOut | common
+	var s socketOperations
+	s.eventInfo.Ready.Store(uint64(initial))
+
+	// Each caller consumes a different I/O bit, so neither needs to query C.
+	masks := [...]waiter.EventMask{waiter.EventIn | common, waiter.EventOut | common}
+	var got [len(masks)]waiter.EventMask
+	var wg sync.WaitGroup
+	for i, mask := range masks {
+		wg.Go(func() {
+			got[i] = s.Readiness(mask)
+		})
+	}
+	wg.Wait()
+	for i, mask := range masks {
+		if got[i] != mask {
+			t.Errorf("Readiness(%#x) = %#x, want %#x", mask, got[i], mask)
+		}
+	}
+	if got := s.Readiness(common); got != common {
+		t.Errorf("Readiness(%#x) = %#x, want %#x", common, got, common)
+	}
+}


### PR DESCRIPTION
Plugin readiness checks read and clear a cache that the notifier updates under its own mutex. Readers do not acquire that mutex, so consuming cached events races with notification updates and other readiness checks. The unsynchronized cache dates to 079c1a937be.

Make the cache atomic and consume requested IN/OUT bits with a snapshot CAS. Preserve unrelated events and the existing fallback when not all requested I/O events are cached. Avoid acquiring the notifier mutex in Readiness, since notification callbacks can re-enter it.

Add a concurrent-readiness regression using disjoint cached I/O bits, retaining error, hangup, and high bits without invoking the plugin C implementation. Annotate the atomic cache and notifier registration contracts, and document the external owner of the remaining event state.

Assisted-by: Codex
