### PR TITLE
checklocks: guard the syslog buffer

### DIFF
--- a/pkg/sentry/kernel/syslog.go
+++ b/pkg/sentry/kernel/syslog.go
@@ -27,10 +27,11 @@ import (
 //
 // +stateify savable
 type syslog struct {
-	// mu protects the below.
 	mu sync.Mutex `state:"nosave"`
 
 	// msg is the syslog message buffer. It is lazily initialized.
+	//
+	// +checklocks:mu
 	msg []byte
 }
 


### PR DESCRIPTION
Enforce mutex protection for lazy initialization and reads of the kernel log buffer. Log continues returning a copy of the stored bytes.

Assisted-by: Codex
