### PR TITLE
checklocks: enforce networking state ownership

### DIFF
--- a/nogo.yaml
+++ b/nogo.yaml
@@ -261,6 +261,8 @@ analyzers:
         - pkg/sentry/fs/fs.go          # Intentional.
         - pkg/sentry/fs/gofer/inode.go # Intentional.
         - pkg/refs/refcounter_test.go  # Intentional.
+        # Lock-order validator tests intentionally have no protected data.
+        - '^pkg/sync/locking/lockdep_test\.go:'
   SA4016: # Useless bitwise operations.
     internal:
       exclude:

--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -250,36 +250,32 @@ func (*domainnameData) GetDynamicBytesPoller(ctx context.Context) *vfs.DynamicBy
 }
 
 // tcpSackData implements vfs.WritableDynamicBytesSource for
-// /proc/sys/net/tcp_sack.
+// /proc/sys/net/ipv4/tcp_sack.
 //
 // +stateify savable
 type tcpSackData struct {
 	kernfs.DynamicBytesFile
 
-	stack   inet.Stack `state:"wait"`
-	enabled *bool
+	stack inet.Stack `state:"wait"`
 }
 
 var _ vfs.WritableDynamicBytesSource = (*tcpSackData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
 func (d *tcpSackData) Generate(ctx context.Context, buf *bytes.Buffer) error {
-	if d.enabled == nil {
-		sack, err := d.stack.TCPSACKEnabled()
-		if err != nil {
-			return err
-		}
-		d.enabled = &sack
+	enabled, err := d.stack.TCPSACKEnabled()
+	if err != nil {
+		return err
 	}
 
 	val := "0\n"
-	if *d.enabled {
+	if enabled {
 		// Technically, this is not quite compatible with Linux. Linux stores these
 		// as an integer, so if you write "2" into tcp_sack, you should get 2 back.
 		// Tough luck.
 		val = "1\n"
 	}
-	_, err := buf.WriteString(val)
+	_, err = buf.WriteString(val)
 	return err
 }
 
@@ -294,11 +290,7 @@ func (d *tcpSackData) Write(ctx context.Context, _ *vfs.FileDescription, src use
 	if err != nil || n == 0 {
 		return 0, err
 	}
-	if d.enabled == nil {
-		d.enabled = new(bool)
-	}
-	*d.enabled = buf[0] != 0
-	return n, d.stack.SetTCPSACKEnabled(*d.enabled)
+	return n, d.stack.SetTCPSACKEnabled(buf[0] != 0)
 }
 
 // tcpRecoveryData implements vfs.WritableDynamicBytesSource for
@@ -430,7 +422,13 @@ func (d *tcpMemData) writeSizeLocked(size inet.TCPBufferSize) error {
 type ipForwarding struct {
 	kernfs.DynamicBytesFile
 
-	stack   inet.Stack `state:"wait"`
+	stack inet.Stack `state:"wait"`
+	mu    sync.Mutex `state:"nosave"`
+
+	// enabled is the last value written here, which may differ from the
+	// forwarding state of individual interfaces.
+	//
+	// +checklocks:mu
 	enabled bool
 }
 
@@ -438,16 +436,18 @@ var _ vfs.WritableDynamicBytesSource = (*ipForwarding)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
 func (ipf *ipForwarding) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	ipf.mu.Lock()
+	enabled := ipf.enabled
+	ipf.mu.Unlock()
+
 	val := "0\n"
-	if ipf.enabled {
-		// Technically, this is not quite compatible with Linux. Linux stores these
-		// as an integer, so if you write "2" into tcp_sack, you should get 2 back.
-		// Tough luck.
+	if enabled {
+		// Linux preserves the written integer; this file reports a boolean,
+		// so a nonzero value such as "2" is read back as "1".
 		val = "1\n"
 	}
-	buf.WriteString(val)
-
-	return nil
+	_, err := buf.WriteString(val)
+	return err
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
@@ -461,6 +461,8 @@ func (ipf *ipForwarding) Write(ctx context.Context, _ *vfs.FileDescription, src 
 	if err != nil || n == 0 {
 		return 0, err
 	}
+	ipf.mu.Lock()
+	defer ipf.mu.Unlock()
 	ipf.enabled = buf[0] != 0
 	if err := ipf.stack.SetForwarding(ipv4.ProtocolNumber, ipf.enabled); err != nil {
 		return 0, err
@@ -476,23 +478,14 @@ type portRange struct {
 	kernfs.DynamicBytesFile
 
 	stack inet.Stack `state:"wait"`
-
-	// start and end store the port range. We must save/restore this here,
-	// since a netstack instance is created on restore.
-	start *uint16
-	end   *uint16
 }
 
 var _ vfs.WritableDynamicBytesSource = (*portRange)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
 func (pr *portRange) Generate(ctx context.Context, buf *bytes.Buffer) error {
-	if pr.start == nil {
-		start, end := pr.stack.PortRange()
-		pr.start = &start
-		pr.end = &end
-	}
-	_, err := fmt.Fprintf(buf, "%d %d\n", *pr.start, *pr.end)
+	start, end := pr.stack.PortRange()
+	_, err := fmt.Fprintf(buf, "%d %d\n", start, end)
 	return err
 }
 
@@ -517,12 +510,6 @@ func (pr *portRange) Write(ctx context.Context, _ *vfs.FileDescription, src user
 	if err := pr.stack.SetPortRange(uint16(ports[0]), uint16(ports[1])); err != nil {
 		return 0, err
 	}
-	if pr.start == nil {
-		pr.start = new(uint16)
-		pr.end = new(uint16)
-	}
-	*pr.start = uint16(ports[0])
-	*pr.end = uint16(ports[1])
 	return n, nil
 }
 

--- a/pkg/sentry/fsimpl/proc/tasks_sys_test.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys_test.go
@@ -23,6 +23,7 @@ import (
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
 	"gvisor.dev/gvisor/pkg/usermem"
@@ -109,8 +110,55 @@ func TestNetStatDataRowsHaveMatchingFields(t *testing.T) {
 	}
 }
 
-// TestIPForwarding tests the implementation of
-// /proc/sys/net/ipv4/ip_forwarding
+type readOnlySACKTestStack struct {
+	*inet.TestStack
+}
+
+func (*readOnlySACKTestStack) SetTCPSACKEnabled(bool) error {
+	return linuxerr.EACCES
+}
+
+func TestTCPSACKReadback(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		writeErr error
+		want     string
+	}{
+		{name: "shared stack", want: "1\n"},
+		{name: "rejected write", writeErr: linuxerr.EACCES, want: "0\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := contexttest.Context(t)
+			s := inet.NewTestStack()
+			s.TCPSACKFlag = false
+			reader := &tcpSackData{stack: s}
+			writer := &tcpSackData{stack: s}
+			if tc.writeErr != nil {
+				writer = &tcpSackData{stack: &readOnlySACKTestStack{TestStack: s}}
+				reader = writer
+			}
+			var buf bytes.Buffer
+			if err := reader.Generate(ctx, &buf); err != nil {
+				t.Fatal(err)
+			}
+
+			const value = "1\n"
+			if n, err := writer.Write(ctx, nil, usermem.BytesIOSequence([]byte(value)), 0); n != int64(len(value)) || err != tc.writeErr {
+				t.Fatalf("Write() = (%d, %v), want (%d, %v)", n, err, len(value), tc.writeErr)
+			}
+			buf.Reset()
+			if err := reader.Generate(ctx, &buf); err != nil {
+				t.Fatal(err)
+			}
+			if got := buf.String(); got != tc.want {
+				t.Errorf("Generate() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestConfigureIPForwarding tests the implementation of
+// /proc/sys/net/ipv4/ip_forward.
 func TestConfigureIPForwarding(t *testing.T) {
 	ctx := context.Background()
 	s := inet.NewTestStack()
@@ -175,6 +223,43 @@ func TestConfigureIPForwarding(t *testing.T) {
 				t.Errorf("s.IPForwarding incorrect; got: %v, want: %v", got, want)
 			}
 		})
+	}
+}
+
+type portRangeTestStack struct {
+	*inet.TestStack
+	start, end uint16
+}
+
+func (s *portRangeTestStack) PortRange() (uint16, uint16) {
+	return s.start, s.end
+}
+
+func (s *portRangeTestStack) SetPortRange(start, end uint16) error {
+	s.start, s.end = start, end
+	return nil
+}
+
+func TestPortRangeSharedStack(t *testing.T) {
+	ctx := contexttest.Context(t)
+	s := &portRangeTestStack{TestStack: inet.NewTestStack(), start: 32768, end: 60999}
+	reader := &portRange{stack: s}
+	writer := &portRange{stack: s}
+	var buf bytes.Buffer
+	if err := reader.Generate(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+
+	const updated = "40000 50000\n"
+	if n, err := writer.Write(ctx, nil, usermem.BytesIOSequence([]byte(updated)), 0); n != int64(len(updated)) || err != nil {
+		t.Fatalf("Write() = (%d, %v), want (%d, nil)", n, err, len(updated))
+	}
+	buf.Reset()
+	if err := reader.Generate(ctx, &buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != updated {
+		t.Errorf("Generate() = %q, want %q", got, updated)
 	}
 }
 

--- a/pkg/sentry/inet/abstract_socket_namespace.go
+++ b/pkg/sentry/inet/abstract_socket_namespace.go
@@ -43,6 +43,8 @@ type AbstractSocketNamespace struct {
 	// TryIncRef() must be called in case the socket is concurrently being
 	// destroyed. It is the responsibility of the socket to remove itself from the
 	// abstract socket namespace when it is destroyed.
+	//
+	// +checklocks:mu
 	endpoints map[string]abstractEndpoint
 }
 
@@ -59,8 +61,10 @@ func (e *boundEndpoint) Release(ctx context.Context) {
 	e.BoundEndpoint.Release(ctx)
 }
 
-func (a *AbstractSocketNamespace) init() {
-	a.endpoints = make(map[string]abstractEndpoint)
+func newAbstractSocketNamespace() AbstractSocketNamespace {
+	return AbstractSocketNamespace{
+		endpoints: make(map[string]abstractEndpoint),
+	}
 }
 
 // BoundEndpoint retrieves the endpoint bound to the given name. The return

--- a/pkg/sentry/inet/namespace.go
+++ b/pkg/sentry/inet/namespace.go
@@ -65,7 +65,7 @@ func NewRootNamespace(stack Stack, creator NetworkStackCreator, userNS *auth.Use
 	if eventPublishingStack, ok := stack.(InterfaceEventPublisher); ok {
 		eventPublishingStack.AddInterfaceEventSubscriber(n.netlinkMcastTable)
 	}
-	n.abstractSockets.init()
+	n.abstractSockets = newAbstractSocketNamespace()
 	return n
 }
 
@@ -161,7 +161,7 @@ func (n *Namespace) init() {
 			eventPublishingStack.AddInterfaceEventSubscriber(n.netlinkMcastTable)
 		}
 	}
-	n.abstractSockets.init()
+	n.abstractSockets = newAbstractSocketNamespace()
 }
 
 // afterLoad is invoked by stateify.

--- a/pkg/sentry/socket/hostinet/save_restore.go
+++ b/pkg/sentry/socket/hostinet/save_restore.go
@@ -49,7 +49,9 @@ type listenerState struct {
 }
 
 var restoredListeners struct {
-	mu      sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	sockets []*Socket
 }
 

--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -119,8 +119,6 @@ type Socket struct {
 
 	// If persistentEventMask is non-zero, persistentEntry is a no-op waiter
 	// that is registered in queue for all events in persistentEventMask.
-	// Mutations to persistentEventMask and persistentEntry are serialized by
-	// persistentEventMu.
 	//
 	// Bits in persistentEventMask are set by EventRegister(), and never unset.
 	// This ensures that queue.Events() does not change (necessitating calls to
@@ -129,9 +127,14 @@ type Socket struct {
 	// masks, as when e.g. applications repeatedly call poll() with the same
 	// event mask, or blocking accept() / read() / write() / recvmsg() /
 	// sendmsg() / etc., on the same socket.
-	persistentEventMu   sync.Mutex `state:"nosave"`
+	persistentEventMu sync.Mutex `state:"nosave"`
+
+	// +checklocks:persistentEventMu
+	// +checkatomic
 	persistentEventMask atomicbitops.Uint64
-	persistentEntry     waiter.Entry
+
+	// +checklocks:persistentEventMu
+	persistentEntry waiter.Entry
 
 	// fd is the host socket fd. It must have O_NONBLOCK, so that operations
 	// will return EWOULDBLOCK instead of blocking on the host. This allows us to
@@ -140,9 +143,13 @@ type Socket struct {
 
 	// recvClosed indicates that the socket has been shutdown for reading
 	// (SHUT_RD or SHUT_RDWR).
+	//
+	// +checkatomic
 	recvClosed atomicbitops.Bool
 
 	// listenBacklog is the backlog passed to the most recent listen(2).
+	//
+	// +checkatomic
 	listenBacklog atomicbitops.Int32
 
 	// savedListener is set by beforeSave if this socket is listening.

--- a/pkg/sentry/socket/netlink/port/port.go
+++ b/pkg/sentry/socket/netlink/port/port.go
@@ -36,10 +36,11 @@ const maxPorts = 10000
 //
 // +stateify savable
 type Manager struct {
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// ports contains a map of allocated ports for each protocol.
+	//
+	// +checklocks:mu
 	ports map[int]map[int32]struct{}
 }
 

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -437,23 +437,31 @@ type sock struct {
 	// +checklocks:mu
 	readWriter usermem.IOSequenceReadWriter `state:"nosave"`
 
-	// readMu protects access to the below fields.
 	readMu sync.Mutex `state:"nosave"`
 
 	// sockOptTimestamp corresponds to SO_TIMESTAMP. When true, timestamps
 	// of returned messages can be returned via control messages. When
 	// false, the same timestamp is instead stored and can be read via the
-	// SIOCGSTAMP ioctl. It is protected by readMu. See socket(7).
+	// SIOCGSTAMP ioctl. See socket(7).
+	//
+	// +checklocks:readMu
 	sockOptTimestamp bool
-	// timestampValid indicates whether timestamp for SIOCGSTAMP has been
-	// set. It is protected by readMu.
+
+	// timestampValid indicates whether timestamp for SIOCGSTAMP has been set.
+	//
+	// +checklocks:readMu
 	timestampValid bool
-	// timestamp holds the timestamp to use with SIOCTSTAMP. It is only
-	// valid when timestampValid is true. It is protected by readMu.
+
+	// timestamp holds the timestamp to use with SIOCGSTAMP. It is only
+	// valid when timestampValid is true.
+	//
+	// +checklocks:readMu
 	timestamp time.Time `state:".(int64)"`
 
 	// TODO(b/153685824): Move this to SocketOptions.
 	// sockOptInq corresponds to TCP_INQ.
+	//
+	// +checklocks:readMu
 	sockOptInq bool
 }
 
@@ -3079,6 +3087,7 @@ func (s *sock) GetPeerCreds(*kernel.Task) (marshal.Marshallable, *syserr.Error) 
 	return nil, syserr.ErrNotSupported
 }
 
+// +checklocks:s.readMu
 func (s *sock) fillCmsgInq(cmsg *socket.ControlMessages) {
 	if !s.sockOptInq {
 		return
@@ -3211,6 +3220,7 @@ func (s *sock) nonBlockingRead(ctx context.Context, dst usermem.IOSequence, peek
 	return res.Count, 0, nil, 0, cmsg, syserr.TranslateNetstackError(err)
 }
 
+// +checklocks:s.readMu
 func (s *sock) netstackToLinuxControlMessages(cm tcpip.ReceivableControlMessages) socket.ControlMessages {
 	readCM := socket.NewIPControlMessages(s.family, cm)
 	return socket.ControlMessages{
@@ -3249,7 +3259,7 @@ func (s *sock) linuxToNetstackControlMessages(cm socket.ControlMessages) tcpip.S
 // updateTimestamp sets the timestamp for SIOCGSTAMP. It should be called after
 // successfully writing packet data out to userspace.
 //
-// Precondition: s.readMu must be locked.
+// +checklocks:s.readMu
 func (s *sock) updateTimestamp(cm tcpip.ReceivableControlMessages) {
 	// Save the SIOCGSTAMP timestamp only if SO_TIMESTAMP is disabled.
 	if !s.sockOptTimestamp {

--- a/pkg/sentry/socket/plugin/BUILD
+++ b/pkg/sentry/socket/plugin/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/atomicbitops",
         "//pkg/seccomp",
         "//pkg/sentry/inet",
         "//pkg/waiter",

--- a/pkg/sentry/socket/plugin/plugin.go
+++ b/pkg/sentry/socket/plugin/plugin.go
@@ -18,6 +18,7 @@
 package plugin
 
 import (
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/sentry/inet"
 	"gvisor.dev/gvisor/pkg/waiter"
 )
@@ -68,31 +69,37 @@ func GetPluginStack() PluginStack {
 	return pluginStack
 }
 
-// EventInfo is a struct that holds information necessary to a socket
-// notification mechanisms.
+// EventInfo holds a socket's notification queue and readiness cache.
+//
+// Mask and Waiting are protected by the owning notifier's mutex. EventInfo
+// does not retain that notifier, so checklocks cannot express these guards.
 type EventInfo struct {
-	// Queue is the socket corresponding event queue.
+	// Wq is the socket's event queue, initialized before registration.
+	// The pointer is immutable; the queue synchronizes its own entries.
 	Wq *waiter.Queue
 
 	// Mask represents events this socket registered.
 	Mask waiter.EventMask
 
-	// Ready represents events has been currently reported.
-	Ready waiter.EventMask
+	// Ready caches reported events. The notifier updates it concurrently with
+	// socket readiness checks, which consume cached IN/OUT events.
+	//
+	// +checkatomic
+	Ready atomicbitops.Uint64
 
-	// Waiting represents whether there is any waiting event.
+	// Waiting is the notifier's record of whether this socket is registered
+	// with the plugin stack's epoll instance.
 	Waiting bool
 }
 
 // PluginNotifier represents a set of operations to handle
 // plugin network stack's event notification mechanisms.
 type PluginNotifier interface {
-	// AddFD registers a new socket fd and its corresponding
-	// event notification info into the global fdMap.
+	// AddFD registers a socket fd and its event notification state with
+	// the notifier.
 	AddFD(fd uint32, eventinfo *EventInfo) error
 
-	// RemoveFD unregisters a socket fd and its corresponding
-	// event notification info from the global fdMap.
+	// RemoveFD unregisters a socket fd from the notifier.
 	RemoveFD(fd uint32)
 
 	// UpdateFD updates the set of events the socket fd needs

--- a/pkg/sentry/socket/plugin/stack/BUILD
+++ b/pkg/sentry/socket/plugin/stack/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/abi/linux",
         "//pkg/abi/linux/errno",
+        "//pkg/atomicbitops",
         "//pkg/binary",
         "//pkg/context",
         "//pkg/errors/linuxerr",
@@ -44,4 +45,12 @@ go_library(
         "//pkg/waiter",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_test(
+    name = "stack_test",
+    size = "small",
+    srcs = ["socket_test.go"],
+    library = ":stack",
+    deps = ["//pkg/waiter"],
 )

--- a/pkg/sentry/socket/plugin/stack/notifier.go
+++ b/pkg/sentry/socket/plugin/stack/notifier.go
@@ -21,6 +21,7 @@ import (
 	"syscall"
 
 	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/sentry/socket/plugin"
 	"gvisor.dev/gvisor/pkg/sentry/socket/plugin/cgo"
 	"gvisor.dev/gvisor/pkg/waiter"
@@ -29,14 +30,16 @@ import (
 // Notifier holds all the state necessary to issue notifications when
 // IO events occur on the observed FDs in plugin stack.
 type Notifier struct {
-	// the epoll FD used to register for io notifications.
+	// epFD is the epoll FD used for event registration. It is initialized by
+	// waitAndNotify before signaling ioInit and is immutable afterward.
 	epFD int32
 
-	// mu protects eventMap.
 	mu sync.Mutex
 
 	// eventMap maps file descriptors to their notification queues
 	// and waiting status.
+	//
+	// +checklocks:mu
 	eventMap map[uint32]*plugin.EventInfo
 }
 
@@ -64,7 +67,7 @@ func NewNotifier() *Notifier {
 	return n
 }
 
-// AddFD implements plugin.PluginNotifier.AddFD.
+// AddFD adds fd and its event notification state to n.eventMap.
 func (n *Notifier) AddFD(fd uint32, eventInfo *plugin.EventInfo) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -78,14 +81,15 @@ func (n *Notifier) AddFD(fd uint32, eventInfo *plugin.EventInfo) {
 	n.eventMap[fd] = eventInfo
 }
 
-// RemoveFD implements plugin.PluginNotifier.RemoveFD.
+// RemoveFD removes fd's event notification state from n.eventMap.
 func (n *Notifier) RemoveFD(fd uint32) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 	delete(n.eventMap, fd)
 }
 
-// UpdateFD implements plugin.PluginNotifier.UpdateFD.
+// UpdateFD updates fd's event registration in the plugin stack's epoll
+// instance.
 func (n *Notifier) UpdateFD(fd uint32) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -131,7 +135,7 @@ func (n *Notifier) waitAndNotify(ioInit chan int32) error {
 			}
 
 			ev := waiter.EventMask(events[i].Events)
-			eventInfo.Ready |= ev & (eventInfo.Mask | waiter.EventErr | waiter.EventHUp)
+			atomicbitops.OrUint64(&eventInfo.Ready, uint64(ev&(eventInfo.Mask|waiter.EventErr|waiter.EventHUp)))
 			// When an error occurred, invoke all events
 			if ev&(waiter.EventErr|waiter.EventHUp) != 0 {
 				ev |= waiter.EventIn | waiter.EventOut
@@ -142,6 +146,7 @@ func (n *Notifier) waitAndNotify(ioInit chan int32) error {
 	}
 }
 
+// +checklocks:n.mu
 func (n *Notifier) waitFD(fd uint32, eventInfo *plugin.EventInfo) {
 	mask := eventInfo.Wq.Events()
 
@@ -156,10 +161,10 @@ func (n *Notifier) waitFD(fd uint32, eventInfo *plugin.EventInfo) {
 		eventInfo.Waiting = true
 	case eventInfo.Waiting && mask == 0:
 		cgo.EpollCtl(n.epFD, syscall.EPOLL_CTL_DEL, fd, uint32(mask))
-		eventInfo.Ready = 0
+		eventInfo.Ready.Store(0)
 		eventInfo.Waiting = false
 	case eventInfo.Waiting && mask != 0:
 		cgo.EpollCtl(n.epFD, syscall.EPOLL_CTL_MOD, fd, uint32(mask))
-		eventInfo.Ready &= mask
+		atomicbitops.AndUint64(&eventInfo.Ready, uint64(mask))
 	}
 }

--- a/pkg/sentry/socket/plugin/stack/socket.go
+++ b/pkg/sentry/socket/plugin/stack/socket.go
@@ -263,24 +263,21 @@ func (s *socketOperations) EventUnregister(e *waiter.Entry) {
 
 // Readiness implements socket.Socket.Readiness.
 func (s *socketOperations) Readiness(mask waiter.EventMask) waiter.EventMask {
-	var events waiter.EventMask
-
-	evInfo := &s.eventInfo
-	iomask := mask & (waiter.EventIn | waiter.EventOut)
-
-	// Fast path condition:
-	// 1. The event needed has been reported by plugin stack io-thread; or
-	// 2. POLLIN or POLLOUT event has been reported by io-thread.
-	// Directly report current event without invoking cgo Readiness again.
-	if evInfo.Ready&iomask == iomask {
-		events = evInfo.Ready & mask
-		// Clear plugin stack eventInfo record after consuming IN/OUT event.
-		evInfo.Ready &= ^iomask
-	} else {
-		events = waiter.EventMask(cgo.Readiness(s.fd, uint64(mask)))
+	iomask := uint64(mask & (waiter.EventIn | waiter.EventOut))
+	// Notification callbacks can check readiness while holding the notifier
+	// mutex, so accessing the cache must not acquire that mutex.
+	for {
+		ready := s.eventInfo.Ready.Load()
+		// Use the cache only if all requested IN/OUT events are present.
+		if ready&iomask != iomask {
+			return waiter.EventMask(cgo.Readiness(s.fd, uint64(mask)))
+		}
+		// Consume requested I/O bits without overwriting unrelated updates.
+		// A failed CAS must recheck whether the cache still suffices.
+		if iomask == 0 || s.eventInfo.Ready.CompareAndSwap(ready, ready&^iomask) {
+			return waiter.EventMask(ready) & mask
+		}
 	}
-
-	return events
 }
 
 // Epollable implements socket.Socket.Epollable.

--- a/pkg/sentry/socket/plugin/stack/socket_test.go
+++ b/pkg/sentry/socket/plugin/stack/socket_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"sync"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/waiter"
+)
+
+func TestConcurrentReadiness(t *testing.T) {
+	// Include a high bit to catch truncation of the full-width cache.
+	const common = waiter.EventErr | waiter.EventHUp | waiter.EventMask(1<<40)
+	const initial = waiter.EventIn | waiter.EventOut | common
+	var s socketOperations
+	s.eventInfo.Ready.Store(uint64(initial))
+
+	// Each caller consumes a different I/O bit, so neither needs to query C.
+	masks := [...]waiter.EventMask{waiter.EventIn | common, waiter.EventOut | common}
+	var got [len(masks)]waiter.EventMask
+	var wg sync.WaitGroup
+	for i, mask := range masks {
+		wg.Go(func() {
+			got[i] = s.Readiness(mask)
+		})
+	}
+	wg.Wait()
+	for i, mask := range masks {
+		if got[i] != mask {
+			t.Errorf("Readiness(%#x) = %#x, want %#x", mask, got[i], mask)
+		}
+	}
+	if got := s.eventInfo.Ready.Load(); got != uint64(common) {
+		t.Errorf("cached readiness = %#x, want %#x", got, common)
+	}
+}

--- a/pkg/sentry/socket/unix/transport/connectioned.go
+++ b/pkg/sentry/socket/unix/transport/connectioned.go
@@ -112,19 +112,27 @@ type connectionedEndpoint struct {
 	// will store the peer's credentials. The use of this option is possible
 	// only for connected `AF_UNIX` stream sockets and for `AF_UNIX` stream and
 	// datagram socket pairs created using socketpair(2)
+	//
+	// During connection setup, the accepted endpoint's credentials are
+	// initialized under the listener's lock, which prevents Accept from
+	// returning it.
+	//
+	// +checklocks:endpointMutex
 	peerCreds CredentialsControlMessage
 
 	// acceptedChan is per the TCP endpoint implementation. Note that the
 	// sockets in this channel are _already in the connected state_, and
 	// have another associated connectionedEndpoint.
 	//
-	// If nil, then no listen call has been made.
+	// If nil, the endpoint is not listening.
+	//
+	// +checklocks:endpointMutex
 	acceptedChan chan *connectionedEndpoint `state:".([]*connectionedEndpoint)"`
 
 	// boundSocketFD corresponds to a bound socket on the host filesystem
 	// that may listen and accept incoming connections.
 	//
-	// boundSocketFD is protected by baseEndpoint.mu.
+	// +checklocks:endpointMutex
 	boundSocketFD BoundSocketFD
 }
 
@@ -162,21 +170,23 @@ func NewPair(ctx context.Context, stype linux.SockType, uid uniqueid.Provider) (
 	q2 := &queue{readerWaiters: b.WaitQueue, writerWaiters: a.WaitQueue, limit: defaultBufferSize}
 	q2.InitRefs()
 
+	// newConnectioned returned private endpoints; neither is published before
+	// this function returns. checklocks cannot track those returned allocations.
 	if stype == linux.SOCK_STREAM {
-		a.receiver = &streamQueueReceiver{queueReceiver: queueReceiver{q1}}
-		b.receiver = &streamQueueReceiver{queueReceiver: queueReceiver{q2}}
+		a.receiver = &streamQueueReceiver{queueReceiver: queueReceiver{q1}} // +checklocksignore
+		b.receiver = &streamQueueReceiver{queueReceiver: queueReceiver{q2}} // +checklocksignore
 	} else {
-		a.receiver = &queueReceiver{q1}
-		b.receiver = &queueReceiver{q2}
+		a.receiver = &queueReceiver{q1} // +checklocksignore
+		b.receiver = &queueReceiver{q2} // +checklocksignore
 	}
 
 	q2.IncRef()
-	a.peer = &queueSender{
+	a.peer = &queueSender{ // +checklocksignore
 		endpoint:   b,
 		writeQueue: q2,
 	}
 	q1.IncRef()
-	b.peer = &queueSender{
+	b.peer = &queueSender{ // +checklocksignore
 		endpoint:   a,
 		writeQueue: q1,
 	}
@@ -216,6 +226,8 @@ func (e *connectionedEndpoint) WaiterQueue() *waiter.Queue {
 
 // isBound returns true iff the connectionedEndpoint is bound (but not
 // listening).
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) isBound() bool {
 	return e.path != "" && e.acceptedChan == nil
 }
@@ -227,6 +239,9 @@ func (e *connectionedEndpoint) Listening() bool {
 	return e.ListeningLocked()
 }
 
+// ListeningLocked implements ConnectingEndpoint.ListeningLocked.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) ListeningLocked() bool {
 	return e.acceptedChan != nil
 }
@@ -237,6 +252,9 @@ func (e *connectionedEndpoint) ListeningLocked() bool {
 // The socket will be a fresh state after a call to close and may be reused.
 // That is, close may be used to "unbind" or "disconnect" the socket in error
 // paths.
+//
+// The caller must exclude operations using the Receiver being released,
+// including RecvMsg calls that retained it before Close acquired the lock.
 func (e *connectionedEndpoint) Close(ctx context.Context) {
 	var acceptedChan chan *connectionedEndpoint
 	e.Lock()
@@ -293,18 +311,19 @@ func (e *connectionedEndpoint) Close(ctx context.Context) {
 	e.ResetBoundSocketFD(ctx)
 	if r != nil {
 		r.NotifyStateChange()
+		// Close's caller excludes other uses of r; detaching it above alone
+		// does not wait for an in-flight RecvMsg to finish.
 		r.Release(ctx)
 	}
 }
 
-func (e *connectionedEndpoint) swapPeerCredsLocked(ctx context.Context, cend ConnectingEndpoint, ne *connectionedEndpoint) *syserr.Error {
-	ce, ok := cend.(*connectionedEndpoint)
-	if !ok {
-		return syserr.ErrInvalidEndpointState
-	}
-	// Swap peer credentials between the two endpoints.
-	ne.peerCreds, ce.peerCreds = ce.peerCreds, ne.peerCreds
-	return nil
+// swapPeerCredsLocked exchanges credentials with other while both endpoints
+// are locked.
+//
+// +checklocks:e.endpointMutex
+// +checklocks:other.endpointMutex
+func (e *connectionedEndpoint) swapPeerCredsLocked(other *connectionedEndpoint) {
+	e.peerCreds, other.peerCreds = other.peerCreds, e.peerCreds
 }
 
 // BidirectionalConnect implements BoundEndpoint.BidirectionalConnect.
@@ -388,9 +407,14 @@ func (e *connectionedEndpoint) BidirectionalConnect(ctx context.Context, ce Conn
 		}
 		readQueue.IncRef()
 		if e.stype == linux.SOCK_STREAM {
-			if err := e.swapPeerCredsLocked(ctx, ce, ne); err != nil {
-				return err
+			connectingEP, ok := ce.(*connectionedEndpoint)
+			if !ok {
+				return syserr.ErrInvalidEndpointState
 			}
+			// ce is locked through ConnectingEndpoint, and the listener
+			// lock prevents Accept from returning ne. checklocks cannot
+			// relate the interface lock or prove pending-child ownership.
+			connectingEP.swapPeerCredsLocked(ne) // +checklocksignore
 			returnConnect(&streamQueueReceiver{queueReceiver: queueReceiver{readQueue: readQueue}}, peer)
 		} else {
 			returnConnect(&queueReceiver{readQueue: readQueue}, peer)
@@ -422,12 +446,14 @@ func (e *connectionedEndpoint) UnidirectionalConnect(ctx context.Context) (Sende
 // Connect attempts to directly connect to another Endpoint.
 // Implements Endpoint.Connect.
 func (e *connectionedEndpoint) Connect(ctx context.Context, server BoundEndpoint) *syserr.Error {
-	returnConnect := func(r Receiver, ce Sender) {
-		e.receiver = r
-		e.peer = ce
+	returnConnect := func(r Receiver, peer Sender) {
+		// BidirectionalConnect calls this synchronously with e locked.
+		// checklocks cannot propagate that lock through the callback.
+		e.receiver = r // +checklocksignore
+		e.peer = peer  // +checklocksignore
 		// Make sure the newly created connected endpoint's write queue is updated
 		// to reflect this endpoint's send buffer size.
-		if bufSz := e.peer.SetSendBufferSize(e.ops.GetSendBufferSize()); bufSz != e.ops.GetSendBufferSize() {
+		if bufSz := peer.SetSendBufferSize(e.ops.GetSendBufferSize()); bufSz != e.ops.GetSendBufferSize() {
 			e.ops.SetSendBufferSize(bufSz, false /* notify */)
 			e.ops.SetReceiveBufferSize(bufSz, false /* notify */)
 		}
@@ -504,9 +530,11 @@ func (e *connectionedEndpoint) Accept(ctx context.Context, peerAddr *Address) (E
 	return ne, nil
 }
 
-// Preconditions:
-//   - e.Listening()
-//   - e is locked.
+// getAcceptedEndpointLocked accepts a connection with the endpoint locked.
+//
+// Preconditions: the endpoint must be listening.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) getAcceptedEndpointLocked(ctx context.Context) (*connectionedEndpoint, *syserr.Error) {
 	// Accept connections from within the sentry first, since this avoids
 	// an RPC to the gofer on the common path.
@@ -575,6 +603,7 @@ func (e *connectionedEndpoint) SendMsg(ctx context.Context, data [][]byte, c Con
 	return e.baseEndpoint.SendMsg(ctx, data, c, to)
 }
 
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) isBoundSocketReadable() bool {
 	if e.boundSocketFD == nil {
 		return false

--- a/pkg/sentry/socket/unix/transport/connectioned_state.go
+++ b/pkg/sentry/socket/unix/transport/connectioned_state.go
@@ -16,7 +16,11 @@ package transport
 
 import "context"
 
-// saveAcceptedChan is invoked by stateify.
+// saveAcceptedChan is invoked by stateify. Generated serialization callers
+// supply quiescence rather than holding endpointMutex and are exempt from
+// checklocks.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) saveAcceptedChan() []*connectionedEndpoint {
 	// If acceptedChan is nil (i.e. we are not listening) then we will save nil.
 	// Otherwise we create a (possibly empty) slice of the values in acceptedChan and
@@ -41,7 +45,11 @@ func (e *connectionedEndpoint) saveAcceptedChan() []*connectionedEndpoint {
 	return acceptedSlice
 }
 
-// loadAcceptedChan is invoked by stateify.
+// loadAcceptedChan is invoked by stateify. Generated serialization callers
+// supply quiescence rather than holding endpointMutex and are exempt from
+// checklocks.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) loadAcceptedChan(_ context.Context, acceptedSlice []*connectionedEndpoint) {
 	// If acceptedSlice is nil, then acceptedChan should also be nil.
 	if acceptedSlice != nil {
@@ -54,7 +62,10 @@ func (e *connectionedEndpoint) loadAcceptedChan(_ context.Context, acceptedSlice
 	}
 }
 
-// beforeSave is invoked by stateify.
+// beforeSave is invoked by stateify. Generated serialization callers supply
+// quiescence rather than holding endpointMutex and are exempt from checklocks.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) beforeSave() {
 	if e.boundSocketFD != nil {
 		panic("Cannot save endpoint with bound host socket")

--- a/pkg/sentry/socket/unix/transport/connectionless.go
+++ b/pkg/sentry/socket/unix/transport/connectionless.go
@@ -51,12 +51,16 @@ func NewConnectionless(ctx context.Context) Endpoint {
 }
 
 // isBound returns true iff the endpoint is bound.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionlessEndpoint) isBound() bool {
 	return e.path != ""
 }
 
 // Close puts the endpoint in a closed state and frees all resources associated
-// with it.
+// with it. The caller must exclude operations using the Receiver being
+// released, including RecvMsg calls that retained it before Close took the
+// lock.
 func (e *connectionlessEndpoint) Close(ctx context.Context) {
 	e.Lock()
 	peer := e.peer
@@ -75,6 +79,8 @@ func (e *connectionlessEndpoint) Close(ctx context.Context) {
 		peer.Release(ctx)
 	}
 	r.NotifyStateChange()
+	// Close's caller excludes other uses of r; detaching it above alone does
+	// not wait for an in-flight RecvMsg to finish.
 	r.Release(ctx)
 }
 

--- a/pkg/sentry/socket/unix/transport/queue.go
+++ b/pkg/sentry/socket/unix/transport/queue.go
@@ -36,11 +36,22 @@ type queue struct {
 	readerWaiters *waiter.Queue
 	writerWaiters *waiter.Queue
 
-	mu       queueMutex `state:"nosave"`
-	closed   atomicbitops.Bool
-	unread   bool
-	used     int64
-	limit    int64
+	mu queueMutex `state:"nosave"`
+
+	// +checklocks:mu
+	// +checkatomic
+	closed atomicbitops.Bool
+
+	// +checklocks:mu
+	unread bool
+
+	// +checklocks:mu
+	used int64
+
+	// +checklocks:mu
+	limit int64
+
+	// +checklocks:mu
 	dataList messageList
 }
 
@@ -100,6 +111,8 @@ func (q *queue) IsReadable() bool {
 // free.
 //
 // See net/unix/af_unix.c:unix_writeable.
+//
+// +checklocks:q.mu
 func (q *queue) bufWritable() bool {
 	return 4*q.used < q.limit
 }

--- a/pkg/sentry/socket/unix/transport/queue_test.go
+++ b/pkg/sentry/socket/unix/transport/queue_test.go
@@ -171,7 +171,10 @@ func TestEnqueueRightsOwnership(t *testing.T) {
 			}
 
 			if !test.wantQueued {
-				if q.dataList.Front() != nil {
+				q.mu.Lock()
+				empty := q.dataList.Front() == nil
+				q.mu.Unlock()
+				if !empty {
 					t.Errorf("queue holds a message, want none")
 				}
 				return

--- a/pkg/sentry/socket/unix/transport/unix.go
+++ b/pkg/sentry/socket/unix/transport/unix.go
@@ -185,7 +185,8 @@ type Endpoint interface {
 	waiter.Waitable
 
 	// Close puts the endpoint in a closed state and frees all resources
-	// associated with it.
+	// associated with it. The caller must exclude operations using the
+	// Receiver being released, including previously started RecvMsg calls.
 	Close(ctx context.Context)
 
 	// RecvMsg reads data and a control message from the endpoint. This method
@@ -302,6 +303,9 @@ type BoundEndpoint interface {
 	// connection information (Receiver and Sender) upon a
 	// successful connect. The callback should only be called on a successful
 	// connect.
+	//
+	// returnConnect is invoked synchronously while the ConnectingEndpoint's
+	// lock is held. The callback must not acquire that lock.
 	//
 	// For a connection attempt to be successful, the ConnectingEndpoint must
 	// be unconnected and not listening and the BoundEndpoint whose
@@ -443,8 +447,8 @@ type Receiver interface {
 	// RecvMaxQueueSize should return -1 if the operation isn't supported.
 	RecvMaxQueueSize() int64
 
-	// Release releases any resources owned by the Receiver. It should be
-	// called before dropping all references to a Receiver.
+	// Release releases any resources owned by the Receiver. The caller must
+	// exclude every other operation on the Receiver during and after Release.
 	Release(ctx context.Context)
 }
 
@@ -551,10 +555,16 @@ func (q *queueReceiver) Release(ctx context.Context) {
 type streamQueueReceiver struct {
 	queueReceiver
 
-	mu      streamQueueReceiverMutex `state:"nosave"`
-	buffer  []byte
+	mu streamQueueReceiverMutex `state:"nosave"`
+
+	// +checklocks:mu
+	buffer []byte
+
+	// +checklocks:mu
 	control ControlMessages
-	addr    Address
+
+	// +checklocks:mu
+	addr Address
 }
 
 func vecCopy(data [][]byte, buf []byte) (int64, [][]byte, []byte) {
@@ -724,6 +734,12 @@ func (q *streamQueueReceiver) Recv(ctx context.Context, data [][]byte, args Recv
 }
 
 // Release implements Receiver.Release.
+//
+// Preconditions: no other operation may use q during or after Release.
+// Receiver.Release cannot express this concrete mutex requirement; interface
+// callers instead establish exclusive lifetime ownership at the call site.
+//
+// +checklocks:q.mu
 func (q *streamQueueReceiver) Release(ctx context.Context) {
 	q.queueReceiver.Release(ctx)
 	q.control.Release(ctx)
@@ -923,37 +939,51 @@ type baseEndpoint struct {
 
 	tcpip.DefaultSocketOptionsHandler
 
-	// Mutex protects the below fields.
-	//
 	// See the lock ordering comment in package kernel/epoll regarding when
 	// this lock can safely be held.
 	endpointMutex `state:"nosave"`
 
 	// receiver allows Messages to be received.
+	//
+	// Operations on a retained Receiver follow its own synchronization and
+	// lifetime requirements; endpointMutex only protects this reference.
+	//
+	// +checklocks:endpointMutex
 	receiver Receiver
 
 	// peer is the Sender through which this endpoint's sends reach its
 	// peer socket; it also exposes the send-side state (writability,
 	// shutdown) of that connection.
+	//
+	// See receiver for synchronization.
+	//
+	// +checklocks:endpointMutex
 	peer Sender
 
 	// path is not empty if the endpoint has been bound,
 	// or may be used if the endpoint is connected.
+	//
+	// +checklocks:endpointMutex
 	path string
 
 	// sendShutdown is true if the write side of the endpoint has been
 	// shut down without closing the peer's read side: sends fail with
 	// EPIPE, but the peer is unaffected. This is how shutdown(SHUT_WR)
-	// behaves on datagram sockets. Protected by endpointMutex.
+	// behaves on datagram sockets.
+	//
+	// +checklocks:endpointMutex
 	sendShutdown bool
 
 	// ops is used to get socket level options.
 	ops tcpip.SocketOptions
 
-	// lastError is the last error returned by getsockopt(SO_ERROR).
-	// This field is protected by lastErrorMu.
 	lastErrorMu sync.Mutex `state:"nosave"`
-	lastError   tcpip.Error
+
+	// lastError is a pending error cleared by LastError. RecvMsg may also
+	// consume it when a receive returns ErrClosedForReceive or ErrWouldBlock.
+	//
+	// +checklocks:lastErrorMu
+	lastError tcpip.Error
 }
 
 // EventRegister implements waiter.Waitable.EventRegister.
@@ -995,7 +1025,7 @@ func (e *baseEndpoint) ConnectedPasscred() bool {
 
 // Connected implements ConnectingEndpoint.Connected.
 //
-// Preconditions: e.mu must be held.
+// +checklocks:e.endpointMutex
 func (e *baseEndpoint) Connected() bool {
 	return e.receiver != nil && e.peer != nil
 }

--- a/pkg/sync/locking/generic_mutex.go
+++ b/pkg/sync/locking/generic_mutex.go
@@ -44,28 +44,28 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *Mutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // Unlock unlocks m.
 // +checklocksignore
 func (m *Mutex) Unlock() {
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Unlock()
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedUnlock(i lockNameIndex) {
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Unlock()
 }
 

--- a/pkg/sync/locking/generic_rwmutex.go
+++ b/pkg/sync/locking/generic_rwmutex.go
@@ -42,14 +42,14 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *RWMutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
@@ -57,20 +57,20 @@ func (m *RWMutex) NestedLock(i lockNameIndex) {
 // +checklocksignore
 func (m *RWMutex) Unlock() {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedUnlock(i lockNameIndex) {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 }
 
 // RLock locks m for reading.
 // +checklocksignore
 func (m *RWMutex) RLock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.RLock()
 }
 
@@ -78,7 +78,7 @@ func (m *RWMutex) RLock() {
 // +checklocksignore
 func (m *RWMutex) RUnlock() {
 	m.mu.RUnlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // RLockBypass locks m for reading without executing the validator.

--- a/pkg/sync/locking/locking.go
+++ b/pkg/sync/locking/locking.go
@@ -25,4 +25,8 @@
 // taken before the target one. For each goroutine, we have the list of
 // currently locked mutexes. And finally, all lock methods check that
 // ancestors of currently locked mutexes don't contain the target one.
+//
+// Lockdep bookkeeping may allocate maps and stack traces. Generated mutexes
+// exempt calls to this optional instrumentation from checkescape contracts;
+// the underlying mutex operations and their callers remain checked.
 package locking

--- a/pkg/tcpip/adapters/gonet/BUILD
+++ b/pkg/tcpip/adapters/gonet/BUILD
@@ -25,7 +25,6 @@ go_test(
     srcs = ["gonet_test.go"],
     library = ":gonet",
     deps = [
-        "//pkg/sync",
         "//pkg/tcpip",
         "//pkg/tcpip/header",
         "//pkg/tcpip/link/loopback",

--- a/pkg/tcpip/adapters/gonet/gonet.go
+++ b/pkg/tcpip/adapters/gonet/gonet.go
@@ -128,18 +128,23 @@ func (l *TCPListener) Addr() net.Addr {
 }
 
 type deadlineTimer struct {
-	// mu protects the fields below.
 	mu sync.Mutex
 
-	readTimer     *time.Timer
-	readCancelCh  chan struct{}
-	writeTimer    *time.Timer
+	// +checklocks:mu
+	readTimer *time.Timer
+	// +checklocks:mu
+	readCancelCh chan struct{}
+	// +checklocks:mu
+	writeTimer *time.Timer
+	// +checklocks:mu
 	writeCancelCh chan struct{}
 }
 
-func (d *deadlineTimer) init() {
-	d.readCancelCh = make(chan struct{})
-	d.writeCancelCh = make(chan struct{})
+func newDeadlineTimer() deadlineTimer {
+	return deadlineTimer{
+		readCancelCh:  make(chan struct{}),
+		writeCancelCh: make(chan struct{}),
+	}
 }
 
 func (d *deadlineTimer) readCancel() <-chan struct{} {
@@ -157,11 +162,11 @@ func (d *deadlineTimer) writeCancel() <-chan struct{} {
 
 // setDeadline contains the shared logic for setting a deadline.
 //
-// cancelCh and timer must be pointers to deadlineTimer.readCancelCh and
-// deadlineTimer.readTimer or deadlineTimer.writeCancelCh and
-// deadlineTimer.writeTimer.
+// cancelCh and timer must point to d.readCancelCh and d.readTimer, or to
+// d.writeCancelCh and d.writeTimer. checklocks verifies that d.mu is held,
+// but cannot prove that the arguments identify the matching fields of d.
 //
-// setDeadline must only be called while holding d.mu.
+// +checklocks:d.mu
 func (d *deadlineTimer) setDeadline(cancelCh *chan struct{}, timer **time.Timer, t time.Time) {
 	if *timer != nil && !(*timer).Stop() {
 		*cancelCh = make(chan struct{})
@@ -234,7 +239,7 @@ type TCPConn struct {
 	wq *waiter.Queue
 	ep tcpip.Endpoint
 
-	// readMu serializes reads and implicitly protects read.
+	// readMu serializes reads.
 	//
 	// Lock ordering:
 	// If both readMu and deadlineTimer.mu are to be used in a single
@@ -243,17 +248,18 @@ type TCPConn struct {
 
 	// read contains bytes that have been read from the endpoint,
 	// but haven't yet been returned.
+	//
+	// +checklocks:readMu
 	read []byte
 }
 
 // NewTCPConn creates a new TCPConn.
 func NewTCPConn(wq *waiter.Queue, ep tcpip.Endpoint) *TCPConn {
-	c := &TCPConn{
-		wq: wq,
-		ep: ep,
+	return &TCPConn{
+		deadlineTimer: newDeadlineTimer(),
+		wq:            wq,
+		ep:            ep,
 	}
-	c.deadlineTimer.init()
-	return c
 }
 
 // Accept implements net.Conn.Accept.
@@ -553,12 +559,11 @@ type UDPConn struct {
 
 // NewUDPConn creates a new UDPConn.
 func NewUDPConn(wq *waiter.Queue, ep tcpip.Endpoint) *UDPConn {
-	c := &UDPConn{
-		ep: ep,
-		wq: wq,
+	return &UDPConn{
+		deadlineTimer: newDeadlineTimer(),
+		ep:            ep,
+		wq:            wq,
 	}
-	c.deadlineTimer.init()
-	return c
 }
 
 // DialUDP creates a new UDPConn.

--- a/pkg/tcpip/adapters/gonet/gonet_test.go
+++ b/pkg/tcpip/adapters/gonet/gonet_test.go
@@ -22,10 +22,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"golang.org/x/net/nettest"
-	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/loopback"
@@ -764,18 +764,11 @@ func makePipe() (c1, c2 net.Conn, stop func(), err error) {
 }
 
 func TestTCPConnTransfer(t *testing.T) {
-	c1, c2, _, err := makePipe()
+	c1, c2, stop, err := makePipe()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		if err := c1.Close(); err != nil {
-			t.Error("c1.Close():", err)
-		}
-		if err := c2.Close(); err != nil {
-			t.Error("c2.Close():", err)
-		}
-	}()
+	t.Cleanup(stop)
 
 	c1.SetDeadline(time.Now().Add(time.Second))
 	c2.SetDeadline(time.Now().Add(time.Second))
@@ -1011,22 +1004,19 @@ func TestNetTest(t *testing.T) {
 
 // NOTE(gvisor.dev/issue/9885): Regression test.
 func TestDeadlineTimerAfterZeroValue(t *testing.T) {
-	timer := &deadlineTimer{}
-	timer.init()
-
-	wg := sync.WaitGroup{}
-	ch := timer.readCancel()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	synctest.Test(t, func(t *testing.T) {
+		timer := newDeadlineTimer()
+		ch := timer.readCancel()
+		// Keep the future timer pending even if the host deschedules this test.
+		for _, deadline := range []time.Time{time.Now().Add(10 * time.Second), {}, time.Unix(1, 0)} {
+			if err := timer.SetReadDeadline(deadline); err != nil {
+				t.Fatalf("SetReadDeadline(%v): %v", deadline, err)
+			}
+		}
 		select {
 		case <-ch:
-		case <-time.After(1 * time.Second):
-			t.Fail()
+		default:
+			t.Fatal("original cancellation channel was not closed")
 		}
-	}()
-	timer.SetReadDeadline(time.Now().Add(10 * time.Second))
-	timer.SetReadDeadline(time.Time{})
-	timer.SetReadDeadline(time.Unix(1, 0))
-	wg.Wait()
+	})
 }

--- a/pkg/tcpip/link/nested/nested.go
+++ b/pkg/tcpip/link/nested/nested.go
@@ -34,8 +34,9 @@ type Endpoint struct {
 	child    stack.LinkEndpoint
 	embedder stack.NetworkDispatcher
 
-	// mu protects dispatcher.
-	mu         sync.RWMutex `state:"nosave"`
+	mu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:mu
 	dispatcher stack.NetworkDispatcher
 }
 

--- a/pkg/tcpip/link/qdisc/fifo/qdisc_test.go
+++ b/pkg/tcpip/link/qdisc/fifo/qdisc_test.go
@@ -33,7 +33,9 @@ var _ stack.LinkWriter = (*countWriter)(nil)
 
 // countWriter implements LinkWriter.
 type countWriter struct {
-	mu             sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	packetsWritten int
 	packetsWanted  int
 	done           chan struct{}
@@ -99,6 +101,9 @@ func TestWriteMorePacketsThanBatchSize(t *testing.T) {
 		done := make(chan struct{})
 		lower := &countWriter{done: done, packetsWanted: want}
 		linkEp := fifo.New(lower, 1, 1000)
+		// Close each iteration promptly below; this idempotent fallback
+		// also joins the dispatcher if the test fails first.
+		t.Cleanup(linkEp.Close)
 		for i := 0; i < want; i++ {
 			pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 				Payload: buffer.MakeWithData(v),
@@ -109,7 +114,10 @@ func TestWriteMorePacketsThanBatchSize(t *testing.T) {
 		select {
 		case <-done:
 		case <-time.After(1 * time.Second):
-			t.Fatalf("expected %d packets, but got only %d", want, lower.packetsWritten)
+			lower.mu.Lock()
+			packetsWritten := lower.packetsWritten
+			lower.mu.Unlock()
+			t.Fatalf("expected %d packets, but got only %d", want, packetsWritten)
 		}
 		linkEp.Close()
 	}

--- a/pkg/tcpip/link/qdisc/tbf/tbf_test.go
+++ b/pkg/tcpip/link/qdisc/tbf/tbf_test.go
@@ -40,9 +40,13 @@ type fakeEndpoint struct {
 	gsoMaxSize      uint32
 	supportedGSO    stack.SupportedGSO
 
-	mu             sync.Mutex
-	batchSizes     []int
-	bytesWritten   int
+	mu sync.Mutex
+
+	// +checklocks:mu
+	batchSizes []int
+	// +checklocks:mu
+	bytesWritten int
+	// +checklocks:mu
 	packetsWritten int
 	packetsWanted  int // 0 disables the done signal
 	done           chan struct{}

--- a/pkg/tcpip/link/tun/device.go
+++ b/pkg/tcpip/link/tun/device.go
@@ -41,14 +41,23 @@ var zeroMAC [6]byte
 
 // Device is an opened /dev/net/tun device.
 //
+// File lifetime must exclude final Release from concurrent file operations.
+// Capturing the endpoint under mu does not take an additional reference.
+//
 // +stateify savable
 type Device struct {
 	waiter.Queue
 
-	mu           deviceRWMutex `state:"nosave"`
-	endpoint     *tunEndpoint
+	mu deviceRWMutex `state:"nosave"`
+	// +checklocks:mu
+	endpoint *tunEndpoint
+	// +checklocks:mu
 	notifyHandle *channel.NotificationHandle
-	flags        Flags
+
+	// flags is set by SetIff and immutable for that association.
+	//
+	// +checklocks:mu
+	flags Flags
 }
 
 // Flags set properties of a Device
@@ -209,6 +218,7 @@ func (d *Device) MTU() (uint32, error) {
 func (d *Device) Write(data *buffer.View) (int64, error) {
 	d.mu.RLock()
 	endpoint := d.endpoint
+	flags := d.flags
 	d.mu.RUnlock()
 	if endpoint == nil {
 		return 0, linuxerr.EBADFD
@@ -221,7 +231,7 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 
 	// Packet information.
 	var pktInfoHdr PacketInfoHeader
-	if !d.flags.NoPacketInfo {
+	if !flags.NoPacketInfo {
 		if dataLen < PacketInfoHeaderSize {
 			// Ignore bad packet.
 			return dataLen, nil
@@ -235,7 +245,7 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 
 	// Ethernet header (TAP only).
 	var ethHdr header.Ethernet
-	if d.flags.TAP {
+	if flags.TAP {
 		if data.Size() < header.EthernetMinimumSize {
 			// Ignore bad packet.
 			return dataLen, nil
@@ -254,7 +264,7 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 		protocol = pktInfoHdr.Protocol()
 	case ethHdr != nil:
 		protocol = ethHdr.Type()
-	case d.flags.TUN:
+	case flags.TUN:
 		// TUN interface with IFF_NO_PI enabled, thus
 		// we need to determine protocol from version field
 		if data.Size() == 0 {
@@ -284,6 +294,7 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 func (d *Device) Read() (*buffer.View, error) {
 	d.mu.RLock()
 	endpoint := d.endpoint
+	noPacketInfo := d.flags.NoPacketInfo
 	d.mu.RUnlock()
 	if endpoint == nil {
 		return nil, linuxerr.EBADFD
@@ -293,17 +304,17 @@ func (d *Device) Read() (*buffer.View, error) {
 	if pkt == nil {
 		return nil, linuxerr.ErrWouldBlock
 	}
-	v := d.encodePkt(pkt)
+	v := encodePkt(pkt, noPacketInfo)
 	pkt.DecRef()
 	return v, nil
 }
 
 // encodePkt encodes packet for fd side.
-func (d *Device) encodePkt(pkt *stack.PacketBuffer) *buffer.View {
+func encodePkt(pkt *stack.PacketBuffer, noPacketInfo bool) *buffer.View {
 	var view *buffer.View
 
 	// Packet information.
-	if !d.flags.NoPacketInfo {
+	if !noPacketInfo {
 		view = buffer.NewView(PacketInfoHeaderSize + pkt.Size())
 		view.Grow(PacketInfoHeaderSize)
 		hdr := PacketInfoHeader(view.AsSlice())
@@ -371,10 +382,13 @@ type tunEndpoint struct {
 	name  string
 	isTap bool
 
-	mu            endpointMutex `state:"nosave"`
-	onCloseAction func()        `state:"nosave"`
-	persistent    bool
-	closed        bool
+	mu endpointMutex `state:"nosave"`
+	// +checklocks:mu
+	onCloseAction func() `state:"nosave"`
+	// +checklocks:mu
+	persistent bool
+	// +checklocks:mu
+	closed bool
 }
 
 func (e *tunEndpoint) setPersistent(v bool) {

--- a/pkg/tcpip/link/veth/veth.go
+++ b/pkg/tcpip/link/veth/veth.go
@@ -29,11 +29,17 @@ var _ stack.GSOEndpoint = (*Endpoint)(nil)
 
 // +stateify savable
 type veth struct {
-	mu           vethRWMutex `state:"nosave"`
-	closed       bool
+	mu vethRWMutex `state:"nosave"`
+
+	// +checklocks:mu
+	closed bool
+
 	backlogQueue chan vethPacket `state:"nosave"`
-	mtu          uint32
-	endpoints    [2]Endpoint
+
+	// +checklocks:mu
+	mtu uint32
+
+	endpoints [2]Endpoint
 }
 
 func (v *veth) close() {

--- a/pkg/tcpip/network/internal/fragmentation/fragmentation.go
+++ b/pkg/tcpip/network/internal/fragmentation/fragmentation.go
@@ -83,12 +83,19 @@ type FragmentID struct {
 //
 // +stateify savable
 type Fragmentation struct {
-	mu             sync.Mutex `state:"nosave"`
-	highLimit      int
-	lowLimit       int
-	reassemblers   map[FragmentID]*reassembler
-	rList          reassemblerList
-	memSize        int
+	mu        sync.Mutex `state:"nosave"`
+	highLimit int
+	lowLimit  int
+
+	// +checklocks:mu
+	reassemblers map[FragmentID]*reassembler
+
+	// +checklocks:mu
+	rList reassemblerList
+
+	// +checklocks:mu
+	memSize int
+
 	timeout        time.Duration
 	blockSize      uint16
 	clock          tcpip.Clock
@@ -101,6 +108,12 @@ type TimeoutHandler interface {
 	// OnReassemblyTimeout will be called with the first fragment (or nil, if the
 	// first fragment has not been received) of a packet whose reassembly has
 	// timed out.
+	//
+	// The call is synchronous with the owning Fragmentation's mutex held. The
+	// handler must not reenter that Fragmentation's Process or Release methods.
+	//
+	// checklocks cannot name that mutex because TimeoutHandler does not expose
+	// the owning Fragmentation.
 	OnReassemblyTimeout(pkt *stack.PacketBuffer)
 }
 
@@ -158,6 +171,8 @@ func NewFragmentation(blockSize uint16, highMemoryLimit, lowMemoryLimit int, rea
 // proto is the protocol number marked in the fragment being processed. It has
 // to be given here outside of the FragmentID struct because IPv6 should not use
 // the protocol to identify a fragment.
+//
+// +checklocksexclude:f.mu
 func (f *Fragmentation) Process(
 	id FragmentID, first, last uint16, more bool, proto uint8, pkt *stack.PacketBuffer) (
 	*stack.PacketBuffer, uint8, bool, error) {
@@ -180,6 +195,7 @@ func (f *Fragmentation) Process(
 
 	f.mu.Lock()
 	if f.reassemblers == nil {
+		f.mu.Unlock()
 		return nil, 0, false, fmt.Errorf("Release() called before fragmentation processing could finish")
 	}
 
@@ -228,6 +244,8 @@ func (f *Fragmentation) Process(
 }
 
 // Release releases all underlying resources.
+//
+// +checklocksexclude:f.mu
 func (f *Fragmentation) Release() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -237,40 +255,51 @@ func (f *Fragmentation) Release() {
 	f.reassemblers = nil
 }
 
+// +checklocks:f.mu
+// +checklocksexclude:r.mu
 func (f *Fragmentation) release(r *reassembler, timedOut bool) {
 	// Before releasing a fragment we need to check if r is already marked as done.
 	// Otherwise, we would delete it twice.
 	if r.checkDoneOrMark() {
 		return
 	}
+	// checkDoneOrMark waited for active processing under r.mu. Since it
+	// returned false, this call marked r done, so subsequent process calls
+	// return before accessing r.memSize, r.pkt, or r.holes. This call now owns
+	// those fields exclusively without r.mu. checklocks cannot model this
+	// ownership transfer.
 
 	delete(f.reassemblers, r.id)
 	f.rList.Remove(r)
-	f.memSize -= r.memSize
+	memSize := r.memSize // +checklocksignore
+	f.memSize -= memSize
 	if f.memSize < 0 {
 		log.Warningf("memory counter < 0 (%d), this is an accounting bug that requires investigation", f.memSize)
 		f.memSize = 0
 	}
 
+	pkt := r.pkt // +checklocksignore
 	if h := f.timeoutHandler; timedOut && h != nil {
-		h.OnReassemblyTimeout(r.pkt)
+		h.OnReassemblyTimeout(pkt)
 	}
-	if r.pkt != nil {
-		r.pkt.DecRef()
-		r.pkt = nil
+	if pkt != nil {
+		pkt.DecRef()
+		r.pkt = nil // +checklocksignore
 	}
-	for _, h := range r.holes {
+	for _, h := range r.holes { // +checklocksignore
 		if h.pkt != nil {
 			h.pkt.DecRef()
 			h.pkt = nil
 		}
 	}
-	r.holes = nil
+	r.holes = nil // +checklocksignore
 }
 
 // releaseReassemblersLocked releases already-expired reassemblers, then
 // schedules the job to call back itself for the remaining reassemblers if
-// any. This function must be called with f.mu locked.
+// any.
+//
+// +checklocks:f.mu
 func (f *Fragmentation) releaseReassemblersLocked() {
 	now := f.clock.NowMonotonic()
 	for {

--- a/pkg/tcpip/network/internal/fragmentation/fragmentation_test.go
+++ b/pkg/tcpip/network/internal/fragmentation/fragmentation_test.go
@@ -49,6 +49,38 @@ func pkt(size int, pieces ...string) *stack.PacketBuffer {
 	})
 }
 
+func TestProcessAfterRelease(t *testing.T) {
+	f := NewFragmentation(minBlockSize, HighFragThreshold, LowFragThreshold, reassembleTimeout, &faketime.NullClock{}, nil)
+	f.Release()
+
+	done := make(chan error, 1)
+	go func() {
+		p := pkt(1, "x")
+		out, _, _, err := f.Process(FragmentID{}, 0, 0, false, 0, p)
+		p.DecRef()
+		if out != nil {
+			out.DecRef()
+		}
+		if err == nil {
+			done <- errors.New("Process succeeded after Release")
+			return
+		}
+		f.Release()
+		done <- nil
+	}()
+
+	// Keep a real-time watchdog: the regression blocks on f.mu, and mutex
+	// waits are not durably blocked in synctest, so its clock would not advance.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Process after Release or subsequent Release blocked")
+	}
+}
+
 type processInput struct {
 	id    FragmentID
 	first uint16
@@ -137,6 +169,7 @@ func TestFragmentationProcess(t *testing.T) {
 						t.Errorf("got Process(%+v, %d, %d, %t, %d, _) = (_, %d, _, _), want = (_, %d, _, _)",
 							in.id, in.first, in.last, in.more, in.proto, proto, firstFragmentProto)
 					}
+					f.mu.Lock()
 					if _, ok := f.reassemblers[in.id]; ok {
 						t.Errorf("Process(%d) did not remove buffer from reassemblers", i)
 					}
@@ -145,6 +178,7 @@ func TestFragmentationProcess(t *testing.T) {
 							t.Errorf("Process(%d) did not remove buffer from rList", i)
 						}
 					}
+					f.mu.Unlock()
 				}
 			}
 		})
@@ -277,7 +311,10 @@ func TestReassemblingTimeout(t *testing.T) {
 						t.Fatalf("%s: got done = %t, want = %t", event.name, done, event.expectDone)
 					}
 				}
-				if got, want := f.memSize, event.memSizeAfterEvent; got != want {
+				f.mu.Lock()
+				gotMemSize := f.memSize
+				f.mu.Unlock()
+				if got, want := gotMemSize, event.memSizeAfterEvent; got != want {
 					t.Errorf("%s: got f.memSize = %d, want = %d", event.name, got, want)
 				}
 			}
@@ -324,6 +361,7 @@ func TestMemoryLimits(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	f.mu.Lock()
 	if _, ok := f.reassemblers[FragmentID{ID: 0}]; ok {
 		t.Errorf("Memory limits are not respected: id=0 has not been evicted.")
 	}
@@ -333,6 +371,7 @@ func TestMemoryLimits(t *testing.T) {
 	if _, ok := f.reassemblers[FragmentID{ID: 3}]; !ok {
 		t.Errorf("Implementation of memory limits is wrong: id=3 is not present.")
 	}
+	f.mu.Unlock()
 }
 
 func TestMemoryLimitsIgnoresDuplicates(t *testing.T) {
@@ -355,7 +394,10 @@ func TestMemoryLimitsIgnoresDuplicates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := f.memSize, memSize; got != want {
+	f.mu.Lock()
+	gotMemSize := f.memSize
+	f.mu.Unlock()
+	if got, want := gotMemSize, memSize; got != want {
 		t.Errorf("Wrong size, duplicates are not handled correctly: got=%d, want=%d.", got, want)
 	}
 }
@@ -693,11 +735,15 @@ func TestTimeoutHandler(t *testing.T) {
 				}
 			}
 			if !test.wantError {
+				f.mu.Lock()
 				r, ok := f.reassemblers[id]
+				if ok {
+					f.release(r, true)
+				}
+				f.mu.Unlock()
 				if !ok {
 					t.Fatal("Reassembler not found")
 				}
-				f.release(r, true)
 			}
 			switch {
 			case handler.pkt != nil && test.wantPkt == nil:

--- a/pkg/tcpip/network/internal/fragmentation/reassembler.go
+++ b/pkg/tcpip/network/internal/fragmentation/reassembler.go
@@ -15,14 +15,21 @@
 package fragmentation
 
 import (
+	"cmp"
 	"math"
-	"sort"
+	"slices"
 
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
 
+// hole describes a missing or received range in a reassembler.
+//
+// Published fields follow the owning reassembler's mutex or its exclusive
+// cleanup ownership. A hole has no owner pointer, so checklocks cannot resolve
+// that mutex for aliases to its fields.
+//
 // +stateify savable
 type hole struct {
 	first  uint16
@@ -34,18 +41,42 @@ type hole struct {
 	pkt *stack.PacketBuffer
 }
 
+// reassembler holds a packet's fragments until reassembly or release.
+//
+// Fragmentation.release claims exclusive ownership of memSize, holes, and pkt
+// by marking reassembly done under mu. Those cleanup accesses need exceptions
+// because checklocks cannot model the ownership transfer.
+//
 // +stateify savable
 type reassembler struct {
+	// reassemblerEntry is protected by the owning Fragmentation.mu. There is
+	// no reference back to that Fragmentation, so checklocks cannot name its
+	// mutex here.
 	reassemblerEntry
-	id        FragmentID
-	memSize   int
-	proto     uint8
-	mu        sync.Mutex `state:"nosave"`
-	holes     []hole
-	filled    int
-	done      bool
+	id FragmentID
+
+	// mu follows the owning Fragmentation.mu in lock order.
+	mu sync.Mutex `state:"nosave"`
+
+	// +checklocks:mu
+	memSize int
+
+	// +checklocks:mu
+	proto uint8
+
+	// +checklocks:mu
+	holes []hole
+
+	// +checklocks:mu
+	filled int
+
+	// +checklocks:mu
+	done bool
+
 	createdAt tcpip.MonotonicTime
-	pkt       *stack.PacketBuffer
+
+	// +checklocks:mu
+	pkt *stack.PacketBuffer
 }
 
 func newReassembler(id FragmentID, clock tcpip.Clock) *reassembler {
@@ -62,6 +93,7 @@ func newReassembler(id FragmentID, clock tcpip.Clock) *reassembler {
 	return r
 }
 
+// +checklocksexclude:r.mu
 func (r *reassembler) process(first, last uint16, more bool, proto uint8, pkt *stack.PacketBuffer) (*stack.PacketBuffer, uint8, bool, int, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -178,8 +210,8 @@ func (r *reassembler) process(first, last uint16, more bool, proto uint8, pkt *s
 		return nil, 0, false, memConsumed, nil
 	}
 
-	sort.Slice(r.holes, func(i, j int) bool {
-		return r.holes[i].first < r.holes[j].first
+	slices.SortFunc(r.holes, func(a, b hole) int {
+		return cmp.Compare(a.first, b.first)
 	})
 
 	resPkt := r.holes[0].pkt.Clone()
@@ -189,6 +221,7 @@ func (r *reassembler) process(first, last uint16, more bool, proto uint8, pkt *s
 	return resPkt, r.proto, true /* done */, memConsumed, nil
 }
 
+// +checklocksexclude:r.mu
 func (r *reassembler) checkDoneOrMark() bool {
 	r.mu.Lock()
 	prev := r.done

--- a/pkg/tcpip/network/internal/fragmentation/reassembler_test.go
+++ b/pkg/tcpip/network/internal/fragmentation/reassembler_test.go
@@ -188,6 +188,8 @@ func TestReassemblerProcess(t *testing.T) {
 			// after reassembler error or completion. Without release(), the
 			// reassembler will leak PacketBuffers.
 			defer func() {
+				r.mu.Lock()
+				defer r.mu.Unlock()
 				for _, h := range r.holes {
 					if h.pkt != nil {
 						h.pkt.DecRef()
@@ -221,6 +223,8 @@ func TestReassemblerProcess(t *testing.T) {
 				return bytes.Equal(a.Data().AsRange().ToSlice(), b.Data().AsRange().ToSlice())
 			}
 
+			r.mu.Lock()
+			defer r.mu.Unlock()
 			if isDone {
 				if diff := cmp.Diff(
 					test.want, r.holes,

--- a/pkg/tcpip/ports/ports.go
+++ b/pkg/tcpip/ports/ports.go
@@ -219,18 +219,27 @@ func (ad addrToDevice) isAvailable(res Reservation, portSpecified bool) bool {
 //
 // +stateify savable
 type PortManager struct {
-	// mu protects allocatedPorts.
 	// LOCK ORDERING: mu > ephemeralMu.
 	mu sync.RWMutex `state:"nosave"`
+
 	// allocatedPorts is a nesting of maps that ultimately map Reservations
 	// to FlagCounters describing whether the Reservation is valid and can
 	// be reused.
+	//
+	// mu also protects nested maps reached through allocatedPorts. Their
+	// helper receivers have no reference to this PortManager, so checklocks
+	// cannot express those helpers' owner-lock precondition.
+	//
+	// +checklocks:mu
 	allocatedPorts map[portDescriptor]addrToDevice
 
-	// ephemeralMu protects firstEphemeral and numEphemeral.
-	ephemeralMu    sync.RWMutex `state:"nosave"`
+	ephemeralMu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:ephemeralMu
 	firstEphemeral uint16
-	numEphemeral   uint16
+
+	// +checklocks:ephemeralMu
+	numEphemeral uint16
 }
 
 // NewPortManager creates new PortManager.
@@ -251,6 +260,9 @@ type PortTester func(port uint16) (good bool, err tcpip.Error)
 // possible ephemeral ports, allowing the caller to decide whether a given port
 // is suitable for its needs, and stopping when a port is found or an error
 // occurs.
+//
+// testPort is called synchronously without ephemeralMu held. Locks held by
+// the caller remain held during the callback.
 func (pm *PortManager) PickEphemeralPort(rng rand.RNG, testPort PortTester) (port uint16, err tcpip.Error) {
 	pm.ephemeralMu.RLock()
 	firstEphemeral := pm.firstEphemeral
@@ -289,6 +301,9 @@ func pickEphemeralPort(offset uint32, first, count uint16, testPort PortTester) 
 // An optional PortTester can be passed in which if provided will be used to
 // test if the picked port can be used. The function should return true if the
 // port is safe to use, false otherwise.
+//
+// testPort is called synchronously with pm.mu held and must not call methods
+// that acquire the same pm.mu.
 func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortTester) (reservedPort uint16, err tcpip.Error) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -313,20 +328,22 @@ func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortT
 		return res.Port, nil
 	}
 
-	// A port wasn't specified, so try to find one.
+	// A port wasn't specified, so try to find one. PickEphemeralPort calls
+	// this callback synchronously with pm.mu still held, but checklocks
+	// analyzes passed callbacks without the caller's lock state.
 	return pm.PickEphemeralPort(rng, func(p uint16) (bool, tcpip.Error) {
 		res.Port = p
-		if !pm.reserveSpecificPortLocked(res, false /* portSpecified */) {
+		if !pm.reserveSpecificPortLocked(res, false /* portSpecified */) { // +checklocksignore
 			return false, nil
 		}
 		if testPort != nil {
 			ok, err := testPort(p)
 			if err != nil {
-				pm.releasePortLocked(res)
+				pm.releasePortLocked(res) // +checklocksignore
 				return false, err
 			}
 			if !ok {
-				pm.releasePortLocked(res)
+				pm.releasePortLocked(res) // +checklocksignore
 				return false, nil
 			}
 		}
@@ -336,6 +353,8 @@ func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortT
 
 // reserveSpecificPortLocked tries to reserve the given port on all given
 // protocols.
+//
+// +checklocks:pm.mu
 func (pm *PortManager) reserveSpecificPortLocked(res Reservation, portSpecified bool) bool {
 	// Make sure the port is available.
 	for _, network := range res.Networks {
@@ -435,6 +454,9 @@ func (pm *PortManager) ReleasePort(res Reservation) {
 	pm.releasePortLocked(res)
 }
 
+// releasePortLocked releases a reservation without dropping the caller's lock.
+//
+// +checklocks:pm.mu
 func (pm *PortManager) releasePortLocked(res Reservation) {
 	dst := res.dst()
 	for _, network := range res.Networks {

--- a/pkg/tcpip/socketops.go
+++ b/pkg/tcpip/socketops.go
@@ -230,9 +230,12 @@ type SocketOptions struct {
 	// passing is enabled for IPv6.
 	ipv6RecvErrEnabled atomicbitops.Uint32
 
-	// errQueue is the per-socket error queue. It is protected by errQueueMu.
 	errQueueMu sync.Mutex `state:"nosave"`
-	errQueue   sockErrorList
+
+	// errQueue is the per-socket error queue.
+	//
+	// +checklocks:errQueueMu
+	errQueue sockErrorList
 
 	// bindToDevice determines the device to which the socket is bound.
 	bindToDevice atomicbitops.Int32
@@ -264,11 +267,12 @@ type SocketOptions struct {
 	// mark is the mark value set for the socket.
 	mark atomicbitops.Uint32
 
-	// mu protects the access to the below fields.
 	mu sync.Mutex `state:"nosave"`
 
 	// linger determines the amount of time the socket should linger before
 	// close. We currently implement this option for TCP socket only.
+	//
+	// +checklocks:mu
 	linger LingerOption
 }
 

--- a/pkg/tcpip/stack/rand.go
+++ b/pkg/tcpip/stack/rand.go
@@ -22,7 +22,9 @@ import (
 
 // lockedRandomSource provides a threadsafe rand.Source.
 type lockedRandomSource struct {
-	mu  sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	src rand.Source
 }
 

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -2857,10 +2857,11 @@ type ProtocolAddress struct {
 }
 
 var (
-	// danglingEndpointsMu protects access to danglingEndpoints.
 	danglingEndpointsMu sync.Mutex
 
 	// danglingEndpoints tracks all dangling endpoints no longer owned by the app.
+	//
+	// +checklocks:danglingEndpointsMu
 	danglingEndpoints = make(map[Endpoint]struct{})
 )
 

--- a/pkg/tcpip/transport/tcp/accept.go
+++ b/pkg/tcpip/transport/tcp/accept.go
@@ -86,9 +86,11 @@ type listenContext struct {
 	// this context. Can be nil if the context is created by the forwarder.
 	listenEP *Endpoint
 
-	// hasherMu protects hasher.
 	hasherMu hasherMutex
+
 	// hasher is the hash function used to generate a SYN cookie.
+	//
+	// +checklocks:hasherMu
 	hasher hash.Hash
 
 	// v6Only is true if listenEP is a dual stack socket and has the
@@ -231,7 +233,10 @@ func (l *listenContext) createConnectingEndpoint(s *segment, rcvdSynOpts header.
 // NOTE: h.ep.mu is not held and must be acquired if any state needs to be
 // modified.
 //
-// Precondition: if l.listenEP != nil, l.listenEP.mu must be locked.
+// If l.listenEP is nil, no listener mutex exists; callers must establish
+// that case. checklocks cannot express this conditional lock requirement.
+//
+// +checklocks:l.listenEP.mu
 func (l *listenContext) startHandshake(s *segment, opts header.TCPSynOptions, queue *waiter.Queue, owner tcpip.PacketOwner) (h *handshake, _ tcpip.Error) {
 	// Create new endpoint.
 	irs := s.sequenceNumber
@@ -258,7 +263,7 @@ func (l *listenContext) startHandshake(s *segment, opts header.TCPSynOptions, qu
 
 		// Propagate any inheritable options from the listening endpoint
 		// to the newly created endpoint.
-		l.listenEP.propagateInheritableOptionsLocked(ep) // +checklocksforce:ep.mu
+		l.listenEP.propagateInheritableOptionsLocked(ep)
 
 		if !ep.reserveTupleLocked() {
 			ep.mu.Unlock()
@@ -300,7 +305,10 @@ func (l *listenContext) startHandshake(s *segment, opts header.TCPSynOptions, qu
 // performHandshake performs a TCP 3-way handshake. On success, the new
 // established endpoint is returned.
 //
-// Precondition: if l.listenEP != nil, l.listenEP.mu must be locked.
+// If l.listenEP is nil, no listener mutex exists; callers must establish
+// that case. checklocks cannot express this conditional lock requirement.
+//
+// +checklocks:l.listenEP.mu
 func (l *listenContext) performHandshake(s *segment, opts header.TCPSynOptions, queue *waiter.Queue, owner tcpip.PacketOwner) (*Endpoint, tcpip.Error) {
 	waitEntry, notifyCh := waiter.NewChannelEntry(waiter.WritableEvents)
 	queue.EventRegister(&waitEntry)
@@ -433,7 +441,10 @@ func (a *acceptQueue) isFull() bool {
 // handleListenSegment is called when a listening endpoint receives a segment
 // and needs to handle it.
 //
+// Preconditions: ctx.listenEP == e.
+//
 // +checklocks:e.mu
+// +checklocks:ctx.listenEP.mu
 func (e *Endpoint) handleListenSegment(ctx *listenContext, s *segment) tcpip.Error {
 	e.rcvQueueMu.Lock()
 	rcvClosed := e.RcvClosed

--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -401,7 +401,11 @@ func (h *handshake) synRcvdState(s *segment) tcpip.Error {
 	// If we receive a SYN cookie ACK, just use the cookie seqnum.
 	if !h.checkAck(s) && h.listenEP != nil {
 		iss := s.ackNumber - 1
-		data, ok := h.listenEP.listenCtx.isCookieValid(s.id, iss, s.sequenceNumber-1)
+		// This handshake retains its listener, whose context is fixed once
+		// listening; repeated Listen calls change only the backlog.
+		// checklocks cannot express this listener-lifetime exception.
+		listenCtx := h.listenEP.listenCtx // +checklocksignore
+		data, ok := listenCtx.isCookieValid(s.id, iss, s.sequenceNumber-1)
 		if !ok || int(data) >= len(mssTable) {
 			// This isn't a valid cookie.
 			// RFC 793, page 72 (https://datatracker.ietf.org/doc/html/rfc793#page-72):
@@ -981,6 +985,8 @@ func sendTCP(r *stack.Route, tf tcpFields, pkt *stack.PacketBuffer, gso stack.GS
 }
 
 // makeOptions makes an options slice.
+//
+// +checklocks:e.mu
 func (e *Endpoint) makeOptions(sackBlocks []header.SACKBlock) []byte {
 	options := getOptions()
 	offset := 0
@@ -1161,7 +1167,7 @@ func (e *Endpoint) tryDeliverSegmentFromClosedEndpoint(s *segment) {
 	}
 	if ep == nil {
 		if !s.flags.Contains(header.TCPFlagRst) {
-			replyWithReset(e.stack, s, stack.DefaultTOS, tcpip.UseDefaultIPv4TTL, tcpip.UseDefaultIPv6HopLimit)
+			_ = replyWithReset(e.stack, s, stack.DefaultTOS, tcpip.UseDefaultIPv4TTL, tcpip.UseDefaultIPv6HopLimit)
 		}
 		return
 	}
@@ -1444,6 +1450,8 @@ func (e *Endpoint) resetKeepaliveTimer(receivedData bool) {
 }
 
 // disableKeepaliveTimer stops the keepalive timer.
+//
+// +checklocks:e.mu
 func (e *Endpoint) disableKeepaliveTimer() {
 	e.keepalive.Lock()
 	e.keepalive.timer.disable()

--- a/pkg/tcpip/transport/tcp/dispatcher.go
+++ b/pkg/tcpip/transport/tcp/dispatcher.go
@@ -35,7 +35,9 @@ import (
 //
 // +stateify savable
 type epQueue struct {
-	mu   epQueueMutex `state:"nosave"`
+	mu epQueueMutex `state:"nosave"`
+
+	// +checklocks:mu
 	list endpointList `state:"nosave"`
 }
 

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -286,38 +286,43 @@ func (*Stats) IsEndpointStats() {}
 // +stateify savable
 type sndQueueInfo struct {
 	sndQueueMu sndQueueMutex `state:"nosave"`
+
+	// +checklocks:sndQueueMu
 	TCPSndBufState
 }
 
-// CloneState clones sq into other. It is not thread safe
+// CloneState clones sq into other. The caller must exclusively own other.
+// other is a standalone snapshot without an owning mutex; the source-lock
+// contract does not establish the caller's exclusive ownership of other.
+//
+// +checklocks:sq.sndQueueMu
 func (sq *sndQueueInfo) CloneState(other *TCPSndBufState) {
 	other.SndBufSize = sq.SndBufSize
 	other.SndBufUsed = sq.SndBufUsed
 	other.SndClosed = sq.SndClosed
 	other.PacketTooBigCount = sq.PacketTooBigCount
 	other.SndMTU = sq.SndMTU
-	other.AutoTuneSndBufDisabled = atomicbitops.FromUint32(sq.AutoTuneSndBufDisabled.RacyLoad())
+	other.AutoTuneSndBufDisabled.Store(sq.AutoTuneSndBufDisabled.Load())
 }
 
 // Endpoint represents a TCP endpoint. This struct serves as the interface
 // between users of the endpoint and the protocol implementation; it is legal to
-// have concurrent goroutines make calls into the endpoint, they are properly
-// synchronized. The protocol implementation, however, runs in a single
-// goroutine.
+// have concurrent goroutines make calls into the endpoint, which synchronizes
+// their access with background protocol processing.
 //
 // Each endpoint has a few mutexes:
 //
-// e.mu -> Primary mutex for an endpoint must be held for all operations except
-// in e.Readiness where acquiring it will result in a deadlock in epoll
-// implementation.
+// e.mu -> Protects endpoint fields unless another mutex or atomic access is
+// documented. Readiness must not acquire it, since doing so would deadlock with
+// epoll.
 //
-// The following three mutexes can be acquired independent of e.mu but if
-// acquired with e.mu then e.mu must be acquired first.
+// The following mutexes can be acquired independently of e.mu, but if both
+// are acquired, e.mu must be acquired first.
 //
 // e.acceptMu -> Protects e.acceptQueue.
 // e.rcvQueueMu -> Protects e.rcvQueue's associated fields but not e.rcvQueue
 // itself.
-// e.sndQueueMu -> Protects the e.sndQueue and associated fields.
+// e.sndQueueInfo.sndQueueMu -> Protects non-atomic send-buffer state.
 // e.lastErrorMu -> Protects the lastError field.
 //
 // LOCKING/UNLOCKING of the endpoint.  The locking of an endpoint is different
@@ -344,16 +349,18 @@ func (sq *sndQueueInfo) CloneState(other *TCPSndBufState) {
 // +checklocksalias:snd.ep.mu=mu
 // +checklocksalias:rcv.ep.mu=mu
 // +checklocksalias:h.ep.mu=mu
+// +checklocksalias:listenCtx.listenEP.mu=mu
 // +stateify savable
 type Endpoint struct {
+	// +checklocks:mu
 	TCPEndpointStateInner
+
 	stack.TransportEndpointInfo
 	tcpip.DefaultSocketOptionsHandler
 
-	// EndpointEntry is used to queue endpoints for processing to the
-	// a given tcp processor goroutine.
-	//
-	// Precondition: epQueue.mu must be held to read/write this field..
+	// endpointEntry links this endpoint into a TCP processor's epQueue.
+	// The queue's mu protects the links. Endpoint has no reference to the
+	// owning epQueue, so checklocks cannot resolve that mutex.
 	endpointEntry `state:"nosave"`
 
 	// pendingProcessingMu protects pendingProcessing.
@@ -372,13 +379,17 @@ type Endpoint struct {
 
 	// hardError is meaningful only when state is stateError. It stores the
 	// error to be returned when read/write syscalls are called and the
-	// endpoint is in this state. hardError is protected by endpoint mu.
+	// endpoint is in this state.
+	//
+	// +checklocks:mu
 	hardError tcpip.Error
 
-	// lastError represents the last error that the endpoint reported;
-	// access to it is protected by the following mutex.
 	lastErrorMu lastErrorMutex `state:"nosave"`
-	lastError   tcpip.Error
+
+	// lastError represents the last error that the endpoint reported.
+	//
+	// +checklocks:lastErrorMu
+	lastError tcpip.Error
 
 	rcvQueueMu rcvQueueMutex `state:"nosave"`
 
@@ -392,12 +403,14 @@ type Endpoint struct {
 	// the buffer not including any segment overheads.
 	rcvMemUsed atomicbitops.Int32
 
-	// mu protects all endpoint fields unless documented otherwise. mu must
-	// be acquired before interacting with the endpoint fields.
+	// mu protects endpoint fields unless another mutex or atomic access is
+	// documented.
+	mu sync.CrossGoroutineMutex `state:"nosave"`
+
+	// ownedByUser indicates whether a user goroutine holds mu.
 	//
-	// During handshake, mu is locked by the protocol listen goroutine and
-	// released by the handshake completion goroutine.
-	mu          sync.CrossGoroutineMutex `state:"nosave"`
+	// +checklocks:mu
+	// +checkatomic
 	ownedByUser atomicbitops.Uint32
 
 	// rcvQueue is the queue for ready-for-delivery segments.
@@ -409,8 +422,9 @@ type Endpoint struct {
 	// methods.
 	state atomicbitops.Uint32 `state:".(EndpointState)"`
 
-	// connectionDirectionState holds current state of send and receive,
-	// accessed atomically
+	// connectionDirectionState records whether sending and receiving are closed.
+	//
+	// +checkatomic
 	connectionDirectionState atomicbitops.Uint32
 
 	// origEndpointState is only used during a restore phase to save the
@@ -418,12 +432,25 @@ type Endpoint struct {
 	// state.
 	origEndpointState uint32 `state:"nosave"`
 
-	isPortReserved    bool
-	isRegistered      bool
-	boundNICID        tcpip.NICID
-	route             *stack.Route `state:"nosave"`
-	ipv4TTL           uint8
-	ipv6HopLimit      int16
+	// +checklocks:mu
+	isPortReserved bool
+
+	// +checklocks:mu
+	isRegistered bool
+
+	// +checklocks:mu
+	boundNICID tcpip.NICID
+
+	// +checklocks:mu
+	route *stack.Route `state:"nosave"`
+
+	// +checklocks:mu
+	ipv4TTL uint8
+
+	// +checklocks:mu
+	ipv6HopLimit int16
+
+	// +checklocks:mu
 	isConnectNotified bool
 
 	// h stores a reference to the current handshake state if the endpoint is in
@@ -433,13 +460,19 @@ type Endpoint struct {
 	h *handshake
 
 	// portFlags stores the current values of port related flags.
+	//
+	// +checklocks:mu
 	portFlags ports.Flags
 
 	// Values used to reserve a port or register a transport endpoint
 	// (which ever happens first).
+	//
+	// +checklocks:mu
 	boundBindToDevice tcpip.NICID
-	boundPortFlags    ports.Flags
-	boundDest         tcpip.FullAddress
+	// +checklocks:mu
+	boundPortFlags ports.Flags
+	// +checklocks:mu
+	boundDest tcpip.FullAddress
 
 	// effectiveNetProtos contains the network protocols actually in use. In
 	// most cases it will only contain "netProto", but in cases like IPv6
@@ -447,19 +480,29 @@ type Endpoint struct {
 	// protocols (e.g., IPv6 and IPv4) or a single different protocol (e.g.,
 	// IPv4 when IPv6 endpoint is bound or connected to an IPv4 mapped
 	// address).
+	//
+	// +checklocks:mu
 	effectiveNetProtos []tcpip.NetworkProtocolNumber
 
-	// recentTSTime is the unix time when we last updated
+	// recentTSTime is the monotonic time when we last updated
 	// TCPEndpointStateInner.RecentTS.
+	//
+	// +checklocks:mu
 	recentTSTime tcpip.MonotonicTime
 
 	// shutdownFlags represent the current shutdown state of the endpoint.
+	//
+	// +checklocks:mu
 	shutdownFlags tcpip.ShutdownFlags
 
 	// tcpRecovery is the loss recovery algorithm used by TCP.
+	//
+	// +checklocks:mu
 	tcpRecovery tcpip.TCPRecovery
 
 	// sack holds TCP SACK related information for this endpoint.
+	//
+	// +checklocks:mu
 	sack SACKInfo
 
 	// delay enables Nagle's algorithm.
@@ -468,6 +511,8 @@ type Endpoint struct {
 	delay uint32
 
 	// scoreboard holds TCP SACK Scoreboard information for this endpoint.
+	//
+	// +checklocks:mu
 	scoreboard *SACKScoreboard
 
 	// segmentQueue is used to hand received segments to the protocol
@@ -477,6 +522,8 @@ type Endpoint struct {
 
 	// userMSS if non-zero is the MSS value explicitly set by the user
 	// for this endpoint using the TCP_MAXSEG setsockopt.
+	//
+	// +checklocks:mu
 	userMSS uint16
 
 	// maxSynRetries is the maximum number of SYN retransmits that TCP should
@@ -484,10 +531,14 @@ type Endpoint struct {
 	//
 	// NOTE: This is currently a no-op and does not change the SYN
 	// retransmissions.
+	//
+	// +checklocks:mu
 	maxSynRetries uint8
 
 	// windowClamp is used to bound the size of the advertised window to
 	// this value.
+	//
+	// +checklocks:mu
 	windowClamp uint32
 
 	// sndQueueInfo contains the implementation of the endpoint's send queue.
@@ -495,6 +546,8 @@ type Endpoint struct {
 
 	// cc stores the name of the Congestion Control algorithm to use for
 	// this endpoint.
+	//
+	// +checklocks:mu
 	cc tcpip.CongestionControlOption
 
 	// keepalive manages TCP keepalive state. When the connection is idle
@@ -507,6 +560,8 @@ type Endpoint struct {
 	// a connection w/ pending data to send. A connection that has pending
 	// unacked data will be forcibily aborted if the timeout is reached
 	// without any data being acked.
+	//
+	// +checklocks:mu
 	userTimeout time.Duration
 
 	// deferAccept if non-zero specifies a user specified time during
@@ -514,6 +569,8 @@ type Endpoint struct {
 	// ACK is a bare ACK and carries no data. If the timeout is crossed then
 	// the bare ACK is accepted and the connection is delivered to the
 	// listener.
+	//
+	// +checklocks:mu
 	deferAccept time.Duration
 
 	// acceptMu protects accepQueue
@@ -526,8 +583,10 @@ type Endpoint struct {
 	// +checklocks:acceptMu
 	acceptQueue acceptQueue
 
+	// +checklocks:mu
 	rcv *receiver `state:"wait"`
 
+	// +checklocks:mu
 	snd *sender `state:"wait"`
 
 	// The goroutine drain completion notification channel.
@@ -548,24 +607,32 @@ type Endpoint struct {
 	connectingAddress tcpip.Address
 
 	// amss is the advertised MSS to the peer by this endpoint.
+	//
+	// +checklocks:mu
 	amss uint16
 
 	// sendTOS represents IPv4 TOS or IPv6 TrafficClass,
 	// applied while sending packets. Defaults to 0 as on Linux.
+	//
+	// +checklocks:mu
 	sendTOS uint8
 
+	// +checklocks:mu
 	gso stack.GSO
 
 	stats Stats
 
-	// tcpLingerTimeout is the maximum amount of a time a socket
-	// a socket stays in TIME_WAIT state before being marked
-	// closed.
+	// tcpLingerTimeout bounds how long an orphaned socket in FIN-WAIT-2
+	// waits for the peer's FIN before closing.
+	//
+	// +checklocks:mu
 	tcpLingerTimeout time.Duration
 
 	// closed indicates that the user has called closed on the
 	// endpoint and at this point the endpoint is only around
 	// to complete the TCP shutdown.
+	//
+	// +checklocks:mu
 	closed bool
 
 	// txHash is the transport layer hash to be set on outbound packets
@@ -580,20 +647,28 @@ type Endpoint struct {
 
 	// lastOutOfWindowAckTime is the time at which the an ACK was sent in response
 	// to an out of window segment being received by this endpoint.
+	//
+	// +checklocks:mu
 	lastOutOfWindowAckTime tcpip.MonotonicTime
 
 	// finWait2Timer is used to reap orphaned sockets in FIN-WAIT-2 where the peer
 	// is yet to send a FIN but on our end the socket is fully closed i.e. endpoint.Close()
 	// has been called on the socket. This timer is not started for sockets that
 	// are waiting for a peer FIN but are not closed.
+	//
+	// +checklocks:mu
 	finWait2Timer tcpip.Timer `state:"nosave"`
 
 	// timeWaitTimer is used to reap a socket once a socket has been in TIME-WAIT state
 	// for tcp.DefaultTCPTimeWaitTimeout seconds.
+	//
+	// +checklocks:mu
 	timeWaitTimer tcpip.Timer `state:"nosave"`
 
-	// listenCtx is used by listening endpoints to store state used while listening for
-	// connections. Nil otherwise.
+	// listenCtx holds this endpoint's listener state. When non-nil,
+	// listenCtx.listenEP points back to this endpoint.
+	//
+	// +checklocks:mu
 	listenCtx *listenContext `state:"nosave"`
 
 	// limRdr is reused to avoid allocations.
@@ -808,12 +883,16 @@ func (e *Endpoint) EndpointState() EndpointState {
 }
 
 // setRecentTimestamp sets the recentTS field to the provided value.
+//
+// +checklocks:e.mu
 func (e *Endpoint) setRecentTimestamp(recentTS uint32) {
 	e.RecentTS = recentTS
 	e.recentTSTime = e.stack.Clock().NowMonotonic()
 }
 
 // recentTimestamp returns the value of the recentTS field.
+//
+// +checklocks:e.mu
 func (e *Endpoint) recentTimestamp() uint32 {
 	return e.RecentTS
 }
@@ -843,11 +922,25 @@ func calculateTTL(route *stack.Route, ipv4TTL uint8, ipv6HopLimit int16) uint8 {
 // +stateify savable
 type keepalive struct {
 	keepaliveMutex `state:"nosave"`
-	idle           time.Duration
-	interval       time.Duration
-	count          int
-	unacked        int
-	// should never be a zero timer if the endpoint is not closed.
+
+	// +checklocks:keepaliveMutex
+	idle time.Duration
+
+	// +checklocks:keepaliveMutex
+	interval time.Duration
+
+	// +checklocks:keepaliveMutex
+	count int
+
+	// +checklocks:keepaliveMutex
+	unacked int
+
+	// timer is initialized during endpoint construction and restore. All other
+	// accesses require the owning endpoint's mu; keepaliveMutex alone is not
+	// sufficient. keepalive has no reference to that endpoint, so checklocks
+	// cannot resolve its mutex.
+	//
+	// It should never be a zero timer if the endpoint is not closed.
 	timer timer       `state:"nosave"`
 	waker sleep.Waker `state:"nosave"`
 }
@@ -996,6 +1089,8 @@ func (e *Endpoint) Readiness(mask waiter.EventMask) waiter.EventMask {
 }
 
 // Purging pending rcv segments is only necessary on RST.
+//
+// +checklocks:e.mu
 func (e *Endpoint) purgePendingRcvQueue() {
 	if e.rcv != nil {
 		for e.rcv.pendingRcvdSegments.Len() > 0 {
@@ -1160,8 +1255,10 @@ func (e *Endpoint) closeNoShutdownLocked() {
 	e.waiterQueue.Notify(eventMask)
 }
 
-// closePendingAcceptableConnections closes all connections that have completed
-// handshake but not yet been delivered to the application.
+// closePendingAcceptableConnectionsLocked closes connections whose handshake
+// completed but which have not yet been delivered to the application.
+//
+// +checklocks:e.mu
 func (e *Endpoint) closePendingAcceptableConnectionsLocked() {
 	e.acceptMu.Lock()
 
@@ -1263,6 +1360,8 @@ func wndFromSpace(space int) int {
 
 // initialReceiveWindow returns the initial receive window to advertise in the
 // SYN/SYN-ACK.
+//
+// +checklocks:e.mu
 func (e *Endpoint) initialReceiveWindow() int {
 	rcvWnd := wndFromSpace(e.receiveBufferAvailable())
 	if rcvWnd > math.MaxUint16 {
@@ -1844,7 +1943,10 @@ func (e *Endpoint) OnSetReceiveBufferSize(rcvBufSz, oldSz int64) (newSz int64, p
 
 // OnSetSendBufferSize implements tcpip.SocketOptionsHandler.OnSetSendBufferSize.
 func (e *Endpoint) OnSetSendBufferSize(sz int64) int64 {
-	e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled.Store(1)
+	// Only this atomic flag is accessed without sndQueueMu; checklocks
+	// cannot express that leaf exception to the enclosing state guard.
+	disabled := &e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled // +checklocksignore
+	disabled.Store(1)
 	return sz
 }
 
@@ -2296,6 +2398,9 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 		}
 
 		bindToDevice := tcpip.NICID(e.ops.GetBindToDevice())
+		portFlags := e.portFlags
+		// PickEphemeralPort invokes this synchronously with e.mu held. Its
+		// PortTester parameter cannot express the captured owner's lock.
 		if _, err := e.stack.PickEphemeralPort(e.stack.SecureRNG(), func(p uint16) (bool, tcpip.Error) {
 			if sameAddr && p == e.TransportEndpointInfo.ID.RemotePort {
 				return false, nil
@@ -2305,7 +2410,7 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 				Transport:    ProtocolNumber,
 				Addr:         e.TransportEndpointInfo.ID.LocalAddress,
 				Port:         p,
-				Flags:        e.portFlags,
+				Flags:        portFlags,
 				BindToDevice: bindToDevice,
 				Dest:         addr,
 			}
@@ -2352,7 +2457,7 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 					Transport:    ProtocolNumber,
 					Addr:         e.TransportEndpointInfo.ID.LocalAddress,
 					Port:         p,
-					Flags:        e.portFlags,
+					Flags:        portFlags,
 					BindToDevice: bindToDevice,
 					Dest:         addr,
 				}
@@ -2361,15 +2466,18 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 				}
 			}
 
-			id := e.TransportEndpointInfo.ID
-			id.LocalPort = p
-			if err := e.stack.RegisterTransportEndpoint(netProtos, ProtocolNumber, id, e, e.portFlags, bindToDevice); err != nil {
+			// Initialize the ID before publishing the endpoint: ICMP error
+			// delivery reads it without acquiring e.mu.
+			oldID := e.TransportEndpointInfo.ID
+			e.TransportEndpointInfo.ID.LocalPort = p
+			if err := e.stack.RegisterTransportEndpoint(netProtos, ProtocolNumber, e.TransportEndpointInfo.ID, e, portFlags, bindToDevice); err != nil {
+				e.TransportEndpointInfo.ID = oldID
 				portRes := ports.Reservation{
 					Networks:     netProtos,
 					Transport:    ProtocolNumber,
 					Addr:         e.TransportEndpointInfo.ID.LocalAddress,
 					Port:         p,
-					Flags:        e.portFlags,
+					Flags:        portFlags,
 					BindToDevice: bindToDevice,
 					Dest:         addr,
 				}
@@ -2382,11 +2490,10 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 
 			// Port picking successful. Save the details of
 			// the selected port.
-			e.TransportEndpointInfo.ID = id
-			e.isPortReserved = true
-			e.boundBindToDevice = bindToDevice
-			e.boundPortFlags = e.portFlags
-			e.boundDest = addr
+			e.isPortReserved = true            // +checklocksignore
+			e.boundBindToDevice = bindToDevice // +checklocksignore
+			e.boundPortFlags = portFlags       // +checklocksignore
+			e.boundDest = addr                 // +checklocksignore
 			return true, nil
 		}); err != nil {
 			e.stack.Stats().TCP.FailedPortReservations.Increment()
@@ -2750,7 +2857,10 @@ func (e *Endpoint) Accept(peerAddr *tcpip.FullAddress) (tcpip.Endpoint, *waiter.
 		return nil, nil, &tcpip.ErrWouldBlock{}
 	}
 	if peerAddr != nil {
-		*peerAddr = n.getRemoteAddress()
+		// The child's tuple is fixed before enqueueing and remains valid
+		// even after it closes. Restored children finish rebinding before
+		// the listener accepts. checklocks cannot model this lifetime.
+		*peerAddr = n.getRemoteAddress() // +checklocksignore
 	}
 	return n, n.waiterQueue, nil
 }
@@ -2813,6 +2923,8 @@ func (e *Endpoint) bindLocked(addr tcpip.FullAddress) (err tcpip.Error) {
 		BindToDevice: bindToDevice,
 		Dest:         tcpip.FullAddress{},
 	}
+	// ReservePort invokes this synchronously with e.mu held. Its PortTester
+	// parameter cannot express the captured owner's lock.
 	port, err := e.stack.ReservePort(e.stack.SecureRNG(), portRes, func(p uint16) (bool, tcpip.Error) {
 		id := e.TransportEndpointInfo.ID
 		id.LocalPort = p
@@ -2824,7 +2936,7 @@ func (e *Endpoint) bindLocked(addr tcpip.FullAddress) (err tcpip.Error) {
 		// demuxer. Further connected endpoints always have a remote
 		// address/port. Hence this will only return an error if there is a matching
 		// listening endpoint.
-		if err := e.stack.CheckRegisterTransportEndpoint(netProtos, ProtocolNumber, id, e.portFlags, bindToDevice); err != nil {
+		if err := e.stack.CheckRegisterTransportEndpoint(netProtos, ProtocolNumber, id, portRes.Flags, bindToDevice); err != nil {
 			return false, nil
 		}
 		return true, nil
@@ -2872,6 +2984,7 @@ func (e *Endpoint) GetRemoteAddress() (tcpip.FullAddress, tcpip.Error) {
 	return e.getRemoteAddress(), nil
 }
 
+// +checklocks:e.mu
 func (e *Endpoint) getRemoteAddress() tcpip.FullAddress {
 	return tcpip.FullAddress{
 		Addr: e.TransportEndpointInfo.ID.RemoteAddress,
@@ -3095,14 +3208,15 @@ func (e *Endpoint) maxReceiveBufferSize() int {
 	return rs.Max
 }
 
-// directionState returns the close state of send and receive part of the endpoint
+// connDirectionState returns the send and receive close state of the endpoint.
 func (e *Endpoint) connDirectionState() connDirectionState {
 	return connDirectionState(e.connectionDirectionState.Load())
 }
 
-// updateDirectionState updates the close state of send and receive part of the endpoint
-func (e *Endpoint) updateConnDirectionState(state connDirectionState) connDirectionState {
-	return connDirectionState(e.connectionDirectionState.Swap(uint32(e.connDirectionState() | state)))
+// updateConnDirectionState adds closed directions to the endpoint's state.
+// Passing connDirectionStateOpen leaves the state unchanged.
+func (e *Endpoint) updateConnDirectionState(state connDirectionState) {
+	atomicbitops.OrUint32(&e.connectionDirectionState, uint32(state))
 }
 
 // rcvWndScaleForHandshake computes the receive window scale to offer to the
@@ -3125,6 +3239,8 @@ func (e *Endpoint) rcvWndScaleForHandshake() int {
 
 // updateRecentTimestamp updates the recent timestamp using the algorithm
 // described in https://tools.ietf.org/html/rfc7323#section-4.3
+//
+// +checklocks:e.mu
 func (e *Endpoint) updateRecentTimestamp(tsVal uint32, maxSentAck seqnum.Value, segSeq seqnum.Value) {
 	if e.SendTSOk && seqnum.Value(e.recentTimestamp()).LessThan(seqnum.Value(tsVal)) && segSeq.LessThanEq(maxSentAck) {
 		e.setRecentTimestamp(tsVal)
@@ -3134,6 +3250,8 @@ func (e *Endpoint) updateRecentTimestamp(tsVal uint32, maxSentAck seqnum.Value, 
 // maybeEnableTimestamp marks the timestamp option enabled for this endpoint if
 // the SYN options indicate that timestamp option was negotiated. It also
 // initializes the recentTS with the value provided in synOpts.TSval.
+//
+// +checklocks:e.mu
 func (e *Endpoint) maybeEnableTimestamp(synOpts header.TCPSynOptions) {
 	if synOpts.TS {
 		e.SendTSOk = true
@@ -3141,14 +3259,17 @@ func (e *Endpoint) maybeEnableTimestamp(synOpts header.TCPSynOptions) {
 	}
 }
 
+// +checklocks:e.mu
 func (e *Endpoint) tsVal(now tcpip.MonotonicTime) uint32 {
 	return e.TSOffset.TSVal(now)
 }
 
+// +checklocks:e.mu
 func (e *Endpoint) tsValNow() uint32 {
 	return e.tsVal(e.stack.Clock().NowMonotonic())
 }
 
+// +checklocks:e.mu
 func (e *Endpoint) elapsed(now tcpip.MonotonicTime, tsEcr uint32) time.Duration {
 	return e.TSOffset.Elapsed(now, tsEcr)
 }
@@ -3156,6 +3277,8 @@ func (e *Endpoint) elapsed(now tcpip.MonotonicTime, tsEcr uint32) time.Duration 
 // maybeEnableSACKPermitted marks the SACKPermitted option enabled for this endpoint
 // if the SYN options indicate that the SACK option was negotiated and the TCP
 // stack is configured to enable TCP SACK option.
+//
+// +checklocks:e.mu
 func (e *Endpoint) maybeEnableSACKPermitted(synOpts header.TCPSynOptions) {
 	var v tcpip.TCPSACKEnabled
 	if err := e.stack.TransportProtocolOption(ProtocolNumber, &v); err != nil {
@@ -3164,11 +3287,13 @@ func (e *Endpoint) maybeEnableSACKPermitted(synOpts header.TCPSynOptions) {
 	}
 	if bool(v) && synOpts.SACKPermitted {
 		e.SACKPermitted = true
-		e.stack.TransportProtocolOption(ProtocolNumber, &e.tcpRecovery)
+		_ = e.stack.TransportProtocolOption(ProtocolNumber, &e.tcpRecovery)
 	}
 }
 
 // maxOptionSize return the maximum size of TCP options.
+//
+// +checklocks:e.mu
 func (e *Endpoint) maxOptionSize() (size int) {
 	var maxSackBlocks [header.TCPMaxSACKBlocks]header.SACKBlock
 	options := e.makeOptions(maxSackBlocks[:])
@@ -3220,6 +3345,7 @@ func (e *Endpoint) completeStateLocked(s *TCPEndpointState) {
 	s.Sender.SpuriousRecovery = e.snd.spuriousRecovery
 }
 
+// +checklocks:e.mu
 func (e *Endpoint) initHostGSO() {
 	switch e.route.NetProto() {
 	case header.IPv4ProtocolNumber:
@@ -3236,6 +3362,7 @@ func (e *Endpoint) initHostGSO() {
 	e.gso.MaxSize = e.route.GSOMaxSize()
 }
 
+// +checklocks:e.mu
 func (e *Endpoint) initGSO() {
 	if e.route.HasHostGSOCapability() {
 		e.initHostGSO()
@@ -3294,6 +3421,8 @@ func GetTCPSendBufferLimits(sh tcpip.StackHandler) tcpip.SendBufferSizeOption {
 }
 
 // allowOutOfWindowAck returns true if an out-of-window ACK can be sent now.
+//
+// +checklocks:e.mu
 func (e *Endpoint) allowOutOfWindowAck() bool {
 	now := e.stack.Clock().NowMonotonic()
 
@@ -3330,7 +3459,10 @@ func (e *Endpoint) computeTCPSendBufferSize() int64 {
 
 	// Auto tuning is disabled when the user explicitly sets the send
 	// buffer size with SO_SNDBUF option.
-	if disabled := e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled.Load(); disabled == 1 {
+	// Only this atomic flag is accessed without sndQueueMu; checklocks
+	// cannot express that leaf exception to the enclosing state guard.
+	disabled := &e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled // +checklocksignore
+	if disabled.Load() == 1 {
 		return curSndBufSz
 	}
 

--- a/pkg/tcpip/transport/tcp/endpoint_state.go
+++ b/pkg/tcpip/transport/tcp/endpoint_state.go
@@ -177,6 +177,7 @@ func (e *Endpoint) closeEndpointAtRestore() {
 
 // Restore implements tcpip.RestoredEndpoint.Restore.
 func (e *Endpoint) Restore(s *stack.Stack) {
+	e.mu.Lock()
 	if !e.EndpointState().closed() {
 		e.keepalive.timer.init(s.Clock(), timerHandler(e, e.keepaliveTimerExpired))
 	}
@@ -189,7 +190,6 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 	e.ops.InitHandler(e, e.stack, GetTCPSendBufferLimits, GetTCPReceiveBufferLimits)
 	e.segmentQueue.thaw()
 
-	e.mu.Lock()
 	id := e.ID
 	terminateAtRestore := e.terminateAtRestore
 	e.mu.Unlock()
@@ -229,10 +229,13 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 				log.Infof("Cannot find the route %+v", e.TransportEndpointInfo.ID)
 				return
 			}
+			e.mu.Lock()
 			e.boundNICID = r.NICID()
+			e.mu.Unlock()
 			r.Release()
 		}
 		bind()
+		e.mu.Lock()
 		if e.connectingAddress.BitLen() == 0 {
 			e.connectingAddress = e.TransportEndpointInfo.ID.RemoteAddress
 			// This endpoint is accepted by netstack but not yet by
@@ -251,7 +254,6 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 		e.scoreboard.Reset()
 		// Unregister the endpoint before registering again during Connect.
 		e.stack.UnregisterTransportEndpoint(e.effectiveNetProtos, header.TCPProtocolNumber, e.TransportEndpointInfo.ID, e, e.boundPortFlags, e.boundBindToDevice)
-		e.mu.Lock()
 		err := e.connect(tcpip.FullAddress{NIC: e.boundNICID, Addr: e.connectingAddress, Port: e.TransportEndpointInfo.ID.RemotePort}, false /* handshake */)
 		if _, ok := err.(*tcpip.ErrConnectStarted); !ok {
 			log.Warningf("TCP endpoint connect failed for connected endpoint with ID: %+v err: %v", id, err)
@@ -302,7 +304,10 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 			connectedLoading.Wait()
 			listenLoading.Wait()
 			bind()
-			err := e.Connect(tcpip.FullAddress{NIC: e.boundNICID, Addr: e.connectingAddress, Port: e.TransportEndpointInfo.ID.RemotePort})
+			e.mu.Lock()
+			addr := tcpip.FullAddress{NIC: e.boundNICID, Addr: e.connectingAddress, Port: e.TransportEndpointInfo.ID.RemotePort}
+			e.mu.Unlock()
+			err := e.Connect(addr)
 			if _, ok := err.(*tcpip.ErrConnectStarted); !ok {
 				log.Warningf("TCP endpoint connect failed for connecting endpoint with ID: %+v err: %v", id, err)
 				e.Close()
@@ -351,8 +356,10 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 			tcpip.AsyncLoading.Done()
 		}()
 	case epState == StateClose:
+		e.mu.Lock()
 		e.isPortReserved = false
 		e.state.Store(uint32(StateClose))
+		e.mu.Unlock()
 		e.stack.CompleteTransportEndpointCleanup(e)
 		tcpip.DeleteDanglingEndpoint(e)
 	case epState == StateError:

--- a/pkg/tcpip/transport/tcp/forwarder.go
+++ b/pkg/tcpip/transport/tcp/forwarder.go
@@ -34,9 +34,12 @@ type Forwarder struct {
 	maxInFlight int
 	handler     func(*ForwarderRequest)
 
-	mu       forwarderMutex
+	mu forwarderMutex
+
+	// +checklocks:mu
 	inFlight map[stack.TransportEndpointID]struct{}
-	listen   *listenContext
+
+	listen *listenContext
 }
 
 // NewForwarder allocates and initializes a new forwarder with the given
@@ -107,8 +110,12 @@ func (f *Forwarder) HandlePacket(id stack.TransportEndpointID, pkt *stack.Packet
 // and passed to the client. Clients must eventually call Complete() on it, and
 // may optionally create an endpoint to represent it via CreateEndpoint.
 type ForwarderRequest struct {
-	mu         forwarderRequestMutex
-	forwarder  *Forwarder
+	mu forwarderRequestMutex
+
+	// +checklocks:mu
+	forwarder *Forwarder
+
+	// +checklocks:mu
 	segment    *segment
 	synOptions header.TCPSynOptions
 }
@@ -116,6 +123,8 @@ type ForwarderRequest struct {
 // ID returns the 4-tuple (src address, src port, dst address, dst port) that
 // represents the connection request.
 func (r *ForwarderRequest) ID() stack.TransportEndpointID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.segment.id
 }
 
@@ -135,7 +144,7 @@ func (r *ForwarderRequest) Complete(sendReset bool) {
 	r.forwarder.mu.Unlock()
 
 	if sendReset {
-		replyWithReset(r.forwarder.stack, r.segment, stack.DefaultTOS, tcpip.UseDefaultIPv4TTL, tcpip.UseDefaultIPv6HopLimit)
+		_ = replyWithReset(r.forwarder.stack, r.segment, stack.DefaultTOS, tcpip.UseDefaultIPv4TTL, tcpip.UseDefaultIPv6HopLimit)
 	}
 
 	// Release all resources.
@@ -155,7 +164,10 @@ func (r *ForwarderRequest) CreateEndpoint(queue *waiter.Queue) (tcpip.Endpoint, 
 	}
 
 	f := r.forwarder
-	ep, err := f.listen.performHandshake(r.segment, header.TCPSynOptions{
+	// NewForwarder creates f.listen with no listener endpoint, so there is
+	// no listener mutex to hold. checklocks cannot express that conditional
+	// lock requirement.
+	ep, err := f.listen.performHandshake(r.segment, header.TCPSynOptions{ // +checklocksignore
 		MSS:           r.synOptions.MSS,
 		WS:            r.synOptions.WS,
 		TS:            r.synOptions.TS,

--- a/pkg/tcpip/transport/tcp/protocol.go
+++ b/pkg/tcpip/transport/tcp/protocol.go
@@ -89,24 +89,42 @@ const (
 type protocol struct {
 	stack *stack.Stack
 
-	mu                         protocolRWMutex `state:"nosave"`
-	sackEnabled                bool
-	recovery                   tcpip.TCPRecovery
-	delayEnabled               bool
-	alwaysUseSynCookies        bool
-	sendBufferSize             tcpip.TCPSendBufferSizeRangeOption
-	recvBufferSize             tcpip.TCPReceiveBufferSizeRangeOption
-	congestionControl          string
+	mu protocolRWMutex `state:"nosave"`
+
+	// +checklocks:mu
+	sackEnabled bool
+	// +checklocks:mu
+	recovery tcpip.TCPRecovery
+	// +checklocks:mu
+	delayEnabled bool
+	// +checklocks:mu
+	alwaysUseSynCookies bool
+	// +checklocks:mu
+	sendBufferSize tcpip.TCPSendBufferSizeRangeOption
+	// +checklocks:mu
+	recvBufferSize tcpip.TCPReceiveBufferSizeRangeOption
+	// +checklocks:mu
+	congestionControl string
+	// availableCongestionControl is immutable after construction.
 	availableCongestionControl []string
-	moderateReceiveBuffer      bool
-	lingerTimeout              time.Duration
-	timeWaitTimeout            time.Duration
-	timeWaitReuse              tcpip.TCPTimeWaitReuseOption
-	minRTO                     time.Duration
-	maxRTO                     time.Duration
-	maxRetries                 uint32
-	synRetries                 uint8
-	dispatcher                 dispatcher
+	// +checklocks:mu
+	moderateReceiveBuffer bool
+	// +checklocks:mu
+	lingerTimeout time.Duration
+	// +checklocks:mu
+	timeWaitTimeout time.Duration
+	// +checklocks:mu
+	timeWaitReuse tcpip.TCPTimeWaitReuseOption
+	// +checklocks:mu
+	minRTO time.Duration
+	// +checklocks:mu
+	maxRTO time.Duration
+	// +checklocks:mu
+	maxRetries uint32
+	// +checklocks:mu
+	synRetries uint8
+
+	dispatcher dispatcher
 
 	// probe, if not nil, will be invoked any time an endpoint receives a
 	// TCP segment.

--- a/pkg/tcpip/transport/tcp/rack.go
+++ b/pkg/tcpip/transport/tcp/rack.go
@@ -77,6 +77,8 @@ func (rc *rackControl) init(snd *sender, iss seqnum.Value) {
 
 // update will update the RACK related fields when an ACK has been received.
 // See: https://tools.ietf.org/html/draft-ietf-tcpm-rack-09#section-6.2
+//
+// +checklocks:rc.snd.ep.mu
 func (rc *rackControl) update(seg *segment, ackSeg *segment) {
 	// Compute the RTT sample against the time the ACK was received at ingress
 	// (ackSeg.rcvdTime), not the current clock. The two differ when the ACK was
@@ -156,6 +158,8 @@ func (rc *rackControl) setDSACKSeen(dsackSeen bool) {
 
 // shouldSchedulePTO dictates whether we should schedule a PTO or not.
 // See https://tools.ietf.org/html/draft-ietf-tcpm-rack-08#section-7.5.1.
+//
+// +checklocks:s.ep.mu
 func (s *sender) shouldSchedulePTO() bool {
 	// Schedule PTO only if RACK loss detection is enabled.
 	return s.ep.tcpRecovery&tcpip.TCPRACKLossDetection != 0 &&

--- a/pkg/tcpip/transport/tcp/segment_queue.go
+++ b/pkg/tcpip/transport/tcp/segment_queue.go
@@ -18,14 +18,17 @@ package tcp
 //
 // +stateify savable
 type segmentQueue struct {
-	mu     segmentQueueMutex `state:"nosave"`
-	list   segmentList       `state:"wait"`
-	ep     *Endpoint
+	mu segmentQueueMutex `state:"nosave"`
+	// +checklocks:mu
+	list segmentList `state:"wait"`
+	ep   *Endpoint
+	// +checklocks:mu
 	frozen bool
 }
 
-// emptyLocked determines if the queue is empty.
-// Preconditions: q.mu must be held.
+// emptyLocked is equivalent to empty with q.mu already held.
+//
+// +checklocks:q.mu
 func (q *segmentQueue) emptyLocked() bool {
 	return q.list.Empty()
 }
@@ -39,13 +42,9 @@ func (q *segmentQueue) empty() bool {
 
 // enqueue adds the given segment to the queue.
 //
-// Returns true when the segment is successfully added to the queue, in which
-// case ownership of the reference is transferred to the queue. And returns
-// false if the queue is full, in which case ownership is retained by the
-// caller.
+// If enqueue succeeds, the queue acquires its own reference and returns true.
+// Otherwise it returns false. The caller retains its reference in either case.
 func (q *segmentQueue) enqueue(s *segment) bool {
-	// q.ep.receiveBufferParams() must be called without holding q.mu to
-	// avoid lock order inversion.
 	bufSz := q.ep.ops.GetReceiveBufferSize()
 	used := q.ep.receiveMemUsed()
 

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -247,6 +247,7 @@ func (wl *protectedWriteList) InsertAfter(before, seg *segment) {
 type rtt struct {
 	rttMutex `state:"nosave"`
 
+	// +checklocks:rttMutex
 	TCPRTTState
 }
 
@@ -346,6 +347,8 @@ func (s *sender) initCongestionControl(congestionControlName tcpip.CongestionCon
 }
 
 // initLossRecovery initiates the loss recovery algorithm for the sender.
+//
+// +checklocks:s.ep.mu
 func (s *sender) initLossRecovery() lossRecovery {
 	if s.ep.SACKPermitted {
 		return newSACKRecovery(s)
@@ -1430,6 +1433,7 @@ func checkDSACK(rcvdSeg *segment) bool {
 	return false
 }
 
+// +checklocks:s.ep.mu
 func (s *sender) recordRetransmitTS() {
 	// See: https://datatracker.ietf.org/doc/html/rfc3522#section-3.2
 	//

--- a/pkg/tcpip/transport/tcp/state.go
+++ b/pkg/tcpip/transport/tcp/state.go
@@ -417,6 +417,8 @@ type TCPSndBufState struct {
 
 	// AutoTuneSndBufDisabled indicates that the auto tuning of send buffer
 	// is disabled.
+	//
+	// +checkatomic
 	AutoTuneSndBufDisabled atomicbitops.Uint32
 }
 

--- a/pkg/tcpip/transport/tcp/test/e2e/forwarder_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/forwarder_test.go
@@ -39,6 +39,11 @@ func TestForwarderSendMSSLessThanMTU(t *testing.T) {
 	s := c.Stack()
 	ch := make(chan tcpip.Error, 1)
 	f := tcp.NewForwarder(s, 65536, 10, func(r *tcp.ForwarderRequest) {
+		if id := r.ID(); id.LocalAddress != context.StackAddr || id.LocalPort != context.StackPort ||
+			id.RemoteAddress != context.TestAddr || id.RemotePort != context.TestPort {
+			t.Errorf("ID() = %+v, want local %v:%d, remote %v:%d",
+				id, context.StackAddr, context.StackPort, context.TestAddr, context.TestPort)
+		}
 		var err tcpip.Error
 		c.EP, err = r.CreateEndpoint(&c.WQ)
 		ch <- err

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -153,9 +154,34 @@ func TestGiveUpConnect(t *testing.T) {
 	}
 }
 
+type handshakeClock struct {
+	tcpip.Clock
+	arm    <-chan struct{}
+	resume <-chan struct{}
+}
+
+func (c *handshakeClock) NowMonotonic() tcpip.MonotonicTime {
+	select {
+	case <-c.arm:
+		<-c.resume
+	default:
+	}
+	return c.Clock.NowMonotonic()
+}
+
 // Test for ICMP error handling without completing handshake.
 func TestConnectICMPError(t *testing.T) {
-	c := context.New(t, e2e.DefaultMTU)
+	arm, resume := make(chan struct{}), make(chan struct{})
+	c := context.NewWithOpts(t, context.Options{
+		EnableV4: true,
+		EnableV6: true,
+		MTU:      e2e.DefaultMTU,
+		Clock: &handshakeClock{
+			Clock:  faketime.NewManualClock(),
+			arm:    arm,
+			resume: resume,
+		},
+	})
 	defer c.Cleanup()
 
 	var wq waiter.Queue
@@ -163,16 +189,79 @@ func TestConnectICMPError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEndpoint failed: %s", err)
 	}
+	c.EP = ep
+	ep.SocketOptions().SetIPv4RecvError(true)
+	if err := c.Stack().SetPortRange(context.StackPort, context.StackPort); err != nil {
+		t.Fatalf("SetPortRange failed: %s", err)
+	}
 
 	waitEntry, notifyCh := waiter.NewChannelEntry(waiter.EventHUp)
 	wq.EventRegister(&waitEntry)
 	defer wq.EventUnregister(&waitEntry)
 
-	{
+	quoted := c.BuildSegmentWithAddrs(nil, &context.Headers{
+		SrcPort: context.StackPort,
+		DstPort: context.TestPort,
+		Flags:   header.TCPFlagSyn,
+	}, context.StackAddr, context.TestAddr)
+	defer quoted.Release()
+	quote := buffer.NewViewWithData(quoted.Flatten())
+	defer quote.Release()
+
+	var wg sync.WaitGroup
+	resumeHandshake := sync.OnceFunc(func() { close(resume) })
+	defer func() {
+		resumeHandshake()
+		wg.Wait()
+		for err := ep.SocketOptions().DequeueErr(); err != nil; err = ep.SocketOptions().DequeueErr() {
+			err.Payload.Release()
+		}
+	}()
+
+	// Pause the first handshake clock read, after registration but before SYN
+	// allocation and route cleanup can synchronize with ICMP delivery. Observe
+	// only the registry, not a signal from Connect after its ID assignment.
+	close(arm)
+	wg.Go(func() {
 		err := ep.Connect(tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort})
 		if d := cmp.Diff(&tcpip.ErrConnectStarted{}, err); d != "" {
-			t.Fatalf("ep.Connect(...) mismatch (-want +got):\n%s", d)
+			t.Errorf("ep.Connect(...) mismatch (-want +got):\n%s", d)
 		}
+	})
+	waitFor := func(what string, ready func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for !ready() {
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for %s", what)
+			}
+			runtime.Gosched()
+		}
+	}
+	id := stack.TransportEndpointID{
+		LocalAddress:  context.StackAddr,
+		LocalPort:     context.StackPort,
+		RemoteAddress: context.TestAddr,
+		RemotePort:    context.TestPort,
+	}
+	waitFor("endpoint registration", func() bool {
+		return c.Stack().FindTransportEndpoint(ipv4.ProtocolNumber, tcp.ProtocolNumber, id, 1) != nil
+	})
+	wg.Go(func() {
+		c.SendICMPPacket(header.ICMPv4DstUnreachable, header.ICMPv4HostUnreachable, nil, quote, e2e.DefaultMTU)
+	})
+	waitFor("queued ICMP error", func() bool { return ep.SocketOptions().PeekErr() != nil })
+	resumeHandshake()
+	wg.Wait()
+	sockErr := ep.SocketOptions().DequeueErr()
+	defer sockErr.Payload.Release()
+	if got, want := sockErr.Offender.Port, uint16(context.StackPort); got != want {
+		t.Errorf("ICMP error local port = %d, want %d", got, want)
+	}
+	// GetPacket may call FailNow before returning ownership of its allocated
+	// view. Avoid entering it after a failure that would bypass our Release.
+	if t.Failed() {
+		return
 	}
 
 	syn := c.GetPacket()
@@ -183,19 +272,15 @@ func TestConnectICMPError(t *testing.T) {
 		LastErrorLocked() tcpip.Error
 	})
 
-	c.SendICMPPacket(header.ICMPv4DstUnreachable, header.ICMPv4HostUnreachable, nil, syn, e2e.DefaultMTU)
-
-	for {
-		if err := wep.LastErrorLocked(); err != nil {
-			if d := cmp.Diff(&tcpip.ErrHostUnreachable{}, err); d != "" {
-				t.Errorf("ep.LastErrorLocked() mismatch (-want +got):\n%s", d)
-			}
-			break
-		}
-		time.Sleep(time.Millisecond)
+	if d := cmp.Diff(&tcpip.ErrHostUnreachable{}, wep.LastErrorLocked()); d != "" {
+		t.Errorf("ep.LastErrorLocked() mismatch (-want +got):\n%s", d)
 	}
 
-	<-notifyCh
+	select {
+	case <-notifyCh:
+	default:
+		t.Fatal("ICMP error did not notify the endpoint")
+	}
 
 	// The stack would have unregistered the endpoint because of the ICMP error.
 	// Expect a RST for any subsequent packets sent to the endpoint.
@@ -5797,6 +5882,14 @@ func TestTCPEndpointProbe(t *testing.T) {
 
 	c.CreateConnected(context.TestInitialSequenceNumber, 30000, -1 /* epRcvBuf */)
 	port = c.Port // c.Port is set during CreateConnected.
+
+	// The socket option callback can run concurrently with the probe without
+	// holding the endpoint or send queue mutex.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	wg.Go(func() {
+		_ = c.EP.(*tcp.Endpoint).OnSetSendBufferSize(4096)
+	})
 
 	data := []byte{1, 2, 3}
 	iss := seqnum.Value(context.TestInitialSequenceNumber).Add(1)

--- a/pkg/tcpip/transport/udp/endpoint.go
+++ b/pkg/tcpip/transport/udp/endpoint.go
@@ -67,26 +67,40 @@ type endpoint struct {
 	stats       tcpip.TransportEndpointStats
 	ops         tcpip.SocketOptions
 
-	// The following fields are used to manage the receive queue, and are
-	// protected by rcvMu.
-	rcvMu      sync.Mutex `state:"nosave"`
-	rcvReady   bool
-	rcvList    udpPacketList
+	// The following fields are used to manage the receive queue.
+	rcvMu sync.Mutex `state:"nosave"`
+	// +checklocks:rcvMu
+	rcvReady bool
+	// +checklocks:rcvMu
+	rcvList udpPacketList
+	// +checklocks:rcvMu
 	rcvBufSize int
-	rcvClosed  bool
+	// +checklocks:rcvMu
+	rcvClosed bool
+	// frozen prevents packet delivery during save/restore.
+	//
+	// +checklocks:rcvMu
+	frozen bool
 
 	lastErrorMu sync.Mutex `state:"nosave"`
-	lastError   tcpip.Error
 
-	// The following fields are protected by the mu mutex.
-	mu        sync.RWMutex `state:"nosave"`
+	// +checklocks:lastErrorMu
+	lastError tcpip.Error
+
+	mu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:mu
 	portFlags ports.Flags
 
-	// Values used to reserve a port or register a transport endpoint.
-	// (which ever happens first).
+	// Values used to reserve a port or register a transport endpoint,
+	// whichever happens first.
+	//
+	// +checklocks:mu
 	boundBindToDevice tcpip.NICID
-	boundPortFlags    ports.Flags
+	// +checklocks:mu
+	boundPortFlags ports.Flags
 
+	// +checklocks:mu
 	readShutdown bool
 
 	// effectiveNetProtos contains the network protocols actually in use. In
@@ -95,13 +109,13 @@ type endpoint struct {
 	// protocols (e.g., IPv6 and IPv4) or a single different protocol (e.g.,
 	// IPv4 when IPv6 endpoint is bound or connected to an IPv4 mapped
 	// address).
+	//
+	// +checklocks:mu
 	effectiveNetProtos []tcpip.NetworkProtocolNumber
 
-	// frozen indicates if the packets should be delivered to the endpoint
-	// during restore.
-	frozen bool
-
-	localPort  uint16
+	// +checklocks:mu
+	localPort uint16
+	// +checklocks:mu
 	remotePort uint16
 }
 
@@ -445,11 +459,12 @@ func (e *endpoint) prepareForWrite(p tcpip.Payloader, opts tcpip.WriteOptions) (
 	}, nil
 }
 
+// +checklocksexclude:e.mu
 func (e *endpoint) write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcpip.Error) {
 	// Do not hold lock when sending as loopback is synchronous and if the UDP
 	// datagram ends up generating an ICMP response then it can result in a
 	// deadlock where the ICMP response handling ends up acquiring this endpoint's
-	// mutex using e.mu.RLock() in endpoint.HandleControlPacket which can cause a
+	// mutex using e.mu.RLock() in endpoint.onICMPError which can cause a
 	// deadlock if another caller is trying to acquire e.mu in exclusive mode w/
 	// e.mu.Lock(). Since e.mu.Lock() prevents any new read locks to ensure the
 	// lock can be eventually acquired.
@@ -656,39 +671,9 @@ func (e *endpoint) Connect(addr tcpip.FullAddress) tcpip.Error {
 	defer e.mu.Unlock()
 
 	err := e.net.ConnectAndThen(addr, func(netProto tcpip.NetworkProtocolNumber, previousID, nextID stack.TransportEndpointID) tcpip.Error {
-		nextID.LocalPort = e.localPort
-		nextID.RemotePort = addr.Port
-
-		// Even if we're connected, this endpoint can still be used to send
-		// packets on a different network protocol, so we register both even if
-		// v6only is set to false and this is an ipv6 endpoint.
-		netProtos := []tcpip.NetworkProtocolNumber{netProto}
-		if netProto == header.IPv6ProtocolNumber && !e.ops.GetV6Only() && e.stack.CheckNetworkProtocol(header.IPv4ProtocolNumber) {
-			netProtos = []tcpip.NetworkProtocolNumber{
-				header.IPv4ProtocolNumber,
-				header.IPv6ProtocolNumber,
-			}
-		}
-
-		oldPortFlags := e.boundPortFlags
-
-		// Remove the old registration.
-		if e.localPort != 0 {
-			previousID.LocalPort = e.localPort
-			previousID.RemotePort = e.remotePort
-			e.stack.UnregisterTransportEndpoint(e.effectiveNetProtos, ProtocolNumber, previousID, e, oldPortFlags, e.boundBindToDevice)
-		}
-
-		nextID, btd, err := e.registerWithStack(netProtos, nextID)
-		if err != nil {
-			return err
-		}
-
-		e.localPort = nextID.LocalPort
-		e.remotePort = nextID.RemotePort
-		e.boundBindToDevice = btd
-		e.effectiveNetProtos = netProtos
-		return nil
+		// ConnectAndThen invokes this synchronously while Connect retains e.mu.
+		// checklocks cannot propagate that captured lock into the callback.
+		return e.registerConnectedEndpointLocked(netProto, previousID, nextID, addr.Port) // +checklocksignore
 	})
 	if err != nil {
 		return err
@@ -697,6 +682,46 @@ func (e *endpoint) Connect(addr tcpip.FullAddress) tcpip.Error {
 	e.rcvMu.Lock()
 	e.rcvReady = true
 	e.rcvMu.Unlock()
+	return nil
+}
+
+// registerConnectedEndpointLocked registers the connection selected by
+// network.Endpoint.ConnectAndThen.
+//
+// +checklocks:e.mu
+func (e *endpoint) registerConnectedEndpointLocked(netProto tcpip.NetworkProtocolNumber, previousID, nextID stack.TransportEndpointID, remotePort uint16) tcpip.Error {
+	nextID.LocalPort = e.localPort
+	nextID.RemotePort = remotePort
+
+	// Even if we're connected, this endpoint can still be used to send
+	// packets on a different network protocol, so we register both even if
+	// v6only is set to false and this is an ipv6 endpoint.
+	netProtos := []tcpip.NetworkProtocolNumber{netProto}
+	if netProto == header.IPv6ProtocolNumber && !e.ops.GetV6Only() && e.stack.CheckNetworkProtocol(header.IPv4ProtocolNumber) {
+		netProtos = []tcpip.NetworkProtocolNumber{
+			header.IPv4ProtocolNumber,
+			header.IPv6ProtocolNumber,
+		}
+	}
+
+	oldPortFlags := e.boundPortFlags
+
+	// Remove the old registration.
+	if e.localPort != 0 {
+		previousID.LocalPort = e.localPort
+		previousID.RemotePort = e.remotePort
+		e.stack.UnregisterTransportEndpoint(e.effectiveNetProtos, ProtocolNumber, previousID, e, oldPortFlags, e.boundBindToDevice)
+	}
+
+	nextID, btd, err := e.registerWithStack(netProtos, nextID)
+	if err != nil {
+		return err
+	}
+
+	e.localPort = nextID.LocalPort
+	e.remotePort = nextID.RemotePort
+	e.boundBindToDevice = btd
+	e.effectiveNetProtos = netProtos
 	return nil
 }
 
@@ -754,6 +779,9 @@ func (*endpoint) Accept(*tcpip.FullAddress) (tcpip.Endpoint, *waiter.Queue, tcpi
 	return nil, nil, &tcpip.ErrNotSupported{}
 }
 
+// registerWithStack reserves and registers id.
+//
+// +checklocks:e.mu
 func (e *endpoint) registerWithStack(netProtos []tcpip.NetworkProtocolNumber, id stack.TransportEndpointID) (stack.TransportEndpointID, tcpip.NICID, tcpip.Error) {
 	bindToDevice := tcpip.NICID(e.ops.GetBindToDevice())
 	if e.localPort == 0 {
@@ -791,6 +819,9 @@ func (e *endpoint) registerWithStack(netProtos []tcpip.NetworkProtocolNumber, id
 	return id, bindToDevice, err
 }
 
+// bindLocked binds an initial endpoint while retaining e.mu for the caller.
+//
+// +checklocks:e.mu
 func (e *endpoint) bindLocked(addr tcpip.FullAddress) tcpip.Error {
 	// Don't allow binding once endpoint is not in the initial state
 	// anymore.
@@ -799,30 +830,9 @@ func (e *endpoint) bindLocked(addr tcpip.FullAddress) tcpip.Error {
 	}
 
 	err := e.net.BindAndThen(addr, func(boundNetProto tcpip.NetworkProtocolNumber, boundAddr tcpip.Address) tcpip.Error {
-		// Expand netProtos to include v4 and v6 if the caller is binding to a
-		// wildcard (empty) address, and this is an IPv6 endpoint with v6only
-		// set to false.
-		netProtos := []tcpip.NetworkProtocolNumber{boundNetProto}
-		if boundNetProto == header.IPv6ProtocolNumber && !e.ops.GetV6Only() && boundAddr == (tcpip.Address{}) && e.stack.CheckNetworkProtocol(header.IPv4ProtocolNumber) {
-			netProtos = []tcpip.NetworkProtocolNumber{
-				header.IPv6ProtocolNumber,
-				header.IPv4ProtocolNumber,
-			}
-		}
-
-		id := stack.TransportEndpointID{
-			LocalPort:    addr.Port,
-			LocalAddress: boundAddr,
-		}
-		id, btd, err := e.registerWithStack(netProtos, id)
-		if err != nil {
-			return err
-		}
-
-		e.localPort = id.LocalPort
-		e.boundBindToDevice = btd
-		e.effectiveNetProtos = netProtos
-		return nil
+		// BindAndThen invokes this synchronously while bindLocked retains e.mu.
+		// checklocks cannot propagate that captured lock into the callback.
+		return e.registerBoundEndpointLocked(boundNetProto, boundAddr, addr.Port) // +checklocksignore
 	})
 	if err != nil {
 		return err
@@ -831,6 +841,37 @@ func (e *endpoint) bindLocked(addr tcpip.FullAddress) tcpip.Error {
 	e.rcvMu.Lock()
 	e.rcvReady = true
 	e.rcvMu.Unlock()
+	return nil
+}
+
+// registerBoundEndpointLocked registers the local address selected by
+// network.Endpoint.BindAndThen.
+//
+// +checklocks:e.mu
+func (e *endpoint) registerBoundEndpointLocked(boundNetProto tcpip.NetworkProtocolNumber, boundAddr tcpip.Address, port uint16) tcpip.Error {
+	// Expand netProtos to include v4 and v6 if the caller is binding to a
+	// wildcard (empty) address, and this is an IPv6 endpoint with v6only
+	// set to false.
+	netProtos := []tcpip.NetworkProtocolNumber{boundNetProto}
+	if boundNetProto == header.IPv6ProtocolNumber && !e.ops.GetV6Only() && boundAddr == (tcpip.Address{}) && e.stack.CheckNetworkProtocol(header.IPv4ProtocolNumber) {
+		netProtos = []tcpip.NetworkProtocolNumber{
+			header.IPv6ProtocolNumber,
+			header.IPv4ProtocolNumber,
+		}
+	}
+
+	id := stack.TransportEndpointID{
+		LocalPort:    port,
+		LocalAddress: boundAddr,
+	}
+	id, btd, err := e.registerWithStack(netProtos, id)
+	if err != nil {
+		return err
+	}
+
+	e.localPort = id.LocalPort
+	e.boundBindToDevice = btd
+	e.effectiveNetProtos = netProtos
 	return nil
 }
 
@@ -1090,15 +1131,14 @@ func (e *endpoint) SocketOptions() *tcpip.SocketOptions {
 
 // freeze prevents any more packets from being delivered to the endpoint.
 func (e *endpoint) freeze() {
-	e.mu.Lock()
+	e.rcvMu.Lock()
 	e.frozen = true
-	e.mu.Unlock()
+	e.rcvMu.Unlock()
 }
 
-// thaw unfreezes a previously frozen endpoint using endpoint.freeze() allows
-// new packets to be delivered again.
+// thaw allows packet delivery again after freeze.
 func (e *endpoint) thaw() {
-	e.mu.Lock()
+	e.rcvMu.Lock()
 	e.frozen = false
-	e.mu.Unlock()
+	e.rcvMu.Unlock()
 }

--- a/pkg/tcpip/transport/udp/endpoint_state.go
+++ b/pkg/tcpip/transport/udp/endpoint_state.go
@@ -55,8 +55,7 @@ func (e *endpoint) Restore(s *stack.Stack) {
 		return
 	}
 
-	// Unfreeze the endpoint to handle packets.
-	e.frozen = false
+	e.thaw()
 	e.ops.InitHandler(e, e.stack, tcpip.GetStackSendBufferLimits, tcpip.GetStackReceiveBufferLimits)
 }
 

--- a/tools/bazeldefs/go.bzl
+++ b/tools/bazeldefs/go.bzl
@@ -3,7 +3,7 @@
 load("@bazel_gazelle//:def.bzl", _gazelle = "gazelle")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@io_bazel_rules_go//go:def.bzl", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "GoArchive", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", _go_grpc_library = "go_grpc_library", _go_proto_library = "go_proto_library")
 load("//tools/bazeldefs:defs.bzl", "select_arch", "select_system")
 
@@ -88,6 +88,10 @@ def go_importpath(target):
     """Returns the importpath for the target."""
     return target[GoLibrary].importpath
 
+def go_binary_archive(target):
+    """Returns compiled Go archive metadata for a binary target."""
+    return target[GoArchive].data
+
 def go_library(name, bazel_cgo = False, bazel_cdeps = [], bazel_clinkopts = [], bazel_copts = [], **kwargs):
     """Wrapper for `go_library` rule.
 
@@ -159,13 +163,14 @@ def go_embed_libraries(target):
         return target.attr.embed
     return []
 
-def go_context(ctx, goos = None, goarch = None):
+def go_context(ctx, goos = None, goarch = None, attr = None):
     """Extracts a standard Go context struct.
 
     Args:
       ctx: the starlark context (required).
       goos: the GOOS value.
       goarch: the GOARCH value.
+      attr: the analyzed rule's attributes for aspect callers.
 
     Returns:
       A context Go struct with pointers to Go toolchain components.
@@ -174,7 +179,7 @@ def go_context(ctx, goos = None, goarch = None):
     # We don't change anything for the standard library analysis. All Go files
     # are available in all instances. Note that this includes the standard
     # library sources, which are analyzed by nogo.
-    go_ctx = _go_context(ctx)
+    go_ctx = _go_context(ctx, attr = attr)
 
     nogo_args = []
     if go_ctx.mode.race:

--- a/tools/checkescape/test3/BUILD
+++ b/tools/checkescape/test3/BUILD
@@ -1,0 +1,17 @@
+load("//tools:defs.bzl", "go_binary")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_binary(
+    name = "test3",
+    srcs = [
+        "main.go",
+        "tagged.go",
+    ],
+    gotags = ["checkescape_binary"],
+    pure = True,
+    testonly = True,
+)

--- a/tools/checkescape/test3/main.go
+++ b/tools/checkescape/test3/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Binary test3 checks build-tag and archive selection for nogo.
 package main
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
-
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+func main() {
+	// Analysis must use the binary's build tags to resolve this constant.
+	_ = taggedValue
 }

--- a/tools/checkescape/test3/tagged.go
+++ b/tools/checkescape/test3/tagged.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build checkescape_binary
+
 package main
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
+const taggedValue = true
 
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+// unusedAllocation remains in the Go archive but is removed by the linker.
+// The stack check rejects checkescape's conservative fallback if objdump fails.
+//
+// +mustescape:local,heap
+// +checkescape:stack
+//
+//go:noinline
+//go:nosplit
+func unusedAllocation() *int {
+	return new(int)
 }

--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -44,6 +44,20 @@ type foo struct {
 This will ensure that all accesses to bar are atomic, with the exception of
 operations on newly allocated objects (when detectable).
 
+An atomic call must use the annotated address as its receiver or atomic
+location. Storing that address as the payload of another atomic value does not
+make accesses through the stored pointer atomic.
+
+For global variables, atomic-use checking applies only when `+checkatomic` is
+present, for example:
+
+```go
+var (
+  // +checkatomic
+  globalValue atomicbitops.Int32
+)
+```
+
 ## Lock Enforcement
 
 Individual struct members may be protected by annotations that indicate locking
@@ -73,6 +87,8 @@ These semantics are enforceable on `sync.Mutex`, `sync.RWMutex` and
 `sync.Locker` fields. Semantics with respect to reading and writing are
 automatically detected and enforced. If an access is read-only, then the lock
 need only be held as a read lock, in the case of an `sync.RWMutex`.
+Annotations on a field declaration with multiple names apply to every named
+field in that declaration.
 
 The locks must be resolvable within the scope of the declaration. This means the
 lock must refer to one of:
@@ -82,7 +98,57 @@ lock must refer to one of:
 *   A global lock (e.g. globalMu).
 *   A lock resolvable from a global struct (e.g. globalX.mu).
 
+A field with multiple guards can additionally use `+checklocksreadany` when
+reads require **any one** guard, but writes require **all** guards exclusively:
+
+```go
+type example struct {
+    mu sync.Mutex
+    otherMu sync.RWMutex
+
+    // +checklocks:mu
+    // +checklocks:otherMu
+    // +checklocksreadany
+    value int
+}
+```
+
+A reader may hold `mu`, or hold `otherMu` for reading or writing. A writer must
+hold both mutexes for writing, so it excludes readers using either guard.
+The modifier applies only to fields, requires at least one `+checklocks` guard,
+and takes no arguments. Only value reads and immediately following loads
+qualify. Retaining an address or passing it to a function requires all guards
+exclusively, as with other guarded address uses; the modifier does not add
+alias lifetime tracking.
+With `+checkatomic`, atomic reads remain allowed without any guard. Holding
+any guard additionally permits an immediate non-atomic load, including a direct
+`atomicbitops.RacyLoad` call. This permission requires the field address's sole
+use to immediately follow it in the same basic block; retained addresses,
+casts, and deferred calls do not qualify. Atomic writes still require all
+guards exclusively, and non-atomic writes remain forbidden even with all
+guards held. The modifier cannot be combined with a field's `+checklocksignore`.
+
 Like atomic access enforcement, checks may be elided on newly allocated objects.
+
+### Global Variable Annotations
+
+Global variables also support lock and atomic annotations. Put annotations above
+a standalone declaration or above an individual entry in a `var` block:
+
+```go
+var globalMu sync.Mutex
+
+// +checklocks:globalMu
+var first int
+
+var (
+    // +checklocks:globalMu
+    second, third int
+)
+```
+
+Annotations apply to every named variable in that declaration or block entry.
+Comments above an entire `var` block do not annotate its entries.
 
 ### Function Annotations
 
@@ -195,13 +261,16 @@ by a mutex. Generally, this imposes the following requirements:
 
 For a read, one of the following must be true:
 
-1.  A lock held be held.
+1.  All guards must be held.
 1.  The access is atomic.
 
 For a write, both of the following must be true:
 
-1.  The lock must be held.
+1.  All guards must be held exclusively.
 1.  The write must be atomic.
+
+Shared RWMutex locks satisfy the lock-held read condition, but not the write
+condition.
 
 In order to annotate a relevant field, simply apply *both* annotations from
 above. For example:
@@ -217,10 +286,19 @@ type foo struct {
 
 This enforces that the preconditions above are upheld.
 
-This also applies to atomic wrapper types (for example, atomic.Int32). In the
-mixed case, lock-free access is limited to read-only atomic operations such as
-Load. Any atomic write operation (for example, Store, Swap, or Add) requires the
-lock to be held.
+This also applies to atomic wrapper types such as `atomic.Int32` and
+`atomic.Pointer[T]`. In the mixed case, lock-free access is limited to read-only
+atomic operations such as Load. Any atomic write operation (for example, Store,
+Swap, or Add) requires the lock to be held exclusively.
+
+The non-atomic `atomicbitops.RacyLoad` method follows the mixed read rule above.
+`RacyStore` and `RacyAdd` do not satisfy the atomic-write requirement, even with
+the lock held, because other readers may access the field atomically without
+locking. The exceptions for newly allocated objects still apply.
+
+Deferred atomic calls are supported for pure atomic fields and globals. Deferred
+calls on values with both atomic and mutex requirements remain unsupported: their
+locks would need to be checked when the calls execute, not when they are deferred.
 
 ## Ignoring and Forcing
 

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -17,6 +17,8 @@ package checklocks
 import (
 	"go/token"
 	"go/types"
+	"maps"
+	"slices"
 	"strings"
 
 	"golang.org/x/tools/go/ssa"
@@ -90,7 +92,7 @@ func (pc *passContext) checkTypeAlignment(pkg *types.Package, typ *types.Named) 
 	}
 }
 
-// atomicRules specify read constraints.
+// atomicRules specifies permitted access modes.
 type atomicRules int
 
 const (
@@ -98,22 +100,54 @@ const (
 	readWriteAtomic
 	readOnlyAtomic
 	mixedAtomic
+	readOnlyMixedAtomic
 )
 
-// checkAtomicCall checks for an atomic access.
-//
-// inst is the instruction analyzed, obj is used only for maybeFail.
-func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, ar atomicRules) {
+// functionPackage also resolves methods from indirectly imported packages,
+// which buildssa may represent using type information without an SSA package.
+func functionPackage(fn *ssa.Function) *types.Package {
+	if pkg := fn.Package(); pkg != nil {
+		return pkg.Pkg
+	}
+	obj, ok := fn.Object().(*types.Func)
+	if !ok || fn.Signature.Recv() == nil {
+		return nil
+	}
+	recv := obj.Type().(*types.Signature).Recv()
+	// Wrappers may retain the original method object but change or remove
+	// its receiver. They must not inherit the method's atomic privileges.
+	if recv == nil || !types.Identical(fn.Signature.Recv().Type(), recv.Type()) {
+		return nil
+	}
+	return obj.Pkg()
+}
+
+// checkAtomicCall checks whether inst accesses the value atomically.
+func (pc *passContext) checkAtomicCall(inst ssa.Instruction, value ssa.Value, ar atomicRules) {
+	allowNonAtomicRead := ar == mixedAtomic || ar == readOnlyMixedAtomic
 	switch x := inst.(type) {
-	case *ssa.Call:
-		if x.Common().IsInvoke() {
+	case *ssa.Call, *ssa.Defer:
+		if _, deferred := x.(*ssa.Defer); deferred {
+			// Pure atomic access does not depend on lock state. Guarded
+			// deferred accesses would need their locks checked at execution,
+			// not registration, so keep rejecting those conservatively.
+			if ar != readWriteAtomic {
+				break
+			}
+			// Deferred uses previously reached the force-aware fallback.
+			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
+				return
+			}
+		}
+		call := x.(ssa.CallInstruction).Common()
+		if call.IsInvoke() {
 			if ar != nonAtomic {
 				// This is an illegal interface dispatch.
 				pc.maybeFail(inst.Pos(), "dynamic dispatch with atomic-only field")
 			}
 			return
 		}
-		fn, ok := x.Common().Value.(*ssa.Function)
+		fn, ok := call.Value.(*ssa.Function)
 		if !ok {
 			if ar != nonAtomic {
 				// This is an illegal call to a non-static function.
@@ -121,7 +155,11 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 			}
 			return
 		}
-		pkg := fn.Package()
+		// Generic instantiation wrappers may have no package of their own.
+		if origin := fn.Origin(); origin != nil {
+			fn = origin
+		}
+		pkg := functionPackage(fn)
 		if pkg == nil {
 			if ar != nonAtomic {
 				// This is a call to some shared wrapper function.
@@ -133,12 +171,18 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 		if obj := fn.Object(); obj != nil && pc.pass.ImportObjectFact(obj, &lff) && lff.Ignore {
 			return
 		}
-		if name := pkg.Pkg.Name(); name != "atomic" && name != "atomicbitops" {
+		if name := pkg.Name(); name != "atomic" && name != "atomicbitops" {
 			if ar != nonAtomic {
 				// This is an illegal call to a non-atomic package function.
 				pc.maybeFail(inst.Pos(), "dispatch to non-atomic function with atomic-only field")
 			}
 			return
+		}
+		// Only the receiver (or first argument to a free function) is the
+		// atomic location. Storing the field's address as a pointer payload
+		// would let later accesses bypass its atomic requirement.
+		if len(call.Args) == 0 || call.Args[0] != value {
+			break
 		}
 		if ar == nonAtomic {
 			if fn.Signature.Recv() != nil {
@@ -151,8 +195,20 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic function")
 			}
 		}
-		if !strings.HasPrefix(fn.Name(), "Load") && ar == readOnlyAtomic {
-			// We are not allowing any reads in this context.
+		if pkg.Name() == "atomicbitops" && strings.HasPrefix(fn.Name(), "Racy") {
+			// Racy methods are non-atomic. Mixed access permits non-atomic
+			// reads under the lock, but writes must remain atomic for
+			// concurrent lock-free readers.
+			if ar != nonAtomic && (!allowNonAtomicRead || fn.Name() != "RacyLoad") {
+				if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
+					pc.maybeFail(inst.Pos(), "non-atomic operation %s on atomic-only field", fn.Name())
+				}
+			}
+			return
+		}
+		if (ar == readOnlyAtomic || ar == readOnlyMixedAtomic) &&
+			!strings.HasPrefix(fn.Name(), "Load") {
+			// We are not allowing any writes in this context.
 			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic write function, is a lock missing?")
 			}
@@ -162,11 +218,11 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 	case *ssa.ChangeType:
 		// Allow casts for atomic values, but nothing else.
 		if refs := x.Referrers(); refs != nil && len(*refs) == 1 {
-			pc.checkAtomicCall((*refs)[0], obj, ar)
+			pc.checkAtomicCall((*refs)[0], x, ar)
 			return
 		}
 	case *ssa.UnOp:
-		if x.Op == token.MUL && ar == mixedAtomic {
+		if x.Op == token.MUL && allowNonAtomicRead {
 			// This is allowed; this is a strict reading.
 			return
 		}
@@ -245,6 +301,45 @@ type almostInst interface {
 	Referrers() *[]ssa.Instruction
 }
 
+// isImmediateFieldRead reports whether inst reads a value without retaining
+// its address. allowRacyLoad also accepts atomicbitops.RacyLoad.
+func isImmediateFieldRead(inst almostInst, allowRacyLoad bool) bool {
+	switch x := inst.(type) {
+	case *ssa.Field:
+		return true
+	case *ssa.FieldAddr:
+		refs := x.Referrers()
+		if refs == nil || len(*refs) != 1 || x.Block() == nil {
+			return false
+		}
+		// Use instruction order, not source positions: a retained address
+		// may be loaded after an unlock, including on another control path.
+		use := (*refs)[0]
+		instrs := x.Block().Instrs
+		i := slices.Index(instrs, ssa.Instruction(x))
+		if i < 0 || i+1 >= len(instrs) || instrs[i+1] != use {
+			return false
+		}
+		switch use := use.(type) {
+		case *ssa.UnOp:
+			return use.Op == token.MUL && use.X == x
+		case *ssa.Call:
+			call := use.Common()
+			fn := call.StaticCallee()
+			if !allowRacyLoad || fn == nil || len(call.Args) != 1 || call.Args[0] != x {
+				return false
+			}
+			if origin := fn.Origin(); origin != nil {
+				fn = origin
+			}
+			pkg := functionPackage(fn)
+			return pkg != nil && pkg.Path() == "gvisor.dev/gvisor/pkg/atomicbitops" &&
+				fn.Signature.Recv() != nil && fn.Name() == "RacyLoad"
+		}
+	}
+	return false
+}
+
 // checkGuards checks the guards held.
 //
 // This also enforces atomicity constraints for fields that must be accessed
@@ -253,15 +348,21 @@ type almostInst interface {
 //
 // Note that this function is not called if lff.Ignore is true, since it cannot
 // discover any local anonymous functions or closures.
-func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj types.Object, ls *lockState, isWrite bool) {
+func (pc *passContext) checkGuards(inst almostInst, value, from ssa.Value, accessObj types.Object, ls *lockState, isWrite bool) {
 	var (
 		lgf         lockGuardFacts
 		guardsFound int
-		guardsHeld  = make(map[string]struct{}) // Keyed by resolved string.
+		// guardsHeld maps resolved names to exclusive (true) or shared (false).
+		guardsHeld = make(map[string]bool)
 	)
 
 	// Load the facts for the object accessed.
 	pc.importLockGuardFacts(accessObj, &lgf)
+	if lgf.ReadAny && lgf.AtomicDisposition == atomicDisallow {
+		// Unlike the optimistic isWrite check, alternative reader guards
+		// must not admit an address used for mutation or escaping aliases.
+		isWrite = isWrite || !isImmediateFieldRead(inst, false /* allowRacyLoad */)
+	}
 	pc.applyTypeAliases(ls, from)
 
 	// Check guards held.
@@ -275,14 +376,15 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		}
 		s, ok := ls.isHeld(r, isWrite)
 		if ok {
-			guardsHeld[s] = struct{}{}
+			_, exclusive := ls.isHeld(r, true)
+			guardsHeld[s] = exclusive
 			continue
 		}
 		if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
 			// Mark this as locked, since it has been forced. All
 			// forces are treated as an exclusive lock.
 			s, _ := ls.lockField(r, true /* exclusive */)
-			guardsHeld[s] = struct{}{}
+			guardsHeld[s] = true
 			continue
 		}
 		// Note that we may allow this if the disposition is atomic,
@@ -291,10 +393,15 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		// access is atomic. Further, len(guardsHeld) < guardsFound
 		// will be true for this case, so we require it to be
 		// read-only.
-		if lgf.AtomicDisposition != atomicRequired {
+		if lgf.AtomicDisposition != atomicRequired && (!lgf.ReadAny || isWrite) {
 			// There is no force key, no atomic access and no lock held.
 			pc.maybeFail(inst.Pos(), "invalid field access, %s (%s) must be locked when accessing %s (locks: %s)", guardName, s, accessObj.Name(), ls.String())
 		}
+	}
+
+	if lgf.ReadAny && lgf.AtomicDisposition == atomicDisallow && !isWrite && len(guardsHeld) == 0 {
+		guards := strings.Join(slices.Sorted(maps.Keys(lgf.GuardedBy)), ", ")
+		pc.maybeFail(inst.Pos(), "invalid field access, at least one of %s must be locked when reading %s (locks: %s)", guards, accessObj.Name(), ls.String())
 	}
 
 	// Check the atomic access for this field.
@@ -307,11 +414,22 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 				ar = readOnlyAtomic
 			} else {
 				ar = mixedAtomic
+				for _, exclusive := range guardsHeld {
+					if !exclusive {
+						ar = readOnlyMixedAtomic
+						break
+					}
+				}
 			}
+		}
+		if ar == readOnlyAtomic && lgf.ReadAny && len(guardsHeld) > 0 && isImmediateFieldRead(inst, true /* allowRacyLoad */) {
+			// Permit only an immediate non-atomic read under an alternative
+			// guard. Writes still need every guard held exclusively.
+			ar = readOnlyMixedAtomic
 		}
 		if refs := inst.Referrers(); refs != nil {
 			for _, otherInst := range *refs {
-				pc.checkAtomicCall(otherInst, accessObj, ar)
+				pc.checkAtomicCall(otherInst, value, ar)
 			}
 		}
 		// Check that this is not otherwise written non-atomically,
@@ -327,7 +445,7 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		// Check that this is *not* used atomically.
 		if refs := inst.Referrers(); refs != nil {
 			for _, otherInst := range *refs {
-				pc.checkAtomicCall(otherInst, accessObj, nonAtomic)
+				pc.checkAtomicCall(otherInst, value, nonAtomic)
 			}
 		}
 	}
@@ -373,22 +491,35 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 }
 
 // checkFieldAccess checks the validity of a field access.
-func (pc *passContext) checkFieldAccess(inst almostInst, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
+func (pc *passContext) checkFieldAccess(inst ssa.Value, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
 	fieldObj, _ := findField(structObj.Type(), field)
-	pc.checkGuards(inst, structObj, fieldObj, ls, isWrite)
+	pc.checkGuards(inst, inst, structObj, fieldObj, ls, isWrite)
 }
 
-// noReferrers wraps an instruction as an almostInst.
-type noReferrers struct {
+// globalAccess exposes a global's consuming instruction to atomic checks.
+type globalAccess struct {
 	ssa.Instruction
+	checkAtomic bool
 }
 
 // Referrers implements almostInst.Referrers.
-func (noReferrers) Referrers() *[]ssa.Instruction { return nil }
+func (a globalAccess) Referrers() *[]ssa.Instruction {
+	if !a.checkAtomic {
+		return nil
+	}
+	return &[]ssa.Instruction{a.Instruction}
+}
 
 // checkGlobalAccess checks the validity of a global access.
 func (pc *passContext) checkGlobalAccess(inst ssa.Instruction, g *ssa.Global, ls *lockState, isWrite bool) {
-	pc.checkGuards(noReferrers{inst}, g, g.Object(), ls, isWrite)
+	var lgf lockGuardFacts
+	pc.importLockGuardFacts(g.Object(), &lgf)
+	pc.checkGuards(globalAccess{
+		Instruction: inst,
+		// Only explicitly annotated globals opt into atomic-use checking.
+		// Direct writes are diagnosed separately by checkGuards.
+		checkAtomic: !isWrite && lgf.AtomicDisposition == atomicRequired,
+	}, g, g, g.Object(), ls, isWrite)
 }
 
 func (pc *passContext) checkCall(call callCommon, lff *lockFunctionFacts, ls *lockState) {
@@ -478,6 +609,10 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 		}
 		// Acquire the lock per the annotation.
 		r := fg.Resolver.resolveCall(pc, ls, call.Common().Args, call.Value())
+		if !r.valid() {
+			pc.maybeFail(call.Pos(), "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.lockField(r, fg.Exclusive); !ok && !lff.Ignore {
 			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 				pc.maybeFail(call.Pos(), "attempt to acquire %s (%s), but already held (locks: %s)", fieldName, s, ls.String())
@@ -495,10 +630,10 @@ func exclusiveStr(exclusive bool) string {
 }
 
 // checkFunctionCall checks preconditions for function calls, and tracks the
-// lock state by recording relevant calls to sync functions. Note that calls to
-// atomic functions are tracked by checkFieldAccess by looking directly at the
-// referrers (because ordering doesn't matter there, so we need not scan in
-// instruction order).
+// lock state by recording relevant calls to sync functions. Atomic field
+// referrers are checked by checkFieldAccess using the lock state at the field
+// access, not at a later use of a retained field address. Direct global atomic
+// operations are checked at their consuming instructions.
 func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *lockFunctionFacts, ls *lockState) {
 	// Extract the "receiver" properly.
 	var args []ssa.Value
@@ -525,6 +660,10 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check that excluded locks are not held on entry.
 	for fieldName, fg := range lff.ExcludedOnEntry {
 		r := resolve(fg)
+		if !r.valid() {
+			pc.maybeFail(callPos, "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); ok {
 			if !forced && !lff.Ignore {
 				if fg.Exclusive {
@@ -539,6 +678,10 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check all guards required are held.
 	for fieldName, fg := range lff.HeldOnEntry {
 		r := resolve(fg)
+		if !r.valid() {
+			pc.maybeFail(callPos, "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); !ok {
 			if !forced && !lff.Ignore {
 				pc.maybeFail(callPos, "must hold %s %s (%s) to call %s, but not held (locks: %s)", fieldName, exclusiveStr(fg.Exclusive), s, fn.Name(), ls.String())
@@ -658,9 +801,8 @@ type callCommon interface {
 // checkInstruction checks the legality the single instruction based on the
 // current lockState.
 func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionFacts, ls *lockState) (*ssa.Return, *lockState) {
-	// Record any observed globals, and check for violations. The global
-	// value is not itself an instruction, but we check all referrers to
-	// see where they are consumed.
+	// Globals are values, not instructions. Check each use with the current
+	// instruction's lock state.
 	var stackLocal [16]*ssa.Value
 	ops := inst.Operands(stackLocal[:])
 	for _, v := range ops {
@@ -668,10 +810,11 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 			continue
 		}
 		g, ok := (*v).(*ssa.Global)
-		if !ok {
+		if !ok || lff.Ignore {
 			continue
 		}
-		_, isWrite := inst.(*ssa.Store)
+		store, ok := inst.(*ssa.Store)
+		isWrite := ok && store.Addr == g
 		pc.checkGlobalAccess(inst, g, ls, isWrite)
 	}
 
@@ -710,20 +853,22 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 				nonCalls int
 			)
 			for _, ref := range *refs {
-				switch ref.(type) {
-				case *ssa.Call, *ssa.Defer:
-					// Analysis will be done on the call
-					// itself subsequently, including the
-					// lock state at the time of the call.
-					calls++
-				default:
-					// We need to analyze separately. Per
-					// below, this means that we'll analyze
-					// at closure construction time no zero
-					// assumptions about when it will be
-					// called.
-					nonCalls++
+				// Only direct calls are analyzed later with the lock
+				// state at invocation. Passing the closure as an argument
+				// gives no guarantee about when it will be called.
+				switch ref := ref.(type) {
+				case *ssa.Call:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
+				case *ssa.Defer:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
 				}
+				nonCalls++
 			}
 			if calls > 0 && nonCalls == 0 {
 				return nil, nil

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -25,6 +25,7 @@ import (
 const (
 	checkLocksAnnotation     = "// +checklocks:"
 	checkLocksAnnotationRead = "// +checklocksread:"
+	checkLocksReadAny        = "// +checklocksreadany"
 	checkLocksAcquires       = "// +checklocksacquire:"
 	checkLocksAcquiresRead   = "// +checklocksacquireread:"
 	checkLocksReleases       = "// +checklocksrelease:"

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -95,7 +95,7 @@ func (pc *passContext) observationsFor(obj types.Object) *objectObservations {
 }
 
 // forAllGlobals applies the given function to all globals.
-func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
+func (pc *passContext) forAllGlobals(fn func(vs *ast.ValueSpec, decl *ast.GenDecl)) {
 	for _, f := range pc.pass.Files {
 		for _, decl := range f.Decls {
 			d, ok := decl.(*ast.GenDecl)
@@ -103,7 +103,7 @@ func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
 				continue
 			}
 			for _, gs := range d.Specs {
-				fn(gs.(*ast.ValueSpec))
+				fn(gs.(*ast.ValueSpec), d)
 			}
 		}
 	}
@@ -151,12 +151,12 @@ func run(pass *analysis.Pass) (any, error) {
 	pc.extractLineFailures()
 
 	// Find all struct declarations and export relevant facts.
-	pc.forAllGlobals(func(vs *ast.ValueSpec) {
+	pc.forAllGlobals(func(vs *ast.ValueSpec, decl *ast.GenDecl) {
 		if ss, ok := vs.Type.(*ast.StructType); ok {
 			structType := pc.pass.TypesInfo.TypeOf(vs.Type).Underlying().(*types.Struct)
 			pc.structLockGuardFacts(structType, ss)
 		}
-		pc.globalLockGuardFacts(vs)
+		pc.globalLockGuardFacts(vs, decl)
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec, decl *ast.GenDecl) {
 		if ss, ok := ts.Type.(*ast.StructType); ok {

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -106,12 +106,14 @@ func fieldEntryEqual(left, right fieldEntry) bool {
 // fieldList is a simple list of fields, used in two types below.
 type fieldList []fieldEntry
 
-// resolvedValue is an ssa.Value with additional fields.
-//
-// This can be resolved to a string as part of a lock state.
+// resolvedValue identifies a lock through SSA or an exported global identity.
 type resolvedValue struct {
 	value     ssa.Value
 	fieldList fieldList
+
+	// key identifies an imported global whose declaration or package is absent
+	// from SSA. It is synthesized where the declaration's type is available.
+	key string
 }
 
 // makeResolvedValue makes a new resolvedValue.
@@ -124,15 +126,17 @@ func makeResolvedValue(v ssa.Value, fl fieldList) resolvedValue {
 
 // valid indicates whether this is a valid resolvedValue.
 func (rv *resolvedValue) valid() bool {
-	return rv.value != nil
+	return rv.value != nil || rv.key != ""
 }
 
 // valueAndObject returns a string and object.
 //
-// This uses the lockState valueAndObject in order to produce a string and
-// object for the base ssa.Value, then synthesizes a string representation
-// based on the fieldList.
+// An imported identity may have no source object. Otherwise, resolve the base
+// SSA value through lockState and synthesize its field path.
 func (rv *resolvedValue) valueAndObject(ls *lockState) (string, types.Object) {
+	if rv.key != "" {
+		return rv.key, nil
+	}
 	// N.B. obj.Type() and typ should be equal, but a check is omitted
 	// since, 1) we automatically chase through pointers during field
 	// resolution, and 2) obj may be nil if there is no source object.
@@ -172,6 +176,10 @@ type lockGuardFacts struct {
 	// traversal path.
 	GuardedBy map[string]fieldGuardResolver
 
+	// ReadAny allows immediate non-atomic reads with any guard held.
+	// Writes still require all guards exclusively.
+	ReadAny bool
+
 	// AtomicDisposition is the disposition for this field. Note that this
 	// can affect the interpretation of the GuardedBy field above, see the
 	// relevant comment.
@@ -191,6 +199,14 @@ type globalGuard struct {
 
 	// FieldList is the traversal path from object.
 	FieldList fieldList
+
+	// Key preserves the complete lock identity when export data omits the
+	// private global or the caller does not directly import its package.
+	Key string
+}
+
+func globalLockKey(pkgPath, name string) string {
+	return fmt.Sprintf("{global:%s.%s}", pkgPath, name)
 }
 
 // ssaPackager returns the ssa package.
@@ -205,8 +221,12 @@ func (g *globalGuard) resolveCommon(pc *passContext, ls *lockState) resolvedValu
 	if g.PackageName != "" && g.PackageName != state.Pkg.Pkg.Path() {
 		pkg = state.Pkg.Prog.ImportedPackage(g.PackageName)
 	}
-	v := pkg.Members[g.ObjectName].(ssa.Value)
-	return makeResolvedValue(v, g.FieldList)
+	if pkg != nil {
+		if v, ok := pkg.Members[g.ObjectName].(ssa.Value); ok {
+			return makeResolvedValue(v, g.FieldList)
+		}
+	}
+	return resolvedValue{key: g.Key}
 }
 
 // resolveStatic implements functionGuardResolver.resolveStatic.
@@ -730,6 +750,20 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 	}
 	for _, l := range cg.List {
 		pc.extractAnnotations(l.Text, map[string]func(string){
+			checkLocksReadAny: func(p string) {
+				if field, ok := obj.(*types.Var); !ok || !field.IsField() {
+					pc.maybeFail(obj.Pos(), "checklocksreadany is only valid on fields")
+					return
+				}
+				if p != "" {
+					pc.maybeFail(obj.Pos(), "checklocksreadany does not take arguments")
+					return
+				}
+				if lgf.ReadAny {
+					pc.maybeFail(obj.Pos(), "checklocksreadany specified more than once")
+				}
+				lgf.ReadAny = true
+			},
 			checkAtomicAnnotation: func(string) {
 				switch lgf.AtomicDisposition {
 				case atomicRequired:
@@ -773,6 +807,21 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 			},
 		})
 	}
+}
+
+// exportLockGuardFacts validates and exports accumulated lock guard facts.
+// For fields, both the doc comment and trailing comment must have been read.
+func (pc *passContext) exportLockGuardFacts(obj types.Object, lgf *lockGuardFacts) {
+	if lgf.ReadAny {
+		if len(lgf.GuardedBy) == 0 {
+			pc.maybeFail(obj.Pos(), "checklocksreadany requires at least one checklocks guard")
+			lgf.ReadAny = false
+		}
+		if lgf.AtomicDisposition == atomicIgnore {
+			pc.maybeFail(obj.Pos(), "checklocksreadany cannot be combined with checklocksignore")
+			lgf.ReadAny = false
+		}
+	}
 	// Save only if there is something meaningful.
 	if len(lgf.GuardedBy) > 0 || lgf.AtomicDisposition != atomicDisallow {
 		pc.pass.ExportObjectFact(obj, lgf)
@@ -783,9 +832,9 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 func (pc *passContext) findGlobalGuard(pos token.Pos, guardName string) (*globalGuard, types.Object, bool) {
 	// Attempt to resolve the object.
 	parts := strings.Split(guardName, ".")
-	globalObj := pc.pass.Pkg.Scope().Lookup(parts[0])
-	if globalObj == nil {
-		// No global object.
+	globalObj, ok := pc.pass.Pkg.Scope().Lookup(parts[0]).(*types.Var)
+	if !ok {
+		// A type or constant cannot identify a global lock.
 		return nil, nil, false
 	}
 	fl, lockObj, ok := pc.maybeFindFieldListObj(pos, globalObj, parts[1:])
@@ -796,10 +845,18 @@ func (pc *passContext) findGlobalGuard(pos token.Pos, guardName string) (*global
 	if pc.lockKind(pos, lockObj) == nil {
 		return nil, nil, false
 	}
+	key := globalLockKey(pc.pass.Pkg.Path(), globalObj.Name())
+	typ := globalObj.Type()
+	for _, entry := range fl {
+		var obj types.Object
+		key, obj = entry.synthesize(key, typ)
+		typ = obj.Type()
+	}
 	return &globalGuard{
 		ObjectName:  parts[0],
 		PackageName: pc.pass.Pkg.Path(),
 		FieldList:   fl,
+		Key:         key,
 	}, lockObj, true
 }
 
@@ -817,7 +874,6 @@ func (pc *passContext) findGlobalFunctionGuard(pos token.Pos, guardName string) 
 
 // structLockGuardFacts finds all relevant guard information for structures.
 func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.StructType) {
-	var fieldObj *types.Var
 	findLocal := func(pos token.Pos, guardName string) (fieldGuardResolver, bool) {
 		// Try to resolve from the local structure first.
 		if fl, _, objs, ok := pc.resolveFieldListParts(pos, structType, strings.Split(guardName, ".")); ok {
@@ -834,20 +890,28 @@ func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.St
 		// Attempt a global resolution.
 		return pc.findGlobalFieldGuard(pos, guardName)
 	}
-	for i, field := range ss.Fields.List {
-		var lgf lockGuardFacts
-		fieldObj = structType.Field(i) // N.B. Captured above.
-		if field.Doc != nil {
-			pc.fillLockGuardFacts(fieldObj, field.Doc, findLocal, &lgf)
-		}
-		if field.Comment != nil {
-			pc.fillLockGuardFacts(fieldObj, field.Comment, findLocal, &lgf)
-		}
+	fieldIndex := 0
+	for _, field := range ss.Fields.List {
+		// A declaration may name several fields; an embedded field has no
+		// names but still occupies one position in the expanded struct type.
+		for range max(1, len(field.Names)) {
+			fieldObj := structType.Field(fieldIndex)
+			fieldIndex++
+			var lgf lockGuardFacts
+			if field.Doc != nil {
+				pc.fillLockGuardFacts(fieldObj, field.Doc, findLocal, &lgf)
+			}
+			if field.Comment != nil {
+				pc.fillLockGuardFacts(fieldObj, field.Comment, findLocal, &lgf)
+			}
 
-		// See above, for anonymous structure fields.
-		if ss, ok := field.Type.(*ast.StructType); ok {
-			if st, ok := types.Unalias(fieldObj.Type()).(*types.Struct); ok {
-				pc.structLockGuardFacts(st, ss)
+			pc.exportLockGuardFacts(fieldObj, &lgf)
+
+			// See above, for anonymous structure fields.
+			if ss, ok := field.Type.(*ast.StructType); ok {
+				if st, ok := types.Unalias(fieldObj.Type()).(*types.Struct); ok {
+					pc.structLockGuardFacts(st, ss)
+				}
 			}
 		}
 	}
@@ -856,10 +920,21 @@ func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.St
 // globalLockGuardFacts finds all relevant guard information for globals.
 //
 // Note that the Type is checked in checklocks.go at the top-level.
-func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec) {
-	var lgf lockGuardFacts
-	globalObj := pc.pass.TypesInfo.ObjectOf(vs.Names[0])
-	pc.fillLockGuardFacts(globalObj, vs.Doc, pc.findGlobalFieldGuard, &lgf)
+func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec, decl *ast.GenDecl) {
+	cg := vs.Doc
+	if !decl.Lparen.IsValid() {
+		// Standalone declarations attach their comments to the GenDecl.
+		cg = decl.Doc
+	}
+	for _, name := range vs.Names {
+		if name.Name == "_" {
+			continue
+		}
+		var lgf lockGuardFacts
+		globalObj := pc.pass.TypesInfo.ObjectOf(name)
+		pc.fillLockGuardFacts(globalObj, cg, pc.findGlobalFieldGuard, &lgf)
+		pc.exportLockGuardFacts(globalObj, &lgf)
+	}
 }
 
 // countFields gives an accurate field count, according for unnamed arguments
@@ -984,6 +1059,7 @@ func (pc *passContext) functionFacts(d *ast.FuncDecl) {
 				// extremely rare.
 				lff.Ignore = true
 			},
+			checkLocksReadAny:        func(string) { pc.maybeFail(d.Pos(), "checklocksreadany is only valid on fields") },
 			checkLocksAnnotation:     func(guardName string) { lff.addGuardedBy(pc, d, guardName, true /* exclusive */) },
 			checkLocksAnnotationRead: func(guardName string) { lff.addGuardedBy(pc, d, guardName, false /* exclusive */) },
 			checkLocksAcquires:       func(guardName string) { lff.addAcquires(pc, d, guardName, true /* exclusive */) },
@@ -1011,6 +1087,7 @@ func (pc *passContext) typeAliasFacts(ts *ast.TypeSpec, decl *ast.GenDecl) {
 		}
 		for _, l := range cg.List {
 			pc.extractAnnotations(l.Text, map[string]func(string){
+				checkLocksReadAny: func(string) { pc.maybeFail(ts.Pos(), "checklocksreadany is only valid on fields") },
 				checkLocksAlias: func(guardName string) {
 					if !ok {
 						pc.maybeFail(ts.Pos(), "annotation %s is only valid on struct types", guardName)

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -287,12 +287,18 @@ func (l *lockState) valueAndObject(v ssa.Value) (string, types.Object) {
 		}
 		return fmt.Sprintf("{param:%s}", x.Name()), x.Object()
 	case *ssa.Global:
-		return fmt.Sprintf("{global:%s}", x.Name()), x.Object()
+		return globalLockKey(x.Pkg.Pkg.Path(), x.Name()), x.Object()
 	case *ssa.FreeVar:
 		// Attempt to resolve this, in case we are being invoked in a
 		// scope where all the variables are bound.
 		v, ok := l.stored[x]
 		if ok {
+			// Nested closures capture the enclosing FreeVar. Follow that
+			// binding before dereferencing the captured location. A Store
+			// can instead place an address here, with a different type.
+			if fv, ok := v.(*ssa.FreeVar); ok && types.Identical(fv.Type(), x.Type()) {
+				return l.valueAndObject(fv)
+			}
 			// The FreeVar is typically bound to a location, so we
 			// check what's been stored there. Note that the second
 			// may map to the same FreeVar, which we can check.

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -28,9 +28,12 @@ go_library(
         "rwmutex.go",
         "test.go",
     ],
-    # This ensures that there are no dependencies, since we want to explicitly
-    # control expected failures for analysis.
+    # Disable generated marshal/state sources so they do not add unexpected
+    # diagnostics to this fixture.
     marshal = False,
     stateify = False,
-    deps = ["//tools/checklocks/test/crosspkg"],
+    deps = [
+        "//pkg/atomicbitops",
+        "//tools/checklocks/test/crosspkg",
+    ],
 )

--- a/tools/checklocks/test/atomicfields/BUILD
+++ b/tools/checklocks/test/atomicfields/BUILD
@@ -6,11 +6,10 @@ package(
 )
 
 go_library(
-    name = "crosspkg",
-    srcs = ["crosspkg.go"],
-    # See next level up.
+    name = "atomicfields",
+    srcs = ["atomicfields.go"],
     marshal = False,
     stateify = False,
-    visibility = ["//tools/checklocks/test:__pkg__"],
-    deps = ["//tools/checklocks/test/atomicfields"],
+    visibility = ["//tools/checklocks/test/crosspkg:__pkg__"],
+    deps = ["//pkg/atomicbitops"],
 )

--- a/tools/checklocks/test/atomicfields/atomicfields.go
+++ b/tools/checklocks/test/atomicfields/atomicfields.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package atomicfields exposes atomic fields to a consumer that does not
+// directly import their types' packages.
+package atomicfields
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
+)
+
+type Values struct {
+	// +checkatomic
+	Standard atomic.Pointer[int]
+	// +checkatomic
+	Bitops atomicbitops.Uint64
+	// +checkatomic
+	Promoted WrappedAtomic
+
+	Mu      sync.Mutex
+	OtherMu sync.Mutex
+	// +checklocks:Mu
+	// +checklocks:OtherMu
+	// +checklocksreadany
+	// +checkatomic
+	Mixed atomicbitops.Uint64
+}
+
+type WrappedAtomic struct {
+	atomicbitops.Uint64
+}

--- a/tools/checklocks/test/atomicfields/atomicfields.go
+++ b/tools/checklocks/test/atomicfields/atomicfields.go
@@ -43,3 +43,15 @@ type Values struct {
 type WrappedAtomic struct {
 	atomicbitops.Uint64
 }
+
+var globalMu sync.Mutex
+
+// RequirePrivate requires a lock in this indirectly imported package.
+//
+// +checklocks:globalMu
+func (*Values) RequirePrivate() {}
+
+// ExcludePrivate excludes a lock in this indirectly imported package.
+//
+// +checklocksexclude:globalMu
+func (*Values) ExcludePrivate() {}

--- a/tools/checklocks/test/atomics.go
+++ b/tools/checklocks/test/atomics.go
@@ -17,6 +17,8 @@ package test
 import (
 	"sync"
 	"sync/atomic"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 )
 
 type atomicStruct struct {
@@ -29,6 +31,13 @@ type atomicStruct struct {
 	ignored int32
 
 	wrapper atomic.Int32 // safe without any annotations
+	bitops  atomicbitops.Int32
+
+	// +checkatomic
+	atomicBitops atomicbitops.Int32
+
+	// +checkatomic
+	pointer atomic.Pointer[int32]
 }
 
 func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -38,6 +47,11 @@ func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
 
 func testAtomicAccess(tc *atomicStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedAtomically)
+	_ = tc.pointer.Load()
+	tc.pointer.Store(nil)
+	defer tc.pointer.Store(nil)
+	defer atomic.StoreInt32(&tc.accessedAtomically, 1)
+	go tc.pointer.Store(nil) // +checklocksfail=illegal use
 }
 
 func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
@@ -45,8 +59,21 @@ func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
 }
 
 func testNormalAccessInvalid(tc *atomicStruct, v chan int32, p chan *int32) {
-	v <- tc.accessedAtomically  // +checklocksfail
-	p <- &tc.accessedAtomically // +checklocksfail
+	v <- tc.accessedAtomically              // +checklocksfail
+	p <- &tc.accessedAtomically             // +checklocksfail
+	_ = genericLoad(&tc.accessedAtomically) // +checklocksfail=non-atomic function
+	// Keep this return-valued call directly deferred: a wrapper discarding
+	// its result would test a closure instead of the operation's SSA Defer.
+	defer genericLoad(&tc.accessedAtomically) // +checklocksforce
+	// An atomic pointer payload is not the atomic location being accessed.
+	var sink atomic.Pointer[int32]
+	sink.Store(&tc.accessedAtomically)       // +checklocksfail=illegal use
+	defer sink.Store(&tc.accessedAtomically) // +checklocksfail=illegal use
+	*sink.Load() = 1
+}
+
+func genericLoad[T any](p *T) T {
+	return *p
 }
 
 func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -56,7 +83,7 @@ func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
 }
 
 type atomicMixedStruct struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	// +checkatomic
 	// +checklocks:mu
@@ -65,11 +92,20 @@ type atomicMixedStruct struct {
 	// +checkatomic
 	// +checklocks:mu
 	wrapper atomic.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	bitops atomicbitops.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	pointer atomic.Pointer[int32]
 }
 
 func testAtomicMixedValidRead(tc *atomicMixedStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedMixed)
 	v <- tc.wrapper.Load()
+	_ = tc.pointer.Load()
 }
 
 func testAtomicMixedInvalidRead(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -81,7 +117,36 @@ func testAtomicMixedValidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan
 	tc.mu.Lock()
 	atomic.StoreInt32(&tc.accessedMixed, 1)
 	tc.wrapper.Store(1)
+	tc.pointer.Store(nil)
 	tc.mu.Unlock()
+}
+
+func testAtomicMixedReadLocked(tc *atomicMixedStruct) {
+	tc.mu.RLock()
+	defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+	_ = atomic.LoadInt32(&tc.accessedMixed)
+	_ = tc.accessedMixed
+	_ = tc.wrapper.Load()
+	_ = tc.bitops.RacyLoad()
+	_ = tc.pointer.Load()
+	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail=write function
+	tc.wrapper.Store(1)                     // +checklocksfail=write function
+	tc.bitops.Store(1)                      // +checklocksfail=write function
+	tc.bitops.RacyStore(1)                  // +checklocksfail=operation RacyStore
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
+	tc.mu.RUnlock()
+}
+
+// Mixed deferred accesses are unsupported even when execution order is safe.
+func testAtomicMixedDeferred(tc *atomicMixedStruct, unlockFirst bool) {
+	tc.mu.Lock()
+	if unlockFirst {
+		defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+		defer tc.mu.Unlock()
+	} else {
+		defer tc.mu.Unlock()
+		defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+	}
 }
 
 func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -93,6 +158,7 @@ func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p ch
 func testAtomicMixedInvalidAtomicWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
 	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail
 	tc.wrapper.Store(1)                     // +checklocksfail
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
 }
 
 func testAtomicMixedInvalidWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -104,4 +170,105 @@ func testAtomicWrapper(tc *atomicStruct, v chan int32) {
 	v <- tc.wrapper.Load()
 	v <- tc.wrapper.Add(33)
 	tc.wrapper.Store(44)
+	v <- tc.bitops.RacyLoad()
+	v <- tc.bitops.RacyAdd(33)
+	tc.bitops.RacyStore(44)
+}
+
+func testAtomicBitops(tc *atomicStruct) {
+	// Keep direct defers, including the unused result, to check the SSA Defer
+	// path rather than a closure that invokes the operation later.
+	defer tc.atomicBitops.RacyLoad()   // +checklocksfail=non-atomic operation
+	defer tc.atomicBitops.RacyStore(1) // +checklocksfail=non-atomic operation
+	_ = tc.atomicBitops.Load()
+	tc.atomicBitops.Store(1)
+	_ = tc.atomicBitops.Add(1)
+	_ = tc.atomicBitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.atomicBitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.atomicBitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+}
+
+func testAtomicMixedBitops(tc *atomicMixedStruct) {
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)       // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.Add(1)     // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+
+	tc.mu.Lock()
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)
+	_ = tc.bitops.Add(1)
+	_ = tc.bitops.RacyLoad()
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+	tc.mu.Unlock()
+}
+
+// atomicReadAnyStruct permits unlocked atomic reads and non-atomic reads
+// under either lock. Writes need both locks.
+type atomicReadAnyStruct struct {
+	mu      sync.Mutex
+	otherMu sync.RWMutex
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	// +checkatomic
+	wrapper atomicbitops.Int32
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	// +checkatomic
+	value int32
+}
+
+func testAtomicReadAny(tc *atomicReadAnyStruct) {
+	_ = tc.wrapper.Load()
+	_ = tc.wrapper.RacyLoad() // +checklocksfail=non-atomic operation
+	_ = tc.value              // +checklocksfail=illegal use
+
+	tc.mu.Lock()
+	_ = tc.wrapper.RacyLoad()
+	_ = tc.value
+	tc.wrapper.Store(1)    // +checklocksfail=write function
+	_ = tc.wrapper.Swap(1) // +checklocksfail=write function
+	tc.mu.Unlock()
+
+	tc.otherMu.RLock()
+	_ = tc.wrapper.RacyLoad()
+	_ = tc.value
+	_ = tc.wrapper.Add(1) // +checklocksfail=write function
+	tc.mu.Lock()
+	tc.wrapper.Store(1) // +checklocksfail=write function
+	tc.otherMu.RUnlock()
+	tc.otherMu.Lock()
+	tc.wrapper.Store(1)
+	_ = tc.wrapper.Add(1)
+	tc.wrapper.RacyStore(1) // +checklocksfail=non-atomic operation
+	tc.otherMu.Unlock()
+	tc.mu.Unlock()
+}
+
+func testAtomicReadAnyRetained(tc *atomicReadAnyStruct, read bool) {
+	tc.mu.Lock()
+	p := &tc.wrapper
+	tc.mu.Unlock()
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+
+	tc.mu.Lock()
+	p = &tc.wrapper
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.mu.Unlock()
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+
+	// Even when the lock remains held, only immediate uses are supported.
+	tc.mu.Lock()
+	p = &tc.wrapper
+	if read {
+		_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+	}
+	tc.mu.Unlock()
 }

--- a/tools/checklocks/test/closures.go
+++ b/tools/checklocks/test/closures.go
@@ -49,6 +49,9 @@ func testClosureInline(tc *oneGuardStruct) {
 	tc.mu.Lock()
 	func() {
 		tc.guardedField = 1
+		func() {
+			tc.guardedField = 2
+		}()
 	}()
 	tc.mu.Unlock()
 }
@@ -58,8 +61,17 @@ func testClosureIgnore(tc *oneGuardStruct) {
 	// Inherit the checklocksignore.
 	x := func() {
 		tc.guardedField = 1
+		atomicGlobal.RacyStore(1)
 	}
 	x()
+
+	// Passing a closure as an argument is not an inline invocation.
+	callClosure(func() {
+		callPreconditions(tc)
+	})
+	defer callClosure(func() {
+		callPreconditions(tc)
+	})
 }
 
 func testAnonymousInvalid(tc *oneGuardStruct) {

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -110,3 +110,6 @@ func RequirePrivate() {}
 // +checklocksexclude:globalMu
 // +checklocksexclude:globalStruct.mu
 func ExcludePrivate() {}
+
+// IndirectValues exposes methods without importing their defining package.
+type IndirectValues = atomicfields.Values

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -17,6 +17,8 @@ package crosspkg
 
 import (
 	"sync"
+
+	"gvisor.dev/gvisor/tools/checklocks/test/atomicfields"
 )
 
 var (
@@ -24,6 +26,11 @@ var (
 	Foo   int
 	FooMu sync.Mutex
 )
+
+// StandaloneFoo is a guarded global declared outside a var block.
+//
+// +checklocks:FooMu
+var StandaloneFoo int
 
 // GenericGuard is a generic type with a guarded field. This is used to verify
 // that facts exported by this package are correctly imported when another
@@ -33,3 +40,73 @@ type GenericGuard[T any] struct {
 	// +checklocks:Mu
 	Value T
 }
+
+// ReadAnyGuard allows readers to hold either mutex; writers need both.
+type ReadAnyGuard[T any] struct {
+	Mu      sync.Mutex
+	OtherMu sync.RWMutex
+
+	// +checklocks:Mu
+	// +checklocks:OtherMu
+	Value T // +checklocksreadany
+}
+
+// Do not import atomic or atomicbitops here: these methods must be resolved
+// from type information for a transitive dependency, not a direct SSA import.
+func readIndirectAtomics(v *atomicfields.Values) {
+	_ = v.Standard.Load()
+	_ = v.Bitops.Load()
+	v.Standard.Store(nil)
+	v.Bitops.Store(1)
+	_ = v.Bitops.RacyLoad() // +checklocksfail=non-atomic operation
+	// A method expression forces an SSA wrapper instead of selecting the
+	// embedded field directly, as an ordinary promoted call would.
+	_ = (*atomicfields.WrappedAtomic).Load(&v.Promoted) // +checklocksfail=shared function or wrapper
+
+	v.Mu.Lock()
+	_ = v.Mixed.RacyLoad()
+	v.Mu.Unlock()
+}
+
+// Keep the lock/unlock functions out of line so importers do not need these
+// private globals for inlined calls. Their guards still cross the package
+// boundary.
+var globalMu sync.Mutex
+
+var globalStruct struct {
+	mu sync.Mutex
+}
+
+// LockPrivate acquires both private locks.
+//
+// +checklocksacquire:globalMu
+// +checklocksacquire:globalStruct.mu
+//
+//go:noinline
+func LockPrivate() {
+	globalMu.Lock()
+	globalStruct.mu.Lock()
+}
+
+// UnlockPrivate releases both private locks.
+//
+// +checklocksrelease:globalMu
+// +checklocksrelease:globalStruct.mu
+//
+//go:noinline
+func UnlockPrivate() {
+	globalStruct.mu.Unlock()
+	globalMu.Unlock()
+}
+
+// RequirePrivate requires both private locks.
+//
+// +checklocks:globalMu
+// +checklocks:globalStruct.mu
+func RequirePrivate() {}
+
+// ExcludePrivate excludes both private locks.
+//
+// +checklocksexclude:globalMu
+// +checklocksexclude:globalStruct.mu
+func ExcludePrivate() {}

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -16,13 +16,46 @@ package test
 
 import (
 	"sync"
+	"sync/atomic"
 
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
 )
 
 var (
 	globalMu   sync.Mutex
 	globalRWMu sync.RWMutex
+
+	// +checkatomic
+	atomicGlobal = atomicbitops.FromInt32(1)
+
+	// +checkatomic
+	// +checklocks:globalRWMu
+	mixedAtomicGlobal atomicbitops.Int32
+
+	unannotatedAtomicGlobal atomicbitops.Int32
+	unannotatedRawGlobal    int32
+
+	// +checklocks:globalRWMu
+	guardedRawGlobal int32
+)
+
+// +checklocks:globalMu
+var standaloneGlobal int
+
+// +checkatomic
+var standaloneAtomicGlobal int32
+
+var (
+	// +checklocks:globalMu
+	firstGlobal, _, secondGlobal int
+)
+
+// A var block's header does not annotate its entries, even with one spec.
+//
+// +checklocks:globalMu
+var (
+	blockHeaderGlobal int
 )
 
 var globalStruct struct {
@@ -41,7 +74,12 @@ var otherStruct struct {
 }
 
 func testGlobalValid() {
+	blockHeaderGlobal = 1
+
 	globalMu.Lock()
+	standaloneGlobal = 1
+	firstGlobal = 1
+	secondGlobal = 1
 	otherStruct.guardedField1 = 1
 	globalMu.Unlock()
 
@@ -94,18 +132,102 @@ func testGlobalExcludeInvalid() {
 }
 
 func testGlobalInvalid() {
+	standaloneGlobal = 1          // +checklocksfail
+	firstGlobal = 1               // +checklocksfail
+	secondGlobal = 1              // +checklocksfail
+	standaloneAtomicGlobal = 1    // +checklocksfail=non-atomic write
 	globalStruct.guardedField = 1 // +checklocksfail
 	otherStruct.guardedField1 = 1 // +checklocksfail
 	otherStruct.guardedField2 = 1 // +checklocksfail
 	otherStruct.guardedField3 = 1 // +checklocksfail
+	var sink atomic.Pointer[int32]
+	sink.Store(&standaloneAtomicGlobal) // +checklocksfail=illegal use
 }
 
 func testCrosspkgGlobalValid() {
 	crosspkg.FooMu.Lock()
 	crosspkg.Foo = 1
+	crosspkg.StandaloneFoo = 1
 	crosspkg.FooMu.Unlock()
 }
 
 func testCrosspkgGlobalInvalid() {
-	crosspkg.Foo = 1 // +checklocksfail
+	crosspkg.Foo = 1           // +checklocksfail
+	crosspkg.StandaloneFoo = 1 // +checklocksfail
 }
+
+func testAtomicGlobal() {
+	defer atomicGlobal.Store(1)
+	_ = atomicGlobal.Load()
+	atomicGlobal.Store(1)
+	_ = atomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+	atomicGlobal.RacyStore(1)   // +checklocksfail=non-atomic operation
+
+	atomicGlobal = atomicbitops.FromInt32(0) // +checklocksfail=non-atomic write
+}
+
+func testMixedAtomicGlobal() {
+	_ = mixedAtomicGlobal.Load()
+	mixedAtomicGlobal.Store(1)       // +checklocksfail=atomic write function
+	_ = mixedAtomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+
+	globalRWMu.Lock()
+	mixedAtomicGlobal.Store(1)
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.RacyStore(1) // +checklocksfail=non-atomic operation
+	globalRWMu.Unlock()
+
+	globalRWMu.RLock()
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.Store(1) // +checklocksfail=atomic write function
+	globalRWMu.RUnlock()
+}
+
+func testUnannotatedGlobalAtomics(out **int32) {
+	_ = unannotatedAtomicGlobal.RacyLoad()
+	unannotatedAtomicGlobal.RacyStore(1)
+	_ = atomic.LoadInt32(&unannotatedRawGlobal)
+
+	globalRWMu.RLock()
+	_ = atomic.LoadInt32(&guardedRawGlobal)
+	*out = &guardedRawGlobal
+	globalRWMu.RUnlock()
+}
+
+// +checklocksignore
+func testAtomicGlobalIgnore() {
+	atomicGlobal.RacyStore(1)
+	atomicGlobal = atomicbitops.FromInt32(0)
+}
+
+func testCrosspkgPrivateGuards() {
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+	crosspkg.LockPrivate()
+	crosspkg.RequirePrivate()
+	crosspkg.ExcludePrivate() // +checklocksfail=must not hold globalMu|must not hold globalStruct.mu
+	crosspkg.UnlockPrivate()
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+
+	// Same-named globals in this package are different locks.
+	globalMu.Lock()
+	globalStruct.mu.Lock()
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+	globalStruct.mu.Unlock()
+	globalMu.Unlock()
+}
+
+var FooMu sync.Mutex
+
+func testCrosspkgGlobalNameCollision() {
+	FooMu.Lock()
+	crosspkg.Foo = 1 // +checklocksfail=invalid field access, FooMu
+	FooMu.Unlock()
+}
+
+type invalidGlobalMutex = sync.Mutex
+
+// +checklocks:invalidGlobalMutex
+func testGlobalTypeGuard() {} // +checklocksfail=does not have a match

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -227,6 +227,11 @@ func testCrosspkgGlobalNameCollision() {
 	FooMu.Unlock()
 }
 
+func testIndirectGlobalGuards(v *crosspkg.IndirectValues) {
+	v.RequirePrivate() // +checklocksfail=must hold
+	v.ExcludePrivate()
+}
+
 type invalidGlobalMutex = sync.Mutex
 
 // +checklocks:invalidGlobalMutex

--- a/tools/checklocks/test/rwmutex.go
+++ b/tools/checklocks/test/rwmutex.go
@@ -16,6 +16,8 @@ package test
 
 import (
 	"sync"
+
+	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
 )
 
 // oneReadGuardStruct has one read-guarded field.
@@ -64,5 +66,130 @@ func testRWExcludeWriteSatisfied(tc *oneReadGuardStruct) {
 func testRWExcludeWriteViolated(tc *oneReadGuardStruct) {
 	tc.mu.Lock()
 	testRWExcludeWrite(tc) // +checklocksfail
+	tc.mu.Unlock()
+}
+
+func testReadAnyGuards(tc *crosspkg.ReadAnyGuard[int]) {
+	_ = tc.Value // +checklocksfail=at least one
+	tc.Mu.Lock()
+	_ = tc.Value
+	tc.Value = 1 // +checklocksfail=OtherMu
+	tc.Mu.Unlock()
+
+	tc.OtherMu.RLock()
+	_ = tc.Value
+	tc.Value = 2 // +checklocksfail=access, Mu|access, OtherMu
+	tc.OtherMu.RUnlock()
+
+	tc.Mu.Lock()
+	tc.OtherMu.RLock()
+	tc.Value = 3 // +checklocksfail=OtherMu
+	tc.OtherMu.RUnlock()
+	tc.OtherMu.Lock()
+	tc.Value = 4
+	tc.OtherMu.Unlock()
+	tc.Mu.Unlock()
+}
+
+type invalidReadAnyGuards struct {
+	mu sync.Mutex
+
+	// +checklocksreadany
+	unguarded int // +checklocksfail=requires at least one
+
+	// +checklocks:mu
+	// +checklocksreadany
+	// +checklocksreadany
+	duplicate int // +checklocksfail=specified more than once
+
+	// +checklocks:mu
+	// +checklocksreadany:mu
+	argument int // +checklocksfail=does not take arguments
+
+	// +checklocks:mu
+	// +checklocksreadany
+	// +checklocksignore
+	ignored int // +checklocksfail=cannot be combined
+}
+
+// +checklocksreadany
+func invalidReadAnyFunction() {} // +checklocksfail=only valid on fields
+
+var (
+	// +checklocksreadany
+	invalidReadAnyGlobal int // +checklocksfail=only valid on fields
+)
+
+func testReadAnyIndirectWrites(tc *crosspkg.ReadAnyGuard[struct{ member int }]) {
+	tc.Mu.Lock()
+	tc.Value.member = 1             // +checklocksfail=OtherMu
+	mutateReadAny(&tc.Value.member) // +checklocksfail=OtherMu
+	tc.OtherMu.RLock()
+	tc.Value.member = 2 // +checklocksfail=OtherMu
+	tc.OtherMu.RUnlock()
+	tc.Mu.Unlock()
+}
+
+func mutateReadAny(p *int) {
+	*p = 1
+}
+
+// +checklocksreadany
+type invalidReadAnyType int // +checklocksfail=only valid on fields
+
+// A modifier may precede a guard in the field's trailing comment.
+type readAnyTrailingGuard struct {
+	mu sync.Mutex
+
+	// +checklocksreadany
+	value int // +checklocks:mu
+}
+
+// +checklocksreadany
+var invalidStandaloneReadAny int // +checklocksfail=only valid on fields
+
+func testReadAnyRetainedAddress(tc *crosspkg.ReadAnyGuard[int]) {
+	tc.Mu.Lock()
+	p := &tc.Value // +checklocksfail=OtherMu
+	tc.Mu.Unlock()
+	_ = *p
+
+	// An immediate first load must not authorize a later unlocked load.
+	tc.Mu.Lock()
+	p = &tc.Value // +checklocksfail=OtherMu
+	_ = *p
+	tc.Mu.Unlock()
+	_ = *p
+}
+
+// +checklocksread:tc.OtherMu
+func testReadAnyPrecondition(tc *crosspkg.ReadAnyGuard[int]) int {
+	return tc.Value
+}
+
+type groupedReadAnyGuards struct {
+	mu, otherMu sync.Mutex
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	first, second int
+
+	// +checklocks:mu
+	last int
+}
+
+func testGroupedReadAnyGuards(tc *groupedReadAnyGuards) {
+	tc.first = 1  // +checklocksfail=access, mu|access, otherMu
+	tc.second = 2 // +checklocksfail=access, mu|access, otherMu
+	tc.last = 3   // +checklocksfail=access, mu
+	tc.mu.Lock()
+	_ = tc.first
+	_ = tc.second
+	tc.last = 3
+	tc.otherMu.Lock()
+	tc.first = 1
+	tc.second = 2
+	tc.otherMu.Unlock()
 	tc.mu.Unlock()
 }

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -90,22 +90,11 @@ def go_binary(name, nogo = True, pure = False, static = False, x_defs = None, **
         **kwargs
     )
     if nogo:
-        # Note that the nogo rule applies only for go_library and go_test
-        # targets, therefore we construct a library from the binary sources.
-        # This is done because the binary may not be in a form that objdump
-        # supports (i.e. a pure Go binary).
-        _go_library(
-            name = name + "_nogo_library",
-            srcs = kwargs.get("srcs", []),
-            deps = kwargs.get("deps", []),
-            embedsrcs = kwargs.get("embedsrcs", []),
-            testonly = 1,
-        )
         nogo_test(
             name = name + "_nogo",
             config = "//:nogo_config",
             srcs = kwargs.get("srcs", []),
-            deps = [":" + name + "_nogo_library"],
+            deps = [":" + name],
             tags = ["nogo"],
         )
 

--- a/tools/go_generics/go_merge/main.go
+++ b/tools/go_generics/go_merge/main.go
@@ -21,9 +21,12 @@ import (
 	"go/ast"
 	"go/format"
 	"go/parser"
+	"go/printer"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 
 	"gvisor.dev/gvisor/tools/constraintutil"
@@ -52,13 +55,17 @@ func main() {
 
 	// Load all files.
 	files := make(map[string]*ast.File)
+	comments := make(ast.CommentMap)
 	fset := token.NewFileSet()
 	var name string
-	for _, fname := range flag.Args() {
+	// Match MergePackageFiles' declaration order when assigning token positions.
+	srcs := slices.Sorted(slices.Values(flag.Args()))
+	for _, fname := range srcs {
 		f, err := parser.ParseFile(fset, fname, nil, parser.ParseComments|parser.DeclarationErrors|parser.SpuriousErrors)
 		if err != nil {
 			fatalf("%v\n", err)
 		}
+		maps.Copy(comments, ast.NewCommentMap(fset, f, f.Comments))
 
 		files[fname] = f
 		if name == "" {
@@ -75,13 +82,13 @@ func main() {
 	}
 	f := ast.MergePackageFiles(pkg, ast.FilterUnassociatedComments|ast.FilterFuncDuplicates|ast.FilterImportDuplicates)
 
-	// Create a new declaration slice with all imports at the top, merging any
-	// redundant imports.
+	// Put imports first and remove redundant specs. Keep the original import
+	// declarations so their comments retain valid positions within each file.
 	imports := make(map[string]*ast.ImportSpec)
-	var importNames []string // Keep imports in the original order to get deterministic output.
-	var anonImports []*ast.ImportSpec
+	newDecls := make([]ast.Decl, 0, len(f.Decls))
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); ok && g.Tok == token.IMPORT {
+			specs := g.Specs[:0]
 			for _, s := range g.Specs {
 				i := s.(*ast.ImportSpec)
 				p, _ := strconv.Unquote(i.Path.Value)
@@ -92,7 +99,7 @@ func main() {
 					n = i.Name.Name
 				}
 				if n == "_" {
-					anonImports = append(anonImports, i)
+					specs = append(specs, i)
 				} else {
 					if i2, ok := imports[n]; ok {
 						if first, second := i.Path.Value, i2.Path.Value; first != second {
@@ -100,28 +107,15 @@ func main() {
 						}
 					} else {
 						imports[n] = i
-						importNames = append(importNames, n)
+						specs = append(specs, i)
 					}
 				}
 			}
+			if len(specs) > 0 {
+				g.Specs = specs
+				newDecls = append(newDecls, g)
+			}
 		}
-	}
-	newDecls := make([]ast.Decl, 0, len(f.Decls))
-	if l := len(imports) + len(anonImports); l > 0 {
-		// Non-NoPos Lparen is needed for Go to recognize more than one spec in
-		// ast.GenDecl.Specs.
-		d := &ast.GenDecl{
-			Tok:    token.IMPORT,
-			Lparen: token.NoPos + 1,
-			Specs:  make([]ast.Spec, 0, l),
-		}
-		for _, i := range importNames {
-			d.Specs = append(d.Specs, imports[i])
-		}
-		for _, i := range anonImports {
-			d.Specs = append(d.Specs, i)
-		}
-		newDecls = append(newDecls, d)
 	}
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); !ok || g.Tok != token.IMPORT {
@@ -136,10 +130,24 @@ func main() {
 		fatalf("Failed to read build constraints: %v\n", err)
 	}
 
-	// Write the output file.
+	// Print each declaration with only its own comments. Imports moved from
+	// later files must not pull earlier declarations' inline annotations forward.
+	// Template instances omit package documentation; build constraints are
+	// reconstructed separately below.
 	var buf bytes.Buffer
-	if err := format.Node(&buf, fset, f); err != nil {
-		fatalf("formatting: %v\n", err)
+	_, _ = fmt.Fprintf(&buf, "package %s\n\n", name)
+	for _, decl := range f.Decls {
+		if err := format.Node(&buf, fset, &printer.CommentedNode{
+			Node:     decl,
+			Comments: comments.Filter(decl).Comments(),
+		}); err != nil {
+			fatalf("formatting: %v\n", err)
+		}
+		_, _ = buf.WriteString("\n\n")
+	}
+	source, err := format.Source(buf.Bytes())
+	if err != nil {
+		fatalf("formatting merged source: %v\n", err)
 	}
 	outf, err := os.OpenFile(*output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -147,7 +155,7 @@ func main() {
 	}
 	defer outf.Close()
 	outf.WriteString(constraintutil.Lines(bcexpr))
-	if _, err := outf.Write(buf.Bytes()); err != nil {
+	if _, err := outf.Write(source); err != nil {
 		fatalf("write: %v\n", err)
 	}
 }

--- a/tools/go_generics/tests/simple/BUILD
+++ b/tools/go_generics/tests/simple/BUILD
@@ -4,7 +4,11 @@ package(default_applicable_licenses = ["//:license"])
 
 go_generics_test(
     name = "simple",
-    inputs = ["input.go"],
+    # Reverse source order to exercise comment positions across merged files.
+    inputs = [
+        "second.go",
+        "input.go",
+    ],
     output = "output.go",
     suffix = "New",
     types = {
@@ -16,4 +20,5 @@ go_generics_test(
 glaze_ignore = [
     "input.go",
     "output.go",
+    "second.go",
 ]

--- a/tools/go_generics/tests/simple/input.go
+++ b/tools/go_generics/tests/simple/input.go
@@ -14,6 +14,8 @@
 
 package tests
 
+import _ "os" // Earlier blank import.
+
 type T int
 
 var global T
@@ -27,6 +29,7 @@ func g(a T, b int) {
 
 	d := (*T)(nil)
 	_ = d
+	_ = new(T) // escapes: test annotation.
 }
 
 type R struct {

--- a/tools/go_generics/tests/simple/output.go
+++ b/tools/go_generics/tests/simple/output.go
@@ -14,6 +14,10 @@
 
 package main
 
+import _ "os" // Earlier blank import.
+
+import "fmt" // Later named import.
+
 var globalNew Q
 
 func fNew(_ Q, a int) {
@@ -25,6 +29,7 @@ func gNew(a Q, b int) {
 
 	d := (*Q)(nil)
 	_ = d
+	_ = new(Q) // escapes: test annotation.
 }
 
 type RNew struct {
@@ -41,3 +46,7 @@ const (
 )
 
 type YNew Q
+
+func hNew(a Q) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
+}

--- a/tools/go_generics/tests/simple/second.go
+++ b/tools/go_generics/tests/simple/second.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tests
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
+import "fmt" // Later named import.
 
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+func h(a T) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
 }

--- a/tools/nogo/check/BUILD
+++ b/tools/nogo/check/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -57,5 +57,16 @@ go_library(
         "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_default_library",
         "@org_golang_x_tools//go/gcexportdata:go_default_library",
+    ],
+)
+
+go_test(
+    name = "check_test",
+    size = "small",
+    srcs = ["check_test.go"],
+    library = ":check",
+    deps = [
+        "//tools/nogo/flags",
+        "@org_golang_x_tools//go/analysis:go_default_library",
     ],
 )

--- a/tools/nogo/check/check.go
+++ b/tools/nogo/check/check.go
@@ -55,14 +55,8 @@ var (
 	releaseTagsErr error
 )
 
-// Hack! factFacts only provides facts loaded from directly imported packages
-// for efficiency (see importer.cache). In general, if you need a fact from a
-// package that isn't otherwise imported, the expectation is that you will add
-// a dummy import/use of the desired package to ensure it is a dependency.
-//
-// Unfortunately, some packages need facts from internal packages. Since
-// internal packages cannot be imported we explicitly import in this tool to
-// ensure the facts are available to ImportPackageFact.
+// Preload type information needed to decode facts from internal packages that
+// analyzed packages cannot import directly.
 var internalPackages = []string{
 	// Required by pkg/sync for internal/abi.MapType.
 	"internal/abi",
@@ -145,12 +139,25 @@ type importer struct {
 
 	analyzers map[*analysis.Analyzer]analyzer
 
-	// mu protects cache & bundles (see below).
-	mu    sync.Mutex
-	cache map[string]*importerEntry // key is package path (see sources above).
+	// mu protects cache, bundles, and factsErr (see below).
+	mu sync.Mutex
 
-	// bundles is protected by mu, but once set is immutable.
+	// cache is keyed by package path (see sources above).
+	//
+	// +checklocks:mu
+	cache map[string]*importerEntry
+
+	// bundles and each bundle's decoded-package cache are protected by mu.
+	// A bundle has no link to this importer, so checklocks cannot express
+	// that protection for the bundle's internal cache.
+	//
+	// +checklocks:mu
 	bundles []*facts.Bundle
+
+	// factsErr is the first error loading package facts.
+	//
+	// +checklocks:mu
+	factsErr error
 
 	// importsMu protects imports.
 	importsMu sync.Mutex
@@ -159,8 +166,7 @@ type importer struct {
 
 // loadBundles loads all bundle files.
 //
-// This should only be called from loadFacts, below. After calling this
-// function, i.bundles may be read freely without holding a lock.
+// This should only be called from loadFacts, below.
 func (i *importer) loadBundles() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -187,9 +193,8 @@ func (i *importer) loadBundles() error {
 
 // loadFacts returns all package facts for the given name.
 //
-// This should be called only from importPackage, as this may deserialize a
-// facts file (which is an expensive operation). Callers should generally rely
-// on fastFacts to access facts for packages that have already been imported.
+// This may deserialize a facts file. Callers should generally use fastFacts
+// to cache the result.
 func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 	// Attempt to load from the fact map.
 	filename, ok := flags.FactMap[pkg.Path()]
@@ -211,7 +216,10 @@ func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 		return nil, fmt.Errorf("error loading bundles: %w", err)
 	}
 
-	// Try to import from the bundle.
+	// Bundle.Package memoizes decoded packages, including across concurrent
+	// requests for facts from different packages.
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	for _, bundleFacts := range i.bundles {
 		localFacts, err := bundleFacts.Package(pkg)
 		if err != nil {
@@ -233,10 +241,14 @@ func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 func (i *importer) fastFacts(pkg *types.Package) *facts.Package {
 	i.mu.Lock()
 	e, ok := i.cache[pkg.Path()]
-	i.mu.Unlock()
 	if !ok {
-		return nil
+		// Export data can introduce a package without importPackage. Cache
+		// its facts, but leave pkg nil so a later import still loads types
+		// or analyzes source instead of treating this as a completed import.
+		e = new(importerEntry)
+		i.cache[pkg.Path()] = e
 	}
+	i.mu.Unlock()
 
 	e.factsMu.Lock()
 	defer e.factsMu.Unlock()
@@ -249,9 +261,12 @@ func (i *importer) fastFacts(pkg *types.Package) *facts.Package {
 	// Load the facts.
 	facts, err := i.loadFacts(pkg)
 	if err != nil {
-		// There are no facts available, but no good way to propagate
-		// this minor error. It may be intentional that no analysis was
-		// performed on some part of the standard library, for example.
+		// Optional fact absence is not an error; unreadable inputs are.
+		i.mu.Lock()
+		if i.factsErr == nil {
+			i.factsErr = fmt.Errorf("loading facts for %q: %w", pkg.Path(), err)
+		}
+		i.mu.Unlock()
 		return nil
 	}
 	e.facts = facts // Cache the result.
@@ -717,6 +732,12 @@ func (i *importer) checkPackage(path string, srcs []string) (*types.Package, Fin
 		// Wait for completion.
 		wg.Wait()
 	}
+	i.mu.Lock()
+	factsErr := i.factsErr
+	i.mu.Unlock()
+	if factsErr != nil {
+		return astPackage, findings, astFacts, factsErr
+	}
 	for a := range ready {
 		// Check the error. If we generate an error here, we report
 		// this as a finding that can be suppressed. Some analyzers
@@ -778,7 +799,12 @@ func Package(path string, srcs []string) (FindingSet, facts.Serializer, error) {
 	return findings, facts, nil
 }
 
-// allFactsAndFindings returns all factsAndFindings from an importer.
+// allFactsAndFindings returns the collected findings and package facts.
+//
+// Imports and analysis must have completed: mu does not protect the cached
+// entries' findings and facts.
+//
+// +checklocks:i.mu
 func (i *importer) allFactsAndFindings() (FindingSet, *facts.Bundle) {
 	var (
 		findings = make(FindingSet, 0)
@@ -814,7 +840,8 @@ func TemplateFuncs(path string, srcs []string) (map[string]any, any, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	_, allFacts := i.allFactsAndFindings()
+	// checkPackage joined all analyzers; this private importer is quiescent.
+	_, allFacts := i.allFactsAndFindings() // +checklocksignore
 	funcMap, err := facts.ResolveFuncs(pkg, localFacts, allFacts)
 	if err != nil {
 		return nil, nil, err
@@ -926,6 +953,7 @@ func Bundle(sources map[string][]string, roots []string) (FindingSet, facts.Seri
 		}
 	}
 
-	findings, facts := i.allFactsAndFindings()
+	// All imports and their analyzers completed; this importer is quiescent.
+	findings, facts := i.allFactsAndFindings() // +checklocksignore
 	return findings, facts, nil
 }

--- a/tools/nogo/check/check_test.go
+++ b/tools/nogo/check/check_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"go/token"
+	"go/types"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+	"gvisor.dev/gvisor/tools/nogo/flags"
+)
+
+type factsLoadTestFact struct{}
+
+func (*factsLoadTestFact) AFact() {}
+
+func TestDeclaredFactsErrors(t *testing.T) {
+	savedFactMap, savedBundles := flags.FactMap, flags.Bundles
+	t.Cleanup(func() {
+		flags.FactMap, flags.Bundles = savedFactMap, savedBundles
+	})
+	var malformed bytes.Buffer
+	if err := gob.NewEncoder(&malformed).Encode([]struct {
+		Key   string
+		Value any
+	}{{Value: "bad"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		supplied bool
+		create   bool
+		contents []byte
+		bundles  [][]byte // A nil entry omits the package from that bundle.
+		wantErr  error
+		wantText string
+	}{
+		{name: "absent"},
+		{name: "missing", supplied: true, wantErr: os.ErrNotExist},
+		{name: "empty", supplied: true, create: true, wantErr: io.EOF},
+		{name: "wrong_type", supplied: true, create: true, contents: malformed.Bytes(), wantText: "invalid fact payload"},
+		{name: "bundle_absent", bundles: [][]byte{nil}},
+		{name: "bundle_empty", bundles: [][]byte{{}}, wantErr: io.EOF},
+		{name: "later_bundle_wrong_type", bundles: [][]byte{nil, malformed.Bytes()}, wantText: "invalid fact payload"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dep := types.NewPackage("indirect", "indirect")
+			flags.FactMap = make(map[string]string)
+			flags.Bundles = nil
+			if tc.supplied {
+				filename := filepath.Join(t.TempDir(), "facts")
+				flags.FactMap[dep.Path()] = filename
+				if tc.create {
+					if err := os.WriteFile(filename, tc.contents, 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			for _, contents := range tc.bundles {
+				var buf bytes.Buffer
+				zw := zip.NewWriter(&buf)
+				if contents != nil {
+					w, err := zw.Create(dep.Path())
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := w.Write(contents); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := zw.Close(); err != nil {
+					t.Fatal(err)
+				}
+				filename := filepath.Join(t.TempDir(), "bundle.zip")
+				if err := os.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+					t.Fatal(err)
+				}
+				flags.Bundles = append(flags.Bundles, filename)
+			}
+			a := &analysis.Analyzer{
+				Name:      "importfact",
+				FactTypes: []analysis.Fact{new(factsLoadTestFact)},
+				Run: func(p *analysis.Pass) (any, error) {
+					// Fact absence is allowed; input errors must fail the driver.
+					_ = p.ImportPackageFact(dep, new(factsLoadTestFact))
+					return nil, nil
+				},
+			}
+			i := &importer{
+				fset:      token.NewFileSet(),
+				cache:     make(map[string]*importerEntry),
+				analyzers: map[*analysis.Analyzer]analyzer{a: &plainAnalyzer{a}},
+			}
+			// An empty package exercises fact loading without SDK imports.
+			_, findings, _, err := i.checkPackage("test", nil)
+			if tc.wantText != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+					t.Fatalf("checkPackage() error = %v, want %q (findings: %v)", err, tc.wantText, findings)
+				}
+			} else if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("checkPackage() error = %v, want %v", err, tc.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), dep.Path()) {
+				t.Errorf("checkPackage() error = %v, want package path %q", err, dep.Path())
+			}
+		})
+	}
+}

--- a/tools/nogo/cli/BUILD
+++ b/tools/nogo/cli/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -19,4 +19,12 @@ go_library(
         "@in_gopkg_yaml_v2//:go_default_library",
         "@org_golang_x_term//:go_default_library",
     ],
+)
+
+go_test(
+    name = "cli_test",
+    size = "small",
+    srcs = ["cli_test.go"],
+    library = ":cli",
+    deps = ["//tools/nogo/flags"],
 )

--- a/tools/nogo/cli/cli.go
+++ b/tools/nogo/cli/cli.go
@@ -65,7 +65,7 @@ func closeOutput(w io.Writer) {
 	}
 }
 
-// failure exits with the given failure message.
+// failure prints the given failure message and returns a failure status.
 func failure(fmtStr string, v ...any) subcommands.ExitStatus {
 	fmt.Fprintf(os.Stderr, fmtStr+"\n", v...)
 	return subcommands.ExitFailure
@@ -514,7 +514,7 @@ func (r *Render) Execute(ctx context.Context, fs *flag.FlagSet, args ...any) sub
 }
 
 // goVersionRe matches a `go VERSION` line in go.mod, capturing VERSION.
-var goVersionRe = regexp.MustCompile(`^go\s+(\S+)`)
+var goVersionRe = regexp.MustCompile(`(?m)^go[ \t]+(\S+)`)
 
 // resolveGOVERSION sets flags.GOVERSION from flags.GOVERSIONModFile, if necessary.
 func resolveGOVERSION() error {
@@ -535,7 +535,7 @@ func resolveGOVERSION() error {
 	if len(m) != 2 {
 		return fmt.Errorf("go line not found in go.mod:\n%s", string(b))
 	}
-	flags.GOVERSION = m[1]
+	flags.GOVERSION = "go" + m[1]
 	return nil
 }
 
@@ -549,7 +549,7 @@ func Main() {
 	subcommands.Register(subcommands.FlagsCommand(), "")
 	flag.CommandLine.Parse(os.Args[1:])
 	if err := resolveGOVERSION(); err != nil {
-		failure("error resolving GOVERSION: %v", err)
+		os.Exit(int(failure("error resolving GOVERSION: %v", err)))
 	}
 	os.Exit(int(subcommands.Execute(context.Background())))
 }

--- a/tools/nogo/cli/cli_test.go
+++ b/tools/nogo/cli/cli_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gvisor.dev/gvisor/tools/nogo/flags"
+)
+
+func TestResolveGOVERSION(t *testing.T) {
+	oldVersion, oldModFile := flags.GOVERSION, flags.GOVERSIONModFile
+	t.Cleanup(func() {
+		flags.GOVERSION, flags.GOVERSIONModFile = oldVersion, oldModFile
+	})
+	for _, tc := range []struct {
+		name, contents, want string
+	}{
+		{"stdlib", "module std\n\ngo 1.26\n", "go1.26"},
+		{"comments-and-crlf", "// Header.\r\nmodule std\r\ngo\t1.26\r\n", "go1.26"},
+		{"missing", "module std\n", ""},
+		{"split-directive", "module std\ngo\n1.26\n", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			modFile := filepath.Join(t.TempDir(), "go.mod")
+			if err := os.WriteFile(modFile, []byte(tc.contents), 0644); err != nil {
+				t.Fatal(err)
+			}
+			flags.GOVERSION = ""
+			flags.GOVERSIONModFile = modFile
+			if err := resolveGOVERSION(); err != nil {
+				if tc.want != "" {
+					t.Fatalf("resolveGOVERSION: %v", err)
+				}
+				return
+			}
+			if tc.want == "" {
+				t.Fatal("resolveGOVERSION succeeded without a valid go directive")
+			}
+			if got := flags.GOVERSION; got != tc.want {
+				t.Errorf("GOVERSION = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/nogo/defs.bzl
+++ b/tools/nogo/defs.bzl
@@ -1,7 +1,7 @@
 """Nogo rules."""
 
 load("//tools:arch.bzl", "arch_transition")
-load("//tools/bazeldefs:go.bzl", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
+load("//tools/bazeldefs:go.bzl", "go_binary_archive", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
 
 NogoConfigInfo = provider(
     "information about a nogo configuration",
@@ -70,7 +70,7 @@ def _nogo_stdlib_impl(ctx):
     go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps = [])
 
     # GOVERSION of std is set by the std go.mod.
-    args.append("-GOVERSION-mod-file=%s" % go_ctx.stdlib_mod)
+    args.append("-GOVERSION-mod-file=%s" % go_ctx.stdlib_mod.path)
 
     # Build the analyzer command.
     facts_file = ctx.actions.declare_file(ctx.label.name + ".facts")
@@ -135,6 +135,7 @@ NogoInfo = provider(
     "information for nogo analysis",
     fields = {
         "facts": "serialized package facts",
+        "transitive_facts": "depset of (import path, facts file) pairs",
         "raw_findings": "raw package findings (if relevant)",
         "importpath": "package import path",
         "binaries": "package binary files",
@@ -161,14 +162,14 @@ def _select_objfile(files):
         a_files = x_files
     return a_files[0], x_files[0]
 
-def _nogo_config(ctx, deps):
+def _nogo_config(ctx, deps, attr = None):
     # Build a configuration for the given set of deps. This is most basic
     # configuration and is used by the stdlib. For a more complete config, the
     # _nogo_package_config function may be used.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
     nogo_target_info = ctx.attr._target[NogoTargetInfo]
-    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch)
+    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch, attr = attr)
     args = go_ctx.nogo_args + [
         "-go=%s" % go_ctx.go.path,
         "-GOOS=%s" % go_ctx.goos,
@@ -177,6 +178,7 @@ def _nogo_config(ctx, deps):
     ]
     inputs = []
     raw_findings = []
+    fact_sets = []
     for dep in deps:
         extras = nogo_extra_proto_deps(dep)
         for importpath, a_file, x_file in extras:
@@ -198,7 +200,7 @@ def _nogo_config(ctx, deps):
         a_file, x_file = _select_objfile(info.binaries)
         args.append("-archive=%s=%s" % (info.importpath, a_file.path))
         args.append("-import=%s=%s" % (info.importpath, x_file.path))
-        args.append("-facts=%s=%s" % (info.importpath, info.facts.path))
+        fact_sets.append(info.transitive_facts)
 
         # Collect all findings; duplicates are resolved at the end.
         raw_findings.extend(info.raw_findings)
@@ -206,27 +208,26 @@ def _nogo_config(ctx, deps):
         # Ensure the above are available as inputs.
         inputs.append(a_file)
         inputs.append(x_file)
-        inputs.append(info.facts)
+
+    # Export data can expose types and methods from indirect imports. Their
+    # facts must be available even without a direct source import.
+    for importpath, facts_file in depset(transitive = fact_sets).to_list():
+        args.append("-facts=%s=%s" % (importpath, facts_file.path))
+        inputs.append(facts_file)
 
     return (go_ctx, args, inputs, raw_findings)
 
-def _nogo_package_config(ctx, deps, importpath = None, target = None):
+def _nogo_package_config(ctx, deps, importpath = None, objfiles = (None, None), attr = None):
     # See _nogo_config. This includes package details.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
-    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps)
+    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps, attr = attr)
 
     # GOVERSION of packages are set by the project language version.
     args.append("-GOVERSION=%s" % go_ctx.lang_version)
 
-    # Add the module itself, for the type sanity check. This applies only to
-    # the libraries, and not binaries or tests.
-    binaries = []
-    if target != None:
-        binaries.extend(target.files.to_list())
-        if hasattr(target.output_groups, "compilation_outputs"):
-            binaries.extend(target.output_groups.compilation_outputs.to_list())
-    target_afile, target_xfile = _select_objfile(binaries)
+    # Add the compiled package itself for analyzers that inspect object code.
+    target_afile, target_xfile = objfiles
     if target_xfile != None:
         args.append("-archive=%s=%s" % (importpath, target_afile.path))
         args.append("-import=%s=%s" % (importpath, target_xfile.path))
@@ -263,7 +264,8 @@ def _nogo_aspect_impl(target, ctx):
     # since there is guaranteed to be no conflict. However for consistency,
     # we should not introduce new go_tool_library dependencies unless strictly
     # necessary.
-    if ctx.rule.kind in ("go_library", "go_tool_library", "go_binary", "go_test"):
+    is_binary = ctx.rule.kind in ("go_binary", "go_non_executable_binary")
+    if is_binary or ctx.rule.kind in ("go_library", "go_tool_library", "go_test"):
         srcs = ctx.rule.files.srcs
         deps = ctx.rule.attr.deps
     elif ctx.rule.kind in ("go_proto_library", "go_wrap_cc"):
@@ -287,14 +289,24 @@ def _nogo_aspect_impl(target, ctx):
         if hasattr(info, "deps"):
             deps = deps + info.deps
 
-    # Extract the importpath for this package.
-    if ctx.rule.kind == "go_test":
-        importpath = "test"
+    # Binary analysis needs the compiled Go archive, not the linked executable:
+    # the linker can remove functions that checkescape still needs to inspect.
+    if is_binary:
+        archive = go_binary_archive(target)
+        importpath = archive.importpath
+        objfiles = (archive.file, archive.export_file)
+        binaries = list(objfiles)
     else:
-        importpath = go_importpath(target)
+        importpath = "test" if ctx.rule.kind == "go_test" else go_importpath(target)
+        binaries = target.files.to_list()
+        compilation_outputs = binaries
+        if hasattr(target.output_groups, "compilation_outputs"):
+            compilation_outputs = compilation_outputs + target.output_groups.compilation_outputs.to_list()
+        objfiles = _select_objfile(compilation_outputs)
 
-    # Build a complete configuration, referring to the library rule.
-    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, target = target)
+    # Use the analyzed rule's transitioned Go configuration, including its build
+    # tags, rather than the aspect's own attributes.
+    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, objfiles = objfiles, attr = ctx.rule.attr)
 
     # Build the argument file, and the runner.
     facts_file = ctx.actions.declare_file(ctx.label.name + ".facts")
@@ -322,9 +334,17 @@ def _nogo_aspect_impl(target, ctx):
     return [
         NogoInfo(
             facts = facts_file,
+            transitive_facts = depset(
+                [(importpath, facts_file)],
+                transitive = [
+                    dep[NogoInfo].transitive_facts
+                    for dep in deps
+                    if hasattr(dep[NogoInfo], "transitive_facts")
+                ],
+            ),
             raw_findings = raw_findings + [findings_file],
             importpath = importpath,
-            binaries = target.files.to_list(),
+            binaries = binaries,
             srcs = srcs,
             deps = deps,
         ),
@@ -463,9 +483,8 @@ nogo_aspect_tricorder = aspect(
 def _nogo_facts_render_impl(ctx):
     """Extract nogo facts."""
 
-    # Build a complete configuration. Note that we don't care about the import
-    # path, since this will generate facts only. We use ctx as the target here,
-    # since this will refer to ctx.files (which contains no binaries).
+    # Rendering dependency facts needs neither an import path nor an archive
+    # for the package containing the template.
     go_ctx, args, inputs, _ = _nogo_package_config(ctx, ctx.attr.deps)
 
     # Build the runner.

--- a/tools/nogo/facts/facts.go
+++ b/tools/nogo/facts/facts.go
@@ -118,6 +118,10 @@ func (p *Package) ReadFrom(pkg *types.Package, r io.Reader) error {
 		return err
 	}
 	for _, fi := range is {
+		objectFacts, ok := fi.Value.([]analysis.Fact)
+		if !ok {
+			return fmt.Errorf("invalid fact payload for %q: %T", fi.Key, fi.Value)
+		}
 		var (
 			obj types.Object
 			err error
@@ -130,7 +134,7 @@ func (p *Package) ReadFrom(pkg *types.Package, r io.Reader) error {
 			// object. We just suppress this error and ignore it.
 			continue
 		}
-		p.Objects[obj] = fi.Value.([]analysis.Fact)
+		p.Objects[obj] = objectFacts
 	}
 	return nil
 }
@@ -229,7 +233,8 @@ func (b *Bundle) Add(path string, facts *Package) {
 	b.decoded[path] = facts
 }
 
-// Package looks up the given package in the bundle.
+// Package looks up the given package in the bundle. It returns nil without an
+// error if the package is absent, or an error if its facts cannot be read.
 func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 	// Already decoded?
 	if facts, ok := b.decoded[pkg.Path()]; ok {
@@ -240,7 +245,7 @@ func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 		// Nothing available.
 		//
 		// N.B. some bundles contain only cached packages.
-		return nil, fmt.Errorf("no facts available for package %q", pkg.Path())
+		return nil, nil
 	}
 
 	// Find based on the reader.
@@ -266,7 +271,7 @@ func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 	}
 
 	// Nothing available.
-	return nil, fmt.Errorf("no facts available for package %q", pkg.Path())
+	return nil, nil
 }
 
 func resolveConstants(pkg *types.Package, localPkg *types.Package, localFacts *Package, allFacts *Bundle) (checkconst.Constants, error) {
@@ -278,10 +283,10 @@ func resolveConstants(pkg *types.Package, localPkg *types.Package, localFacts *P
 	} else {
 		importFacts, err := allFacts.Package(pkg)
 		if err != nil {
-			return c, fmt.Errorf("no facts available for package %q", pkg.Path())
+			return c, fmt.Errorf("loading facts for package %q: %w", pkg.Path(), err)
 		}
 		if importFacts == nil {
-			panic("nil importFacts")
+			return c, fmt.Errorf("no facts available for package %q", pkg.Path())
 		}
 		factSource = importFacts
 	}

--- a/tools/nogo/sanity/sanity_test.sh
+++ b/tools/nogo/sanity/sanity_test.sh
@@ -28,7 +28,7 @@ if [[ "${rc}" -eq "0" ]]; then
   echo "Expected failure; got success."
   exit 1
 fi
-if [[ "${output}" =~ ^sanity.go:[0-9]+:[0-9]+:.*%d.*string.*$ ]]; then
+if [[ "${output}" != *'fmt.Fprintf format %d has arg "hello world!" of wrong type string'* ]]; then
   echo "Expected format error; not found."
   exit 1
 fi


### PR DESCRIPTION
Reserved for Unix transport contracts and fixes after #14237 land.

The diff still contains the earlier broad network annotation and runtime fixes and checker prerequisites; it has not yet been narrowed to the reserved scope. The extracted changes are in #14354 and #14366–#14371. See #14349 for the remaining dependencies.

Assisted-by: Codex