### PR TITLE
checklocks: enforce memory and restore ownership

### DIFF
--- a/nogo.yaml
+++ b/nogo.yaml
@@ -261,6 +261,8 @@ analyzers:
         - pkg/sentry/fs/fs.go          # Intentional.
         - pkg/sentry/fs/gofer/inode.go # Intentional.
         - pkg/refs/refcounter_test.go  # Intentional.
+        # Lock-order validator tests intentionally have no protected data.
+        - '^pkg/sync/locking/lockdep_test\.go:'
   SA4016: # Useless bitwise operations.
     internal:
       exclude:

--- a/pkg/ring0/pagetables/pcids.go
+++ b/pkg/ring0/pagetables/pcids.go
@@ -19,17 +19,17 @@ import (
 )
 
 // PCIDs is a simple PCID database.
-//
-// This is not protected by locks and is thus suitable for use only with a
-// single CPU at a time.
 type PCIDs struct {
-	// mu protects below.
 	mu sync.Mutex
 
 	// cache are the assigned page tables.
+	//
+	// +checklocks:mu
 	cache map[*PageTables]uint16
 
 	// avail are available PCIDs.
+	//
+	// +checklocks:mu
 	avail []uint16
 }
 

--- a/pkg/sentry/fsimpl/cgroup2fs/cpuset.go
+++ b/pkg/sentry/fsimpl/cgroup2fs/cpuset.go
@@ -31,13 +31,18 @@ import (
 
 // +stateify savable
 type cpuset struct {
-	c        *cgroup
-	parent   *cpuset
+	c      *cgroup
+	parent *cpuset
+
+	// +checkatomic
 	detached atomicbitops.Bool
 
 	mu sync.Mutex `state:"nosave"`
 
+	// +checklocks:mu
 	cpus *bitmap.Bitmap
+
+	// +checklocks:mu
 	mems *bitmap.Bitmap
 }
 

--- a/pkg/sentry/fsimpl/cgroupfs/cpuacct.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cpuacct.go
@@ -49,13 +49,15 @@ type cpuacctController struct {
 	mu sync.Mutex `state:"nosave"`
 
 	// taskCommittedCharges tracks charges for a task already attributed to this
-	// cgroup. This is used to avoid double counting usage for live
-	// tasks. Protected by mu.
+	// cgroup. This is used to avoid double counting usage for live tasks.
+	//
+	// +checklocks:mu
 	taskCommittedCharges map[*kernel.Task]usage.CPUStats
 
 	// usage is the cumulative CPU time used by past tasks in this cgroup. Note
-	// that this doesn't include usage by live tasks currently in the
-	// cgroup. Protected by mu.
+	// that this doesn't include usage by live tasks currently in the cgroup.
+	//
+	// +checklocks:mu
 	usage usage.CPUStats
 }
 
@@ -136,7 +138,9 @@ func (c *cpuacctCgroup) cpuacctController() *cpuacctController {
 	return c.controllers[kernel.CgroupControllerCPUAcct].(*cpuacctController)
 }
 
-// checklocks:c.fs.tasksMu
+// collectCPUStatsLocked includes descendant charges under the shared task lock.
+//
+// +checklocksread:c.fs.tasksMu
 func (c *cpuacctCgroup) collectCPUStatsLocked(acc *usage.CPUStats) {
 	ctl := c.cpuacctController()
 	for t := range c.ts {
@@ -152,7 +156,10 @@ func (c *cpuacctCgroup) collectCPUStatsLocked(acc *usage.CPUStats) {
 
 	c.forEachChildDir(func(d *dir) {
 		cg := cpuacctCgroup{d.cgi}
-		cg.collectCPUStatsLocked(acc)
+		// forEachChildDir visits the same filesystem synchronously while
+		// c.fs.tasksMu is read-locked. checklocks cannot carry that lock or
+		// relate cg.fs to c.fs through the callback's directory argument.
+		cg.collectCPUStatsLocked(acc) // +checklocksignore
 	})
 }
 

--- a/pkg/sentry/fsimpl/cgroupfs/cpuset.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cpuset.go
@@ -42,7 +42,10 @@ type cpusetController struct {
 
 	mu sync.Mutex `state:"nosave"`
 
+	// +checklocks:mu
 	cpus *bitmap.Bitmap
+
+	// +checklocks:mu
 	mems *bitmap.Bitmap
 }
 

--- a/pkg/sentry/fsimpl/cgroupfs/devices.go
+++ b/pkg/sentry/fsimpl/cgroupfs/devices.go
@@ -132,12 +132,15 @@ type devicesController struct {
 	controllerStateless
 	controllerNoResource
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// Allow or deny the device rules below.
+	//
+	// +checklocks:mu
 	defaultAllow bool
-	deviceRules  map[deviceID]permission
+
+	// +checklocks:mu
+	deviceRules map[deviceID]permission
 }
 
 // +stateify savable
@@ -182,12 +185,14 @@ func (d *controlledDevicesData) Generate(ctx context.Context, buf *bytes.Buffer)
 	return d.c.generate(ctx, buf)
 }
 
+// +checklocks:c.mu
 func (c *devicesController) addRule(id deviceID, newPermission permission) error {
 	existingPermission := c.deviceRules[id]
 	c.deviceRules[id] = existingPermission.union(newPermission)
 	return nil
 }
 
+// +checklocks:c.mu
 func (c *devicesController) removeRule(id deviceID, p permission) error {
 	// cgroupv1 ignores silently requests to remove a partially-matching wildcard rule,
 	// which are {majorDevice:wildcardDevice}, {wildcardDevice:minorDevice}, and {wildcardDevice:wildcardDevice}
@@ -214,6 +219,7 @@ func (c *devicesController) removeRule(id deviceID, p permission) error {
 	return nil
 }
 
+// +checklocks:c.mu
 func (c *devicesController) applyRule(id deviceID, p permission, allow bool) error {
 	if !id.controllerType.valid() {
 		return linuxerr.EINVAL

--- a/pkg/sentry/fsimpl/cgroupfs/pids.go
+++ b/pkg/sentry/fsimpl/cgroupfs/pids.go
@@ -59,7 +59,6 @@ type pidsController struct {
 	// since cgroupfs doesn't allow cross directory renames.
 	isRoot bool
 
-	// mu protects the fields below.
 	mu pidsControllerMutex `state:"nosave"`
 
 	// pendingTotal and pendingPool tracks the charge for processes starting
@@ -71,15 +70,21 @@ type pidsController struct {
 	// We also track which task owns the pending charge so we can cancel the
 	// charge if a task creation fails after the Charge call.
 	//
-	// pendingTotal and pendingPool are both protected by mu.
+	// +checklocks:mu
 	pendingTotal int64
-	pendingPool  map[*kernel.Task]int64
+
+	// +checklocks:mu
+	pendingPool map[*kernel.Task]int64
 
 	// committed represent charges for tasks that have already started and
-	// called Enter. Protected by mu.
+	// called Enter.
+	//
+	// +checklocks:mu
 	committed int64
 
-	// max is the PID limit for this cgroup. Protected by mu.
+	// max is the PID limit for this cgroup.
+	//
+	// +checklocks:mu
 	max int64
 }
 

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -443,7 +443,9 @@ go_test(
     name = "kernel_test",
     size = "small",
     srcs = [
+        "async_loader_test.go",
         "fd_table_test.go",
+        "kernel_restore_test.go",
         "table_test.go",
         "task_test.go",
         "timekeeper_test.go",
@@ -460,6 +462,7 @@ go_test(
         "//pkg/sentry/kernel/sched",
         "//pkg/sentry/limits",
         "//pkg/sentry/pgalloc",
+        "//pkg/sentry/state/stateio",
         "//pkg/sentry/time",
         "//pkg/sentry/usage",
         "//pkg/sentry/vfs",

--- a/pkg/sentry/kernel/async_loader_test.go
+++ b/pkg/sentry/kernel/async_loader_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"testing/synctest"
+
+	"gvisor.dev/gvisor/pkg/sentry/state/stateio"
+)
+
+func TestAsyncMFLoaderStartupError(t *testing.T) {
+	// The bubble detects a missing mainMFStartWg completion as a deadlock,
+	// without a timeout. This test does not depend on virtual time.
+	synctest.Test(t, func(t *testing.T) {
+		// A sub-page read limit fails before metadata or mainMF is loaded.
+		pages := stateio.NewIOReader(bytes.NewReader(nil), 1, 1, 1)
+		metadata := io.NopCloser(bytes.NewReader(nil))
+		loader := NewAsyncMFLoader(metadata, pages, nil, nil)
+
+		const want = "stateio.AsyncReader.MaxReadBytes() (1) must be at least one page)"
+		startErr := loader.WaitMainMFStart()
+		if startErr == nil || startErr.Error() != want {
+			t.Fatalf("WaitMainMFStart() = %v, want %q", startErr, want)
+		}
+		if err := loader.WaitMetadata(); err != startErr {
+			t.Errorf("WaitMetadata() = %v, want %v", err, startErr)
+		}
+		if err := loader.Wait(); err != startErr {
+			t.Errorf("Wait() = %v, want %v", err, startErr)
+		}
+	})
+}

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -402,23 +402,28 @@ type Kernel struct {
 	// It's protected by extMu.
 	containerNames map[string]string
 
-	// checkpointMu is used to protect the checkpointing related fields below.
+	// Lock order: checkpointMu precedes CheckpointWait.mu.
 	checkpointMu sync.Mutex `state:"nosave"`
 
 	// additionalCheckpointState stores additional state that needs
-	// to be checkpointed. It's protected by checkpointMu.
+	// to be checkpointed.
+	//
+	// +checklocks:checkpointMu
 	additionalCheckpointState map[any]any
 
 	// saver implements the Saver interface, which (as of writing) supports
-	// asynchronous checkpointing. It's protected by checkpointMu.
+	// asynchronous checkpointing.
+	//
+	// +checklocks:checkpointMu
 	saver Saver `state:"nosave"`
 
 	// CheckpointWait is used to wait for a checkpoint to complete.
 	CheckpointWait CheckpointWaitable
 
-	// checkpointGen aims to track the number of times the kernel has been
-	// successfully checkpointed. Callers of checkpoint must notify the kernel
-	// when checkpoint/restore are done. It's protected by checkpointMu.
+	// checkpointGen describes the latest checkpoint attempt or restore.
+	// Callers must notify the kernel when checkpoint/restore are done.
+	//
+	// +checklocks:checkpointMu
 	checkpointGen CheckpointGeneration
 
 	// SaveRestoreExecConfig stores configuration options for the save/restore
@@ -438,9 +443,11 @@ type Kernel struct {
 	// MaxKeySetSize is the maximum number of keys in a key set.
 	MaxKeySetSize atomicbitops.Int32
 
-	// fsSaveWaiters holds waiters for Kernel.WaitForFSSave. fsSaveWaiters is
-	// protected by fsSaveMu.
-	fsSaveMu      fsSaveMutex  `state:"nosave"`
+	fsSaveMu fsSaveMutex `state:"nosave"`
+
+	// fsSaveWaiters holds waiters for Kernel.WaitForFSSave.
+	//
+	// +checklocks:fsSaveMu
 	fsSaveWaiters []chan error `state:"nosave"`
 
 	// HostNamePoller is notified when the system hostname changes in *any*

--- a/pkg/sentry/kernel/kernel_restore.go
+++ b/pkg/sentry/kernel/kernel_restore.go
@@ -41,8 +41,8 @@ type Saver interface {
 //
 // +stateify savable
 type CheckpointGeneration struct {
-	// Count is incremented every time a checkpoint is triggered, even if the
-	// checkpoint failed.
+	// Count is incremented after each checkpoint attempt, including failures,
+	// and on restore.
 	Count uint32
 	// Restore indicates if the current instance resumed after the checkpoint or
 	// it was restored from a checkpoint.
@@ -50,6 +50,9 @@ type CheckpointGeneration struct {
 }
 
 // AddStateToCheckpoint adds a key-value pair to be additionally checkpointed.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) AddStateToCheckpoint(key, v any) {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -61,6 +64,9 @@ func (k *Kernel) AddStateToCheckpoint(key, v any) {
 
 // PopCheckpointState pops a key-value pair from the additional checkpoint
 // state. If the key doesn't exist, nil is returned.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) PopCheckpointState(key any) any {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -73,6 +79,9 @@ func (k *Kernel) PopCheckpointState(key any) any {
 
 // SetSaver sets the kernel's Saver.
 // Thread-compatible.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) SetSaver(s Saver) {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -81,6 +90,9 @@ func (k *Kernel) SetSaver(s Saver) {
 
 // Saver returns the kernel's Saver.
 // Thread-compatible.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) Saver() Saver {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -88,6 +100,9 @@ func (k *Kernel) Saver() Saver {
 }
 
 // CheckpointGen returns the current checkpoint generation.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) CheckpointGen() CheckpointGeneration {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -96,6 +111,9 @@ func (k *Kernel) CheckpointGen() CheckpointGeneration {
 }
 
 // IncCheckpointGenOnRestore increments the checkpoint generation upon restore.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) IncCheckpointGenOnRestore() {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -108,6 +126,9 @@ func (k *Kernel) IncCheckpointGenOnRestore() {
 
 // OnCheckpointAttempt is called when a checkpoint attempt is completed. err is
 // any checkpoint errors that may have occurred.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) OnCheckpointAttempt(err error) {
 	if err == nil {
 		log.Infof("Checkpoint completed successfully.")
@@ -124,7 +145,11 @@ func (k *Kernel) OnCheckpointAttempt(err error) {
 	k.CheckpointWait.signal(k.checkpointGen, err)
 }
 
-// WaitForCheckpoint waits for the Kernel to have been successfully checkpointed.
+// WaitForCheckpoint waits for the next checkpoint generation or an error
+// notification, and returns the reported error.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) WaitForCheckpoint() error {
 	// Send checkpoint result to a channel and wait on it.
 	ch := make(chan error, 1)
@@ -136,6 +161,8 @@ func (k *Kernel) WaitForCheckpoint() error {
 }
 
 // SignalAllCheckpointWaiters signals all checkpoint waiters with err.
+//
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) SignalAllCheckpointWaiters(err error) {
 	k.CheckpointWait.signal(CheckpointGeneration{Count: math.MaxUint32}, err)
 }
@@ -145,6 +172,9 @@ type checkpointWaiter struct {
 	count uint32
 	// callback is the function that will be called when the checkpoint generation
 	// reaches the desired count. It is set to nil after the callback is called.
+	//
+	// It is protected by the owning CheckpointWaitable's mu. The waiter has
+	// no reference to that owner, so checklocks cannot name the mutex here.
 	callback func(CheckpointGeneration, error)
 }
 
@@ -153,21 +183,29 @@ type checkpointWaiter struct {
 //
 // +stateify savable
 type CheckpointWaitable struct {
+	// k is set before the waitable is used and remains unchanged.
 	k *Kernel
 
 	mu sync.Mutex `state:"nosave"`
 
 	// Don't save the waiters, because they are repopulated after restore. It also
 	// allows for external entities to wait for the checkpoint.
+	//
+	// +checklocks:mu
 	waiters map[*checkpointWaiter]struct{} `state:"nosave"`
 }
 
-// Register registers a callback that is notified when the checkpoint generation count is higher
-// than the desired count.
+// Register registers a callback that is notified when the checkpoint generation
+// reaches the desired count.
+//
+// cb runs with mu held and may also run with the kernel's checkpoint mutex
+// held. It must not call methods that acquire either mutex. checklocks cannot
+// attach these owner-lock requirements to the supplied function value.
+//
+// +checklocksexclude:w.mu
+// +checklocksexclude:w.k.checkpointMu
 func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), count uint32) any {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	waiter := &checkpointWaiter{
 		count:    count,
 		callback: cb,
@@ -176,8 +214,17 @@ func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), coun
 		w.waiters = make(map[*checkpointWaiter]struct{})
 	}
 	w.waiters[waiter] = struct{}{}
+	w.mu.Unlock()
 
-	if gen := w.k.CheckpointGen(); count <= gen.Count {
+	// Publish the waiter before reading the generation to avoid missing a
+	// checkpoint. Do not hold mu while acquiring checkpointMu: notification
+	// holds checkpointMu while acquiring mu.
+	gen := w.k.CheckpointGen()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	// Notification may have already delivered the checkpoint's error.
+	if waiter.callback != nil && count <= gen.Count {
 		// The checkpoint has already occurred. Signal immediately.
 		waiter.callback(gen, nil)
 		waiter.callback = nil
@@ -185,8 +232,10 @@ func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), coun
 	return waiter
 }
 
-// Unregister unregisters a waiter. It must be called even if the channel
-// was signalled.
+// Unregister unregisters a waiter. It must be called even if the callback
+// has already run.
+//
+// +checklocksexclude:w.mu
 func (w *CheckpointWaitable) Unregister(key any) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -197,6 +246,9 @@ func (w *CheckpointWaitable) Unregister(key any) {
 	}
 }
 
+// signal notifies waiters whose desired generation has been reached.
+//
+// +checklocksexclude:w.mu
 func (w *CheckpointWaitable) signal(gen CheckpointGeneration, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -262,6 +314,10 @@ type AsyncMFLoader struct {
 	// MemoryFiles, once they are known. This channel is written to exactly once.
 	privateMFsChan chan map[checkpoint.ResourceID]*pgalloc.MemoryFile
 
+	// Error fields are published by WaitGroup completion rather than a mutex:
+	// mainMFStartWg publishes mainMetadataErr, metadataWg publishes metadataErr,
+	// and loadWg publishes loadErr. Readers wait for the corresponding group.
+	// checklocks cannot express these completion-based publication boundaries.
 	mainMFStartWg   sync.WaitGroup
 	mainMetadataErr error
 
@@ -306,6 +362,9 @@ func (mfl *AsyncMFLoader) backgroundGoroutine(pagesMetadata io.ReadCloser, pages
 	}, timeline) // transfers ownership of pagesFile
 	if err != nil {
 		mfl.loadWg.Done()
+		mfl.mainMetadataErr = err
+		mfl.metadataErr = err
+		mfl.mainMFStartWg.Done()
 		log.Warningf("Failed to start async page loading: %v", err)
 		return
 	}

--- a/pkg/sentry/kernel/kernel_restore_test.go
+++ b/pkg/sentry/kernel/kernel_restore_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestCheckpointRegistrationDuringNotification(t *testing.T) {
+	var k Kernel
+	w := &k.CheckpointWait
+	w.k = &k
+	gen := CheckpointGeneration{Count: 1}
+	wantErr := errors.New("checkpoint failed")
+	type result struct {
+		gen CheckpointGeneration
+		err error
+	}
+	results := make(chan result, 2)
+	registered := make(chan any, 1)
+	notified := make(chan struct{})
+
+	// Hold the generation lock as a checkpoint producer does. Registration
+	// must not hold the waiters lock while waiting to read this generation.
+	k.checkpointMu.Lock()
+	k.checkpointGen = gen
+	go func() {
+		registered <- w.Register(func(gen CheckpointGeneration, err error) {
+			results <- result{gen, err}
+		}, gen.Count)
+	}()
+	go func() {
+		for {
+			w.mu.Lock()
+			pending := len(w.waiters) != 0
+			w.mu.Unlock()
+			if pending {
+				break
+			}
+			runtime.Gosched()
+		}
+		w.signal(gen, wantErr)
+		close(notified)
+	}()
+
+	// Mutex contention is not durably blocking in synctest, so its clock
+	// cannot advance a watchdog when the original lock inversion occurs.
+	// Use a real-time deadline to release both goroutines on that failure.
+	var blocked bool
+	select {
+	case <-notified:
+	case <-time.After(5 * time.Second):
+		blocked = true
+	}
+	// Release the generation lock even on failure, so the original lock
+	// inversion cannot strand either goroutine during test cleanup.
+	k.checkpointMu.Unlock()
+	key := <-registered
+	<-notified
+	w.Unregister(key)
+	if blocked {
+		t.Fatal("checkpoint notification blocked on registration")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d callbacks, want 1", len(results))
+	}
+	if got := <-results; got.gen != gen || got.err != wantErr {
+		t.Fatalf("callback = (%+v, %v), want (%+v, %v)", got.gen, got.err, gen, wantErr)
+	}
+}

--- a/pkg/sentry/mm/address_space.go
+++ b/pkg/sentry/mm/address_space.go
@@ -35,10 +35,11 @@ func (mm *MemoryManager) AddressSpace() platform.AddressSpace {
 // mapASLocked maps addresses in ar into mm.as.
 //
 // Preconditions:
-//   - mm.activeMu must be locked.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
 //   - pseg == mm.pmas.LowerBoundSegment(ar.Start).
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) mapASLocked(ctx context.Context, pseg pmaIterator, ar hostarch.AddrRange, platformEffect memmap.MMapPlatformEffect) error {
 	if platformEffect == memmap.PlatformEffectCommit && ar.Length() > (1<<30) {
 		// FIXME(b/445932215, b/445939339): Don't precommit very large ranges
@@ -121,7 +122,7 @@ func (mm *MemoryManager) mapASLocked(ctx context.Context, pseg pmaIterator, ar h
 
 // unmapASLocked removes all AddressSpace mappings for addresses in ar.
 //
-// Preconditions: mm.activeMu must be locked.
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) unmapASLocked(ar hostarch.AddrRange) {
 	if ar.Length() == 0 {
 		return

--- a/pkg/sentry/mm/aio_context.go
+++ b/pkg/sentry/mm/aio_context.go
@@ -29,10 +29,11 @@ import (
 //
 // +stateify savable
 type aioManager struct {
-	// mu protects below.
 	mu aioManagerMutex `state:"nosave"`
 
-	// aioContexts is the set of asynchronous I/O contexts.
+	// contexts is the set of asynchronous I/O contexts.
+	//
+	// +checklocks:mu
 	contexts map[uint64]*AIOContext
 }
 
@@ -69,7 +70,7 @@ func (a *aioManager) newAIOContext(events uint32, id uint64) bool {
 //
 // Nil is returned if the context does not exist.
 //
-// Precondition: mm.aioManager.mu is locked.
+// +checklocks:mm.aioManager.mu
 func (mm *MemoryManager) destroyAIOContextLocked(ctx context.Context, id uint64) *AIOContext {
 	aioCtx, ok := mm.aioManager.contexts[id]
 	if !ok {
@@ -104,12 +105,15 @@ type ioResult struct {
 // +stateify savable
 type AIOContext struct {
 	// requestReady is the notification channel used for all requests.
+	//
+	// +checklocks:mu
 	requestReady chan struct{} `state:"nosave"`
 
-	// mu protects below.
 	mu aioContextMutex `state:"nosave"`
 
 	// results is the set of completed requests.
+	//
+	// +checklocks:mu
 	results ioList
 
 	// maxOutstanding is the maximum number of outstanding entries; this value
@@ -119,9 +123,13 @@ type AIOContext struct {
 	// outstanding is the number of requests outstanding; this will effectively
 	// be the number of entries in the result list or that are expected to be
 	// added to the result list.
+	//
+	// +checklocks:mu
 	outstanding uint32
 
 	// dead is set when the context is destroyed.
+	//
+	// +checklocks:mu
 	dead bool `state:"zerovalue"`
 }
 
@@ -133,7 +141,7 @@ func (aio *AIOContext) destroy() {
 	aio.checkForDone()
 }
 
-// Preconditions: ctx.mu must be held by caller.
+// +checklocks:aio.mu
 func (aio *AIOContext) checkForDone() {
 	if aio.dead && aio.outstanding == 0 {
 		close(aio.requestReady)

--- a/pkg/sentry/mm/aio_context_state.go
+++ b/pkg/sentry/mm/aio_context_state.go
@@ -20,7 +20,9 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
 )
 
-// afterLoad is invoked by stateify.
+// afterLoad is invoked by stateify before the restored context is in use.
+//
+// +checklocks:aio.mu
 func (aio *AIOContext) afterLoad(context.Context) {
 	aio.requestReady = make(chan struct{}, 1)
 }

--- a/pkg/sentry/mm/debug.go
+++ b/pkg/sentry/mm/debug.go
@@ -59,7 +59,11 @@ func (mm *MemoryManager) DebugString(ctx context.Context) string {
 	return b.String()
 }
 
-// Preconditions: mm.activeMu must be locked.
+// debugStringEntryLocked formats pseg for DebugString. The generated iterator
+// has no MemoryManager reference, so checklocks cannot name the owning mutex.
+//
+// Preconditions: the owning MemoryManager's activeMu is held at least for
+// reading.
 func (pseg pmaIterator) debugStringEntryLocked() []byte {
 	var b bytes.Buffer
 

--- a/pkg/sentry/mm/io.go
+++ b/pkg/sentry/mm/io.go
@@ -715,12 +715,13 @@ func (mm *MemoryManager) withVecInternalMappings(ctx context.Context, ars hostar
 // called.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - pseg.Range().Contains(ar.Start).
 //   - pmas must exist for all addresses in ar.
 //   - ar.Length() != 0.
 //
 // Postconditions: getIOMappingsLocked does not invalidate iterators into mm.pmas.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getIOMappingsLocked(pseg pmaIterator, ar hostarch.AddrRange, at hostarch.AccessType) (safemem.BlockSeq, *ioBufTracker, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -759,12 +760,12 @@ slowPath:
 // are valid until either mm.activeMu is unlocked or ioBufTracker.flush() is
 // called.
 //
-// Preconditions:
-//   - mm.activeMu must be locked for writing.
-//   - pmas must exist for all addresses in ar.
+// Preconditions: pmas must exist for all addresses in ars.
 //
 // Postconditions: getVecIOMappingsLocked does not invalidate iterators into
 // mm.pmas
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getVecIOMappingsLocked(ars hostarch.AddrRangeSeq, at hostarch.AccessType) (safemem.BlockSeq, *ioBufTracker, error) {
 	if ars.NumRanges() == 1 {
 		ar := ars.Head()
@@ -807,13 +808,14 @@ func (mm *MemoryManager) getVecIOMappingsLocked(ars hostarch.AddrRangeSeq, at ho
 // ioBufTracker.flush() is called.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - pseg.Range().Contains(ar.Start).
 //   - pmas must exist for all addresses in ar.
 //   - ar.Length() != 0.
 //
 // Postconditions: getIOMappingsTrackedLocked does not invalidate iterators
 // into mm.pmas.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getIOMappingsTrackedLocked(pseg pmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, ims []safemem.Block, t *ioBufTracker, unbufBytes uint64) ([]safemem.Block, *ioBufTracker, uint64, error) {
 	for {
 		pmaAR := ar.Intersect(pseg.Range())

--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -129,7 +129,10 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 		// Inform the Mappable, if any, of the new mapping.
 		if vma.mappable != nil {
 			if err := vma.mappable.AddMapping(ctx, mm2, vmaAR, vma.off, vma.canWriteMappableLocked()); err != nil {
-				_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs)
+				// Fork still exclusively owns mm2's VMA and mapping-accounting
+				// state. AddMapping only exposes its activeMu-protected
+				// invalidation state.
+				_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs) // +checklocksignore
 				as.Release()
 				return nil, err
 			}
@@ -233,7 +236,10 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 							pseg.ValuePtr().file.DecRef(pseg.fileRange())
 						}
 						mm2.pmas.RemoveAll()
-						_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs)
+						// Fork still exclusively owns mm2's VMA and mapping-accounting
+						// state. AddMapping only exposes its activeMu-protected
+						// invalidation state.
+						_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs) // +checklocksignore
 						as.Release()
 						return nil, err
 					}
@@ -309,11 +315,12 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 // may be pinned for DMA. It returns the gap after the inserted pma.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
-//   - mm2.activeMu must be locked for writing.
 //   - srcpseg.ValuePtr().private == true.
 //   - dstpgap must be the gap in mm2.pmas at which the new pma should be
 //     inserted.
+//
+// +checklocks:mm.activeMu
+// +checklocks:mm2.activeMu
 func (mm *MemoryManager) forkCopyPMALocked(mm2 *MemoryManager, srcpseg pmaIterator, dstpgap pmaGapIterator, memCgID uint32) (pmaGapIterator, error) {
 	if err := srcpseg.getInternalMappingsLocked(); err != nil {
 		return dstpgap, err

--- a/pkg/sentry/mm/mm.go
+++ b/pkg/sentry/mm/mm.go
@@ -31,8 +31,8 @@
 //						mm.AIOContext.mu
 //
 // Only mm.MemoryManager.Fork is permitted to lock mm.MemoryManager.activeMu in
-// multiple mm.MemoryManagers, as it does so in a well-defined order (forked
-// child first).
+// multiple mm.MemoryManagers, as it does so in a well-defined order (parent
+// first, then the new child).
 package mm
 
 import (
@@ -79,6 +79,8 @@ type MemoryManager struct {
 	// users is the number of dependencies on the mappings in the MemoryManager.
 	// When the number of references in users reaches zero, all mappings are
 	// unmapped.
+	//
+	// +checkatomic
 	users atomicbitops.Int32
 
 	// mappingMu is analogous to Linux's struct mm_struct::mmap_sem.
@@ -90,37 +92,37 @@ type MemoryManager struct {
 	//
 	// Invariants: vmas are always page-aligned.
 	//
-	// vmas is protected by mappingMu.
+	// +checklocks:mappingMu
 	vmas vmaSet
 
 	// brk is the mm's brk, which is manipulated using the brk(2) system call.
 	// The brk is initially set up by the loader which maps an executable
 	// binary into the mm.
 	//
-	// brk is protected by mappingMu.
+	// +checklocks:mappingMu
 	brk hostarch.AddrRange
 
 	// usageAS is vmas.Span(), cached to accelerate RLIMIT_AS checks.
 	//
-	// usageAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	usageAS uint64
 
 	// lockedAS is the combined size in bytes of all vmas with vma.mlockMode !=
 	// memmap.MLockNone.
 	//
-	// lockedAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	lockedAS uint64
 
 	// dataAS is the size of private data segments, like mm_struct->data_vm.
 	// It means the vma which is private, writable, not stack.
 	//
-	// dataAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	dataAS uint64
 
 	// New VMAs created by MMap use whichever of memmap.MMapOpts.MLockMode or
 	// defMLockMode is greater.
 	//
-	// defMLockMode is protected by mappingMu.
+	// +checklocks:mappingMu
 	defMLockMode memmap.MLockMode
 
 	// activeMu is loosely analogous to Linux's struct
@@ -133,40 +135,43 @@ type MemoryManager struct {
 	// a copy.
 	//
 	// Inserting or removing segments from pmas should happen along with a
-	// call to mm.insertRSS or mm.removeRSS.
+	// call to mm.addRSSLocked or mm.removeRSSLocked.
 	//
 	// Invariants: pmas are always page-aligned. If a pma exists for a given
 	// address, a vma must also exist for that address.
 	//
-	// pmas is protected by activeMu.
+	// +checklocks:activeMu
 	pmas pmaSet
 
 	// curRSS is pmas.Span(), cached to accelerate updates to maxRSS. It is
 	// reported as the MemoryManager's RSS.
 	//
-	// maxRSS should be modified only via insertRSS and removeRSS, not
+	// curRSS should be modified only via addRSSLocked and removeRSSLocked, not
 	// directly.
 	//
-	// maxRSS is protected by activeMu.
+	// +checklocks:activeMu
 	curRSS uint64
 
 	// maxRSS is the maximum resident set size in bytes of a MemoryManager.
 	// It is tracked as the application adds and removes mappings to pmas.
 	//
-	// maxRSS should be modified only via insertRSS, not directly.
+	// maxRSS should be modified only via addRSSLocked, not directly.
 	//
-	// maxRSS is protected by activeMu.
+	// +checklocks:activeMu
 	maxRSS uint64
 
 	// hasPinned is true if pages in this MemoryManager have ever been pinned
 	// by Pin. It is never cleared, even if all pinned pages are unpinned;
 	// compare Linux's MMF_HAS_PINNED.
 	//
-	// hasPinned is protected by activeMu.
+	// +checklocks:activeMu
 	hasPinned bool
 
 	// as is the platform.AddressSpace that pmas are mapped into. as is immutable
-	// until users becomes 0, at which point as becomes nil.
+	// until users becomes 0, at which point as becomes nil. Reads with a live
+	// user reference need no lock. activeMu serializes teardown and invalidation
+	// after the last user; checklocks cannot express this lifetime-dependent
+	// locking.
 	as platform.AddressSpace `state:"nosave"`
 
 	// If captureInvalidations is true, calls to MM.Invalidate() are recorded
@@ -174,15 +179,20 @@ type MemoryManager struct {
 	// This is to avoid a race condition in MM.Fork(); see that function for
 	// details.
 	//
-	// Both captureInvalidations and capturedInvalidations are protected by
-	// activeMu. Neither need to be saved since captureInvalidations is only
+	// Neither field needs to be saved since captureInvalidations is only
 	// enabled during MM.Fork(), during which saving can't occur.
-	captureInvalidations  bool             `state:"zerovalue"`
+	//
+	// +checklocks:activeMu
+	captureInvalidations bool `state:"zerovalue"`
+
+	// +checklocks:activeMu
 	capturedInvalidations []invalidateArgs `state:"nosave"`
 
 	// dumpability describes if and how this MemoryManager may be dumped to
 	// userspace. This is read under kernel.TaskSet.mu, so it can't be protected
 	// by metadataMu.
+	//
+	// +checkatomic
 	dumpability atomicbitops.Int32
 
 	metadataMu metadataMutex `state:"nosave"`
@@ -191,25 +201,25 @@ type MemoryManager struct {
 	// modified by prctl(PR_SET_MM_ARG_START/PR_SET_MM_ARG_END). No
 	// requirements apply to argv; we do not require that argv.WellFormed().
 	//
-	// argv is protected by metadataMu.
+	// +checklocks:metadataMu
 	argv hostarch.AddrRange
 
 	// envv is the application envv. This is set up by the loader and may be
 	// modified by prctl(PR_SET_MM_ENV_START/PR_SET_MM_ENV_END). No
 	// requirements apply to envv; we do not require that envv.WellFormed().
 	//
-	// envv is protected by metadataMu.
+	// +checklocks:metadataMu
 	envv hostarch.AddrRange
 
 	// auxv is the ELF's auxiliary vector.
 	//
-	// auxv is protected by metadataMu.
+	// +checklocks:metadataMu
 	auxv arch.Auxv
 
 	// executable is the executable for this MemoryManager. If executable
-	// is not nil, it holds a reference on the Dirent.
+	// is not nil, it holds a reference on the FileDescription.
 	//
-	// executable is protected by metadataMu.
+	// +checklocks:metadataMu
 	executable *vfs.FileDescription
 
 	// aioManager keeps track of AIOContexts used for async IOs. AIOManager
@@ -217,22 +227,34 @@ type MemoryManager struct {
 	aioManager aioManager
 
 	// vdsoSigReturnAddr is the address of 'vdso_sigreturn'.
+	//
+	// +checklocks:metadataMu
 	vdsoSigReturnAddr uint64
 
 	// membarrierPrivateEnabled is non-zero if EnableMembarrierPrivate has
 	// previously been called. Since, as of this writing,
 	// MEMBARRIER_CMD_PRIVATE_EXPEDITED is implemented as a global memory
 	// barrier, membarrierPrivateEnabled has no other effect.
+	//
+	// +checkatomic
 	membarrierPrivateEnabled atomicbitops.Uint32
 
 	// membarrierRSeqEnabled is non-zero if EnableMembarrierRSeq has previously
 	// been called.
+	//
+	// +checkatomic
 	membarrierRSeqEnabled atomicbitops.Uint32
 }
 
 // vma represents a virtual memory area.
 //
-// Note: new fields added to this struct must be added to vma.Copy and
+// After MemoryManager construction, fields in stored VMAs are protected by its
+// mappingMu, except as noted below. Detached copies are exclusively owned.
+//
+// Neither vma nor its generated iterators have a MemoryManager backpointer,
+// so checklocks cannot name the owner mutex for their fields and methods.
+//
+// Note: new fields added to this struct must be added to vma.copy and
 // vmaSetFunctions.Merge.
 //
 // +stateify savable
@@ -304,8 +326,12 @@ type vma struct {
 	// lastFault records the last address that was paged faulted. It hints at
 	// which direction addresses in this vma are being accessed.
 	//
-	// This field can be read atomically, and written with mm.activeMu locked for
-	// writing and mm.mapping locked.
+	// Accesses to this field in stored VMAs are atomic. Fault updates hold
+	// mappingMu at least for reading and activeMu for writing. After
+	// construction, VMA-set mutations hold mappingMu for writing, excluding
+	// fault updates. Detached copies may use ordinary reads and writes.
+	//
+	// +checkatomic
 	lastFault uintptr
 }
 
@@ -331,6 +357,11 @@ func (v *vma) copy() vma {
 }
 
 // pma represents a platform mapping area.
+//
+// Stored PMA metadata is protected by the owning MemoryManager.activeMu.
+// Detached copies of the metadata can be used under exclusive ownership.
+// Neither pma nor its generated iterators have a MemoryManager backpointer,
+// so checklocks cannot name the owner mutex for their fields and methods.
 //
 // +stateify savable
 type pma struct {

--- a/pkg/sentry/mm/mm_test.go
+++ b/pkg/sentry/mm/mm_test.go
@@ -52,6 +52,8 @@ func testMemoryManager(ctx context.Context, t *testing.T) *MemoryManager {
 }
 
 func (mm *MemoryManager) realUsageAS() uint64 {
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
 	return uint64(mm.vmas.Span())
 }
 
@@ -68,18 +70,20 @@ func TestUsageASUpdates(t *testing.T) {
 		t.Fatalf("MMap got err %v want nil", err)
 	}
 	realUsage := mm.realUsageAS()
-	if mm.usageAS != realUsage {
-		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", mm.usageAS, realUsage)
+	if got := mm.VirtualMemorySize(); got != realUsage {
+		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", got, realUsage)
 	}
 
 	mm.MUnmap(ctx, addr, hostarch.PageSize)
 	realUsage = mm.realUsageAS()
-	if mm.usageAS != realUsage {
-		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", mm.usageAS, realUsage)
+	if got := mm.VirtualMemorySize(); got != realUsage {
+		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", got, realUsage)
 	}
 }
 
 func (mm *MemoryManager) realDataAS() uint64 {
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
 	var sz uint64
 	for seg := mm.vmas.FirstSegment(); seg.Ok(); seg = seg.NextSegment() {
 		vma := seg.ValuePtr()
@@ -104,32 +108,32 @@ func TestDataASUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MMap got err %v want nil", err)
 	}
-	if mm.dataAS == 0 {
+	if mm.VirtualDataSize() == 0 {
 		t.Fatalf("dataAS is 0, wanted not 0")
 	}
 	realDataAS := mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MUnmap(ctx, addr, hostarch.PageSize)
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MProtect(addr+hostarch.PageSize, hostarch.PageSize, hostarch.Read, false)
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MRemap(ctx, addr+2*hostarch.PageSize, hostarch.PageSize, 2*hostarch.PageSize, MRemapOpts{
 		Move: MRemapMayMove,
 	})
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 }
 

--- a/pkg/sentry/mm/pma.go
+++ b/pkg/sentry/mm/pma.go
@@ -35,9 +35,9 @@ import (
 // iterator to the pma containing ar.Start. Otherwise it returns a terminal
 // iterator.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - ar.Length() != 0.
+// Preconditions: ar.Length() != 0.
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) existingPMAsLocked(ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool, needInternalMappings bool) pmaIterator {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -73,7 +73,7 @@ func (mm *MemoryManager) existingPMAsLocked(ar hostarch.AddrRange, at hostarch.A
 // existingVecPMAsLocked returns true if pmas exist for all addresses in ars,
 // and support access of type (at, ignorePermissions).
 //
-// Preconditions: mm.activeMu must be locked.
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) existingVecPMAsLocked(ars hostarch.AddrRangeSeq, at hostarch.AccessType, ignorePermissions bool, needInternalMappings bool) bool {
 	for ; !ars.IsEmpty(); ars = ars.Tail() {
 		if ar := ars.Head(); ar.Length() != 0 && !mm.existingPMAsLocked(ar, at, ignorePermissions, needInternalMappings).Ok() {
@@ -105,12 +105,13 @@ func (mm *MemoryManager) existingVecPMAsLocked(ars hostarch.AddrRangeSeq, at hos
 // mm/internal.h:gup_must_unshare(FOLL_PIN|FOLL_LONGTERM).
 //
 // Preconditions:
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - vseg.Range().Contains(ar.Start).
 //   - vmas must exist for all addresses in ar, and support accesses of type at
 //     (i.e. permission checks must have been performed against vmas).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getPMAsLocked(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, callerIndirectCommit, forPin bool) (pmaIterator, pmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -153,11 +154,11 @@ func (mm *MemoryManager) getPMAsLocked(ctx context.Context, vseg vmaIterator, ar
 // exist. If this is not equal to ars, it returns a non-nil error explaining
 // why.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
-//   - vmas must exist for all addresses in ars, and support accesses of type at
-//     (i.e. permission checks must have been performed against vmas).
+// Preconditions: vmas must exist for all addresses in ars, and support accesses
+// of type at (i.e. permission checks must have been performed against vmas).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getVecPMAsLocked(ctx context.Context, ars hostarch.AddrRangeSeq, at hostarch.AccessType, callerIndirectCommit bool) (hostarch.AddrRangeSeq, error) {
 	for arsit := ars; !arsit.IsEmpty(); arsit = arsit.Tail() {
 		ar := arsit.Head()
@@ -230,6 +231,9 @@ func (mm *MemoryManager) getAllocationDirection(ar hostarch.AddrRange, vma *vma)
 //   - getPMAsInternalLocked additionally requires that ar is page-aligned.
 //     getPMAsInternalLocked is an implementation helper for getPMAsLocked and
 //     getVecPMAsLocked; other clients should call one of those instead.
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getPMAsInternalLocked(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, callerIndirectCommit, forPin bool) (pmaIterator, pmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -628,10 +632,10 @@ func hugepageAligned(ar hostarch.AddrRange) hostarch.AddrRange {
 // the memory it maps, isPMACopyOnWriteLocked will take ownership of the memory
 // and update the pma to indicate that it does not require copy-on-write.
 //
-// Preconditions:
-//   - vseg.Range().IsSupersetOf(pseg.Range()).
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
+// Preconditions: vseg.Range().IsSupersetOf(pseg.Range()).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) isPMACopyOnWriteLocked(vseg vmaIterator, pseg pmaIterator) bool {
 	pma := pseg.ValuePtr()
 	if !pma.needCOW {
@@ -676,9 +680,10 @@ func (mm *MemoryManager) Invalidate(ar hostarch.AddrRange, opts memmap.Invalidat
 // addresses in ar.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) invalidateLocked(ar hostarch.AddrRange, invalidatePrivate, invalidateShared bool) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -827,12 +832,13 @@ func Unpin(prs []PinnedRange) {
 // movePMAsLocked moves all pmas in oldAR to newAR.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - oldAR.Length() != 0.
 //   - oldAR.Length() <= newAR.Length().
 //   - !oldAR.Overlaps(newAR).
 //   - mm.pmas.IsEmptyRange(newAR).
 //   - oldAR and newAR must be page-aligned.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) movePMAsLocked(oldAR, newAR hostarch.AddrRange) {
 	if checkInvariants {
 		if !oldAR.WellFormed() || oldAR.Length() == 0 || !oldAR.IsPageAligned() {
@@ -881,12 +887,13 @@ func (mm *MemoryManager) movePMAsLocked(oldAR, newAR hostarch.AddrRange) {
 // internalMappingsLocked returns cached internal mappings for addresses in ar.
 //
 // Preconditions:
-//   - mm.activeMu must be locked.
 //   - While mm.activeMu was locked, a call to
 //     existingPMAsLocked(needInternalMappings=true) succeeded for all
 //     addresses in ar.
 //   - ar.Length() != 0.
 //   - pseg.Range().Contains(ar.Start).
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) internalMappingsLocked(pseg pmaIterator, ar hostarch.AddrRange) safemem.BlockSeq {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -921,11 +928,11 @@ func (mm *MemoryManager) internalMappingsLocked(pseg pmaIterator, ar hostarch.Ad
 // vecInternalMappingsLocked returns cached internal mappings for addresses in
 // ars.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - While mm.activeMu was locked, a call to
-//     existingVecPMAsLocked(needInternalMappings=true) succeeded for all
-//     addresses in ars.
+// Preconditions: While mm.activeMu was locked, a call to
+// existingVecPMAsLocked(needInternalMappings=true) succeeded for all addresses
+// in ars.
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) vecInternalMappingsLocked(ars hostarch.AddrRangeSeq) safemem.BlockSeq {
 	var ims []safemem.Block
 	for ; !ars.IsEmpty(); ars = ars.Tail() {
@@ -943,7 +950,7 @@ func (mm *MemoryManager) vecInternalMappingsLocked(ars hostarch.AddrRangeSeq) sa
 // addRSSLocked updates the current and maximum resident set size of a
 // MemoryManager to reflect the insertion of a pma at ar.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) addRSSLocked(ar hostarch.AddrRange) {
 	mm.curRSS += uint64(ar.Length())
 	if mm.curRSS > mm.maxRSS {
@@ -954,7 +961,7 @@ func (mm *MemoryManager) addRSSLocked(ar hostarch.AddrRange) {
 // removeRSSLocked updates the current resident set size of a MemoryManager to
 // reflect the removal of a pma at ar.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) removeRSSLocked(ar hostarch.AddrRange) {
 	mm.curRSS -= uint64(ar.Length())
 }
@@ -1008,9 +1015,9 @@ func (pmaSetFunctions) Split(ar hostarch.AddrRange, p pma, split hostarch.Addr) 
 // findOrSeekPrevUpperBoundPMA returns mm.pmas.UpperBoundSegment(addr), but may do
 // so by scanning linearly backward from pgap.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - addr <= pgap.Start().
+// Preconditions: addr <= pgap.Start().
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) findOrSeekPrevUpperBoundPMA(addr hostarch.Addr, pgap pmaGapIterator) pmaIterator {
 	if checkInvariants {
 		if !pgap.Ok() {
@@ -1030,9 +1037,10 @@ func (mm *MemoryManager) findOrSeekPrevUpperBoundPMA(addr hostarch.Addr, pgap pm
 }
 
 // getInternalMappingsLocked ensures that pseg.ValuePtr().internalMappings is
-// non-empty.
+// non-empty. The generated iterator identifies a set node and index, not its
+// MemoryManager, so checklocks cannot name the owning mutex.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// Preconditions: the owning MemoryManager's activeMu is held for writing.
 func (pseg pmaIterator) getInternalMappingsLocked() error {
 	pma := pseg.ValuePtr()
 	if pma.internalMappings.IsEmpty() {

--- a/pkg/sentry/mm/procfs.go
+++ b/pkg/sentry/mm/procfs.go
@@ -76,7 +76,9 @@ func (mm *MemoryManager) MapsCallbackFuncForBuffer(buf *bytes.Buffer) MapsCallba
 }
 
 // ReadMapsDataInto is called by fsimpl/proc.mapsData.Generate to
-// implement /proc/[pid]/maps.
+// implement /proc/[pid]/maps. It invokes fn synchronously with mappingMu read
+// locked. The callback must not reacquire mappingMu or violate the lock order;
+// checklocks cannot attach this incoming lock state to the function value.
 func (mm *MemoryManager) ReadMapsDataInto(ctx context.Context, fn MapsCallbackFunc) {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -98,14 +100,14 @@ func (mm *MemoryManager) ReadMapsDataInto(ctx context.Context, fn MapsCallbackFu
 // vmaMapsEntryLocked returns a /proc/[pid]/maps entry for the vma iterated by
 // vseg, including the trailing newline.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) vmaMapsEntryLocked(ctx context.Context, vseg vmaIterator) []byte {
 	var b bytes.Buffer
 	mm.appendVMAMapsEntryLocked(ctx, vseg, mm.MapsCallbackFuncForBuffer(&b))
 	return b.Bytes()
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) appendVMAMapsEntryLocked(ctx context.Context, vseg vmaIterator, fn MapsCallbackFunc) {
 	vma := vseg.ValuePtr()
 	private := "p"
@@ -149,13 +151,14 @@ func (mm *MemoryManager) ReadSmapsDataInto(ctx context.Context, buf *bytes.Buffe
 // vmaSmapsEntryLocked returns a /proc/[pid]/smaps entry for the vma iterated
 // by vseg, including the trailing newline.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) vmaSmapsEntryLocked(ctx context.Context, vseg vmaIterator) []byte {
 	var b bytes.Buffer
 	mm.vmaSmapsEntryIntoLocked(ctx, vseg, &b)
 	return b.Bytes()
 }
 
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) vmaSmapsEntryIntoLocked(ctx context.Context, vseg vmaIterator, b *bytes.Buffer) {
 	mm.appendVMAMapsEntryLocked(ctx, vseg, mm.MapsCallbackFuncForBuffer(b))
 	vma := vseg.ValuePtr()

--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -174,9 +174,9 @@ func (mm *MemoryManager) MMap(ctx context.Context, opts memmap.MMapOpts) (hostar
 // populateVMA obtains pmas for addresses in ar in the given vma, and maps them
 // into mm.as if it is active.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked.
-//   - vseg.Range().IsSupersetOf(ar).
+// Preconditions: vseg.Range().IsSupersetOf(ar).
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) populateVMA(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, platformEffect memmap.MMapPlatformEffect) error {
 	if !vseg.ValuePtr().effectivePerms.Any() {
 		// mm.mapASLocked() will no-op due to platform.AddressSpace.MapFile()

--- a/pkg/sentry/mm/vma.go
+++ b/pkg/sentry/mm/vma.go
@@ -34,9 +34,9 @@ import (
 // calls to functions that drop mapping identities within a scope should reuse
 // the same slice.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked for writing.
-//   - opts must be valid as defined by the checks in MMap.
+// Preconditions: opts must be valid as defined by the checks in MMap.
+//
+// +checklocks:mm.mappingMu
 func (mm *MemoryManager) createVMALocked(ctx context.Context, opts memmap.MMapOpts, droppedIDs []memmap.MappingIdentity) (vmaIterator, hostarch.AddrRange, []memmap.MappingIdentity, error) {
 	if opts.MaxPerms != opts.MaxPerms.Effective() {
 		panic(fmt.Sprintf("Non-effective MaxPerms %s cannot be enforced", opts.MaxPerms))
@@ -172,7 +172,7 @@ const (
 
 // findAvailableLocked finds an allocatable range.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findAvailableLocked(length uint64, opts findAvailableOpts) (hostarch.Addr, error) {
 	if opts.Fixed {
 		opts.Map32Bit = false
@@ -231,7 +231,7 @@ func (mm *MemoryManager) applicationAddrRange() hostarch.AddrRange {
 	return hostarch.AddrRange{mm.layout.MinAddr, mm.layout.MaxAddr}
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findLowestAvailableLocked(length, alignment uint64, bounds hostarch.AddrRange) (hostarch.Addr, error) {
 	for gap := mm.vmas.LowerBoundGap(bounds.Start); gap.Ok() && gap.Start() < bounds.End; gap = gap.NextLargeEnoughGap(hostarch.Addr(length)) {
 		if gr := gap.availableRange().Intersect(bounds); uint64(gr.Length()) >= length {
@@ -250,7 +250,7 @@ func (mm *MemoryManager) findLowestAvailableLocked(length, alignment uint64, bou
 	return 0, linuxerr.ENOMEM
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findHighestAvailableLocked(length, alignment uint64, bounds hostarch.AddrRange) (hostarch.Addr, error) {
 	for gap := mm.vmas.UpperBoundGap(bounds.End); gap.Ok() && gap.End() > bounds.Start; gap = gap.PrevLargeEnoughGap(hostarch.Addr(length)) {
 		if gr := gap.availableRange().Intersect(bounds); uint64(gr.Length()) >= length {
@@ -270,7 +270,7 @@ func (mm *MemoryManager) findHighestAvailableLocked(length, alignment uint64, bo
 	return 0, linuxerr.ENOMEM
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) mlockedBytesRangeLocked(ar hostarch.AddrRange) uint64 {
 	var total uint64
 	for vseg := mm.vmas.LowerBoundSegment(ar.Start); vseg.Ok() && vseg.Start() < ar.End; vseg = vseg.NextSegment() {
@@ -296,6 +296,8 @@ func (mm *MemoryManager) mlockedBytesRangeLocked(ar hostarch.AddrRange) uint64 {
 // Preconditions:
 //   - mm.mappingMu must be locked for reading; it may be temporarily unlocked.
 //   - ar.Length() != 0.
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) getVMAsLocked(ctx context.Context, ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool) (vmaIterator, vmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -352,6 +354,8 @@ func (mm *MemoryManager) getVMAsLocked(ctx context.Context, ar hostarch.AddrRang
 // temporarily unlocked.
 //
 // Postconditions: ars is not mutated.
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) getVecVMAsLocked(ctx context.Context, ars hostarch.AddrRangeSeq, at hostarch.AccessType, ignorePermissions bool) (hostarch.AddrRangeSeq, error) {
 	for arsit := ars; !arsit.IsEmpty(); arsit = arsit.Tail() {
 		ar := arsit.Head()
@@ -383,9 +387,10 @@ const guardBytes = 256 * hostarch.PageSize
 // the same slice.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.mappingMu
 func (mm *MemoryManager) unmapLocked(ctx context.Context, ar hostarch.AddrRange, droppedIDs []memmap.MappingIdentity) (vmaGapIterator, []memmap.MappingIdentity) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -409,15 +414,19 @@ func (mm *MemoryManager) unmapLocked(ctx context.Context, ar hostarch.AddrRange,
 // the same slice.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.mappingMu
 func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrRange, droppedIDs []memmap.MappingIdentity) (vmaGapIterator, []memmap.MappingIdentity) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
 			panic(fmt.Sprintf("invalid ar: %v", ar))
 		}
 	}
+	// RemoveRangeWith invokes this callback synchronously, so this method's
+	// entry ownership contract covers its updates. checklocks does not
+	// propagate that contract into a passed callback.
 	vgap := mm.vmas.RemoveRangeWith(ar, func(vseg vmaIterator) {
 		vmaAR := vseg.Range()
 		vma := vseg.ValuePtr()
@@ -427,12 +436,12 @@ func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrR
 		if vma.id != nil {
 			droppedIDs = append(droppedIDs, vma.id)
 		}
-		mm.usageAS -= uint64(vmaAR.Length())
+		mm.usageAS -= uint64(vmaAR.Length()) // +checklocksignore
 		if vma.isPrivateDataLocked() {
-			mm.dataAS -= uint64(vmaAR.Length())
+			mm.dataAS -= uint64(vmaAR.Length()) // +checklocksignore
 		}
 		if vma.mlockMode != memmap.MLockNone {
-			mm.lockedAS -= uint64(vmaAR.Length())
+			mm.lockedAS -= uint64(vmaAR.Length()) // +checklocksignore
 		}
 	})
 	return vgap, droppedIDs
@@ -446,14 +455,23 @@ func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrR
 //
 // canWriteMappableLocked is equivalent to Linux's VM_SHARED.
 //
-// Preconditions: mm.mappingMu must be locked.
+// Preconditions: the owning MemoryManager's mappingMu is held at least for
+// reading, or v is exclusively owned (a detached copy or construction-owned
+// VMA).
+//
+// The vma type describes the missing owner link for checklocks.
 func (v *vma) canWriteMappableLocked() bool {
 	return !v.private && v.maxPerms.Write
 }
 
-// isPrivateDataLocked identify the data segments - private, writable, not stack
+// isPrivateDataLocked reports whether v is a private, writable, non-stack
+// data segment.
 //
-// Preconditions: mm.mappingMu must be locked.
+// Preconditions: the owning MemoryManager's mappingMu is held at least for
+// reading, or v is exclusively owned (a detached copy or construction-owned
+// VMA).
+//
+// The vma type describes the missing owner link for checklocks.
 func (v *vma) isPrivateDataLocked() bool {
 	return v.realPerms.Write && v.private && !v.growsDown
 }
@@ -598,10 +616,11 @@ func (vseg vmaIterator) addrRangeOf(mr memmap.MappableRange) hostarch.AddrRange 
 }
 
 // seekNextLowerBound returns mm.vmas.LowerBoundSegment(addr), but does so by
-// scanning linearly forward from vseg.
+// scanning linearly forward from vseg. The generated iterator has no
+// MemoryManager reference, so checklocks cannot name the owning mutex.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked.
+//   - The owning MemoryManager's mappingMu is held at least for reading.
 //   - addr >= vseg.Start().
 func (vseg vmaIterator) seekNextLowerBound(addr hostarch.Addr) vmaIterator {
 	if checkInvariants {

--- a/pkg/sentry/pgalloc/BUILD
+++ b/pkg/sentry/pgalloc/BUILD
@@ -212,8 +212,13 @@ go_test(
     ],
     library = ":pgalloc",
     deps = [
+        "//pkg/context",
         "//pkg/hostarch",
+        "//pkg/memutil",
         "//pkg/sentry/memmap",
+        "//pkg/sentry/usage",
+        "//pkg/state",
+        "//pkg/state/wire",
     ],
 )
 

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -108,14 +108,16 @@ type MemoryFile struct {
 	// are *not* waste, allowing use of segment.Set gap-tracking to efficiently
 	// find ranges for both release and recycling allocations.
 	//
-	// unwasteSmall and unwasteHuge are protected by mu.
+	// +checklocks:mu
 	unwasteSmall unwasteSet
-	unwasteHuge  unwasteSet
+
+	// +checklocks:mu
+	unwasteHuge unwasteSet
 
 	// haveWaste is true if there may be at least one waste page in the
 	// MemoryFile.
 	//
-	// haveWaste is protected by mu.
+	// +checklocks:mu
 	haveWaste bool
 
 	// releaseCond is signaled (with mu locked) when haveWaste or destroyed
@@ -129,13 +131,16 @@ type MemoryFile struct {
 	// allowing use of segment.Set gap-tracking to efficiently find free ranges
 	// for allocation.
 	//
-	// unfreeSmall and unfreeHuge are protected by mu.
+	// +checklocks:mu
 	unfreeSmall unfreeSet
-	unfreeHuge  unfreeSet
+
+	// +checklocks:mu
+	unfreeHuge unfreeSet
 
 	// subreleased maps hugepage-aligned file offsets to the number of
 	// sub-released small pages within the hugepage beginning at that offset.
-	// subreleased is protected by mu.
+	//
+	// +checklocks:mu
 	subreleased map[uint64]uint64
 
 	// These fields are used for memory accounting.
@@ -151,33 +156,41 @@ type MemoryFile struct {
 	// each page. Non-empty gaps in memAcct represent pages known to be
 	// uncommitted (void, free, and sub-released pages).
 	//
+	// +checklocks:mu
+	memAcct memAcctSet
+
 	// knownCommittedBytes is the number of bytes in the file known to be
 	// committed, i.e. the span of all segments in memAcct for which
 	// knownCommitted is true.
 	//
-	// commitSeq is a sequence counter used to detect races between scans for
-	// committed pages and concurrent decommitment.
+	// +checklocks:mu
+	knownCommittedBytes uint64
+
+	// commitSeq detects races between commitment scans and decommitment.
 	//
+	// +checklocks:mu
+	commitSeq uint64
+
 	// nextCommitScan is the next time at which UpdateUsage(nil) may scan the
 	// backing file for commitment information.
 	//
-	// ongoingCommitScan is true while UpdateUsage(nil) is in progress. Writing
-	// to it requires f.mu to be locked, but reading it does not.
+	// +checklocks:mu
+	nextCommitScan time.Time
+
+	// ongoingCommitScan is true while UpdateUsage(nil) is in progress.
 	//
-	// isSaving is true during f.SaveTo() to prevent concurrent calls to
-	// f.UpdateUsage() from marking pages as committed.
+	// +checkatomic
+	// +checklocks:mu
+	ongoingCommitScan atomic.Bool
+
+	// isSaving prevents UpdateUsage from marking pages committed during SaveTo.
 	//
-	// All of these fields are protected by mu.
-	memAcct             memAcctSet
-	knownCommittedBytes uint64
-	commitSeq           uint64
-	nextCommitScan      time.Time
-	ongoingCommitScan   atomic.Bool
-	isSaving            bool
+	// +checklocks:mu
+	isSaving bool
 
 	// evictable maps EvictableMemoryUsers to eviction state.
 	//
-	// evictable is protected by mu.
+	// +checklocks:mu
 	evictable map[EvictableMemoryUser]*evictableMemoryUserInfo
 
 	// evictionWG counts the number of goroutines currently performing evictions.
@@ -187,11 +200,15 @@ type MemoryFile struct {
 	opts MemoryFileOpts
 
 	// savable is true if this MemoryFile will be saved via SaveTo() during
-	// the kernel's SaveTo operation. savable is protected by mu.
+	// the kernel's SaveTo operation.
+	//
+	// +checklocks:mu
 	savable bool
 
 	// destroyed is set by Destroy to instruct the releaser goroutine to
-	// release all MemoryFile resources and exit. destroyed is protected by mu.
+	// release all MemoryFile resources and exit.
+	//
+	// +checklocks:mu
 	destroyed bool
 
 	// stopNotifyPressure stops memory cgroup pressure level
@@ -201,6 +218,8 @@ type MemoryFile struct {
 
 	// If asyncPageLoad is non-nil, it tracks the state of in-progress or
 	// failed async page loading.
+	//
+	// +checkatomic
 	asyncPageLoad atomic.Pointer[asyncMemoryFileLoad]
 
 	// file is the backing file. The file pointer is immutable.
@@ -212,7 +231,12 @@ type MemoryFile struct {
 	// quiet cache line, since MapInternal() is by far the hottest path through
 	// pgalloc.
 	//
-	// chunks is protected by mu. chunks slices are immutable.
+	// Published slice headers are immutable. Chunk mappings are populated during
+	// restore and cleared during destruction. The annotation governs the pointer,
+	// not its elements.
+	//
+	// +checkatomic
+	// +checklocks:mu
 	chunks atomic.Pointer[[]chunkInfo]
 }
 
@@ -229,7 +253,8 @@ const (
 type chunkInfo struct {
 	// mapping is the start address of a mapping of the chunk.
 	//
-	// mapping is immutable.
+	// mapping is initialized during allocation or restore and cleared during
+	// destruction; it does not change while the chunk is in use.
 	mapping uintptr `state:"nosave"`
 
 	// huge is true if this chunk is expected to be hugepage-backed and false if
@@ -245,7 +270,7 @@ func (f *MemoryFile) chunksLoad() []chunkInfo {
 
 // forEachChunk invokes fn on a sequence of chunks that collectively span all
 // bytes in fr. In each call, chunkFR is the subset of fr that falls within
-// chunk. If any call to f returns false, forEachChunk stops iteration and
+// chunk. If any call to fn returns false, forEachChunk stops iteration and
 // returns.
 func (f *MemoryFile) forEachChunk(fr memmap.FileRange, fn func(chunk *chunkInfo, chunkFR memmap.FileRange) bool) {
 	chunks := f.chunksLoad()
@@ -268,6 +293,10 @@ type unwasteInfo struct{}
 
 // unfreeInfo is the value type of MemoryFile.unfreeSmall/Huge.
 //
+// Stored values are protected by the owning MemoryFile's mu. Values and
+// generated iterators have no owner back-reference for checklocks to use;
+// Merge and Split also operate on copied values.
+//
 // +stateify savable
 type unfreeInfo struct {
 	// refs is the per-page reference count. refs is non-zero for used pages,
@@ -277,6 +306,10 @@ type unfreeInfo struct {
 }
 
 // memAcctInfo is the value type of MemoryFile.memAcct.
+//
+// Values share the owning MemoryFile's mutex.
+// Values and generated iterators have no MemoryFile back-reference through
+// which checklocks could name that owner; Merge and Split operate on copies.
 //
 // +stateify savable
 type memAcctInfo struct {
@@ -334,6 +367,9 @@ type EvictableMemoryUser interface {
 // type EvictableRange <generated using go_generics>
 
 // evictableMemoryUserInfo is the value type of MemoryFile.evictable.
+//
+// Both fields are protected by the owning MemoryFile's mu. Entries have no
+// back-reference to that MemoryFile, so checklocks cannot name the mutex here.
 type evictableMemoryUserInfo struct {
 	// ranges tracks all evictable ranges for the given user.
 	ranges evictableRangeSet
@@ -444,7 +480,9 @@ func NewMemoryFile(file *os.File, opts MemoryFileOpts) (*MemoryFile, error) {
 		opts: opts,
 		file: file,
 	}
-	f.initFields()
+	// f was just allocated; no callback or releaser can access it yet.
+	// checklocks cannot substitute this ownership for initFields' mutex contract.
+	f.initFields() // +checklocksignore
 
 	if f.opts.DelayedEviction == DelayedEvictionEnabled && f.opts.UseHostMemcgPressure {
 		stop, err := hostmm.NotifyCurrentMemcgPressureCallback(func() {
@@ -469,6 +507,11 @@ func NewMemoryFile(file *os.File, opts MemoryFileOpts) (*MemoryFile, error) {
 	return f, nil
 }
 
+// initFields initializes f's bookkeeping before publication.
+//
+// Preconditions: f has not been initialized or shared with other goroutines.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) initFields() {
 	// Initially, all pages are void.
 	fullFR := memmap.FileRange{0, math.MaxUint64}
@@ -530,7 +573,9 @@ func (f *MemoryFile) Destroy() {
 	f.releaseCond.Signal()
 }
 
-// Preconditions: f.mu must be locked.
+// releaserDestroyLocked releases the backing file and chunk mappings.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) releaserDestroyLocked() {
 	if !f.destroyed {
 		panic("destroyed is no longer set")
@@ -774,15 +819,15 @@ func (f *MemoryFile) Allocate(length uint64, opts AllocOpts) (memmap.FileRange, 
 }
 
 func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.FileRange, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	unwaste := &f.unwasteSmall
 	unfree := &f.unfreeSmall
 	if alloc.huge {
 		unwaste = &f.unwasteHuge
 		unfree = &f.unfreeHuge
 	}
-
-	f.mu.Lock()
-	defer f.mu.Unlock()
 
 	if alloc.willCommit {
 		// Try to recycle waste pages, since this avoids the overhead of
@@ -808,10 +853,12 @@ func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.Fi
 			}
 			unwaste.Insert(uwgap, fr, unwasteInfo{})
 			// Update reference count for these pages from 0 to 1.
+			// MutateFullRange calls back synchronously with f.mu held, but
+			// checklocks does not propagate that lock state into the callback.
 			unfree.MutateFullRange(fr, func(ufseg unfreeIterator) bool {
 				uf := ufseg.ValuePtr()
 				if uf.refs != 0 {
-					panic(fmt.Sprintf("waste pages %v have unexpected refcount %d during recycling of %v\n%s", ufseg.Range(), uf.refs, fr, f.stringLocked()))
+					panic(fmt.Sprintf("waste pages %v have unexpected refcount %d during recycling of %v\n%s", ufseg.Range(), uf.refs, fr, f.stringLocked())) // +checklocksignore
 				}
 				uf.refs = 1
 				return true
@@ -819,16 +866,19 @@ func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.Fi
 			// These pages should all be unknown-commitment or known-committed;
 			// mark them unknown-commitment, for consistency with non-recycling
 			// allocations (below).
+			//
+			// MutateFullRange is synchronous; checklocks does not carry the held
+			// f.mu into the callback.
 			f.memAcct.MutateFullRange(fr, func(maseg memAcctIterator) bool {
 				ma := maseg.ValuePtr()
 				malen := maseg.Range().Length()
 				if ma.knownCommitted {
 					if ma.kind != usage.System {
-						panic(fmt.Sprintf("waste pages %v have unexpected kind %v\n%s", maseg.Range(), ma.kind, f.stringLocked()))
+						panic(fmt.Sprintf("waste pages %v have unexpected kind %v\n%s", maseg.Range(), ma.kind, f.stringLocked())) // +checklocksignore
 					}
 					ma.knownCommitted = false
-					ma.commitSeq = f.commitSeq
-					f.knownCommittedBytes -= malen
+					ma.commitSeq = f.commitSeq     // +checklocksignore
+					f.knownCommittedBytes -= malen // +checklocksignore
 					if !f.opts.DisableMemoryAccounting {
 						usage.MemoryAccounting.Dec(malen, usage.System, ma.memCgID)
 					}
@@ -889,7 +939,9 @@ retryFree:
 	return
 }
 
-// Preconditions: f.mu must be locked.
+// extendChunksLocked grows the backing file and publishes its new chunks.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) extendChunksLocked(alloc *allocState) error {
 	unfree := &f.unfreeSmall
 	if alloc.huge {
@@ -1091,19 +1143,21 @@ func (f *MemoryFile) Decommit(fr memmap.FileRange) {
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// MutateFullRange is synchronous; checklocks does not carry the held
+	// f.mu into the callback.
 	f.memAcct.MutateFullRange(fr, func(maseg memAcctIterator) bool {
 		ma := maseg.ValuePtr()
 		if ma.knownCommitted {
 			ma.knownCommitted = false
 			malen := maseg.Range().Length()
-			f.knownCommittedBytes -= malen
+			f.knownCommittedBytes -= malen // +checklocksignore
 			if !f.opts.DisableMemoryAccounting {
 				usage.MemoryAccounting.Dec(malen, ma.kind, ma.memCgID)
 			}
 		}
 		// Update commitSeq to invalidate any observations made by
 		// concurrent calls to f.updateUsageLocked().
-		ma.commitSeq = f.commitSeq
+		ma.commitSeq = f.commitSeq // +checklocksignore
 		return true
 	})
 }
@@ -1154,10 +1208,12 @@ func (f *MemoryFile) HasUniqueRef(fr memmap.FileRange) bool {
 	hasUniqueRef := true
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// forEachChunk invokes this callback synchronously with f.mu held.
+	// checklocks does not propagate that lock state into the callback.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unfree := &f.unfreeSmall
+		unfree := &f.unfreeSmall // +checklocksignore
 		if chunk.huge {
-			unfree = &f.unfreeHuge
+			unfree = &f.unfreeHuge // +checklocksignore
 		}
 		unfree.VisitFullRange(fr, func(ufseg unfreeIterator) bool {
 			if ufseg.ValuePtr().refs != 1 {
@@ -1182,10 +1238,12 @@ func (f *MemoryFile) FirstSharedRange(fr memmap.FileRange) (memmap.FileRange, bo
 	var sr memmap.FileRange
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// forEachChunk invokes this callback synchronously with f.mu held.
+	// checklocks does not propagate that lock state into the callback.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unfree := &f.unfreeSmall
+		unfree := &f.unfreeSmall // +checklocksignore
 		if chunk.huge {
-			unfree = &f.unfreeHuge
+			unfree = &f.unfreeHuge // +checklocksignore
 		}
 		cont := true
 		unfree.VisitFullRange(chunkFR, func(ufseg unfreeIterator) bool {
@@ -1221,12 +1279,16 @@ func (f *MemoryFile) IncRef(fr memmap.FileRange, memCgID uint32) {
 	f.incRefLocked(fr)
 }
 
-// Preconditions: f.mu must be locked.
+// incRefLocked increments reference counts for pages in fr with f.mu held.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) incRefLocked(fr memmap.FileRange) {
+	// forEachChunk invokes this callback synchronously with f.mu held.
+	// checklocks does not propagate that lock state into the callback.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unfree := &f.unfreeSmall
+		unfree := &f.unfreeSmall // +checklocksignore
 		if chunk.huge {
-			unfree = &f.unfreeHuge
+			unfree = &f.unfreeHuge // +checklocksignore
 		}
 		unfree.MutateFullRange(chunkFR, func(ufseg unfreeIterator) bool {
 			uf := ufseg.ValuePtr()
@@ -1250,12 +1312,14 @@ func (f *MemoryFile) DecRef(fr memmap.FileRange) {
 	defer f.mu.Unlock()
 
 	haveWaste := false
+	// forEachChunk is synchronous; checklocks cannot carry the held f.mu
+	// into this callback or its nested range callbacks.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unwaste := &f.unwasteSmall
-		unfree := &f.unfreeSmall
+		unwaste := &f.unwasteSmall // +checklocksignore
+		unfree := &f.unfreeSmall   // +checklocksignore
 		if chunk.huge {
-			unwaste = &f.unwasteHuge
-			unfree = &f.unfreeHuge
+			unwaste = &f.unwasteHuge // +checklocksignore
+			unfree = &f.unfreeHuge   // +checklocksignore
 		}
 		unfree.MutateFullRange(chunkFR, func(ufseg unfreeIterator) bool {
 			uf := ufseg.ValuePtr()
@@ -1270,7 +1334,7 @@ func (f *MemoryFile) DecRef(fr memmap.FileRange) {
 				haveWaste = true
 				// Reclassify waste memory as System until it's recycled or
 				// released.
-				f.memAcct.MutateFullRange(wasteFR, func(maseg memAcctIterator) bool {
+				f.memAcct.MutateFullRange(wasteFR, func(maseg memAcctIterator) bool { // +checklocksignore
 					ma := maseg.ValuePtr()
 					if !f.opts.DisableMemoryAccounting && ma.knownCommitted {
 						usage.MemoryAccounting.Move(maseg.Range().Length(), usage.System, ma.kind, ma.memCgID)
@@ -1281,7 +1345,10 @@ func (f *MemoryFile) DecRef(fr memmap.FileRange) {
 				})
 				// Cancel any pending async load on waste pages.
 				if apl := f.asyncPageLoad.Load(); apl != nil {
-					apl.cancelWasteLoad(wasteFR)
+					// DecRef holds f.mu across both synchronous callbacks;
+					// apl came from f.asyncPageLoad, so apl.f is f. checklocks
+					// loses that lock state and owner identity in this callback.
+					apl.cancelWasteLoad(wasteFR) // +checklocksignore
 				}
 			}
 			return true
@@ -1348,7 +1415,10 @@ MainLoop:
 	}
 }
 
-// Preconditions: f.mu must be locked; it may be unlocked and reacquired.
+// releaseLocked releases fr, temporarily dropping f.mu while decommitting
+// pages.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) releaseLocked(fr memmap.FileRange, huge bool) {
 	defer func() {
 		maseg := f.memAcct.LowerBoundSegmentSplitBefore(fr.Start)
@@ -1671,13 +1741,16 @@ func (f *MemoryFile) UpdateUsage(memCgIDs map[uint32]struct{}) error {
 // updateUsageLocked attempts to detect commitment of previously-uncommitted
 // pages, and updates memory accounting to reflect newly-committed pages.
 //
-// Precondition: f.mu must be held; it may be unlocked and reacquired.
+// The mutex may be temporarily released while querying page commitment.
+//
 // +checklocks:f.mu
 func (f *MemoryFile) updateUsageLocked(memCgIDs map[uint32]struct{}) error {
 	// Track if anything changed to elide the merge.
 	changedAny := false
 	defer func() {
-		if changedAny {
+		// SaveTo may have started while mincore released f.mu, and may
+		// retain accounting iterators across its own unlocks.
+		if changedAny && !f.isSaving {
 			f.memAcct.MergeAll()
 		}
 	}()
@@ -1734,9 +1807,11 @@ func (f *MemoryFile) updateUsageLocked(memCgIDs map[uint32]struct{}) error {
 			// Query for new pages in core.
 			// NOTE(b/165896008): mincore might take a really long time. So
 			// unlock f.mu while mincore runs.
-			lastCommitSeq := f.commitSeq
-			f.commitSeq++
-			f.mu.Unlock() // +checklocksforce
+			// forEachChunk calls back with f.mu held, but checklocks cannot
+			// infer that incoming lock state. The reacquisition below is checked.
+			lastCommitSeq := f.commitSeq // +checklocksignore
+			f.commitSeq++                // +checklocksignore
+			f.mu.Unlock()                // +checklocksforce
 			err := mincore(s, buf)
 			f.mu.Lock()
 			if err != nil {
@@ -1877,7 +1952,9 @@ func (f *MemoryFile) String() string {
 	return f.stringLocked()
 }
 
-// Preconditions: f.mu must be locked.
+// stringLocked formats f's allocation state with f.mu held.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) stringLocked() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "unwasteSmall:\n%s", &f.unwasteSmall)
@@ -1904,7 +1981,9 @@ func (f *MemoryFile) StartEvictions() {
 	f.startEvictionsLocked()
 }
 
-// Preconditions: f.mu must be locked.
+// startEvictionsLocked starts eviction workers and reports whether any started.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) startEvictionsLocked() bool {
 	startedAny := false
 	for user, info := range f.evictable {
@@ -1921,7 +2000,8 @@ func (f *MemoryFile) startEvictionsLocked() bool {
 // Preconditions:
 //   - info == f.evictable[user].
 //   - !info.evicting.
-//   - f.mu must be locked.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) startEvictionGoroutineLocked(user EvictableMemoryUser, info *evictableMemoryUserInfo) {
 	info.evicting = true
 	f.evictionWG.Add(1)

--- a/pkg/sentry/pgalloc/pgalloc_64k_test.go
+++ b/pkg/sentry/pgalloc/pgalloc_64k_test.go
@@ -404,23 +404,29 @@ func TestFindAllocatable64K(t *testing.T) {
 					DisableMemoryAccounting: true,
 				},
 			}
-			f.initFields()
+			// f is a local fixture with no releaser or published references.
+			// checklocks cannot substitute this ownership for the mutex contract.
+			f.initFields() // +checklocksignore
 			chunks := make([]chunkInfo, len(test.chunkHuge))
 			for i, huge := range test.chunkHuge {
 				chunks[i].huge = huge
 				chunkFR := memmap.FileRange{uint64(i) * chunkSize, uint64(i+1) * chunkSize}
 				if huge {
-					f.unfreeHuge.RemoveRange(chunkFR)
+					f.unfreeHuge.RemoveRange(chunkFR) // +checklocksignore
 				} else {
-					f.unfreeSmall.RemoveRange(chunkFR)
+					f.unfreeSmall.RemoveRange(chunkFR) // +checklocksignore
 				}
 			}
-			f.chunks.Store(&chunks)
+			// f remains local to this fixture; checklocks does not track that
+			// ownership through initFields.
+			f.chunks.Store(&chunks) // +checklocksignore
+			// The synchronous callbacks below only initialize this private
+			// fixture; checklocks cannot track that ownership into them.
 			for _, es := range test.existing {
 				f.forEachChunk(memmap.FileRange{es.start, es.end}, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall
+					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall // +checklocksignore
 					if chunk.huge {
-						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge
+						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge // +checklocksignore
 					}
 					switch es.state {
 					case existingUsed:
@@ -433,7 +439,7 @@ func TestFindAllocatable64K(t *testing.T) {
 					default:
 						t.Fatalf("existingSegment %+v has unknown state", es)
 					}
-					f.memAcct.InsertRange(chunkFR, memAcctInfo{
+					f.memAcct.InsertRange(chunkFR, memAcctInfo{ // +checklocksignore
 						wasteOrReleasing: es.state != existingUsed,
 					})
 					return true

--- a/pkg/sentry/pgalloc/pgalloc_test.go
+++ b/pkg/sentry/pgalloc/pgalloc_test.go
@@ -17,10 +17,20 @@
 package pgalloc
 
 import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"runtime"
+	"sync"
 	"testing"
 
+	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/memutil"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
+	"gvisor.dev/gvisor/pkg/state"
+	"gvisor.dev/gvisor/pkg/state/wire"
 )
 
 const (
@@ -523,23 +533,29 @@ func TestFindAllocatable(t *testing.T) {
 					DisableMemoryAccounting: true,
 				},
 			}
-			f.initFields()
+			// f is a local fixture with no releaser or published references.
+			// checklocks cannot substitute this ownership for the mutex contract.
+			f.initFields() // +checklocksignore
 			chunks := make([]chunkInfo, len(test.chunkHuge))
 			for i, huge := range test.chunkHuge {
 				chunks[i].huge = huge
 				chunkFR := memmap.FileRange{uint64(i) * chunkSize, uint64(i+1) * chunkSize}
 				if huge {
-					f.unfreeHuge.RemoveRange(chunkFR)
+					f.unfreeHuge.RemoveRange(chunkFR) // +checklocksignore
 				} else {
-					f.unfreeSmall.RemoveRange(chunkFR)
+					f.unfreeSmall.RemoveRange(chunkFR) // +checklocksignore
 				}
 			}
-			f.chunks.Store(&chunks)
+			// f remains local to this fixture; checklocks does not track that
+			// ownership through initFields.
+			f.chunks.Store(&chunks) // +checklocksignore
+			// The synchronous callbacks below only initialize this private
+			// fixture; checklocks cannot track that ownership into them.
 			for _, es := range test.existing {
 				f.forEachChunk(memmap.FileRange{es.start, es.end}, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall
+					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall // +checklocksignore
 					if chunk.huge {
-						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge
+						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge // +checklocksignore
 					}
 					switch es.state {
 					case existingUsed:
@@ -552,7 +568,7 @@ func TestFindAllocatable(t *testing.T) {
 					default:
 						t.Fatalf("existingSegment %+v has unknown state", es)
 					}
-					f.memAcct.InsertRange(chunkFR, memAcctInfo{
+					f.memAcct.InsertRange(chunkFR, memAcctInfo{ // +checklocksignore
 						wasteOrReleasing: es.state != existingUsed,
 					})
 					return true
@@ -583,5 +599,149 @@ func TestFindAllocatable(t *testing.T) {
 				t.Errorf("findAllocatableAndMarkUsed(%+v): got: end=%#x, want: %#x\n%v", alloc, fr.End, wantEnd, f)
 			}
 		})
+	}
+}
+
+// readFunc lets the restore test intervene after a page reaches its mapping.
+type readFunc func([]byte) (int, error)
+
+// Read implements io.Reader.
+func (f readFunc) Read(p []byte) (int, error) {
+	return f(p)
+}
+
+func TestLoadFromWithUpdateUsage(t *testing.T) {
+	newMemoryFile := func() *MemoryFile {
+		t.Helper()
+		memfd, err := memutil.CreateMemFD("pgalloc-test", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		file := os.NewFile(uintptr(memfd), "pgalloc-test")
+		f, err := NewMemoryFile(file, MemoryFileOpts{
+			DisableMemoryAccounting: true,
+		})
+		if err != nil {
+			_ = file.Close()
+			t.Fatal(err)
+		}
+		t.Cleanup(f.Destroy)
+		return f
+	}
+
+	ctx := context.Background()
+	src := newMemoryFile()
+	fr, err := src.Allocate(3*page, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { src.DecRef(fr) })
+
+	want := make([]byte, 3*page)
+	want[0], want[2*page] = 1, 2
+	// The first three-page allocation fits in one chunk.
+	src.forEachMappingSlice(fr, func(bs []byte) {
+		bs[0], bs[2*page] = want[0], want[2*page]
+	})
+	var saved bytes.Buffer
+	if err := src.SaveTo(ctx, &saved, &SaveOpts{
+		ExcludeCommittedZeroPages: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data := saved.Bytes()
+	metadataEnd := 8 + int(binary.LittleEndian.Uint64(data[:8]))
+	probe := bytes.NewReader(data[metadataEnd:])
+	length, object, err := state.ReadHeader(&wire.Reader{Reader: probe})
+	if err != nil || object || length != page {
+		t.Fatalf("first page header: length=%d object=%t err=%v",
+			length, object, err)
+	}
+	firstPayloadEnd := len(data) - probe.Len() + int(length)
+
+	dst := newMemoryFile()
+	t.Cleanup(func() {
+		// LoadFrom may fail before or after importing this reference.
+		dst.mu.Lock()
+		seg := dst.unfreeSmall.FindSegment(fr.Start)
+		hasRef := seg.Ok() && seg.Value().refs != 0
+		dst.mu.Unlock()
+		if hasRef {
+			dst.DecRef(fr)
+		}
+	})
+
+	stop := make(chan struct{})
+	scanned := make(chan error, 1)
+	var scanWG sync.WaitGroup
+	scanWG.Go(func() {
+		// Observe host commitment without synchronizing with LoadFrom. A
+		// signal from the reader would hide missing mapping publication.
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			committed, err := dst.TotalUsage()
+			if err != nil {
+				scanned <- err
+				return
+			}
+			if committed >= 2*page {
+				scanned <- dst.UpdateUsage(nil)
+				return
+			}
+			runtime.Gosched()
+		}
+	})
+	t.Cleanup(func() {
+		close(stop)
+		scanWG.Wait()
+	})
+
+	input := bytes.NewReader(data)
+	updated := false
+	reader := readFunc(func(p []byte) (int, error) {
+		n, err := input.Read(p)
+		if !updated && len(data)-input.Len() >= firstPayloadEnd {
+			updated = true
+			// Model neighboring-page commitment without requiring THP.
+			// This preserves the omitted page's zero contents.
+			dst.forEachMappingSlice(memmap.FileRange{
+				Start: fr.Start + page,
+				End:   fr.Start + 2*page,
+			}, func(bs []byte) {
+				clear(bs)
+			})
+			if err := <-scanned; err != nil {
+				t.Fatalf("UpdateUsage during restore: %v", err)
+			}
+		}
+		return n, err
+	})
+	if err := dst.LoadFrom(ctx, reader, &LoadOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("restore never reached the accounting update")
+	}
+	dst.forEachMappingSlice(fr, func(bs []byte) {
+		if !bytes.Equal(bs, want) {
+			t.Error("restored pages differ from saved pages")
+		}
+	})
+	if input.Len() != 0 {
+		t.Errorf("restore left %d bytes unread", input.Len())
+	}
+
+	// Count both restored pages and the zero page committed during loading.
+	dst.mu.Lock()
+	committed := dst.knownCommittedBytes
+	dst.mu.Unlock()
+	if committed != 3*page {
+		t.Errorf("committed bytes after restore: got %d, want %d",
+			committed, 3*page)
 	}
 }

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"runtime"
 	"sync/atomic"
@@ -66,13 +67,11 @@ func (f *MemoryFile) ResourceID() checkpoint.ResourceID {
 	return f.opts.ResourceID
 }
 
+// +checklocks:f.mu
 func (f *MemoryFile) exportMetadataProto() *pgallocpb.MemoryFileMetadataProto {
 	pb := &pgallocpb.MemoryFileMetadataProto{
 		Version:     1,
-		Subreleased: make(map[uint64]uint64, len(f.subreleased)),
-	}
-	for k, v := range f.subreleased {
-		pb.Subreleased[k] = v
+		Subreleased: maps.Clone(f.subreleased),
 	}
 	chunks := f.chunksLoad()
 	pb.Chunks = make([]*pgallocpb.ChunkInfoProto, len(chunks))
@@ -122,14 +121,21 @@ func (f *MemoryFile) exportMetadataProto() *pgallocpb.MemoryFileMetadataProto {
 	return pb
 }
 
+// importMetadataProto restores f's bookkeeping before its mappings are loaded.
+//
+// Preconditions: f is newly created and has not been used for allocations or
+// registered with async page loading.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) importMetadataProto(pb *pgallocpb.MemoryFileMetadataProto) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	if pb.Version != 1 {
 		return fmt.Errorf("unsupported MemoryFileMetadataProto version %d", pb.Version)
 	}
 	f.subreleased = make(map[uint64]uint64, len(pb.Subreleased))
-	for k, v := range pb.Subreleased {
-		f.subreleased[k] = v
-	}
+	maps.Copy(f.subreleased, pb.Subreleased)
 	chunks := make([]chunkInfo, len(pb.Chunks))
 	for i, c := range pb.Chunks {
 		chunks[i] = chunkInfo{
@@ -317,30 +323,32 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 		updatePendingWasCommitted bool
 		updatePendingNowCommitted bool
 	)
+	// These local batching callbacks run synchronously while SaveTo holds
+	// f.mu. checklocks does not propagate the caller's lock state through them.
 	updateNow := func(maseg memAcctIterator, fr memmap.FileRange, wasCommitted, nowCommitted bool) memAcctIterator {
 		amount := fr.Length()
 		if amount == 0 {
 			return maseg
 		}
 		if wasCommitted != nowCommitted {
-			maseg = f.memAcct.Isolate(maseg, fr)
+			maseg = f.memAcct.Isolate(maseg, fr) // +checklocksignore
 			ma := maseg.ValuePtr()
 			if nowCommitted {
 				ma.knownCommitted = true
 				ma.commitSeq = 0
-				f.knownCommittedBytes += amount
+				f.knownCommittedBytes += amount // +checklocksignore
 				if !f.opts.DisableMemoryAccounting {
 					usage.MemoryAccounting.Inc(amount, ma.kind, ma.memCgID)
 				}
 			} else {
 				ma.knownCommitted = false
-				ma.commitSeq = f.commitSeq
-				f.knownCommittedBytes -= amount
+				ma.commitSeq = f.commitSeq      // +checklocksignore
+				f.knownCommittedBytes -= amount // +checklocksignore
 				if !f.opts.DisableMemoryAccounting {
 					usage.MemoryAccounting.Dec(amount, ma.kind, ma.memCgID)
 				}
 			}
-			maseg = f.memAcct.Unisolate(maseg)
+			maseg = f.memAcct.Unisolate(maseg) // +checklocksignore
 		}
 		if nowCommitted {
 			asyncWritePages(fr)
@@ -528,10 +536,15 @@ type AsyncPagesFileSave struct {
 	mu apfsMutex
 
 	// saveOff is the offset in the pages file at which the next page to be
-	// inserted into unsaved will be saved. saveOff is protected by mu.
+	// inserted into unsaved will be saved. PagesFileOffset may read it
+	// between MemoryFile.SaveTo calls using this pages file.
+	//
+	// +checklocks:mu
 	saveOff uint64
 
-	// unsaved tracks pages that have not been saved. unsaved is protected by mu.
+	// unsaved tracks pages that have not been saved.
+	//
+	// +checklocks:mu
 	unsaved ringdeque.Deque[apsRange]
 
 	// stStatus communicates state from MemoryFile.SaveTo() and its callers to
@@ -541,8 +554,9 @@ type AsyncPagesFileSave struct {
 	// Padding before fields used mostly by the async page saver goroutine:
 	_ [hostarch.CacheLineSize]byte
 
-	// bytesSaved is the number of write-completed bytes. bytesSaved is
-	// protected by statsMu.
+	// bytesSaved is the number of write-completed bytes.
+	//
+	// +checklocks:mu
 	bytesSaved uint64
 
 	// When async page saving is enabled, MemoryFile.SaveTo() enqueues writes
@@ -557,11 +571,16 @@ type AsyncPagesFileSave struct {
 	// full. timeFullStart was the value of gohacks.Nanotime() when the I/O
 	// queue last became full; if it is currently not full, timeFullStart is
 	// MaxInt64. durFull is the duration elapsed while the I/O queue was full,
-	// not counting time elapsed since timeFullStart. These fields are
-	// protected by statsMu.
-	bytesFull     uint64
+	// not counting time elapsed since timeFullStart.
+	//
+	// +checklocks:mu
+	bytesFull uint64
+
+	// +checklocks:mu
 	timeFullStart int64
-	durFull       time.Duration
+
+	// +checklocks:mu
+	durFull time.Duration
 
 	// Following fields are exclusive to the async page saver goroutine.
 
@@ -678,7 +697,13 @@ func (apfs *AsyncPagesFileSave) MemoryFilesDone() {
 
 // PagesFileOffset returns the offset into the pages file of the next page to
 // be written.
+//
+// Preconditions: MemoryFile.SaveTo must not run concurrently using apfs.
+//
+// +checklocksexclude:apfs.mu
 func (apfs *AsyncPagesFileSave) PagesFileOffset() uint64 {
+	apfs.mu.Lock()
+	defer apfs.mu.Unlock()
 	return apfs.saveOff
 }
 
@@ -1014,6 +1039,14 @@ type LoadOpts struct {
 }
 
 // LoadFrom loads MemoryFile state from the given stream.
+//
+// Preconditions: f is newly created and has not been used for allocations.
+// UpdateUsage may run concurrently, but the caller must exclude operations
+// that allocate, release, or save memory and other calls to LoadFrom until it
+// returns. Asynchronous page loading started by LoadFrom may proceed
+// concurrently and may continue after it returns.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) (err error) {
 	mfTimeline := opts.Timeline.Fork(fmt.Sprintf("mf:%p", f)).Lease()
 	defer mfTimeline.End()
@@ -1069,11 +1102,14 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 			return fmt.Errorf("failed to mmap MemoryFile: %w", errno)
 		}
 		mfTimeline.Reached("mmaped chunks")
+		// Publish mappings to commitment scans before loading page contents.
+		f.mu.Lock()
 		for i := range chunks {
 			chunk := &chunks[i]
 			chunk.mapping = m
 			m += chunkSize
 		}
+		f.mu.Unlock()
 		madviseWG.Add(1)
 		go func() {
 			defer madviseWG.Done()
@@ -1147,11 +1183,13 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 	wr := wire.Reader{Reader: r}
 	timePagesStart := gohacks.Nanotime()
 	minUnloadedInit := false
-	for maseg := f.memAcct.FirstSegment(); maseg.Ok(); maseg = maseg.NextSegment() {
-		if !maseg.ValuePtr().knownCommitted {
+	// Saved ranges define the stream layout. Live accounting may merge ranges
+	// during import or while UpdateUsage observes restored pages.
+	for _, ma := range pb.MemAcct {
+		if !ma.KnownCommitted {
 			continue
 		}
-		maFR := maseg.Range()
+		maFR := memmap.FileRange{Start: ma.Start, End: ma.End}
 		amount := maFR.Length()
 		// Wait for all chunks spanned by this segment to be madvised.
 		for madviseEnd.Load() < maFR.End {
@@ -1200,16 +1238,21 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 		// Update accounting for restored pages. We need to do this here since
 		// these segments are marked as "known committed", and will be skipped
 		// over on accounting scans.
+		f.mu.Lock()
 		f.knownCommittedBytes += amount
 		if !f.opts.DisableMemoryAccounting {
-			usage.MemoryAccounting.Inc(amount, maseg.ValuePtr().kind, maseg.ValuePtr().memCgID)
+			usage.MemoryAccounting.Inc(amount, usage.MemoryKind(ma.Kind), ma.MemCgId)
 		}
+		f.mu.Unlock()
 	}
 	durPages := time.Duration(gohacks.Nanotime() - timePagesStart)
+	f.mu.Lock()
+	knownCommittedBytes := f.knownCommittedBytes
+	f.mu.Unlock()
 	if amfl != nil {
-		log.Infof("MemoryFile(%p): loaded page file offsets in %s; async loading %d bytes", f, durPages, f.knownCommittedBytes)
+		log.Infof("MemoryFile(%p): loaded page file offsets in %s; async loading %d bytes", f, durPages, knownCommittedBytes)
 	} else {
-		log.Infof("MemoryFile(%p): loaded pages in %s (%d bytes, %.3f MB/s)", f, durPages, f.knownCommittedBytes, float64(f.knownCommittedBytes)*1e-6/durPages.Seconds())
+		log.Infof("MemoryFile(%p): loaded pages in %s (%d bytes, %.3f MB/s)", f, durPages, knownCommittedBytes, float64(knownCommittedBytes)*1e-6/durPages.Seconds())
 	}
 
 	return nil
@@ -1222,11 +1265,15 @@ type AsyncPagesFileLoad struct {
 	// If errVal is not nil, it is an error that has terminated asynchronous
 	// page loading. errVal can only be set by the async page loader goroutine,
 	// and can only transition from nil to non-nil once, after which it is
-	// immutable. errVal is stored with mu locked.
+	// immutable.
+	//
+	// +checkatomic
+	// +checklocks:mu
 	errVal atomic.Value
 
 	// priority contains possibly-unstarted ranges with at least one waiter.
-	// priority is protected by mu.
+	//
+	// +checklocks:mu
 	priority ringdeque.Deque[aplFileRange]
 
 	// lfStatus communicates MemoryFile.LoadFrom() state to the async page
@@ -1236,34 +1283,51 @@ type AsyncPagesFileLoad struct {
 	// Padding before state used mostly by the async page loader goroutine:
 	_ [hostarch.CacheLineSize]byte
 
-	// amfls tracks MemoryFiles that are currently loading from the pages file.
-	// amfls is protected by amflsMu.
 	amflsMu amflsMutex
-	amfls   asyncMemoryFileLoadList
 
-	// numWaiters is the current number of waiting waiters. numWaiters is
-	// protected by mu.
+	// amfls tracks MemoryFiles that are currently loading from the pages file.
+	//
+	// +checklocks:amflsMu
+	amfls asyncMemoryFileLoadList
+
+	// numWaiters is the current number of waiting waiters.
+	//
+	// +checklocks:mu
 	numWaiters int
 
 	// totalWaiters is the number of waiters that have ever waited for pages
-	// from this pages file. totalWaiters is protected by mu.
+	// from this pages file.
+	//
+	// +checklocks:mu
 	totalWaiters int
 
 	// timeStartWaiters was the value of gohacks.Nanotime() when numWaiters
 	// most recently transitioned from 0 to 1. If numWaiters is 0,
-	// timeStartWaiters is MaxInt64. timeStartWaiters is protected by mu.
+	// timeStartWaiters is MaxInt64.
+	//
+	// +checklocks:mu
 	timeStartWaiters int64
 
-	// nsWaitedOne is the duration for which at least one waiter was waiting
-	// for a load. nsWaitedTotal is the duration for which waiters were waiting
-	// for loads, summed across all waiters. bytesWaited is the number of bytes
-	// for which at least one waiter waited. These fields are protected by mu.
-	durWaitedOne   time.Duration
+	// durWaitedOne is the duration for which at least one waiter was waiting
+	// for a load.
+	//
+	// +checklocks:mu
+	durWaitedOne time.Duration
+
+	// durWaitedTotal is the duration for which waiters were waiting for loads,
+	// summed across all waiters.
+	//
+	// +checklocks:mu
 	durWaitedTotal time.Duration
-	bytesWaited    uint64
+
+	// bytesWaited is the number of bytes for which at least one waiter waited.
+	//
+	// +checklocks:mu
+	bytesWaited uint64
 
 	// bytesLoaded is the number of bytes that have been loaded so far.
-	// bytesLoaded is protected by mu.
+	//
+	// +checklocks:mu
 	bytesLoaded uint64
 
 	// Following fields are exclusive to the async page loader goroutine.
@@ -1318,26 +1382,42 @@ func (apfl *AsyncPagesFileLoad) err() error {
 
 // asyncMemoryFileLoad holds async page loading state for a single MemoryFile.
 type asyncMemoryFileLoad struct {
-	// Immutable fields:
-	f            *MemoryFile
-	pf           *AsyncPagesFileLoad
-	df           stateio.DestinationFile
+	// f, pf, and df are immutable.
+	f  *MemoryFile
+	pf *AsyncPagesFileLoad
+	df stateio.DestinationFile
+
+	// doneCallback is called and cleared when loading completes or fails.
+	//
+	// +checklocks:pf.amflsMu
+	// +checklocks:pf.mu
 	doneCallback func(error)
-	timeline     *timing.Timeline
+
+	// timeline is an immutable pointer to the async load timeline.
+	timeline *timing.Timeline
 
 	// minUnloaded is the MemoryFile offset of the first unloaded byte.
+	//
+	// +checkatomic
 	minUnloaded atomicbitops.Uint64
 
 	// unloaded tracks pages in the MemoryFile that have not been loaded.
-	// unloaded is protected by pf.mu.
+	//
+	// +checklocks:pf.mu
 	unloaded aplUnloadedSet
 
 	// lfDone is true if MemoryFile.LoadFrom() has finished inserting into
-	// unloaded. lfDone is protected by pf.mu.
+	// unloaded.
+	//
+	// +checklocks:pf.mu
 	lfDone bool
 
 	// asyncMemoryFileLoadEntry links into pf.amfls. asyncMemoryFileLoadEntry
 	// is protected by pf.amflsMu.
+	//
+	// Generated list methods access the links without a parent-lock
+	// precondition, so checklocks cannot verify that their callers hold
+	// pf.amflsMu.
 	asyncMemoryFileLoadEntry
 
 	// Padding before state exclusive to the async page loader goroutine:
@@ -1349,6 +1429,11 @@ type asyncMemoryFileLoad struct {
 }
 
 // aplUnloadedInfo is the value type of asyncMemoryFileLoad.unloaded.
+//
+// Stored values are protected by the owning asyncMemoryFileLoad.pf.mu.
+// Values and generated iterators have no back-reference to that owner, so
+// checklocks cannot resolve its mutex. Merge and Split also operate on
+// copied values.
 type aplUnloadedInfo struct {
 	// off is the offset into the pages file at which the represented pages
 	// begin.
@@ -1362,18 +1447,21 @@ type aplUnloadedInfo struct {
 }
 
 type aplWaiter struct {
-	// wakeup is used by a caller of MemoryFile.awaitLoad() to block until all
-	// pages in fr are loaded. wakeup is internally synchronized. fr is
-	// immutable after initialization.
+	// wakeup is used by asyncMemoryFileLoad.awaitLoad() to block until all pages
+	// in fr are loaded. wakeup is internally synchronized. fr is
+	// immutable until the waiter is returned to aplWaiterPool.
 	wakeup syncevent.Waiter
 	fr     memmap.FileRange
 
 	// timeStart was the value of gohacks.Nanotime() when this waiter started
-	// waiting. timeStart is immutable after initialization.
+	// waiting. It is immutable until the waiter is returned to aplWaiterPool.
 	timeStart int64
 
 	// pending is the number of unloaded bytes that this waiter is waiting for.
-	// pending is protected by aplShared.mu.
+	// pending is protected by the owning AsyncPagesFileLoad.mu.
+	//
+	// The owner is determined by the unloaded segments containing this
+	// waiter; aplWaiter has no pointer to that loader for checklocks to use.
 	pending uint64
 }
 
@@ -1505,10 +1593,12 @@ func (amfl *asyncMemoryFileLoad) awaitLoad(fr memmap.FileRange) error {
 		ul := ulseg.ValuePtr()
 		ulFR := ulseg.Range()
 		ullen := ulFR.Length()
+		// MutateRange invokes this callback synchronously with apfl.mu held.
+		// checklocks does not propagate the caller's lock state into it.
 		if len(ul.waiters) == 0 {
-			apfl.bytesWaited += ullen
+			apfl.bytesWaited += ullen // +checklocksignore
 			if !ul.started {
-				apfl.priority.PushBack(aplFileRange{amfl, ulFR})
+				apfl.priority.PushBack(aplFileRange{amfl, ulFR}) // +checklocksignore
 			}
 			if logAwaitedLoads {
 				log.Infof("MemoryFile(%p): prioritize %v", amfl.f, ulFR)
@@ -1699,8 +1789,10 @@ func (apfl *AsyncPagesFileLoad) main() {
 		// unloaded) segments.
 		apfl.amflsMu.Lock()
 		apfl.mu.Lock()
+		// Each entry in apfl.amfls belongs to apfl. checklocks cannot prove
+		// amfl.pf == apfl after the list lookup.
 		for amfl := apfl.amfls.Front(); amfl != nil; amfl = amfl.Next() {
-			for ulseg := amfl.unloaded.FirstSegment(); ulseg.Ok(); ulseg = ulseg.NextSegment() {
+			for ulseg := amfl.unloaded.FirstSegment(); ulseg.Ok(); ulseg = ulseg.NextSegment() { // +checklocksignore
 				ul := ulseg.ValuePtr()
 				ullen := ulseg.Range().Length()
 				for _, w := range ul.waiters {
@@ -1712,9 +1804,9 @@ func (apfl *AsyncPagesFileLoad) main() {
 				ul.started = false
 				ul.waiters = nil
 			}
-			if amfl.doneCallback != nil {
-				amfl.doneCallback(apfl.err())
-				amfl.doneCallback = nil
+			if amfl.doneCallback != nil { // +checklocksignore
+				amfl.doneCallback(apfl.err()) // +checklocksignore
+				amfl.doneCallback = nil       // +checklocksignore
 			}
 		}
 		apfl.mu.Unlock()
@@ -1796,12 +1888,15 @@ func (apfl *AsyncPagesFileLoad) main() {
 		apfl.mu.Lock()
 		for apfl.canEnqueue() && !apfl.priority.Empty() {
 			fr := apfl.priority.PopFront()
+			// awaitLoad queued this range on its own pages-file loader, so
+			// fr.amfl.pf == apfl. checklocks cannot recover that identity here.
+			//
 			// All pages in apfl.priority have non-zero waiters and were split
 			// around fr by fr.amfl.awaitLoad(), and fr.amfl.unloaded never
 			// merges segments with waiters. Thus, we don't need to split
 			// around fr again, and fr.Intersect(ulseg.Range()) ==
 			// ulseg.Range().
-			ulseg := fr.amfl.unloaded.LowerBoundSegment(fr.Start)
+			ulseg := fr.amfl.unloaded.LowerBoundSegment(fr.Start) // +checklocksignore
 			for ulseg.Ok() && ulseg.Start() < fr.End {
 				ul := ulseg.ValuePtr()
 				ulFR := ulseg.Range()
@@ -1822,7 +1917,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 					break
 				}
 				ulFR.End = ulFR.Start + n
-				ulseg = fr.amfl.unloaded.SplitAfter(ulseg, ulFR.End)
+				ulseg = fr.amfl.unloaded.SplitAfter(ulseg, ulFR.End) // +checklocksignore
 				ulseg.ValuePtr().started = true
 				fr.Start = ulFR.End
 				if fr.Length() > 0 {
@@ -1853,7 +1948,9 @@ func (apfl *AsyncPagesFileLoad) main() {
 			for amfl := apfl.amfls.Front(); amfl != nil; amfl = amfl.Next() {
 				amfl.f.mu.Lock()
 				apfl.mu.Lock()
-				ulseg := amfl.unloaded.LowerBoundSegment(amfl.minUnstarted)
+				// Membership in apfl.amfls establishes amfl.pf == apfl,
+				// which checklocks cannot infer from this iterator.
+				ulseg := amfl.unloaded.LowerBoundSegment(amfl.minUnstarted) // +checklocksignore
 				for ulseg.Ok() {
 					ul := ulseg.ValuePtr()
 					ulFR := ulseg.Range()
@@ -1872,7 +1969,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 						break amflsLoop
 					}
 					ulFR.End = ulFR.Start + n
-					ulseg = amfl.unloaded.SplitAfter(ulseg, ulFR.End)
+					ulseg = amfl.unloaded.SplitAfter(ulseg, ulFR.End) // +checklocksignore
 					ulseg.ValuePtr().started = true
 					amfl.minUnstarted = ulFR.End
 					amfl.f.incRefLocked(ulFR)
@@ -1949,6 +2046,8 @@ func (apfl *AsyncPagesFileLoad) main() {
 			}
 			apfl.bytesLoaded += op.total
 			amfl := op.amfl
+			// enqueueRange records only MemoryFiles belonging to apfl in ops.
+			// checklocks cannot recover amfl.pf == apfl from the completed op.
 			haveWaiters := false
 			now := int64(0)
 			for _, fr := range op.frs {
@@ -1956,7 +2055,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 				// when they were started (above), and fr.amfl.unloaded never
 				// merges started segments. Thus, we don't need to split around
 				// fr again, and fr.Intersect(ulseg.Range()) == ulseg.Range().
-				for ulseg := amfl.unloaded.FindSegment(fr.Start); ulseg.Ok() && ulseg.Start() < fr.End; ulseg = amfl.unloaded.Remove(ulseg).NextSegment() {
+				for ulseg := amfl.unloaded.FindSegment(fr.Start); ulseg.Ok() && ulseg.Start() < fr.End; ulseg = amfl.unloaded.Remove(ulseg).NextSegment() { // +checklocksignore
 					ul := ulseg.ValuePtr()
 					ullen := ulseg.Range().Length()
 					if !ul.started {
@@ -1972,7 +2071,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 							}
 							// This definition of "wait time" skips the time
 							// taken for w to wake up (bad), but avoids having
-							// to lock apfl.mu again in apfl.awaitLoad()
+							// to lock apfl.mu again in asyncMemoryFileLoad.awaitLoad()
 							// (good).
 							apfl.durWaitedTotal += time.Duration(now - w.timeStart)
 							apfl.numWaiters--
@@ -1989,18 +2088,19 @@ func (apfl *AsyncPagesFileLoad) main() {
 			}
 			// Keep amfl.minUnloaded up to date. We can only determine this
 			// accurately if insertions into amfl.unloaded are complete.
-			if amfl.lfDone {
-				if amfl.unloaded.IsEmpty() {
+			if amfl.lfDone { // +checklocksignore
+				if amfl.unloaded.IsEmpty() { // +checklocksignore
 					amfl.minUnloaded.Store(math.MaxUint64)
 					apfl.amfls.Remove(amfl)
 					amfl.f.asyncPageLoad.Store(nil)
 					amfl.timeline.End()
-					if amfl.doneCallback != nil {
-						amfl.doneCallback(nil)
-						amfl.doneCallback = nil
+					if amfl.doneCallback != nil { // +checklocksignore
+						amfl.doneCallback(nil)  // +checklocksignore
+						amfl.doneCallback = nil // +checklocksignore
 					}
 				} else {
-					amfl.minUnloaded.Store(amfl.unloaded.FirstSegment().Start())
+					minUnloaded := amfl.unloaded.FirstSegment().Start() // +checklocksignore
+					amfl.minUnloaded.Store(minUnloaded)
 				}
 			}
 		}
@@ -2014,9 +2114,13 @@ func (apfl *AsyncPagesFileLoad) main() {
 	}
 }
 
+// cancelWasteLoad cancels unstarted loads for pages becoming waste.
+//
 // Preconditions:
-// - All pages in fr must be becoming waste pages.
-// - fr must be page-aligned.
+//   - All pages in fr must be becoming waste pages.
+//   - fr must be page-aligned.
+//
+// +checklocks:amfl.f.mu
 func (amfl *asyncMemoryFileLoad) cancelWasteLoad(fr memmap.FileRange) {
 	// Lockless fast path:
 	if fr.End <= amfl.minUnloaded.Load() {
@@ -2029,7 +2133,7 @@ func (amfl *asyncMemoryFileLoad) cancelWasteLoad(fr memmap.FileRange) {
 		ul := ulseg.ValuePtr()
 		if ul.started {
 			// This shouldn't be possible since page references are held while
-			// reading (see MemoryFile.asyncPageLoadMain()).
+			// reading (see AsyncPagesFileLoad.main()).
 			panic(fmt.Sprintf("pages %v becoming waste during inflight read from async loading", ulseg.Range()))
 		}
 		if n := len(ul.waiters); n != 0 {

--- a/pkg/sentry/usage/memory.go
+++ b/pkg/sentry/usage/memory.go
@@ -76,10 +76,14 @@ const (
 	Mapped
 )
 
-// memoryStats tracks application memory usage in bytes. All fields correspond to the
-// memory category with the same name. This object is thread-safe if accessed
-// through the provided methods. The public fields may be safely accessed
-// directly on a copy of the object obtained from Memory.Copy().
+// memoryStats tracks application memory usage in bytes by category.
+//
+// Its methods require the owning MemoryLocked.mu, both for aggregate counters
+// and for entries in MemCgIDToMemStats. This also makes multi-category totals
+// and copies consistent. memoryStats has no link back to its owner, so
+// checklocks cannot name that mutex for these helpers or counter aliases.
+//
+// MemoryLocked.Copy and CopyPerCg return detached MemoryStats scalar values.
 type memoryStats struct {
 	System    atomicbitops.Uint64
 	Anonymous atomicbitops.Uint64
@@ -91,7 +95,7 @@ type memoryStats struct {
 
 // incLocked adds a usage of 'val' bytes from memory category 'kind'.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) incLocked(val uint64, kind MemoryKind) {
 	switch kind {
 	case System:
@@ -113,7 +117,7 @@ func (ms *memoryStats) incLocked(val uint64, kind MemoryKind) {
 
 // decLocked removes a usage of 'val' bytes from memory category 'kind'.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) decLocked(val uint64, kind MemoryKind) {
 	switch kind {
 	case System:
@@ -135,7 +139,7 @@ func (ms *memoryStats) decLocked(val uint64, kind MemoryKind) {
 
 // totalLocked returns a total usage.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) totalLocked() (total uint64) {
 	total += ms.System.RacyLoad()
 	total += ms.Anonymous.RacyLoad()
@@ -146,9 +150,9 @@ func (ms *memoryStats) totalLocked() (total uint64) {
 	return
 }
 
-// copyLocked returns a copy of the structure.
+// copyLocked returns a detached scalar snapshot of the counters.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) copyLocked() MemoryStats {
 	return MemoryStats{
 		System:    ms.System.RacyLoad(),
@@ -180,10 +184,14 @@ var DirtyMemoryAccounting = &DirtyMemoryStats{}
 type DirtyMemoryStats struct {
 	// Dirty is the total bytes of memory that have been modified but not yet
 	// written back to the underlying storage.
+	//
+	// +checkatomic
 	Dirty atomicbitops.Uint64
 
 	// Writeback is the total bytes of memory currently being written back
 	// to the underlying storage.
+	//
+	// +checkatomic
 	Writeback atomicbitops.Uint64
 }
 
@@ -224,20 +232,29 @@ func (d *DirtyMemoryStats) Copy() (dirty, writeback uint64) {
 // initially zeroed. Any added field will be ignored by an older API and will be
 // zero if read by a newer API.
 type RTMemoryStats struct {
+	// +checkatomic
 	RTMapped atomicbitops.Uint64
 }
 
-// MemoryLocked is Memory with access methods.
+// MemoryLocked serializes aggregate and per-cgroup memory accounting.
 type MemoryLocked struct {
 	mu memoryMutex
-	// memoryStats records the memory stats.
+
+	// memoryStats records the aggregate memory stats.
+	//
+	// +checklocks:mu
 	memoryStats
+
 	// RTMemoryStats records the memory stats that need to be exposed through
 	// shared page.
 	*RTMemoryStats
+
 	// File is the backing file storing the memory stats.
 	File *os.File
+
 	// MemCgIDToMemStats is the map of cgroup ids to memory stats.
+	//
+	// +checklocks:mu
 	MemCgIDToMemStats map[uint32]*memoryStats
 }
 
@@ -286,6 +303,7 @@ func Init() error {
 // resident.
 var MemoryAccounting *MemoryLocked
 
+// +checklocks:m.mu
 func (m *MemoryLocked) incLockedPerCg(val uint64, kind MemoryKind, memCgID uint32) {
 	if _, ok := m.MemCgIDToMemStats[memCgID]; !ok {
 		m.MemCgIDToMemStats[memCgID] = &memoryStats{}
@@ -314,6 +332,7 @@ func (m *MemoryLocked) Inc(val uint64, kind MemoryKind, memCgID uint32) {
 	}
 }
 
+// +checklocks:m.mu
 func (m *MemoryLocked) decLockedPerCg(val uint64, kind MemoryKind, memCgID uint32) {
 	if _, ok := m.MemCgIDToMemStats[memCgID]; !ok {
 		panic(fmt.Sprintf("invalid memory cgroup id: %v", memCgID))

--- a/pkg/sync/locking/generic_mutex.go
+++ b/pkg/sync/locking/generic_mutex.go
@@ -44,28 +44,28 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *Mutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // Unlock unlocks m.
 // +checklocksignore
 func (m *Mutex) Unlock() {
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Unlock()
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *Mutex) NestedUnlock(i lockNameIndex) {
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Unlock()
 }
 

--- a/pkg/sync/locking/generic_rwmutex.go
+++ b/pkg/sync/locking/generic_rwmutex.go
@@ -42,14 +42,14 @@ const ()
 // Lock locks m.
 // +checklocksignore
 func (m *RWMutex) Lock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.Lock()
 }
 
 // NestedLock locks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedLock(i lockNameIndex) {
-	locking.AddGLock(genericMarkIndex, int(i))
+	locking.AddGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 	m.mu.Lock()
 }
 
@@ -57,20 +57,20 @@ func (m *RWMutex) NestedLock(i lockNameIndex) {
 // +checklocksignore
 func (m *RWMutex) Unlock() {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // NestedUnlock unlocks m knowing that another lock of the same type is held.
 // +checklocksignore
 func (m *RWMutex) NestedUnlock(i lockNameIndex) {
 	m.mu.Unlock()
-	locking.DelGLock(genericMarkIndex, int(i))
+	locking.DelGLock(genericMarkIndex, int(i)) // escapes: lockdep.
 }
 
 // RLock locks m for reading.
 // +checklocksignore
 func (m *RWMutex) RLock() {
-	locking.AddGLock(genericMarkIndex, -1)
+	locking.AddGLock(genericMarkIndex, -1) // escapes: lockdep.
 	m.mu.RLock()
 }
 
@@ -78,7 +78,7 @@ func (m *RWMutex) RLock() {
 // +checklocksignore
 func (m *RWMutex) RUnlock() {
 	m.mu.RUnlock()
-	locking.DelGLock(genericMarkIndex, -1)
+	locking.DelGLock(genericMarkIndex, -1) // escapes: lockdep.
 }
 
 // RLockBypass locks m for reading without executing the validator.

--- a/pkg/sync/locking/locking.go
+++ b/pkg/sync/locking/locking.go
@@ -25,4 +25,8 @@
 // taken before the target one. For each goroutine, we have the list of
 // currently locked mutexes. And finally, all lock methods check that
 // ancestors of currently locked mutexes don't contain the target one.
+//
+// Lockdep bookkeeping may allocate maps and stack traces. Generated mutexes
+// exempt calls to this optional instrumentation from checkescape contracts;
+// the underlying mutex operations and their callers remain checked.
 package locking

--- a/runsc/boot/fscheckpoint.go
+++ b/runsc/boot/fscheckpoint.go
@@ -266,15 +266,29 @@ type fsRestore struct {
 	mfs         map[checkpoint.ResourceID]*fscheckpoint.MemoryFile
 	tmpfs       map[checkpoint.ResourceID]*fscheckpoint.Tmpfs
 
-	waitMu  sync.Mutex
-	waitMap map[string]*fsRestoreContainer // key is container ID
+	waitMu sync.Mutex
+
+	// waitMap tracks restore completion by container ID.
+	//
+	// +checklocks:waitMu
+	waitMap map[string]*fsRestoreContainer
 }
 
 type fsRestoreContainer struct {
-	// These fields are protected by fsRestore.waitMu.
-	err        error
-	asyncLoads int // number of MemoryFiles currently in async page loading
-	cond       sync.Cond
+	// err is the first error encountered while restoring this container.
+	//
+	// +checklocks:cond.L
+	err error
+
+	// asyncLoads counts MemoryFiles currently in async page loading.
+	//
+	// +checklocks:cond.L
+	asyncLoads int
+
+	// cond wakes waiters when an error occurs or all async loads complete.
+	// ensureContainer sets L to the owning fsRestore's waitMu before
+	// publishing the entry in waitMap; L is not reassigned afterwards.
+	cond sync.Cond
 }
 
 // fsRestoreOpts holds options to startFSRestore.
@@ -500,6 +514,9 @@ func (fsr *fsRestore) ensureContainer(cid string) *fsRestoreContainer {
 	return c
 }
 
+// setError records the first non-nil error and wakes waiters, returning err.
+//
+// +checklocks:c.cond.L
 func (c *fsRestoreContainer) setError(err error) error {
 	if c.err == nil && err != nil {
 		c.err = err
@@ -526,24 +543,28 @@ func (fsr *fsRestore) memoryFileLoadArgs(id checkpoint.ResourceID, cid string) (
 	fsr.waitMu.Lock()
 	defer fsr.waitMu.Unlock()
 	c := fsr.ensureContainer(cid)
+	// ensureContainer binds c.cond.L to the held fsr.waitMu. checklocks
+	// cannot recover that identity from the returned entry.
 	if mmf.PagesMetadataEnd > uint64(len(pagesMetadata)) {
 		if err != nil {
-			return nil, 0, nil, c.setError(fmt.Errorf("failed to read pages metadata: %w", err))
+			return nil, 0, nil, c.setError(fmt.Errorf("failed to read pages metadata: %w", err)) // +checklocksignore
 		}
-		return nil, 0, nil, c.setError(fmt.Errorf("MemoryFile %q has pages metadata range [%d, %d) beyond pages metadata file size %d", mmf.ResourceID, mmf.PagesMetadataStart, mmf.PagesMetadataEnd, len(pagesMetadata)))
+		return nil, 0, nil, c.setError(fmt.Errorf("MemoryFile %q has pages metadata range [%d, %d) beyond pages metadata file size %d", mmf.ResourceID, mmf.PagesMetadataStart, mmf.PagesMetadataEnd, len(pagesMetadata))) // +checklocksignore
 	}
-	c.asyncLoads++
+	c.asyncLoads++ // +checklocksignore
 	return bytes.NewReader(pagesMetadata[mmf.PagesMetadataStart:mmf.PagesMetadataEnd]), mmf.PagesStart, func(err error) {
 		fsr.waitMu.Lock()
 		defer fsr.waitMu.Unlock()
-		c.asyncLoads--
+		// The captured entry still uses fsr.waitMu as c.cond.L; checklocks
+		// cannot relate that interface value to the lock acquired above.
+		c.asyncLoads-- // +checklocksignore
 		switch {
 		case err != nil:
-			if c.err == nil {
-				c.err = err
+			if c.err == nil { // +checklocksignore
+				c.err = err // +checklocksignore
 			}
 			fallthrough
-		case c.asyncLoads == 0:
+		case c.asyncLoads == 0: // +checklocksignore
 			c.cond.Broadcast()
 		}
 	}, nil
@@ -570,10 +591,12 @@ func (fsr *fsRestore) tmpfsSourceTar(id checkpoint.ResourceID, cid string) (io.R
 		return io.NopCloser(bytes.NewReader(multiTar[mt.TarStart:mt.TarEnd])), nil
 	}
 	c := fsr.ensureContainer(cid)
+	// ensureContainer binds c.cond.L to the held fsr.waitMu. checklocks
+	// cannot recover that identity from the returned entry.
 	if err != nil {
-		return nil, c.setError(fmt.Errorf("failed to read tar archive: %w", err))
+		return nil, c.setError(fmt.Errorf("failed to read tar archive: %w", err)) // +checklocksignore
 	}
-	return nil, c.setError(fmt.Errorf("tmpfs %q has tar range [%d, %d) beyond multi-tar file size %d", mt.ResourceID, mt.TarStart, mt.TarEnd, len(multiTar)))
+	return nil, c.setError(fmt.Errorf("tmpfs %q has tar range [%d, %d) beyond multi-tar file size %d", mt.ResourceID, mt.TarStart, mt.TarEnd, len(multiTar))) // +checklocksignore
 }
 
 // wait blocks until either all filesystems have been restored for the
@@ -593,11 +616,13 @@ func (fsr *fsRestore) wait(cid string) error {
 	if c == nil {
 		return fmt.Errorf("no filesystems restored for container %s", cid)
 	}
+	// Entries are published with c.cond.L bound to fsr.waitMu. checklocks
+	// cannot recover that identity through the waitMap lookup.
 	for {
-		if c.err != nil {
-			return c.err
+		if c.err != nil { // +checklocksignore
+			return c.err // +checklocksignore
 		}
-		if c.asyncLoads == 0 {
+		if c.asyncLoads == 0 { // +checklocksignore
 			return nil
 		}
 		c.cond.Wait()

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -339,6 +339,8 @@ type Loader struct {
 
 	// networkArgs contains the routes and links which were scraped from the
 	// host network namespace during sandbox creation.
+	//
+	// +checklocks:mu
 	networkArgs *CreateLinksAndRoutesArgs
 
 	// pinRing accumulates host FDs to pin before seccomp filters are
@@ -346,6 +348,8 @@ type Loader struct {
 	pinRing pinring.PinRing
 
 	// fsSaveFDs are FDs used for user-triggered filesystem checkpoint saving.
+	//
+	// +checklocks:mu
 	fsSaveFDs []*fd.FD
 
 	// fsSaveCheckpointGofer is true if fsSaveFDs contains only one FD, which
@@ -934,6 +938,13 @@ func New(args Args) (*Loader, error) {
 }
 
 // ConfigureNetwork implements inet.NetworkArgs.ConfigureNetwork.
+//
+// Startup calls this directly before installing seccomp filters. Restore
+// calls it synchronously through Kernel.LoadFrom after installing filters.
+// Both callers hold l.mu, but the restore interface call cannot convey this
+// concrete lock contract to checklocks.
+//
+// +checklocks:l.mu
 func (l *Loader) ConfigureNetwork(s inet.Stack) error {
 	if h, ok := s.(*hostinet.Stack); ok {
 		h.SetFiles(l.hostinetNetDevFile, l.hostinetNetSNMPFile)

--- a/tools/bazeldefs/go.bzl
+++ b/tools/bazeldefs/go.bzl
@@ -3,7 +3,7 @@
 load("@bazel_gazelle//:def.bzl", _gazelle = "gazelle")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@io_bazel_rules_go//go:def.bzl", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "GoArchive", "GoLibrary", _go_binary = "go_binary", _go_context = "go_context", _go_library = "go_library", _go_path = "go_path", _go_test = "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", _go_grpc_library = "go_grpc_library", _go_proto_library = "go_proto_library")
 load("//tools/bazeldefs:defs.bzl", "select_arch", "select_system")
 
@@ -88,6 +88,10 @@ def go_importpath(target):
     """Returns the importpath for the target."""
     return target[GoLibrary].importpath
 
+def go_binary_archive(target):
+    """Returns compiled Go archive metadata for a binary target."""
+    return target[GoArchive].data
+
 def go_library(name, bazel_cgo = False, bazel_cdeps = [], bazel_clinkopts = [], bazel_copts = [], **kwargs):
     """Wrapper for `go_library` rule.
 
@@ -159,13 +163,14 @@ def go_embed_libraries(target):
         return target.attr.embed
     return []
 
-def go_context(ctx, goos = None, goarch = None):
+def go_context(ctx, goos = None, goarch = None, attr = None):
     """Extracts a standard Go context struct.
 
     Args:
       ctx: the starlark context (required).
       goos: the GOOS value.
       goarch: the GOARCH value.
+      attr: the analyzed rule's attributes for aspect callers.
 
     Returns:
       A context Go struct with pointers to Go toolchain components.
@@ -174,7 +179,7 @@ def go_context(ctx, goos = None, goarch = None):
     # We don't change anything for the standard library analysis. All Go files
     # are available in all instances. Note that this includes the standard
     # library sources, which are analyzed by nogo.
-    go_ctx = _go_context(ctx)
+    go_ctx = _go_context(ctx, attr = attr)
 
     nogo_args = []
     if go_ctx.mode.race:

--- a/tools/checkescape/test3/BUILD
+++ b/tools/checkescape/test3/BUILD
@@ -1,0 +1,17 @@
+load("//tools:defs.bzl", "go_binary")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_binary(
+    name = "test3",
+    srcs = [
+        "main.go",
+        "tagged.go",
+    ],
+    gotags = ["checkescape_binary"],
+    pure = True,
+    testonly = True,
+)

--- a/tools/checkescape/test3/main.go
+++ b/tools/checkescape/test3/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Binary test3 checks build-tag and archive selection for nogo.
 package main
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
-
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+func main() {
+	// Analysis must use the binary's build tags to resolve this constant.
+	_ = taggedValue
 }

--- a/tools/checkescape/test3/tagged.go
+++ b/tools/checkescape/test3/tagged.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build checkescape_binary
+
 package main
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
+const taggedValue = true
 
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+// unusedAllocation remains in the Go archive but is removed by the linker.
+// The stack check rejects checkescape's conservative fallback if objdump fails.
+//
+// +mustescape:local,heap
+// +checkescape:stack
+//
+//go:noinline
+//go:nosplit
+func unusedAllocation() *int {
+	return new(int)
 }

--- a/tools/checklocks/README.md
+++ b/tools/checklocks/README.md
@@ -44,6 +44,20 @@ type foo struct {
 This will ensure that all accesses to bar are atomic, with the exception of
 operations on newly allocated objects (when detectable).
 
+An atomic call must use the annotated address as its receiver or atomic
+location. Storing that address as the payload of another atomic value does not
+make accesses through the stored pointer atomic.
+
+For global variables, atomic-use checking applies only when `+checkatomic` is
+present, for example:
+
+```go
+var (
+  // +checkatomic
+  globalValue atomicbitops.Int32
+)
+```
+
 ## Lock Enforcement
 
 Individual struct members may be protected by annotations that indicate locking
@@ -73,6 +87,8 @@ These semantics are enforceable on `sync.Mutex`, `sync.RWMutex` and
 `sync.Locker` fields. Semantics with respect to reading and writing are
 automatically detected and enforced. If an access is read-only, then the lock
 need only be held as a read lock, in the case of an `sync.RWMutex`.
+Annotations on a field declaration with multiple names apply to every named
+field in that declaration.
 
 The locks must be resolvable within the scope of the declaration. This means the
 lock must refer to one of:
@@ -82,7 +98,57 @@ lock must refer to one of:
 *   A global lock (e.g. globalMu).
 *   A lock resolvable from a global struct (e.g. globalX.mu).
 
+A field with multiple guards can additionally use `+checklocksreadany` when
+reads require **any one** guard, but writes require **all** guards exclusively:
+
+```go
+type example struct {
+    mu sync.Mutex
+    otherMu sync.RWMutex
+
+    // +checklocks:mu
+    // +checklocks:otherMu
+    // +checklocksreadany
+    value int
+}
+```
+
+A reader may hold `mu`, or hold `otherMu` for reading or writing. A writer must
+hold both mutexes for writing, so it excludes readers using either guard.
+The modifier applies only to fields, requires at least one `+checklocks` guard,
+and takes no arguments. Only value reads and immediately following loads
+qualify. Retaining an address or passing it to a function requires all guards
+exclusively, as with other guarded address uses; the modifier does not add
+alias lifetime tracking.
+With `+checkatomic`, atomic reads remain allowed without any guard. Holding
+any guard additionally permits an immediate non-atomic load, including a direct
+`atomicbitops.RacyLoad` call. This permission requires the field address's sole
+use to immediately follow it in the same basic block; retained addresses,
+casts, and deferred calls do not qualify. Atomic writes still require all
+guards exclusively, and non-atomic writes remain forbidden even with all
+guards held. The modifier cannot be combined with a field's `+checklocksignore`.
+
 Like atomic access enforcement, checks may be elided on newly allocated objects.
+
+### Global Variable Annotations
+
+Global variables also support lock and atomic annotations. Put annotations above
+a standalone declaration or above an individual entry in a `var` block:
+
+```go
+var globalMu sync.Mutex
+
+// +checklocks:globalMu
+var first int
+
+var (
+    // +checklocks:globalMu
+    second, third int
+)
+```
+
+Annotations apply to every named variable in that declaration or block entry.
+Comments above an entire `var` block do not annotate its entries.
 
 ### Function Annotations
 
@@ -195,13 +261,16 @@ by a mutex. Generally, this imposes the following requirements:
 
 For a read, one of the following must be true:
 
-1.  A lock held be held.
+1.  All guards must be held.
 1.  The access is atomic.
 
 For a write, both of the following must be true:
 
-1.  The lock must be held.
+1.  All guards must be held exclusively.
 1.  The write must be atomic.
+
+Shared RWMutex locks satisfy the lock-held read condition, but not the write
+condition.
 
 In order to annotate a relevant field, simply apply *both* annotations from
 above. For example:
@@ -217,10 +286,19 @@ type foo struct {
 
 This enforces that the preconditions above are upheld.
 
-This also applies to atomic wrapper types (for example, atomic.Int32). In the
-mixed case, lock-free access is limited to read-only atomic operations such as
-Load. Any atomic write operation (for example, Store, Swap, or Add) requires the
-lock to be held.
+This also applies to atomic wrapper types such as `atomic.Int32` and
+`atomic.Pointer[T]`. In the mixed case, lock-free access is limited to read-only
+atomic operations such as Load. Any atomic write operation (for example, Store,
+Swap, or Add) requires the lock to be held exclusively.
+
+The non-atomic `atomicbitops.RacyLoad` method follows the mixed read rule above.
+`RacyStore` and `RacyAdd` do not satisfy the atomic-write requirement, even with
+the lock held, because other readers may access the field atomically without
+locking. The exceptions for newly allocated objects still apply.
+
+Deferred atomic calls are supported for pure atomic fields and globals. Deferred
+calls on values with both atomic and mutex requirements remain unsupported: their
+locks would need to be checked when the calls execute, not when they are deferred.
 
 ## Ignoring and Forcing
 

--- a/tools/checklocks/analysis.go
+++ b/tools/checklocks/analysis.go
@@ -17,6 +17,8 @@ package checklocks
 import (
 	"go/token"
 	"go/types"
+	"maps"
+	"slices"
 	"strings"
 
 	"golang.org/x/tools/go/ssa"
@@ -90,7 +92,7 @@ func (pc *passContext) checkTypeAlignment(pkg *types.Package, typ *types.Named) 
 	}
 }
 
-// atomicRules specify read constraints.
+// atomicRules specifies permitted access modes.
 type atomicRules int
 
 const (
@@ -98,22 +100,54 @@ const (
 	readWriteAtomic
 	readOnlyAtomic
 	mixedAtomic
+	readOnlyMixedAtomic
 )
 
-// checkAtomicCall checks for an atomic access.
-//
-// inst is the instruction analyzed, obj is used only for maybeFail.
-func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, ar atomicRules) {
+// functionPackage also resolves methods from indirectly imported packages,
+// which buildssa may represent using type information without an SSA package.
+func functionPackage(fn *ssa.Function) *types.Package {
+	if pkg := fn.Package(); pkg != nil {
+		return pkg.Pkg
+	}
+	obj, ok := fn.Object().(*types.Func)
+	if !ok || fn.Signature.Recv() == nil {
+		return nil
+	}
+	recv := obj.Type().(*types.Signature).Recv()
+	// Wrappers may retain the original method object but change or remove
+	// its receiver. They must not inherit the method's atomic privileges.
+	if recv == nil || !types.Identical(fn.Signature.Recv().Type(), recv.Type()) {
+		return nil
+	}
+	return obj.Pkg()
+}
+
+// checkAtomicCall checks whether inst accesses the value atomically.
+func (pc *passContext) checkAtomicCall(inst ssa.Instruction, value ssa.Value, ar atomicRules) {
+	allowNonAtomicRead := ar == mixedAtomic || ar == readOnlyMixedAtomic
 	switch x := inst.(type) {
-	case *ssa.Call:
-		if x.Common().IsInvoke() {
+	case *ssa.Call, *ssa.Defer:
+		if _, deferred := x.(*ssa.Defer); deferred {
+			// Pure atomic access does not depend on lock state. Guarded
+			// deferred accesses would need their locks checked at execution,
+			// not registration, so keep rejecting those conservatively.
+			if ar != readWriteAtomic {
+				break
+			}
+			// Deferred uses previously reached the force-aware fallback.
+			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
+				return
+			}
+		}
+		call := x.(ssa.CallInstruction).Common()
+		if call.IsInvoke() {
 			if ar != nonAtomic {
 				// This is an illegal interface dispatch.
 				pc.maybeFail(inst.Pos(), "dynamic dispatch with atomic-only field")
 			}
 			return
 		}
-		fn, ok := x.Common().Value.(*ssa.Function)
+		fn, ok := call.Value.(*ssa.Function)
 		if !ok {
 			if ar != nonAtomic {
 				// This is an illegal call to a non-static function.
@@ -121,7 +155,11 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 			}
 			return
 		}
-		pkg := fn.Package()
+		// Generic instantiation wrappers may have no package of their own.
+		if origin := fn.Origin(); origin != nil {
+			fn = origin
+		}
+		pkg := functionPackage(fn)
 		if pkg == nil {
 			if ar != nonAtomic {
 				// This is a call to some shared wrapper function.
@@ -133,12 +171,18 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 		if obj := fn.Object(); obj != nil && pc.pass.ImportObjectFact(obj, &lff) && lff.Ignore {
 			return
 		}
-		if name := pkg.Pkg.Name(); name != "atomic" && name != "atomicbitops" {
+		if name := pkg.Name(); name != "atomic" && name != "atomicbitops" {
 			if ar != nonAtomic {
 				// This is an illegal call to a non-atomic package function.
 				pc.maybeFail(inst.Pos(), "dispatch to non-atomic function with atomic-only field")
 			}
 			return
+		}
+		// Only the receiver (or first argument to a free function) is the
+		// atomic location. Storing the field's address as a pointer payload
+		// would let later accesses bypass its atomic requirement.
+		if len(call.Args) == 0 || call.Args[0] != value {
+			break
 		}
 		if ar == nonAtomic {
 			if fn.Signature.Recv() != nil {
@@ -151,8 +195,20 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic function")
 			}
 		}
-		if !strings.HasPrefix(fn.Name(), "Load") && ar == readOnlyAtomic {
-			// We are not allowing any reads in this context.
+		if pkg.Name() == "atomicbitops" && strings.HasPrefix(fn.Name(), "Racy") {
+			// Racy methods are non-atomic. Mixed access permits non-atomic
+			// reads under the lock, but writes must remain atomic for
+			// concurrent lock-free readers.
+			if ar != nonAtomic && (!allowNonAtomicRead || fn.Name() != "RacyLoad") {
+				if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
+					pc.maybeFail(inst.Pos(), "non-atomic operation %s on atomic-only field", fn.Name())
+				}
+			}
+			return
+		}
+		if (ar == readOnlyAtomic || ar == readOnlyMixedAtomic) &&
+			!strings.HasPrefix(fn.Name(), "Load") {
+			// We are not allowing any writes in this context.
 			if _, ok := pc.forced[pc.positionKey(inst.Pos())]; !ok {
 				pc.maybeFail(inst.Pos(), "unexpected call to atomic write function, is a lock missing?")
 			}
@@ -162,11 +218,11 @@ func (pc *passContext) checkAtomicCall(inst ssa.Instruction, obj types.Object, a
 	case *ssa.ChangeType:
 		// Allow casts for atomic values, but nothing else.
 		if refs := x.Referrers(); refs != nil && len(*refs) == 1 {
-			pc.checkAtomicCall((*refs)[0], obj, ar)
+			pc.checkAtomicCall((*refs)[0], x, ar)
 			return
 		}
 	case *ssa.UnOp:
-		if x.Op == token.MUL && ar == mixedAtomic {
+		if x.Op == token.MUL && allowNonAtomicRead {
 			// This is allowed; this is a strict reading.
 			return
 		}
@@ -245,6 +301,45 @@ type almostInst interface {
 	Referrers() *[]ssa.Instruction
 }
 
+// isImmediateFieldRead reports whether inst reads a value without retaining
+// its address. allowRacyLoad also accepts atomicbitops.RacyLoad.
+func isImmediateFieldRead(inst almostInst, allowRacyLoad bool) bool {
+	switch x := inst.(type) {
+	case *ssa.Field:
+		return true
+	case *ssa.FieldAddr:
+		refs := x.Referrers()
+		if refs == nil || len(*refs) != 1 || x.Block() == nil {
+			return false
+		}
+		// Use instruction order, not source positions: a retained address
+		// may be loaded after an unlock, including on another control path.
+		use := (*refs)[0]
+		instrs := x.Block().Instrs
+		i := slices.Index(instrs, ssa.Instruction(x))
+		if i < 0 || i+1 >= len(instrs) || instrs[i+1] != use {
+			return false
+		}
+		switch use := use.(type) {
+		case *ssa.UnOp:
+			return use.Op == token.MUL && use.X == x
+		case *ssa.Call:
+			call := use.Common()
+			fn := call.StaticCallee()
+			if !allowRacyLoad || fn == nil || len(call.Args) != 1 || call.Args[0] != x {
+				return false
+			}
+			if origin := fn.Origin(); origin != nil {
+				fn = origin
+			}
+			pkg := functionPackage(fn)
+			return pkg != nil && pkg.Path() == "gvisor.dev/gvisor/pkg/atomicbitops" &&
+				fn.Signature.Recv() != nil && fn.Name() == "RacyLoad"
+		}
+	}
+	return false
+}
+
 // checkGuards checks the guards held.
 //
 // This also enforces atomicity constraints for fields that must be accessed
@@ -253,15 +348,21 @@ type almostInst interface {
 //
 // Note that this function is not called if lff.Ignore is true, since it cannot
 // discover any local anonymous functions or closures.
-func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj types.Object, ls *lockState, isWrite bool) {
+func (pc *passContext) checkGuards(inst almostInst, value, from ssa.Value, accessObj types.Object, ls *lockState, isWrite bool) {
 	var (
 		lgf         lockGuardFacts
 		guardsFound int
-		guardsHeld  = make(map[string]struct{}) // Keyed by resolved string.
+		// guardsHeld maps resolved names to exclusive (true) or shared (false).
+		guardsHeld = make(map[string]bool)
 	)
 
 	// Load the facts for the object accessed.
 	pc.importLockGuardFacts(accessObj, &lgf)
+	if lgf.ReadAny && lgf.AtomicDisposition == atomicDisallow {
+		// Unlike the optimistic isWrite check, alternative reader guards
+		// must not admit an address used for mutation or escaping aliases.
+		isWrite = isWrite || !isImmediateFieldRead(inst, false /* allowRacyLoad */)
+	}
 	pc.applyTypeAliases(ls, from)
 
 	// Check guards held.
@@ -275,14 +376,15 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		}
 		s, ok := ls.isHeld(r, isWrite)
 		if ok {
-			guardsHeld[s] = struct{}{}
+			_, exclusive := ls.isHeld(r, true)
+			guardsHeld[s] = exclusive
 			continue
 		}
 		if _, ok := pc.forced[pc.positionKey(inst.Pos())]; ok {
 			// Mark this as locked, since it has been forced. All
 			// forces are treated as an exclusive lock.
 			s, _ := ls.lockField(r, true /* exclusive */)
-			guardsHeld[s] = struct{}{}
+			guardsHeld[s] = true
 			continue
 		}
 		// Note that we may allow this if the disposition is atomic,
@@ -291,10 +393,15 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		// access is atomic. Further, len(guardsHeld) < guardsFound
 		// will be true for this case, so we require it to be
 		// read-only.
-		if lgf.AtomicDisposition != atomicRequired {
+		if lgf.AtomicDisposition != atomicRequired && (!lgf.ReadAny || isWrite) {
 			// There is no force key, no atomic access and no lock held.
 			pc.maybeFail(inst.Pos(), "invalid field access, %s (%s) must be locked when accessing %s (locks: %s)", guardName, s, accessObj.Name(), ls.String())
 		}
+	}
+
+	if lgf.ReadAny && lgf.AtomicDisposition == atomicDisallow && !isWrite && len(guardsHeld) == 0 {
+		guards := strings.Join(slices.Sorted(maps.Keys(lgf.GuardedBy)), ", ")
+		pc.maybeFail(inst.Pos(), "invalid field access, at least one of %s must be locked when reading %s (locks: %s)", guards, accessObj.Name(), ls.String())
 	}
 
 	// Check the atomic access for this field.
@@ -307,11 +414,22 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 				ar = readOnlyAtomic
 			} else {
 				ar = mixedAtomic
+				for _, exclusive := range guardsHeld {
+					if !exclusive {
+						ar = readOnlyMixedAtomic
+						break
+					}
+				}
 			}
+		}
+		if ar == readOnlyAtomic && lgf.ReadAny && len(guardsHeld) > 0 && isImmediateFieldRead(inst, true /* allowRacyLoad */) {
+			// Permit only an immediate non-atomic read under an alternative
+			// guard. Writes still need every guard held exclusively.
+			ar = readOnlyMixedAtomic
 		}
 		if refs := inst.Referrers(); refs != nil {
 			for _, otherInst := range *refs {
-				pc.checkAtomicCall(otherInst, accessObj, ar)
+				pc.checkAtomicCall(otherInst, value, ar)
 			}
 		}
 		// Check that this is not otherwise written non-atomically,
@@ -327,7 +445,7 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 		// Check that this is *not* used atomically.
 		if refs := inst.Referrers(); refs != nil {
 			for _, otherInst := range *refs {
-				pc.checkAtomicCall(otherInst, accessObj, nonAtomic)
+				pc.checkAtomicCall(otherInst, value, nonAtomic)
 			}
 		}
 	}
@@ -373,22 +491,35 @@ func (pc *passContext) checkGuards(inst almostInst, from ssa.Value, accessObj ty
 }
 
 // checkFieldAccess checks the validity of a field access.
-func (pc *passContext) checkFieldAccess(inst almostInst, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
+func (pc *passContext) checkFieldAccess(inst ssa.Value, structObj ssa.Value, field int, ls *lockState, isWrite bool) {
 	fieldObj, _ := findField(structObj.Type(), field)
-	pc.checkGuards(inst, structObj, fieldObj, ls, isWrite)
+	pc.checkGuards(inst, inst, structObj, fieldObj, ls, isWrite)
 }
 
-// noReferrers wraps an instruction as an almostInst.
-type noReferrers struct {
+// globalAccess exposes a global's consuming instruction to atomic checks.
+type globalAccess struct {
 	ssa.Instruction
+	checkAtomic bool
 }
 
 // Referrers implements almostInst.Referrers.
-func (noReferrers) Referrers() *[]ssa.Instruction { return nil }
+func (a globalAccess) Referrers() *[]ssa.Instruction {
+	if !a.checkAtomic {
+		return nil
+	}
+	return &[]ssa.Instruction{a.Instruction}
+}
 
 // checkGlobalAccess checks the validity of a global access.
 func (pc *passContext) checkGlobalAccess(inst ssa.Instruction, g *ssa.Global, ls *lockState, isWrite bool) {
-	pc.checkGuards(noReferrers{inst}, g, g.Object(), ls, isWrite)
+	var lgf lockGuardFacts
+	pc.importLockGuardFacts(g.Object(), &lgf)
+	pc.checkGuards(globalAccess{
+		Instruction: inst,
+		// Only explicitly annotated globals opt into atomic-use checking.
+		// Direct writes are diagnosed separately by checkGuards.
+		checkAtomic: !isWrite && lgf.AtomicDisposition == atomicRequired,
+	}, g, g, g.Object(), ls, isWrite)
 }
 
 func (pc *passContext) checkCall(call callCommon, lff *lockFunctionFacts, ls *lockState) {
@@ -478,6 +609,10 @@ func (pc *passContext) postFunctionCallUpdate(call callCommon, lff *lockFunction
 		}
 		// Acquire the lock per the annotation.
 		r := fg.Resolver.resolveCall(pc, ls, call.Common().Args, call.Value())
+		if !r.valid() {
+			pc.maybeFail(call.Pos(), "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.lockField(r, fg.Exclusive); !ok && !lff.Ignore {
 			if _, ok := pc.forced[pc.positionKey(call.Pos())]; !ok && !lff.Ignore {
 				pc.maybeFail(call.Pos(), "attempt to acquire %s (%s), but already held (locks: %s)", fieldName, s, ls.String())
@@ -495,10 +630,10 @@ func exclusiveStr(exclusive bool) string {
 }
 
 // checkFunctionCall checks preconditions for function calls, and tracks the
-// lock state by recording relevant calls to sync functions. Note that calls to
-// atomic functions are tracked by checkFieldAccess by looking directly at the
-// referrers (because ordering doesn't matter there, so we need not scan in
-// instruction order).
+// lock state by recording relevant calls to sync functions. Atomic field
+// referrers are checked by checkFieldAccess using the lock state at the field
+// access, not at a later use of a retained field address. Direct global atomic
+// operations are checked at their consuming instructions.
 func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *lockFunctionFacts, ls *lockState) {
 	// Extract the "receiver" properly.
 	var args []ssa.Value
@@ -525,6 +660,10 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check that excluded locks are not held on entry.
 	for fieldName, fg := range lff.ExcludedOnEntry {
 		r := resolve(fg)
+		if !r.valid() {
+			pc.maybeFail(callPos, "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); ok {
 			if !forced && !lff.Ignore {
 				if fg.Exclusive {
@@ -539,6 +678,10 @@ func (pc *passContext) checkFunctionCall(call callCommon, fn *types.Func, lff *l
 	// Check all guards required are held.
 	for fieldName, fg := range lff.HeldOnEntry {
 		r := resolve(fg)
+		if !r.valid() {
+			pc.maybeFail(callPos, "field %s cannot be resolved", fieldName)
+			continue
+		}
 		if s, ok := ls.isHeld(r, fg.Exclusive); !ok {
 			if !forced && !lff.Ignore {
 				pc.maybeFail(callPos, "must hold %s %s (%s) to call %s, but not held (locks: %s)", fieldName, exclusiveStr(fg.Exclusive), s, fn.Name(), ls.String())
@@ -658,9 +801,8 @@ type callCommon interface {
 // checkInstruction checks the legality the single instruction based on the
 // current lockState.
 func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionFacts, ls *lockState) (*ssa.Return, *lockState) {
-	// Record any observed globals, and check for violations. The global
-	// value is not itself an instruction, but we check all referrers to
-	// see where they are consumed.
+	// Globals are values, not instructions. Check each use with the current
+	// instruction's lock state.
 	var stackLocal [16]*ssa.Value
 	ops := inst.Operands(stackLocal[:])
 	for _, v := range ops {
@@ -668,10 +810,11 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 			continue
 		}
 		g, ok := (*v).(*ssa.Global)
-		if !ok {
+		if !ok || lff.Ignore {
 			continue
 		}
-		_, isWrite := inst.(*ssa.Store)
+		store, ok := inst.(*ssa.Store)
+		isWrite := ok && store.Addr == g
 		pc.checkGlobalAccess(inst, g, ls, isWrite)
 	}
 
@@ -710,20 +853,22 @@ func (pc *passContext) checkInstruction(inst ssa.Instruction, lff *lockFunctionF
 				nonCalls int
 			)
 			for _, ref := range *refs {
-				switch ref.(type) {
-				case *ssa.Call, *ssa.Defer:
-					// Analysis will be done on the call
-					// itself subsequently, including the
-					// lock state at the time of the call.
-					calls++
-				default:
-					// We need to analyze separately. Per
-					// below, this means that we'll analyze
-					// at closure construction time no zero
-					// assumptions about when it will be
-					// called.
-					nonCalls++
+				// Only direct calls are analyzed later with the lock
+				// state at invocation. Passing the closure as an argument
+				// gives no guarantee about when it will be called.
+				switch ref := ref.(type) {
+				case *ssa.Call:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
+				case *ssa.Defer:
+					if ref.Common().Value == x {
+						calls++
+						continue
+					}
 				}
+				nonCalls++
 			}
 			if calls > 0 && nonCalls == 0 {
 				return nil, nil

--- a/tools/checklocks/annotations.go
+++ b/tools/checklocks/annotations.go
@@ -25,6 +25,7 @@ import (
 const (
 	checkLocksAnnotation     = "// +checklocks:"
 	checkLocksAnnotationRead = "// +checklocksread:"
+	checkLocksReadAny        = "// +checklocksreadany"
 	checkLocksAcquires       = "// +checklocksacquire:"
 	checkLocksAcquiresRead   = "// +checklocksacquireread:"
 	checkLocksReleases       = "// +checklocksrelease:"

--- a/tools/checklocks/checklocks.go
+++ b/tools/checklocks/checklocks.go
@@ -95,7 +95,7 @@ func (pc *passContext) observationsFor(obj types.Object) *objectObservations {
 }
 
 // forAllGlobals applies the given function to all globals.
-func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
+func (pc *passContext) forAllGlobals(fn func(vs *ast.ValueSpec, decl *ast.GenDecl)) {
 	for _, f := range pc.pass.Files {
 		for _, decl := range f.Decls {
 			d, ok := decl.(*ast.GenDecl)
@@ -103,7 +103,7 @@ func (pc *passContext) forAllGlobals(fn func(ts *ast.ValueSpec)) {
 				continue
 			}
 			for _, gs := range d.Specs {
-				fn(gs.(*ast.ValueSpec))
+				fn(gs.(*ast.ValueSpec), d)
 			}
 		}
 	}
@@ -151,12 +151,12 @@ func run(pass *analysis.Pass) (any, error) {
 	pc.extractLineFailures()
 
 	// Find all struct declarations and export relevant facts.
-	pc.forAllGlobals(func(vs *ast.ValueSpec) {
+	pc.forAllGlobals(func(vs *ast.ValueSpec, decl *ast.GenDecl) {
 		if ss, ok := vs.Type.(*ast.StructType); ok {
 			structType := pc.pass.TypesInfo.TypeOf(vs.Type).Underlying().(*types.Struct)
 			pc.structLockGuardFacts(structType, ss)
 		}
-		pc.globalLockGuardFacts(vs)
+		pc.globalLockGuardFacts(vs, decl)
 	})
 	pc.forAllTypes(func(ts *ast.TypeSpec, decl *ast.GenDecl) {
 		if ss, ok := ts.Type.(*ast.StructType); ok {

--- a/tools/checklocks/facts.go
+++ b/tools/checklocks/facts.go
@@ -106,12 +106,14 @@ func fieldEntryEqual(left, right fieldEntry) bool {
 // fieldList is a simple list of fields, used in two types below.
 type fieldList []fieldEntry
 
-// resolvedValue is an ssa.Value with additional fields.
-//
-// This can be resolved to a string as part of a lock state.
+// resolvedValue identifies a lock through SSA or an exported global identity.
 type resolvedValue struct {
 	value     ssa.Value
 	fieldList fieldList
+
+	// key identifies an imported global whose declaration or package is absent
+	// from SSA. It is synthesized where the declaration's type is available.
+	key string
 }
 
 // makeResolvedValue makes a new resolvedValue.
@@ -124,15 +126,17 @@ func makeResolvedValue(v ssa.Value, fl fieldList) resolvedValue {
 
 // valid indicates whether this is a valid resolvedValue.
 func (rv *resolvedValue) valid() bool {
-	return rv.value != nil
+	return rv.value != nil || rv.key != ""
 }
 
 // valueAndObject returns a string and object.
 //
-// This uses the lockState valueAndObject in order to produce a string and
-// object for the base ssa.Value, then synthesizes a string representation
-// based on the fieldList.
+// An imported identity may have no source object. Otherwise, resolve the base
+// SSA value through lockState and synthesize its field path.
 func (rv *resolvedValue) valueAndObject(ls *lockState) (string, types.Object) {
+	if rv.key != "" {
+		return rv.key, nil
+	}
 	// N.B. obj.Type() and typ should be equal, but a check is omitted
 	// since, 1) we automatically chase through pointers during field
 	// resolution, and 2) obj may be nil if there is no source object.
@@ -172,6 +176,10 @@ type lockGuardFacts struct {
 	// traversal path.
 	GuardedBy map[string]fieldGuardResolver
 
+	// ReadAny allows immediate non-atomic reads with any guard held.
+	// Writes still require all guards exclusively.
+	ReadAny bool
+
 	// AtomicDisposition is the disposition for this field. Note that this
 	// can affect the interpretation of the GuardedBy field above, see the
 	// relevant comment.
@@ -191,6 +199,14 @@ type globalGuard struct {
 
 	// FieldList is the traversal path from object.
 	FieldList fieldList
+
+	// Key preserves the complete lock identity when export data omits the
+	// private global or the caller does not directly import its package.
+	Key string
+}
+
+func globalLockKey(pkgPath, name string) string {
+	return fmt.Sprintf("{global:%s.%s}", pkgPath, name)
 }
 
 // ssaPackager returns the ssa package.
@@ -205,8 +221,12 @@ func (g *globalGuard) resolveCommon(pc *passContext, ls *lockState) resolvedValu
 	if g.PackageName != "" && g.PackageName != state.Pkg.Pkg.Path() {
 		pkg = state.Pkg.Prog.ImportedPackage(g.PackageName)
 	}
-	v := pkg.Members[g.ObjectName].(ssa.Value)
-	return makeResolvedValue(v, g.FieldList)
+	if pkg != nil {
+		if v, ok := pkg.Members[g.ObjectName].(ssa.Value); ok {
+			return makeResolvedValue(v, g.FieldList)
+		}
+	}
+	return resolvedValue{key: g.Key}
 }
 
 // resolveStatic implements functionGuardResolver.resolveStatic.
@@ -730,6 +750,20 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 	}
 	for _, l := range cg.List {
 		pc.extractAnnotations(l.Text, map[string]func(string){
+			checkLocksReadAny: func(p string) {
+				if field, ok := obj.(*types.Var); !ok || !field.IsField() {
+					pc.maybeFail(obj.Pos(), "checklocksreadany is only valid on fields")
+					return
+				}
+				if p != "" {
+					pc.maybeFail(obj.Pos(), "checklocksreadany does not take arguments")
+					return
+				}
+				if lgf.ReadAny {
+					pc.maybeFail(obj.Pos(), "checklocksreadany specified more than once")
+				}
+				lgf.ReadAny = true
+			},
 			checkAtomicAnnotation: func(string) {
 				switch lgf.AtomicDisposition {
 				case atomicRequired:
@@ -773,6 +807,21 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 			},
 		})
 	}
+}
+
+// exportLockGuardFacts validates and exports accumulated lock guard facts.
+// For fields, both the doc comment and trailing comment must have been read.
+func (pc *passContext) exportLockGuardFacts(obj types.Object, lgf *lockGuardFacts) {
+	if lgf.ReadAny {
+		if len(lgf.GuardedBy) == 0 {
+			pc.maybeFail(obj.Pos(), "checklocksreadany requires at least one checklocks guard")
+			lgf.ReadAny = false
+		}
+		if lgf.AtomicDisposition == atomicIgnore {
+			pc.maybeFail(obj.Pos(), "checklocksreadany cannot be combined with checklocksignore")
+			lgf.ReadAny = false
+		}
+	}
 	// Save only if there is something meaningful.
 	if len(lgf.GuardedBy) > 0 || lgf.AtomicDisposition != atomicDisallow {
 		pc.pass.ExportObjectFact(obj, lgf)
@@ -783,9 +832,9 @@ func (pc *passContext) fillLockGuardFacts(obj types.Object, cg *ast.CommentGroup
 func (pc *passContext) findGlobalGuard(pos token.Pos, guardName string) (*globalGuard, types.Object, bool) {
 	// Attempt to resolve the object.
 	parts := strings.Split(guardName, ".")
-	globalObj := pc.pass.Pkg.Scope().Lookup(parts[0])
-	if globalObj == nil {
-		// No global object.
+	globalObj, ok := pc.pass.Pkg.Scope().Lookup(parts[0]).(*types.Var)
+	if !ok {
+		// A type or constant cannot identify a global lock.
 		return nil, nil, false
 	}
 	fl, lockObj, ok := pc.maybeFindFieldListObj(pos, globalObj, parts[1:])
@@ -796,10 +845,18 @@ func (pc *passContext) findGlobalGuard(pos token.Pos, guardName string) (*global
 	if pc.lockKind(pos, lockObj) == nil {
 		return nil, nil, false
 	}
+	key := globalLockKey(pc.pass.Pkg.Path(), globalObj.Name())
+	typ := globalObj.Type()
+	for _, entry := range fl {
+		var obj types.Object
+		key, obj = entry.synthesize(key, typ)
+		typ = obj.Type()
+	}
 	return &globalGuard{
 		ObjectName:  parts[0],
 		PackageName: pc.pass.Pkg.Path(),
 		FieldList:   fl,
+		Key:         key,
 	}, lockObj, true
 }
 
@@ -817,7 +874,6 @@ func (pc *passContext) findGlobalFunctionGuard(pos token.Pos, guardName string) 
 
 // structLockGuardFacts finds all relevant guard information for structures.
 func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.StructType) {
-	var fieldObj *types.Var
 	findLocal := func(pos token.Pos, guardName string) (fieldGuardResolver, bool) {
 		// Try to resolve from the local structure first.
 		if fl, _, objs, ok := pc.resolveFieldListParts(pos, structType, strings.Split(guardName, ".")); ok {
@@ -834,20 +890,28 @@ func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.St
 		// Attempt a global resolution.
 		return pc.findGlobalFieldGuard(pos, guardName)
 	}
-	for i, field := range ss.Fields.List {
-		var lgf lockGuardFacts
-		fieldObj = structType.Field(i) // N.B. Captured above.
-		if field.Doc != nil {
-			pc.fillLockGuardFacts(fieldObj, field.Doc, findLocal, &lgf)
-		}
-		if field.Comment != nil {
-			pc.fillLockGuardFacts(fieldObj, field.Comment, findLocal, &lgf)
-		}
+	fieldIndex := 0
+	for _, field := range ss.Fields.List {
+		// A declaration may name several fields; an embedded field has no
+		// names but still occupies one position in the expanded struct type.
+		for range max(1, len(field.Names)) {
+			fieldObj := structType.Field(fieldIndex)
+			fieldIndex++
+			var lgf lockGuardFacts
+			if field.Doc != nil {
+				pc.fillLockGuardFacts(fieldObj, field.Doc, findLocal, &lgf)
+			}
+			if field.Comment != nil {
+				pc.fillLockGuardFacts(fieldObj, field.Comment, findLocal, &lgf)
+			}
 
-		// See above, for anonymous structure fields.
-		if ss, ok := field.Type.(*ast.StructType); ok {
-			if st, ok := types.Unalias(fieldObj.Type()).(*types.Struct); ok {
-				pc.structLockGuardFacts(st, ss)
+			pc.exportLockGuardFacts(fieldObj, &lgf)
+
+			// See above, for anonymous structure fields.
+			if ss, ok := field.Type.(*ast.StructType); ok {
+				if st, ok := types.Unalias(fieldObj.Type()).(*types.Struct); ok {
+					pc.structLockGuardFacts(st, ss)
+				}
 			}
 		}
 	}
@@ -856,10 +920,21 @@ func (pc *passContext) structLockGuardFacts(structType *types.Struct, ss *ast.St
 // globalLockGuardFacts finds all relevant guard information for globals.
 //
 // Note that the Type is checked in checklocks.go at the top-level.
-func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec) {
-	var lgf lockGuardFacts
-	globalObj := pc.pass.TypesInfo.ObjectOf(vs.Names[0])
-	pc.fillLockGuardFacts(globalObj, vs.Doc, pc.findGlobalFieldGuard, &lgf)
+func (pc *passContext) globalLockGuardFacts(vs *ast.ValueSpec, decl *ast.GenDecl) {
+	cg := vs.Doc
+	if !decl.Lparen.IsValid() {
+		// Standalone declarations attach their comments to the GenDecl.
+		cg = decl.Doc
+	}
+	for _, name := range vs.Names {
+		if name.Name == "_" {
+			continue
+		}
+		var lgf lockGuardFacts
+		globalObj := pc.pass.TypesInfo.ObjectOf(name)
+		pc.fillLockGuardFacts(globalObj, cg, pc.findGlobalFieldGuard, &lgf)
+		pc.exportLockGuardFacts(globalObj, &lgf)
+	}
 }
 
 // countFields gives an accurate field count, according for unnamed arguments
@@ -984,6 +1059,7 @@ func (pc *passContext) functionFacts(d *ast.FuncDecl) {
 				// extremely rare.
 				lff.Ignore = true
 			},
+			checkLocksReadAny:        func(string) { pc.maybeFail(d.Pos(), "checklocksreadany is only valid on fields") },
 			checkLocksAnnotation:     func(guardName string) { lff.addGuardedBy(pc, d, guardName, true /* exclusive */) },
 			checkLocksAnnotationRead: func(guardName string) { lff.addGuardedBy(pc, d, guardName, false /* exclusive */) },
 			checkLocksAcquires:       func(guardName string) { lff.addAcquires(pc, d, guardName, true /* exclusive */) },
@@ -1011,6 +1087,7 @@ func (pc *passContext) typeAliasFacts(ts *ast.TypeSpec, decl *ast.GenDecl) {
 		}
 		for _, l := range cg.List {
 			pc.extractAnnotations(l.Text, map[string]func(string){
+				checkLocksReadAny: func(string) { pc.maybeFail(ts.Pos(), "checklocksreadany is only valid on fields") },
 				checkLocksAlias: func(guardName string) {
 					if !ok {
 						pc.maybeFail(ts.Pos(), "annotation %s is only valid on struct types", guardName)

--- a/tools/checklocks/state.go
+++ b/tools/checklocks/state.go
@@ -287,12 +287,18 @@ func (l *lockState) valueAndObject(v ssa.Value) (string, types.Object) {
 		}
 		return fmt.Sprintf("{param:%s}", x.Name()), x.Object()
 	case *ssa.Global:
-		return fmt.Sprintf("{global:%s}", x.Name()), x.Object()
+		return globalLockKey(x.Pkg.Pkg.Path(), x.Name()), x.Object()
 	case *ssa.FreeVar:
 		// Attempt to resolve this, in case we are being invoked in a
 		// scope where all the variables are bound.
 		v, ok := l.stored[x]
 		if ok {
+			// Nested closures capture the enclosing FreeVar. Follow that
+			// binding before dereferencing the captured location. A Store
+			// can instead place an address here, with a different type.
+			if fv, ok := v.(*ssa.FreeVar); ok && types.Identical(fv.Type(), x.Type()) {
+				return l.valueAndObject(fv)
+			}
 			// The FreeVar is typically bound to a location, so we
 			// check what's been stored there. Note that the second
 			// may map to the same FreeVar, which we can check.

--- a/tools/checklocks/test/BUILD
+++ b/tools/checklocks/test/BUILD
@@ -28,9 +28,12 @@ go_library(
         "rwmutex.go",
         "test.go",
     ],
-    # This ensures that there are no dependencies, since we want to explicitly
-    # control expected failures for analysis.
+    # Disable generated marshal/state sources so they do not add unexpected
+    # diagnostics to this fixture.
     marshal = False,
     stateify = False,
-    deps = ["//tools/checklocks/test/crosspkg"],
+    deps = [
+        "//pkg/atomicbitops",
+        "//tools/checklocks/test/crosspkg",
+    ],
 )

--- a/tools/checklocks/test/atomicfields/BUILD
+++ b/tools/checklocks/test/atomicfields/BUILD
@@ -6,11 +6,10 @@ package(
 )
 
 go_library(
-    name = "crosspkg",
-    srcs = ["crosspkg.go"],
-    # See next level up.
+    name = "atomicfields",
+    srcs = ["atomicfields.go"],
     marshal = False,
     stateify = False,
-    visibility = ["//tools/checklocks/test:__pkg__"],
-    deps = ["//tools/checklocks/test/atomicfields"],
+    visibility = ["//tools/checklocks/test/crosspkg:__pkg__"],
+    deps = ["//pkg/atomicbitops"],
 )

--- a/tools/checklocks/test/atomicfields/atomicfields.go
+++ b/tools/checklocks/test/atomicfields/atomicfields.go
@@ -1,0 +1,45 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package atomicfields exposes atomic fields to a consumer that does not
+// directly import their types' packages.
+package atomicfields
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
+)
+
+type Values struct {
+	// +checkatomic
+	Standard atomic.Pointer[int]
+	// +checkatomic
+	Bitops atomicbitops.Uint64
+	// +checkatomic
+	Promoted WrappedAtomic
+
+	Mu      sync.Mutex
+	OtherMu sync.Mutex
+	// +checklocks:Mu
+	// +checklocks:OtherMu
+	// +checklocksreadany
+	// +checkatomic
+	Mixed atomicbitops.Uint64
+}
+
+type WrappedAtomic struct {
+	atomicbitops.Uint64
+}

--- a/tools/checklocks/test/atomicfields/atomicfields.go
+++ b/tools/checklocks/test/atomicfields/atomicfields.go
@@ -43,3 +43,15 @@ type Values struct {
 type WrappedAtomic struct {
 	atomicbitops.Uint64
 }
+
+var globalMu sync.Mutex
+
+// RequirePrivate requires a lock in this indirectly imported package.
+//
+// +checklocks:globalMu
+func (*Values) RequirePrivate() {}
+
+// ExcludePrivate excludes a lock in this indirectly imported package.
+//
+// +checklocksexclude:globalMu
+func (*Values) ExcludePrivate() {}

--- a/tools/checklocks/test/atomics.go
+++ b/tools/checklocks/test/atomics.go
@@ -17,6 +17,8 @@ package test
 import (
 	"sync"
 	"sync/atomic"
+
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 )
 
 type atomicStruct struct {
@@ -29,6 +31,13 @@ type atomicStruct struct {
 	ignored int32
 
 	wrapper atomic.Int32 // safe without any annotations
+	bitops  atomicbitops.Int32
+
+	// +checkatomic
+	atomicBitops atomicbitops.Int32
+
+	// +checkatomic
+	pointer atomic.Pointer[int32]
 }
 
 func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -38,6 +47,11 @@ func testNormalAccess(tc *atomicStruct, v chan int32, p chan *int32) {
 
 func testAtomicAccess(tc *atomicStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedAtomically)
+	_ = tc.pointer.Load()
+	tc.pointer.Store(nil)
+	defer tc.pointer.Store(nil)
+	defer atomic.StoreInt32(&tc.accessedAtomically, 1)
+	go tc.pointer.Store(nil) // +checklocksfail=illegal use
 }
 
 func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
@@ -45,8 +59,21 @@ func testAtomicAccessInvalid(tc *atomicStruct, v chan int32) {
 }
 
 func testNormalAccessInvalid(tc *atomicStruct, v chan int32, p chan *int32) {
-	v <- tc.accessedAtomically  // +checklocksfail
-	p <- &tc.accessedAtomically // +checklocksfail
+	v <- tc.accessedAtomically              // +checklocksfail
+	p <- &tc.accessedAtomically             // +checklocksfail
+	_ = genericLoad(&tc.accessedAtomically) // +checklocksfail=non-atomic function
+	// Keep this return-valued call directly deferred: a wrapper discarding
+	// its result would test a closure instead of the operation's SSA Defer.
+	defer genericLoad(&tc.accessedAtomically) // +checklocksforce
+	// An atomic pointer payload is not the atomic location being accessed.
+	var sink atomic.Pointer[int32]
+	sink.Store(&tc.accessedAtomically)       // +checklocksfail=illegal use
+	defer sink.Store(&tc.accessedAtomically) // +checklocksfail=illegal use
+	*sink.Load() = 1
+}
+
+func genericLoad[T any](p *T) T {
+	return *p
 }
 
 func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
@@ -56,7 +83,7 @@ func testIgnored(tc *atomicStruct, v chan int32, p chan *int32) {
 }
 
 type atomicMixedStruct struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	// +checkatomic
 	// +checklocks:mu
@@ -65,11 +92,20 @@ type atomicMixedStruct struct {
 	// +checkatomic
 	// +checklocks:mu
 	wrapper atomic.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	bitops atomicbitops.Int32
+
+	// +checkatomic
+	// +checklocks:mu
+	pointer atomic.Pointer[int32]
 }
 
 func testAtomicMixedValidRead(tc *atomicMixedStruct, v chan int32) {
 	v <- atomic.LoadInt32(&tc.accessedMixed)
 	v <- tc.wrapper.Load()
+	_ = tc.pointer.Load()
 }
 
 func testAtomicMixedInvalidRead(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -81,7 +117,36 @@ func testAtomicMixedValidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan
 	tc.mu.Lock()
 	atomic.StoreInt32(&tc.accessedMixed, 1)
 	tc.wrapper.Store(1)
+	tc.pointer.Store(nil)
 	tc.mu.Unlock()
+}
+
+func testAtomicMixedReadLocked(tc *atomicMixedStruct) {
+	tc.mu.RLock()
+	defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+	_ = atomic.LoadInt32(&tc.accessedMixed)
+	_ = tc.accessedMixed
+	_ = tc.wrapper.Load()
+	_ = tc.bitops.RacyLoad()
+	_ = tc.pointer.Load()
+	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail=write function
+	tc.wrapper.Store(1)                     // +checklocksfail=write function
+	tc.bitops.Store(1)                      // +checklocksfail=write function
+	tc.bitops.RacyStore(1)                  // +checklocksfail=operation RacyStore
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
+	tc.mu.RUnlock()
+}
+
+// Mixed deferred accesses are unsupported even when execution order is safe.
+func testAtomicMixedDeferred(tc *atomicMixedStruct, unlockFirst bool) {
+	tc.mu.Lock()
+	if unlockFirst {
+		defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+		defer tc.mu.Unlock()
+	} else {
+		defer tc.mu.Unlock()
+		defer tc.pointer.Store(nil) // +checklocksfail=illegal use
+	}
 }
 
 func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -93,6 +158,7 @@ func testAtomicMixedInvalidLockedWrite(tc *atomicMixedStruct, v chan int32, p ch
 func testAtomicMixedInvalidAtomicWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
 	atomic.StoreInt32(&tc.accessedMixed, 1) // +checklocksfail
 	tc.wrapper.Store(1)                     // +checklocksfail
+	tc.pointer.Store(nil)                   // +checklocksfail=write function
 }
 
 func testAtomicMixedInvalidWrite(tc *atomicMixedStruct, v chan int32, p chan *int32) {
@@ -104,4 +170,105 @@ func testAtomicWrapper(tc *atomicStruct, v chan int32) {
 	v <- tc.wrapper.Load()
 	v <- tc.wrapper.Add(33)
 	tc.wrapper.Store(44)
+	v <- tc.bitops.RacyLoad()
+	v <- tc.bitops.RacyAdd(33)
+	tc.bitops.RacyStore(44)
+}
+
+func testAtomicBitops(tc *atomicStruct) {
+	// Keep direct defers, including the unused result, to check the SSA Defer
+	// path rather than a closure that invokes the operation later.
+	defer tc.atomicBitops.RacyLoad()   // +checklocksfail=non-atomic operation
+	defer tc.atomicBitops.RacyStore(1) // +checklocksfail=non-atomic operation
+	_ = tc.atomicBitops.Load()
+	tc.atomicBitops.Store(1)
+	_ = tc.atomicBitops.Add(1)
+	_ = tc.atomicBitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.atomicBitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.atomicBitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+}
+
+func testAtomicMixedBitops(tc *atomicMixedStruct) {
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)       // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.Add(1)     // +checklocksfail=unexpected call to atomic write function
+	_ = tc.bitops.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+
+	tc.mu.Lock()
+	_ = tc.bitops.Load()
+	tc.bitops.Store(1)
+	_ = tc.bitops.Add(1)
+	_ = tc.bitops.RacyLoad()
+	tc.bitops.RacyStore(1)   // +checklocksfail=non-atomic operation
+	_ = tc.bitops.RacyAdd(1) // +checklocksfail=non-atomic operation
+	tc.mu.Unlock()
+}
+
+// atomicReadAnyStruct permits unlocked atomic reads and non-atomic reads
+// under either lock. Writes need both locks.
+type atomicReadAnyStruct struct {
+	mu      sync.Mutex
+	otherMu sync.RWMutex
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	// +checkatomic
+	wrapper atomicbitops.Int32
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	// +checkatomic
+	value int32
+}
+
+func testAtomicReadAny(tc *atomicReadAnyStruct) {
+	_ = tc.wrapper.Load()
+	_ = tc.wrapper.RacyLoad() // +checklocksfail=non-atomic operation
+	_ = tc.value              // +checklocksfail=illegal use
+
+	tc.mu.Lock()
+	_ = tc.wrapper.RacyLoad()
+	_ = tc.value
+	tc.wrapper.Store(1)    // +checklocksfail=write function
+	_ = tc.wrapper.Swap(1) // +checklocksfail=write function
+	tc.mu.Unlock()
+
+	tc.otherMu.RLock()
+	_ = tc.wrapper.RacyLoad()
+	_ = tc.value
+	_ = tc.wrapper.Add(1) // +checklocksfail=write function
+	tc.mu.Lock()
+	tc.wrapper.Store(1) // +checklocksfail=write function
+	tc.otherMu.RUnlock()
+	tc.otherMu.Lock()
+	tc.wrapper.Store(1)
+	_ = tc.wrapper.Add(1)
+	tc.wrapper.RacyStore(1) // +checklocksfail=non-atomic operation
+	tc.otherMu.Unlock()
+	tc.mu.Unlock()
+}
+
+func testAtomicReadAnyRetained(tc *atomicReadAnyStruct, read bool) {
+	tc.mu.Lock()
+	p := &tc.wrapper
+	tc.mu.Unlock()
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+
+	tc.mu.Lock()
+	p = &tc.wrapper
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+	tc.mu.Unlock()
+	_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+
+	// Even when the lock remains held, only immediate uses are supported.
+	tc.mu.Lock()
+	p = &tc.wrapper
+	if read {
+		_ = p.RacyLoad() // +checklocksfail=non-atomic operation
+	}
+	tc.mu.Unlock()
 }

--- a/tools/checklocks/test/closures.go
+++ b/tools/checklocks/test/closures.go
@@ -49,6 +49,9 @@ func testClosureInline(tc *oneGuardStruct) {
 	tc.mu.Lock()
 	func() {
 		tc.guardedField = 1
+		func() {
+			tc.guardedField = 2
+		}()
 	}()
 	tc.mu.Unlock()
 }
@@ -58,8 +61,17 @@ func testClosureIgnore(tc *oneGuardStruct) {
 	// Inherit the checklocksignore.
 	x := func() {
 		tc.guardedField = 1
+		atomicGlobal.RacyStore(1)
 	}
 	x()
+
+	// Passing a closure as an argument is not an inline invocation.
+	callClosure(func() {
+		callPreconditions(tc)
+	})
+	defer callClosure(func() {
+		callPreconditions(tc)
+	})
 }
 
 func testAnonymousInvalid(tc *oneGuardStruct) {

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -110,3 +110,6 @@ func RequirePrivate() {}
 // +checklocksexclude:globalMu
 // +checklocksexclude:globalStruct.mu
 func ExcludePrivate() {}
+
+// IndirectValues exposes methods without importing their defining package.
+type IndirectValues = atomicfields.Values

--- a/tools/checklocks/test/crosspkg/crosspkg.go
+++ b/tools/checklocks/test/crosspkg/crosspkg.go
@@ -17,6 +17,8 @@ package crosspkg
 
 import (
 	"sync"
+
+	"gvisor.dev/gvisor/tools/checklocks/test/atomicfields"
 )
 
 var (
@@ -24,6 +26,11 @@ var (
 	Foo   int
 	FooMu sync.Mutex
 )
+
+// StandaloneFoo is a guarded global declared outside a var block.
+//
+// +checklocks:FooMu
+var StandaloneFoo int
 
 // GenericGuard is a generic type with a guarded field. This is used to verify
 // that facts exported by this package are correctly imported when another
@@ -33,3 +40,73 @@ type GenericGuard[T any] struct {
 	// +checklocks:Mu
 	Value T
 }
+
+// ReadAnyGuard allows readers to hold either mutex; writers need both.
+type ReadAnyGuard[T any] struct {
+	Mu      sync.Mutex
+	OtherMu sync.RWMutex
+
+	// +checklocks:Mu
+	// +checklocks:OtherMu
+	Value T // +checklocksreadany
+}
+
+// Do not import atomic or atomicbitops here: these methods must be resolved
+// from type information for a transitive dependency, not a direct SSA import.
+func readIndirectAtomics(v *atomicfields.Values) {
+	_ = v.Standard.Load()
+	_ = v.Bitops.Load()
+	v.Standard.Store(nil)
+	v.Bitops.Store(1)
+	_ = v.Bitops.RacyLoad() // +checklocksfail=non-atomic operation
+	// A method expression forces an SSA wrapper instead of selecting the
+	// embedded field directly, as an ordinary promoted call would.
+	_ = (*atomicfields.WrappedAtomic).Load(&v.Promoted) // +checklocksfail=shared function or wrapper
+
+	v.Mu.Lock()
+	_ = v.Mixed.RacyLoad()
+	v.Mu.Unlock()
+}
+
+// Keep the lock/unlock functions out of line so importers do not need these
+// private globals for inlined calls. Their guards still cross the package
+// boundary.
+var globalMu sync.Mutex
+
+var globalStruct struct {
+	mu sync.Mutex
+}
+
+// LockPrivate acquires both private locks.
+//
+// +checklocksacquire:globalMu
+// +checklocksacquire:globalStruct.mu
+//
+//go:noinline
+func LockPrivate() {
+	globalMu.Lock()
+	globalStruct.mu.Lock()
+}
+
+// UnlockPrivate releases both private locks.
+//
+// +checklocksrelease:globalMu
+// +checklocksrelease:globalStruct.mu
+//
+//go:noinline
+func UnlockPrivate() {
+	globalStruct.mu.Unlock()
+	globalMu.Unlock()
+}
+
+// RequirePrivate requires both private locks.
+//
+// +checklocks:globalMu
+// +checklocks:globalStruct.mu
+func RequirePrivate() {}
+
+// ExcludePrivate excludes both private locks.
+//
+// +checklocksexclude:globalMu
+// +checklocksexclude:globalStruct.mu
+func ExcludePrivate() {}

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -16,13 +16,46 @@ package test
 
 import (
 	"sync"
+	"sync/atomic"
 
+	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
 )
 
 var (
 	globalMu   sync.Mutex
 	globalRWMu sync.RWMutex
+
+	// +checkatomic
+	atomicGlobal = atomicbitops.FromInt32(1)
+
+	// +checkatomic
+	// +checklocks:globalRWMu
+	mixedAtomicGlobal atomicbitops.Int32
+
+	unannotatedAtomicGlobal atomicbitops.Int32
+	unannotatedRawGlobal    int32
+
+	// +checklocks:globalRWMu
+	guardedRawGlobal int32
+)
+
+// +checklocks:globalMu
+var standaloneGlobal int
+
+// +checkatomic
+var standaloneAtomicGlobal int32
+
+var (
+	// +checklocks:globalMu
+	firstGlobal, _, secondGlobal int
+)
+
+// A var block's header does not annotate its entries, even with one spec.
+//
+// +checklocks:globalMu
+var (
+	blockHeaderGlobal int
 )
 
 var globalStruct struct {
@@ -41,7 +74,12 @@ var otherStruct struct {
 }
 
 func testGlobalValid() {
+	blockHeaderGlobal = 1
+
 	globalMu.Lock()
+	standaloneGlobal = 1
+	firstGlobal = 1
+	secondGlobal = 1
 	otherStruct.guardedField1 = 1
 	globalMu.Unlock()
 
@@ -94,18 +132,102 @@ func testGlobalExcludeInvalid() {
 }
 
 func testGlobalInvalid() {
+	standaloneGlobal = 1          // +checklocksfail
+	firstGlobal = 1               // +checklocksfail
+	secondGlobal = 1              // +checklocksfail
+	standaloneAtomicGlobal = 1    // +checklocksfail=non-atomic write
 	globalStruct.guardedField = 1 // +checklocksfail
 	otherStruct.guardedField1 = 1 // +checklocksfail
 	otherStruct.guardedField2 = 1 // +checklocksfail
 	otherStruct.guardedField3 = 1 // +checklocksfail
+	var sink atomic.Pointer[int32]
+	sink.Store(&standaloneAtomicGlobal) // +checklocksfail=illegal use
 }
 
 func testCrosspkgGlobalValid() {
 	crosspkg.FooMu.Lock()
 	crosspkg.Foo = 1
+	crosspkg.StandaloneFoo = 1
 	crosspkg.FooMu.Unlock()
 }
 
 func testCrosspkgGlobalInvalid() {
-	crosspkg.Foo = 1 // +checklocksfail
+	crosspkg.Foo = 1           // +checklocksfail
+	crosspkg.StandaloneFoo = 1 // +checklocksfail
 }
+
+func testAtomicGlobal() {
+	defer atomicGlobal.Store(1)
+	_ = atomicGlobal.Load()
+	atomicGlobal.Store(1)
+	_ = atomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+	atomicGlobal.RacyStore(1)   // +checklocksfail=non-atomic operation
+
+	atomicGlobal = atomicbitops.FromInt32(0) // +checklocksfail=non-atomic write
+}
+
+func testMixedAtomicGlobal() {
+	_ = mixedAtomicGlobal.Load()
+	mixedAtomicGlobal.Store(1)       // +checklocksfail=atomic write function
+	_ = mixedAtomicGlobal.RacyLoad() // +checklocksfail=non-atomic operation
+
+	globalRWMu.Lock()
+	mixedAtomicGlobal.Store(1)
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.RacyStore(1) // +checklocksfail=non-atomic operation
+	globalRWMu.Unlock()
+
+	globalRWMu.RLock()
+	_ = mixedAtomicGlobal.RacyLoad()
+	mixedAtomicGlobal.Store(1) // +checklocksfail=atomic write function
+	globalRWMu.RUnlock()
+}
+
+func testUnannotatedGlobalAtomics(out **int32) {
+	_ = unannotatedAtomicGlobal.RacyLoad()
+	unannotatedAtomicGlobal.RacyStore(1)
+	_ = atomic.LoadInt32(&unannotatedRawGlobal)
+
+	globalRWMu.RLock()
+	_ = atomic.LoadInt32(&guardedRawGlobal)
+	*out = &guardedRawGlobal
+	globalRWMu.RUnlock()
+}
+
+// +checklocksignore
+func testAtomicGlobalIgnore() {
+	atomicGlobal.RacyStore(1)
+	atomicGlobal = atomicbitops.FromInt32(0)
+}
+
+func testCrosspkgPrivateGuards() {
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+	crosspkg.LockPrivate()
+	crosspkg.RequirePrivate()
+	crosspkg.ExcludePrivate() // +checklocksfail=must not hold globalMu|must not hold globalStruct.mu
+	crosspkg.UnlockPrivate()
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+
+	// Same-named globals in this package are different locks.
+	globalMu.Lock()
+	globalStruct.mu.Lock()
+	crosspkg.RequirePrivate() // +checklocksfail=must hold globalMu|must hold globalStruct.mu
+	crosspkg.ExcludePrivate()
+	globalStruct.mu.Unlock()
+	globalMu.Unlock()
+}
+
+var FooMu sync.Mutex
+
+func testCrosspkgGlobalNameCollision() {
+	FooMu.Lock()
+	crosspkg.Foo = 1 // +checklocksfail=invalid field access, FooMu
+	FooMu.Unlock()
+}
+
+type invalidGlobalMutex = sync.Mutex
+
+// +checklocks:invalidGlobalMutex
+func testGlobalTypeGuard() {} // +checklocksfail=does not have a match

--- a/tools/checklocks/test/globals.go
+++ b/tools/checklocks/test/globals.go
@@ -227,6 +227,11 @@ func testCrosspkgGlobalNameCollision() {
 	FooMu.Unlock()
 }
 
+func testIndirectGlobalGuards(v *crosspkg.IndirectValues) {
+	v.RequirePrivate() // +checklocksfail=must hold
+	v.ExcludePrivate()
+}
+
 type invalidGlobalMutex = sync.Mutex
 
 // +checklocks:invalidGlobalMutex

--- a/tools/checklocks/test/rwmutex.go
+++ b/tools/checklocks/test/rwmutex.go
@@ -16,6 +16,8 @@ package test
 
 import (
 	"sync"
+
+	"gvisor.dev/gvisor/tools/checklocks/test/crosspkg"
 )
 
 // oneReadGuardStruct has one read-guarded field.
@@ -64,5 +66,130 @@ func testRWExcludeWriteSatisfied(tc *oneReadGuardStruct) {
 func testRWExcludeWriteViolated(tc *oneReadGuardStruct) {
 	tc.mu.Lock()
 	testRWExcludeWrite(tc) // +checklocksfail
+	tc.mu.Unlock()
+}
+
+func testReadAnyGuards(tc *crosspkg.ReadAnyGuard[int]) {
+	_ = tc.Value // +checklocksfail=at least one
+	tc.Mu.Lock()
+	_ = tc.Value
+	tc.Value = 1 // +checklocksfail=OtherMu
+	tc.Mu.Unlock()
+
+	tc.OtherMu.RLock()
+	_ = tc.Value
+	tc.Value = 2 // +checklocksfail=access, Mu|access, OtherMu
+	tc.OtherMu.RUnlock()
+
+	tc.Mu.Lock()
+	tc.OtherMu.RLock()
+	tc.Value = 3 // +checklocksfail=OtherMu
+	tc.OtherMu.RUnlock()
+	tc.OtherMu.Lock()
+	tc.Value = 4
+	tc.OtherMu.Unlock()
+	tc.Mu.Unlock()
+}
+
+type invalidReadAnyGuards struct {
+	mu sync.Mutex
+
+	// +checklocksreadany
+	unguarded int // +checklocksfail=requires at least one
+
+	// +checklocks:mu
+	// +checklocksreadany
+	// +checklocksreadany
+	duplicate int // +checklocksfail=specified more than once
+
+	// +checklocks:mu
+	// +checklocksreadany:mu
+	argument int // +checklocksfail=does not take arguments
+
+	// +checklocks:mu
+	// +checklocksreadany
+	// +checklocksignore
+	ignored int // +checklocksfail=cannot be combined
+}
+
+// +checklocksreadany
+func invalidReadAnyFunction() {} // +checklocksfail=only valid on fields
+
+var (
+	// +checklocksreadany
+	invalidReadAnyGlobal int // +checklocksfail=only valid on fields
+)
+
+func testReadAnyIndirectWrites(tc *crosspkg.ReadAnyGuard[struct{ member int }]) {
+	tc.Mu.Lock()
+	tc.Value.member = 1             // +checklocksfail=OtherMu
+	mutateReadAny(&tc.Value.member) // +checklocksfail=OtherMu
+	tc.OtherMu.RLock()
+	tc.Value.member = 2 // +checklocksfail=OtherMu
+	tc.OtherMu.RUnlock()
+	tc.Mu.Unlock()
+}
+
+func mutateReadAny(p *int) {
+	*p = 1
+}
+
+// +checklocksreadany
+type invalidReadAnyType int // +checklocksfail=only valid on fields
+
+// A modifier may precede a guard in the field's trailing comment.
+type readAnyTrailingGuard struct {
+	mu sync.Mutex
+
+	// +checklocksreadany
+	value int // +checklocks:mu
+}
+
+// +checklocksreadany
+var invalidStandaloneReadAny int // +checklocksfail=only valid on fields
+
+func testReadAnyRetainedAddress(tc *crosspkg.ReadAnyGuard[int]) {
+	tc.Mu.Lock()
+	p := &tc.Value // +checklocksfail=OtherMu
+	tc.Mu.Unlock()
+	_ = *p
+
+	// An immediate first load must not authorize a later unlocked load.
+	tc.Mu.Lock()
+	p = &tc.Value // +checklocksfail=OtherMu
+	_ = *p
+	tc.Mu.Unlock()
+	_ = *p
+}
+
+// +checklocksread:tc.OtherMu
+func testReadAnyPrecondition(tc *crosspkg.ReadAnyGuard[int]) int {
+	return tc.Value
+}
+
+type groupedReadAnyGuards struct {
+	mu, otherMu sync.Mutex
+
+	// +checklocks:mu
+	// +checklocks:otherMu
+	// +checklocksreadany
+	first, second int
+
+	// +checklocks:mu
+	last int
+}
+
+func testGroupedReadAnyGuards(tc *groupedReadAnyGuards) {
+	tc.first = 1  // +checklocksfail=access, mu|access, otherMu
+	tc.second = 2 // +checklocksfail=access, mu|access, otherMu
+	tc.last = 3   // +checklocksfail=access, mu
+	tc.mu.Lock()
+	_ = tc.first
+	_ = tc.second
+	tc.last = 3
+	tc.otherMu.Lock()
+	tc.first = 1
+	tc.second = 2
+	tc.otherMu.Unlock()
 	tc.mu.Unlock()
 }

--- a/tools/defs.bzl
+++ b/tools/defs.bzl
@@ -90,22 +90,11 @@ def go_binary(name, nogo = True, pure = False, static = False, x_defs = None, **
         **kwargs
     )
     if nogo:
-        # Note that the nogo rule applies only for go_library and go_test
-        # targets, therefore we construct a library from the binary sources.
-        # This is done because the binary may not be in a form that objdump
-        # supports (i.e. a pure Go binary).
-        _go_library(
-            name = name + "_nogo_library",
-            srcs = kwargs.get("srcs", []),
-            deps = kwargs.get("deps", []),
-            embedsrcs = kwargs.get("embedsrcs", []),
-            testonly = 1,
-        )
         nogo_test(
             name = name + "_nogo",
             config = "//:nogo_config",
             srcs = kwargs.get("srcs", []),
-            deps = [":" + name + "_nogo_library"],
+            deps = [":" + name],
             tags = ["nogo"],
         )
 

--- a/tools/go_generics/go_merge/main.go
+++ b/tools/go_generics/go_merge/main.go
@@ -21,9 +21,12 @@ import (
 	"go/ast"
 	"go/format"
 	"go/parser"
+	"go/printer"
 	"go/token"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 
 	"gvisor.dev/gvisor/tools/constraintutil"
@@ -52,13 +55,17 @@ func main() {
 
 	// Load all files.
 	files := make(map[string]*ast.File)
+	comments := make(ast.CommentMap)
 	fset := token.NewFileSet()
 	var name string
-	for _, fname := range flag.Args() {
+	// Match MergePackageFiles' declaration order when assigning token positions.
+	srcs := slices.Sorted(slices.Values(flag.Args()))
+	for _, fname := range srcs {
 		f, err := parser.ParseFile(fset, fname, nil, parser.ParseComments|parser.DeclarationErrors|parser.SpuriousErrors)
 		if err != nil {
 			fatalf("%v\n", err)
 		}
+		maps.Copy(comments, ast.NewCommentMap(fset, f, f.Comments))
 
 		files[fname] = f
 		if name == "" {
@@ -75,13 +82,13 @@ func main() {
 	}
 	f := ast.MergePackageFiles(pkg, ast.FilterUnassociatedComments|ast.FilterFuncDuplicates|ast.FilterImportDuplicates)
 
-	// Create a new declaration slice with all imports at the top, merging any
-	// redundant imports.
+	// Put imports first and remove redundant specs. Keep the original import
+	// declarations so their comments retain valid positions within each file.
 	imports := make(map[string]*ast.ImportSpec)
-	var importNames []string // Keep imports in the original order to get deterministic output.
-	var anonImports []*ast.ImportSpec
+	newDecls := make([]ast.Decl, 0, len(f.Decls))
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); ok && g.Tok == token.IMPORT {
+			specs := g.Specs[:0]
 			for _, s := range g.Specs {
 				i := s.(*ast.ImportSpec)
 				p, _ := strconv.Unquote(i.Path.Value)
@@ -92,7 +99,7 @@ func main() {
 					n = i.Name.Name
 				}
 				if n == "_" {
-					anonImports = append(anonImports, i)
+					specs = append(specs, i)
 				} else {
 					if i2, ok := imports[n]; ok {
 						if first, second := i.Path.Value, i2.Path.Value; first != second {
@@ -100,28 +107,15 @@ func main() {
 						}
 					} else {
 						imports[n] = i
-						importNames = append(importNames, n)
+						specs = append(specs, i)
 					}
 				}
 			}
+			if len(specs) > 0 {
+				g.Specs = specs
+				newDecls = append(newDecls, g)
+			}
 		}
-	}
-	newDecls := make([]ast.Decl, 0, len(f.Decls))
-	if l := len(imports) + len(anonImports); l > 0 {
-		// Non-NoPos Lparen is needed for Go to recognize more than one spec in
-		// ast.GenDecl.Specs.
-		d := &ast.GenDecl{
-			Tok:    token.IMPORT,
-			Lparen: token.NoPos + 1,
-			Specs:  make([]ast.Spec, 0, l),
-		}
-		for _, i := range importNames {
-			d.Specs = append(d.Specs, imports[i])
-		}
-		for _, i := range anonImports {
-			d.Specs = append(d.Specs, i)
-		}
-		newDecls = append(newDecls, d)
 	}
 	for _, d := range f.Decls {
 		if g, ok := d.(*ast.GenDecl); !ok || g.Tok != token.IMPORT {
@@ -136,10 +130,24 @@ func main() {
 		fatalf("Failed to read build constraints: %v\n", err)
 	}
 
-	// Write the output file.
+	// Print each declaration with only its own comments. Imports moved from
+	// later files must not pull earlier declarations' inline annotations forward.
+	// Template instances omit package documentation; build constraints are
+	// reconstructed separately below.
 	var buf bytes.Buffer
-	if err := format.Node(&buf, fset, f); err != nil {
-		fatalf("formatting: %v\n", err)
+	_, _ = fmt.Fprintf(&buf, "package %s\n\n", name)
+	for _, decl := range f.Decls {
+		if err := format.Node(&buf, fset, &printer.CommentedNode{
+			Node:     decl,
+			Comments: comments.Filter(decl).Comments(),
+		}); err != nil {
+			fatalf("formatting: %v\n", err)
+		}
+		_, _ = buf.WriteString("\n\n")
+	}
+	source, err := format.Source(buf.Bytes())
+	if err != nil {
+		fatalf("formatting merged source: %v\n", err)
 	}
 	outf, err := os.OpenFile(*output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
@@ -147,7 +155,7 @@ func main() {
 	}
 	defer outf.Close()
 	outf.WriteString(constraintutil.Lines(bcexpr))
-	if _, err := outf.Write(buf.Bytes()); err != nil {
+	if _, err := outf.Write(source); err != nil {
 		fatalf("write: %v\n", err)
 	}
 }

--- a/tools/go_generics/tests/simple/BUILD
+++ b/tools/go_generics/tests/simple/BUILD
@@ -4,7 +4,11 @@ package(default_applicable_licenses = ["//:license"])
 
 go_generics_test(
     name = "simple",
-    inputs = ["input.go"],
+    # Reverse source order to exercise comment positions across merged files.
+    inputs = [
+        "second.go",
+        "input.go",
+    ],
     output = "output.go",
     suffix = "New",
     types = {
@@ -16,4 +20,5 @@ go_generics_test(
 glaze_ignore = [
     "input.go",
     "output.go",
+    "second.go",
 ]

--- a/tools/go_generics/tests/simple/input.go
+++ b/tools/go_generics/tests/simple/input.go
@@ -14,6 +14,8 @@
 
 package tests
 
+import _ "os" // Earlier blank import.
+
 type T int
 
 var global T
@@ -27,6 +29,7 @@ func g(a T, b int) {
 
 	d := (*T)(nil)
 	_ = d
+	_ = new(T) // escapes: test annotation.
 }
 
 type R struct {

--- a/tools/go_generics/tests/simple/output.go
+++ b/tools/go_generics/tests/simple/output.go
@@ -14,6 +14,10 @@
 
 package main
 
+import _ "os" // Earlier blank import.
+
+import "fmt" // Later named import.
+
 var globalNew Q
 
 func fNew(_ Q, a int) {
@@ -25,6 +29,7 @@ func gNew(a Q, b int) {
 
 	d := (*Q)(nil)
 	_ = d
+	_ = new(Q) // escapes: test annotation.
 }
 
 type RNew struct {
@@ -41,3 +46,7 @@ const (
 )
 
 type YNew Q
+
+func hNew(a Q) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
+}

--- a/tools/go_generics/tests/simple/second.go
+++ b/tools/go_generics/tests/simple/second.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The gVisor Authors.
+// Copyright 2026 The gVisor Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,31 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package tests
 
-type FooNew struct {
-	Q
-	Bar map[string]Q `json:"bar,omitempty"`
-}
+import "fmt" // Later named import.
 
-type BazNew struct {
-	T someTypeNotT
-}
-
-func (f FooNew) GetBar(name string) Q {
-	b, ok := f.Bar[name]
-	if ok {
-		b = f.Apply(b)
-	} else {
-		b = f.Q
-	}
-	return b
-}
-
-func foobarNew() {
-	a := BazNew{}
-	a.Q = 0 // should not be renamed, this is a limitation
-
-	b := otherpkg.UnrelatedType{}
-	b.Q = 0 // should not be renamed, this is a limitation
+func h(a T) string {
+	return fmt.Sprint(a) // escapes: test annotation in a second file.
 }

--- a/tools/nogo/check/BUILD
+++ b/tools/nogo/check/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -57,5 +57,16 @@ go_library(
         "@org_golang_x_tools//go/analysis/passes/unsafeptr:go_default_library",
         "@org_golang_x_tools//go/analysis/passes/unusedresult:go_default_library",
         "@org_golang_x_tools//go/gcexportdata:go_default_library",
+    ],
+)
+
+go_test(
+    name = "check_test",
+    size = "small",
+    srcs = ["check_test.go"],
+    library = ":check",
+    deps = [
+        "//tools/nogo/flags",
+        "@org_golang_x_tools//go/analysis:go_default_library",
     ],
 )

--- a/tools/nogo/check/check.go
+++ b/tools/nogo/check/check.go
@@ -55,14 +55,8 @@ var (
 	releaseTagsErr error
 )
 
-// Hack! factFacts only provides facts loaded from directly imported packages
-// for efficiency (see importer.cache). In general, if you need a fact from a
-// package that isn't otherwise imported, the expectation is that you will add
-// a dummy import/use of the desired package to ensure it is a dependency.
-//
-// Unfortunately, some packages need facts from internal packages. Since
-// internal packages cannot be imported we explicitly import in this tool to
-// ensure the facts are available to ImportPackageFact.
+// Preload type information needed to decode facts from internal packages that
+// analyzed packages cannot import directly.
 var internalPackages = []string{
 	// Required by pkg/sync for internal/abi.MapType.
 	"internal/abi",
@@ -145,12 +139,25 @@ type importer struct {
 
 	analyzers map[*analysis.Analyzer]analyzer
 
-	// mu protects cache & bundles (see below).
-	mu    sync.Mutex
-	cache map[string]*importerEntry // key is package path (see sources above).
+	// mu protects cache, bundles, and factsErr (see below).
+	mu sync.Mutex
 
-	// bundles is protected by mu, but once set is immutable.
+	// cache is keyed by package path (see sources above).
+	//
+	// +checklocks:mu
+	cache map[string]*importerEntry
+
+	// bundles and each bundle's decoded-package cache are protected by mu.
+	// A bundle has no link to this importer, so checklocks cannot express
+	// that protection for the bundle's internal cache.
+	//
+	// +checklocks:mu
 	bundles []*facts.Bundle
+
+	// factsErr is the first error loading package facts.
+	//
+	// +checklocks:mu
+	factsErr error
 
 	// importsMu protects imports.
 	importsMu sync.Mutex
@@ -159,8 +166,7 @@ type importer struct {
 
 // loadBundles loads all bundle files.
 //
-// This should only be called from loadFacts, below. After calling this
-// function, i.bundles may be read freely without holding a lock.
+// This should only be called from loadFacts, below.
 func (i *importer) loadBundles() error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -187,9 +193,8 @@ func (i *importer) loadBundles() error {
 
 // loadFacts returns all package facts for the given name.
 //
-// This should be called only from importPackage, as this may deserialize a
-// facts file (which is an expensive operation). Callers should generally rely
-// on fastFacts to access facts for packages that have already been imported.
+// This may deserialize a facts file. Callers should generally use fastFacts
+// to cache the result.
 func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 	// Attempt to load from the fact map.
 	filename, ok := flags.FactMap[pkg.Path()]
@@ -211,7 +216,10 @@ func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 		return nil, fmt.Errorf("error loading bundles: %w", err)
 	}
 
-	// Try to import from the bundle.
+	// Bundle.Package memoizes decoded packages, including across concurrent
+	// requests for facts from different packages.
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	for _, bundleFacts := range i.bundles {
 		localFacts, err := bundleFacts.Package(pkg)
 		if err != nil {
@@ -233,10 +241,14 @@ func (i *importer) loadFacts(pkg *types.Package) (*facts.Package, error) {
 func (i *importer) fastFacts(pkg *types.Package) *facts.Package {
 	i.mu.Lock()
 	e, ok := i.cache[pkg.Path()]
-	i.mu.Unlock()
 	if !ok {
-		return nil
+		// Export data can introduce a package without importPackage. Cache
+		// its facts, but leave pkg nil so a later import still loads types
+		// or analyzes source instead of treating this as a completed import.
+		e = new(importerEntry)
+		i.cache[pkg.Path()] = e
 	}
+	i.mu.Unlock()
 
 	e.factsMu.Lock()
 	defer e.factsMu.Unlock()
@@ -249,9 +261,12 @@ func (i *importer) fastFacts(pkg *types.Package) *facts.Package {
 	// Load the facts.
 	facts, err := i.loadFacts(pkg)
 	if err != nil {
-		// There are no facts available, but no good way to propagate
-		// this minor error. It may be intentional that no analysis was
-		// performed on some part of the standard library, for example.
+		// Optional fact absence is not an error; unreadable inputs are.
+		i.mu.Lock()
+		if i.factsErr == nil {
+			i.factsErr = fmt.Errorf("loading facts for %q: %w", pkg.Path(), err)
+		}
+		i.mu.Unlock()
 		return nil
 	}
 	e.facts = facts // Cache the result.
@@ -717,6 +732,12 @@ func (i *importer) checkPackage(path string, srcs []string) (*types.Package, Fin
 		// Wait for completion.
 		wg.Wait()
 	}
+	i.mu.Lock()
+	factsErr := i.factsErr
+	i.mu.Unlock()
+	if factsErr != nil {
+		return astPackage, findings, astFacts, factsErr
+	}
 	for a := range ready {
 		// Check the error. If we generate an error here, we report
 		// this as a finding that can be suppressed. Some analyzers
@@ -778,7 +799,12 @@ func Package(path string, srcs []string) (FindingSet, facts.Serializer, error) {
 	return findings, facts, nil
 }
 
-// allFactsAndFindings returns all factsAndFindings from an importer.
+// allFactsAndFindings returns the collected findings and package facts.
+//
+// Imports and analysis must have completed: mu does not protect the cached
+// entries' findings and facts.
+//
+// +checklocks:i.mu
 func (i *importer) allFactsAndFindings() (FindingSet, *facts.Bundle) {
 	var (
 		findings = make(FindingSet, 0)
@@ -814,7 +840,8 @@ func TemplateFuncs(path string, srcs []string) (map[string]any, any, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	_, allFacts := i.allFactsAndFindings()
+	// checkPackage joined all analyzers; this private importer is quiescent.
+	_, allFacts := i.allFactsAndFindings() // +checklocksignore
 	funcMap, err := facts.ResolveFuncs(pkg, localFacts, allFacts)
 	if err != nil {
 		return nil, nil, err
@@ -926,6 +953,7 @@ func Bundle(sources map[string][]string, roots []string) (FindingSet, facts.Seri
 		}
 	}
 
-	findings, facts := i.allFactsAndFindings()
+	// All imports and their analyzers completed; this importer is quiescent.
+	findings, facts := i.allFactsAndFindings() // +checklocksignore
 	return findings, facts, nil
 }

--- a/tools/nogo/check/check_test.go
+++ b/tools/nogo/check/check_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"go/token"
+	"go/types"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/analysis"
+	"gvisor.dev/gvisor/tools/nogo/flags"
+)
+
+type factsLoadTestFact struct{}
+
+func (*factsLoadTestFact) AFact() {}
+
+func TestDeclaredFactsErrors(t *testing.T) {
+	savedFactMap, savedBundles := flags.FactMap, flags.Bundles
+	t.Cleanup(func() {
+		flags.FactMap, flags.Bundles = savedFactMap, savedBundles
+	})
+	var malformed bytes.Buffer
+	if err := gob.NewEncoder(&malformed).Encode([]struct {
+		Key   string
+		Value any
+	}{{Value: "bad"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		supplied bool
+		create   bool
+		contents []byte
+		bundles  [][]byte // A nil entry omits the package from that bundle.
+		wantErr  error
+		wantText string
+	}{
+		{name: "absent"},
+		{name: "missing", supplied: true, wantErr: os.ErrNotExist},
+		{name: "empty", supplied: true, create: true, wantErr: io.EOF},
+		{name: "wrong_type", supplied: true, create: true, contents: malformed.Bytes(), wantText: "invalid fact payload"},
+		{name: "bundle_absent", bundles: [][]byte{nil}},
+		{name: "bundle_empty", bundles: [][]byte{{}}, wantErr: io.EOF},
+		{name: "later_bundle_wrong_type", bundles: [][]byte{nil, malformed.Bytes()}, wantText: "invalid fact payload"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dep := types.NewPackage("indirect", "indirect")
+			flags.FactMap = make(map[string]string)
+			flags.Bundles = nil
+			if tc.supplied {
+				filename := filepath.Join(t.TempDir(), "facts")
+				flags.FactMap[dep.Path()] = filename
+				if tc.create {
+					if err := os.WriteFile(filename, tc.contents, 0600); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+			for _, contents := range tc.bundles {
+				var buf bytes.Buffer
+				zw := zip.NewWriter(&buf)
+				if contents != nil {
+					w, err := zw.Create(dep.Path())
+					if err != nil {
+						t.Fatal(err)
+					}
+					if _, err := w.Write(contents); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := zw.Close(); err != nil {
+					t.Fatal(err)
+				}
+				filename := filepath.Join(t.TempDir(), "bundle.zip")
+				if err := os.WriteFile(filename, buf.Bytes(), 0600); err != nil {
+					t.Fatal(err)
+				}
+				flags.Bundles = append(flags.Bundles, filename)
+			}
+			a := &analysis.Analyzer{
+				Name:      "importfact",
+				FactTypes: []analysis.Fact{new(factsLoadTestFact)},
+				Run: func(p *analysis.Pass) (any, error) {
+					// Fact absence is allowed; input errors must fail the driver.
+					_ = p.ImportPackageFact(dep, new(factsLoadTestFact))
+					return nil, nil
+				},
+			}
+			i := &importer{
+				fset:      token.NewFileSet(),
+				cache:     make(map[string]*importerEntry),
+				analyzers: map[*analysis.Analyzer]analyzer{a: &plainAnalyzer{a}},
+			}
+			// An empty package exercises fact loading without SDK imports.
+			_, findings, _, err := i.checkPackage("test", nil)
+			if tc.wantText != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantText) {
+					t.Fatalf("checkPackage() error = %v, want %q (findings: %v)", err, tc.wantText, findings)
+				}
+			} else if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("checkPackage() error = %v, want %v", err, tc.wantErr)
+			}
+			if err != nil && !strings.Contains(err.Error(), dep.Path()) {
+				t.Errorf("checkPackage() error = %v, want package path %q", err, dep.Path())
+			}
+		})
+	}
+}

--- a/tools/nogo/cli/BUILD
+++ b/tools/nogo/cli/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -19,4 +19,12 @@ go_library(
         "@in_gopkg_yaml_v2//:go_default_library",
         "@org_golang_x_term//:go_default_library",
     ],
+)
+
+go_test(
+    name = "cli_test",
+    size = "small",
+    srcs = ["cli_test.go"],
+    library = ":cli",
+    deps = ["//tools/nogo/flags"],
 )

--- a/tools/nogo/cli/cli.go
+++ b/tools/nogo/cli/cli.go
@@ -65,7 +65,7 @@ func closeOutput(w io.Writer) {
 	}
 }
 
-// failure exits with the given failure message.
+// failure prints the given failure message and returns a failure status.
 func failure(fmtStr string, v ...any) subcommands.ExitStatus {
 	fmt.Fprintf(os.Stderr, fmtStr+"\n", v...)
 	return subcommands.ExitFailure
@@ -514,7 +514,7 @@ func (r *Render) Execute(ctx context.Context, fs *flag.FlagSet, args ...any) sub
 }
 
 // goVersionRe matches a `go VERSION` line in go.mod, capturing VERSION.
-var goVersionRe = regexp.MustCompile(`^go\s+(\S+)`)
+var goVersionRe = regexp.MustCompile(`(?m)^go[ \t]+(\S+)`)
 
 // resolveGOVERSION sets flags.GOVERSION from flags.GOVERSIONModFile, if necessary.
 func resolveGOVERSION() error {
@@ -535,7 +535,7 @@ func resolveGOVERSION() error {
 	if len(m) != 2 {
 		return fmt.Errorf("go line not found in go.mod:\n%s", string(b))
 	}
-	flags.GOVERSION = m[1]
+	flags.GOVERSION = "go" + m[1]
 	return nil
 }
 
@@ -549,7 +549,7 @@ func Main() {
 	subcommands.Register(subcommands.FlagsCommand(), "")
 	flag.CommandLine.Parse(os.Args[1:])
 	if err := resolveGOVERSION(); err != nil {
-		failure("error resolving GOVERSION: %v", err)
+		os.Exit(int(failure("error resolving GOVERSION: %v", err)))
 	}
 	os.Exit(int(subcommands.Execute(context.Background())))
 }

--- a/tools/nogo/cli/cli_test.go
+++ b/tools/nogo/cli/cli_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gvisor.dev/gvisor/tools/nogo/flags"
+)
+
+func TestResolveGOVERSION(t *testing.T) {
+	oldVersion, oldModFile := flags.GOVERSION, flags.GOVERSIONModFile
+	t.Cleanup(func() {
+		flags.GOVERSION, flags.GOVERSIONModFile = oldVersion, oldModFile
+	})
+	for _, tc := range []struct {
+		name, contents, want string
+	}{
+		{"stdlib", "module std\n\ngo 1.26\n", "go1.26"},
+		{"comments-and-crlf", "// Header.\r\nmodule std\r\ngo\t1.26\r\n", "go1.26"},
+		{"missing", "module std\n", ""},
+		{"split-directive", "module std\ngo\n1.26\n", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			modFile := filepath.Join(t.TempDir(), "go.mod")
+			if err := os.WriteFile(modFile, []byte(tc.contents), 0644); err != nil {
+				t.Fatal(err)
+			}
+			flags.GOVERSION = ""
+			flags.GOVERSIONModFile = modFile
+			if err := resolveGOVERSION(); err != nil {
+				if tc.want != "" {
+					t.Fatalf("resolveGOVERSION: %v", err)
+				}
+				return
+			}
+			if tc.want == "" {
+				t.Fatal("resolveGOVERSION succeeded without a valid go directive")
+			}
+			if got := flags.GOVERSION; got != tc.want {
+				t.Errorf("GOVERSION = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/tools/nogo/defs.bzl
+++ b/tools/nogo/defs.bzl
@@ -1,7 +1,7 @@
 """Nogo rules."""
 
 load("//tools:arch.bzl", "arch_transition")
-load("//tools/bazeldefs:go.bzl", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
+load("//tools/bazeldefs:go.bzl", "go_binary_archive", "go_context", "go_embed_libraries", "go_importpath", "go_rule", "nogo_extra_proto_deps")
 
 NogoConfigInfo = provider(
     "information about a nogo configuration",
@@ -70,7 +70,7 @@ def _nogo_stdlib_impl(ctx):
     go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps = [])
 
     # GOVERSION of std is set by the std go.mod.
-    args.append("-GOVERSION-mod-file=%s" % go_ctx.stdlib_mod)
+    args.append("-GOVERSION-mod-file=%s" % go_ctx.stdlib_mod.path)
 
     # Build the analyzer command.
     facts_file = ctx.actions.declare_file(ctx.label.name + ".facts")
@@ -135,6 +135,7 @@ NogoInfo = provider(
     "information for nogo analysis",
     fields = {
         "facts": "serialized package facts",
+        "transitive_facts": "depset of (import path, facts file) pairs",
         "raw_findings": "raw package findings (if relevant)",
         "importpath": "package import path",
         "binaries": "package binary files",
@@ -161,14 +162,14 @@ def _select_objfile(files):
         a_files = x_files
     return a_files[0], x_files[0]
 
-def _nogo_config(ctx, deps):
+def _nogo_config(ctx, deps, attr = None):
     # Build a configuration for the given set of deps. This is most basic
     # configuration and is used by the stdlib. For a more complete config, the
     # _nogo_package_config function may be used.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
     nogo_target_info = ctx.attr._target[NogoTargetInfo]
-    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch)
+    go_ctx = go_context(ctx, goos = nogo_target_info.goos, goarch = nogo_target_info.goarch, attr = attr)
     args = go_ctx.nogo_args + [
         "-go=%s" % go_ctx.go.path,
         "-GOOS=%s" % go_ctx.goos,
@@ -177,6 +178,7 @@ def _nogo_config(ctx, deps):
     ]
     inputs = []
     raw_findings = []
+    fact_sets = []
     for dep in deps:
         extras = nogo_extra_proto_deps(dep)
         for importpath, a_file, x_file in extras:
@@ -198,7 +200,7 @@ def _nogo_config(ctx, deps):
         a_file, x_file = _select_objfile(info.binaries)
         args.append("-archive=%s=%s" % (info.importpath, a_file.path))
         args.append("-import=%s=%s" % (info.importpath, x_file.path))
-        args.append("-facts=%s=%s" % (info.importpath, info.facts.path))
+        fact_sets.append(info.transitive_facts)
 
         # Collect all findings; duplicates are resolved at the end.
         raw_findings.extend(info.raw_findings)
@@ -206,27 +208,26 @@ def _nogo_config(ctx, deps):
         # Ensure the above are available as inputs.
         inputs.append(a_file)
         inputs.append(x_file)
-        inputs.append(info.facts)
+
+    # Export data can expose types and methods from indirect imports. Their
+    # facts must be available even without a direct source import.
+    for importpath, facts_file in depset(transitive = fact_sets).to_list():
+        args.append("-facts=%s=%s" % (importpath, facts_file.path))
+        inputs.append(facts_file)
 
     return (go_ctx, args, inputs, raw_findings)
 
-def _nogo_package_config(ctx, deps, importpath = None, target = None):
+def _nogo_package_config(ctx, deps, importpath = None, objfiles = (None, None), attr = None):
     # See _nogo_config. This includes package details.
     #
     # Returns (go_ctx, args, inputs, raw_findings).
-    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps)
+    go_ctx, args, inputs, raw_findings = _nogo_config(ctx, deps, attr = attr)
 
     # GOVERSION of packages are set by the project language version.
     args.append("-GOVERSION=%s" % go_ctx.lang_version)
 
-    # Add the module itself, for the type sanity check. This applies only to
-    # the libraries, and not binaries or tests.
-    binaries = []
-    if target != None:
-        binaries.extend(target.files.to_list())
-        if hasattr(target.output_groups, "compilation_outputs"):
-            binaries.extend(target.output_groups.compilation_outputs.to_list())
-    target_afile, target_xfile = _select_objfile(binaries)
+    # Add the compiled package itself for analyzers that inspect object code.
+    target_afile, target_xfile = objfiles
     if target_xfile != None:
         args.append("-archive=%s=%s" % (importpath, target_afile.path))
         args.append("-import=%s=%s" % (importpath, target_xfile.path))
@@ -263,7 +264,8 @@ def _nogo_aspect_impl(target, ctx):
     # since there is guaranteed to be no conflict. However for consistency,
     # we should not introduce new go_tool_library dependencies unless strictly
     # necessary.
-    if ctx.rule.kind in ("go_library", "go_tool_library", "go_binary", "go_test"):
+    is_binary = ctx.rule.kind in ("go_binary", "go_non_executable_binary")
+    if is_binary or ctx.rule.kind in ("go_library", "go_tool_library", "go_test"):
         srcs = ctx.rule.files.srcs
         deps = ctx.rule.attr.deps
     elif ctx.rule.kind in ("go_proto_library", "go_wrap_cc"):
@@ -287,14 +289,24 @@ def _nogo_aspect_impl(target, ctx):
         if hasattr(info, "deps"):
             deps = deps + info.deps
 
-    # Extract the importpath for this package.
-    if ctx.rule.kind == "go_test":
-        importpath = "test"
+    # Binary analysis needs the compiled Go archive, not the linked executable:
+    # the linker can remove functions that checkescape still needs to inspect.
+    if is_binary:
+        archive = go_binary_archive(target)
+        importpath = archive.importpath
+        objfiles = (archive.file, archive.export_file)
+        binaries = list(objfiles)
     else:
-        importpath = go_importpath(target)
+        importpath = "test" if ctx.rule.kind == "go_test" else go_importpath(target)
+        binaries = target.files.to_list()
+        compilation_outputs = binaries
+        if hasattr(target.output_groups, "compilation_outputs"):
+            compilation_outputs = compilation_outputs + target.output_groups.compilation_outputs.to_list()
+        objfiles = _select_objfile(compilation_outputs)
 
-    # Build a complete configuration, referring to the library rule.
-    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, target = target)
+    # Use the analyzed rule's transitioned Go configuration, including its build
+    # tags, rather than the aspect's own attributes.
+    go_ctx, args, inputs, raw_findings = _nogo_package_config(ctx, deps, importpath = importpath, objfiles = objfiles, attr = ctx.rule.attr)
 
     # Build the argument file, and the runner.
     facts_file = ctx.actions.declare_file(ctx.label.name + ".facts")
@@ -322,9 +334,17 @@ def _nogo_aspect_impl(target, ctx):
     return [
         NogoInfo(
             facts = facts_file,
+            transitive_facts = depset(
+                [(importpath, facts_file)],
+                transitive = [
+                    dep[NogoInfo].transitive_facts
+                    for dep in deps
+                    if hasattr(dep[NogoInfo], "transitive_facts")
+                ],
+            ),
             raw_findings = raw_findings + [findings_file],
             importpath = importpath,
-            binaries = target.files.to_list(),
+            binaries = binaries,
             srcs = srcs,
             deps = deps,
         ),
@@ -463,9 +483,8 @@ nogo_aspect_tricorder = aspect(
 def _nogo_facts_render_impl(ctx):
     """Extract nogo facts."""
 
-    # Build a complete configuration. Note that we don't care about the import
-    # path, since this will generate facts only. We use ctx as the target here,
-    # since this will refer to ctx.files (which contains no binaries).
+    # Rendering dependency facts needs neither an import path nor an archive
+    # for the package containing the template.
     go_ctx, args, inputs, _ = _nogo_package_config(ctx, ctx.attr.deps)
 
     # Build the runner.

--- a/tools/nogo/facts/facts.go
+++ b/tools/nogo/facts/facts.go
@@ -118,6 +118,10 @@ func (p *Package) ReadFrom(pkg *types.Package, r io.Reader) error {
 		return err
 	}
 	for _, fi := range is {
+		objectFacts, ok := fi.Value.([]analysis.Fact)
+		if !ok {
+			return fmt.Errorf("invalid fact payload for %q: %T", fi.Key, fi.Value)
+		}
 		var (
 			obj types.Object
 			err error
@@ -130,7 +134,7 @@ func (p *Package) ReadFrom(pkg *types.Package, r io.Reader) error {
 			// object. We just suppress this error and ignore it.
 			continue
 		}
-		p.Objects[obj] = fi.Value.([]analysis.Fact)
+		p.Objects[obj] = objectFacts
 	}
 	return nil
 }
@@ -229,7 +233,8 @@ func (b *Bundle) Add(path string, facts *Package) {
 	b.decoded[path] = facts
 }
 
-// Package looks up the given package in the bundle.
+// Package looks up the given package in the bundle. It returns nil without an
+// error if the package is absent, or an error if its facts cannot be read.
 func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 	// Already decoded?
 	if facts, ok := b.decoded[pkg.Path()]; ok {
@@ -240,7 +245,7 @@ func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 		// Nothing available.
 		//
 		// N.B. some bundles contain only cached packages.
-		return nil, fmt.Errorf("no facts available for package %q", pkg.Path())
+		return nil, nil
 	}
 
 	// Find based on the reader.
@@ -266,7 +271,7 @@ func (b *Bundle) Package(pkg *types.Package) (*Package, error) {
 	}
 
 	// Nothing available.
-	return nil, fmt.Errorf("no facts available for package %q", pkg.Path())
+	return nil, nil
 }
 
 func resolveConstants(pkg *types.Package, localPkg *types.Package, localFacts *Package, allFacts *Bundle) (checkconst.Constants, error) {
@@ -278,10 +283,10 @@ func resolveConstants(pkg *types.Package, localPkg *types.Package, localFacts *P
 	} else {
 		importFacts, err := allFacts.Package(pkg)
 		if err != nil {
-			return c, fmt.Errorf("no facts available for package %q", pkg.Path())
+			return c, fmt.Errorf("loading facts for package %q: %w", pkg.Path(), err)
 		}
 		if importFacts == nil {
-			panic("nil importFacts")
+			return c, fmt.Errorf("no facts available for package %q", pkg.Path())
 		}
 		factSource = importFacts
 	}

--- a/tools/nogo/sanity/sanity_test.sh
+++ b/tools/nogo/sanity/sanity_test.sh
@@ -28,7 +28,7 @@ if [[ "${rc}" -eq "0" ]]; then
   echo "Expected failure; got success."
   exit 1
 fi
-if [[ "${output}" =~ ^sanity.go:[0-9]+:[0-9]+:.*%d.*string.*$ ]]; then
+if [[ "${output}" != *'fmt.Fprintf format %d has arg "hello world!" of wrong type string'* ]]; then
   echo "Expected format error; not found."
   exit 1
 fi


### PR DESCRIPTION
Reserved for allocator atomic-pointer contracts after #14237 and #14360 land.

The diff still contains the earlier broad memory annotation and restore fixes and checker prerequisites; it has not yet been narrowed to the reserved scope. The extracted changes are in #14351 and #14360. See #14349 for the remaining dependencies.

Assisted-by: Codex