### PR TITLE
checklocks: publish initialized TCP endpoint IDs

### DIFF
--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -2361,9 +2361,12 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 				}
 			}
 
-			id := e.TransportEndpointInfo.ID
-			id.LocalPort = p
-			if err := e.stack.RegisterTransportEndpoint(netProtos, ProtocolNumber, id, e, e.portFlags, bindToDevice); err != nil {
+			// Initialize the ID before publishing the endpoint: ICMP error
+			// delivery reads it without acquiring e.mu.
+			oldID := e.TransportEndpointInfo.ID
+			e.TransportEndpointInfo.ID.LocalPort = p
+			if err := e.stack.RegisterTransportEndpoint(netProtos, ProtocolNumber, e.TransportEndpointInfo.ID, e, e.portFlags, bindToDevice); err != nil {
+				e.TransportEndpointInfo.ID = oldID
 				portRes := ports.Reservation{
 					Networks:     netProtos,
 					Transport:    ProtocolNumber,
@@ -2382,7 +2385,6 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 
 			// Port picking successful. Save the details of
 			// the selected port.
-			e.TransportEndpointInfo.ID = id
 			e.isPortReserved = true
 			e.boundBindToDevice = bindToDevice
 			e.boundPortFlags = e.portFlags

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -153,9 +154,34 @@ func TestGiveUpConnect(t *testing.T) {
 	}
 }
 
+type handshakeClock struct {
+	tcpip.Clock
+	arm    <-chan struct{}
+	resume <-chan struct{}
+}
+
+func (c *handshakeClock) NowMonotonic() tcpip.MonotonicTime {
+	select {
+	case <-c.arm:
+		<-c.resume
+	default:
+	}
+	return c.Clock.NowMonotonic()
+}
+
 // Test for ICMP error handling without completing handshake.
 func TestConnectICMPError(t *testing.T) {
-	c := context.New(t, e2e.DefaultMTU)
+	arm, resume := make(chan struct{}), make(chan struct{})
+	c := context.NewWithOpts(t, context.Options{
+		EnableV4: true,
+		EnableV6: true,
+		MTU:      e2e.DefaultMTU,
+		Clock: &handshakeClock{
+			Clock:  faketime.NewManualClock(),
+			arm:    arm,
+			resume: resume,
+		},
+	})
 	defer c.Cleanup()
 
 	var wq waiter.Queue
@@ -163,16 +189,77 @@ func TestConnectICMPError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEndpoint failed: %s", err)
 	}
+	c.EP = ep
+	ep.SocketOptions().SetIPv4RecvError(true)
+	if err := c.Stack().SetPortRange(context.StackPort, context.StackPort); err != nil {
+		t.Fatalf("SetPortRange failed: %s", err)
+	}
 
 	waitEntry, notifyCh := waiter.NewChannelEntry(waiter.EventHUp)
 	wq.EventRegister(&waitEntry)
 	defer wq.EventUnregister(&waitEntry)
 
-	{
+	quoted := c.BuildSegmentWithAddrs(nil, &context.Headers{
+		SrcPort: context.StackPort,
+		DstPort: context.TestPort,
+		Flags:   header.TCPFlagSyn,
+	}, context.StackAddr, context.TestAddr)
+	defer quoted.Release()
+	quote := buffer.NewViewWithData(quoted.Flatten())
+	defer quote.Release()
+
+	var wg sync.WaitGroup
+	resumeHandshake := sync.OnceFunc(func() { close(resume) })
+	defer func() {
+		resumeHandshake()
+		wg.Wait()
+		for err := ep.SocketOptions().DequeueErr(); err != nil; err = ep.SocketOptions().DequeueErr() {
+			err.Payload.Release()
+		}
+	}()
+
+	// Pause the first handshake clock read, after registration but before SYN
+	// allocation and route cleanup can synchronize with ICMP delivery. Observe
+	// only the registry, not a signal from Connect after its ID assignment.
+	close(arm)
+	wg.Go(func() {
 		err := ep.Connect(tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort})
 		if d := cmp.Diff(&tcpip.ErrConnectStarted{}, err); d != "" {
-			t.Fatalf("ep.Connect(...) mismatch (-want +got):\n%s", d)
+			t.Errorf("ep.Connect(...) mismatch (-want +got):\n%s", d)
 		}
+	})
+	waitFor := func(what string, ready func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for !ready() {
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for %s", what)
+			}
+			runtime.Gosched()
+		}
+	}
+	id := stack.TransportEndpointID{
+		LocalAddress:  context.StackAddr,
+		LocalPort:     context.StackPort,
+		RemoteAddress: context.TestAddr,
+		RemotePort:    context.TestPort,
+	}
+	waitFor("endpoint registration", func() bool {
+		return c.Stack().FindTransportEndpoint(ipv4.ProtocolNumber, tcp.ProtocolNumber, id, 1) != nil
+	})
+	wg.Go(func() {
+		c.SendICMPPacket(header.ICMPv4DstUnreachable, header.ICMPv4HostUnreachable, nil, quote, e2e.DefaultMTU)
+	})
+	waitFor("queued ICMP error", func() bool { return ep.SocketOptions().PeekErr() != nil })
+	resumeHandshake()
+	wg.Wait()
+	sockErr := ep.SocketOptions().DequeueErr()
+	defer sockErr.Payload.Release()
+	if got, want := sockErr.Offender.Port, uint16(context.StackPort); got != want {
+		t.Errorf("ICMP error local port = %d, want %d", got, want)
+	}
+	if t.Failed() {
+		return
 	}
 
 	syn := c.GetPacket()
@@ -183,19 +270,15 @@ func TestConnectICMPError(t *testing.T) {
 		LastErrorLocked() tcpip.Error
 	})
 
-	c.SendICMPPacket(header.ICMPv4DstUnreachable, header.ICMPv4HostUnreachable, nil, syn, e2e.DefaultMTU)
-
-	for {
-		if err := wep.LastErrorLocked(); err != nil {
-			if d := cmp.Diff(&tcpip.ErrHostUnreachable{}, err); d != "" {
-				t.Errorf("ep.LastErrorLocked() mismatch (-want +got):\n%s", d)
-			}
-			break
-		}
-		time.Sleep(time.Millisecond)
+	if d := cmp.Diff(&tcpip.ErrHostUnreachable{}, wep.LastErrorLocked()); d != "" {
+		t.Errorf("ep.LastErrorLocked() mismatch (-want +got):\n%s", d)
 	}
 
-	<-notifyCh
+	select {
+	case <-notifyCh:
+	default:
+		t.Fatal("ICMP error did not notify the endpoint")
+	}
 
 	// The stack would have unregistered the endpoint because of the ICMP error.
 	// Expect a RST for any subsequent packets sent to the endpoint.


### PR DESCRIPTION
TCP ICMP errors read endpoint addresses and ports without taking the endpoint mutex since 62b4c2f5173. An active connection previously published its selected ephemeral tuple before assigning it to the endpoint, so an incoming error could race with that assignment or report a zero local port.

Assign the selected port before registering the endpoint and restore the old ID if registration fails. Taking the endpoint mutex in the ICMP reader would deadlock synchronous loopback errors during writes.

Extend the existing connect-error test to deliver a matching ICMP error as soon as the endpoint is registered. Pause the handshake clock before SYN allocation so later synchronization cannot hide the publication race.

Assisted-by: Codex
