### PR TITLE
checklocks: enforce pipe and notification locks

### DIFF
--- a/pkg/fdnotifier/fdnotifier.go
+++ b/pkg/fdnotifier/fdnotifier.go
@@ -30,7 +30,11 @@ import (
 )
 
 type fdInfo struct {
-	queue   *waiter.Queue
+	// queue is immutable after registration. Its entries have their own lock.
+	queue *waiter.Queue
+
+	// waiting is protected by the owning notifier's mu. fdInfo does not retain
+	// a pointer to that owner for a checklocks annotation.
 	waiting bool
 }
 
@@ -42,13 +46,15 @@ type notifier struct {
 	epFD int
 
 	// pauseMu synchronizes notifications with save/restore.
+	// It precedes mu in lock order.
 	pauseMu sync.Mutex
 
-	// mu protects fdMap.
 	mu sync.Mutex
 
 	// fdMap maps file descriptors to their notification queues and waiting
 	// status.
+	//
+	// +checklocks:mu
 	fdMap map[int32]*fdInfo
 }
 
@@ -69,7 +75,9 @@ func newNotifier() (*notifier, error) {
 	return w, nil
 }
 
-// waitFD waits on mask for fd. The fdMap mutex must be hold.
+// waitFD waits on mask for fd.
+//
+// +checklocks:n.mu
 func (n *notifier) waitFD(fd int32, fi *fdInfo, mask waiter.EventMask) error {
 	if !fi.waiting && mask == 0 {
 		return nil
@@ -184,11 +192,15 @@ func (n *notifier) waitAndNotify() error {
 }
 
 // pause suspends notifications until resume is called.
+//
+// +checklocksacquire:n.pauseMu
 func (n *notifier) pause() {
 	n.pauseMu.Lock()
 }
 
 // resume ends the effect of a previous call to pause.
+//
+// +checklocksrelease:n.pauseMu
 func (n *notifier) resume() {
 	n.pauseMu.Unlock()
 }
@@ -233,12 +245,16 @@ func HasFD(fd int32) bool {
 }
 
 // Pause suspends notifications until Resume is called.
+//
+// +checklocksacquire:shared.notifier.pauseMu
 func Pause() {
 	ensureSharedNotifier()
 	shared.notifier.pause()
 }
 
 // Resume ends the effect of a previous call to Pause.
+//
+// +checklocksrelease:shared.notifier.pauseMu
 func Resume() {
 	shared.notifier.resume()
 }

--- a/pkg/sentry/kernel/pipe/pipe.go
+++ b/pkg/sentry/kernel/pipe/pipe.go
@@ -117,18 +117,25 @@ type Pipe struct {
 	isNamed bool
 
 	// The number of active readers for this pipe.
+	//
+	// +checkatomic
 	readers atomicbitops.Int32
 
 	// The total number of readers for this pipe.
+	//
+	// +checkatomic
 	totalReaders atomicbitops.Int32
 
 	// The number of active writers for this pipe.
+	//
+	// +checkatomic
 	writers atomicbitops.Int32
 
 	// The total number of writers for this pipe.
+	//
+	// +checkatomic
 	totalWriters atomicbitops.Int32
 
-	// mu protects all pipe internal state below.
 	mu pipeMutex `state:"nosave"`
 
 	// buf holds the pipe's data. buf is a circular buffer; the first valid
@@ -137,7 +144,10 @@ type Pipe struct {
 	// avoids needing to heap-allocate a new safemem.Block slice when buf is
 	// resized. bufBlockSeq is a safemem.BlockSeq representing bufBlocks.
 	//
-	// These fields are protected by mu.
+	// These fields are protected by mu during normal use; afterLoad rebuilds
+	// the buffer views before publication. peekLocked and consumeLocked are
+	// also called through spliceOrTee's callback, whose held pipe lock is not
+	// visible to checklocks.
 	buf         []byte
 	bufBlocks   [2]safemem.Block `state:"nosave"`
 	bufBlockSeq safemem.BlockSeq `state:"nosave"`
@@ -147,7 +157,7 @@ type Pipe struct {
 	// max is the maximum size of the pipe in bytes. When this max has been
 	// reached, writers will get EWOULDBLOCK.
 	//
-	// This is protected by mu.
+	// +checklocks:mu
 	max int64
 
 	// hadWriter indicates if this pipe ever had a writer. Note that this
@@ -155,7 +165,7 @@ type Pipe struct {
 	// that there has been a writer at some point since the pipe was
 	// created.
 	//
-	// This is protected by mu.
+	// +checklocks:mu
 	hadWriter bool
 }
 
@@ -163,20 +173,15 @@ type Pipe struct {
 //
 // N.B. The size will be bounded.
 func NewPipe(isNamed bool, sizeBytes int64) *Pipe {
-	var p Pipe
-	initPipe(&p, isNamed, sizeBytes)
+	p := newPipe(isNamed, sizeBytes)
 	return &p
 }
 
-func initPipe(pipe *Pipe, isNamed bool, sizeBytes int64) {
-	if sizeBytes < MinimumPipeSize {
-		sizeBytes = MinimumPipeSize
+func newPipe(isNamed bool, sizeBytes int64) Pipe {
+	return Pipe{
+		isNamed: isNamed,
+		max:     min(max(sizeBytes, MinimumPipeSize), MaximumPipeSize),
 	}
-	if sizeBytes > MaximumPipeSize {
-		sizeBytes = MaximumPipeSize
-	}
-	pipe.isNamed = isNamed
-	pipe.max = sizeBytes
 }
 
 // peekLocked passes the first count bytes in the pipe, starting at offset off,
@@ -247,8 +252,7 @@ func (p *Pipe) consumeLocked(n int64) {
 // accordingly. Callers are still responsible for calling
 // p.queue.Notify(waiter.ReadableEvents) with p.mu unlocked.
 //
-// Preconditions:
-//   - p.mu must be locked.
+// +checklocks:p.mu
 func (p *Pipe) writeLocked(count int64, f func(safemem.BlockSeq) (uint64, error)) (int64, error) {
 	// Can't write to a pipe with no readers.
 	if !p.HasReaders() {
@@ -367,7 +371,7 @@ func (p *Pipe) HasWriters() bool {
 
 // rReadinessLocked calculates the read readiness.
 //
-// Precondition: mu must be held.
+// +checklocks:p.mu
 func (p *Pipe) rReadinessLocked() waiter.EventMask {
 	ready := waiter.EventMask(0)
 	if p.HasReaders() && p.size != 0 {
@@ -393,7 +397,7 @@ func (p *Pipe) rReadiness() waiter.EventMask {
 
 // wReadinessLocked calculates the write readiness.
 //
-// Precondition: mu must be held.
+// +checklocks:p.mu
 func (p *Pipe) wReadinessLocked() waiter.EventMask {
 	ready := waiter.EventMask(0)
 	if p.HasWriters() && p.size < p.max {
@@ -439,6 +443,7 @@ func (p *Pipe) queued() int64 {
 	return p.queuedLocked()
 }
 
+// +checklocks:p.mu
 func (p *Pipe) queuedLocked() int64 {
 	return p.size
 }

--- a/pkg/sentry/kernel/pipe/vfs.go
+++ b/pkg/sentry/kernel/pipe/vfs.go
@@ -42,9 +42,7 @@ type VFSPipe struct {
 
 // NewVFSPipe returns an initialized VFSPipe.
 func NewVFSPipe(isNamed bool, sizeBytes int64) *VFSPipe {
-	var vp VFSPipe
-	initPipe(&vp.pipe, isNamed, sizeBytes)
-	return &vp
+	return &VFSPipe{pipe: newPipe(isNamed, sizeBytes)}
 }
 
 // Pipe returns the underlying Pipe object.
@@ -144,7 +142,6 @@ func (vp *VFSPipe) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, s
 	return fd, nil
 }
 
-// Preconditions: vp.mu must be held.
 func (vp *VFSPipe) newFD(mnt *vfs.Mount, vfsd *vfs.Dentry, statusFlags uint32, locks *vfs.FileLocks, creds *auth.Credentials) (*vfs.FileDescription, error) {
 	fd := &VFSPipeFD{
 		pipe: &vp.pipe,
@@ -176,7 +173,9 @@ type VFSPipeFD struct {
 	pipe *Pipe
 
 	// lastAddr is the last hostarch.Addr at which a call to a
-	// VFSPipeFD.(usermem.IO) method ended. lastAddr is protected by pipe.mu.
+	// VFSPipeFD.(usermem.IO) method ended.
+	//
+	// +checklocks:pipe.mu
 	lastAddr hostarch.Addr
 }
 
@@ -341,10 +340,10 @@ func (fd *VFSPipeFD) SpliceFromNonPipe(ctx context.Context, in *vfs.FileDescript
 }
 
 // CopyIn implements usermem.IO.CopyIn. Note that it is the caller's
-// responsibility to call fd.pipe.Notify(waiter.WritableEvents) after the read
-// is completed.
+// responsibility to call fd.pipe.queue.Notify(waiter.WritableEvents) after
+// the read is completed.
 //
-// Preconditions: fd.pipe.mu must be locked.
+// +checklocks:fd.pipe.mu
 func (fd *VFSPipeFD) CopyIn(ctx context.Context, addr hostarch.Addr, dst []byte, opts usermem.IOOpts) (int, error) {
 	if addr != fd.lastAddr {
 		log.Traceback("Non-sequential VFSPipeFD.CopyIn: lastAddr=%#x addr=%#x", fd.lastAddr, addr)
@@ -361,7 +360,7 @@ func (fd *VFSPipeFD) CopyIn(ctx context.Context, addr hostarch.Addr, dst []byte,
 // responsibility to call fd.pipe.queue.Notify(waiter.ReadableEvents) after the
 // write is completed.
 //
-// Preconditions: fd.pipe.mu must be locked.
+// +checklocks:fd.pipe.mu
 func (fd *VFSPipeFD) CopyOut(ctx context.Context, addr hostarch.Addr, src []byte, opts usermem.IOOpts) (int, error) {
 	if addr != fd.lastAddr {
 		log.Traceback("Non-sequential VFSPipeFD.CopyOut: lastAddr=%#x addr=%#x", fd.lastAddr, addr)
@@ -376,7 +375,7 @@ func (fd *VFSPipeFD) CopyOut(ctx context.Context, addr hostarch.Addr, src []byte
 
 // ZeroOut implements usermem.IO.ZeroOut.
 //
-// Preconditions: fd.pipe.mu must be locked.
+// +checklocks:fd.pipe.mu
 func (fd *VFSPipeFD) ZeroOut(ctx context.Context, addr hostarch.Addr, toZero int64, opts usermem.IOOpts) (int64, error) {
 	if addr != fd.lastAddr {
 		log.Traceback("Non-sequential VFSPipeFD.ZeroOut: lastAddr=%#x addr=%#x", fd.lastAddr, addr)
@@ -393,7 +392,7 @@ func (fd *VFSPipeFD) ZeroOut(ctx context.Context, addr hostarch.Addr, toZero int
 // responsibility to call fd.pipe.consumeLocked() and
 // fd.pipe.queue.Notify(waiter.WritableEvents) after the read is completed.
 //
-// Preconditions: fd.pipe.mu must be locked.
+// +checklocks:fd.pipe.mu
 func (fd *VFSPipeFD) CopyInTo(ctx context.Context, ars hostarch.AddrRangeSeq, dst safemem.Writer, opts usermem.IOOpts) (int64, error) {
 	total := int64(0)
 	for !ars.IsEmpty() {
@@ -419,7 +418,7 @@ func (fd *VFSPipeFD) CopyInTo(ctx context.Context, ars hostarch.AddrRangeSeq, ds
 // responsibility to call fd.pipe.queue.Notify(waiter.ReadableEvents) after the
 // write is completed.
 //
-// Preconditions: fd.pipe.mu must be locked.
+// +checklocks:fd.pipe.mu
 func (fd *VFSPipeFD) CopyOutFrom(ctx context.Context, ars hostarch.AddrRangeSeq, src safemem.Reader, opts usermem.IOOpts) (int64, error) {
 	total := int64(0)
 	for !ars.IsEmpty() {

--- a/pkg/waiter/waiter.go
+++ b/pkg/waiter/waiter.go
@@ -142,7 +142,10 @@ type Entry struct {
 	// eventListener receives the notification.
 	eventListener EventListener
 
-	// mask should be immutable once queued.
+	// mask is initialized before registration. While queued, SetQueuedMask
+	// updates it under the owning queue's mu. Calls to Mask or NotifyEvent
+	// must not race with mask updates. The queue is not stored in Entry, so
+	// its lock cannot be named by a field annotation.
 	mask EventMask
 }
 
@@ -225,6 +228,7 @@ func (NoopListener) NotifyEvent(mask EventMask) {}
 //
 // +stateify savable
 type Queue struct {
+	// +checklocks:mu
 	list waiterList
 	mu   sync.RWMutex `state:"nosave"`
 }


### PR DESCRIPTION
Enforce existing ownership of pipe state, waiter membership, and host FD notification registrations. Describe the notifier pause/resume lock effects so callers can be checked across save and restore.

Check pipe IO preconditions, counters, capacity, and splice offsets. Construct pipes as fresh values so their capacity can be guarded without locking an unpublished pipe. Keep the callback, restore, and external-owner contracts explicit where field annotations cannot express them.

Assisted-by: Codex
