### PR TITLE
checklocks: guard shared process contexts

### DIFF
--- a/pkg/sentry/kernel/fs_context.go
+++ b/pkg/sentry/kernel/fs_context.go
@@ -29,7 +29,9 @@ import (
 type FSContext struct {
 	FSContextRefs
 
-	// mu protects below.
+	// mu protects root and cwd after publication. Clone, setns, and unshare
+	// adjust unpublished Fork results without mu. checklocks cannot track
+	// the exclusive ownership of these returned objects.
 	mu fsContextMutex `state:"nosave"`
 
 	// root is the filesystem root.
@@ -41,9 +43,13 @@ type FSContext struct {
 	// umask is the current file mode creation mask. When a thread using this
 	// context invokes a syscall that creates a file, bits set in umask are
 	// removed from the permissions that the file is created with.
+	//
+	// +checklocks:mu
 	umask uint
 
 	// preventSharing is true for the duration of an associated Task's execve
+	//
+	// +checklocks:mu
 	preventSharing bool
 }
 
@@ -245,12 +251,14 @@ func (f *FSContext) share() bool {
 
 // unshareFromTask removes the FSContext f from the given Task t and replaces it with newF.
 // It returns a bool indicating whether f needs to be destroyed.
-
+//
 // This func operates without compromising a concurrent checkAndPreventSharingOutsideTG(): t's
 // association with f is severed atomically by holding f.mu, allowing the concurrent func to
 // correctly ascribe extra ref counts to tasks outside of t's thread group.
 //
-// Preconditions: The caller must be on the task goroutine and must hold t.mu.
+// Preconditions: The caller must be on the task goroutine.
+//
+// +checklocks:t.mu
 func (f *FSContext) unshareFromTask(t *Task, newF *FSContext) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/sentry/kernel/uts_namespace.go
+++ b/pkg/sentry/kernel/uts_namespace.go
@@ -26,11 +26,15 @@ import (
 //
 // +stateify savable
 type UTSNamespace struct {
-	// mu protects all fields below.
-	mu                sync.Mutex `state:"nosave"`
-	hostName          string
-	hostNameChanged   bool
-	domainName        string
+	mu sync.Mutex `state:"nosave"`
+
+	// +checklocks:mu
+	hostName string
+	// +checklocks:mu
+	hostNameChanged bool
+	// +checklocks:mu
+	domainName string
+	// +checklocks:mu
 	domainNameChanged bool
 
 	// userns is the user namespace associated with the UTSNamespace.
@@ -40,6 +44,7 @@ type UTSNamespace struct {
 	// userns is immutable.
 	userns *auth.UserNamespace
 
+	// +checklocks:mu
 	inode *nsfs.Inode
 }
 


### PR DESCRIPTION
Enforce existing mutex ownership of filesystem-context flags and UTS namespace state, including the task lock required when reassociating a filesystem context.

Document root and cwd's unpublished initialization phase: the checker does not track exclusive ownership of returned Fork results. Preserve directory-reference release outside FSContext.mu and unlocked UTS notifications.

Assisted-by: Codex
