### PR TITLE
checklocks: enforce Unix socket ownership

### DIFF
--- a/pkg/sentry/inet/abstract_socket_namespace.go
+++ b/pkg/sentry/inet/abstract_socket_namespace.go
@@ -43,6 +43,8 @@ type AbstractSocketNamespace struct {
 	// TryIncRef() must be called in case the socket is concurrently being
 	// destroyed. It is the responsibility of the socket to remove itself from the
 	// abstract socket namespace when it is destroyed.
+	//
+	// +checklocks:mu
 	endpoints map[string]abstractEndpoint
 }
 
@@ -59,8 +61,10 @@ func (e *boundEndpoint) Release(ctx context.Context) {
 	e.BoundEndpoint.Release(ctx)
 }
 
-func (a *AbstractSocketNamespace) init() {
-	a.endpoints = make(map[string]abstractEndpoint)
+func newAbstractSocketNamespace() AbstractSocketNamespace {
+	return AbstractSocketNamespace{
+		endpoints: make(map[string]abstractEndpoint),
+	}
 }
 
 // BoundEndpoint retrieves the endpoint bound to the given name. The return

--- a/pkg/sentry/inet/namespace.go
+++ b/pkg/sentry/inet/namespace.go
@@ -65,7 +65,7 @@ func NewRootNamespace(stack Stack, creator NetworkStackCreator, userNS *auth.Use
 	if eventPublishingStack, ok := stack.(InterfaceEventPublisher); ok {
 		eventPublishingStack.AddInterfaceEventSubscriber(n.netlinkMcastTable)
 	}
-	n.abstractSockets.init()
+	n.abstractSockets = newAbstractSocketNamespace()
 	return n
 }
 
@@ -161,7 +161,7 @@ func (n *Namespace) init() {
 			eventPublishingStack.AddInterfaceEventSubscriber(n.netlinkMcastTable)
 		}
 	}
-	n.abstractSockets.init()
+	n.abstractSockets = newAbstractSocketNamespace()
 }
 
 // afterLoad is invoked by stateify.

--- a/pkg/sentry/socket/unix/transport/connectioned.go
+++ b/pkg/sentry/socket/unix/transport/connectioned.go
@@ -112,6 +112,10 @@ type connectionedEndpoint struct {
 	// will store the peer's credentials. The use of this option is possible
 	// only for connected `AF_UNIX` stream sockets and for `AF_UNIX` stream and
 	// datagram socket pairs created using socketpair(2)
+	//
+	// Protected by endpointMutex. During connection setup, the accepted
+	// endpoint's credentials are initialized under the listener's lock,
+	// which prevents Accept from returning it.
 	peerCreds CredentialsControlMessage
 
 	// acceptedChan is per the TCP endpoint implementation. Note that the
@@ -119,12 +123,14 @@ type connectionedEndpoint struct {
 	// have another associated connectionedEndpoint.
 	//
 	// If nil, then no listen call has been made.
+	//
+	// Protected by endpointMutex except during quiescent save/restore.
 	acceptedChan chan *connectionedEndpoint `state:".([]*connectionedEndpoint)"`
 
 	// boundSocketFD corresponds to a bound socket on the host filesystem
 	// that may listen and accept incoming connections.
 	//
-	// boundSocketFD is protected by baseEndpoint.mu.
+	// Protected by endpointMutex except for the quiescent beforeSave check.
 	boundSocketFD BoundSocketFD
 }
 
@@ -216,6 +222,8 @@ func (e *connectionedEndpoint) WaiterQueue() *waiter.Queue {
 
 // isBound returns true iff the connectionedEndpoint is bound (but not
 // listening).
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) isBound() bool {
 	return e.path != "" && e.acceptedChan == nil
 }
@@ -227,6 +235,9 @@ func (e *connectionedEndpoint) Listening() bool {
 	return e.ListeningLocked()
 }
 
+// ListeningLocked implements ConnectingEndpoint.ListeningLocked.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) ListeningLocked() bool {
 	return e.acceptedChan != nil
 }
