### PR TITLE
checklocks: annotate memory and timer locking

### DIFF
--- a/pkg/ring0/pagetables/pcids.go
+++ b/pkg/ring0/pagetables/pcids.go
@@ -19,17 +19,17 @@ import (
 )
 
 // PCIDs is a simple PCID database.
-//
-// This is not protected by locks and is thus suitable for use only with a
-// single CPU at a time.
 type PCIDs struct {
-	// mu protects below.
 	mu sync.Mutex
 
 	// cache are the assigned page tables.
+	//
+	// +checklocks:mu
 	cache map[*PageTables]uint16
 
 	// avail are available PCIDs.
+	//
+	// +checklocks:mu
 	avail []uint16
 }
 
@@ -57,6 +57,8 @@ func NewPCIDs(start, size uint16) *PCIDs {
 //
 // This may overwrite any previous assignment provided. If this in the case,
 // true is returned to indicate that the PCID should be flushed.
+//
+// +checklocksexclude:p.mu
 func (p *PCIDs) Assign(pt *PageTables) (uint16, bool) {
 	p.mu.Lock()
 	if pcid, ok := p.cache[pt]; ok {
@@ -94,6 +96,8 @@ func (p *PCIDs) Assign(pt *PageTables) (uint16, bool) {
 }
 
 // Drop drops references to a set of page tables.
+//
+// +checklocksexclude:p.mu
 func (p *PCIDs) Drop(pt *PageTables) {
 	p.mu.Lock()
 	if pcid, ok := p.cache[pt]; ok {

--- a/pkg/sentry/fsimpl/cgroup2fs/cpuset.go
+++ b/pkg/sentry/fsimpl/cgroup2fs/cpuset.go
@@ -31,13 +31,18 @@ import (
 
 // +stateify savable
 type cpuset struct {
-	c        *cgroup
-	parent   *cpuset
+	c      *cgroup
+	parent *cpuset
+
+	// +checkatomic
 	detached atomicbitops.Bool
 
 	mu sync.Mutex `state:"nosave"`
 
+	// +checklocks:mu
 	cpus *bitmap.Bitmap
+
+	// +checklocks:mu
 	mems *bitmap.Bitmap
 }
 
@@ -81,6 +86,8 @@ type cpusetCpus struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:cc.cs.mu
 func (cc *cpusetCpus) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	cc.cs.mu.Lock()
 	defer cc.cs.mu.Unlock()
@@ -93,6 +100,8 @@ func (cc *cpusetCpus) Generate(ctx context.Context, buf *bytes.Buffer) error {
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
+//
+// +checklocksexclude:cc.cs.mu
 func (cc *cpusetCpus) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
 	if src.NumBytes() > hostarch.PageSize {
 		return 0, linuxerr.EINVAL
@@ -131,6 +140,8 @@ type cpusetMems struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:cm.cs.mu
 func (cm *cpusetMems) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	cm.cs.mu.Lock()
 	defer cm.cs.mu.Unlock()
@@ -143,6 +154,8 @@ func (cm *cpusetMems) Generate(ctx context.Context, buf *bytes.Buffer) error {
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
+//
+// +checklocksexclude:cm.cs.mu
 func (cm *cpusetMems) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
 	if src.NumBytes() > hostarch.PageSize {
 		return 0, linuxerr.EINVAL

--- a/pkg/sentry/fsimpl/cgroupfs/cpuacct.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cpuacct.go
@@ -49,13 +49,15 @@ type cpuacctController struct {
 	mu sync.Mutex `state:"nosave"`
 
 	// taskCommittedCharges tracks charges for a task already attributed to this
-	// cgroup. This is used to avoid double counting usage for live
-	// tasks. Protected by mu.
+	// cgroup. This is used to avoid double counting usage for live tasks.
+	//
+	// +checklocks:mu
 	taskCommittedCharges map[*kernel.Task]usage.CPUStats
 
 	// usage is the cumulative CPU time used by past tasks in this cgroup. Note
-	// that this doesn't include usage by live tasks currently in the
-	// cgroup. Protected by mu.
+	// that this doesn't include usage by live tasks currently in the cgroup.
+	//
+	// +checklocks:mu
 	usage usage.CPUStats
 }
 
@@ -91,6 +93,8 @@ func (c *cpuacctController) AddControlFiles(ctx context.Context, creds *auth.Cre
 func (c *cpuacctController) Enter(t *kernel.Task) {}
 
 // Leave implements controller.Leave.
+//
+// +checklocksexclude:c.mu
 func (c *cpuacctController) Leave(t *kernel.Task) {
 	charge := t.CPUStats()
 	c.mu.Lock()
@@ -106,6 +110,11 @@ func (c *cpuacctController) PrepareMigrate(t *kernel.Task, src controller) error
 }
 
 // CommitMigrate implements controller.CommitMigrate.
+//
+// The caller must also not hold src's controller mutex. checklocks cannot
+// name that concrete mutex through the controller interface.
+//
+// +checklocksexclude:c.mu
 func (c *cpuacctController) CommitMigrate(t *kernel.Task, src controller) {
 	charge := t.CPUStats()
 
@@ -136,7 +145,12 @@ func (c *cpuacctCgroup) cpuacctController() *cpuacctController {
 	return c.controllers[kernel.CgroupControllerCPUAcct].(*cpuacctController)
 }
 
-// checklocks:c.fs.tasksMu
+// collectCPUStatsLocked includes descendant charges under the shared task lock.
+//
+// It acquires each visited controller's mutex. The caller must not hold those
+// mutexes; checklocks cannot name their owners through the controller map.
+//
+// +checklocksread:c.fs.tasksMu
 func (c *cpuacctCgroup) collectCPUStatsLocked(acc *usage.CPUStats) {
 	ctl := c.cpuacctController()
 	for t := range c.ts {
@@ -152,10 +166,14 @@ func (c *cpuacctCgroup) collectCPUStatsLocked(acc *usage.CPUStats) {
 
 	c.forEachChildDir(func(d *dir) {
 		cg := cpuacctCgroup{d.cgi}
-		cg.collectCPUStatsLocked(acc)
+		// forEachChildDir visits the same filesystem synchronously while
+		// c.fs.tasksMu is read-locked. checklocks cannot carry that lock or
+		// relate cg.fs to c.fs through the callback's directory argument.
+		cg.collectCPUStatsLocked(acc) // +checklocksignore
 	})
 }
 
+// +checklocksexclude:c.fs.tasksMu
 func (c *cpuacctCgroup) collectCPUStats() usage.CPUStats {
 	c.fs.tasksMu.RLock()
 	defer c.fs.tasksMu.RUnlock()
@@ -171,6 +189,8 @@ type cpuacctStatData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.fs.tasksMu
 func (d *cpuacctStatData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	cs := d.collectCPUStats()
 	fmt.Fprintf(buf, "user %d\n", linux.ClockTFromDuration(cs.UserTime))
@@ -184,6 +204,8 @@ type cpuacctUsageData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.fs.tasksMu
 func (d *cpuacctUsageData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	cs := d.collectCPUStats()
 	fmt.Fprintf(buf, "%d\n", cs.UserTime.Nanoseconds()+cs.SysTime.Nanoseconds())
@@ -196,6 +218,8 @@ type cpuacctUsageUserData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.fs.tasksMu
 func (d *cpuacctUsageUserData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	cs := d.collectCPUStats()
 	fmt.Fprintf(buf, "%d\n", cs.UserTime.Nanoseconds())
@@ -208,6 +232,8 @@ type cpuacctUsageSysData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.fs.tasksMu
 func (d *cpuacctUsageSysData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	cs := d.collectCPUStats()
 	fmt.Fprintf(buf, "%d\n", cs.SysTime.Nanoseconds())

--- a/pkg/sentry/fsimpl/cgroupfs/cpuset.go
+++ b/pkg/sentry/fsimpl/cgroupfs/cpuset.go
@@ -42,7 +42,10 @@ type cpusetController struct {
 
 	mu sync.Mutex `state:"nosave"`
 
+	// +checklocks:mu
 	cpus *bitmap.Bitmap
+
+	// +checklocks:mu
 	mems *bitmap.Bitmap
 }
 
@@ -65,6 +68,8 @@ func newCPUSetController(k *kernel.Kernel, fs *filesystem) *cpusetController {
 }
 
 // Clone implements controller.Clone.
+//
+// +checklocksexclude:c.mu
 func (c *cpusetController) Clone() controller {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -92,6 +97,8 @@ type cpusData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.c.mu
 func (d *cpusData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	d.c.mu.Lock()
 	defer d.c.mu.Unlock()
@@ -100,11 +107,15 @@ func (d *cpusData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
+//
+// +checklocksexclude:d.c.mu
 func (d *cpusData) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
 	return d.WriteBackground(ctx, src)
 }
 
 // WriteBackground implements writableControllerFileImpl.WriteBackground.
+//
+// +checklocksexclude:d.c.mu
 func (d *cpusData) WriteBackground(ctx context.Context, src usermem.IOSequence) (int64, error) {
 	if src.NumBytes() > hostarch.PageSize {
 		return 0, linuxerr.EINVAL
@@ -140,6 +151,8 @@ type memsData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.c.mu
 func (d *memsData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	d.c.mu.Lock()
 	defer d.c.mu.Unlock()
@@ -148,11 +161,15 @@ func (d *memsData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
+//
+// +checklocksexclude:d.c.mu
 func (d *memsData) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
 	return d.WriteBackground(ctx, src)
 }
 
 // WriteBackground implements writableControllerFileImpl.WriteBackground.
+//
+// +checklocksexclude:d.c.mu
 func (d *memsData) WriteBackground(ctx context.Context, src usermem.IOSequence) (int64, error) {
 	if src.NumBytes() > hostarch.PageSize {
 		return 0, linuxerr.EINVAL

--- a/pkg/sentry/fsimpl/cgroupfs/devices.go
+++ b/pkg/sentry/fsimpl/cgroupfs/devices.go
@@ -132,12 +132,15 @@ type devicesController struct {
 	controllerStateless
 	controllerNoResource
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// Allow or deny the device rules below.
+	//
+	// +checklocks:mu
 	defaultAllow bool
-	deviceRules  map[deviceID]permission
+
+	// +checklocks:mu
+	deviceRules map[deviceID]permission
 }
 
 // +stateify savable
@@ -151,6 +154,8 @@ func (d *allowedDevicesData) Generate(ctx context.Context, buf *bytes.Buffer) er
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
+//
+// +checklocksexclude:d.c.mu
 func (d *allowedDevicesData) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
 	return d.c.write(ctx, src, offset, true)
 }
@@ -166,6 +171,8 @@ func (d *deniedDevicesData) Generate(ctx context.Context, buf *bytes.Buffer) err
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
+//
+// +checklocksexclude:d.c.mu
 func (d *deniedDevicesData) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
 	return d.c.write(ctx, src, offset, false)
 }
@@ -178,16 +185,20 @@ type controlledDevicesData struct {
 // Generate implements vfs.DynamicBytesSource.Generate.
 //
 // The corresponding devices.list shows devices for which access control is set.
+//
+// +checklocksexclude:d.c.mu
 func (d *controlledDevicesData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	return d.c.generate(ctx, buf)
 }
 
+// +checklocks:c.mu
 func (c *devicesController) addRule(id deviceID, newPermission permission) error {
 	existingPermission := c.deviceRules[id]
 	c.deviceRules[id] = existingPermission.union(newPermission)
 	return nil
 }
 
+// +checklocks:c.mu
 func (c *devicesController) removeRule(id deviceID, p permission) error {
 	// cgroupv1 ignores silently requests to remove a partially-matching wildcard rule,
 	// which are {majorDevice:wildcardDevice}, {wildcardDevice:minorDevice}, and {wildcardDevice:wildcardDevice}
@@ -214,6 +225,7 @@ func (c *devicesController) removeRule(id deviceID, p permission) error {
 	return nil
 }
 
+// +checklocks:c.mu
 func (c *devicesController) applyRule(id deviceID, p permission, allow bool) error {
 	if !id.controllerType.valid() {
 		return linuxerr.EINVAL
@@ -237,6 +249,7 @@ func (c *devicesController) applyRule(id deviceID, p permission, allow bool) err
 	return c.removeRule(id, p)
 }
 
+// +checklocksexclude:c.mu
 func (c *devicesController) generate(ctx context.Context, buf *bytes.Buffer) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -259,6 +272,7 @@ func (c *devicesController) generate(ctx context.Context, buf *bytes.Buffer) err
 	return nil
 }
 
+// +checklocksexclude:c.mu
 func (c *devicesController) write(ctx context.Context, src usermem.IOSequence, offset int64, allow bool) (int64, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -326,6 +340,8 @@ func newDevicesController(fs *filesystem) *devicesController {
 }
 
 // Clone implements controller.Clone.
+//
+// +checklocksexclude:c.mu
 func (c *devicesController) Clone() controller {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/pkg/sentry/fsimpl/cgroupfs/pids.go
+++ b/pkg/sentry/fsimpl/cgroupfs/pids.go
@@ -59,7 +59,6 @@ type pidsController struct {
 	// since cgroupfs doesn't allow cross directory renames.
 	isRoot bool
 
-	// mu protects the fields below.
 	mu pidsControllerMutex `state:"nosave"`
 
 	// pendingTotal and pendingPool tracks the charge for processes starting
@@ -71,15 +70,21 @@ type pidsController struct {
 	// We also track which task owns the pending charge so we can cancel the
 	// charge if a task creation fails after the Charge call.
 	//
-	// pendingTotal and pendingPool are both protected by mu.
+	// +checklocks:mu
 	pendingTotal int64
-	pendingPool  map[*kernel.Task]int64
+
+	// +checklocks:mu
+	pendingPool map[*kernel.Task]int64
 
 	// committed represent charges for tasks that have already started and
-	// called Enter. Protected by mu.
+	// called Enter.
+	//
+	// +checklocks:mu
 	committed int64
 
-	// max is the PID limit for this cgroup. Protected by mu.
+	// max is the PID limit for this cgroup.
+	//
+	// +checklocks:mu
 	max int64
 }
 
@@ -98,6 +103,8 @@ func newRootPIDsController(fs *filesystem) *pidsController {
 }
 
 // Clone implements controller.Clone.
+//
+// +checklocksexclude:c.mu
 func (c *pidsController) Clone() controller {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -126,6 +133,8 @@ func (c *pidsController) AddControlFiles(ctx context.Context, creds *auth.Creden
 // charge is pending for t, one pending charge is converted to a committed
 // charge, and the net change in total charges is zero. If no charge is pending,
 // a new charge is added directly to the committed pool.
+//
+// +checklocksexclude:c.mu
 func (c *pidsController) Enter(t *kernel.Task) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -149,6 +158,8 @@ func (c *pidsController) Enter(t *kernel.Task) {
 }
 
 // Leave implements controller.Leave.
+//
+// +checklocksexclude:c.mu
 func (c *pidsController) Leave(t *kernel.Task) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -160,6 +171,9 @@ func (c *pidsController) Leave(t *kernel.Task) {
 }
 
 // PrepareMigrate implements controller.PrepareMigrate.
+//
+// The caller must not hold src's controller mutex. checklocks cannot name
+// that concrete mutex through the controller interface.
 func (c *pidsController) PrepareMigrate(t *kernel.Task, src controller) error {
 	srcC := src.(*pidsController)
 	srcC.mu.Lock()
@@ -178,6 +192,11 @@ func (c *pidsController) PrepareMigrate(t *kernel.Task, src controller) error {
 // Migrations can cause a cgroup to exceed its limit. CommitMigrate can only be
 // called for tasks with committed charges, PrepareMigrate will deny migrations
 // prior to Enter.
+//
+// The caller must also not hold src's controller mutex. checklocks cannot
+// name that concrete mutex through the controller interface.
+//
+// +checklocksexclude:c.mu
 func (c *pidsController) CommitMigrate(t *kernel.Task, src controller) {
 	// Note: The charge is allowed to exceed max on migration. The charge may
 	// not exceed max when incurred due to a fork/clone, which will call
@@ -202,6 +221,8 @@ func (c *pidsController) AbortMigrate(t *kernel.Task, src controller) {}
 // pool. Charge are committed from the pending pool by Enter. The caller is
 // responsible for ensuring negative charges correspond to previous positive
 // charges. Negative charges that cause an underflow result in a panic.
+//
+// +checklocksexclude:c.mu
 func (c *pidsController) Charge(t *kernel.Task, d *kernfs.Dentry, res kernel.CgroupResourceType, value int64) error {
 	if res != kernel.CgroupResourcePID {
 		panic(fmt.Sprintf("cgroupfs: pids controller invalid resource type %v", res))
@@ -249,6 +270,8 @@ type pidsCurrentData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.c.mu
 func (d *pidsCurrentData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	d.c.mu.Lock()
 	defer d.c.mu.Unlock()
@@ -262,6 +285,8 @@ type pidsMaxData struct {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.c.mu
 func (d *pidsMaxData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	d.c.mu.Lock()
 	defer d.c.mu.Unlock()
@@ -276,11 +301,15 @@ func (d *pidsMaxData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 }
 
 // Write implements vfs.WritableDynamicBytesSource.Write.
+//
+// +checklocksexclude:d.c.mu
 func (d *pidsMaxData) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
 	return d.WriteBackground(ctx, src)
 }
 
 // WriteBackground implements writableControllerFileImpl.WriteBackground.
+//
+// +checklocksexclude:d.c.mu
 func (d *pidsMaxData) WriteBackground(ctx context.Context, src usermem.IOSequence) (int64, error) {
 	buf := copyScratchBufferFromContext(ctx, hostarch.PageSize)
 	ncpy, err := src.CopyIn(ctx, buf)

--- a/pkg/sentry/ktime/sampled_timer.go
+++ b/pkg/sentry/ktime/sampled_timer.go
@@ -27,29 +27,39 @@ import (
 //
 // +stateify savable
 type SampledTimer struct {
-	// clock is the time source. clock is protected by mu and clockSeq.
+	// clock is the time source. SetClock writes it under mu and a clockSeq
+	// writer section. Clock reads it through SeqAtomicLoadSampledClock, which
+	// validates the sequence after loading. checklocks cannot express this
+	// sequence-validated alternative to holding mu.
 	clockSeq sync.SeqCount `state:"nosave"`
 	clock    SampledClock
 
 	// listener is notified of expirations. listener is immutable.
 	listener Listener
 
-	// mu protects the following mutable fields.
 	mu sync.Mutex `state:"nosave"`
 
-	// setting is the timer setting. setting is protected by mu.
+	// setting is the timer setting.
+	//
+	// +checklocks:mu
 	setting Setting
 
+	// +checklocks:mu
 	pauseState timerPauseState
 
-	// kicker is used to wake the SampledTimer goroutine. The kicker pointer is
-	// immutable, but its state is protected by mu.
+	// kicker wakes the SampledTimer goroutine. Its pointer is fixed after
+	// init. Resets occur under mu. Destroy sets timerDestroyed under mu to
+	// prevent later tick resets, then stops the kicker after unlocking.
 	kicker *time.Timer `state:"nosave"`
 
-	// entry is registered with clock.EventRegister. entry is immutable.
+	// entry is registered with clock.EventRegister. Its notification setup
+	// is fixed after init, but registration links belong to the clock's
+	// waiter queue. SampledClock does not expose that queue's concrete lock
+	// to checklocks. EventUnregister excludes notifications before Destroy
+	// closes events.
 	//
-	// Per comment in SampledClock, entry must be re-registered after restore;
-	// per comment in SampledTimer.Load, this is done in SampledTimer.Resume.
+	// Generated StateLoad does not restore entry. Resume reinitializes and
+	// re-registers it after kernel.Timekeeper.SetClocks, as explained below.
 	entry waiter.Entry `state:"nosave"`
 
 	// events is the channel that will be notified whenever entry receives an
@@ -79,7 +89,9 @@ func NewSampledTimer(clock SampledClock, listener Listener) *SampledTimer {
 		clock:    clock,
 		listener: listener,
 	}
-	t.init()
+	// t is newly allocated; init finishes setup before starting its goroutine.
+	// checklocks cannot substitute this ownership for the mu requirement.
+	t.init() // +checklocksignore
 	return t
 }
 
@@ -88,6 +100,8 @@ func NewSampledTimer(clock SampledClock, listener Listener) *SampledTimer {
 //
 // Preconditions: t.mu must be locked, or the caller must have exclusive access
 // to t.
+//
+// +checklocks:t.mu
 func (t *SampledTimer) init() {
 	if t.kicker != nil {
 		return
@@ -103,6 +117,8 @@ func (t *SampledTimer) init() {
 }
 
 // Destroy implements Timer.Destroy.
+//
+// +checklocksexclude:t.mu
 func (t *SampledTimer) Destroy() {
 	// Stop the timer, ensuring that the goroutine will not call
 	// t.kicker.Reset, before calling t.kicker.Stop.
@@ -119,6 +135,8 @@ func (t *SampledTimer) Destroy() {
 }
 
 // Pause implements Timer.Pause.
+//
+// +checklocksexclude:t.mu
 func (t *SampledTimer) Pause() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -133,6 +151,8 @@ func (t *SampledTimer) Pause() {
 }
 
 // Resume implements Timer.Resume.
+//
+// +checklocksexclude:t.mu
 func (t *SampledTimer) Resume() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -159,6 +179,8 @@ func (t *SampledTimer) Clock() Clock {
 }
 
 // Get implements Timer.Get.
+//
+// +checklocksexclude:t.mu
 func (t *SampledTimer) Get() (Time, Setting) {
 	// Optimistically read t.Clock().Now() before locking t.mu, as t.clock is
 	// unlikely to change.
@@ -182,6 +204,8 @@ func (t *SampledTimer) Get() (Time, Setting) {
 }
 
 // Set implements Timer.Set.
+//
+// +checklocksexclude:t.mu
 func (t *SampledTimer) Set(s Setting, f func()) (Time, Setting) {
 	// Optimistically read t.Clock().Now() before locking t.mu, as t.clock is
 	// unlikely to change.
@@ -212,6 +236,8 @@ func (t *SampledTimer) Set(s Setting, f func()) (Time, Setting) {
 }
 
 // SetClock atomically changes a SampledTimer's Clock and Setting.
+//
+// +checklocksexclude:t.mu
 func (t *SampledTimer) SetClock(c SampledClock, s Setting) {
 	var now Time
 	if s.Enabled {
@@ -246,6 +272,8 @@ func (t *SampledTimer) runGoroutine() {
 
 // tick requests that the SampledTimer immediately check for expirations and
 // re-evaluate when it should next check for expirations.
+//
+// +checklocksexclude:t.mu
 func (t *SampledTimer) tick() {
 	// Optimistically read t.Clock().Now() before locking t.mu, as t.clock is
 	// unlikely to change.
@@ -267,7 +295,7 @@ func (t *SampledTimer) tick() {
 	t.resetKickerLocked(now)
 }
 
-// Preconditions: t.mu must be locked.
+// +checklocks:t.mu
 func (t *SampledTimer) resetKickerLocked(now Time) {
 	if t.setting.Enabled {
 		// Clock.WallTimeUntil may return a negative value. This is fine;

--- a/pkg/sentry/ktime/synthetic_timer.go
+++ b/pkg/sentry/ktime/synthetic_timer.go
@@ -31,13 +31,15 @@ type SyntheticTimer struct {
 	clock    *SyntheticClock
 	listener Listener
 
-	// setting is the timer's current setting. setting is protected by
-	// clock.mu.
+	// setting is the timer's current setting.
+	//
+	// +checklocks:clock.mu
 	setting Setting
 
 	// syntheticTimerEntry links the SyntheticTimer into
 	// syntheticTimerQueue.timers when setting.Enabled == true.
-	// syntheticTimerEntry is protected by mu.
+	// Its links are protected by clock.mu, but the generated entry accessors
+	// have no link back to this timer from which to name that lock.
 	syntheticTimerEntry
 }
 
@@ -48,12 +50,16 @@ type SyntheticTimer struct {
 type SyntheticClock struct {
 	mu sync.Mutex `state:"nosave"`
 
-	// now is the Clock's current time. Writes to now require that mu is
-	// locked.
+	// now is the Clock's current time.
+	//
+	// +checkatomic
+	// +checklocks:mu
 	now atomicbitops.Int64
 
 	// timers maps each timer expiration time to a list of all enabled timers
-	// with that expiration time. timers is protected by mu.
+	// with that expiration time.
+	//
+	// +checklocks:mu
 	timers syntheticTimerSet
 }
 
@@ -61,6 +67,10 @@ type SyntheticClock struct {
 //
 // +stateify savable
 type syntheticTimerQueue struct {
+	// timers is protected by the owning SyntheticClock's mu. Every member's
+	// clock pointer identifies that same SyntheticClock, but this queue has
+	// no clock pointer and checklocks cannot recover the owner through
+	// generated set/list traversal.
 	timers syntheticTimerList
 }
 
@@ -78,6 +88,8 @@ func (t *SyntheticTimer) Init(clock *SyntheticClock, listener Listener) {
 }
 
 // Destroy implements Timer.Destroy.
+//
+// +checklocksexclude:t.clock.mu
 func (t *SyntheticTimer) Destroy() {
 	// Just stop the timer.
 	t.clock.mu.Lock()
@@ -106,6 +118,8 @@ func (t *SyntheticTimer) Clock() Clock {
 }
 
 // Get implements Timer.Get.
+//
+// +checklocksexclude:t.clock.mu
 func (t *SyntheticTimer) Get() (Time, Setting) {
 	t.clock.mu.Lock()
 	defer t.clock.mu.Unlock()
@@ -115,6 +129,8 @@ func (t *SyntheticTimer) Get() (Time, Setting) {
 }
 
 // Set implements Timer.Set.
+//
+// +checklocksexclude:t.clock.mu
 func (t *SyntheticTimer) Set(s Setting, f func()) (Time, Setting) {
 	t.clock.mu.Lock()
 	defer t.clock.mu.Unlock()
@@ -146,7 +162,7 @@ func (c *SyntheticClock) Now() Time {
 	return FromNanoseconds(c.now.Load())
 }
 
-// Preconditions: c.mu must be locked.
+// +checklocks:c.mu
 func (c *SyntheticClock) nowLocked() Time {
 	return FromNanoseconds(c.now.RacyLoad())
 }
@@ -162,6 +178,8 @@ func (c *SyntheticClock) NewTimer(listener Listener) Timer {
 //   - now.Nanoseconds() >= 0.
 //   - The caller must not hold locks following Timer methods in the lock order
 //     (since Listener notification requires acquiring such locks).
+//
+// +checklocksexclude:c.mu
 func (c *SyntheticClock) Store(now Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -174,13 +192,15 @@ func (c *SyntheticClock) Store(now Time) {
 //   - c's resulting current time >= 0.
 //   - The caller must not hold locks following Timer methods in the lock order
 //     (since Listener notification requires acquiring such locks).
+//
+// +checklocksexclude:c.mu
 func (c *SyntheticClock) Add(delta time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.setTimeLocked(c.now.RacyLoad() + delta.Nanoseconds())
 }
 
-// Preconditions: c.mu must be locked.
+// +checklocks:c.mu
 func (c *SyntheticClock) setTimeLocked(nowNS int64) {
 	if nowNS < 0 {
 		panic(fmt.Sprintf("invalid time %d", nowNS))
@@ -201,20 +221,27 @@ func (c *SyntheticClock) setTimeLocked(nowNS int64) {
 		for !timers.Empty() {
 			t := timers.Front()
 			timers.Remove(t)
-			s, exp := t.setting.At(now)
+			// Every member of c.timers has t.clock == c. checklocks cannot
+			// recover that owner identity from generated list traversal.
+			s, exp := t.setting.At(now) // +checklocksignore
 			if exp == 0 {
-				panic(fmt.Sprintf("ktime.SyntheticClock (time=%d) contains enqueued timer %p for time=%d with unexpired setting %+v", nowNS, t, seg.Start(), t.setting))
+				panic(fmt.Sprintf("ktime.SyntheticClock (time=%d) contains enqueued timer %p for time=%d with unexpired setting %+v", nowNS, t, seg.Start(), t.setting)) // +checklocksignore
 			}
-			t.setting = s
+			t.setting = s // +checklocksignore
 			t.listener.NotifyTimer(exp)
-			if t.setting.Enabled {
-				c.addTimerLocked(t)
+			if t.setting.Enabled { // +checklocksignore
+				c.addTimerLocked(t) // +checklocksignore
 			}
 		}
 	}
 }
 
-// Preconditions: c.mu must be locked.
+// addTimerLocked inserts enabled t into c's timer index.
+//
+// Preconditions: t.clock == c.
+//
+// +checklocks:c.mu
+// +checklocks:t.clock.mu
 func (c *SyntheticClock) addTimerLocked(t *SyntheticTimer) {
 	nextNS := uint64(t.setting.Next.Nanoseconds())
 	seg, gap := c.timers.Find(nextNS)
@@ -224,7 +251,12 @@ func (c *SyntheticClock) addTimerLocked(t *SyntheticTimer) {
 	seg.ValuePtr().timers.PushBack(t)
 }
 
-// Preconditions: c.mu must be locked.
+// delTimerLocked removes t from c's timer index.
+//
+// Preconditions: t.clock == c, and t is enqueued.
+//
+// +checklocks:c.mu
+// +checklocks:t.clock.mu
 func (c *SyntheticClock) delTimerLocked(t *SyntheticTimer) {
 	nextNS := uint64(t.setting.Next.Nanoseconds())
 	seg := c.timers.FindSegment(nextNS)

--- a/pkg/sentry/mm/address_space.go
+++ b/pkg/sentry/mm/address_space.go
@@ -35,10 +35,11 @@ func (mm *MemoryManager) AddressSpace() platform.AddressSpace {
 // mapASLocked maps addresses in ar into mm.as.
 //
 // Preconditions:
-//   - mm.activeMu must be locked.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
 //   - pseg == mm.pmas.LowerBoundSegment(ar.Start).
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) mapASLocked(ctx context.Context, pseg pmaIterator, ar hostarch.AddrRange, platformEffect memmap.MMapPlatformEffect) error {
 	if platformEffect == memmap.PlatformEffectCommit && ar.Length() > (1<<30) {
 		// FIXME(b/445932215, b/445939339): Don't precommit very large ranges
@@ -121,7 +122,7 @@ func (mm *MemoryManager) mapASLocked(ctx context.Context, pseg pmaIterator, ar h
 
 // unmapASLocked removes all AddressSpace mappings for addresses in ar.
 //
-// Preconditions: mm.activeMu must be locked.
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) unmapASLocked(ar hostarch.AddrRange) {
 	if ar.Length() == 0 {
 		return

--- a/pkg/sentry/mm/aio_context.go
+++ b/pkg/sentry/mm/aio_context.go
@@ -29,13 +29,15 @@ import (
 //
 // +stateify savable
 type aioManager struct {
-	// mu protects below.
 	mu aioManagerMutex `state:"nosave"`
 
-	// aioContexts is the set of asynchronous I/O contexts.
+	// contexts is the set of asynchronous I/O contexts.
+	//
+	// +checklocks:mu
 	contexts map[uint64]*AIOContext
 }
 
+// +checklocksexclude:mm.aioManager.mu
 func (mm *MemoryManager) destroyAIOManager(ctx context.Context) {
 	mm.aioManager.mu.Lock()
 	defer mm.aioManager.mu.Unlock()
@@ -48,6 +50,8 @@ func (mm *MemoryManager) destroyAIOManager(ctx context.Context) {
 // newAIOContext creates a new context for asynchronous I/O.
 //
 // Returns false if 'id' is currently in use.
+//
+// +checklocksexclude:a.mu
 func (a *aioManager) newAIOContext(events uint32, id uint64) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -63,13 +67,16 @@ func (a *aioManager) newAIOContext(events uint32, id uint64) bool {
 	return true
 }
 
-// destroyAIOContext destroys an asynchronous I/O context. It doesn't wait for
-// for pending requests to complete. Returns the destroyed AIOContext so it can
-// be drained.
+// destroyAIOContextLocked destroys an asynchronous I/O context while holding
+// mm.aioManager.mu. It returns the context for draining without waiting for
+// pending requests to complete.
 //
 // Nil is returned if the context does not exist.
 //
-// Precondition: mm.aioManager.mu is locked.
+// The caller must not hold the target context's mu. checklocks cannot name
+// that mutex in this contract because the context comes from the map.
+//
+// +checklocks:mm.aioManager.mu
 func (mm *MemoryManager) destroyAIOContextLocked(ctx context.Context, id uint64) *AIOContext {
 	aioCtx, ok := mm.aioManager.contexts[id]
 	if !ok {
@@ -84,6 +91,8 @@ func (mm *MemoryManager) destroyAIOContextLocked(ctx context.Context, id uint64)
 // lookupAIOContext looks up the given context.
 //
 // Returns false if context does not exist.
+//
+// +checklocksexclude:a.mu
 func (a *aioManager) lookupAIOContext(id uint64) (*AIOContext, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -106,10 +115,11 @@ type AIOContext struct {
 	// requestReady is the notification channel used for all requests.
 	requestReady chan struct{} `state:"nosave"`
 
-	// mu protects below.
 	mu aioContextMutex `state:"nosave"`
 
 	// results is the set of completed requests.
+	//
+	// +checklocks:mu
 	results ioList
 
 	// maxOutstanding is the maximum number of outstanding entries; this value
@@ -119,13 +129,19 @@ type AIOContext struct {
 	// outstanding is the number of requests outstanding; this will effectively
 	// be the number of entries in the result list or that are expected to be
 	// added to the result list.
+	//
+	// +checklocks:mu
 	outstanding uint32
 
 	// dead is set when the context is destroyed.
+	//
+	// +checklocks:mu
 	dead bool `state:"zerovalue"`
 }
 
 // destroy marks the context dead.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) destroy() {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -133,7 +149,7 @@ func (aio *AIOContext) destroy() {
 	aio.checkForDone()
 }
 
-// Preconditions: ctx.mu must be held by caller.
+// +checklocks:aio.mu
 func (aio *AIOContext) checkForDone() {
 	if aio.dead && aio.outstanding == 0 {
 		close(aio.requestReady)
@@ -143,6 +159,8 @@ func (aio *AIOContext) checkForDone() {
 
 // Prepare reserves space for a new request, returning nil if available.
 // Returns EAGAIN if the context is busy and EINVAL if the context is dead.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) Prepare() error {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -160,6 +178,8 @@ func (aio *AIOContext) Prepare() error {
 
 // PopRequest pops a completed request if available, this function does not do
 // any blocking. Returns false if no request is available.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) PopRequest() (any, bool) {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -179,6 +199,8 @@ func (aio *AIOContext) PopRequest() (any, bool) {
 
 // FinishRequest finishes a pending request. It queues up the data
 // and notifies listeners.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) FinishRequest(data any) {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -197,6 +219,8 @@ func (aio *AIOContext) FinishRequest(data any) {
 // WaitChannel returns a channel that is notified when an AIO request is
 // completed. Returns nil if the context is destroyed and there are no more
 // outstanding requests.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) WaitChannel() chan struct{} {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -204,6 +228,8 @@ func (aio *AIOContext) WaitChannel() chan struct{} {
 }
 
 // Dead returns true if the context has been destroyed.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) Dead() bool {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -211,6 +237,8 @@ func (aio *AIOContext) Dead() bool {
 }
 
 // CancelPendingRequest forgets about a request that hasn't yet completed.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) CancelPendingRequest() {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -223,6 +251,8 @@ func (aio *AIOContext) CancelPendingRequest() {
 }
 
 // Drain drops all completed requests. Pending requests remain untouched.
+//
+// +checklocksexclude:aio.mu
 func (aio *AIOContext) Drain() {
 	aio.mu.Lock()
 	defer aio.mu.Unlock()
@@ -305,6 +335,10 @@ func (m *aioMappable) RemoveMapping(context.Context, memmap.MappingSpace, hostar
 }
 
 // CopyMapping implements memmap.Mappable.CopyMapping.
+//
+// The caller must not hold ms's AIO manager mutex or the source context's
+// mutex. checklocks cannot express these entry exclusions through the
+// interface-typed mapping space and the context map lookup.
 func (m *aioMappable) CopyMapping(ctx context.Context, ms memmap.MappingSpace, srcAR, dstAR hostarch.AddrRange, offset uint64, _ bool) error {
 	// Don't allow mappings to be expanded (in Linux, fs/aio.c:aio_ring_mmap()
 	// sets VM_DONTEXPAND).
@@ -363,6 +397,10 @@ func (m *aioMappable) InvalidateUnsavable(ctx context.Context) error {
 // NewAIOContext creates a new context for asynchronous I/O.
 //
 // NewAIOContext is analogous to Linux's fs/aio.c:ioctx_alloc().
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
+// +checklocksexclude:mm.aioManager.mu
 func (mm *MemoryManager) NewAIOContext(ctx context.Context, events uint32) (uint64, error) {
 	// libaio get_ioevents() expects context "handle" to be a valid address.
 	// libaio peeks inside looking for a magic number. This function allocates
@@ -396,6 +434,10 @@ func (mm *MemoryManager) NewAIOContext(ctx context.Context, events uint32) (uint
 
 // DestroyAIOContext destroys an asynchronous I/O context. It returns the
 // destroyed context. nil if the context does not exist.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
+// +checklocksexclude:mm.aioManager.mu
 func (mm *MemoryManager) DestroyAIOContext(ctx context.Context, id uint64) *AIOContext {
 	if !mm.isValidAddr(ctx, id) {
 		return nil
@@ -417,6 +459,10 @@ func (mm *MemoryManager) DestroyAIOContext(ctx context.Context, id uint64) *AIOC
 
 // LookupAIOContext looks up the given context. It returns false if the context
 // does not exist.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
+// +checklocksexclude:mm.aioManager.mu
 func (mm *MemoryManager) LookupAIOContext(ctx context.Context, id uint64) (*AIOContext, bool) {
 	aioCtx, ok := mm.aioManager.lookupAIOContext(id)
 	if !ok {
@@ -433,6 +479,9 @@ func (mm *MemoryManager) LookupAIOContext(ctx context.Context, id uint64) (*AIOC
 
 // isValidAddr determines if the address `id` is valid. (Linux also reads 4
 // bytes from id).
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) isValidAddr(ctx context.Context, id uint64) bool {
 	var buf [4]byte
 	_, err := mm.CopyIn(ctx, hostarch.Addr(id), buf[:], usermem.IOOpts{})

--- a/pkg/sentry/mm/debug.go
+++ b/pkg/sentry/mm/debug.go
@@ -34,11 +34,17 @@ const (
 )
 
 // String implements fmt.Stringer.String.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) String() string {
 	return mm.DebugString(context.Background())
 }
 
 // DebugString returns a string containing information about mm for debugging.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) DebugString(ctx context.Context) string {
 	var b bytes.Buffer
 
@@ -59,7 +65,11 @@ func (mm *MemoryManager) DebugString(ctx context.Context) string {
 	return b.String()
 }
 
-// Preconditions: mm.activeMu must be locked.
+// debugStringEntryLocked formats pseg for DebugString. The generated iterator
+// has no MemoryManager reference, so checklocks cannot name the owning mutex.
+//
+// Preconditions: the owning MemoryManager's activeMu is held at least for
+// reading.
 func (pseg pmaIterator) debugStringEntryLocked() []byte {
 	var b bytes.Buffer
 

--- a/pkg/sentry/mm/io.go
+++ b/pkg/sentry/mm/io.go
@@ -109,6 +109,9 @@ func translateIOError(ctx context.Context, err error) error {
 }
 
 // CopyOut implements usermem.IO.CopyOut.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) CopyOut(ctx context.Context, addr hostarch.Addr, src []byte, opts usermem.IOOpts) (int, error) {
 	ar, ok := mm.CheckIORange(addr, int64(len(src)))
 	if !ok {
@@ -133,6 +136,8 @@ func (mm *MemoryManager) CopyOut(ctx context.Context, addr hostarch.Addr, src []
 	return mm.imCopyOut(ctx, ar, src, opts)
 }
 
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) asCopyOut(ctx context.Context, ar hostarch.AddrRange, src []byte, opts usermem.IOOpts) (int, error) {
 	var done int
 	for {
@@ -155,6 +160,8 @@ func (mm *MemoryManager) asCopyOut(ctx context.Context, ar hostarch.AddrRange, s
 	}
 }
 
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) imCopyOut(ctx context.Context, ar hostarch.AddrRange, src []byte, opts usermem.IOOpts) (int, error) {
 	n64, err := mm.withInternalMappings(ctx, ar, hostarch.Write, opts.IgnorePermissions, func(ims safemem.BlockSeq) (uint64, error) {
 		n, err := safemem.CopySeq(ims, safemem.BlockSeqOf(safemem.BlockFromSafeSlice(src)))
@@ -164,6 +171,9 @@ func (mm *MemoryManager) imCopyOut(ctx context.Context, ar hostarch.AddrRange, s
 }
 
 // CopyIn implements usermem.IO.CopyIn.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) CopyIn(ctx context.Context, addr hostarch.Addr, dst []byte, opts usermem.IOOpts) (int, error) {
 	ar, ok := mm.CheckIORange(addr, int64(len(dst)))
 	if !ok {
@@ -188,6 +198,8 @@ func (mm *MemoryManager) CopyIn(ctx context.Context, addr hostarch.Addr, dst []b
 	return mm.imCopyIn(ctx, ar, dst, opts)
 }
 
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) asCopyIn(ctx context.Context, ar hostarch.AddrRange, dst []byte, opts usermem.IOOpts) (int, error) {
 	var done int
 	for {
@@ -210,6 +222,8 @@ func (mm *MemoryManager) asCopyIn(ctx context.Context, ar hostarch.AddrRange, ds
 	}
 }
 
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) imCopyIn(ctx context.Context, ar hostarch.AddrRange, dst []byte, opts usermem.IOOpts) (int, error) {
 	n64, err := mm.withInternalMappings(ctx, ar, hostarch.Read, opts.IgnorePermissions, func(ims safemem.BlockSeq) (uint64, error) {
 		n, err := safemem.CopySeq(safemem.BlockSeqOf(safemem.BlockFromSafeSlice(dst)), ims)
@@ -219,6 +233,9 @@ func (mm *MemoryManager) imCopyIn(ctx context.Context, ar hostarch.AddrRange, ds
 }
 
 // ZeroOut implements usermem.IO.ZeroOut.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) ZeroOut(ctx context.Context, addr hostarch.Addr, toZero int64, opts usermem.IOOpts) (int64, error) {
 	ar, ok := mm.CheckIORange(addr, toZero)
 	if !ok {
@@ -238,6 +255,8 @@ func (mm *MemoryManager) ZeroOut(ctx context.Context, addr hostarch.Addr, toZero
 	return mm.imZeroOut(ctx, ar, opts)
 }
 
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) asZeroOut(ctx context.Context, ar hostarch.AddrRange, opts usermem.IOOpts) (int64, error) {
 	var done int64
 	for {
@@ -260,6 +279,8 @@ func (mm *MemoryManager) asZeroOut(ctx context.Context, ar hostarch.AddrRange, o
 	}
 }
 
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) imZeroOut(ctx context.Context, ar hostarch.AddrRange, opts usermem.IOOpts) (int64, error) {
 	return mm.withInternalMappings(ctx, ar, hostarch.Write, opts.IgnorePermissions, func(dsts safemem.BlockSeq) (uint64, error) {
 		n, err := safemem.ZeroSeq(dsts)
@@ -268,6 +289,9 @@ func (mm *MemoryManager) imZeroOut(ctx context.Context, ar hostarch.AddrRange, o
 }
 
 // CopyOutFrom implements usermem.IO.CopyOutFrom.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) CopyOutFrom(ctx context.Context, ars hostarch.AddrRangeSeq, src safemem.Reader, opts usermem.IOOpts) (int64, error) {
 	var ok bool
 	ars, ok = mm.checkIOVec(ars)
@@ -315,6 +339,9 @@ func (mm *MemoryManager) CopyOutFrom(ctx context.Context, ars hostarch.AddrRange
 }
 
 // CopyInTo implements usermem.IO.CopyInTo.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) CopyInTo(ctx context.Context, ars hostarch.AddrRangeSeq, dst safemem.Writer, opts usermem.IOOpts) (int64, error) {
 	var ok bool
 	ars, ok = mm.checkIOVec(ars)
@@ -360,6 +387,9 @@ func (mm *MemoryManager) CopyInTo(ctx context.Context, ars hostarch.AddrRangeSeq
 // requested length. It returns the length to which it was able to either
 // initialize PMAs for, or ascertain that PMAs exist for. If this length is
 // smaller than the requested length it returns an error explaining why.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) EnsurePMAsExist(ctx context.Context, addr hostarch.Addr, length int64, opts usermem.IOOpts) (int64, error) {
 	ar, ok := mm.CheckIORange(addr, length)
 	if !ok {
@@ -372,6 +402,9 @@ func (mm *MemoryManager) EnsurePMAsExist(ctx context.Context, addr hostarch.Addr
 }
 
 // SwapUint32 implements usermem.IO.SwapUint32.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) SwapUint32(ctx context.Context, addr hostarch.Addr, new uint32, opts usermem.IOOpts) (uint32, error) {
 	ar, ok := mm.CheckIORange(addr, 4)
 	if !ok {
@@ -419,6 +452,9 @@ func (mm *MemoryManager) SwapUint32(ctx context.Context, addr hostarch.Addr, new
 }
 
 // CompareAndSwapUint32 implements usermem.IO.CompareAndSwapUint32.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) CompareAndSwapUint32(ctx context.Context, addr hostarch.Addr, old, new uint32, opts usermem.IOOpts) (uint32, error) {
 	ar, ok := mm.CheckIORange(addr, 4)
 	if !ok {
@@ -466,6 +502,9 @@ func (mm *MemoryManager) CompareAndSwapUint32(ctx context.Context, addr hostarch
 }
 
 // LoadUint32 implements usermem.IO.LoadUint32.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) LoadUint32(ctx context.Context, addr hostarch.Addr, opts usermem.IOOpts) (uint32, error) {
 	ar, ok := mm.CheckIORange(addr, 4)
 	if !ok {
@@ -519,6 +558,9 @@ func (mm *MemoryManager) LoadUint32(ctx context.Context, addr hostarch.Addr, opt
 //   - mm.as != nil.
 //   - ioar.Length() != 0.
 //   - ioar.Contains(addr).
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) handleASIOFault(ctx context.Context, addr hostarch.Addr, ioar hostarch.AddrRange, at hostarch.AccessType) error {
 	// Try to map all remaining pages in the I/O operation. This RoundUp can't
 	// overflow because otherwise it would have been caught by CheckIORange.
@@ -571,7 +613,14 @@ func (mm *MemoryManager) handleASIOFault(ctx context.Context, addr hostarch.Addr
 // functions have this property, but returns an int64 since this is usually
 // more useful for usermem.IO methods.
 //
+// f runs synchronously and must not retain the mappings after returning,
+// reacquire activeMu, or acquire a mutex preceding it, including mappingMu.
+// checklocks does not carry the held lock state through the function value.
+//
 // Preconditions: 0 < ar.Length() <= math.MaxInt64.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) withInternalMappings(ctx context.Context, ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool, f func(safemem.BlockSeq) (uint64, error)) (int64, error) {
 	// If pmas are already available, we can do IO without touching mm.vmas or
 	// mm.mappingMu.
@@ -641,7 +690,13 @@ func (mm *MemoryManager) withInternalMappings(ctx context.Context, ar hostarch.A
 // cached. It then calls f with mm.activeMu locked for reading, passing
 // internal mappings for the subset of ars for which this property holds.
 //
+// f has the same mapping-lifetime and lock-order requirements as in
+// withInternalMappings.
+//
 // Preconditions: !ars.IsEmpty().
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) withVecInternalMappings(ctx context.Context, ars hostarch.AddrRangeSeq, at hostarch.AccessType, ignorePermissions bool, f func(safemem.BlockSeq) (uint64, error)) (int64, error) {
 	// withInternalMappings is faster than withVecInternalMappings because of
 	// iterator plumbing (this isn't generally practical in the vector case due
@@ -715,12 +770,13 @@ func (mm *MemoryManager) withVecInternalMappings(ctx context.Context, ars hostar
 // called.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - pseg.Range().Contains(ar.Start).
 //   - pmas must exist for all addresses in ar.
 //   - ar.Length() != 0.
 //
 // Postconditions: getIOMappingsLocked does not invalidate iterators into mm.pmas.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getIOMappingsLocked(pseg pmaIterator, ar hostarch.AddrRange, at hostarch.AccessType) (safemem.BlockSeq, *ioBufTracker, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -759,12 +815,12 @@ slowPath:
 // are valid until either mm.activeMu is unlocked or ioBufTracker.flush() is
 // called.
 //
-// Preconditions:
-//   - mm.activeMu must be locked for writing.
-//   - pmas must exist for all addresses in ar.
+// Preconditions: pmas must exist for all addresses in ars.
 //
 // Postconditions: getVecIOMappingsLocked does not invalidate iterators into
 // mm.pmas
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getVecIOMappingsLocked(ars hostarch.AddrRangeSeq, at hostarch.AccessType) (safemem.BlockSeq, *ioBufTracker, error) {
 	if ars.NumRanges() == 1 {
 		ar := ars.Head()
@@ -807,13 +863,14 @@ func (mm *MemoryManager) getVecIOMappingsLocked(ars hostarch.AddrRangeSeq, at ho
 // ioBufTracker.flush() is called.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - pseg.Range().Contains(ar.Start).
 //   - pmas must exist for all addresses in ar.
 //   - ar.Length() != 0.
 //
 // Postconditions: getIOMappingsTrackedLocked does not invalidate iterators
 // into mm.pmas.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getIOMappingsTrackedLocked(pseg pmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, ims []safemem.Block, t *ioBufTracker, unbufBytes uint64) ([]safemem.Block, *ioBufTracker, uint64, error) {
 	for {
 		pmaAR := ar.Intersect(pseg.Range())

--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -63,6 +63,10 @@ func (mm *MemoryManager) SetMmapLayout(ac *arch.Context64, r *limits.LimitSet) (
 
 // Fork creates a copy of mm with 1 user, as for Linux syscalls fork() or
 // clone() (without CLONE_VM).
+//
+// +checklocksexclude:mm.metadataMu
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 	as, err := mm.p.NewAddressSpace()
 	if err != nil {
@@ -129,7 +133,10 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 		// Inform the Mappable, if any, of the new mapping.
 		if vma.mappable != nil {
 			if err := vma.mappable.AddMapping(ctx, mm2, vmaAR, vma.off, vma.canWriteMappableLocked()); err != nil {
-				_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs)
+				// Fork still exclusively owns mm2's VMA and mapping-accounting
+				// state. AddMapping only exposes its activeMu-protected
+				// invalidation state.
+				_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs) // +checklocksignore
 				as.Release()
 				return nil, err
 			}
@@ -233,7 +240,10 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 							pseg.ValuePtr().file.DecRef(pseg.fileRange())
 						}
 						mm2.pmas.RemoveAll()
-						_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs)
+						// Fork still exclusively owns mm2's VMA and mapping-accounting
+						// state. AddMapping only exposes its activeMu-protected
+						// invalidation state.
+						_, droppedIDs = mm2.removeVMAsLocked(ctx, mm2.applicationAddrRange(), droppedIDs) // +checklocksignore
 						as.Release()
 						return nil, err
 					}
@@ -309,11 +319,12 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 // may be pinned for DMA. It returns the gap after the inserted pma.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
-//   - mm2.activeMu must be locked for writing.
 //   - srcpseg.ValuePtr().private == true.
 //   - dstpgap must be the gap in mm2.pmas at which the new pma should be
 //     inserted.
+//
+// +checklocks:mm.activeMu
+// +checklocks:mm2.activeMu
 func (mm *MemoryManager) forkCopyPMALocked(mm2 *MemoryManager, srcpseg pmaIterator, dstpgap pmaGapIterator, memCgID uint32) (pmaGapIterator, error) {
 	if err := srcpseg.getInternalMappingsLocked(); err != nil {
 		return dstpgap, err
@@ -363,6 +374,11 @@ func (mm *MemoryManager) IncUsers() bool {
 
 // DecUsers decrements mm's user count. If the user count reaches 0, all
 // mappings in mm are unmapped.
+//
+// +checklocksexclude:mm.aioManager.mu
+// +checklocksexclude:mm.metadataMu
+// +checklocksexclude:mm.activeMu
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) DecUsers(ctx context.Context) {
 	if users := mm.users.Add(-1); users > 0 {
 		return

--- a/pkg/sentry/mm/metadata.go
+++ b/pkg/sentry/mm/metadata.go
@@ -50,6 +50,8 @@ func (mm *MemoryManager) SetDumpability(d Dumpability) {
 // ArgvStart returns the start of the application argument vector.
 //
 // There is no guarantee that this value is sensible w.r.t. ArgvEnd.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) ArgvStart() hostarch.Addr {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -57,6 +59,8 @@ func (mm *MemoryManager) ArgvStart() hostarch.Addr {
 }
 
 // SetArgvStart sets the start of the application argument vector.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) SetArgvStart(a hostarch.Addr) {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -66,6 +70,8 @@ func (mm *MemoryManager) SetArgvStart(a hostarch.Addr) {
 // ArgvEnd returns the end of the application argument vector.
 //
 // There is no guarantee that this value is sensible w.r.t. ArgvStart.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) ArgvEnd() hostarch.Addr {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -73,6 +79,8 @@ func (mm *MemoryManager) ArgvEnd() hostarch.Addr {
 }
 
 // SetArgvEnd sets the end of the application argument vector.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) SetArgvEnd(a hostarch.Addr) {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -82,6 +90,8 @@ func (mm *MemoryManager) SetArgvEnd(a hostarch.Addr) {
 // EnvvStart returns the start of the application environment vector.
 //
 // There is no guarantee that this value is sensible w.r.t. EnvvEnd.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) EnvvStart() hostarch.Addr {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -89,6 +99,8 @@ func (mm *MemoryManager) EnvvStart() hostarch.Addr {
 }
 
 // SetEnvvStart sets the start of the application environment vector.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) SetEnvvStart(a hostarch.Addr) {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -98,6 +110,8 @@ func (mm *MemoryManager) SetEnvvStart(a hostarch.Addr) {
 // EnvvEnd returns the end of the application environment vector.
 //
 // There is no guarantee that this value is sensible w.r.t. EnvvStart.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) EnvvEnd() hostarch.Addr {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -105,6 +119,8 @@ func (mm *MemoryManager) EnvvEnd() hostarch.Addr {
 }
 
 // SetEnvvEnd sets the end of the application environment vector.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) SetEnvvEnd(a hostarch.Addr) {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -112,6 +128,8 @@ func (mm *MemoryManager) SetEnvvEnd(a hostarch.Addr) {
 }
 
 // Auxv returns the current map of auxiliary vectors.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) Auxv() arch.Auxv {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -119,6 +137,8 @@ func (mm *MemoryManager) Auxv() arch.Auxv {
 }
 
 // SetAuxv sets the entire map of auxiliary vectors.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) SetAuxv(auxv arch.Auxv) {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -129,6 +149,8 @@ func (mm *MemoryManager) SetAuxv(auxv arch.Auxv) {
 //
 // An additional reference will be taken in the case of a non-nil executable,
 // which must be released by the caller.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) Executable() *vfs.FileDescription {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -144,6 +166,8 @@ func (mm *MemoryManager) Executable() *vfs.FileDescription {
 // SetExecutable sets the executable.
 //
 // This takes a reference on d.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) SetExecutable(ctx context.Context, fd *vfs.FileDescription) {
 	mm.metadataMu.Lock()
 
@@ -166,6 +190,8 @@ func (mm *MemoryManager) SetExecutable(ctx context.Context, fd *vfs.FileDescript
 }
 
 // VDSOSigReturn returns the address of vdso_sigreturn.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) VDSOSigReturn() uint64 {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()
@@ -173,6 +199,8 @@ func (mm *MemoryManager) VDSOSigReturn() uint64 {
 }
 
 // SetVDSOSigReturn sets the address of vdso_sigreturn.
+//
+// +checklocksexclude:mm.metadataMu
 func (mm *MemoryManager) SetVDSOSigReturn(addr uint64) {
 	mm.metadataMu.Lock()
 	defer mm.metadataMu.Unlock()

--- a/pkg/sentry/mm/mm.go
+++ b/pkg/sentry/mm/mm.go
@@ -31,8 +31,8 @@
 //						mm.AIOContext.mu
 //
 // Only mm.MemoryManager.Fork is permitted to lock mm.MemoryManager.activeMu in
-// multiple mm.MemoryManagers, as it does so in a well-defined order (forked
-// child first).
+// multiple mm.MemoryManagers, as it does so in a well-defined order (parent
+// first, then the new child).
 package mm
 
 import (
@@ -79,6 +79,8 @@ type MemoryManager struct {
 	// users is the number of dependencies on the mappings in the MemoryManager.
 	// When the number of references in users reaches zero, all mappings are
 	// unmapped.
+	//
+	// +checkatomic
 	users atomicbitops.Int32
 
 	// mappingMu is analogous to Linux's struct mm_struct::mmap_sem.
@@ -90,37 +92,37 @@ type MemoryManager struct {
 	//
 	// Invariants: vmas are always page-aligned.
 	//
-	// vmas is protected by mappingMu.
+	// +checklocks:mappingMu
 	vmas vmaSet
 
 	// brk is the mm's brk, which is manipulated using the brk(2) system call.
 	// The brk is initially set up by the loader which maps an executable
 	// binary into the mm.
 	//
-	// brk is protected by mappingMu.
+	// +checklocks:mappingMu
 	brk hostarch.AddrRange
 
 	// usageAS is vmas.Span(), cached to accelerate RLIMIT_AS checks.
 	//
-	// usageAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	usageAS uint64
 
 	// lockedAS is the combined size in bytes of all vmas with vma.mlockMode !=
 	// memmap.MLockNone.
 	//
-	// lockedAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	lockedAS uint64
 
 	// dataAS is the size of private data segments, like mm_struct->data_vm.
 	// It means the vma which is private, writable, not stack.
 	//
-	// dataAS is protected by mappingMu.
+	// +checklocks:mappingMu
 	dataAS uint64
 
 	// New VMAs created by MMap use whichever of memmap.MMapOpts.MLockMode or
 	// defMLockMode is greater.
 	//
-	// defMLockMode is protected by mappingMu.
+	// +checklocks:mappingMu
 	defMLockMode memmap.MLockMode
 
 	// activeMu is loosely analogous to Linux's struct
@@ -133,40 +135,43 @@ type MemoryManager struct {
 	// a copy.
 	//
 	// Inserting or removing segments from pmas should happen along with a
-	// call to mm.insertRSS or mm.removeRSS.
+	// call to mm.addRSSLocked or mm.removeRSSLocked.
 	//
 	// Invariants: pmas are always page-aligned. If a pma exists for a given
 	// address, a vma must also exist for that address.
 	//
-	// pmas is protected by activeMu.
+	// +checklocks:activeMu
 	pmas pmaSet
 
 	// curRSS is pmas.Span(), cached to accelerate updates to maxRSS. It is
 	// reported as the MemoryManager's RSS.
 	//
-	// maxRSS should be modified only via insertRSS and removeRSS, not
+	// curRSS should be modified only via addRSSLocked and removeRSSLocked, not
 	// directly.
 	//
-	// maxRSS is protected by activeMu.
+	// +checklocks:activeMu
 	curRSS uint64
 
 	// maxRSS is the maximum resident set size in bytes of a MemoryManager.
 	// It is tracked as the application adds and removes mappings to pmas.
 	//
-	// maxRSS should be modified only via insertRSS, not directly.
+	// maxRSS should be modified only via addRSSLocked, not directly.
 	//
-	// maxRSS is protected by activeMu.
+	// +checklocks:activeMu
 	maxRSS uint64
 
 	// hasPinned is true if pages in this MemoryManager have ever been pinned
 	// by Pin. It is never cleared, even if all pinned pages are unpinned;
 	// compare Linux's MMF_HAS_PINNED.
 	//
-	// hasPinned is protected by activeMu.
+	// +checklocks:activeMu
 	hasPinned bool
 
 	// as is the platform.AddressSpace that pmas are mapped into. as is immutable
-	// until users becomes 0, at which point as becomes nil.
+	// until users becomes 0, at which point as becomes nil. Reads with a live
+	// user reference need no lock. activeMu serializes teardown and invalidation
+	// after the last user; checklocks cannot express this lifetime-dependent
+	// locking.
 	as platform.AddressSpace `state:"nosave"`
 
 	// If captureInvalidations is true, calls to MM.Invalidate() are recorded
@@ -174,15 +179,20 @@ type MemoryManager struct {
 	// This is to avoid a race condition in MM.Fork(); see that function for
 	// details.
 	//
-	// Both captureInvalidations and capturedInvalidations are protected by
-	// activeMu. Neither need to be saved since captureInvalidations is only
+	// Neither field needs to be saved since captureInvalidations is only
 	// enabled during MM.Fork(), during which saving can't occur.
-	captureInvalidations  bool             `state:"zerovalue"`
+	//
+	// +checklocks:activeMu
+	captureInvalidations bool `state:"zerovalue"`
+
+	// +checklocks:activeMu
 	capturedInvalidations []invalidateArgs `state:"nosave"`
 
 	// dumpability describes if and how this MemoryManager may be dumped to
 	// userspace. This is read under kernel.TaskSet.mu, so it can't be protected
 	// by metadataMu.
+	//
+	// +checkatomic
 	dumpability atomicbitops.Int32
 
 	metadataMu metadataMutex `state:"nosave"`
@@ -191,25 +201,25 @@ type MemoryManager struct {
 	// modified by prctl(PR_SET_MM_ARG_START/PR_SET_MM_ARG_END). No
 	// requirements apply to argv; we do not require that argv.WellFormed().
 	//
-	// argv is protected by metadataMu.
+	// +checklocks:metadataMu
 	argv hostarch.AddrRange
 
 	// envv is the application envv. This is set up by the loader and may be
 	// modified by prctl(PR_SET_MM_ENV_START/PR_SET_MM_ENV_END). No
 	// requirements apply to envv; we do not require that envv.WellFormed().
 	//
-	// envv is protected by metadataMu.
+	// +checklocks:metadataMu
 	envv hostarch.AddrRange
 
 	// auxv is the ELF's auxiliary vector.
 	//
-	// auxv is protected by metadataMu.
+	// +checklocks:metadataMu
 	auxv arch.Auxv
 
 	// executable is the executable for this MemoryManager. If executable
-	// is not nil, it holds a reference on the Dirent.
+	// is not nil, it holds a reference on the FileDescription.
 	//
-	// executable is protected by metadataMu.
+	// +checklocks:metadataMu
 	executable *vfs.FileDescription
 
 	// aioManager keeps track of AIOContexts used for async IOs. AIOManager
@@ -217,22 +227,34 @@ type MemoryManager struct {
 	aioManager aioManager
 
 	// vdsoSigReturnAddr is the address of 'vdso_sigreturn'.
+	//
+	// +checklocks:metadataMu
 	vdsoSigReturnAddr uint64
 
 	// membarrierPrivateEnabled is non-zero if EnableMembarrierPrivate has
 	// previously been called. Since, as of this writing,
 	// MEMBARRIER_CMD_PRIVATE_EXPEDITED is implemented as a global memory
 	// barrier, membarrierPrivateEnabled has no other effect.
+	//
+	// +checkatomic
 	membarrierPrivateEnabled atomicbitops.Uint32
 
 	// membarrierRSeqEnabled is non-zero if EnableMembarrierRSeq has previously
 	// been called.
+	//
+	// +checkatomic
 	membarrierRSeqEnabled atomicbitops.Uint32
 }
 
 // vma represents a virtual memory area.
 //
-// Note: new fields added to this struct must be added to vma.Copy and
+// After MemoryManager construction, fields in stored VMAs are protected by its
+// mappingMu, except as noted below. Detached copies are exclusively owned.
+//
+// Neither vma nor its generated iterators have a MemoryManager backpointer,
+// so checklocks cannot name the owner mutex for their fields and methods.
+//
+// Note: new fields added to this struct must be added to vma.copy and
 // vmaSetFunctions.Merge.
 //
 // +stateify savable
@@ -304,8 +326,12 @@ type vma struct {
 	// lastFault records the last address that was paged faulted. It hints at
 	// which direction addresses in this vma are being accessed.
 	//
-	// This field can be read atomically, and written with mm.activeMu locked for
-	// writing and mm.mapping locked.
+	// Accesses to this field in stored VMAs are atomic. Fault updates hold
+	// mappingMu at least for reading and activeMu for writing. After
+	// construction, VMA-set mutations hold mappingMu for writing, excluding
+	// fault updates. Detached copies may use ordinary reads and writes.
+	//
+	// +checkatomic
 	lastFault uintptr
 }
 
@@ -331,6 +357,11 @@ func (v *vma) copy() vma {
 }
 
 // pma represents a platform mapping area.
+//
+// Stored PMA metadata is protected by the owning MemoryManager.activeMu.
+// Detached copies of the metadata can be used under exclusive ownership.
+// Neither pma nor its generated iterators have a MemoryManager backpointer,
+// so checklocks cannot name the owner mutex for their fields and methods.
 //
 // +stateify savable
 type pma struct {

--- a/pkg/sentry/mm/mm_test.go
+++ b/pkg/sentry/mm/mm_test.go
@@ -51,7 +51,10 @@ func testMemoryManager(ctx context.Context, t *testing.T) *MemoryManager {
 	return testMemoryManagerWithMmapDirection(ctx, t, arch.MmapBottomUp)
 }
 
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) realUsageAS() uint64 {
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
 	return uint64(mm.vmas.Span())
 }
 
@@ -68,18 +71,21 @@ func TestUsageASUpdates(t *testing.T) {
 		t.Fatalf("MMap got err %v want nil", err)
 	}
 	realUsage := mm.realUsageAS()
-	if mm.usageAS != realUsage {
-		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", mm.usageAS, realUsage)
+	if got := mm.VirtualMemorySize(); got != realUsage {
+		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", got, realUsage)
 	}
 
 	mm.MUnmap(ctx, addr, hostarch.PageSize)
 	realUsage = mm.realUsageAS()
-	if mm.usageAS != realUsage {
-		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", mm.usageAS, realUsage)
+	if got := mm.VirtualMemorySize(); got != realUsage {
+		t.Fatalf("usageAS believes %v bytes are mapped; %v bytes are actually mapped", got, realUsage)
 	}
 }
 
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) realDataAS() uint64 {
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
 	var sz uint64
 	for seg := mm.vmas.FirstSegment(); seg.Ok(); seg = seg.NextSegment() {
 		vma := seg.ValuePtr()
@@ -104,32 +110,32 @@ func TestDataASUpdates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MMap got err %v want nil", err)
 	}
-	if mm.dataAS == 0 {
+	if mm.VirtualDataSize() == 0 {
 		t.Fatalf("dataAS is 0, wanted not 0")
 	}
 	realDataAS := mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MUnmap(ctx, addr, hostarch.PageSize)
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MProtect(addr+hostarch.PageSize, hostarch.PageSize, hostarch.Read, false)
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 
 	mm.MRemap(ctx, addr+2*hostarch.PageSize, hostarch.PageSize, 2*hostarch.PageSize, MRemapOpts{
 		Move: MRemapMayMove,
 	})
 	realDataAS = mm.realDataAS()
-	if mm.dataAS != realDataAS {
-		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", mm.dataAS, realDataAS)
+	if got := mm.VirtualDataSize(); got != realDataAS {
+		t.Fatalf("dataAS believes %v bytes are mapped; %v bytes are actually mapped", got, realDataAS)
 	}
 }
 

--- a/pkg/sentry/mm/pma.go
+++ b/pkg/sentry/mm/pma.go
@@ -35,9 +35,9 @@ import (
 // iterator to the pma containing ar.Start. Otherwise it returns a terminal
 // iterator.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - ar.Length() != 0.
+// Preconditions: ar.Length() != 0.
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) existingPMAsLocked(ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool, needInternalMappings bool) pmaIterator {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -73,7 +73,7 @@ func (mm *MemoryManager) existingPMAsLocked(ar hostarch.AddrRange, at hostarch.A
 // existingVecPMAsLocked returns true if pmas exist for all addresses in ars,
 // and support access of type (at, ignorePermissions).
 //
-// Preconditions: mm.activeMu must be locked.
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) existingVecPMAsLocked(ars hostarch.AddrRangeSeq, at hostarch.AccessType, ignorePermissions bool, needInternalMappings bool) bool {
 	for ; !ars.IsEmpty(); ars = ars.Tail() {
 		if ar := ars.Head(); ar.Length() != 0 && !mm.existingPMAsLocked(ar, at, ignorePermissions, needInternalMappings).Ok() {
@@ -105,12 +105,13 @@ func (mm *MemoryManager) existingVecPMAsLocked(ars hostarch.AddrRangeSeq, at hos
 // mm/internal.h:gup_must_unshare(FOLL_PIN|FOLL_LONGTERM).
 //
 // Preconditions:
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - vseg.Range().Contains(ar.Start).
 //   - vmas must exist for all addresses in ar, and support accesses of type at
 //     (i.e. permission checks must have been performed against vmas).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getPMAsLocked(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, callerIndirectCommit, forPin bool) (pmaIterator, pmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -153,11 +154,11 @@ func (mm *MemoryManager) getPMAsLocked(ctx context.Context, vseg vmaIterator, ar
 // exist. If this is not equal to ars, it returns a non-nil error explaining
 // why.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
-//   - vmas must exist for all addresses in ars, and support accesses of type at
-//     (i.e. permission checks must have been performed against vmas).
+// Preconditions: vmas must exist for all addresses in ars, and support accesses
+// of type at (i.e. permission checks must have been performed against vmas).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getVecPMAsLocked(ctx context.Context, ars hostarch.AddrRangeSeq, at hostarch.AccessType, callerIndirectCommit bool) (hostarch.AddrRangeSeq, error) {
 	for arsit := ars; !arsit.IsEmpty(); arsit = arsit.Tail() {
 		ar := arsit.Head()
@@ -230,6 +231,9 @@ func (mm *MemoryManager) getAllocationDirection(ar hostarch.AddrRange, vma *vma)
 //   - getPMAsInternalLocked additionally requires that ar is page-aligned.
 //     getPMAsInternalLocked is an implementation helper for getPMAsLocked and
 //     getVecPMAsLocked; other clients should call one of those instead.
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) getPMAsInternalLocked(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, at hostarch.AccessType, callerIndirectCommit, forPin bool) (pmaIterator, pmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -628,10 +632,10 @@ func hugepageAligned(ar hostarch.AddrRange) hostarch.AddrRange {
 // the memory it maps, isPMACopyOnWriteLocked will take ownership of the memory
 // and update the pma to indicate that it does not require copy-on-write.
 //
-// Preconditions:
-//   - vseg.Range().IsSupersetOf(pseg.Range()).
-//   - mm.mappingMu must be locked.
-//   - mm.activeMu must be locked for writing.
+// Preconditions: vseg.Range().IsSupersetOf(pseg.Range()).
+//
+// +checklocksread:mm.mappingMu
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) isPMACopyOnWriteLocked(vseg vmaIterator, pseg pmaIterator) bool {
 	pma := pseg.ValuePtr()
 	if !pma.needCOW {
@@ -656,6 +660,8 @@ func (mm *MemoryManager) isPMACopyOnWriteLocked(vseg vmaIterator, pseg pmaIterat
 }
 
 // Invalidate implements memmap.MappingSpace.Invalidate.
+//
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) Invalidate(ar hostarch.AddrRange, opts memmap.InvalidateOpts) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -676,9 +682,10 @@ func (mm *MemoryManager) Invalidate(ar hostarch.AddrRange, opts memmap.Invalidat
 // addresses in ar.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) invalidateLocked(ar hostarch.AddrRange, invalidatePrivate, invalidateShared bool) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -745,6 +752,9 @@ func (mm *MemoryManager) invalidateLocked(ar hostarch.AddrRange, invalidatePriva
 // Preconditions:
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) Pin(ctx context.Context, ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool) ([]PinnedRange, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -827,12 +837,13 @@ func Unpin(prs []PinnedRange) {
 // movePMAsLocked moves all pmas in oldAR to newAR.
 //
 // Preconditions:
-//   - mm.activeMu must be locked for writing.
 //   - oldAR.Length() != 0.
 //   - oldAR.Length() <= newAR.Length().
 //   - !oldAR.Overlaps(newAR).
 //   - mm.pmas.IsEmptyRange(newAR).
 //   - oldAR and newAR must be page-aligned.
+//
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) movePMAsLocked(oldAR, newAR hostarch.AddrRange) {
 	if checkInvariants {
 		if !oldAR.WellFormed() || oldAR.Length() == 0 || !oldAR.IsPageAligned() {
@@ -881,12 +892,13 @@ func (mm *MemoryManager) movePMAsLocked(oldAR, newAR hostarch.AddrRange) {
 // internalMappingsLocked returns cached internal mappings for addresses in ar.
 //
 // Preconditions:
-//   - mm.activeMu must be locked.
 //   - While mm.activeMu was locked, a call to
 //     existingPMAsLocked(needInternalMappings=true) succeeded for all
 //     addresses in ar.
 //   - ar.Length() != 0.
 //   - pseg.Range().Contains(ar.Start).
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) internalMappingsLocked(pseg pmaIterator, ar hostarch.AddrRange) safemem.BlockSeq {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -921,11 +933,11 @@ func (mm *MemoryManager) internalMappingsLocked(pseg pmaIterator, ar hostarch.Ad
 // vecInternalMappingsLocked returns cached internal mappings for addresses in
 // ars.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - While mm.activeMu was locked, a call to
-//     existingVecPMAsLocked(needInternalMappings=true) succeeded for all
-//     addresses in ars.
+// Preconditions: While mm.activeMu was locked, a call to
+// existingVecPMAsLocked(needInternalMappings=true) succeeded for all addresses
+// in ars.
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) vecInternalMappingsLocked(ars hostarch.AddrRangeSeq) safemem.BlockSeq {
 	var ims []safemem.Block
 	for ; !ars.IsEmpty(); ars = ars.Tail() {
@@ -943,7 +955,7 @@ func (mm *MemoryManager) vecInternalMappingsLocked(ars hostarch.AddrRangeSeq) sa
 // addRSSLocked updates the current and maximum resident set size of a
 // MemoryManager to reflect the insertion of a pma at ar.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) addRSSLocked(ar hostarch.AddrRange) {
 	mm.curRSS += uint64(ar.Length())
 	if mm.curRSS > mm.maxRSS {
@@ -954,7 +966,7 @@ func (mm *MemoryManager) addRSSLocked(ar hostarch.AddrRange) {
 // removeRSSLocked updates the current resident set size of a MemoryManager to
 // reflect the removal of a pma at ar.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// +checklocks:mm.activeMu
 func (mm *MemoryManager) removeRSSLocked(ar hostarch.AddrRange) {
 	mm.curRSS -= uint64(ar.Length())
 }
@@ -1008,9 +1020,9 @@ func (pmaSetFunctions) Split(ar hostarch.AddrRange, p pma, split hostarch.Addr) 
 // findOrSeekPrevUpperBoundPMA returns mm.pmas.UpperBoundSegment(addr), but may do
 // so by scanning linearly backward from pgap.
 //
-// Preconditions:
-//   - mm.activeMu must be locked.
-//   - addr <= pgap.Start().
+// Preconditions: addr <= pgap.Start().
+//
+// +checklocksread:mm.activeMu
 func (mm *MemoryManager) findOrSeekPrevUpperBoundPMA(addr hostarch.Addr, pgap pmaGapIterator) pmaIterator {
 	if checkInvariants {
 		if !pgap.Ok() {
@@ -1030,9 +1042,10 @@ func (mm *MemoryManager) findOrSeekPrevUpperBoundPMA(addr hostarch.Addr, pgap pm
 }
 
 // getInternalMappingsLocked ensures that pseg.ValuePtr().internalMappings is
-// non-empty.
+// non-empty. The generated iterator identifies a set node and index, not its
+// MemoryManager, so checklocks cannot name the owning mutex.
 //
-// Preconditions: mm.activeMu must be locked for writing.
+// Preconditions: the owning MemoryManager's activeMu is held for writing.
 func (pseg pmaIterator) getInternalMappingsLocked() error {
 	pma := pseg.ValuePtr()
 	if pma.internalMappings.IsEmpty() {

--- a/pkg/sentry/mm/procfs.go
+++ b/pkg/sentry/mm/procfs.go
@@ -76,7 +76,11 @@ func (mm *MemoryManager) MapsCallbackFuncForBuffer(buf *bytes.Buffer) MapsCallba
 }
 
 // ReadMapsDataInto is called by fsimpl/proc.mapsData.Generate to
-// implement /proc/[pid]/maps.
+// implement /proc/[pid]/maps. It invokes fn synchronously with mappingMu read
+// locked. The callback must not reacquire mappingMu or violate the lock order;
+// checklocks cannot attach this incoming lock state to the function value.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) ReadMapsDataInto(ctx context.Context, fn MapsCallbackFunc) {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -98,14 +102,14 @@ func (mm *MemoryManager) ReadMapsDataInto(ctx context.Context, fn MapsCallbackFu
 // vmaMapsEntryLocked returns a /proc/[pid]/maps entry for the vma iterated by
 // vseg, including the trailing newline.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) vmaMapsEntryLocked(ctx context.Context, vseg vmaIterator) []byte {
 	var b bytes.Buffer
 	mm.appendVMAMapsEntryLocked(ctx, vseg, mm.MapsCallbackFuncForBuffer(&b))
 	return b.Bytes()
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) appendVMAMapsEntryLocked(ctx context.Context, vseg vmaIterator, fn MapsCallbackFunc) {
 	vma := vseg.ValuePtr()
 	private := "p"
@@ -133,6 +137,9 @@ func (mm *MemoryManager) appendVMAMapsEntryLocked(ctx context.Context, vseg vmaI
 
 // ReadSmapsDataInto is called by fsimpl/proc.smapsData.Generate to
 // implement /proc/[pid]/maps.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) ReadSmapsDataInto(ctx context.Context, buf *bytes.Buffer) {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -149,13 +156,16 @@ func (mm *MemoryManager) ReadSmapsDataInto(ctx context.Context, buf *bytes.Buffe
 // vmaSmapsEntryLocked returns a /proc/[pid]/smaps entry for the vma iterated
 // by vseg, including the trailing newline.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) vmaSmapsEntryLocked(ctx context.Context, vseg vmaIterator) []byte {
 	var b bytes.Buffer
 	mm.vmaSmapsEntryIntoLocked(ctx, vseg, &b)
 	return b.Bytes()
 }
 
+// +checklocksread:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) vmaSmapsEntryIntoLocked(ctx context.Context, vseg vmaIterator, b *bytes.Buffer) {
 	mm.appendVMAMapsEntryLocked(ctx, vseg, mm.MapsCallbackFuncForBuffer(b))
 	vma := vseg.ValuePtr()

--- a/pkg/sentry/mm/save_restore.go
+++ b/pkg/sentry/mm/save_restore.go
@@ -25,6 +25,8 @@ import (
 
 // InvalidateUnsavable invokes memmap.Mappable.InvalidateUnsavable on all
 // Mappables mapped by mm.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) InvalidateUnsavable(ctx context.Context) error {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()

--- a/pkg/sentry/mm/shm.go
+++ b/pkg/sentry/mm/shm.go
@@ -23,6 +23,9 @@ import (
 )
 
 // DetachShm unmaps a sysv shared memory segment.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) DetachShm(ctx context.Context, addr hostarch.Addr) error {
 	if addr != addr.RoundDown() {
 		// "... shmaddr is not aligned on a page boundary." - man shmdt(2)

--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -32,6 +32,9 @@ import (
 // application thread's stack pointer.
 //
 // Preconditions: mm.as != nil.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) HandleUserFault(ctx context.Context, addr hostarch.Addr, at hostarch.AccessType, sp hostarch.Addr) error {
 	addr = hostarch.UntaggedUserAddr(addr)
 	ar, ok := addr.RoundDown().ToRange(hostarch.PageSize)
@@ -72,6 +75,9 @@ func (mm *MemoryManager) HandleUserFault(ctx context.Context, addr hostarch.Addr
 }
 
 // MMap establishes a memory mapping.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MMap(ctx context.Context, opts memmap.MMapOpts) (hostarch.Addr, error) {
 	if opts.Length == 0 {
 		return 0, linuxerr.EINVAL
@@ -174,9 +180,10 @@ func (mm *MemoryManager) MMap(ctx context.Context, opts memmap.MMapOpts) (hostar
 // populateVMA obtains pmas for addresses in ar in the given vma, and maps them
 // into mm.as if it is active.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked.
-//   - vseg.Range().IsSupersetOf(ar).
+// Preconditions: vseg.Range().IsSupersetOf(ar).
+//
+// +checklocksread:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) populateVMA(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, platformEffect memmap.MMapPlatformEffect) error {
 	if !vseg.ValuePtr().effectivePerms.Any() {
 		// mm.mapASLocked() will no-op due to platform.AddressSpace.MapFile()
@@ -221,6 +228,7 @@ func (mm *MemoryManager) populateVMA(ctx context.Context, vseg vmaIterator, ar h
 //
 // Postconditions: mm.mappingMu will be unlocked.
 // +checklocksrelease:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) populateVMAAndUnlock(ctx context.Context, vseg vmaIterator, ar hostarch.AddrRange, platformEffect memmap.MMapPlatformEffect) {
 	if !vseg.ValuePtr().effectivePerms.Any() {
 		// Linux doesn't populate inaccessible pages. See
@@ -258,6 +266,9 @@ func (mm *MemoryManager) populateVMAAndUnlock(ctx context.Context, vseg vmaItera
 }
 
 // MapStack allocates the initial process stack.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MapStack(ctx context.Context) (hostarch.AddrRange, error) {
 	// maxStackSize is the maximum supported process stack size in bytes.
 	//
@@ -307,6 +318,9 @@ func (mm *MemoryManager) MapStack(ctx context.Context) (hostarch.AddrRange, erro
 }
 
 // MUnmap implements the semantics of Linux's munmap(2).
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MUnmap(ctx context.Context, addr hostarch.Addr, length uint64) error {
 	addr = hostarch.UntaggedUserAddr(addr)
 	if addr != addr.RoundDown() {
@@ -362,6 +376,9 @@ const (
 )
 
 // MRemap implements the semantics of Linux's mremap(2).
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MRemap(ctx context.Context, oldAddr hostarch.Addr, oldSize uint64, newSize uint64, opts MRemapOpts) (hostarch.Addr, error) {
 	oldAddr = hostarch.UntaggedUserAddr(oldAddr)
 
@@ -633,6 +650,9 @@ func (mm *MemoryManager) MRemap(ctx context.Context, oldAddr hostarch.Addr, oldS
 }
 
 // MProtect implements the semantics of Linux's mprotect(2).
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MProtect(addr hostarch.Addr, length uint64, realPerms hostarch.AccessType, growsDown bool) error {
 	addr = hostarch.UntaggedUserAddr(addr)
 	if addr.RoundDown() != addr {
@@ -738,6 +758,8 @@ func (mm *MemoryManager) MProtect(addr hostarch.Addr, length uint64, realPerms h
 }
 
 // BrkSetup sets mm's brk address to addr and its brk size to 0.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) BrkSetup(ctx context.Context, addr hostarch.Addr) {
 	var droppedIDs []memmap.MappingIdentity
 	mm.mappingMu.Lock()
@@ -754,6 +776,9 @@ func (mm *MemoryManager) BrkSetup(ctx context.Context, addr hostarch.Addr) {
 
 // Brk implements the semantics of Linux's brk(2), except that it returns an
 // error on failure.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) Brk(ctx context.Context, addr hostarch.Addr) (hostarch.Addr, error) {
 	mm.mappingMu.Lock()
 	// Can't defer mm.mappingMu.Unlock(); see below.
@@ -838,6 +863,9 @@ func (mm *MemoryManager) Brk(ctx context.Context, addr hostarch.Addr) (hostarch.
 
 // MLock implements the semantics of Linux's mlock()/mlock2()/munlock(),
 // depending on mode.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MLock(ctx context.Context, addr hostarch.Addr, length uint64, mode memmap.MLockMode) error {
 	addr = hostarch.UntaggedUserAddr(addr)
 	// Linux allows this to overflow.
@@ -960,6 +988,9 @@ type MLockAllOpts struct {
 
 // MLockAll implements the semantics of Linux's mlockall()/munlockall(),
 // depending on opts.
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MLockAll(ctx context.Context, opts MLockAllOpts) error {
 	if !opts.Current && !opts.Future {
 		return linuxerr.EINVAL
@@ -1029,6 +1060,8 @@ func (mm *MemoryManager) MLockAll(ctx context.Context, opts MLockAllOpts) error 
 }
 
 // NumaPolicy implements the semantics of Linux's get_mempolicy(MPOL_F_ADDR).
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) NumaPolicy(addr hostarch.Addr) (linux.NumaPolicy, uint64, error) {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -1041,6 +1074,8 @@ func (mm *MemoryManager) NumaPolicy(addr hostarch.Addr) (linux.NumaPolicy, uint6
 }
 
 // SetNumaPolicy implements the semantics of Linux's mbind().
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) SetNumaPolicy(addr hostarch.Addr, length uint64, policy linux.NumaPolicy, nodemask uint64) error {
 	if !addr.IsPageAligned() {
 		return linuxerr.EINVAL
@@ -1109,6 +1144,9 @@ func madviseAddrRange(addr hostarch.Addr, length uint64) (hostarch.AddrRange, er
 }
 
 // Decommit implements the semantics of Linux's madvise(MADV_DONTNEED).
+//
+// +checklocksexclude:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) Decommit(addr hostarch.Addr, length uint64) error {
 	addr = hostarch.UntaggedUserAddr(addr)
 	ar, err := madviseAddrRange(addr, length)
@@ -1255,6 +1293,12 @@ func (mm *MemoryManager) Decommit(addr hostarch.Addr, length uint64) error {
 // address range that are not mapped, the Linux version of madvise() ignores
 // them and applies the call to the rest (but returns ENOMEM from the system
 // call, as it should)."
+//
+// f runs synchronously under mappingMu. It must preserve the iterator's
+// validity and must not reacquire mappingMu. checklocks cannot carry the
+// held lock state or iterator ownership through the function value.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) madviseMutateVMAs(addr hostarch.Addr, length uint64, f func(vseg vmaIterator) error) error {
 	ar, err := madviseAddrRange(addr, length)
 	if err != nil {
@@ -1302,6 +1346,8 @@ func (mm *MemoryManager) madviseMutateVMAs(addr hostarch.Addr, length uint64, f 
 // SetDontFork implements the semantics of madvise MADV_DONTFORK.
 //
 // Preconditions: addr and length are page-aligned.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) SetDontFork(addr hostarch.Addr, length uint64, dontfork bool) error {
 	addr = hostarch.UntaggedUserAddr(addr)
 	return mm.madviseMutateVMAs(addr, length, func(vseg vmaIterator) error {
@@ -1312,6 +1358,8 @@ func (mm *MemoryManager) SetDontFork(addr hostarch.Addr, length uint64, dontfork
 
 // SetVMAAnonName implements the semantics of Linux's
 // prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME).
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) SetVMAAnonName(addr hostarch.Addr, length uint64, name string, nameIsNil bool) error {
 	// Check that name contains only valid characters; compare Linux
 	// kernel/sys.c:is_valid_name_char(). `for ... := range string`
@@ -1354,6 +1402,8 @@ type MSyncOpts struct {
 }
 
 // MSync implements the semantics of Linux's msync().
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) MSync(ctx context.Context, addr hostarch.Addr, length uint64, opts MSyncOpts) error {
 	addr = hostarch.UntaggedUserAddr(addr)
 	if addr != addr.RoundDown() {
@@ -1431,6 +1481,8 @@ func (mm *MemoryManager) MSync(ctx context.Context, addr hostarch.Addr, length u
 }
 
 // GetSharedFutexKey is used by kernel.Task.GetSharedKey.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) GetSharedFutexKey(ctx context.Context, addr hostarch.Addr) (futex.Key, error) {
 	ar, ok := addr.ToRange(4) // sizeof(int32).
 	if !ok {
@@ -1465,6 +1517,8 @@ func (mm *MemoryManager) GetSharedFutexKey(ctx context.Context, addr hostarch.Ad
 
 // VirtualMemorySize returns the combined length in bytes of all mappings in
 // mm.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) VirtualMemorySize() uint64 {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -1473,6 +1527,8 @@ func (mm *MemoryManager) VirtualMemorySize() uint64 {
 
 // VirtualMemorySizeRange returns the combined length in bytes of all mappings
 // in ar in mm.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) VirtualMemorySizeRange(ar hostarch.AddrRange) uint64 {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -1480,6 +1536,8 @@ func (mm *MemoryManager) VirtualMemorySizeRange(ar hostarch.AddrRange) uint64 {
 }
 
 // ResidentSetSize returns the value advertised as mm's RSS in bytes.
+//
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) ResidentSetSize() uint64 {
 	mm.activeMu.RLock()
 	defer mm.activeMu.RUnlock()
@@ -1487,6 +1545,8 @@ func (mm *MemoryManager) ResidentSetSize() uint64 {
 }
 
 // MaxResidentSetSize returns the value advertised as mm's max RSS in bytes.
+//
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) MaxResidentSetSize() uint64 {
 	mm.activeMu.RLock()
 	defer mm.activeMu.RUnlock()
@@ -1494,6 +1554,8 @@ func (mm *MemoryManager) MaxResidentSetSize() uint64 {
 }
 
 // VirtualDataSize returns the size of private data segments in mm.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) VirtualDataSize() uint64 {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -1525,6 +1587,8 @@ func (mm *MemoryManager) IsMembarrierRSeqEnabled() bool {
 }
 
 // FindVMAByName finds a vma with the specified name and returns its start address and offset.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) FindVMAByName(ar hostarch.AddrRange, name string) (hostarch.Addr, uint64, error) {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()
@@ -1547,6 +1611,8 @@ func (mm *MemoryManager) FindVMAByName(ar hostarch.AddrRange, name string) (host
 // error if addr is not mapped. The RDMA proxy uses it to bound a
 // driver-private DMA buffer (work queue / doorbell) whose backing region the
 // guest describes by start address only, with no explicit length.
+//
+// +checklocksexclude:mm.mappingMu
 func (mm *MemoryManager) FindVMARange(addr hostarch.Addr) (hostarch.AddrRange, error) {
 	mm.mappingMu.RLock()
 	defer mm.mappingMu.RUnlock()

--- a/pkg/sentry/mm/vma.go
+++ b/pkg/sentry/mm/vma.go
@@ -34,9 +34,10 @@ import (
 // calls to functions that drop mapping identities within a scope should reuse
 // the same slice.
 //
-// Preconditions:
-//   - mm.mappingMu must be locked for writing.
-//   - opts must be valid as defined by the checks in MMap.
+// Preconditions: opts must be valid as defined by the checks in MMap.
+//
+// +checklocks:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) createVMALocked(ctx context.Context, opts memmap.MMapOpts, droppedIDs []memmap.MappingIdentity) (vmaIterator, hostarch.AddrRange, []memmap.MappingIdentity, error) {
 	if opts.MaxPerms != opts.MaxPerms.Effective() {
 		panic(fmt.Sprintf("Non-effective MaxPerms %s cannot be enforced", opts.MaxPerms))
@@ -172,7 +173,7 @@ const (
 
 // findAvailableLocked finds an allocatable range.
 //
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findAvailableLocked(length uint64, opts findAvailableOpts) (hostarch.Addr, error) {
 	if opts.Fixed {
 		opts.Map32Bit = false
@@ -231,7 +232,7 @@ func (mm *MemoryManager) applicationAddrRange() hostarch.AddrRange {
 	return hostarch.AddrRange{mm.layout.MinAddr, mm.layout.MaxAddr}
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findLowestAvailableLocked(length, alignment uint64, bounds hostarch.AddrRange) (hostarch.Addr, error) {
 	for gap := mm.vmas.LowerBoundGap(bounds.Start); gap.Ok() && gap.Start() < bounds.End; gap = gap.NextLargeEnoughGap(hostarch.Addr(length)) {
 		if gr := gap.availableRange().Intersect(bounds); uint64(gr.Length()) >= length {
@@ -250,7 +251,7 @@ func (mm *MemoryManager) findLowestAvailableLocked(length, alignment uint64, bou
 	return 0, linuxerr.ENOMEM
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) findHighestAvailableLocked(length, alignment uint64, bounds hostarch.AddrRange) (hostarch.Addr, error) {
 	for gap := mm.vmas.UpperBoundGap(bounds.End); gap.Ok() && gap.End() > bounds.Start; gap = gap.PrevLargeEnoughGap(hostarch.Addr(length)) {
 		if gr := gap.availableRange().Intersect(bounds); uint64(gr.Length()) >= length {
@@ -270,7 +271,7 @@ func (mm *MemoryManager) findHighestAvailableLocked(length, alignment uint64, bo
 	return 0, linuxerr.ENOMEM
 }
 
-// Preconditions: mm.mappingMu must be locked.
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) mlockedBytesRangeLocked(ar hostarch.AddrRange) uint64 {
 	var total uint64
 	for vseg := mm.vmas.LowerBoundSegment(ar.Start); vseg.Ok() && vseg.Start() < ar.End; vseg = vseg.NextSegment() {
@@ -296,6 +297,8 @@ func (mm *MemoryManager) mlockedBytesRangeLocked(ar hostarch.AddrRange) uint64 {
 // Preconditions:
 //   - mm.mappingMu must be locked for reading; it may be temporarily unlocked.
 //   - ar.Length() != 0.
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) getVMAsLocked(ctx context.Context, ar hostarch.AddrRange, at hostarch.AccessType, ignorePermissions bool) (vmaIterator, vmaGapIterator, error) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 {
@@ -352,6 +355,8 @@ func (mm *MemoryManager) getVMAsLocked(ctx context.Context, ar hostarch.AddrRang
 // temporarily unlocked.
 //
 // Postconditions: ars is not mutated.
+//
+// +checklocksread:mm.mappingMu
 func (mm *MemoryManager) getVecVMAsLocked(ctx context.Context, ars hostarch.AddrRangeSeq, at hostarch.AccessType, ignorePermissions bool) (hostarch.AddrRangeSeq, error) {
 	for arsit := ars; !arsit.IsEmpty(); arsit = arsit.Tail() {
 		ar := arsit.Head()
@@ -383,9 +388,11 @@ const guardBytes = 256 * hostarch.PageSize
 // the same slice.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.mappingMu
+// +checklocksexclude:mm.activeMu
 func (mm *MemoryManager) unmapLocked(ctx context.Context, ar hostarch.AddrRange, droppedIDs []memmap.MappingIdentity) (vmaGapIterator, []memmap.MappingIdentity) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
@@ -409,15 +416,19 @@ func (mm *MemoryManager) unmapLocked(ctx context.Context, ar hostarch.AddrRange,
 // the same slice.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked for writing.
 //   - ar.Length() != 0.
 //   - ar must be page-aligned.
+//
+// +checklocks:mm.mappingMu
 func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrRange, droppedIDs []memmap.MappingIdentity) (vmaGapIterator, []memmap.MappingIdentity) {
 	if checkInvariants {
 		if !ar.WellFormed() || ar.Length() == 0 || !ar.IsPageAligned() {
 			panic(fmt.Sprintf("invalid ar: %v", ar))
 		}
 	}
+	// RemoveRangeWith invokes this callback synchronously, so this method's
+	// entry ownership contract covers its updates. checklocks does not
+	// propagate that contract into a passed callback.
 	vgap := mm.vmas.RemoveRangeWith(ar, func(vseg vmaIterator) {
 		vmaAR := vseg.Range()
 		vma := vseg.ValuePtr()
@@ -427,12 +438,12 @@ func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrR
 		if vma.id != nil {
 			droppedIDs = append(droppedIDs, vma.id)
 		}
-		mm.usageAS -= uint64(vmaAR.Length())
+		mm.usageAS -= uint64(vmaAR.Length()) // +checklocksignore
 		if vma.isPrivateDataLocked() {
-			mm.dataAS -= uint64(vmaAR.Length())
+			mm.dataAS -= uint64(vmaAR.Length()) // +checklocksignore
 		}
 		if vma.mlockMode != memmap.MLockNone {
-			mm.lockedAS -= uint64(vmaAR.Length())
+			mm.lockedAS -= uint64(vmaAR.Length()) // +checklocksignore
 		}
 	})
 	return vgap, droppedIDs
@@ -446,14 +457,23 @@ func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrR
 //
 // canWriteMappableLocked is equivalent to Linux's VM_SHARED.
 //
-// Preconditions: mm.mappingMu must be locked.
+// Preconditions: the owning MemoryManager's mappingMu is held at least for
+// reading, or v is exclusively owned (a detached copy or construction-owned
+// VMA).
+//
+// The vma type describes the missing owner link for checklocks.
 func (v *vma) canWriteMappableLocked() bool {
 	return !v.private && v.maxPerms.Write
 }
 
-// isPrivateDataLocked identify the data segments - private, writable, not stack
+// isPrivateDataLocked reports whether v is a private, writable, non-stack
+// data segment.
 //
-// Preconditions: mm.mappingMu must be locked.
+// Preconditions: the owning MemoryManager's mappingMu is held at least for
+// reading, or v is exclusively owned (a detached copy or construction-owned
+// VMA).
+//
+// The vma type describes the missing owner link for checklocks.
 func (v *vma) isPrivateDataLocked() bool {
 	return v.realPerms.Write && v.private && !v.growsDown
 }
@@ -598,10 +618,11 @@ func (vseg vmaIterator) addrRangeOf(mr memmap.MappableRange) hostarch.AddrRange 
 }
 
 // seekNextLowerBound returns mm.vmas.LowerBoundSegment(addr), but does so by
-// scanning linearly forward from vseg.
+// scanning linearly forward from vseg. The generated iterator has no
+// MemoryManager reference, so checklocks cannot name the owning mutex.
 //
 // Preconditions:
-//   - mm.mappingMu must be locked.
+//   - The owning MemoryManager's mappingMu is held at least for reading.
 //   - addr >= vseg.Start().
 func (vseg vmaIterator) seekNextLowerBound(addr hostarch.Addr) vmaIterator {
 	if checkInvariants {

--- a/pkg/sentry/usage/memory.go
+++ b/pkg/sentry/usage/memory.go
@@ -76,10 +76,14 @@ const (
 	Mapped
 )
 
-// memoryStats tracks application memory usage in bytes. All fields correspond to the
-// memory category with the same name. This object is thread-safe if accessed
-// through the provided methods. The public fields may be safely accessed
-// directly on a copy of the object obtained from Memory.Copy().
+// memoryStats tracks application memory usage in bytes by category.
+//
+// Its methods require the owning MemoryLocked.mu, both for aggregate counters
+// and for entries in MemCgIDToMemStats. This also makes multi-category totals
+// and copies consistent. memoryStats has no link back to its owner, so
+// checklocks cannot name that mutex for these helpers or counter aliases.
+//
+// MemoryLocked.Copy and CopyPerCg return detached MemoryStats scalar values.
 type memoryStats struct {
 	System    atomicbitops.Uint64
 	Anonymous atomicbitops.Uint64
@@ -91,7 +95,7 @@ type memoryStats struct {
 
 // incLocked adds a usage of 'val' bytes from memory category 'kind'.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) incLocked(val uint64, kind MemoryKind) {
 	switch kind {
 	case System:
@@ -113,7 +117,7 @@ func (ms *memoryStats) incLocked(val uint64, kind MemoryKind) {
 
 // decLocked removes a usage of 'val' bytes from memory category 'kind'.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) decLocked(val uint64, kind MemoryKind) {
 	switch kind {
 	case System:
@@ -135,7 +139,7 @@ func (ms *memoryStats) decLocked(val uint64, kind MemoryKind) {
 
 // totalLocked returns a total usage.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) totalLocked() (total uint64) {
 	total += ms.System.RacyLoad()
 	total += ms.Anonymous.RacyLoad()
@@ -146,9 +150,9 @@ func (ms *memoryStats) totalLocked() (total uint64) {
 	return
 }
 
-// copyLocked returns a copy of the structure.
+// copyLocked returns a detached scalar snapshot of the counters.
 //
-// Precondition: must be called when locked.
+// Preconditions: the owning MemoryLocked.mu is held.
 func (ms *memoryStats) copyLocked() MemoryStats {
 	return MemoryStats{
 		System:    ms.System.RacyLoad(),
@@ -180,10 +184,14 @@ var DirtyMemoryAccounting = &DirtyMemoryStats{}
 type DirtyMemoryStats struct {
 	// Dirty is the total bytes of memory that have been modified but not yet
 	// written back to the underlying storage.
+	//
+	// +checkatomic
 	Dirty atomicbitops.Uint64
 
 	// Writeback is the total bytes of memory currently being written back
 	// to the underlying storage.
+	//
+	// +checkatomic
 	Writeback atomicbitops.Uint64
 }
 
@@ -227,17 +235,25 @@ type RTMemoryStats struct {
 	RTMapped atomicbitops.Uint64
 }
 
-// MemoryLocked is Memory with access methods.
+// MemoryLocked serializes aggregate and per-cgroup memory accounting.
 type MemoryLocked struct {
 	mu memoryMutex
-	// memoryStats records the memory stats.
+
+	// memoryStats records the aggregate memory stats.
+	//
+	// +checklocks:mu
 	memoryStats
+
 	// RTMemoryStats records the memory stats that need to be exposed through
 	// shared page.
 	*RTMemoryStats
+
 	// File is the backing file storing the memory stats.
 	File *os.File
+
 	// MemCgIDToMemStats is the map of cgroup ids to memory stats.
+	//
+	// +checklocks:mu
 	MemCgIDToMemStats map[uint32]*memoryStats
 }
 
@@ -286,6 +302,7 @@ func Init() error {
 // resident.
 var MemoryAccounting *MemoryLocked
 
+// +checklocks:m.mu
 func (m *MemoryLocked) incLockedPerCg(val uint64, kind MemoryKind, memCgID uint32) {
 	if _, ok := m.MemCgIDToMemStats[memCgID]; !ok {
 		m.MemCgIDToMemStats[memCgID] = &memoryStats{}
@@ -300,6 +317,8 @@ func (m *MemoryLocked) incLockedPerCg(val uint64, kind MemoryKind, memCgID uint3
 // for the total memory usage.
 //
 // This method is thread-safe.
+//
+// +checklocksexclude:m.mu
 func (m *MemoryLocked) Inc(val uint64, kind MemoryKind, memCgID uint32) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -314,6 +333,7 @@ func (m *MemoryLocked) Inc(val uint64, kind MemoryKind, memCgID uint32) {
 	}
 }
 
+// +checklocks:m.mu
 func (m *MemoryLocked) decLockedPerCg(val uint64, kind MemoryKind, memCgID uint32) {
 	if _, ok := m.MemCgIDToMemStats[memCgID]; !ok {
 		panic(fmt.Sprintf("invalid memory cgroup id: %v", memCgID))
@@ -328,6 +348,8 @@ func (m *MemoryLocked) decLockedPerCg(val uint64, kind MemoryKind, memCgID uint3
 // total usage.
 //
 // This method is thread-safe.
+//
+// +checklocksexclude:m.mu
 func (m *MemoryLocked) Dec(val uint64, kind MemoryKind, memCgID uint32) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -346,6 +368,8 @@ func (m *MemoryLocked) Dec(val uint64, kind MemoryKind, memCgID uint32) {
 // id 'memCgID'.
 //
 // This method is thread-safe.
+//
+// +checklocksexclude:m.mu
 func (m *MemoryLocked) Move(val uint64, to MemoryKind, from MemoryKind, memCgID uint32) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -363,6 +387,8 @@ func (m *MemoryLocked) Move(val uint64, to MemoryKind, from MemoryKind, memCgID 
 // Total returns a total memory usage.
 //
 // This method is thread-safe.
+//
+// +checklocksexclude:m.mu
 func (m *MemoryLocked) Total() uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -372,6 +398,8 @@ func (m *MemoryLocked) Total() uint64 {
 // TotalPerCg returns a total memory usage for a cgroup.
 //
 // This method is thread-safe.
+//
+// +checklocksexclude:m.mu
 func (m *MemoryLocked) TotalPerCg(memCgID uint32) uint64 {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -391,6 +419,8 @@ func (m *MemoryLocked) TotalPerCg(memCgID uint32) uint64 {
 // Copy returns a copy of the structure with a total.
 //
 // This method is thread-safe.
+//
+// +checklocksexclude:m.mu
 func (m *MemoryLocked) Copy() (MemoryStats, uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -400,6 +430,8 @@ func (m *MemoryLocked) Copy() (MemoryStats, uint64) {
 // CopyPerCg returns a copy of the structure with a total for a cgroup.
 //
 // This method is thread-safe.
+//
+// +checklocksexclude:m.mu
 func (m *MemoryLocked) CopyPerCg(memCgID uint32) (MemoryStats, uint64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/sentry/watchdog/watchdog.go
+++ b/pkg/sentry/watchdog/watchdog.go
@@ -130,30 +130,41 @@ type Watchdog struct {
 	// k is where the tasks come from.
 	k *kernel.Kernel
 
-	// stop is used to notify to watchdog should stop.
+	// stop carries stop requests to the monitoring loop. The channel is
+	// initialized by New and reused across runs; it is never closed or replaced.
 	stop chan struct{}
 
-	// done is used to notify when the watchdog has stopped.
+	// done acknowledges the loop's last access to monitoring state, before its
+	// deferred timer cleanup. Like stop, the channel is immutable and reused.
 	done chan struct{}
 
-	// offenders map contains all tasks that are currently stuck.
+	// offenders contains all tasks that are currently stuck. After initialization
+	// it is used only by the monitoring goroutine. checklocks does not model
+	// goroutine ownership.
 	offenders map[*kernel.Task]*offender
 
 	// lastStackDump tracks the last time a stack dump was generated to prevent
 	// spamming the log.
+	//
+	// The monitoring goroutine owns it after Start. Before the first Start,
+	// waitForStart may access it with mu held and startCalled false. checklocks
+	// cannot express this conditional goroutine/mutex ownership.
 	lastStackDump time.Time
 
 	// lastRun is set to the last time the watchdog executed a monitoring loop.
 	lastRun ktime.Time
 
-	// mu protects the fields below.
 	mu sync.Mutex
 
 	// running is true if the watchdog is running.
+	//
+	// +checklocks:mu
 	running bool
 
 	// startCalled is true if Start has ever been called. It remains true
 	// even if Stop is called.
+	//
+	// +checklocks:mu
 	startCalled bool
 }
 
@@ -184,6 +195,8 @@ func New(k *kernel.Kernel, opts Opts) *Watchdog {
 }
 
 // Start starts the watchdog.
+//
+// +checklocksexclude:w.mu
 func (w *Watchdog) Start() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -204,7 +217,11 @@ func (w *Watchdog) Start() {
 	w.running = true
 }
 
-// Stop requests the watchdog to stop and wait for it.
+// Stop requests the watchdog to stop and waits until the monitoring loop no
+// longer accesses monitoring state. It does not wait for deferred timer
+// cleanup.
+//
+// +checklocksexclude:w.mu
 func (w *Watchdog) Stop() {
 	if w.TaskTimeout == 0 {
 		return
@@ -370,6 +387,10 @@ func (w *Watchdog) reportStuckWatchdog() {
 // doAction will take the given action. If the action is LogWarning, the stack
 // is not always dumped to the log to prevent log flooding. "forceStack"
 // guarantees that the stack will be dumped regardless.
+//
+// Preconditions: The caller must be the monitoring goroutine, or waitForStart
+// with mu held and startCalled false. checklocks cannot express this
+// conditional goroutine/mutex ownership.
 func (w *Watchdog) doAction(action Action, forceStack bool, stuckTasks map[int64]struct{}, msg *bytes.Buffer) {
 	switch action {
 	case LogWarning:

--- a/runsc/boot/fscheckpoint.go
+++ b/runsc/boot/fscheckpoint.go
@@ -88,6 +88,8 @@ func GetAnnotationFSCheckpointDirect(spec *specs.Spec) bool {
 }
 
 // FSSave implements kernel.Saver.FSSave.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) FSSave() error {
 	l.mu.Lock()
 	fsSaveFDs := l.fsSaveFDs
@@ -266,15 +268,29 @@ type fsRestore struct {
 	mfs         map[checkpoint.ResourceID]*fscheckpoint.MemoryFile
 	tmpfs       map[checkpoint.ResourceID]*fscheckpoint.Tmpfs
 
-	waitMu  sync.Mutex
-	waitMap map[string]*fsRestoreContainer // key is container ID
+	waitMu sync.Mutex
+
+	// waitMap tracks restore completion by container ID.
+	//
+	// +checklocks:waitMu
+	waitMap map[string]*fsRestoreContainer
 }
 
 type fsRestoreContainer struct {
-	// These fields are protected by fsRestore.waitMu.
-	err        error
-	asyncLoads int // number of MemoryFiles currently in async page loading
-	cond       sync.Cond
+	// err is the first error encountered while restoring this container.
+	//
+	// +checklocks:cond.L
+	err error
+
+	// asyncLoads counts MemoryFiles currently in async page loading.
+	//
+	// +checklocks:cond.L
+	asyncLoads int
+
+	// cond wakes waiters when an error occurs or all async loads complete.
+	// ensureContainer sets L to the owning fsRestore's waitMu before
+	// publishing the entry in waitMap; L is not reassigned afterwards.
+	cond sync.Cond
 }
 
 // fsRestoreOpts holds options to startFSRestore.
@@ -500,6 +516,9 @@ func (fsr *fsRestore) ensureContainer(cid string) *fsRestoreContainer {
 	return c
 }
 
+// setError records the first non-nil error and wakes waiters, returning err.
+//
+// +checklocks:c.cond.L
 func (c *fsRestoreContainer) setError(err error) error {
 	if c.err == nil && err != nil {
 		c.err = err
@@ -508,6 +527,7 @@ func (c *fsRestoreContainer) setError(err error) error {
 	return err
 }
 
+// +checklocksexclude:fsr.waitMu
 func (fsr *fsRestore) memoryFileLoadArgs(id checkpoint.ResourceID, cid string) (io.Reader, uint64, func(error), error) {
 	if fsr == nil {
 		return nil, 0, func(error) {}, nil
@@ -526,29 +546,34 @@ func (fsr *fsRestore) memoryFileLoadArgs(id checkpoint.ResourceID, cid string) (
 	fsr.waitMu.Lock()
 	defer fsr.waitMu.Unlock()
 	c := fsr.ensureContainer(cid)
+	// ensureContainer binds c.cond.L to the held fsr.waitMu. checklocks
+	// cannot recover that identity from the returned entry.
 	if mmf.PagesMetadataEnd > uint64(len(pagesMetadata)) {
 		if err != nil {
-			return nil, 0, nil, c.setError(fmt.Errorf("failed to read pages metadata: %w", err))
+			return nil, 0, nil, c.setError(fmt.Errorf("failed to read pages metadata: %w", err)) // +checklocksignore
 		}
-		return nil, 0, nil, c.setError(fmt.Errorf("MemoryFile %q has pages metadata range [%d, %d) beyond pages metadata file size %d", mmf.ResourceID, mmf.PagesMetadataStart, mmf.PagesMetadataEnd, len(pagesMetadata)))
+		return nil, 0, nil, c.setError(fmt.Errorf("MemoryFile %q has pages metadata range [%d, %d) beyond pages metadata file size %d", mmf.ResourceID, mmf.PagesMetadataStart, mmf.PagesMetadataEnd, len(pagesMetadata))) // +checklocksignore
 	}
-	c.asyncLoads++
+	c.asyncLoads++ // +checklocksignore
 	return bytes.NewReader(pagesMetadata[mmf.PagesMetadataStart:mmf.PagesMetadataEnd]), mmf.PagesStart, func(err error) {
 		fsr.waitMu.Lock()
 		defer fsr.waitMu.Unlock()
-		c.asyncLoads--
+		// The captured entry still uses fsr.waitMu as c.cond.L; checklocks
+		// cannot relate that interface value to the lock acquired above.
+		c.asyncLoads-- // +checklocksignore
 		switch {
 		case err != nil:
-			if c.err == nil {
-				c.err = err
+			if c.err == nil { // +checklocksignore
+				c.err = err // +checklocksignore
 			}
 			fallthrough
-		case c.asyncLoads == 0:
+		case c.asyncLoads == 0: // +checklocksignore
 			c.cond.Broadcast()
 		}
 	}, nil
 }
 
+// +checklocksexclude:fsr.waitMu
 func (fsr *fsRestore) tmpfsSourceTar(id checkpoint.ResourceID, cid string) (io.ReadCloser, error) {
 	if fsr == nil {
 		return nil, nil
@@ -570,15 +595,19 @@ func (fsr *fsRestore) tmpfsSourceTar(id checkpoint.ResourceID, cid string) (io.R
 		return io.NopCloser(bytes.NewReader(multiTar[mt.TarStart:mt.TarEnd])), nil
 	}
 	c := fsr.ensureContainer(cid)
+	// ensureContainer binds c.cond.L to the held fsr.waitMu. checklocks
+	// cannot recover that identity from the returned entry.
 	if err != nil {
-		return nil, c.setError(fmt.Errorf("failed to read tar archive: %w", err))
+		return nil, c.setError(fmt.Errorf("failed to read tar archive: %w", err)) // +checklocksignore
 	}
-	return nil, c.setError(fmt.Errorf("tmpfs %q has tar range [%d, %d) beyond multi-tar file size %d", mt.ResourceID, mt.TarStart, mt.TarEnd, len(multiTar)))
+	return nil, c.setError(fmt.Errorf("tmpfs %q has tar range [%d, %d) beyond multi-tar file size %d", mt.ResourceID, mt.TarStart, mt.TarEnd, len(multiTar))) // +checklocksignore
 }
 
 // wait blocks until either all filesystems have been restored for the
 // container with the given ID, or an error occurs while restoring filesystems
 // for that container.
+//
+// +checklocksexclude:fsr.waitMu
 func (fsr *fsRestore) wait(cid string) error {
 	if fsr == nil {
 		return fmt.Errorf("filesystem restore is not enabled")
@@ -593,11 +622,13 @@ func (fsr *fsRestore) wait(cid string) error {
 	if c == nil {
 		return fmt.Errorf("no filesystems restored for container %s", cid)
 	}
+	// Entries are published with c.cond.L bound to fsr.waitMu. checklocks
+	// cannot recover that identity through the waitMap lookup.
 	for {
-		if c.err != nil {
-			return c.err
+		if c.err != nil { // +checklocksignore
+			return c.err // +checklocksignore
 		}
-		if c.asyncLoads == 0 {
+		if c.asyncLoads == 0 { // +checklocksignore
 			return nil
 		}
 		c.cond.Wait()

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -339,6 +339,8 @@ type Loader struct {
 
 	// networkArgs contains the routes and links which were scraped from the
 	// host network namespace during sandbox creation.
+	//
+	// +checklocks:mu
 	networkArgs *CreateLinksAndRoutesArgs
 
 	// pinRing accumulates host FDs to pin before seccomp filters are
@@ -346,6 +348,8 @@ type Loader struct {
 	pinRing pinring.PinRing
 
 	// fsSaveFDs are FDs used for user-triggered filesystem checkpoint saving.
+	//
+	// +checklocks:mu
 	fsSaveFDs []*fd.FD
 
 	// fsSaveCheckpointGofer is true if fsSaveFDs contains only one FD, which
@@ -353,6 +357,11 @@ type Loader struct {
 	fsSaveCheckpointGofer bool
 
 	// hostinetNetDevFile is the pre-opened /proc/net/dev file for hostinet restore.
+	//
+	// Restore initializes both hostinet files before taking mu.
+	// ConfigureNetwork transfers them while mu is held; restore closes
+	// any unconsumed files without mu. checklocks cannot express this
+	// phase-dependent ownership.
 	hostinetNetDevFile *os.File
 
 	// hostinetNetSNMPFile is the pre-opened /proc/net/snmp file for hostinet restore.
@@ -934,6 +943,13 @@ func New(args Args) (*Loader, error) {
 }
 
 // ConfigureNetwork implements inet.NetworkArgs.ConfigureNetwork.
+//
+// Startup calls this directly before installing seccomp filters. Restore
+// calls it synchronously through Kernel.LoadFrom after installing filters.
+// Both callers hold l.mu, but the restore interface call cannot convey this
+// concrete lock contract to checklocks.
+//
+// +checklocks:l.mu
 func (l *Loader) ConfigureNetwork(s inet.Stack) error {
 	if h, ok := s.(*hostinet.Stack); ok {
 		h.SetFiles(l.hostinetNetDevFile, l.hostinetNetSNMPFile)
@@ -1021,6 +1037,8 @@ func createProcessArgs(id string, spec *specs.Spec, conf *config.Config, creds *
 // Note that this will block until all open control server connections have
 // been closed. For that reason, this should NOT be called in a defer, because
 // a panic in a control server rpc would then hang forever.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) Destroy() {
 	if l.stopSignalForwarding != nil {
 		l.stopSignalForwarding()
@@ -1209,6 +1227,8 @@ func (l *Loader) installSeccompFilters() error {
 }
 
 // Run runs the root container.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) Run() error {
 	err := l.run()
 	l.ctrl.manager.startResultChan <- err
@@ -1223,6 +1243,7 @@ func (l *Loader) Run() error {
 	return nil
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) run() error {
 	if l.root.conf.Network == config.NetworkHost {
 		// Delay host network configuration to this point because network namespace
@@ -1354,6 +1375,8 @@ func (l *Loader) run() error {
 }
 
 // createSubcontainer creates a new container inside the sandbox.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) createSubcontainer(cid string, tty *fd.FD) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -1369,6 +1392,8 @@ func (l *Loader) createSubcontainer(cid string, tty *fd.FD) error {
 // startSubcontainer starts a child container. It returns the thread group ID of
 // the newly created process. Used FDs are either closed or released. It's safe
 // for the caller to close any remaining files upon return.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdioFDs, goferFDs, goferFilestoreFDs []*fd.FD, devGoferFD *fd.FD, goferMountConfs []specutils.GoferMountConf, rootfsUpperTarFD *fd.FD) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -1651,6 +1676,8 @@ func (l *Loader) startGoferMonitor(info *containerInfo) {
 
 // destroySubcontainer stops a container if it is still running and cleans up
 // its filesystem.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) destroySubcontainer(cid string) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -1694,6 +1721,7 @@ func (l *Loader) destroySubcontainer(cid string) error {
 	return nil
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) executeAsync(args *control.ExecArgs) (kernel.ThreadID, error) {
 	// Hold the lock for the entire operation to ensure that exec'd process is
 	// added to 'processes' in case it races with destroyContainer().
@@ -1777,6 +1805,8 @@ func (l *Loader) executeAsync(args *control.ExecArgs) (kernel.ThreadID, error) {
 }
 
 // waitContainer waits for the init process of a container to exit.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) waitContainer(cid string, waitStatus *uint32) error {
 	l.mu.Lock()
 	state := l.state
@@ -1831,6 +1861,7 @@ func (l *Loader) waitContainer(cid string, waitStatus *uint32) error {
 	return nil
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) waitRestore() error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -1845,6 +1876,7 @@ func (l *Loader) waitRestore() error {
 	return l.restoreErr
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) waitPID(tgid kernel.ThreadID, cid string, waitStatus *uint32) error {
 	if tgid <= 0 {
 		return fmt.Errorf("PID (%d) must be positive", tgid)
@@ -2037,6 +2069,8 @@ func (c *sandboxNetstackCreator) CreateStack() (inet.Stack, error) {
 // option, the signal may be sent directly to the indicated process, to all
 // processes in the container, or to the foreground process group. pid is
 // relative to the root PID namespace, not the container's.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) signal(cid string, pid, signo int32, mode SignalDeliveryMode) error {
 	if pid < 0 {
 		return fmt.Errorf("PID (%d) must be positive", pid)
@@ -2084,6 +2118,8 @@ func (l *Loader) signal(cid string, pid, signo int32, mode SignalDeliveryMode) e
 
 // signalProcess sends signal to process in the given container. tgid is
 // relative to the root PID namespace, not the container's.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) signalProcess(cid string, tgid kernel.ThreadID, signo int32) error {
 	execTG, err := l.threadGroupFromID(execID{cid: cid, pid: tgid})
 	if err == nil {
@@ -2106,6 +2142,8 @@ func (l *Loader) signalProcess(cid string, tgid kernel.ThreadID, signo int32) er
 
 // signalForegrondProcessGroup looks up foreground process group from the TTY
 // for the given "tgid" inside container "cid", and send the signal to it.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) signalForegrondProcessGroup(cid string, tgid kernel.ThreadID, signo int32) error {
 	l.mu.Lock()
 	tg, err := l.tryThreadGroupFromIDLocked(execID{cid: cid, pid: tgid})
@@ -2181,6 +2219,8 @@ func (l *Loader) signalProcessGroup(cid string, pgid kernel.ProcessGroupID, sign
 // threadGroupFromID is similar to tryThreadGroupFromIDLocked except that it
 // acquires mutex before calling it and fails in case container hasn't started
 // yet.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) threadGroupFromID(key execID) (*kernel.ThreadGroup, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -2260,6 +2300,8 @@ func createFDTable(ctx context.Context, console bool, stdioFDs []*fd.FD, passFDs
 // represent a two connections each copying to each other (read ends to write ends) in goroutines.
 // The proxies are stored and can be cleaned up, or clean up after themselves if the connection
 // is broken.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) portForward(opts *PortForwardOpts) error {
 	// Validate that we have a stream FD to write to. If this happens then
 	// it means there is a misbehaved urpc client or a bug has occurred.
@@ -2353,6 +2395,7 @@ func (l *Loader) importFD(ctx context.Context, f *os.File) (*vfs.FileDescription
 	return fd, nil
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) containerCount() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -2368,6 +2411,7 @@ func (l *Loader) containerCount() int {
 	return containers
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) pidsCount(cid string) (int, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -2411,6 +2455,7 @@ func (l *Loader) findProcessLocked(key execID) (*execProcess, error) {
 	return ep, nil
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) registerContainer(spec *specs.Spec, cid string) string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -2432,6 +2477,7 @@ func (l *Loader) registerContainerLocked(spec *specs.Spec, cid string) string {
 	return containerName
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) getContainerSpec(containerName string) *specs.Spec {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -2440,6 +2486,8 @@ func (l *Loader) getContainerSpec(containerName string) *specs.Spec {
 
 // SpecEnviron returns the environment variables for the given container from
 // the container spec it was created with.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) SpecEnviron(containerName string) []string {
 	spec := l.getContainerSpec(containerName)
 	if spec == nil {
@@ -2449,6 +2497,7 @@ func (l *Loader) SpecEnviron(containerName string) []string {
 	return spec.Process.Env
 }
 
+// +checklocksexclude:l.mu
 func (l *Loader) containerRuntimeState(cid string) ContainerRuntimeState {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -2477,6 +2526,8 @@ func (l *Loader) containerRuntimeState(cid string) ContainerRuntimeState {
 }
 
 // GetContainerSpecs returns the container specs map.
+//
+// +checklocksexclude:l.mu
 func (l *Loader) GetContainerSpecs() map[string]*specs.Spec {
 	l.mu.Lock()
 	defer l.mu.Unlock()


### PR DESCRIPTION
Annotate existing lock and atomic-access contracts for MemoryManager state, timers, cgroups, watchdogs and the loader. Update MM tests to use guarded mapping reads and synchronized size accessors.

Part of #14349.

Assisted-by: Codex