### PR TITLE
checklocks: enforce proc state ownership

### DIFF
--- a/pkg/sentry/fsimpl/proc/task.go
+++ b/pkg/sentry/fsimpl/proc/task.go
@@ -48,6 +48,7 @@ type taskInode struct {
 
 	dentriesMu dentriesRWMutex `state:"nosave"`
 	// dentries is a list of dentries to be invalidated when the task is destroyed.
+	// +checklocks:dentriesMu
 	dentries map[*kernfs.Dentry]struct{}
 }
 

--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -544,8 +544,8 @@ type memFD struct {
 
 	inode *memInode
 	mm    *mm.MemoryManager
-	// mu guards the fields below.
-	mu     sync.Mutex `state:"nosave"`
+	mu    sync.Mutex `state:"nosave"`
+	// +checklocks:mu
 	offset int64
 }
 

--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -399,7 +399,7 @@ func (d *tcpMemData) Write(ctx context.Context, _ *vfs.FileDescription, src user
 	return n, nil
 }
 
-// Precondition: d.mu must be locked.
+// +checklocks:d.mu
 func (d *tcpMemData) readSizeLocked() (inet.TCPBufferSize, error) {
 	switch d.dir {
 	case tcpRMem:
@@ -411,7 +411,7 @@ func (d *tcpMemData) readSizeLocked() (inet.TCPBufferSize, error) {
 	}
 }
 
-// Precondition: d.mu must be locked.
+// +checklocks:d.mu
 func (d *tcpMemData) writeSizeLocked(size inet.TCPBufferSize) error {
 	switch d.dir {
 	case tcpRMem:


### PR DESCRIPTION
Enforce existing mutex ownership of proc TCP buffer helpers, memory-file offsets, and task dentries. Preserve explicit offsets for positional I/O and detach-before-invalidation during task destruction.

Assisted-by: Codex