@@ -297,6 +308,12 @@ func (e *connectionedEndpoint) Close(ctx context.Context) {
 	}
 }
 
+// swapPeerCredsLocked exchanges credentials while the listener's lock prevents
+// Accept from returning ne.
+//
+// Preconditions: cend must be locked and ne must be a pending endpoint of e.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) swapPeerCredsLocked(ctx context.Context, cend ConnectingEndpoint, ne *connectionedEndpoint) *syserr.Error {
 	ce, ok := cend.(*connectionedEndpoint)
 	if !ok {
@@ -504,9 +521,11 @@ func (e *connectionedEndpoint) Accept(ctx context.Context, peerAddr *Address) (E
 	return ne, nil
 }
 
-// Preconditions:
-//   - e.Listening()
-//   - e is locked.
+// getAcceptedEndpointLocked accepts a connection with the endpoint locked.
+//
+// Preconditions: the endpoint must be listening.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) getAcceptedEndpointLocked(ctx context.Context) (*connectionedEndpoint, *syserr.Error) {
 	// Accept connections from within the sentry first, since this avoids
 	// an RPC to the gofer on the common path.
@@ -575,6 +594,7 @@ func (e *connectionedEndpoint) SendMsg(ctx context.Context, data [][]byte, c Con
 	return e.baseEndpoint.SendMsg(ctx, data, c, to)
 }
 
+// +checklocks:e.endpointMutex
 func (e *connectionedEndpoint) isBoundSocketReadable() bool {
 	if e.boundSocketFD == nil {
 		return false

--- a/pkg/sentry/socket/unix/transport/connectionless.go
+++ b/pkg/sentry/socket/unix/transport/connectionless.go
@@ -51,6 +51,8 @@ func NewConnectionless(ctx context.Context) Endpoint {
 }
 
 // isBound returns true iff the endpoint is bound.
+//
+// +checklocks:e.endpointMutex
 func (e *connectionlessEndpoint) isBound() bool {
 	return e.path != ""
 }

--- a/pkg/sentry/socket/unix/transport/queue.go
+++ b/pkg/sentry/socket/unix/transport/queue.go
@@ -36,11 +36,22 @@ type queue struct {
 	readerWaiters *waiter.Queue
 	writerWaiters *waiter.Queue
 
-	mu       queueMutex `state:"nosave"`
-	closed   atomicbitops.Bool
-	unread   bool
-	used     int64
-	limit    int64
+	mu queueMutex `state:"nosave"`
+
+	// +checklocks:mu
+	// +checkatomic
+	closed atomicbitops.Bool
+
+	// +checklocks:mu
+	unread bool
+
+	// +checklocks:mu
+	used int64
+
+	// +checklocks:mu
+	limit int64
+
+	// +checklocks:mu
 	dataList messageList
 }
 
@@ -100,6 +111,8 @@ func (q *queue) IsReadable() bool {
 // free.
 //
 // See net/unix/af_unix.c:unix_writeable.
+//
+// +checklocks:q.mu
 func (q *queue) bufWritable() bool {
 	return 4*q.used < q.limit
 }

--- a/pkg/sentry/socket/unix/transport/queue_test.go
+++ b/pkg/sentry/socket/unix/transport/queue_test.go
@@ -171,7 +171,10 @@ func TestEnqueueRightsOwnership(t *testing.T) {
 			}
 
 			if !test.wantQueued {
-				if q.dataList.Front() != nil {
+				q.mu.Lock()
+				empty := q.dataList.Front() == nil
+				q.mu.Unlock()
+				if !empty {
 					t.Errorf("queue holds a message, want none")
 				}
 				return

--- a/pkg/sentry/socket/unix/transport/unix.go
+++ b/pkg/sentry/socket/unix/transport/unix.go
@@ -303,6 +303,9 @@ type BoundEndpoint interface {
 	// successful connect. The callback should only be called on a successful
 	// connect.
 	//
+	// returnConnect is invoked synchronously while the ConnectingEndpoint's
+	// lock is held. The callback must not acquire that lock.
+	//
 	// For a connection attempt to be successful, the ConnectingEndpoint must
 	// be unconnected and not listening and the BoundEndpoint whose
 	// BidirectionalConnect method is being called must be listening.
@@ -551,10 +554,17 @@ func (q *queueReceiver) Release(ctx context.Context) {
 type streamQueueReceiver struct {
 	queueReceiver
 
-	mu      streamQueueReceiverMutex `state:"nosave"`
-	buffer  []byte
+	mu streamQueueReceiverMutex `state:"nosave"`
+
+	// +checklocks:mu
+	buffer []byte
+
+	// control is protected by mu while the receiver is in use. Release accesses
+	// it without mu after the owner has stopped using the receiver.
 	control ControlMessages
-	addr    Address
+
+	// +checklocks:mu
+	addr Address
 }
 
 func vecCopy(data [][]byte, buf []byte) (int64, [][]byte, []byte) {
@@ -724,6 +734,8 @@ func (q *streamQueueReceiver) Recv(ctx context.Context, data [][]byte, args Recv
 }
 
 // Release implements Receiver.Release.
+//
+// Preconditions: no other operation may use q during or after Release.
 func (q *streamQueueReceiver) Release(ctx context.Context) {
 	q.queueReceiver.Release(ctx)
 	q.control.Release(ctx)
@@ -923,37 +935,48 @@ type baseEndpoint struct {
 
 	tcpip.DefaultSocketOptionsHandler
 
-	// Mutex protects the below fields.
-	//
 	// See the lock ordering comment in package kernel/epoll regarding when
 	// this lock can safely be held.
 	endpointMutex `state:"nosave"`
 
 	// receiver allows Messages to be received.
+	//
+	// receiver and peer are initialized before publication and subsequently
+	// accessed under endpointMutex. Connect installs them in the synchronous
+	// returnConnect callback, which BidirectionalConnect invokes with the
+	// connecting endpoint locked. Checklocks cannot propagate that lock context
+	// through the callback parameter or track private constructor results.
 	receiver Receiver
 
 	// peer is the Sender through which this endpoint's sends reach its
 	// peer socket; it also exposes the send-side state (writability,
 	// shutdown) of that connection.
+	// See receiver for synchronization.
 	peer Sender
 
 	// path is not empty if the endpoint has been bound,
 	// or may be used if the endpoint is connected.
+	//
+	// +checklocks:endpointMutex
 	path string
 
 	// sendShutdown is true if the write side of the endpoint has been
 	// shut down without closing the peer's read side: sends fail with
 	// EPIPE, but the peer is unaffected. This is how shutdown(SHUT_WR)
-	// behaves on datagram sockets. Protected by endpointMutex.
+	// behaves on datagram sockets.
+	//
+	// +checklocks:endpointMutex
 	sendShutdown bool
 
 	// ops is used to get socket level options.
 	ops tcpip.SocketOptions
 
-	// lastError is the last error returned by getsockopt(SO_ERROR).
-	// This field is protected by lastErrorMu.
 	lastErrorMu sync.Mutex `state:"nosave"`
-	lastError   tcpip.Error
+
+	// lastError is the last error returned by getsockopt(SO_ERROR).
+	//
+	// +checklocks:lastErrorMu
+	lastError tcpip.Error
 }
 
 // EventRegister implements waiter.Waitable.EventRegister.
@@ -995,7 +1018,7 @@ func (e *baseEndpoint) ConnectedPasscred() bool {
 
 // Connected implements ConnectingEndpoint.Connected.
 //
-// Preconditions: e.mu must be held.
+// +checklocks:e.endpointMutex
 func (e *baseEndpoint) Connected() bool {
 	return e.receiver != nil && e.peer != nil
 }


### PR DESCRIPTION
Enforce mutex ownership of Unix transport queues, receive buffers, endpoint state, and the abstract socket namespace. Require the endpoint lock in helpers that assume it and take the existing rights-transfer test's queue snapshot under the queue lock.

Construct the abstract namespace as a fresh value so initialization does not require locking an unpublished object. Preserve weak socket ownership and document the callback, teardown, and save/restore phases that cannot be expressed as unconditional field guards.

Assisted-by: Codex
