### PR TITLE
checklocks: guard the stack random source

### DIFF
--- a/pkg/tcpip/stack/rand.go
+++ b/pkg/tcpip/stack/rand.go
@@ -22,7 +22,9 @@ import (
 
 // lockedRandomSource provides a threadsafe rand.Source.
 type lockedRandomSource struct {
-	mu  sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	src rand.Source
 }
 


### PR DESCRIPTION
Require lockedRandomSource.mu when accessing the underlying random source, making its existing concurrency contract statically checked.

Assisted-by: Codex
