### PR TITLE
checklocks: guard the buffered random reader

### DIFF
--- a/pkg/rand/rand_linux.go
+++ b/pkg/rand/rand_linux.go
@@ -47,7 +47,8 @@ func (r *reader) Read(p []byte) (int, error) {
 // bufferedReader implements a threadsafe buffered io.Reader.
 type bufferedReader struct {
 	mu sync.Mutex
-	r  *bufio.Reader
+	// +checklocks:mu
+	r *bufio.Reader
 }
 
 // Read implements io.Reader.Read.


### PR DESCRIPTION
The Linux random reader serializes access to its shared bufio.Reader with mu. Enforce that existing ownership with checklocks while retaining the minimum-read behavior.

Assisted-by: Codex
