### PR TITLE
checklocks: enforce SysV IPC lock ownership

### DIFF
--- a/pkg/sentry/kernel/ipc/object.go
+++ b/pkg/sentry/kernel/ipc/object.go
@@ -34,16 +34,20 @@ type ID int32
 // Object represents an abstract IPC object with fields common to all IPC
 // mechanisms.
 //
+// After initialization, mutable fields are protected by the containing
+// mechanism's mutex.
+//
 // +stateify savable
 type Object struct {
 	// User namespace which owns the IPC namespace which owns the IPC object.
 	// Immutable.
 	UserNS *auth.UserNamespace
 
-	// ID is a kernel identifier for the IPC object. Immutable.
+	// ID is a kernel identifier assigned during registration, then immutable.
 	ID ID
 
-	// Key is a user-provided identifier for the IPC object. Immutable.
+	// Key is a user-provided identifier for the IPC object. For shared-memory
+	// segments, IPC_RMID changes it to IPC_PRIVATE.
 	Key Key
 
 	// CreatorUID is the UID of user who created the IPC object. Immutable.
@@ -52,13 +56,13 @@ type Object struct {
 	// CreatorGID is the GID of user who created the IPC object. Immutable.
 	CreatorGID auth.KGID
 
-	// OwnerUID is the UID of the current owner of the IPC object. Immutable.
+	// OwnerUID is the UID of the current owner of the IPC object.
 	OwnerUID auth.KUID
 
-	// OwnerGID is the GID of the current owner of the IPC object. Immutable.
+	// OwnerGID is the GID of the current owner of the IPC object.
 	OwnerGID auth.KGID
 
-	// Mode is the access permissions the IPC object.
+	// Mode is the access permissions of the IPC object.
 	Mode linux.FileMode
 }
 
@@ -72,11 +76,13 @@ type Mechanism interface {
 	// Unlock behaves the same as Mutex.Unlock on the mechanism.
 	Unlock()
 
-	// Object returns a pointer to the mechanism's ipc.Object. Mechanism.Lock,
-	// and Mechanism.Unlock should be used when the object is used.
+	// Object returns a pointer to the mechanism's ipc.Object. After
+	// initialization, access to its mutable fields requires the mechanism's lock.
 	Object() *Object
 
 	// Destroy destroys the mechanism.
+	//
+	// Preconditions: The mechanism's mutex must be held.
 	Destroy()
 }
 
@@ -97,6 +103,8 @@ func NewObject(un *auth.UserNamespace, key Key, creator, owner *auth.Credentials
 
 // CheckOwnership verifies whether an IPC object may be accessed using creds as
 // an owner. See ipc/util.c:ipcctl_obtain_check() in Linux.
+//
+// Preconditions: The containing mechanism's mutex must be held.
 func (o *Object) CheckOwnership(creds *auth.Credentials) bool {
 	if o.OwnerUID == creds.EffectiveKUID || o.CreatorUID == creds.EffectiveKUID {
 		return true
@@ -110,6 +118,8 @@ func (o *Object) CheckOwnership(creds *auth.Credentials) bool {
 
 // CheckPermissions verifies whether an IPC object is accessible using creds for
 // access described by req. See ipc/util.c:ipcperms() in Linux.
+//
+// Preconditions: The containing mechanism's mutex must be held.
 func (o *Object) CheckPermissions(creds *auth.Credentials, req vfs.AccessTypes) bool {
 	perms := uint16(o.Mode.Permissions())
 	if o.OwnerUID == creds.EffectiveKUID {
@@ -126,7 +136,7 @@ func (o *Object) CheckPermissions(creds *auth.Credentials, req vfs.AccessTypes) 
 
 // Set modifies attributes for an IPC object. See *ctl(IPC_SET).
 //
-// Precondition: Mechanism.mu must be held.
+// Preconditions: The containing mechanism's mutex must be held.
 func (o *Object) Set(ctx context.Context, perm *linux.IPCPerm) error {
 	creds := auth.CredentialsFromContext(ctx)
 	uid := creds.UserNamespace.MapToKUID(auth.UID(perm.UID))

--- a/pkg/sentry/kernel/msgqueue/msgqueue.go
+++ b/pkg/sentry/kernel/msgqueue/msgqueue.go
@@ -49,6 +49,8 @@ type Registry struct {
 	mu sync.Mutex `state:"nosave"`
 
 	// reg defines basic fields and operations needed for all SysV registries.
+	//
+	// +checklocks:mu
 	reg *ipc.Registry
 }
 
@@ -66,56 +68,82 @@ type Queue struct {
 	// registry is the registry owning this queue. Immutable.
 	registry *Registry
 
-	// mu protects all the fields below.
+	// mu protects queue state and the mutable fields of obj.
 	mu sync.Mutex `state:"nosave"`
 
 	// dead is set to true when a queue is removed from the registry and should
 	// not be used. Operations on the queue should check dead, and return
 	// EIDRM if set to true.
+	//
+	// +checklocks:mu
 	dead bool
 
 	// obj defines basic fields that should be included in all SysV IPC objects.
+	// The pointer is immutable; mutable fields of the object require mu.
 	obj *ipc.Object
 
 	// senders holds a queue of blocked message senders. Senders are notified
 	// when enough space is available in the queue to insert their message.
+	// It is internally synchronized.
 	senders waiter.Queue
 
 	// receivers holds a queue of blocked receivers. Receivers are notified
 	// when a new message is inserted into the queue and can be received.
+	// It is internally synchronized.
 	receivers waiter.Queue
 
 	// messages is a list of sent messages.
+	//
+	// +checklocks:mu
 	messages msgList
 
 	// sendTime is the last time a msgsnd was performed.
+	//
+	// +checklocks:mu
 	sendTime ktime.Time
 
 	// receiveTime is the last time a msgrcv was performed.
+	//
+	// +checklocks:mu
 	receiveTime ktime.Time
 
 	// changeTime is the last time the queue was modified using msgctl.
+	//
+	// +checklocks:mu
 	changeTime ktime.Time
 
 	// byteCount is the current number of message bytes in the queue.
+	//
+	// +checklocks:mu
 	byteCount uint64
 
 	// messageCount is the current number of messages in the queue.
+	//
+	// +checklocks:mu
 	messageCount uint64
 
 	// maxBytes is the maximum allowed number of bytes in the queue, and is also
 	// used as a limit for the number of total possible messages.
+	//
+	// +checklocks:mu
 	maxBytes uint64
 
 	// sendPID is the PID of the process that performed the last msgsnd.
+	//
+	// +checklocks:mu
 	sendPID int32
 
 	// receivePID is the PID of the process that performed the last msgrcv.
+	//
+	// +checklocks:mu
 	receivePID int32
 }
 
 // Message represents a message exchanged through a Queue via msgsnd(2) and
 // msgrcv(2).
+//
+// The containing Queue.mu protects the list links while queued. Type and Text
+// must remain unchanged while queued, including when returned by MSG_COPY.
 //
 // +stateify savable
 type Message struct {
@@ -165,7 +193,7 @@ func (r *Registry) FindOrCreate(ctx context.Context, key ipc.Key, mode linux.Fil
 // newQueueLocked creates a new queue using the given fields. An error is
 // returned if there're no more available identifiers.
 //
-// Precondition: r.mu must be held.
+// +checklocks:r.mu
 func (r *Registry) newQueueLocked(ctx context.Context, key ipc.Key, creds *auth.Credentials, mode linux.FileMode) (*Queue, error) {
 	q := &Queue{
 		registry:    r,
@@ -452,7 +480,7 @@ func (q *Queue) pop(ctx context.Context, creds *auth.Credentials, mType int64, m
 // message is found. If except is true, the first message of a type not equal
 // to mType will be returned.
 //
-// Precondition: caller must hold q.mu.
+// +checklocks:q.mu
 func (q *Queue) msgOfType(mType int64, except bool) *Message {
 	if except {
 		for msg := q.messages.Front(); msg != nil; msg = msg.Next() {
@@ -474,7 +502,7 @@ func (q *Queue) msgOfType(mType int64, except bool) *Message {
 // msgOfTypeLessThan return the first message with the lowest type less
 // than or equal to mType, nil if no such message exists.
 //
-// Precondition: caller must hold q.mu.
+// +checklocks:q.mu
 func (q *Queue) msgOfTypeLessThan(mType int64) (m *Message) {
 	min := mType
 	for msg := q.messages.Front(); msg != nil; msg = msg.Next() {
@@ -488,7 +516,7 @@ func (q *Queue) msgOfTypeLessThan(mType int64) (m *Message) {
 
 // msgAtIndex returns a pointer to a message at given index, nil if non exits.
 //
-// Precondition: caller must hold q.mu.
+// +checklocks:q.mu
 func (q *Queue) msgAtIndex(mType int64) *Message {
 	msg := q.messages.Front()
 	for ; mType != 0 && msg != nil; mType-- {
@@ -565,13 +593,15 @@ func (q *Queue) stat(ctx context.Context, ats vfs.AccessTypes) (*linux.MsqidDS, 
 }
 
 // Lock implements ipc.Mechanism.Lock.
+//
+// +checklocksacquire:q.mu
 func (q *Queue) Lock() {
 	q.mu.Lock()
 }
 
-// Unlock implements ipc.mechanism.Unlock.
+// Unlock implements ipc.Mechanism.Unlock.
 //
-// +checklocksignore
+// +checklocksrelease:q.mu
 func (q *Queue) Unlock() {
 	q.mu.Unlock()
 }
@@ -582,6 +612,8 @@ func (q *Queue) Object() *ipc.Object {
 }
 
 // Destroy implements ipc.Mechanism.Destroy.
+//
+// +checklocks:q.mu
 func (q *Queue) Destroy() {
 	q.dead = true
 

--- a/pkg/sentry/kernel/semaphore/semaphore.go
+++ b/pkg/sentry/kernel/semaphore/semaphore.go
@@ -50,10 +50,14 @@ type Registry struct {
 	mu sync.Mutex `state:"nosave"`
 
 	// reg defines basic fields and operations needed for all SysV registries.
+	//
+	// +checklocks:mu
 	reg *ipc.Registry
 
 	// indexes maintains a mapping between a set's index in virtual array and
 	// its identifier.
+	//
+	// +checklocks:mu
 	indexes map[int32]ipc.ID
 }
 
@@ -64,12 +68,17 @@ type Set struct {
 	// registry owning this sem set. Immutable.
 	registry *Registry
 
-	// mu protects all fields below.
+	// mu protects mutable state below, including the mutable fields of obj.
 	mu sync.Mutex `state:"nosave"`
 
+	// obj points to common IPC metadata. The pointer is immutable; mutable
+	// fields of the object require mu.
 	obj *ipc.Object
 
-	opTime     ktime.Time
+	// +checklocks:mu
+	opTime ktime.Time
+
+	// +checklocks:mu
 	changeTime ktime.Time
 
 	// sems holds all semaphores in the set. The slice itself is immutable after
@@ -78,10 +87,14 @@ type Set struct {
 
 	// dead is set to true when the set is removed and can't be reached anymore.
 	// All waiters must wake up and fail when set is dead.
+	//
+	// +checklocks:mu
 	dead bool
 }
 
 // sem represents a single semaphore from a set.
+//
+// Its fields are protected by the owning Set.mu.
 //
 // +stateify savable
 type sem struct {
@@ -95,12 +108,15 @@ type sem struct {
 //
 // +stateify savable
 type waiter struct {
+	// waiterEntry is protected by the owning Set.mu while queued.
 	waiterEntry
 
 	// value represents how much resource the waiter needs to wake up.
-	// The value is either 0 or negative.
+	// The value is either 0 or negative. Immutable.
 	value int16
-	ch    chan struct{}
+
+	// ch is notified when the waiter can retry. The channel handle is immutable.
+	ch chan struct{}
 }
 
 // NewRegistry creates a new semaphore set registry.
@@ -227,7 +243,7 @@ func (r *Registry) Remove(id ipc.ID, creds *auth.Credentials) error {
 // newSetLocked creates a new Set using given fields. An error is returned if there
 // are no more available identifiers.
 //
-// Precondition: r.mu must be held.
+// +checklocks:r.mu
 func (r *Registry) newSetLocked(ctx context.Context, key ipc.Key, creator *auth.Credentials, mode linux.FileMode, nsems int32) (*Set, error) {
 	set := &Set{
 		registry:   r,
@@ -274,6 +290,7 @@ func (r *Registry) FindByIndex(index int32) *Set {
 	return r.reg.FindByID(id).(*Set)
 }
 
+// +checklocks:r.mu
 func (r *Registry) findIndexByID(id ipc.ID) (int32, bool) {
 	for k, v := range r.indexes {
 		if v == id {
@@ -283,6 +300,7 @@ func (r *Registry) findIndexByID(id ipc.ID) (int32, bool) {
 	return 0, false
 }
 
+// +checklocks:r.mu
 func (r *Registry) findFirstAvailableIndex() (int32, bool) {
 	for index := int32(0); index < setsMax; index++ {
 		if _, present := r.indexes[index]; !present {
@@ -292,6 +310,7 @@ func (r *Registry) findFirstAvailableIndex() (int32, bool) {
 	return 0, false
 }
 
+// +checklocks:r.mu
 func (r *Registry) totalSems() int {
 	totalSems := 0
 	r.reg.ForAllObjects(
@@ -313,17 +332,21 @@ func (s *Set) Object() *ipc.Object {
 }
 
 // Lock implements ipc.Mechanism.Lock.
+//
+// +checklocksacquire:s.mu
 func (s *Set) Lock() {
 	s.mu.Lock()
 }
 
-// Unlock implements ipc.mechanism.Unlock.
+// Unlock implements ipc.Mechanism.Unlock.
 //
-// +checklocksignore
+// +checklocksrelease:s.mu
 func (s *Set) Unlock() {
 	s.mu.Unlock()
 }
 
+// findSem returns the semaphore at num, or nil if num is out of range.
+// Access to the returned semaphore's fields requires s.mu.
 func (s *Set) findSem(num int32) *sem {
 	if num < 0 || int(num) >= s.Size() {
 		return nil
@@ -573,6 +596,7 @@ func (s *Set) ExecuteOps(ctx context.Context, ops []linux.Sembuf, creds *auth.Cr
 	return ch, num, nil
 }
 
+// +checklocks:s.mu
 func (s *Set) executeOps(ctx context.Context, ops []linux.Sembuf, pid int32) (chan struct{}, int32, error) {
 	// Changes to semaphores go to this slice temporarily until they all succeed.
 	tmpVals := make([]int16, len(s.sems))
@@ -650,7 +674,7 @@ func (s *Set) AbortWait(num int32, ch chan struct{}) {
 
 // Destroy implements ipc.Mechanism.Destroy.
 //
-// Preconditions: Caller must hold 's.mu'.
+// +checklocks:s.mu
 func (s *Set) Destroy() {
 	// Notify all waiters. They will fail on the next attempt to execute
 	// operations and return error.
@@ -671,6 +695,8 @@ func abs(val int16) int16 {
 }
 
 // wakeWaiters goes over all waiters and checks which of them can be notified.
+//
+// Preconditions: The owning Set.mu must be held.
 func (s *sem) wakeWaiters() {
 	// Note that this will release all waiters waiting for 0 too.
 	for w := s.waiters.Front(); w != nil; {

--- a/pkg/sentry/kernel/semaphore/semaphore_test.go
+++ b/pkg/sentry/kernel/semaphore/semaphore_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func executeOps(ctx context.Context, t *testing.T, set *Set, ops []linux.Sembuf, block bool) chan struct{} {
+	set.mu.Lock()
 	ch, _, err := set.executeOps(ctx, ops, 123)
+	set.mu.Unlock()
 	if err != nil {
 		t.Fatalf("ExecuteOps(ops) failed, err: %v, ops: %+v", err, ops)
 	}
@@ -124,6 +126,8 @@ func TestNoWait(t *testing.T) {
 
 	ops[0].SemOp = -2
 	ops[0].SemFlg = linux.IPC_NOWAIT
+	set.mu.Lock()
+	defer set.mu.Unlock()
 	if _, _, err := set.executeOps(ctx, ops, 123); err != linuxerr.ErrWouldBlock {
 		t.Fatalf("ExecuteOps(ops) wrong result, got: %v, expected: %v", err, linuxerr.ErrWouldBlock)
 	}
@@ -160,7 +164,10 @@ func TestUnregister(t *testing.T) {
 	if err := r.Remove(set.obj.ID, creds); err != nil {
 		t.Fatalf("Remove(%d) failed, err: %v", set.obj.ID, err)
 	}
-	if !set.dead {
+	set.mu.Lock()
+	dead := set.dead
+	set.mu.Unlock()
+	if !dead {
 		t.Fatalf("set is not dead: %+v", set)
 	}
 	if got := r.FindByID(set.obj.ID); got != nil {

--- a/pkg/sentry/kernel/shm/shm.go
+++ b/pkg/sentry/kernel/shm/shm.go
@@ -66,24 +66,27 @@ type Registry struct {
 
 	// reg defines basic fields and operations needed for all SysV registries.
 	//
-	// Within reg, there are two maps, Objects and KeysToIDs.
+	// Within reg, there are two maps, objects and keysToIDs.
 	//
 	// reg.objects holds all referenced segments, which are removed on the last
 	// DecRef. Thus, it cannot itself hold a reference on the Shm.
 	//
 	// Since removal only occurs after the last (unlocked) DecRef, there
-	// exists a short window during which a Shm still exists in Shm, but is
-	// unreferenced. Users must use TryIncRef to determine if the Shm is
-	// still valid.
+	// exists a short window during which a Shm is still in reg.objects but is
+	// unreferenced. Users must use TryIncRef to determine if the Shm is valid.
 	//
 	// keysToIDs maps segment keys to IDs.
 	//
 	// Shms in keysToIDs are guaranteed to be referenced, as they are
-	// removed by disassociateKey before the last DecRef.
+	// removed by dissociateKey before the last DecRef.
+	//
+	// +checklocks:mu
 	reg *ipc.Registry
 
 	// Sum of the sizes of all existing segments rounded up to page size, in
 	// units of page size.
+	//
+	// +checklocks:mu
 	totalPages uint64
 }
 
@@ -116,10 +119,9 @@ func (r *Registry) FindByID(id ipc.ID) *Shm {
 }
 
 // dissociateKey removes the association between a segment and its key,
-// preventing it from being discovered in the registry. This doesn't necessarily
-// mean the segment is about to be destroyed. This is analogous to unlinking a
-// file; the segment can still be used by a process already referencing it, but
-// cannot be discovered by a new process.
+// preventing it from being found by key. This doesn't necessarily mean the
+// segment is about to be destroyed: it remains accessible by ID while
+// references remain.
 func (r *Registry) dissociateKey(s *Shm) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -200,7 +202,7 @@ func (r *Registry) FindOrCreate(ctx context.Context, pid int32, key ipc.Key, siz
 
 // newShmLocked creates a new segment in the registry.
 //
-// Precondition: Caller must hold r.mu.
+// +checklocks:r.mu
 func (r *Registry) newShmLocked(ctx context.Context, pid int32, key ipc.Key, creator *auth.Credentials, mode linux.FileMode, size uint64) (*Shm, error) {
 	mf := pgalloc.MemoryFileFromContext(ctx)
 	if mf == nil {
@@ -332,6 +334,8 @@ type Shm struct {
 	// via MappingIdentity.
 	ShmRefs
 
+	// mf is initialized during construction or afterLoad, then immutable while
+	// the segment is in use.
 	mf *pgalloc.MemoryFile `state:"nosave"`
 
 	// registry points to the shm registry containing this segment. Immutable.
@@ -350,33 +354,48 @@ type Shm struct {
 	// Invariant: effectiveSize must be a multiple of hostarch.PageSize.
 	effectiveSize uint64
 
-	// fr is the offset into mfp.MemoryFile() that backs this contents of this
-	// segment. Immutable.
+	// fr is the range in mf that backs the contents of this segment. Immutable.
 	fr memmap.FileRange
 
-	// mu protects all fields below.
+	// mu protects mutable state below, including the mutable fields of obj.
 	mu sync.Mutex `state:"nosave"`
 
+	// obj points to common IPC metadata. The pointer is immutable; the ID is
+	// assigned during registration, then immutable. The key, owner IDs, and mode
+	// require mu after initialization.
 	obj *ipc.Object
 
 	// attachTime is updated on every successful shmat.
+	//
+	// +checklocks:mu
 	attachTime ktime.Time
+
 	// detachTime is updated on every successful shmdt.
+	//
+	// +checklocks:mu
 	detachTime ktime.Time
+
 	// changeTime is updated on every successful changes to the segment via
 	// shmctl(IPC_SET).
+	//
+	// +checklocks:mu
 	changeTime ktime.Time
 
-	// creatorPID is the PID of the process that created the segment.
+	// creatorPID is the PID of the process that created the segment. Immutable.
 	creatorPID int32
+
 	// lastAttachDetachPID is the pid of the process that issued the last shmat
 	// or shmdt syscall.
+	//
+	// +checklocks:mu
 	lastAttachDetachPID int32
 
 	// pendingDestruction indicates the segment was marked as destroyed through
-	// shmctl(IPC_RMID). When marked as destroyed, the segment will not be found
-	// in the registry and can no longer be attached. When the last user
-	// detaches from the segment, it is destroyed.
+	// shmctl(IPC_RMID). Its key is dissociated from the registry, but the segment
+	// remains accessible by ID while references remain. It is destroyed when
+	// the last reference is dropped.
+	//
+	// +checklocks:mu
 	pendingDestruction bool
 }
 
@@ -401,18 +420,20 @@ func (s *Shm) Destroy() {
 }
 
 // Lock implements ipc.Mechanism.Lock.
+//
+// +checklocksacquire:s.mu
 func (s *Shm) Lock() {
 	s.mu.Lock()
 }
 
-// Unlock implements ipc.mechanism.Unlock.
+// Unlock implements ipc.Mechanism.Unlock.
 //
-// +checklocksignore
+// +checklocksrelease:s.mu
 func (s *Shm) Unlock() {
 	s.mu.Unlock()
 }
 
-// Precondition: Caller must hold s.mu.
+// +checklocks:s.mu
 func (s *Shm) debugLocked() string {
 	return fmt.Sprintf("Shm{id: %d, key: %d, size: %d bytes, refs: %d, destroyed: %v}",
 		s.obj.ID, s.obj.Key, s.size, s.ReadRefs(), s.pendingDestruction)
@@ -437,9 +458,11 @@ func (s *Shm) InodeID() uint64 {
 	return uint64(s.obj.ID)
 }
 
-// DecRef drops a reference on s.
+// DecRef drops a reference on s. The final reference drop acquires the registry
+// and segment mutexes to remove the segment.
 //
-// Precondition: Caller must not hold s.mu.
+// +checklocksexclude:s.mu
+// +checklocksexclude:s.registry.mu
 func (s *Shm) DecRef(ctx context.Context) {
 	s.ShmRefs.DecRef(func() {
 		s.mf.DecRef(s.fr)


### PR DESCRIPTION
Guard registry access, queue accounting, semaphore metadata, and SHM lifecycle state with their existing owner mutexes. Annotate caller-held helper and destruction contracts, concrete lock effects, and locks excluded by the final SHM reference drop.

Preserve immutable IDs, externally owned IPC metadata, semaphore payloads, and unlocked waiter registration. Document SHM key versus ID lifetime and keep final reference drops outside the registry and segment locks. Existing semaphore tests acquire the locks required by the new contracts.

Assisted-by: Codex
