### PR TITLE
checklocks: enforce signal helper contracts

### DIFF
--- a/pkg/sentry/kernel/signal_handlers.go
+++ b/pkg/sentry/kernel/signal_handlers.go
@@ -27,7 +27,9 @@ type SignalHandlers struct {
 	// ThreadGroup.signalHandlers.)
 	mu signalHandlersMutex `state:"nosave"`
 
-	// actions is the action to be taken upon receiving each signal.
+	// actions is the action to be taken upon receiving each signal. It is
+	// protected by mu after initialization; copy operations populate new,
+	// unpublished maps without locking their new SignalHandlers.
 	actions map[linux.Signal]linux.SigAction
 }
 
@@ -68,10 +70,10 @@ func (sh *SignalHandlers) Reset() *SignalHandlers {
 	return sh2
 }
 
-// copyForExecLocked returns a copy of sh for a thread group that is undergoing
-// an execve. (See comments in Task.finishExec.)
+// copyForExecLocked returns a copy of sh for a thread group undergoing execve.
+// Only ignored signals are retained, with all other action fields cleared.
 //
-// Preconditions: sh.mu must be locked.
+// +checklocks:sh.mu
 func (sh *SignalHandlers) copyForExecLocked() *SignalHandlers {
 	sh2 := NewSignalHandlers()
 	for sig, act := range sh.actions {
@@ -92,9 +94,10 @@ func (sh *SignalHandlers) IsIgnored(sig linux.Signal) bool {
 	return ok && sa.Handler == linux.SIG_IGN
 }
 
-// dequeueActionLocked returns the SignalAct that should be used to handle sig.
+// dequeueAction returns the action for sig, resetting it to the default for
+// subsequent signals if SA_RESETHAND is set.
 //
-// Preconditions: sh.mu must be locked.
+// +checklocks:sh.mu
 func (sh *SignalHandlers) dequeueAction(sig linux.Signal) linux.SigAction {
 	act := sh.actions[sig]
 	if act.Flags&linux.SA_RESETHAND != 0 {

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -156,11 +156,12 @@ type Task struct {
 	// goroutine.
 	signalMask atomicbitops.Uint64
 
-	// If the task goroutine is currently executing Task.sigtimedwait,
+	// If the task goroutine is currently executing Task.Sigtimedwait,
 	// realSignalMask is the previous value of signalMask, which has temporarily
-	// been replaced by Task.sigtimedwait. Otherwise, realSignalMask is 0.
+	// been replaced by Task.Sigtimedwait. Otherwise, realSignalMask is 0.
 	//
-	// realSignalMask is exclusive to the task goroutine.
+	// realSignalMask is protected by the signal mutex and is owned by the task
+	// goroutine.
 	realSignalMask linux.SignalSet
 
 	// If haveSavedSignalMask is true, savedSignalMask is the signal mask that

--- a/pkg/sentry/kernel/task_signals.go
+++ b/pkg/sentry/kernel/task_signals.go
@@ -125,7 +125,7 @@ var StopSignals = linux.MakeSignalSet(linux.SIGSTOP, linux.SIGTSTP, linux.SIGTTI
 // dequeueSignalLocked returns a pending signal that is *not* included in mask.
 // If there are no pending unmasked signals, dequeueSignalLocked returns nil.
 //
-// Preconditions: t.tg.signalHandlers.mu must be locked.
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) dequeueSignalLocked(mask linux.SignalSet) *linux.SignalInfo {
 	if info := t.pendingSignals.dequeue(mask); info != nil {
 		return info
@@ -395,12 +395,12 @@ func (tg *ThreadGroup) SendSignal(info *linux.SignalInfo) error {
 	return tg.leader.sendSignalLocked(info, true /* group */)
 }
 
-// Preconditions: The signal mutex must be locked.
+// Preconditions: t.tg.signalHandlers.mu must be held.
 func (t *Task) sendSignalLocked(info *linux.SignalInfo, group bool) error {
 	return t.sendSignalTimerLocked(info, group, nil)
 }
 
-// Preconditions: The signal mutex must be locked.
+// Preconditions: t.tg.signalHandlers.mu must be held.
 func (t *Task) sendSignalTimerLocked(info *linux.SignalInfo, group bool, timer *IntervalTimer) error {
 	if t.ExitState() == TaskExitDead {
 		return linuxerr.ESRCH
@@ -567,7 +567,7 @@ func (t *Task) forceSignal(sig linux.Signal, unconditional bool) {
 	t.forceSignalLocked(sig, unconditional)
 }
 
-// Preconditions: The signal mutex must be locked.
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) forceSignalLocked(sig linux.Signal, unconditional bool) {
 	blocked := linux.SignalSetOf(sig)&linux.SignalSet(t.signalMask.RacyLoad()) != 0
 	act := t.tg.signalHandlers.actions[sig]
@@ -599,7 +599,7 @@ func (t *Task) SetSignalMask(mask linux.SignalSet) {
 	t.tg.signalHandlers.mu.Unlock()
 }
 
-// Preconditions: The signal mutex must be locked.
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) setSignalMaskLocked(mask linux.SignalSet) {
 	oldMask := linux.SignalSet(t.signalMask.RacyLoad())
 	t.signalMask.Store(uint64(mask))
@@ -865,7 +865,7 @@ func (tg *ThreadGroup) endGroupStopLocked(broadcast bool) {
 // the caller must notify t.tg.leader's parent of a completed group stop (which
 // participateGroupStopLocked cannot do due to holding the wrong locks).
 //
-// Preconditions: The signal mutex must be locked.
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) participateGroupStopLocked() bool {
 	if t.groupStopAcknowledged {
 		return false

--- a/pkg/sentry/kernel/task_stop.go
+++ b/pkg/sentry/kernel/task_stop.go
@@ -107,8 +107,9 @@ func (t *Task) beginInternalStop(s TaskStop) {
 	t.beginInternalStopLocked(s)
 }
 
-// Preconditions: Same as beginInternalStop, plus:
-//   - The signal mutex must be locked.
+// Preconditions: Same as beginInternalStop.
+//
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) beginInternalStopLocked(s TaskStop) {
 	if t.stop != nil {
 		panic(fmt.Sprintf("Attempting to enter internal stop %#v when already in internal stop %#v", s, t.stop))


### PR DESCRIPTION
Require the existing signal-handler mutex in seven task and handler helpers. Preserve task-goroutine, stop-state and signal-mask conditions.

Document private initialization of copied action maps and the signal mutex protecting realSignalMask from remote signal readers. Retain the dynamic handler-locking and pending-signal ownership protocols without changing locks, callbacks, or lock-free reads.

Assisted-by: Codex
