### PR TITLE
checklocks: guard shim service state

### DIFF
--- a/pkg/shim/v1/runsc/epoll.go
+++ b/pkg/shim/v1/runsc/epoll.go
@@ -46,7 +46,9 @@ type epoller struct {
 
 	fd        int
 	publisher events.Publisher
-	set       map[uintptr]*item
+
+	// +checklocks:mu
+	set map[uintptr]*item
 }
 
 type item struct {

--- a/pkg/shim/v1/runsc/oom_v2.go
+++ b/pkg/shim/v1/runsc/oom_v2.go
@@ -46,11 +46,16 @@ type watcherV2 struct {
 	itemCh    chan itemV2
 	publisher shim.Publisher
 
-	mu      sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	cgroups map[string]*cgroupsv2.Manager
+
 	// lastOOM tracks the last published OOM kill count per container.
 	// Shared between the async (EventChan) and sync (isOOM) paths to
 	// prevent duplicate TaskOOM events.
+	//
+	// +checklocks:mu
 	lastOOM map[string]uint64
 }
 

--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -117,12 +117,18 @@ type runscService struct {
 	oomPoller oomPoller
 
 	// containers maps container id to a container.
+	//
+	// +checklocks:mu
 	containers map[string]*Container
 
 	// root is the runsc root directory.
+	//
+	// +checklocks:mu
 	root string
 
 	// runtime is runsc runtime configured for sandbox.
+	//
+	// +checklocks:mu
 	runtime *runsccmd.Runsc
 
 	shutdown shutdown.Service
@@ -921,10 +927,13 @@ func (g *GvisorTaskServer) State(ctx context.Context, req *pb.StateRequest) (*pb
 
 // Version implements taskServer.GvisorTaskServiceExt.
 func (g *GvisorTaskServer) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
-	cmd := exec.Command("runsc", "-version")
-	if g.s.runtime.Command != "" {
-		cmd = exec.Command(g.s.runtime.Command, "-version")
+	g.s.mu.Lock()
+	command := g.s.runtime.Command
+	g.s.mu.Unlock()
+	if command == "" {
+		command = runsccmd.DefaultCommand
 	}
+	cmd := exec.Command(command, "-version")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get runsc version: %w, output: %s", err, string(out))

--- a/pkg/shim/v1/service.go
+++ b/pkg/shim/v1/service.go
@@ -118,14 +118,14 @@ type shimRedirector struct {
 	// main is the extension.TaskServiceExt that is used for all calls to the
 	// container's shim, except for the cases where `ext` is set.
 	//
-	// Protected by mu.
+	// +checklocks:mu
 	main extension.TaskServiceExt
 
 	// ext may intercept calls to the container's shim. During the call to create
 	// container, the extension may be created and the shim will start using it
 	// for all calls to the container's shim.
 	//
-	// Protected by mu.
+	// +checklocks:mu
 	ext extension.TaskServiceExt
 
 	// grouping indicates if shim grouping is enabled.
@@ -137,8 +137,7 @@ type shimRedirector struct {
 
 var _ extension.TaskServiceExt = (*shimRedirector)(nil)
 
-// Preconditions:
-//   - s.mu must be locked
+// +checklocks:s.mu
 func (s *shimRedirector) getLocked() extension.TaskServiceExt {
 	if s.ext == nil {
 		return s.main


### PR DESCRIPTION
Version reads the runtime while sandbox creation can replace it under the service mutex. Snapshot the command under that mutex, then run the subprocess after unlocking.

Annotate the runtime selection, container and OOM registries, and shim redirection state with their owning mutexes.

Assisted-by: Codex
