### PR TITLE
checklocks: fix signal-delivery error exit

### DIFF
--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -451,6 +451,7 @@ go_test(
     library = ":kernel",
     deps = [
         "//pkg/abi",
+        "//pkg/abi/linux",
         "//pkg/context",
         "//pkg/errors/linuxerr",
         "//pkg/hostarch",
@@ -459,7 +460,9 @@ go_test(
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/kernel/sched",
         "//pkg/sentry/limits",
+        "//pkg/sentry/mm",
         "//pkg/sentry/pgalloc",
+        "//pkg/sentry/platform",
         "//pkg/sentry/time",
         "//pkg/sentry/usage",
         "//pkg/sentry/vfs",

--- a/pkg/sentry/kernel/task_exit.go
+++ b/pkg/sentry/kernel/task_exit.go
@@ -152,15 +152,17 @@ func (t *Task) PrepareExit(ws linux.WaitStatus) {
 // ptrace.)
 //
 // Preconditions: The caller must be running on the task goroutine.
+//
+// +checklocksexclude:t.tg.signalHandlers.mu
 func (t *Task) PrepareGroupExit(ws linux.WaitStatus) {
 	t.tg.signalHandlers.mu.Lock()
 	defer t.tg.signalHandlers.mu.Unlock()
 	t.prepareGroupExitLocked(ws)
 }
 
-// Preconditions:
-//   - The caller must be running on the task goroutine.
-//   - The signal mutex must be locked.
+// Preconditions: The caller must be running on the task goroutine.
+//
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) prepareGroupExitLocked(ws linux.WaitStatus) {
 	if t.tg.exiting || t.tg.execing != nil {
 		// Note that if t.tg.exiting is false but t.tg.execing is not nil, i.e.

--- a/pkg/sentry/kernel/task_signals.go
+++ b/pkg/sentry/kernel/task_signals.go
@@ -1048,7 +1048,8 @@ func (*runInterrupt) execute(t *Task) taskRunState {
 	// Are there signals pending?
 	if info := t.dequeueSignalLocked(linux.SignalSet(t.signalMask.RacyLoad())); info != nil {
 		if err := t.p.PullFullState(t.MemoryManager().AddressSpace(), t.Arch()); err != nil {
-			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGILL))
+			t.prepareGroupExitLocked(linux.WaitStatusTerminationSignal(linux.SIGILL))
+			t.tg.signalHandlers.mu.Unlock()
 			return (*runExit)(nil)
 		}
 

--- a/pkg/sentry/kernel/task_test.go
+++ b/pkg/sentry/kernel/task_test.go
@@ -17,7 +17,14 @@ package kernel
 import (
 	"testing"
 
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/sched"
+	"gvisor.dev/gvisor/pkg/sentry/mm"
+	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
+	"gvisor.dev/gvisor/pkg/sentry/platform"
 )
 
 func TestTaskCPU(t *testing.T) {
@@ -72,4 +79,58 @@ func TestTaskCPU(t *testing.T) {
 		}
 	}
 
+}
+
+type pullFullStateErrorContext struct {
+	platform.Context
+}
+
+func (*pullFullStateErrorContext) PullFullState(platform.AddressSpace, *arch.Context64) error {
+	return linuxerr.EIO
+}
+
+func TestRunInterruptPullFullStateError(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mf := pgalloc.MemoryFileFromContext(ctx)
+	defer mf.Destroy()
+	memoryManager, err := mm.NewMemoryManager(platform.FromContext(ctx), mf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer memoryManager.DecUsers(ctx)
+
+	tg := &ThreadGroup{signalHandlers: NewSignalHandlers()}
+	task := &Task{
+		taskNode: taskNode{tg: tg},
+		image: TaskImage{
+			Arch:          new(arch.Context64),
+			MemoryManager: memoryManager,
+		},
+		p: &pullFullStateErrorContext{},
+	}
+	tg.tasks.PushBack(task)
+	tg.signalHandlers.mu.Lock()
+	queued := task.pendingSignals.enqueue(SignalInfoPriv(linux.SIGUSR1), nil)
+	tg.signalHandlers.mu.Unlock()
+	if !queued {
+		t.Fatal("failed to enqueue signal")
+	}
+
+	if next := (*runInterrupt)(nil).execute(task); next != (*runExit)(nil) {
+		t.Fatalf("runInterrupt returned %T, want *runExit", next)
+	}
+
+	// The error path must release the signal mutex before entering runExit.
+	tg.signalHandlers.mu.Lock()
+	defer tg.signalHandlers.mu.Unlock()
+	if !tg.exiting {
+		t.Error("thread group is not exiting")
+	}
+	wantStatus := linux.WaitStatusTerminationSignal(linux.SIGILL)
+	if got := tg.exitStatus; got != wantStatus {
+		t.Errorf("thread group exit status = %v, want %v", got, wantStatus)
+	}
+	if got := task.exitStatus; got != wantStatus {
+		t.Errorf("task exit status = %v, want %v", got, wantStatus)
+	}
 }


### PR DESCRIPTION
Since aeabb7852781, runInterrupt calls PrepareGroupExit while holding the signal mutex if PullFullState fails. The wrapper tries to acquire that mutex again, preventing the task from exiting.

Use the locked helper and release the mutex before returning runExit. Annotate both helper contracts so checklocks catches recursive entry.

Current built-in platform contexts return nil from PullFullState. Exercise the error handling with an injected failure, checking SIGILL group-exit state and mutex release.

Assisted-by: Codex
