### PR TITLE
checklocks: fix proc network sysctl ownership

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -256,30 +256,26 @@ func (*domainnameData) GetDynamicBytesPoller(ctx context.Context) *vfs.DynamicBy
 type tcpSackData struct {
 	kernfs.DynamicBytesFile
 
-	stack   inet.Stack `state:"wait"`
-	enabled *bool
+	stack inet.Stack `state:"wait"`
 }
 
 var _ vfs.WritableDynamicBytesSource = (*tcpSackData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
 func (d *tcpSackData) Generate(ctx context.Context, buf *bytes.Buffer) error {
-	if d.enabled == nil {
-		sack, err := d.stack.TCPSACKEnabled()
-		if err != nil {
-			return err
-		}
-		d.enabled = &sack
+	enabled, err := d.stack.TCPSACKEnabled()
+	if err != nil {
+		return err
 	}
 
 	val := "0\n"
-	if *d.enabled {
+	if enabled {
 		// Technically, this is not quite compatible with Linux. Linux stores these
 		// as an integer, so if you write "2" into tcp_sack, you should get 2 back.
 		// Tough luck.
 		val = "1\n"
 	}
-	_, err := buf.WriteString(val)
+	_, err = buf.WriteString(val)
 	return err
 }
 
@@ -294,11 +290,7 @@ func (d *tcpSackData) Write(ctx context.Context, _ *vfs.FileDescription, src use
 	if err != nil || n == 0 {
 		return 0, err
 	}
-	if d.enabled == nil {
-		d.enabled = new(bool)
-	}
-	*d.enabled = buf[0] != 0
-	return n, d.stack.SetTCPSACKEnabled(*d.enabled)
+	return n, d.stack.SetTCPSACKEnabled(buf[0] != 0)
 }
 
 // tcpRecoveryData implements vfs.WritableDynamicBytesSource for
@@ -430,7 +422,12 @@ func (d *tcpMemData) writeSizeLocked(size inet.TCPBufferSize) error {
 type ipForwarding struct {
 	kernfs.DynamicBytesFile
 
-	stack   inet.Stack `state:"wait"`
+	stack inet.Stack `state:"wait"`
+	mu    sync.Mutex `state:"nosave"`
+
+	// enabled is the last value written here, which may differ from the
+	// forwarding state of individual interfaces.
+	// +checklocks:mu
 	enabled bool
 }
 
@@ -438,8 +435,12 @@ var _ vfs.WritableDynamicBytesSource = (*ipForwarding)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
 func (ipf *ipForwarding) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	ipf.mu.Lock()
+	enabled := ipf.enabled
+	ipf.mu.Unlock()
+
 	val := "0\n"
-	if ipf.enabled {
+	if enabled {
 		// Technically, this is not quite compatible with Linux. Linux stores these
 		// as an integer, so if you write "2" into tcp_sack, you should get 2 back.
 		// Tough luck.
@@ -461,6 +462,8 @@ func (ipf *ipForwarding) Write(ctx context.Context, _ *vfs.FileDescription, src 
 	if err != nil || n == 0 {
 		return 0, err
 	}
+	ipf.mu.Lock()
+	defer ipf.mu.Unlock()
 	ipf.enabled = buf[0] != 0
 	if err := ipf.stack.SetForwarding(ipv4.ProtocolNumber, ipf.enabled); err != nil {
 		return 0, err
@@ -476,23 +479,14 @@ type portRange struct {
 	kernfs.DynamicBytesFile
 
 	stack inet.Stack `state:"wait"`
-
-	// start and end store the port range. We must save/restore this here,
-	// since a netstack instance is created on restore.
-	start *uint16
-	end   *uint16
 }
 
 var _ vfs.WritableDynamicBytesSource = (*portRange)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
 func (pr *portRange) Generate(ctx context.Context, buf *bytes.Buffer) error {
-	if pr.start == nil {
-		start, end := pr.stack.PortRange()
-		pr.start = &start
-		pr.end = &end
-	}
-	_, err := fmt.Fprintf(buf, "%d %d\n", *pr.start, *pr.end)
+	start, end := pr.stack.PortRange()
+	_, err := fmt.Fprintf(buf, "%d %d\n", start, end)
 	return err
 }
 
@@ -517,12 +511,6 @@ func (pr *portRange) Write(ctx context.Context, _ *vfs.FileDescription, src user
 	if err := pr.stack.SetPortRange(uint16(ports[0]), uint16(ports[1])); err != nil {
 		return 0, err
 	}
-	if pr.start == nil {
-		pr.start = new(uint16)
-		pr.end = new(uint16)
-	}
-	*pr.start = uint16(ports[0])
-	*pr.end = uint16(ports[1])
 	return n, nil
 }
 

--- a/pkg/sentry/fsimpl/proc/tasks_sys_test.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys_test.go
@@ -23,6 +23,7 @@ import (
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
 	"gvisor.dev/gvisor/pkg/usermem"
@@ -109,6 +110,53 @@ func TestNetStatDataRowsHaveMatchingFields(t *testing.T) {
 	}
 }
 
+type readOnlySACKTestStack struct {
+	*inet.TestStack
+}
+
+func (*readOnlySACKTestStack) SetTCPSACKEnabled(bool) error {
+	return linuxerr.EACCES
+}
+
+func TestTCPSACKReadback(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		writeErr error
+		want     string
+	}{
+		{name: "shared stack", want: "1\n"},
+		{name: "rejected write", writeErr: linuxerr.EACCES, want: "0\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := contexttest.Context(t)
+			s := inet.NewTestStack()
+			s.TCPSACKFlag = false
+			reader := &tcpSackData{stack: s}
+			writer := &tcpSackData{stack: s}
+			if tc.writeErr != nil {
+				writer = &tcpSackData{stack: &readOnlySACKTestStack{TestStack: s}}
+				reader = writer
+			}
+			var buf bytes.Buffer
+			if err := reader.Generate(ctx, &buf); err != nil {
+				t.Fatal(err)
+			}
+
+			const value = "1\n"
+			if n, err := writer.Write(ctx, nil, usermem.BytesIOSequence([]byte(value)), 0); n != int64(len(value)) || err != tc.writeErr {
+				t.Fatalf("Write() = (%d, %v), want (%d, %v)", n, err, len(value), tc.writeErr)
+			}
+			buf.Reset()
+			if err := reader.Generate(ctx, &buf); err != nil {
+				t.Fatal(err)
+			}
+			if got := buf.String(); got != tc.want {
+				t.Errorf("Generate() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 // TestIPForwarding tests the implementation of
 // /proc/sys/net/ipv4/ip_forwarding
 func TestConfigureIPForwarding(t *testing.T) {
@@ -175,6 +223,43 @@ func TestConfigureIPForwarding(t *testing.T) {
 				t.Errorf("s.IPForwarding incorrect; got: %v, want: %v", got, want)
 			}
 		})
+	}
+}
+
+type portRangeTestStack struct {
+	*inet.TestStack
+	start, end uint16
+}
+
+func (s *portRangeTestStack) PortRange() (uint16, uint16) {
+	return s.start, s.end
+}
+
+func (s *portRangeTestStack) SetPortRange(start, end uint16) error {
+	s.start, s.end = start, end
+	return nil
+}
+
+func TestPortRangeSharedStack(t *testing.T) {
+	ctx := contexttest.Context(t)
+	s := &portRangeTestStack{TestStack: inet.NewTestStack(), start: 32768, end: 60999}
+	reader := &portRange{stack: s}
+	writer := &portRange{stack: s}
+	var buf bytes.Buffer
+	if err := reader.Generate(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	const updated = "40000 50000\n"
+	if n, err := writer.Write(ctx, nil, usermem.BytesIOSequence([]byte(updated)), 0); n != int64(len(updated)) || err != nil {
+		t.Fatalf("Write() = (%d, %v), want (%d, nil)", n, err, len(updated))
+	}
+	buf.Reset()
+	if err := reader.Generate(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != updated {
+		t.Errorf("Generate() = %q, want %q", got, updated)
 	}
 }
 

--- a/pkg/tcpip/ports/ports.go
+++ b/pkg/tcpip/ports/ports.go
@@ -227,10 +227,13 @@ type PortManager struct {
 	// be reused.
 	allocatedPorts map[portDescriptor]addrToDevice
 
-	// ephemeralMu protects firstEphemeral and numEphemeral.
-	ephemeralMu    sync.RWMutex `state:"nosave"`
+	ephemeralMu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:ephemeralMu
 	firstEphemeral uint16
-	numEphemeral   uint16
+
+	// +checklocks:ephemeralMu
+	numEphemeral uint16
 }
 
 // NewPortManager creates new PortManager.
@@ -251,6 +254,9 @@ type PortTester func(port uint16) (good bool, err tcpip.Error)
 // possible ephemeral ports, allowing the caller to decide whether a given port
 // is suitable for its needs, and stopping when a port is found or an error
 // occurs.
+//
+// testPort is called synchronously without ephemeralMu held. Locks held by
+// the caller remain held during the callback.
 func (pm *PortManager) PickEphemeralPort(rng rand.RNG, testPort PortTester) (port uint16, err tcpip.Error) {
 	pm.ephemeralMu.RLock()
 	firstEphemeral := pm.firstEphemeral
@@ -289,6 +295,9 @@ func pickEphemeralPort(offset uint32, first, count uint16, testPort PortTester) 
 // An optional PortTester can be passed in which if provided will be used to
 // test if the picked port can be used. The function should return true if the
 // port is safe to use, false otherwise.
+//
+// testPort is called synchronously with pm.mu held and must not call methods
+// that acquire the same pm.mu.
 func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortTester) (reservedPort uint16, err tcpip.Error) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -313,7 +322,8 @@ func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortT
 		return res.Port, nil
 	}
 
-	// A port wasn't specified, so try to find one.
+	// A port wasn't specified, so try to find one. The callback retains pm.mu,
+	// which checklocks cannot currently track through PickEphemeralPort.
 	return pm.PickEphemeralPort(rng, func(p uint16) (bool, tcpip.Error) {
 		res.Port = p
 		if !pm.reserveSpecificPortLocked(res, false /* portSpecified */) {
@@ -336,6 +346,8 @@ func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortT
 
 // reserveSpecificPortLocked tries to reserve the given port on all given
 // protocols.
+//
+// Preconditions: pm.mu must be locked for writing.
 func (pm *PortManager) reserveSpecificPortLocked(res Reservation, portSpecified bool) bool {
 	// Make sure the port is available.
 	for _, network := range res.Networks {
@@ -435,6 +447,9 @@ func (pm *PortManager) ReleasePort(res Reservation) {
 	pm.releasePortLocked(res)
 }
 
+// releasePortLocked releases a reservation without dropping the caller's lock.
+//
+// Preconditions: pm.mu must be locked for writing.
 func (pm *PortManager) releasePortLocked(res Reservation) {
 	dst := res.dst()
 	for _, network := range res.Networks {


### PR DESCRIPTION
Proc file descriptions share sysctl sources, so per-FD locks do not protect cached state. Read the port range and TCP SACK setting from the synchronized stack instead of retaining unsynchronized duplicate caches. Rejected SACK writes no longer change the value read back. The old netstack replacement path was removed by f4da28bc0a623.

Enforce the mutex protecting PortManager's authoritative ephemeral range with checklocks. Keep the synchronous reservation callback's caller-held lock contract explicit where it cannot yet be annotated.

Forwarding intentionally retains the last-written value introduced by 600d14f83e1d. Give that source its own mutex and serialize the cache update with SetForwarding. Cover cross-source readback and rejected SACK writes.

Assisted-by: Codex
