### PR TITLE
checklocks: lock queue-discipline test accounting

### DIFF
--- a/pkg/tcpip/link/qdisc/fifo/qdisc_test.go
+++ b/pkg/tcpip/link/qdisc/fifo/qdisc_test.go
@@ -33,7 +33,8 @@ var _ stack.LinkWriter = (*countWriter)(nil)
 
 // countWriter implements LinkWriter.
 type countWriter struct {
-	mu             sync.Mutex
+	mu sync.Mutex
+	// +checklocks:mu
 	packetsWritten int
 	packetsWanted  int
 	done           chan struct{}
@@ -109,7 +110,10 @@ func TestWriteMorePacketsThanBatchSize(t *testing.T) {
 		select {
 		case <-done:
 		case <-time.After(1 * time.Second):
-			t.Fatalf("expected %d packets, but got only %d", want, lower.packetsWritten)
+			lower.mu.Lock()
+			packetsWritten := lower.packetsWritten
+			lower.mu.Unlock()
+			t.Fatalf("expected %d packets, but got only %d", want, packetsWritten)
 		}
 		linkEp.Close()
 	}

--- a/pkg/tcpip/link/qdisc/tbf/tbf_test.go
+++ b/pkg/tcpip/link/qdisc/tbf/tbf_test.go
@@ -40,9 +40,12 @@ type fakeEndpoint struct {
 	gsoMaxSize      uint32
 	supportedGSO    stack.SupportedGSO
 
-	mu             sync.Mutex
-	batchSizes     []int
-	bytesWritten   int
+	mu sync.Mutex
+	// +checklocks:mu
+	batchSizes []int
+	// +checklocks:mu
+	bytesWritten int
+	// +checklocks:mu
 	packetsWritten int
 	packetsWanted  int // 0 disables the done signal
 	done           chan struct{}


### PR DESCRIPTION
Guard FIFO and token-bucket test accounting with each fixture's existing mutex. Snapshot the FIFO packet count under that mutex before reporting a timeout, since dispatcher writes may still be in progress.

Assisted-by: Codex
