### PR TITLE
checklocks: annotate kernel and IPC ownership

### DIFF
--- a/pkg/sentry/control/state_cuda.go
+++ b/pkg/sentry/control/state_cuda.go
@@ -92,6 +92,9 @@ func preSaveCuda(k *kernel.Kernel, o *state.SaveOpts) error {
 // cudaProcs returns a list of all CUDA processes in the sandbox. It selects
 // them by collecting processes whose FD table has an open file descriptor to
 // any CUDA device.
+//
+// Callers must not hold any thread-group leader's Task.mu in k.
+// checklocks cannot name the leader mutexes selected by ForEachThreadGroup.
 func cudaProcs(sctx context.Context, k *kernel.Kernel, cudaCheckpointPath string, nvidiaDriverVersionMajor int) []*kernel.ThreadGroup {
 	var procs []*kernel.ThreadGroup
 	k.TaskSet().ForEachThreadGroup(func(tg *kernel.ThreadGroup, tgLeader *kernel.Task) {

--- a/pkg/sentry/control/tpu_control.go
+++ b/pkg/sentry/control/tpu_control.go
@@ -97,6 +97,8 @@ func postResumeTPU(k *kernel.Kernel) error {
 	return nil
 }
 
+// Callers must not hold any thread-group leader's Task.mu in k.
+// checklocks cannot name the leader mutexes selected by ForEachThreadGroup.
 func findTPUTasks(k *kernel.Kernel) []*tpuTaskInfo {
 	var infos []*tpuTaskInfo
 	sctx := k.SupervisorContext()

--- a/pkg/sentry/fsimpl/proc/filesystem.go
+++ b/pkg/sentry/fsimpl/proc/filesystem.go
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 // Package proc implements a partial in-memory file system for procfs.
+//
+// Task-mutex exclusions on concrete proc methods also apply through
+// kernfs.Inode, kernfs.DataSourceProvider, and vfs.DynamicBytesSource.
+// These interfaces do not expose the concrete task owner to checklocks.
 package proc
 
 import (

--- a/pkg/sentry/fsimpl/proc/task.go
+++ b/pkg/sentry/fsimpl/proc/task.go
@@ -246,6 +246,8 @@ func (i *taskOwnedInode) Valid(ctx context.Context, parent *kernfs.Dentry, name 
 }
 
 // Stat implements kernfs.Inode.Stat.
+//
+// +checklocksexclude:i.owner.mu
 func (i *taskOwnedInode) Stat(ctx context.Context, fs *vfs.Filesystem, opts vfs.StatOptions) (linux.Statx, error) {
 	stat, err := i.Inode.Stat(ctx, fs, opts)
 	if err != nil {
@@ -264,12 +266,15 @@ func (i *taskOwnedInode) Stat(ctx context.Context, fs *vfs.Filesystem, opts vfs.
 }
 
 // CheckPermissions implements kernfs.Inode.CheckPermissions.
+//
+// +checklocksexclude:i.owner.mu
 func (i *taskOwnedInode) CheckPermissions(ctx context.Context, creds *auth.Credentials, ats vfs.AccessTypes) error {
 	mode := i.Mode()
 	uid, gid := i.getOwner(mode)
 	return vfs.GenericCheckPermissions(creds, ats, mode, nil, uid, gid)
 }
 
+// +checklocksexclude:i.owner.mu
 func (i *taskOwnedInode) getOwner(mode linux.FileMode) (auth.KUID, auth.KGID) {
 	// By default, set the task owner as the file owner.
 	creds := i.owner.Credentials()

--- a/pkg/sentry/fsimpl/proc/task_fds.go
+++ b/pkg/sentry/fsimpl/proc/task_fds.go
@@ -29,6 +29,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 )
 
+// +checklocksexclude:t.mu
 func getTaskFD(t *kernel.Task, fd int32) (*vfs.FileDescription, kernel.FDFlags) {
 	var (
 		file  *vfs.FileDescription
@@ -42,6 +43,7 @@ func getTaskFD(t *kernel.Task, fd int32) (*vfs.FileDescription, kernel.FDFlags) 
 	return file, flags
 }
 
+// +checklocksexclude:t.mu
 func taskFDExists(ctx context.Context, fs *filesystem, t *kernel.Task, fd int32) bool {
 	var exists bool
 	t.WithMuLocked(func(task *kernel.Task) {
@@ -65,6 +67,8 @@ type fdDir struct {
 }
 
 // IterDirents implements kernfs.inodeDirectory.IterDirents.
+//
+// +checklocksexclude:i.task.mu
 func (i *fdDir) IterDirents(ctx context.Context, mnt *vfs.Mount, cb vfs.IterDirentsCallback, offset, relOffset int64) (int64, error) {
 	var fds []int32
 	i.task.WithMuLocked(func(t *kernel.Task) {
@@ -138,11 +142,15 @@ func (fs *filesystem) newFDDirInode(ctx context.Context, task *kernel.Task) kern
 }
 
 // IterDirents implements kernfs.inodeDirectory.IterDirents.
+//
+// +checklocksexclude:i.fdDir.task.mu
 func (i *fdDirInode) IterDirents(ctx context.Context, mnt *vfs.Mount, cb vfs.IterDirentsCallback, offset, relOffset int64) (int64, error) {
 	return i.fdDir.IterDirents(ctx, mnt, cb, offset, relOffset)
 }
 
 // Lookup implements kernfs.inodeDirectory.Lookup.
+//
+// +checklocksexclude:i.fdDir.task.mu
 func (i *fdDirInode) Lookup(ctx context.Context, name string) (kernfs.Inode, error) {
 	fdInt, err := strconv.ParseInt(name, 10, 32)
 	if err != nil {
@@ -222,6 +230,7 @@ func (fs *filesystem) newFDSymlink(ctx context.Context, task *kernel.Task, fd in
 	return inode
 }
 
+// +checklocksexclude:s.task.mu
 func (s *fdSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error) {
 	if !kernel.ContextCanTrace(ctx, s.task, false) {
 		return "", linuxerr.EACCES
@@ -238,6 +247,7 @@ func (s *fdSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error) 
 	return s.task.Kernel().VFS().PathnameWithDeleted(ctx, root, file.VirtualDentry())
 }
 
+// +checklocksexclude:s.task.mu
 func (s *fdSymlink) Getlink(ctx context.Context, mnt *vfs.Mount) (vfs.VirtualDentry, string, error) {
 	if !kernel.ContextCanTrace(ctx, s.task, false) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
@@ -253,6 +263,8 @@ func (s *fdSymlink) Getlink(ctx context.Context, mnt *vfs.Mount) (vfs.VirtualDen
 }
 
 // Valid implements kernfs.Inode.Valid.
+//
+// +checklocksexclude:s.task.mu
 func (s *fdSymlink) Valid(ctx context.Context, parent *kernfs.Dentry, name string) bool {
 	return taskFDExists(ctx, s.fs, s.task, s.fd)
 }
@@ -291,6 +303,8 @@ func (fs *filesystem) newFDInfoDirInode(ctx context.Context, task *kernel.Task) 
 }
 
 // Lookup implements kernfs.inodeDirectory.Lookup.
+//
+// +checklocksexclude:i.fdDir.task.mu
 func (i *fdInfoDirInode) Lookup(ctx context.Context, name string) (kernfs.Inode, error) {
 	fdInt, err := strconv.ParseInt(name, 10, 32)
 	if err != nil {
@@ -309,6 +323,8 @@ func (i *fdInfoDirInode) Lookup(ctx context.Context, name string) (kernfs.Inode,
 }
 
 // IterDirents implements Inode.IterDirents.
+//
+// +checklocksexclude:i.fdDir.task.mu
 func (i *fdInfoDirInode) IterDirents(ctx context.Context, mnt *vfs.Mount, cb vfs.IterDirentsCallback, offset, relOffset int64) (newOffset int64, err error) {
 	return i.fdDir.IterDirents(ctx, mnt, cb, offset, relOffset)
 }
@@ -343,6 +359,8 @@ type fdInfoData struct {
 var _ dynamicInode = (*fdInfoData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.task.mu
 func (d *fdInfoData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	file, descriptorFlags := getTaskFD(d.task, d.fd)
 	if file == nil {
@@ -376,6 +394,8 @@ func (d *fdInfoData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 }
 
 // Valid implements kernfs.Inode.Valid.
+//
+// +checklocksexclude:d.task.mu
 func (d *fdInfoData) Valid(ctx context.Context, parent *kernfs.Dentry, name string) bool {
 	return taskFDExists(ctx, d.fs, d.task, d.fd)
 }

--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -46,6 +46,8 @@ const maxIDMapLines = 5
 // getMM gets the kernel task's MemoryManager. No additional reference is taken on
 // mm here. This is safe because MemoryManager.destroy is required to leave the
 // MemoryManager in a state where it's still usable as a DynamicBytesSource.
+//
+// +checklocksexclude:task.mu
 func getMM(task *kernel.Task) *mm.MemoryManager {
 	var tmm *mm.MemoryManager
 	task.WithMuLocked(func(t *kernel.Task) {
@@ -59,6 +61,8 @@ func getMM(task *kernel.Task) *mm.MemoryManager {
 // getMMIncRef returns t's MemoryManager. If getMMIncRef succeeds, the
 // MemoryManager's users count is incremented, and must be decremented by the
 // caller when it is no longer in use.
+//
+// +checklocksexclude:task.mu
 func getMMIncRef(task *kernel.Task) (*mm.MemoryManager, error) {
 	var m *mm.MemoryManager
 	task.WithMuLocked(func(t *kernel.Task) {
@@ -233,6 +237,8 @@ type cmdlineData struct {
 var _ dynamicInode = (*cmdlineData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:d.task.mu
 func (d *cmdlineData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	if d.task.ExitState() == kernel.TaskExitDead {
 		return linuxerr.ESRCH
@@ -499,6 +505,8 @@ func (f *memInode) init(ctx context.Context, creds *auth.Credentials, devMajor, 
 }
 
 // Open implements kernfs.Inode.Open.
+//
+// +checklocksexclude:f.task.mu
 func (f *memInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
 	m := getMM(f.task)
 	for {
@@ -726,6 +734,8 @@ func (f *mmFile) Init(ctx context.Context, creds *auth.Credentials, devMajor, de
 }
 
 // DataSource implements kernfs.DataSourceProvider.DataSource()
+//
+// +checklocksexclude:f.task.mu
 func (f *mmFile) DataSource(ctx context.Context) (vfs.DynamicBytesSource, error) {
 	m := getMM(f.task)
 	for {
@@ -812,6 +822,8 @@ type taskStatData struct {
 var _ dynamicInode = (*taskStatData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:s.task.mu
 func (s *taskStatData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	fmt.Fprintf(buf, "%d ", s.pidns.IDOfTask(s.task))
 	fmt.Fprintf(buf, "(%s) ", s.task.Name())
@@ -883,6 +895,8 @@ type statmData struct {
 var _ dynamicInode = (*statmData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:s.task.mu
 func (s *statmData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	var vss, rss uint64
 	if mm := getMM(s.task); mm != nil {
@@ -984,6 +998,8 @@ func (s *statusFD) SetStat(ctx context.Context, opts vfs.SetStatOptions) error {
 }
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:s.task.mu
 func (s *statusFD) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	fmt.Fprintf(buf, "Name:\t%s\n", s.task.Name())
 	fmt.Fprintf(buf, "State:\t%s\n", s.task.StateStatus())
@@ -1166,6 +1182,8 @@ func (fs *filesystem) newExeSymlink(ctx context.Context, task *kernel.Task, ino 
 }
 
 // Readlink implements kernfs.Inode.Readlink.
+//
+// +checklocksexclude:s.task.mu
 func (s *exeSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error) {
 	exec, _, err := s.Getlink(ctx, nil)
 	if err != nil {
@@ -1185,6 +1203,8 @@ func (s *exeSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error)
 }
 
 // Getlink implements kernfs.Inode.Getlink.
+//
+// +checklocksexclude:s.task.mu
 func (s *exeSymlink) Getlink(ctx context.Context, _ *vfs.Mount) (vfs.VirtualDentry, string, error) {
 	if !kernel.ContextCanTrace(ctx, s.task, false) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
@@ -1240,6 +1260,8 @@ func (fs *filesystem) newCwdSymlink(ctx context.Context, task *kernel.Task, ino 
 }
 
 // Readlink implements kernfs.Inode.Readlink.
+//
+// +checklocksexclude:s.task.mu
 func (s *cwdSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error) {
 	cwd, _, err := s.Getlink(ctx, nil)
 	if err != nil {
@@ -1259,6 +1281,8 @@ func (s *cwdSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error)
 }
 
 // Getlink implements kernfs.Inode.Getlink.
+//
+// +checklocksexclude:s.task.mu
 func (s *cwdSymlink) Getlink(ctx context.Context, _ *vfs.Mount) (vfs.VirtualDentry, string, error) {
 	if !kernel.ContextCanTrace(ctx, s.task, false) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
@@ -1303,6 +1327,8 @@ func (fs *filesystem) newRootSymlink(ctx context.Context, task *kernel.Task, ino
 }
 
 // Readlink implements kernfs.Inode.Readlink.
+//
+// +checklocksexclude:s.task.mu
 func (s *rootSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error) {
 	root, _, err := s.Getlink(ctx, nil)
 	if err != nil {
@@ -1322,6 +1348,8 @@ func (s *rootSymlink) Readlink(ctx context.Context, _ *vfs.Mount) (string, error
 }
 
 // Getlink implements kernfs.Inode.Getlink.
+//
+// +checklocksexclude:s.task.mu
 func (s *rootSymlink) Getlink(ctx context.Context, _ *vfs.Mount) (vfs.VirtualDentry, string, error) {
 	if !kernel.ContextCanTrace(ctx, s.task, false) {
 		return vfs.VirtualDentry{}, "", linuxerr.EACCES
@@ -1352,6 +1380,8 @@ var _ dynamicInode = (*mountInfoData)(nil)
 var _ vfs.PollableDynamicBytesSource = (*mountInfoData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:i.task.mu
 func (i *mountInfoData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	var fsctx *kernel.FSContext
 	i.task.WithMuLocked(func(t *kernel.Task) {
@@ -1393,6 +1423,8 @@ var _ dynamicInode = (*mountsData)(nil)
 var _ vfs.PollableDynamicBytesSource = (*mountsData)(nil)
 
 // Generate implements vfs.DynamicBytesSource.Generate.
+//
+// +checklocksexclude:i.task.mu
 func (i *mountsData) Generate(ctx context.Context, buf *bytes.Buffer) error {
 	var fsctx *kernel.FSContext
 	i.task.WithMuLocked(func(t *kernel.Task) {

--- a/pkg/sentry/fsimpl/testutil/kernel.go
+++ b/pkg/sentry/fsimpl/testutil/kernel.go
@@ -130,6 +130,11 @@ func Boot() (*kernel.Kernel, error) {
 }
 
 // CreateTask creates a new bare bones task for tests.
+//
+// Preconditions: tc must belong to the Kernel in ctx.
+//
+// +checklocksexclude:tc.pidns.owner.mu
+// +checklocksexclude:tc.signalHandlers.mu
 func CreateTask(ctx context.Context, name string, tc *kernel.ThreadGroup, mntns *vfs.MountNamespace, root, cwd vfs.VirtualDentry) (*kernel.Task, error) {
 	k := kernel.KernelFromContext(ctx)
 	if k == nil {

--- a/pkg/sentry/kernel/auth/id_map.go
+++ b/pkg/sentry/kernel/auth/id_map.go
@@ -21,37 +21,58 @@ import (
 )
 
 // MapFromKUID translates kuid, a UID in the root namespace, to a UID in ns.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) MapFromKUID(kuid KUID) UID {
 	if ns.parent == nil {
 		return UID(kuid)
 	}
-	return UID(ns.mapID(&ns.uidMapFromParent, uint32(ns.parent.MapFromKUID(kuid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.uidMapFromParent // +checklocksignore
+	return UID(ns.mapID(m, uint32(ns.parent.MapFromKUID(kuid))))
 }
 
 // MapFromKGID translates kgid, a GID in the root namespace, to a GID in ns.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) MapFromKGID(kgid KGID) GID {
 	if ns.parent == nil {
 		return GID(kgid)
 	}
-	return GID(ns.mapID(&ns.gidMapFromParent, uint32(ns.parent.MapFromKGID(kgid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.gidMapFromParent // +checklocksignore
+	return GID(ns.mapID(m, uint32(ns.parent.MapFromKGID(kgid))))
 }
 
 // MapToKUID translates uid, a UID in ns, to a UID in the root namespace.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) MapToKUID(uid UID) KUID {
 	if ns.parent == nil {
 		return KUID(uid)
 	}
-	return ns.parent.MapToKUID(UID(ns.mapID(&ns.uidMapToParent, uint32(uid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.uidMapToParent // +checklocksignore
+	return ns.parent.MapToKUID(UID(ns.mapID(m, uint32(uid))))
 }
 
 // MapToKGID translates gid, a GID in ns, to a GID in the root namespace.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) MapToKGID(gid GID) KGID {
 	if ns.parent == nil {
 		return KGID(gid)
 	}
-	return ns.parent.MapToKGID(GID(ns.mapID(&ns.gidMapToParent, uint32(gid))))
+	// mapID locks ns.mu; checklocks cannot defer checking this map address.
+	m := &ns.gidMapToParent // +checklocksignore
+	return ns.parent.MapToKGID(GID(ns.mapID(m, uint32(gid))))
 }
 
+// mapID translates id through m, which must be one of ns's ID maps.
+//
+// checklocks cannot express this owner relationship for a map argument.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) mapID(m *idMapSet, id uint32) uint32 {
 	if id == NoID {
 		return NoID
@@ -67,7 +88,10 @@ func (ns *UserNamespace) mapID(m *idMapSet, id uint32) uint32 {
 // allIDsMapped returns true if all IDs in the range [start, end) are mapped in
 // m.
 //
-// Preconditions: end >= start.
+// Preconditions: end >= start. m is one of ns's ID maps; checklocks cannot
+// express this owner relationship for a map argument.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) allIDsMapped(m *idMapSet, start, end uint32) bool {
 	ns.mu.NestedLock(userNamespaceLockNs)
 	defer ns.mu.NestedUnlock(userNamespaceLockNs)
@@ -95,6 +119,8 @@ type IDMapEntry struct {
 // Note: SetUIDMap does not place an upper bound on the number of entries, but
 // Linux does. This restriction is implemented in SetUIDMap's caller, the
 // implementation of /proc/[pid]/uid_map.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) SetUIDMap(ctx context.Context, entries []IDMapEntry) error {
 	c := CredentialsFromContext(ctx)
 
@@ -192,6 +218,10 @@ func (ns *UserNamespace) verifyRootUserMapping(c *Credentials, entries []IDMapEn
 	return c.HasCapabilityIn(linux.CAP_SETFCAP, ns.parent)
 }
 
+// trySetUIDMap installs the UID mappings. On error, it may leave partial
+// mappings that the caller must remove before releasing ns.mu.
+//
+// +checklocks:ns.mu
 func (ns *UserNamespace) trySetUIDMap(entries []IDMapEntry) error {
 	for _, e := range entries {
 		// Determine upper bounds and check for overflow. This implicitly
@@ -209,7 +239,10 @@ func (ns *UserNamespace) trySetUIDMap(entries []IDMapEntry) error {
 		// Only the root namespace has a nil parent, and root is assigned
 		// mappings when it's created, so SetUIDMap would have returned EPERM
 		// without reaching this point if ns is root.
-		if !ns.parent.allIDsMapped(&ns.parent.uidMapToParent, e.FirstParentID, lastParentID) {
+		//
+		// allIDsMapped locks the parent; checklocks checks the address first.
+		m := &ns.parent.uidMapToParent // +checklocksignore
+		if !ns.parent.allIDsMapped(m, e.FirstParentID, lastParentID) {
 			return linuxerr.EPERM
 		}
 		// If either of these Adds fail, we have an overlapping range.
@@ -224,6 +257,8 @@ func (ns *UserNamespace) trySetUIDMap(entries []IDMapEntry) error {
 }
 
 // SetGIDMap instructs ns to translate GIDs as specified by entries.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) SetGIDMap(ctx context.Context, entries []IDMapEntry) error {
 	c := CredentialsFromContext(ctx)
 
@@ -264,6 +299,10 @@ func (ns *UserNamespace) SetGIDMap(ctx context.Context, entries []IDMapEntry) er
 	return nil
 }
 
+// trySetGIDMap installs the GID mappings. On error, it may leave partial
+// mappings that the caller must remove before releasing ns.mu.
+//
+// +checklocks:ns.mu
 func (ns *UserNamespace) trySetGIDMap(entries []IDMapEntry) error {
 	for _, e := range entries {
 		lastID := e.FirstID + e.Length
@@ -274,7 +313,9 @@ func (ns *UserNamespace) trySetGIDMap(entries []IDMapEntry) error {
 		if lastParentID <= e.FirstParentID {
 			return linuxerr.EINVAL
 		}
-		if !ns.parent.allIDsMapped(&ns.parent.gidMapToParent, e.FirstParentID, lastParentID) {
+		// allIDsMapped locks the parent; checklocks checks the address first.
+		m := &ns.parent.gidMapToParent // +checklocksignore
+		if !ns.parent.allIDsMapped(m, e.FirstParentID, lastParentID) {
 			return linuxerr.EPERM
 		}
 		if !ns.gidMapFromParent.TryInsertRange(idMapRange{e.FirstParentID, lastParentID}, e.FirstID).Ok() {
@@ -289,16 +330,29 @@ func (ns *UserNamespace) trySetGIDMap(entries []IDMapEntry) error {
 
 // UIDMap returns the user ID mappings configured for ns. If no mappings
 // have been configured, UIDMap returns nil.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) UIDMap() []IDMapEntry {
-	return ns.getIDMap(&ns.uidMapToParent)
+	// getIDMap locks ns.mu; checklocks checks the map address before the call.
+	m := &ns.uidMapToParent // +checklocksignore
+	return ns.getIDMap(m)
 }
 
 // GIDMap returns the group ID mappings configured for ns. If no mappings
 // have been configured, GIDMap returns nil.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) GIDMap() []IDMapEntry {
-	return ns.getIDMap(&ns.gidMapToParent)
+	// getIDMap locks ns.mu; checklocks checks the map address before the call.
+	m := &ns.gidMapToParent // +checklocksignore
+	return ns.getIDMap(m)
 }
 
+// getIDMap copies the entries in m, which must be one of ns's ID maps.
+//
+// checklocks cannot express this owner relationship for a map argument.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) getIDMap(m *idMapSet) []IDMapEntry {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()

--- a/pkg/sentry/kernel/auth/key.go
+++ b/pkg/sentry/kernel/auth/key.go
@@ -292,6 +292,8 @@ type KeySet struct {
 	// keys maps key IDs to the underlying Key struct.
 	// It is initially nil to save on heap space.
 	// It is only initialized when doing mutable transactions on it using `Do`.
+	//
+	// +checklocks:mu
 	keys map[KeySerial]*Key
 }
 
@@ -305,14 +307,18 @@ type LockedKeySet struct {
 // It returns the error that `fn` returns.
 // This is the only function where functions that lock the KeySet.mu for
 // writing may be called.
+//
+// +checklocksexclude:s.txnMu
+// +checklocksexclude:s.mu
 func (s *KeySet) Do(fn func(*LockedKeySet) error) error {
 	s.txnMu.Lock()
 	defer s.txnMu.Unlock()
 	ls := &LockedKeySet{s}
+	// Keep lock and map accesses on ls; checklocks does not track its alias to s.
 	ls.mu.Lock()
-	if s.keys == nil {
+	if ls.keys == nil {
 		// Initialize the map from its zero value, if it hasn't been done yet.
-		s.keys = make(map[KeySerial]*Key)
+		ls.keys = make(map[KeySerial]*Key)
 	}
 	ls.mu.Unlock()
 	return fn(ls)
@@ -321,6 +327,8 @@ func (s *KeySet) Do(fn func(*LockedKeySet) error) error {
 // Lookup looks up a key by ID.
 // Callers must exercise care to verify that the key can be accessed with
 // proper credentials.
+//
+// +checklocksexclude:s.mu
 func (s *KeySet) Lookup(keyID KeySerial) (*Key, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -334,6 +342,10 @@ func (s *KeySet) Lookup(keyID KeySerial) (*Key, error) {
 // ForEach iterates over all keys.
 // If `fn` returns true, iteration stops immediately.
 // Callers must exercise care to only process keys to which they have access.
+//
+// fn runs with s.mu read-locked and must not reacquire that mutex.
+//
+// +checklocksexclude:s.mu
 func (s *KeySet) ForEach(fn func(*Key) bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -361,6 +373,8 @@ func getNewID() (KeySerial, error) {
 }
 
 // Add adds a new Key to the KeySet.
+//
+// +checklocksexclude:s.mu
 func (s *LockedKeySet) Add(description string, creds *Credentials, perms KeyPermissions, keySizeLimit int) (*Key, error) {
 	if len(description) >= MaxKeyDescSize {
 		return nil, linuxerr.EINVAL

--- a/pkg/sentry/kernel/auth/user_namespace.go
+++ b/pkg/sentry/kernel/auth/user_namespace.go
@@ -39,7 +39,7 @@ type UserNamespace struct {
 	// Keys is the set of keys in this namespace.
 	Keys KeySet
 
-	// mu protects the following fields.
+	// mu protects the ID maps, setgroupsAllowed, and inode.
 	//
 	// If mu will be locked in multiple UserNamespaces, it must be locked in
 	// descendant namespaces before ancestors.
@@ -49,21 +49,33 @@ type UserNamespace struct {
 	//
 	// All ID maps, once set, cannot be changed. This means that successful
 	// UID/GID translations cannot be racy.
+	//
+	// +checklocks:mu
 	uidMapFromParent idMapSet
-	uidMapToParent   idMapSet
-	gidMapFromParent idMapSet
-	gidMapToParent   idMapSet
 
-	// parentHadSetfcap is true if the parent namespace had the CAP_SETFCAP
-	// capability when this namespace was created. Similar to
+	// +checklocks:mu
+	uidMapToParent idMapSet
+
+	// +checklocks:mu
+	gidMapFromParent idMapSet
+
+	// +checklocks:mu
+	gidMapToParent idMapSet
+
+	// parentHadSetfcap is true if the creator had CAP_SETFCAP in the parent
+	// namespace when this namespace was created. It is immutable, like
 	// user_namespace.parent_could_setfcap in Linux.
 	parentHadSetfcap bool
 
-	// setgroupsAllowed mirrors USERNS_SETGROUPS_ALLOWED in Linux. Protected by mu.
+	// setgroupsAllowed mirrors USERNS_SETGROUPS_ALLOWED in Linux.
+	//
+	// +checklocks:mu
 	setgroupsAllowed bool
 
 	// inode is the nsfs inode associated with this namespace. This is stored as
 	// refs.TryRefCounter instead of *nsfs.Inode because nsfs imports auth.
+	//
+	// +checklocks:mu
 	inode refs.TryRefCounter
 }
 
@@ -120,6 +132,8 @@ func (ns *UserNamespace) UserNamespace() *UserNamespace {
 // SetInode sets the nsfs inode associated with ns. The initial ref on inode is
 // the task or kernel ref for a newly-created user namespace, so those callers
 // don't need a separate IncRef.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) SetInode(inode refs.TryRefCounter) {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
@@ -127,6 +141,8 @@ func (ns *UserNamespace) SetInode(inode refs.TryRefCounter) {
 }
 
 // IncRef increments ns's inode refcount.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) IncRef() {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
@@ -136,6 +152,8 @@ func (ns *UserNamespace) IncRef() {
 }
 
 // TryGetInode returns ns's inode with an incremented refcount.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) TryGetInode() refs.TryRefCounter {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
@@ -146,6 +164,8 @@ func (ns *UserNamespace) TryGetInode() refs.TryRefCounter {
 }
 
 // DecRef decrements ns's inode refcount.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) DecRef(ctx context.Context) {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
@@ -169,6 +189,8 @@ func (ns *UserNamespace) depth() int {
 
 // NewChildUserNamespace returns a new user namespace created by a caller with
 // credentials c.
+//
+// +checklocksexclude:c.UserNamespace.mu
 func (c *Credentials) NewChildUserNamespace() (*UserNamespace, error) {
 	if c.UserNamespace.depth() >= maxUserNamespaceDepth {
 		// "... Calls to unshare(2) or clone(2) that would cause this limit to
@@ -202,6 +224,8 @@ func (c *Credentials) NewChildUserNamespace() (*UserNamespace, error) {
 }
 
 // SetgroupsAllowed returns ns's USERNS_SETGROUPS_ALLOWED bit.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) SetgroupsAllowed() bool {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
@@ -209,6 +233,8 @@ func (ns *UserNamespace) SetgroupsAllowed() bool {
 }
 
 // MaySetgroups mirrors userns_may_setgroups in Linux.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) MaySetgroups() bool {
 	ns.mu.Lock()
 	defer ns.mu.Unlock()
@@ -216,6 +242,8 @@ func (ns *UserNamespace) MaySetgroups() bool {
 }
 
 // SetSetgroupsAllowed mirrors proc_setgroups_write in Linux.
+//
+// +checklocksexclude:ns.mu
 func (ns *UserNamespace) SetSetgroupsAllowed(ctx context.Context, allow bool) error {
 	c := CredentialsFromContext(ctx)
 	if !c.HasCapabilityIn(linux.CAP_SYS_ADMIN, ns) {

--- a/pkg/sentry/kernel/context.go
+++ b/pkg/sentry/kernel/context.go
@@ -45,6 +45,12 @@ const (
 
 // ContextCanTrace returns true if ctx is permitted to trace t, in the same sense
 // as kernel.Task.CanTrace.
+//
+// The function obtained from CtxCanTrace has Task.CanTrace's lock
+// requirements; checklocks does not propagate contracts through this
+// context function value.
+//
+// +checklocksexclude:t.mu
 func ContextCanTrace(ctx context.Context, t *Task, attach bool) bool {
 	if v := ctx.Value(CtxCanTrace); v != nil {
 		return v.(func(*Task, bool) bool)(t, attach)

--- a/pkg/sentry/kernel/fasync/fasync.go
+++ b/pkg/sentry/kernel/fasync/fasync.go
@@ -51,7 +51,10 @@ func New(fd int) func() vfs.FileAsync {
 //
 // +stateify savable
 type FileAsync struct {
-	// e is immutable after first use (which is protected by mu below).
+	// e is reinitialized for each registration. The waitable synchronizes
+	// accesses through its retained reference.
+	//
+	// +checklocks:regMu
 	e waiter.Entry
 
 	// fd is the file descriptor to notify about.
@@ -68,24 +71,34 @@ type FileAsync struct {
 	// Lock ordering: regMu, mu.
 	regMu regMutex `state:"nosave"`
 
-	// mu protects all following fields.
-	//
-	// Lock ordering: e.mu, mu.
-	mu         fileMutex `state:"nosave"`
-	requester  *auth.Credentials
+	// Wait queue locks precede mu because notification callbacks acquire mu.
+	// Register and Unregister must release mu before calling the waitable.
+	mu fileMutex `state:"nosave"`
+
+	// +checklocks:mu
+	requester *auth.Credentials
+	// +checklocks:mu
 	registered bool
 	// signal is the signal to deliver upon I/O being available.
 	// The default value ("zero signal") means the default SIGIO signal will be
 	// delivered.
+	//
+	// +checklocks:mu
 	signal linux.Signal
 
 	// Only one of the following is allowed to be non-nil.
+	//
+	// +checklocks:mu
 	recipientPG *kernel.ProcessGroup
+	// +checklocks:mu
 	recipientTG *kernel.ThreadGroup
-	recipientT  *kernel.Task
+	// +checklocks:mu
+	recipientT *kernel.Task
 }
 
 // NotifyEvent implements waiter.EventListener.NotifyEvent.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) NotifyEvent(mask waiter.EventMask) {
 	a.mu.Lock()
 	if !a.registered {
@@ -145,6 +158,9 @@ func (a *FileAsync) NotifyEvent(mask waiter.EventMask) {
 // Register sets the file which will be monitored for IO events.
 //
 // The file must not be currently registered.
+//
+// +checklocksexclude:a.mu
+// +checklocksexclude:a.regMu
 func (a *FileAsync) Register(w waiter.Waitable) error {
 	a.regMu.Lock()
 	defer a.regMu.Unlock()
@@ -167,6 +183,9 @@ func (a *FileAsync) Register(w waiter.Waitable) error {
 // Unregister stops monitoring a file.
 //
 // The file must be currently registered.
+//
+// +checklocksexclude:a.mu
+// +checklocksexclude:a.regMu
 func (a *FileAsync) Unregister(w waiter.Waitable) {
 	a.regMu.Lock()
 	defer a.regMu.Unlock()
@@ -185,6 +204,8 @@ func (a *FileAsync) Unregister(w waiter.Waitable) {
 
 // Owner returns who is currently getting signals. All return values will be
 // nil if no one is set to receive signals.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) Owner() (*kernel.Task, *kernel.ThreadGroup, *kernel.ProcessGroup) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -193,6 +214,8 @@ func (a *FileAsync) Owner() (*kernel.Task, *kernel.ThreadGroup, *kernel.ProcessG
 
 // SetOwnerTask sets the owner (who will receive signals) to a specified task.
 // Only this owner will receive signals.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) SetOwnerTask(requester *kernel.Task, recipient *kernel.Task) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -204,6 +227,8 @@ func (a *FileAsync) SetOwnerTask(requester *kernel.Task, recipient *kernel.Task)
 
 // SetOwnerThreadGroup sets the owner (who will receive signals) to a specified
 // thread group. Only this owner will receive signals.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) SetOwnerThreadGroup(requester *kernel.Task, recipient *kernel.ThreadGroup) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -215,6 +240,8 @@ func (a *FileAsync) SetOwnerThreadGroup(requester *kernel.Task, recipient *kerne
 
 // SetOwnerProcessGroup sets the owner (who will receive signals) to a
 // specified process group. Only this owner will receive signals.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) SetOwnerProcessGroup(requester *kernel.Task, recipient *kernel.ProcessGroup) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -225,6 +252,8 @@ func (a *FileAsync) SetOwnerProcessGroup(requester *kernel.Task, recipient *kern
 }
 
 // ClearOwner unsets the current signal recipient.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) ClearOwner() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -237,6 +266,8 @@ func (a *FileAsync) ClearOwner() {
 // Signal returns which signal will be sent to the signal recipient.
 // A value of zero means the signal to deliver wasn't customized, which means
 // the default signal (SIGIO) will be delivered.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) Signal() linux.Signal {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -246,6 +277,8 @@ func (a *FileAsync) Signal() linux.Signal {
 // SetSignal overrides which signal to send when I/O is available.
 // The default behavior can be reset by specifying signal zero, which means
 // to send SIGIO.
+//
+// +checklocksexclude:a.mu
 func (a *FileAsync) SetSignal(signal linux.Signal) error {
 	if signal != 0 && !signal.IsValid() {
 		return linuxerr.EINVAL

--- a/pkg/sentry/kernel/fs_context.go
+++ b/pkg/sentry/kernel/fs_context.go
@@ -41,9 +41,13 @@ type FSContext struct {
 	// umask is the current file mode creation mask. When a thread using this
 	// context invokes a syscall that creates a file, bits set in umask are
 	// removed from the permissions that the file is created with.
+	//
+	// +checklocks:mu
 	umask uint
 
 	// preventSharing is true for the duration of an associated Task's execve
+	//
+	// +checklocks:mu
 	preventSharing bool
 }
 
@@ -63,6 +67,8 @@ func NewFSContext(root, cwd vfs.VirtualDentry, umask uint) *FSContext {
 // destroy destroys the FSContext.
 //
 // Preconditions: f must have no refcount.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) destroy(ctx context.Context) {
 	// Hold f.mu so that we don't race with RootDirectory() and
 	// WorkingDirectory().
@@ -84,6 +90,8 @@ func (f *FSContext) destroy(ctx context.Context) {
 // Note that there may still be calls to WorkingDirectory() or RootDirectory()
 // (that return nil).  This is because valid references may still be held via
 // proc files or other mechanisms.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) DecRef(ctx context.Context) {
 	f.FSContextRefs.DecRef(func() {
 		f.destroy(ctx)
@@ -93,6 +101,8 @@ func (f *FSContext) DecRef(ctx context.Context) {
 // Fork forks this FSContext.
 //
 // This is not a valid call after f is destroyed.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) Fork() *FSContext {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -116,6 +126,8 @@ func (f *FSContext) Fork() *FSContext {
 //
 // This will return an empty vfs.VirtualDentry if called after f is
 // destroyed, otherwise it will return a Dirent with a reference taken.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) WorkingDirectory() vfs.VirtualDentry {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -130,6 +142,8 @@ func (f *FSContext) WorkingDirectory() vfs.VirtualDentry {
 // This will take an extra reference on the VirtualDentry.
 //
 // This is not a valid call after f is destroyed.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) SetWorkingDirectory(ctx context.Context, d vfs.VirtualDentry) {
 	f.mu.Lock()
 
@@ -149,6 +163,8 @@ func (f *FSContext) SetWorkingDirectory(ctx context.Context, d vfs.VirtualDentry
 //
 // This will return an empty vfs.VirtualDentry if called after f is
 // destroyed, otherwise it will return a Dirent with a reference taken.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) RootDirectory() vfs.VirtualDentry {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -162,6 +178,8 @@ func (f *FSContext) RootDirectory() vfs.VirtualDentry {
 // SetRootDirectory sets the root directory. It takes a reference on vd.
 //
 // This is not a valid call after f is destroyed.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) SetRootDirectory(ctx context.Context, vd vfs.VirtualDentry) {
 	if !vd.Ok() {
 		panic("FSContext.SetRootDirectory called with zero-value VirtualDentry")
@@ -182,6 +200,8 @@ func (f *FSContext) SetRootDirectory(ctx context.Context, vd vfs.VirtualDentry) 
 }
 
 // Umask returns the current umask.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) Umask() uint {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -189,6 +209,8 @@ func (f *FSContext) Umask() uint {
 }
 
 // SwapUmask atomically sets the current umask and returns the old umask.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) SwapUmask(mask uint) uint {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -204,6 +226,9 @@ func (f *FSContext) SwapUmask(mask uint) uint {
 // fsContext.allowSharing() is called.
 //
 // See Linux's fs_struct->in_exec.
+//
+// +checklocksexclude:f.mu
+// +checklocksexclude:tg.pidns.owner.mu
 func (f *FSContext) checkAndPreventSharingOutsideTG(tg *ThreadGroup) bool {
 	tg.pidns.owner.mu.RLock()
 	defer tg.pidns.owner.mu.RUnlock()
@@ -225,6 +250,8 @@ func (f *FSContext) checkAndPreventSharingOutsideTG(tg *ThreadGroup) bool {
 }
 
 // allowSharing allows the FSContext to be shared again via clone(2).
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) allowSharing() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -233,6 +260,8 @@ func (f *FSContext) allowSharing() {
 
 // share is a wrapper around IncRef. It returns false if a concurrent execve(2) in one of
 // the thread groups that uses this FSContext has prevented sharing.
+//
+// +checklocksexclude:f.mu
 func (f *FSContext) share() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -245,12 +274,15 @@ func (f *FSContext) share() bool {
 
 // unshareFromTask removes the FSContext f from the given Task t and replaces it with newF.
 // It returns a bool indicating whether f needs to be destroyed.
-
+//
 // This func operates without compromising a concurrent checkAndPreventSharingOutsideTG(): t's
 // association with f is severed atomically by holding f.mu, allowing the concurrent func to
 // correctly ascribe extra ref counts to tasks outside of t's thread group.
 //
-// Preconditions: The caller must be on the task goroutine and must hold t.mu.
+// Preconditions: The caller must be on the task goroutine.
+//
+// +checklocks:t.mu
+// +checklocksexclude:f.mu
 func (f *FSContext) unshareFromTask(t *Task, newF *FSContext) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/sentry/kernel/fs_context.go
+++ b/pkg/sentry/kernel/fs_context.go
@@ -29,13 +29,16 @@ import (
 type FSContext struct {
 	FSContextRefs
 
-	// mu protects below.
 	mu fsContextMutex `state:"nosave"`
 
 	// root is the filesystem root.
+	//
+	// +checklocks:mu
 	root vfs.VirtualDentry
 
 	// cwd is the current working directory.
+	//
+	// +checklocks:mu
 	cwd vfs.VirtualDentry
 
 	// umask is the current file mode creation mask. When a thread using this

--- a/pkg/sentry/kernel/fscheckpoint.go
+++ b/pkg/sentry/kernel/fscheckpoint.go
@@ -57,6 +57,10 @@ type FSSaveOpts struct {
 
 // FSSave collects a filesystem checkpoint as specified by the fscheckpoint
 // package. FSSave takes ownership of resources in opts.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.tasks.mu
+// +checklocksexclude:k.runningTasksMu
 func (k *Kernel) FSSave(ctx context.Context, opts *FSSaveOpts) error {
 	defer func() {
 		if opts.ManifestFile != nil {

--- a/pkg/sentry/kernel/futex/futex.go
+++ b/pkg/sentry/kernel/futex/futex.go
@@ -93,6 +93,11 @@ func (k *Key) matches(k2 *Key) bool {
 }
 
 // Target abstracts memory accesses and keys.
+//
+// LoadUint32, SwapUint32, and CompareAndSwapUint32 may run synchronously with
+// bucket mutexes held. They must not reenter operations acquiring those mutexes.
+// checklocks cannot express the selected bucket owners through Target.
+// GetSharedKey is called before acquiring bucket mutexes.
 type Target interface {
 	context.Context
 
@@ -196,22 +201,25 @@ func atomicOp(t Target, addr hostarch.Addr, opIn uint32) (bool, error) {
 
 // Waiter is the struct which gets enqueued into buckets for wake up routines
 // and requeue routines to scan and notify. Once a Waiter has been enqueued by
-// WaitPrepare(), callers may listen on C for wake up events.
+// WaitPrepare() or LockPI(), callers may listen on C for wake up events.
 type Waiter struct {
 	// Synchronization:
 	//
-	//	- A Waiter that is not enqueued in a bucket is exclusively owned (no
-	//		synchronization applies).
+	//	- A newly created Waiter, or one for which WaitComplete has returned,
+	//		is exclusively owned by its caller.
 	//
-	//	- A Waiter is enqueued in a bucket by calling WaitPrepare(). After this,
+	//	- A Waiter can be enqueued by calling WaitPrepare() or LockPI(). Then
 	//		waiterEntry, bucket, and key are protected by the bucket.mu ("bucket
-	//		lock") of the containing bucket, and bitmask is immutable. Note that
-	//		since bucket is mutated using atomic memory operations, bucket.Load()
+	//		lock") of the containing bucket. bitmask and tid are immutable.
+	//		Since bucket is mutated using atomic memory operations, bucket.Load()
 	//		may be called without holding the bucket lock, although it may change
 	//		racily. See WaitComplete().
 	//
-	//	- A Waiter is only guaranteed to be no longer queued after calling
-	//		WaitComplete().
+	//	- Once enqueued, a Waiter may not be reused until WaitComplete returns.
+	//
+	// Requeue changes which bucket mutex protects waiterEntry and key.
+	// checklocks cannot express a guard obtained from an atomic pointer that
+	// may change; WaitComplete locks and revalidates that pointer explicitly.
 
 	// waiterEntry links Waiter into bucket.waiters.
 	waiterEntry
@@ -241,7 +249,8 @@ func NewWaiter() *Waiter {
 	}
 }
 
-// woken returns true if w has been woken since the last call to WaitPrepare.
+// woken returns true if w has been woken since the last WaitPrepare or LockPI
+// call.
 func (w *Waiter) woken() bool {
 	return len(w.C) != 0
 }
@@ -253,13 +262,14 @@ type bucket struct {
 	// mu protects waiters and contained Waiter state. See comment in Waiter.
 	mu futexBucketMutex `state:"nosave"`
 
+	// +checklocks:mu
 	waiters waiterList `state:"zerovalue"`
 }
 
 // wakeLocked wakes up to n waiters matching the bitmask at the addr for this
 // bucket and returns the number of waiters woken.
 //
-// Preconditions: b.mu must be locked.
+// +checklocks:b.mu
 func (b *bucket) wakeLocked(key *Key, bitmask uint32, n int) int {
 	done := 0
 	for w := b.waiters.Front(); done < n && w != nil; {
@@ -278,26 +288,28 @@ func (b *bucket) wakeLocked(key *Key, bitmask uint32, n int) int {
 	return done
 }
 
+// wakeWaiterLocked removes w from b and wakes it.
+//
+// Preconditions: w must be queued in b.
+//
+// +checklocks:b.mu
 func (b *bucket) wakeWaiterLocked(w *Waiter) {
-	// Remove from the bucket and wake the waiter.
 	b.waiters.Remove(w)
 	w.C <- struct{}{}
 
-	// NOTE: The above channel write establishes a write barrier according
-	// to the memory model, so nothing may be ordered around it. Since
-	// we've dequeued w and will never touch it again, we can safely
-	// store nil to w.bucket here and allow the WaitComplete() to
-	// short-circuit grabbing the bucket lock. If they somehow miss the
-	// store, we are still holding the lock, so we can know that they won't
-	// dequeue w, assume it's free and have the below operation
-	// afterwards.
+	// After notification, bucket is the only part of w this path still
+	// accesses. The atomic nil store lets WaitComplete skip the bucket lock.
+	// If WaitComplete sees the old bucket, it must acquire b.mu and recheck,
+	// so it cannot finish and allow w to be reused before this store.
 	w.bucket.Store(nil)
 }
 
-// requeueLocked takes n waiters from the bucket and moves them to naddr on the
-// bucket "to".
+// requeueLocked requeues up to n waiters matching key from b to to using nkey.
 //
-// Preconditions: b and to must be locked.
+// b and to may be the same bucket, in which case its mutex is held only once.
+//
+// +checklocks:b.mu
+// +checklocks:to.mu
 func (b *bucket) requeueLocked(t Target, to *bucket, key, nkey *Key, n int) int {
 	done := 0
 	for w := b.waiters.Front(); done < n && w != nil; {
@@ -369,6 +381,10 @@ func bucketIndexForAddr(addr hostarch.Addr) uintptr {
 
 // Manager holds futex state for a single virtual address space.
 //
+// Callers of operations that acquire bucket locks must not already hold any
+// potentially acquired bucket's mutex. checklocks can name sharedBucket.mu,
+// but cannot express guards indexed by runtime-selected private bucket IDs.
+//
 // +stateify savable
 type Manager struct {
 	// privateBuckets holds buckets for KindPrivate and KindSharedPrivate
@@ -397,7 +413,9 @@ func (m *Manager) Fork() *Manager {
 }
 
 // lockBucket returns a locked bucket for the given key.
+//
 // +checklocksacquire:b.mu
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) lockBucket(k *Key) (b *bucket) {
 	if k.Kind == KindSharedMappable {
 		b = m.sharedBucket
@@ -408,12 +426,19 @@ func (m *Manager) lockBucket(k *Key) (b *bucket) {
 	return b
 }
 
-// lockBuckets returns locked buckets for the given keys.
-// It returns which bucket was locked first and second. They may be nil in case the buckets are
-// identical or they did not need locking.
+// lockBuckets returns the buckets for k1 and k2 with their mutexes held.
+// If both keys map to the same bucket, its mutex is locked only once.
+//
+// lockedFirst and lockedSecond identify the buckets in lock order.
+// lockedFirst is always non-nil. lockedSecond is nil if and only if b1 == b2.
+// Pass these ordered values to unlockBuckets to release the locks.
+//
+// checklocks cannot express the aliases between b1/b2 and the ordered return
+// values.
 //
 // +checklocksacquire:lockedFirst.mu
 // +checklocksacquire:lockedSecond.mu
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) lockBuckets(k1, k2 *Key) (b1, b2, lockedFirst, lockedSecond *bucket) {
 	// Buckets must be consistently ordered to avoid circular lock
 	// dependencies. We order buckets in m.privateBuckets by index (lowest
@@ -458,7 +483,12 @@ func (m *Manager) lockBuckets(k1, k2 *Key) (b1, b2, lockedFirst, lockedSecond *b
 	return b1, b2, b1, nil // +checklocksforce
 }
 
-// unlockBuckets unlocks two buckets.
+// unlockBuckets releases the locks acquired by lockBuckets in reverse order.
+//
+// Preconditions: lockedFirst and lockedSecond must be the ordered return
+// values from the same call to lockBuckets, and the caller must still hold
+// those locks.
+//
 // +checklocksrelease:lockedFirst.mu
 // +checklocksrelease:lockedSecond.mu
 func (m *Manager) unlockBuckets(lockedFirst, lockedSecond *bucket) {
@@ -470,6 +500,8 @@ func (m *Manager) unlockBuckets(lockedFirst, lockedSecond *bucket) {
 
 // Wake wakes up to n waiters matching the bitmask on the given addr.
 // The number of waiters woken is returned.
+//
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) Wake(t Target, addr hostarch.Addr, private bool, bitmask uint32, n int) (int, error) {
 	// This function is very hot; avoid defer.
 	k, err := getKey(t, addr, private)
@@ -485,6 +517,7 @@ func (m *Manager) Wake(t Target, addr hostarch.Addr, private bool, bitmask uint3
 	return r, nil
 }
 
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) doRequeue(t Target, addr, naddr hostarch.Addr, private bool, checkval bool, val uint32, nwake int, nreq int) (int, error) {
 	k1, err := getKey(t, addr, private)
 	if err != nil {
@@ -506,17 +539,21 @@ func (m *Manager) doRequeue(t Target, addr, naddr hostarch.Addr, private bool, c
 		}
 	}
 
-	// Wake the number required.
-	done := b1.wakeLocked(&k1, ^uint32(0), nwake)
+	// Wake the number required. lockBuckets holds b1.mu and b2.mu through
+	// the ordered handles until unlockBuckets; checklocks cannot relate
+	// those handles to the logical buckets.
+	done := b1.wakeLocked(&k1, ^uint32(0), nwake) // +checklocksignore
 
 	// Requeue the number required.
-	b1.requeueLocked(t, b2, &k1, &k2, nreq)
+	b1.requeueLocked(t, b2, &k1, &k2, nreq) // +checklocksignore
 
 	return done, nil
 }
 
 // Requeue wakes up to nwake waiters on the given addr, and unconditionally
 // requeues up to nreq waiters on naddr.
+//
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) Requeue(t Target, addr, naddr hostarch.Addr, private bool, nwake int, nreq int) (int, error) {
 	return m.doRequeue(t, addr, naddr, private, false, 0, nwake, nreq)
 }
@@ -524,6 +561,8 @@ func (m *Manager) Requeue(t Target, addr, naddr hostarch.Addr, private bool, nwa
 // RequeueCmp atomically checks that the addr contains val (via the Target),
 // wakes up to nwake waiters on addr and then unconditionally requeues nreq
 // waiters on naddr.
+//
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) RequeueCmp(t Target, addr, naddr hostarch.Addr, private bool, val uint32, nwake int, nreq int) (int, error) {
 	return m.doRequeue(t, addr, naddr, private, true, val, nwake, nreq)
 }
@@ -532,6 +571,8 @@ func (m *Manager) RequeueCmp(t Target, addr, naddr hostarch.Addr, private bool, 
 // waiters unconditionally from addr1, and, based on the original value at addr2
 // and a comparison encoded in op, wakes up to nwake2 waiters from addr2.
 // It returns the total number of waiters woken.
+//
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) WakeOp(t Target, addr1, addr2 hostarch.Addr, private bool, nwake1 int, nwake2 int, op uint32) (int, error) {
 	k1, err := getKey(t, addr1, private)
 	if err != nil {
@@ -553,13 +594,15 @@ func (m *Manager) WakeOp(t Target, addr1, addr2 hostarch.Addr, private bool, nwa
 		return 0, err
 	}
 
-	// Wake up up to nwake1 entries from the first bucket.
-	done = b1.wakeLocked(&k1, ^uint32(0), nwake1)
+	// Wake up to nwake1 entries from the first bucket. lockBuckets holds
+	// both logical buckets through the ordered handles until unlockBuckets;
+	// checklocks cannot relate those handles to b1 and b2.
+	done = b1.wakeLocked(&k1, ^uint32(0), nwake1) // +checklocksignore
 
 	// Wake up up to nwake2 entries from the second bucket if the
 	// operation yielded true.
 	if cond {
-		done += b2.wakeLocked(&k2, ^uint32(0), nwake2)
+		done += b2.wakeLocked(&k2, ^uint32(0), nwake2) // +checklocksignore
 	}
 
 	return done, nil
@@ -569,6 +612,8 @@ func (m *Manager) WakeOp(t Target, addr1, addr2 hostarch.Addr, private bool, nwa
 // enqueues w to be woken by a send to w.C. If WaitPrepare returns nil, the
 // Waiter must be subsequently removed by calling WaitComplete, whether or not
 // a wakeup is received on w.C.
+//
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) WaitPrepare(w *Waiter, t Target, addr hostarch.Addr, private bool, val uint32, bitmask uint32) error {
 	k, err := getKey(t, addr, private)
 	if err != nil {
@@ -602,8 +647,11 @@ func (m *Manager) WaitPrepare(w *Waiter, t Target, addr hostarch.Addr, private b
 	return nil
 }
 
-// WaitComplete must be called when a Waiter previously added by WaitPrepare is
-// no longer eligible to be woken.
+// WaitComplete must be called when a Waiter previously added by WaitPrepare or
+// LockPI is no longer eligible to be woken.
+//
+// The caller must not hold the waiter's current bucket mutex. Requeue can
+// change that bucket, so checklocks cannot express this dynamic exclusion.
 func (m *Manager) WaitComplete(w *Waiter, t Target) {
 	// Remove w from the bucket it's in.
 	for {
@@ -647,6 +695,8 @@ func (m *Manager) WaitComplete(w *Waiter, t Target) {
 // FUTEX_OWNER_DIED is only set by the Linux when robust lists are in use (see
 // exit_robust_list()). Given we don't support robust lists, although handled
 // below, it's never set.
+//
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) LockPI(w *Waiter, t Target, addr hostarch.Addr, tid uint32, private, try bool) (bool, error) {
 	k, err := getKey(t, addr, private)
 	if err != nil {
@@ -679,6 +729,7 @@ func (m *Manager) LockPI(w *Waiter, t Target, addr hostarch.Addr, tid uint32, pr
 	return success, nil
 }
 
+// +checklocks:b.mu
 func (m *Manager) lockPILocked(w *Waiter, t Target, addr hostarch.Addr, tid uint32, b *bucket, try bool) (bool, error) {
 	for {
 		cur, err := t.LoadUint32(addr)
@@ -740,6 +791,8 @@ func (m *Manager) lockPILocked(w *Waiter, t Target, addr hostarch.Addr, tid uint
 // The address provided must contain the caller's TID. If there are waiters,
 // TID of the next waiter (FIFO) is set to the given address, and the waiter
 // woken up. If there are no waiters, 0 is set to the address.
+//
+// +checklocksexclude:m.sharedBucket.mu
 func (m *Manager) UnlockPI(t Target, addr hostarch.Addr, tid uint32, private bool) error {
 	k, err := getKey(t, addr, private)
 	if err != nil {
@@ -754,6 +807,7 @@ func (m *Manager) UnlockPI(t Target, addr hostarch.Addr, tid uint32, private boo
 	return err
 }
 
+// +checklocks:b.mu
 func (m *Manager) unlockPILocked(t Target, addr hostarch.Addr, tid uint32, b *bucket, key *Key) error {
 	cur, err := t.LoadUint32(addr)
 	if err != nil {

--- a/pkg/sentry/kernel/ipc/object.go
+++ b/pkg/sentry/kernel/ipc/object.go
@@ -34,16 +34,22 @@ type ID int32
 // Object represents an abstract IPC object with fields common to all IPC
 // mechanisms.
 //
+// After initialization, mutable fields are protected by the containing
+// msgqueue.Queue.mu, semaphore.Set.mu, or shm.Shm.mu. Object has no pointer
+// to that mechanism, so checklocks cannot resolve its mutex for accesses
+// through an escaped *Object.
+//
 // +stateify savable
 type Object struct {
 	// User namespace which owns the IPC namespace which owns the IPC object.
 	// Immutable.
 	UserNS *auth.UserNamespace
 
-	// ID is a kernel identifier for the IPC object. Immutable.
+	// ID is a kernel identifier assigned during registration, then immutable.
 	ID ID
 
-	// Key is a user-provided identifier for the IPC object. Immutable.
+	// Key is a user-provided identifier for the IPC object. For shared-memory
+	// segments, IPC_RMID changes it to IPC_PRIVATE.
 	Key Key
 
 	// CreatorUID is the UID of user who created the IPC object. Immutable.
@@ -52,19 +58,23 @@ type Object struct {
 	// CreatorGID is the GID of user who created the IPC object. Immutable.
 	CreatorGID auth.KGID
 
-	// OwnerUID is the UID of the current owner of the IPC object. Immutable.
+	// OwnerUID is the UID of the current owner of the IPC object.
 	OwnerUID auth.KUID
 
-	// OwnerGID is the GID of the current owner of the IPC object. Immutable.
+	// OwnerGID is the GID of the current owner of the IPC object.
 	OwnerGID auth.KGID
 
-	// Mode is the access permissions the IPC object.
+	// Mode is the access permissions of the IPC object.
 	Mode linux.FileMode
 }
 
 // Mechanism represents a SysV mechanism that holds an IPC object. It can also
 // be looked at as a container for an ipc.Object, which is by definition a fully
 // functional SysV object.
+//
+// checklocks cannot name the concrete mechanism's mutex through this
+// interface. Concrete Lock/Unlock effects and Destroy preconditions do not
+// propagate through interface calls.
 type Mechanism interface {
 	// Lock behaves the same as Mutex.Lock on the mechanism.
 	Lock()
@@ -72,11 +82,13 @@ type Mechanism interface {
 	// Unlock behaves the same as Mutex.Unlock on the mechanism.
 	Unlock()
 
-	// Object returns a pointer to the mechanism's ipc.Object. Mechanism.Lock,
-	// and Mechanism.Unlock should be used when the object is used.
+	// Object returns a pointer to the mechanism's ipc.Object. After
+	// initialization, access to its mutable fields requires the mechanism's lock.
 	Object() *Object
 
 	// Destroy destroys the mechanism.
+	//
+	// Preconditions: The mechanism's mutex must be held.
 	Destroy()
 }
 
@@ -97,6 +109,8 @@ func NewObject(un *auth.UserNamespace, key Key, creator, owner *auth.Credentials
 
 // CheckOwnership verifies whether an IPC object may be accessed using creds as
 // an owner. See ipc/util.c:ipcctl_obtain_check() in Linux.
+//
+// Preconditions: The containing mechanism's mutex must be held.
 func (o *Object) CheckOwnership(creds *auth.Credentials) bool {
 	if o.OwnerUID == creds.EffectiveKUID || o.CreatorUID == creds.EffectiveKUID {
 		return true
@@ -110,6 +124,8 @@ func (o *Object) CheckOwnership(creds *auth.Credentials) bool {
 
 // CheckPermissions verifies whether an IPC object is accessible using creds for
 // access described by req. See ipc/util.c:ipcperms() in Linux.
+//
+// Preconditions: The containing mechanism's mutex must be held.
 func (o *Object) CheckPermissions(creds *auth.Credentials, req vfs.AccessTypes) bool {
 	perms := uint16(o.Mode.Permissions())
 	if o.OwnerUID == creds.EffectiveKUID {
@@ -126,7 +142,7 @@ func (o *Object) CheckPermissions(creds *auth.Credentials, req vfs.AccessTypes) 
 
 // Set modifies attributes for an IPC object. See *ctl(IPC_SET).
 //
-// Precondition: Mechanism.mu must be held.
+// Preconditions: The containing mechanism's mutex must be held.
 func (o *Object) Set(ctx context.Context, perm *linux.IPCPerm) error {
 	creds := auth.CredentialsFromContext(ctx)
 	uid := creds.UserNamespace.MapToKUID(auth.UID(perm.UID))

--- a/pkg/sentry/kernel/ipc/registry.go
+++ b/pkg/sentry/kernel/ipc/registry.go
@@ -23,9 +23,12 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 )
 
-// Registry is similar to Object, but for registries. It represent an abstract
-// SysV IPC registry with fields common to all SysV registries. Registry is not
-// thread-safe, and should be protected using a mutex.
+// Registry contains fields common to all SysV IPC registries.
+//
+// The containing msgqueue.Registry.mu, semaphore.Registry.mu, or
+// shm.Registry.mu protects mutable fields after initialization. Registry has
+// no pointer to its containing registry, so checklocks cannot resolve that
+// mutex for accesses through an escaped *Registry.
 //
 // +stateify savable
 type Registry struct {
@@ -35,7 +38,7 @@ type Registry struct {
 	// objects is a map of IDs to IPC mechanisms.
 	objects map[ID]Mechanism
 
-	// KeysToIDs maps a lookup key to an ID.
+	// keysToIDs maps a lookup key to an ID.
 	keysToIDs map[Key]ID
 
 	// lastIDUsed is used to find the next available ID for object creation.
@@ -86,8 +89,8 @@ func (r *Registry) Find(ctx context.Context, key Key, mode linux.FileMode, creat
 	return nil, nil
 }
 
-// Register adds the given object into Registry.Objects, and assigns it a new
-// ID. It returns an error if all IDs are exhausted.
+// Register adds m to r.objects, assigns it a new ID, and associates its key
+// with that ID in r.keysToIDs. It returns an error if all IDs are exhausted.
 func (r *Registry) Register(m Mechanism) error {
 	id, err := r.newID()
 	if err != nil {
@@ -155,7 +158,14 @@ func (r *Registry) Remove(id ID, creds *auth.Credentials) error {
 	return nil
 }
 
-// ForAllObjects executes a given function for all given objects.
+// ForAllObjects calls f synchronously for each registered mechanism while the
+// caller holds the containing registry's mutex. No reference is transferred.
+// The registry mutex does not protect mutable mechanism state; f must acquire
+// the mechanism's mutex before accessing that state.
+//
+// f must preserve the registry lock and not reenter operations that acquire it.
+// checklocks cannot express this external-owner callback contract. Retaining a
+// mechanism requires a separate lifetime guarantee.
 func (r *Registry) ForAllObjects(f func(o Mechanism)) {
 	for _, o := range r.objects {
 		f(o)
@@ -167,10 +177,9 @@ func (r *Registry) FindByID(id ID) Mechanism {
 	return r.objects[id]
 }
 
-// DissociateKey removes the association between a mechanism and its key
-// (deletes it from r.keysToIDs), preventing it from being discovered by any new
-// process, but not necessarily destroying it. If the given key doesn't exist,
-// nothing is changed.
+// DissociateKey removes the association between a mechanism and its key from
+// r.keysToIDs. Lookup by ID is unaffected, and the mechanism is not destroyed.
+// If the given key doesn't exist, nothing is changed.
 func (r *Registry) DissociateKey(key Key) {
 	delete(r.keysToIDs, key)
 }

--- a/pkg/sentry/kernel/kcov.go
+++ b/pkg/sentry/kernel/kcov.go
@@ -44,30 +44,38 @@ type Kcov struct {
 	// mf stores application memory. It is immutable after creation.
 	mf *pgalloc.MemoryFile
 
-	// mu protects all of the fields below.
 	mu sync.RWMutex
 
 	// mode is the current kcov mode.
+	//
+	// +checklocks:mu
 	mode uint8
 
 	// size is the size of the mapping through which the kernel conveys coverage
 	// information to userspace.
+	//
+	// +checklocks:mu
 	size uint64
 
 	// owningTask is the task that currently owns coverage data on the system. The
 	// interface for kcov essentially requires that coverage is only going to a
 	// single task. Note that kcov should only generate coverage data for the
 	// owning task, but we currently generate global coverage.
+	//
+	// +checklocks:mu
 	owningTask *Task
 
 	// count is a locally cached version of the first uint64 in the kcov data,
 	// which is the number of subsequent entries representing PCs.
 	//
-	// It is used with kcovInode.countBlock(), to copy in/out the first element of
+	// It is used with Kcov.countBlock(), to copy in/out the first element of
 	// the actual data in an efficient manner, avoid boilerplate, and prevent
 	// accidental garbage escapes by the temporary counts.
+	//
+	// +checklocks:mu
 	count uint64
 
+	// +checklocks:mu
 	mappable *mm.SpecialMappable
 }
 
@@ -85,6 +93,9 @@ var coveragePool = sync.Pool{
 }
 
 // TaskWork implements TaskWorker.TaskWork.
+//
+// +checklocksexclude:kcov.mu
+// +checklocksexclude:t.taskWorkMu
 func (kcov *Kcov) TaskWork(t *Task) {
 	kcov.mu.Lock()
 	defer kcov.mu.Unlock()
@@ -120,6 +131,8 @@ func (kcov *Kcov) TaskWork(t *Task) {
 }
 
 // InitTrace performs the KCOV_INIT_TRACE ioctl.
+//
+// +checklocksexclude:kcov.mu
 func (kcov *Kcov) InitTrace(size uint64) error {
 	kcov.mu.Lock()
 	defer kcov.mu.Unlock()
@@ -146,6 +159,8 @@ func (kcov *Kcov) InitTrace(size uint64) error {
 }
 
 // EnableTrace performs the KCOV_ENABLE_TRACE ioctl.
+//
+// +checklocksexclude:kcov.mu
 func (kcov *Kcov) EnableTrace(ctx context.Context, traceKind uint8) error {
 	t := TaskFromContext(ctx)
 	if t == nil {
@@ -185,6 +200,8 @@ func (kcov *Kcov) EnableTrace(ctx context.Context, traceKind uint8) error {
 }
 
 // DisableTrace performs the KCOV_DISABLE_TRACE ioctl.
+//
+// +checklocksexclude:kcov.mu
 func (kcov *Kcov) DisableTrace(ctx context.Context) error {
 	kcov.mu.Lock()
 	defer kcov.mu.Unlock()
@@ -209,6 +226,8 @@ func (kcov *Kcov) DisableTrace(ctx context.Context) error {
 // Clear resets the mode and clears the owning task and memory mapping for kcov.
 // It is called when the fd corresponding to kcov is closed. Note that the mode
 // needs to be set so that the next call to kcov.TaskWork() will exit early.
+//
+// +checklocksexclude:kcov.mu
 func (kcov *Kcov) Clear(ctx context.Context) {
 	kcov.mu.Lock()
 	kcov.mode = linux.KCOV_MODE_INIT
@@ -223,6 +242,8 @@ func (kcov *Kcov) Clear(ctx context.Context) {
 // OnTaskExit is called when the owning task exits. It is similar to
 // kcov.Clear(), except the memory mapping is not cleared, so that the same
 // mapping can be used in the future if kcov is enabled again by another task.
+//
+// +checklocksexclude:kcov.mu
 func (kcov *Kcov) OnTaskExit() {
 	kcov.mu.Lock()
 	kcov.mode = linux.KCOV_MODE_INIT
@@ -232,6 +253,8 @@ func (kcov *Kcov) OnTaskExit() {
 
 // ConfigureMMap is called by the vfs.FileDescription for this kcov instance to
 // implement vfs.FileDescription.ConfigureMMap.
+//
+// +checklocksexclude:kcov.mu
 func (kcov *Kcov) ConfigureMMap(ctx context.Context, opts *memmap.MMapOpts) error {
 	kcov.mu.Lock()
 	defer kcov.mu.Unlock()

--- a/pkg/sentry/kernel/kcov_unsafe.go
+++ b/pkg/sentry/kernel/kcov_unsafe.go
@@ -22,7 +22,13 @@ import (
 
 // countBlock provides a safemem.BlockSeq for kcov.count.
 //
-// Like k.count, the block returned is protected by k.mu.
+// The returned block aliases kcov.count and must only be accessed while
+// kcov.mu is held.
+//
+// The entry annotation cannot enforce that requirement on accesses through
+// the returned BlockSeq.
+//
+// +checklocks:kcov.mu
 func (kcov *Kcov) countBlock() safemem.BlockSeq {
 	return safemem.BlockSeqOf(safemem.BlockFromSafePointer(unsafe.Pointer(&kcov.count), int(unsafe.Sizeof(kcov.count))))
 }

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -95,6 +95,7 @@ import (
 type UserCounters struct {
 	uid auth.KUID
 
+	// +checkatomic
 	rlimitNProc atomicbitops.Uint64
 }
 
@@ -160,6 +161,8 @@ type Kernel struct {
 
 	// started is true if Start has been called. Unless otherwise specified,
 	// all Kernel fields become immutable once started becomes true.
+	//
+	// +checklocks:extMu
 	started bool `state:"nosave"`
 
 	// All of the following fields are immutable unless otherwise specified.
@@ -196,8 +199,14 @@ type Kernel struct {
 	// after all tasks in the thread group have exited, such that ID 1 is no
 	// longer mapped.
 	//
-	// globalInit is mutable until it is assigned by the first successful call
-	// to CreateProcess, and is protected by extMu.
+	// globalInit is assigned by the first successful call to CreateProcess
+	// under extMu. The pointer is immutable afterwards. Task and signal paths
+	// read the published pointer without extMu; taking extMu while holding
+	// TaskSet.mu would reverse the lock order.
+	//
+	// Before publication, readers rely on serialized process creation or the
+	// SupervisorContext caller contract. checklocks cannot express this
+	// publication rule or carry that contract into a Value callback.
 	globalInit *ThreadGroup
 
 	// syslog is the kernel log.
@@ -209,16 +218,20 @@ type Kernel struct {
 	// TaskGoroutineRunningSys or TaskGoroutineRunningApp. i.e., they are
 	// not blocked or stopped.
 	//
-	// runningTasks must be accessed atomically. Increments from 0 to 1 are
-	// further protected by runningTasksMu (see incRunningTasks).
+	// Increments from 0 to 1 also require runningTasksMu (see
+	// incRunningTasks).
+	//
+	// +checkatomic
 	runningTasks atomicbitops.Int64
 
 	// blockedTasks is the total count of tasks currently in
 	// TaskGoroutineBlockedUninterruptible, i.e. uninterruptible sleep. It is
 	// used to implement procs_blocked in /proc/stat.
 	//
-	// blockedTasks must be accessed atomically. It is not saved; on restore it
-	// is repopulated as tasks re-enter uninterruptible sleep.
+	// It is not saved; on restore it is repopulated as tasks re-enter
+	// uninterruptible sleep.
+	//
+	// +checkatomic
 	blockedTasks atomicbitops.Int64 `state:"nosave"`
 
 	// runningTasksCond is signaled when runningTasks is incremented from 0 to 1.
@@ -244,7 +257,7 @@ type Kernel struct {
 	// running, and false if it is blocked in runningTasksCond.Wait() or if it
 	// never started.
 	//
-	// cpuClockTickerRunning is protected by runningTasksMu.
+	// +checklocks:runningTasksMu
 	cpuClockTickerRunning bool
 
 	// cpuClockTickerWakeCh is sent to to wake the goroutine that increments
@@ -262,6 +275,8 @@ type Kernel struct {
 	// strictly slower due to CPU clock ticker goroutine wakeup latency). This
 	// does not use ktime.SyntheticClock since this clock currently does not
 	// need to support timers.
+	//
+	// +checkatomic
 	cpuClock atomicbitops.Int64
 
 	// userCPUClock and userSysCPUClock are kernel-wide cumulative CPU time
@@ -274,19 +289,21 @@ type Kernel struct {
 	// the CPU time of exited tasks. They are used to implement the aggregate
 	// CPU line in /proc/stat (see Kernel.CPUStats).
 	//
-	// userCPUClock and userSysCPUClock must be accessed atomically.
-	userCPUClock    atomicbitops.Int64
+	// +checkatomic
+	userCPUClock atomicbitops.Int64
+
+	// +checkatomic
 	userSysCPUClock atomicbitops.Int64
 
 	// uniqueID is used to generate unique identifiers.
 	//
-	// uniqueID is mutable, and is accessed using atomic memory operations.
+	// +checkatomic
 	uniqueID atomicbitops.Uint64
 
 	// nextInotifyCookie is a monotonically increasing counter used for
 	// generating unique inotify event cookies.
 	//
-	// nextInotifyCookie is mutable.
+	// +checkatomic
 	nextInotifyCookie atomicbitops.Uint32
 
 	// netlinkPorts manages allocation of netlink socket port IDs.
@@ -295,7 +312,8 @@ type Kernel struct {
 	// saveStatus is nil if the sandbox has not been saved, errSaved or
 	// errAutoSaved if it has been saved successfully, or the error causing the
 	// sandbox to exit during save.
-	// It is protected by extMu.
+	//
+	// +checklocks:extMu
 	saveStatus error `state:"nosave"`
 
 	// danglingEndpoints is used to save / restore tcpip.DanglingEndpoints.
@@ -304,8 +322,9 @@ type Kernel struct {
 	// sockets records all network sockets in the system. Protected by extMu.
 	sockets map[*vfs.FileDescription]*SocketRecord
 
-	// nextSocketRecord is the next entry number to use in sockets. Protected
-	// by extMu.
+	// nextSocketRecord is the next entry number to use in sockets.
+	//
+	// +checklocks:extMu
 	nextSocketRecord uint64
 
 	// unimplementedSyscallEmitterOnce is used in the initialization of
@@ -380,6 +399,8 @@ type Kernel struct {
 	// created for the root container. These mounts are then bind mounted
 	// for other application containers by creating their own container
 	// directories.
+	//
+	// +checklocks:cgroupMountsMapMu
 	cgroupMountsMap   map[string]*CgroupMount
 	cgroupMountsMapMu cgroupMountsMutex `state:"nosave"`
 
@@ -392,6 +413,8 @@ type Kernel struct {
 	MaxFDLimit atomicbitops.Int32
 
 	// devGofers maps containers (using its name) to its device gofer client.
+	//
+	// +checklocks:devGofersMu
 	devGofers   map[string]*devutil.GoferClient `state:"nosave"`
 	devGofersMu sync.Mutex                      `state:"nosave"`
 
@@ -507,10 +530,12 @@ type InitKernelArgs struct {
 	Cgroup2FSInit func(ctx context.Context, k *Kernel, vfsObj *vfs.VirtualFilesystem) (*vfs.Filesystem, error)
 }
 
-// Init initialize the Kernel with no tasks.
+// Init initializes the Kernel with no tasks.
 //
 // Callers must manually set Kernel.Platform and call Kernel.SetMemoryFile
 // before calling Init.
+//
+// Preconditions: k has not been initialized and is not in use.
 func (k *Kernel) Init(args InitKernelArgs) error {
 	if args.Timekeeper == nil {
 		return fmt.Errorf("args.Timekeeper is nil")
@@ -666,6 +691,14 @@ func (k *Kernel) Init(args InitKernelArgs) error {
 	return nil
 }
 
+// quiescePausedAnd runs f with kernel timers and CPU-clock updates paused.
+// f runs synchronously with k.extMu held and must not release or reacquire it.
+//
+// Preconditions: The kernel must be paused throughout the call.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.runningTasksMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) quiescePausedAnd(ctx context.Context, f func() error) error {
 	// Do not allow other Kernel methods to affect it while it's being saved.
 	k.extMu.Lock()
@@ -714,6 +747,10 @@ func savePrivateMFs(ctx context.Context, w io.Writer, mfsToSave map[checkpoint.R
 // pagesMetadata, and pagesFile, even if it returns a non-nil error.
 //
 // Preconditions: The kernel must be paused throughout the call to SaveTo.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.runningTasksMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) SaveTo(ctx context.Context, stateFile, pagesMetadata io.WriteCloser, pagesFile stateio.AsyncWriter, appMFExcludeCommittedZeroPages, resume bool) error {
 	if hostarch.PageSize != 4096 {
 		return fmt.Errorf("save is not supported with %dK page size", hostarch.PageSize/1024)
@@ -935,7 +972,9 @@ func (k *Kernel) invalidateUnsavableMappings(ctx context.Context) error {
 	return nil
 }
 
-// LoadFrom returns a new Kernel loaded from args.
+// LoadFrom restores k from r.
+//
+// Preconditions: k is not in use.
 func (k *Kernel) LoadFrom(ctx context.Context, r io.Reader, asyncMFLoader *AsyncMFLoader, timeReady chan struct{}, networkArgs inet.NetworkArgs, clocks sentrytime.Clocks, vfsOpts *vfs.CompleteRestoreOptions, timeline *timing.Timeline) error {
 	defer timeline.End()
 	if hostarch.PageSize != 4096 {
@@ -1042,6 +1081,8 @@ func (k *Kernel) LoadFrom(ctx context.Context, r io.Reader, asyncMFLoader *Async
 
 // ExtractRootfsUpperLayer partially restores the kernel state and extracts the
 // rootfs upper layer to the provided file.
+//
+// Preconditions: k is not in use.
 func (k *Kernel) ExtractRootfsUpperLayer(ctx context.Context, r io.Reader, asyncMFLoader *AsyncMFLoader, timeReady chan struct{}, clocks sentrytime.Clocks, outFD *os.File) error {
 	if hostarch.PageSize != 4096 {
 		return fmt.Errorf("restore is not supported with %dK page size", hostarch.PageSize/1024)
@@ -1201,7 +1242,7 @@ type CreateProcessArgs struct {
 }
 
 // NewContext returns a context.Context that represents the task that will be
-// created by args.NewContext(k).
+// created by Kernel.CreateProcess with args.
 func (args *CreateProcessArgs) NewContext(k *Kernel) context.Context {
 	return &createProcessContext{
 		Context: context.Background(),
@@ -1475,6 +1516,10 @@ func (k *Kernel) StartProcess(tg *ThreadGroup) {
 // Start starts execution of all tasks in k.
 //
 // Preconditions: Start may be called exactly once.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.runningTasksMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) Start() error {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -1511,9 +1556,11 @@ func (k *Kernel) Start() error {
 
 // pauseTimeLocked pauses all Timers and Timekeeper updates.
 //
-// Preconditions:
-//   - Any task goroutines running in k must be stopped.
-//   - k.extMu must be locked.
+// Preconditions: Any task goroutines running in k must be stopped.
+//
+// +checklocks:k.extMu
+// +checklocksexclude:k.runningTasksMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) pauseTimeLocked(ctx context.Context) {
 	// Since all task goroutines have been stopped by precondition, the CPU clock
 	// ticker should stop on its own; wait for it to do so, waking it up from
@@ -1558,9 +1605,9 @@ func (k *Kernel) pauseTimeLocked(ctx context.Context) {
 // pauseTimeLocked has not been previously called, resumeTimeLocked has no
 // effect.
 //
-// Preconditions:
-//   - Any task goroutines running in k must be stopped.
-//   - k.extMu must be locked.
+// Preconditions: Any task goroutines running in k must be stopped.
+//
+// +checklocks:k.extMu
 func (k *Kernel) resumeTimeLocked(ctx context.Context) {
 	// The CPU clock ticker will automatically resume as task goroutines resume
 	// execution.
@@ -1584,6 +1631,7 @@ func (k *Kernel) resumeTimeLocked(ctx context.Context) {
 	}
 }
 
+// +checklocksexclude:k.runningTasksMu
 func (k *Kernel) incRunningTasks() {
 	for {
 		tasks := k.runningTasks.Load()
@@ -1701,6 +1749,8 @@ func (k *Kernel) BlockedTasks() int64 {
 // runningTasks is 0, no task can be in TaskGoroutineRunningSys (such a task
 // counts as running), and the CPU clock is frozen, so a sentry-activity monitor
 // like the watchdog has nothing to observe until a task becomes runnable again.
+//
+// +checklocksexclude:k.runningTasksMu
 func (k *Kernel) WaitForTaskActivity(stop <-chan struct{}) bool {
 	k.runningTasksMu.Lock()
 	if k.runningTasks.Load() != 0 {
@@ -1916,6 +1966,8 @@ func (k *Kernel) GlobalInit() *ThreadGroup {
 }
 
 // TestOnlySetGlobalInit sets the thread group with ID 1 in the root PID namespace.
+//
+// Preconditions: k is exclusively owned by the caller during test setup.
 func (k *Kernel) TestOnlySetGlobalInit(tg *ThreadGroup) {
 	k.globalInit = tg
 }
@@ -1978,6 +2030,8 @@ var (
 // autosaved indicates whether save was triggered by autosave. If it was not
 // saved successfully, err indicates the sandbox error that caused the kernel to
 // exit during save.
+//
+// +checklocksexclude:k.extMu
 func (k *Kernel) SaveStatus() (saved, autosaved bool, err error) {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -1995,6 +2049,8 @@ func (k *Kernel) SaveStatus() (saved, autosaved bool, err error) {
 
 // SetSaveSuccess sets the flag indicating that save completed successfully, if
 // no status was already set.
+//
+// +checklocksexclude:k.extMu
 func (k *Kernel) SetSaveSuccess(autosave bool) {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -2009,6 +2065,8 @@ func (k *Kernel) SetSaveSuccess(autosave bool) {
 
 // SetSaveError sets the sandbox error that caused the kernel to exit during
 // save, if one is not already set.
+//
+// +checklocksexclude:k.extMu
 func (k *Kernel) SetSaveError(err error) {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -2057,6 +2115,8 @@ type SocketRecord struct {
 //
 // Note that the socket table will not hold a reference on the
 // vfs.FileDescription.
+//
+// +checklocksexclude:k.extMu
 func (k *Kernel) RecordSocket(sock *vfs.FileDescription) {
 	k.extMu.Lock()
 	if _, ok := k.sockets[sock]; ok {
@@ -2245,6 +2305,8 @@ func (k *Kernel) CgroupRegistry() *CgroupRegistry {
 // AddCgroupMount adds the cgroup mounts to the cgroupMountsMap. These cgroup
 // mounts are created during the creation of root container process and the
 // reference ownership is transferred to the kernel.
+//
+// +checklocksexclude:k.cgroupMountsMapMu
 func (k *Kernel) AddCgroupMount(ctl string, mnt *CgroupMount) {
 	k.cgroupMountsMapMu.Lock()
 	defer k.cgroupMountsMapMu.Unlock()
@@ -2256,6 +2318,8 @@ func (k *Kernel) AddCgroupMount(ctl string, mnt *CgroupMount) {
 }
 
 // GetCgroupMount returns the cgroup mount for the given cgroup controller.
+//
+// +checklocksexclude:k.cgroupMountsMapMu
 func (k *Kernel) GetCgroupMount(ctl string) *CgroupMount {
 	k.cgroupMountsMapMu.Lock()
 	defer k.cgroupMountsMapMu.Unlock()
@@ -2264,6 +2328,8 @@ func (k *Kernel) GetCgroupMount(ctl string) *CgroupMount {
 }
 
 // releaseCgroupMounts releases the cgroup mounts.
+//
+// +checklocksexclude:k.cgroupMountsMapMu
 func (k *Kernel) releaseCgroupMounts(ctx context.Context) {
 	k.cgroupMountsMapMu.Lock()
 	defer k.cgroupMountsMapMu.Unlock()
@@ -2279,6 +2345,9 @@ func (k *Kernel) releaseCgroupMounts(ctx context.Context) {
 //
 // Precondition: This should only be called after the kernel is fully
 // initialized, e.g. after k.Start() has been called.
+//
+// +checklocksexclude:k.cgroupMountsMapMu
+// +checklocksexclude:k.devGofersMu
 func (k *Kernel) Release() {
 	ctx := k.SupervisorContext()
 	k.releaseCgroupMounts(ctx)
@@ -2406,6 +2475,8 @@ func (k *Kernel) GetUserCounters(uid auth.KUID) *UserCounters {
 
 // AddDevGofer initializes the dev gofer connection and starts tracking it.
 // It takes ownership of goferFD.
+//
+// +checklocksexclude:k.devGofersMu
 func (k *Kernel) AddDevGofer(contName string, goferFD int) error {
 	client, err := devutil.NewGoferClient(k.SupervisorContext(), contName, goferFD)
 	if err != nil {
@@ -2423,6 +2494,8 @@ func (k *Kernel) AddDevGofer(contName string, goferFD int) error {
 
 // RemoveDevGofer closes the dev gofer connection, if one exists, and stops
 // tracking it.
+//
+// +checklocksexclude:k.devGofersMu
 func (k *Kernel) RemoveDevGofer(contName string) {
 	k.devGofersMu.Lock()
 	defer k.devGofersMu.Unlock()
@@ -2436,12 +2509,15 @@ func (k *Kernel) RemoveDevGofer(contName string) {
 
 // GetDevGoferClient implements
 // devutil.GoferClientProviderFromContext.GetDevGoferClient.
+//
+// +checklocksexclude:k.devGofersMu
 func (k *Kernel) GetDevGoferClient(contName string) *devutil.GoferClient {
 	k.devGofersMu.Lock()
 	defer k.devGofersMu.Unlock()
 	return k.devGofers[contName]
 }
 
+// +checklocksexclude:k.devGofersMu
 func (k *Kernel) cleaupDevGofers() {
 	k.devGofersMu.Lock()
 	defer k.devGofersMu.Unlock()

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -2432,6 +2432,8 @@ func (k *Kernel) ReleaseCgroupHierarchy(hid uint32) {
 
 // ReplaceFSContextRoots updates root and cwd to `newRoot` in the FSContext
 // across all tasks whose old root or cwd were `oldRoot`.
+//
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) ReplaceFSContextRoots(ctx context.Context, oldRoot vfs.VirtualDentry, newRoot vfs.VirtualDentry) {
 	k.tasks.mu.RLock()
 	oldRootDecRefs := 0

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1335,7 +1335,7 @@ func (ctx *createProcessContext) getMemoryCgroupID() uint32 {
 }
 
 // CreateProcess creates a new task in a new thread group with the given
-// options. The new task has no parent and is in the root PID namespace.
+// options. The new task has no parent and is in args.PIDNamespace.
 //
 // If k.Start() has already been called, then the created process must be
 // started by calling kernel.StartProcess(tg).
@@ -1348,6 +1348,11 @@ func (ctx *createProcessContext) getMemoryCgroupID() uint32 {
 //
 // Precondition: Caller must take a ref on args.MountNamespace, which is
 // transferred to CreateProcess.
+//
+// args.PIDNamespace must be non-nil and belong to k.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) CreateProcess(args CreateProcessArgs) (*ThreadGroup, ThreadID, error) {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -1774,6 +1779,8 @@ func (k *Kernel) WaitForTaskActivity(stop <-chan struct{}) bool {
 
 // WaitExited blocks until all tasks in k have exited. No tasks can be created
 // after WaitExited returns.
+//
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) WaitExited() {
 	k.tasks.mu.Lock()
 	defer k.tasks.mu.Unlock()
@@ -1795,6 +1802,9 @@ func (k *Kernel) Kill(ws linux.WaitStatus) {
 // until all tasks and asynchronous I/O operations in k have stopped. Multiple
 // calls to Pause nest and require an equal number of calls to Unpause to
 // resume execution.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) Pause() {
 	k.extMu.Lock()
 	k.tasks.BeginExternalStop()
@@ -1804,6 +1814,8 @@ func (k *Kernel) Pause() {
 }
 
 // IsPaused returns true if the kernel is currently paused.
+//
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) IsPaused() bool {
 	return k.tasks.isExternallyStopped()
 }
@@ -1819,6 +1831,9 @@ func (k *Kernel) ReceiveTaskStates() {
 
 // Unpause ends the effect of a previous call to Pause. If Unpause is called
 // without a matching preceding call to Pause, Unpause may panic.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) Unpause() {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -1893,6 +1908,9 @@ func (k *Kernel) SendContainerSignal(cid string, info *linux.SignalInfo) error {
 // Unfortunately, if these are built while tracing is not enabled, then we will
 // not have meaningful trace data. Rebuilding here ensures that we can do so
 // after tracing has been enabled.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) RebuildTraceContexts() {
 	// We need to pause all task goroutines because Task.rebuildTraceContext()
 	// replaces Task.traceContext and Task.traceTask, which are

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1845,6 +1845,10 @@ func (k *Kernel) Unpause() {
 // context is used only for debugging to describe how the signal was received.
 //
 // Preconditions: Kernel must have an init process.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.tasks.mu
+// +checklocksexclude:k.globalInit.signalHandlers.mu
 func (k *Kernel) SendExternalSignal(info *linux.SignalInfo, context string) {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -1854,6 +1858,10 @@ func (k *Kernel) SendExternalSignal(info *linux.SignalInfo, context string) {
 // SendExternalSignalThreadGroup injects a signal into an specific ThreadGroup.
 //
 // This function doesn't skip signals like SendExternalSignal does.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (k *Kernel) SendExternalSignalThreadGroup(tg *ThreadGroup, info *linux.SignalInfo) error {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()
@@ -1864,6 +1872,12 @@ func (k *Kernel) SendExternalSignalThreadGroup(tg *ThreadGroup, info *linux.Sign
 // given process group.
 //
 // This function doesn't skip signals like SendExternalSignal does.
+//
+// Callers must not hold a signal mutex for any target thread group.
+// checklocks cannot express this dynamically selected lock set.
+//
+// +checklocksexclude:k.extMu
+// +checklocksexclude:k.tasks.mu
 func (k *Kernel) SendExternalSignalProcessGroup(pg *ProcessGroup, info *linux.SignalInfo) error {
 	k.extMu.Lock()
 	defer k.extMu.Unlock()

--- a/pkg/sentry/kernel/msgqueue/msgqueue.go
+++ b/pkg/sentry/kernel/msgqueue/msgqueue.go
@@ -49,6 +49,8 @@ type Registry struct {
 	mu sync.Mutex `state:"nosave"`
 
 	// reg defines basic fields and operations needed for all SysV registries.
+	//
+	// +checklocks:mu
 	reg *ipc.Registry
 }
 
@@ -66,56 +68,86 @@ type Queue struct {
 	// registry is the registry owning this queue. Immutable.
 	registry *Registry
 
-	// mu protects all the fields below.
+	// mu protects queue state and the mutable fields of obj.
 	mu sync.Mutex `state:"nosave"`
 
 	// dead is set to true when a queue is removed from the registry and should
 	// not be used. Operations on the queue should check dead, and return
 	// EIDRM if set to true.
+	//
+	// +checklocks:mu
 	dead bool
 
 	// obj defines basic fields that should be included in all SysV IPC objects.
+	// The pointer is immutable; mutable fields of the object require mu.
 	obj *ipc.Object
 
 	// senders holds a queue of blocked message senders. Senders are notified
 	// when enough space is available in the queue to insert their message.
+	// It is internally synchronized.
 	senders waiter.Queue
 
 	// receivers holds a queue of blocked receivers. Receivers are notified
 	// when a new message is inserted into the queue and can be received.
+	// It is internally synchronized.
 	receivers waiter.Queue
 
 	// messages is a list of sent messages.
+	//
+	// +checklocks:mu
 	messages msgList
 
 	// sendTime is the last time a msgsnd was performed.
+	//
+	// +checklocks:mu
 	sendTime ktime.Time
 
 	// receiveTime is the last time a msgrcv was performed.
+	//
+	// +checklocks:mu
 	receiveTime ktime.Time
 
 	// changeTime is the last time the queue was modified using msgctl.
+	//
+	// +checklocks:mu
 	changeTime ktime.Time
 
 	// byteCount is the current number of message bytes in the queue.
+	//
+	// +checklocks:mu
 	byteCount uint64
 
 	// messageCount is the current number of messages in the queue.
+	//
+	// +checklocks:mu
 	messageCount uint64
 
 	// maxBytes is the maximum allowed number of bytes in the queue, and is also
 	// used as a limit for the number of total possible messages.
+	//
+	// +checklocks:mu
 	maxBytes uint64
 
 	// sendPID is the PID of the process that performed the last msgsnd.
+	//
+	// +checklocks:mu
 	sendPID int32
 
 	// receivePID is the PID of the process that performed the last msgrcv.
+	//
+	// +checklocks:mu
 	receivePID int32
 }
 
 // Message represents a message exchanged through a Queue via msgsnd(2) and
 // msgrcv(2).
+//
+// The containing Queue.mu protects the list links while queued. Message has
+// no Queue pointer, so checklocks cannot infer that owner from list membership.
+//
+// Once enqueued, Type, Text's slice header, and its backing bytes must remain
+// unchanged while queued or while any returned alias is retained. MSG_COPY
+// returns the same Message, so those aliases may outlive a later dequeue.
 //
 // +stateify savable
 type Message struct {
@@ -139,6 +171,8 @@ func (m *Message) makeCopy() *Message {
 
 // FindOrCreate creates a new message queue or returns an existing one. See
 // msgget(2).
+//
+// +checklocksexclude:r.mu
 func (r *Registry) FindOrCreate(ctx context.Context, key ipc.Key, mode linux.FileMode, private, create, exclusive bool) (*Queue, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -165,7 +199,7 @@ func (r *Registry) FindOrCreate(ctx context.Context, key ipc.Key, mode linux.Fil
 // newQueueLocked creates a new queue using the given fields. An error is
 // returned if there're no more available identifiers.
 //
-// Precondition: r.mu must be held.
+// +checklocks:r.mu
 func (r *Registry) newQueueLocked(ctx context.Context, key ipc.Key, creds *auth.Credentials, mode linux.FileMode) (*Queue, error) {
 	q := &Queue{
 		registry:    r,
@@ -186,6 +220,8 @@ func (r *Registry) newQueueLocked(ctx context.Context, key ipc.Key, creds *auth.
 // Remove removes the queue with specified ID. All waiters (readers and
 // writers) and writers will be awakened and fail. Remove will return an error
 // if the ID is invalid, or the user doesn't have privileges.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) Remove(id ipc.ID, creds *auth.Credentials) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -196,6 +232,8 @@ func (r *Registry) Remove(id ipc.ID, creds *auth.Credentials) error {
 
 // FindByID returns the queue with the specified ID and an error if the ID
 // doesn't exist.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) FindByID(id ipc.ID) (*Queue, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -222,6 +260,8 @@ func (r *Registry) IPCInfo(ctx context.Context) *linux.MsgInfo {
 }
 
 // MsgInfo reports global parameters for message queues. See msgctl(MSG_INFO).
+//
+// +checklocksexclude:r.mu
 func (r *Registry) MsgInfo(ctx context.Context) *linux.MsgInfo {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -251,6 +291,10 @@ func (r *Registry) MsgInfo(ctx context.Context) *linux.MsgInfo {
 
 // Send appends a message to the message queue, and returns an error if sending
 // fails. See msgsnd(2).
+//
+// +checklocksexclude:q.mu
+// +checklocksexclude:q.receivers.mu
+// +checklocksexclude:q.senders.mu
 func (q *Queue) Send(ctx context.Context, m Message, wait bool, pid int32) error {
 	// Try to perform a non-blocking send using queue.append. If EWOULDBLOCK
 	// is returned, start the blocking procedure. Otherwise, return normally.
@@ -288,6 +332,9 @@ func (q *Queue) Send(ctx context.Context, m Message, wait bool, pid int32) error
 // receivers that a message has been inserted. It returns an error if adding
 // the message would cause the queue to exceed its maximum capacity, which can
 // be used as a signal to block the task. Other errors should be returned as is.
+//
+// +checklocksexclude:q.mu
+// +checklocksexclude:q.receivers.mu
 func (q *Queue) push(ctx context.Context, m Message, creds *auth.Credentials, pid int32) error {
 	if m.Type <= 0 {
 		return linuxerr.EINVAL
@@ -344,7 +391,15 @@ func (q *Queue) push(ctx context.Context, m Message, creds *auth.Credentials, pi
 	return nil
 }
 
-// Receive removes a message from the queue and returns it. See msgrcv(2).
+// Receive returns the selected Message, removing it unless flags includes
+// MSG_COPY. It does not make an independent copy of the message.
+//
+// Callers must preserve the payload immutability described by Message, since
+// returned aliases may survive removal. See msgrcv(2).
+//
+// +checklocksexclude:q.mu
+// +checklocksexclude:q.receivers.mu
+// +checklocksexclude:q.senders.mu
 func (q *Queue) Receive(ctx context.Context, mType int64, maxSize uint64, flags, pid int32) (*Message, error) {
 	if maxSize > math.MaxInt64 {
 		return nil, linuxerr.EINVAL
@@ -383,6 +438,9 @@ func (q *Queue) Receive(ctx context.Context, mType int64, maxSize uint64, flags,
 // returns an error for all the cases specified in msgrcv(2). If the queue is
 // empty or no message of the specified type is available, a EWOULDBLOCK error
 // is returned, which can then be used as a signal to block the process or fail.
+//
+// +checklocksexclude:q.mu
+// +checklocksexclude:q.senders.mu
 func (q *Queue) pop(ctx context.Context, creds *auth.Credentials, mType int64, maxSize uint64, flags, pid int32) (*Message, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -452,7 +510,7 @@ func (q *Queue) pop(ctx context.Context, creds *auth.Credentials, mType int64, m
 // message is found. If except is true, the first message of a type not equal
 // to mType will be returned.
 //
-// Precondition: caller must hold q.mu.
+// +checklocks:q.mu
 func (q *Queue) msgOfType(mType int64, except bool) *Message {
 	if except {
 		for msg := q.messages.Front(); msg != nil; msg = msg.Next() {
@@ -474,7 +532,7 @@ func (q *Queue) msgOfType(mType int64, except bool) *Message {
 // msgOfTypeLessThan return the first message with the lowest type less
 // than or equal to mType, nil if no such message exists.
 //
-// Precondition: caller must hold q.mu.
+// +checklocks:q.mu
 func (q *Queue) msgOfTypeLessThan(mType int64) (m *Message) {
 	min := mType
 	for msg := q.messages.Front(); msg != nil; msg = msg.Next() {
@@ -488,7 +546,7 @@ func (q *Queue) msgOfTypeLessThan(mType int64) (m *Message) {
 
 // msgAtIndex returns a pointer to a message at given index, nil if non exits.
 //
-// Precondition: caller must hold q.mu.
+// +checklocks:q.mu
 func (q *Queue) msgAtIndex(mType int64) *Message {
 	msg := q.messages.Front()
 	for ; mType != 0 && msg != nil; mType-- {
@@ -498,6 +556,8 @@ func (q *Queue) msgAtIndex(mType int64) *Message {
 }
 
 // Set modifies some values of the queue. See msgctl(IPC_SET).
+//
+// +checklocksexclude:q.mu
 func (q *Queue) Set(ctx context.Context, ds *linux.MsqidDS) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -521,18 +581,24 @@ func (q *Queue) Set(ctx context.Context, ds *linux.MsqidDS) error {
 
 // Stat returns a MsqidDS object filled with information about the queue. See
 // msgctl(IPC_STAT) and msgctl(MSG_STAT).
+//
+// +checklocksexclude:q.mu
 func (q *Queue) Stat(ctx context.Context) (*linux.MsqidDS, error) {
 	return q.stat(ctx, vfs.MayRead)
 }
 
 // StatAny is similar to Queue.Stat, but doesn't require read permission. See
 // msgctl(MSG_STAT_ANY).
+//
+// +checklocksexclude:q.mu
 func (q *Queue) StatAny(ctx context.Context) (*linux.MsqidDS, error) {
 	return q.stat(ctx, 0)
 }
 
 // stat returns a MsqidDS object filled with information about the queue. An
 // error is returned if the user doesn't have the specified permissions.
+//
+// +checklocksexclude:q.mu
 func (q *Queue) stat(ctx context.Context, ats vfs.AccessTypes) (*linux.MsqidDS, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -565,13 +631,15 @@ func (q *Queue) stat(ctx context.Context, ats vfs.AccessTypes) (*linux.MsqidDS, 
 }
 
 // Lock implements ipc.Mechanism.Lock.
+//
+// +checklocksacquire:q.mu
 func (q *Queue) Lock() {
 	q.mu.Lock()
 }
 
-// Unlock implements ipc.mechanism.Unlock.
+// Unlock implements ipc.Mechanism.Unlock.
 //
-// +checklocksignore
+// +checklocksrelease:q.mu
 func (q *Queue) Unlock() {
 	q.mu.Unlock()
 }
@@ -582,6 +650,10 @@ func (q *Queue) Object() *ipc.Object {
 }
 
 // Destroy implements ipc.Mechanism.Destroy.
+//
+// +checklocks:q.mu
+// +checklocksexclude:q.receivers.mu
+// +checklocksexclude:q.senders.mu
 func (q *Queue) Destroy() {
 	q.dead = true
 

--- a/pkg/sentry/kernel/pidfd.go
+++ b/pkg/sentry/kernel/pidfd.go
@@ -129,6 +129,9 @@ func (t *Task) pidFDOpen(pid *pid, isThread bool, nonBlock bool) (*vfs.FileDescr
 }
 
 // PIDFDGetFD helps implement the Linux syscall pidfd_getfd(2).
+//
+// Callers must not hold the mutex of the task selected by pidfd.
+// checklocks cannot name that task from the descriptor number.
 func (t *Task) PIDFDGetFD(pidfd int32, targetfd int32, flags uint32) (uintptr, error) {
 	file := t.GetFile(pidfd)
 	if file == nil {

--- a/pkg/sentry/kernel/posixtimer.go
+++ b/pkg/sentry/kernel/posixtimer.go
@@ -140,7 +140,10 @@ func (it *IntervalTimer) NotifyTimer(exp uint64) {
 	si.SetTimerID(it.id)
 	si.SetSigval(it.sigval)
 	// si_overrun is set when the signal is dequeued.
-	if err := it.target.sendSignalTimerLocked(si, it.group, it); err != nil {
+	//
+	// signalLock returned it.target.tg's current handler with sh.mu held;
+	// checklocks does not relate that result to the thread-group field.
+	if err := it.target.sendSignalTimerLocked(si, it.group, it); err != nil { // +checklocksignore
 		it.signalRejectedLocked()
 	}
 }

--- a/pkg/sentry/kernel/ptrace.go
+++ b/pkg/sentry/kernel/ptrace.go
@@ -106,6 +106,8 @@ const (
 //
 // We currently do not implement privileged executables (set-user/group-ID bits
 // and file capabilities), so that case is not reachable.
+//
+// +checklocksexclude:target.mu
 func (t *Task) CanTrace(target *Task, attach bool) bool {
 	// "If the calling thread and the target thread are in the same thread
 	// group, access is always allowed." - ptrace(2)
@@ -135,6 +137,8 @@ func (t *Task) CanTrace(target *Task, attach bool) bool {
 
 // canTraceLocked is the same as CanTrace, except the caller must already hold
 // the TaskSet mutex (for reading or writing).
+//
+// +checklocksexclude:target.mu
 func (t *Task) canTraceLocked(target *Task, attach bool) bool {
 	if t.tg == target.tg {
 		return true
@@ -156,6 +160,8 @@ func (t *Task) canTraceLocked(target *Task, attach bool) bool {
 // kernel/ptrace.c:__ptrace_may_access as well as the commoncap LSM
 // implementation of the security_ptrace_access_check() interface, which is
 // always invoked.
+//
+// +checklocksexclude:target.mu
 func (t *Task) canTraceStandard(target *Task, attach bool) bool {
 	// """
 	// TODO(gvisor.dev/issue/260): 1. If the access mode specifies
@@ -474,6 +480,7 @@ func (t *Task) ptraceUnstop(mode ptraceSyscallMode, singlestep bool, sig linux.S
 	return nil
 }
 
+// +checklocksexclude:t.mu
 func (t *Task) ptraceTraceme() error {
 	t.tg.pidns.owner.mu.Lock()
 	defer t.tg.pidns.owner.mu.Unlock()
@@ -508,6 +515,8 @@ func (t *Task) ptraceTraceme() error {
 
 // ptraceAttach implements ptrace(PTRACE_ATTACH, target) if seize is false, and
 // ptrace(PTRACE_SEIZE, target, 0, opts) if seize is true. t is the caller.
+//
+// +checklocksexclude:target.mu
 func (t *Task) ptraceAttach(target *Task, seize bool, opts uintptr) error {
 	t.tg.pidns.owner.mu.Lock()
 	defer t.tg.pidns.owner.mu.Unlock()
@@ -1042,6 +1051,10 @@ type runPtraceAfterExecveCredsLock struct {
 	data   hostarch.Addr
 }
 
+// The task run loop calls this state without r.target.mu held; the
+// taskRunState interface does not expose the target task.
+//
+// +checklocksexclude:r.target.mu
 func (r *runPtraceAfterExecveCredsLock) execute(t *Task) taskRunState {
 	if t.killed() {
 		// execveCredsMutexUnlock() will not pass us the lock after we were killed, so there is no
@@ -1061,6 +1074,8 @@ func (r *runPtraceAfterExecveCredsLock) execute(t *Task) taskRunState {
 }
 
 // Ptrace implements ptrace(2) excluding PTRACE_ATTACH and PTRACE_SEIZE.
+//
+// +checklocksexclude:t.mu
 func (t *Task) Ptrace(req int64, pid ThreadID, addr, data hostarch.Addr) error {
 	// PTRACE_TRACEME ignores all other arguments.
 	if req == linux.PTRACE_TRACEME {

--- a/pkg/sentry/kernel/semaphore/semaphore.go
+++ b/pkg/sentry/kernel/semaphore/semaphore.go
@@ -50,10 +50,14 @@ type Registry struct {
 	mu sync.Mutex `state:"nosave"`
 
 	// reg defines basic fields and operations needed for all SysV registries.
+	//
+	// +checklocks:mu
 	reg *ipc.Registry
 
 	// indexes maintains a mapping between a set's index in virtual array and
 	// its identifier.
+	//
+	// +checklocks:mu
 	indexes map[int32]ipc.ID
 }
 
@@ -64,24 +68,34 @@ type Set struct {
 	// registry owning this sem set. Immutable.
 	registry *Registry
 
-	// mu protects all fields below.
+	// mu protects mutable state below, including the mutable fields of obj.
 	mu sync.Mutex `state:"nosave"`
 
+	// obj points to common IPC metadata. The pointer is immutable; mutable
+	// fields of the object require mu.
 	obj *ipc.Object
 
-	opTime     ktime.Time
+	// +checklocks:mu
+	opTime ktime.Time
+
+	// +checklocks:mu
 	changeTime ktime.Time
 
-	// sems holds all semaphores in the set. The slice itself is immutable after
-	// it's been set, however each 'sem' object in the slice requires 'mu' lock.
+	// sems holds all semaphores in the set. Its slice header is immutable after
+	// initialization; access to mutable fields of its elements requires mu.
 	sems []sem
 
 	// dead is set to true when the set is removed and can't be reached anymore.
 	// All waiters must wake up and fail when set is dead.
+	//
+	// +checklocks:mu
 	dead bool
 }
 
 // sem represents a single semaphore from a set.
+//
+// Its fields are protected by the owning Set.mu. sem has no pointer to its
+// Set, so checklocks cannot infer that mutex from membership in Set.sems.
 //
 // +stateify savable
 type sem struct {
@@ -95,12 +109,17 @@ type sem struct {
 //
 // +stateify savable
 type waiter struct {
+	// waiterEntry is protected by the owning Set.mu while queued.
+	// waiter has no Set pointer, so checklocks cannot recover that owner
+	// through list membership.
 	waiterEntry
 
 	// value represents how much resource the waiter needs to wake up.
-	// The value is either 0 or negative.
+	// The value is either 0 or negative. Immutable.
 	value int16
-	ch    chan struct{}
+
+	// ch is notified when the waiter can retry. The channel handle is immutable.
+	ch chan struct{}
 }
 
 // NewRegistry creates a new semaphore set registry.
@@ -116,6 +135,8 @@ func NewRegistry(userNS *auth.UserNamespace) *Registry {
 // a new set is always created. If create is false, it fails if a set cannot
 // be found. If exclusive is true, it fails if a set with the same key already
 // exists.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) FindOrCreate(ctx context.Context, key ipc.Key, nsems int32, mode linux.FileMode, private, create, exclusive bool) (*Set, error) {
 	if nsems < 0 || nsems > semsMax {
 		return nil, linuxerr.EINVAL
@@ -179,6 +200,8 @@ func (r *Registry) IPCInfo() *linux.SemInfo {
 // SemInfo returns a seminfo structure containing the same information as
 // for IPC_INFO, except that SemUsz field returns the number of existing
 // semaphore sets, and SemAem field returns the number of existing semaphores.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) SemInfo() *linux.SemInfo {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -192,6 +215,8 @@ func (r *Registry) SemInfo() *linux.SemInfo {
 
 // HighestIndex returns the index of the highest used entry in
 // the kernel's array.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) HighestIndex() int32 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -209,6 +234,8 @@ func (r *Registry) HighestIndex() int32 {
 
 // Remove removes set with give 'id' from the registry and marks the set as
 // dead. All waiters will be awakened and fail.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) Remove(id ipc.ID, creds *auth.Credentials) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -227,7 +254,7 @@ func (r *Registry) Remove(id ipc.ID, creds *auth.Credentials) error {
 // newSetLocked creates a new Set using given fields. An error is returned if there
 // are no more available identifiers.
 //
-// Precondition: r.mu must be held.
+// +checklocks:r.mu
 func (r *Registry) newSetLocked(ctx context.Context, key ipc.Key, creator *auth.Credentials, mode linux.FileMode, nsems int32) (*Set, error) {
 	set := &Set{
 		registry:   r,
@@ -252,6 +279,8 @@ func (r *Registry) newSetLocked(ctx context.Context, key ipc.Key, creator *auth.
 }
 
 // FindByID looks up a set given an ID.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) FindByID(id ipc.ID) *Set {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -263,6 +292,8 @@ func (r *Registry) FindByID(id ipc.ID) *Set {
 }
 
 // FindByIndex looks up a set given an index.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) FindByIndex(index int32) *Set {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -274,6 +305,7 @@ func (r *Registry) FindByIndex(index int32) *Set {
 	return r.reg.FindByID(id).(*Set)
 }
 
+// +checklocks:r.mu
 func (r *Registry) findIndexByID(id ipc.ID) (int32, bool) {
 	for k, v := range r.indexes {
 		if v == id {
@@ -283,6 +315,7 @@ func (r *Registry) findIndexByID(id ipc.ID) (int32, bool) {
 	return 0, false
 }
 
+// +checklocks:r.mu
 func (r *Registry) findFirstAvailableIndex() (int32, bool) {
 	for index := int32(0); index < setsMax; index++ {
 		if _, present := r.indexes[index]; !present {
@@ -292,6 +325,7 @@ func (r *Registry) findFirstAvailableIndex() (int32, bool) {
 	return 0, false
 }
 
+// +checklocks:r.mu
 func (r *Registry) totalSems() int {
 	totalSems := 0
 	r.reg.ForAllObjects(
@@ -313,17 +347,22 @@ func (s *Set) Object() *ipc.Object {
 }
 
 // Lock implements ipc.Mechanism.Lock.
+//
+// +checklocksacquire:s.mu
 func (s *Set) Lock() {
 	s.mu.Lock()
 }
 
-// Unlock implements ipc.mechanism.Unlock.
+// Unlock implements ipc.Mechanism.Unlock.
 //
-// +checklocksignore
+// +checklocksrelease:s.mu
 func (s *Set) Unlock() {
 	s.mu.Unlock()
 }
 
+// findSem returns the semaphore at num, or nil if num is out of range.
+// It reads only the immutable slice header. Access to the returned semaphore's
+// mutable fields requires s.mu; sem has no link back to s for checklocks.
 func (s *Set) findSem(num int32) *sem {
 	if num < 0 || int(num) >= s.Size() {
 		return nil
@@ -331,12 +370,15 @@ func (s *Set) findSem(num int32) *sem {
 	return &s.sems[num]
 }
 
-// Size returns the number of semaphores in the set. Size is immutable.
+// Size returns the number of semaphores in the set. The slice header is
+// immutable, so Size does not require s.mu.
 func (s *Set) Size() int {
 	return len(s.sems)
 }
 
 // Set modifies attributes for a semaphore set. See semctl(IPC_SET).
+//
+// +checklocksexclude:s.mu
 func (s *Set) Set(ctx context.Context, ds *linux.SemidDS) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -350,16 +392,21 @@ func (s *Set) Set(ctx context.Context, ds *linux.SemidDS) error {
 }
 
 // GetStat extracts semid_ds information from the set.
+//
+// +checklocksexclude:s.mu
 func (s *Set) GetStat(creds *auth.Credentials) (*linux.SemidDS, error) {
 	// "The calling process must have read permission on the semaphore set."
 	return s.semStat(creds, vfs.MayRead)
 }
 
 // GetStatAny extracts semid_ds information from the set without requiring read access.
+//
+// +checklocksexclude:s.mu
 func (s *Set) GetStatAny(creds *auth.Credentials) (*linux.SemidDS, error) {
 	return s.semStat(creds, 0)
 }
 
+// +checklocksexclude:s.mu
 func (s *Set) semStat(creds *auth.Credentials, ats vfs.AccessTypes) (*linux.SemidDS, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -385,6 +432,8 @@ func (s *Set) semStat(creds *auth.Credentials, ats vfs.AccessTypes) (*linux.Semi
 }
 
 // SetVal overrides a semaphore value, waking up waiters as needed.
+//
+// +checklocksexclude:s.mu
 func (s *Set) SetVal(ctx context.Context, num int32, val int16, creds *auth.Credentials, pid int32) error {
 	if val < 0 || val > valueMax {
 		return linuxerr.ERANGE
@@ -415,6 +464,8 @@ func (s *Set) SetVal(ctx context.Context, num int32, val int16, creds *auth.Cred
 // sets semaphore's PID which was fixed in Linux 4.6.
 //
 // 'len(vals)' must be equal to 's.Size()'.
+//
+// +checklocksexclude:s.mu
 func (s *Set) SetValAll(ctx context.Context, vals []uint16, creds *auth.Credentials, pid int32) error {
 	if len(vals) != s.Size() {
 		panic(fmt.Sprintf("vals length (%d) different that Set.Size() (%d)", len(vals), s.Size()))
@@ -447,6 +498,8 @@ func (s *Set) SetValAll(ctx context.Context, vals []uint16, creds *auth.Credenti
 }
 
 // GetVal returns a semaphore value.
+//
+// +checklocksexclude:s.mu
 func (s *Set) GetVal(num int32, creds *auth.Credentials) (int16, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -464,6 +517,8 @@ func (s *Set) GetVal(num int32, creds *auth.Credentials) (int16, error) {
 }
 
 // GetValAll returns value for all semaphores.
+//
+// +checklocksexclude:s.mu
 func (s *Set) GetValAll(creds *auth.Credentials) ([]uint16, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -481,6 +536,8 @@ func (s *Set) GetValAll(creds *auth.Credentials) ([]uint16, error) {
 }
 
 // GetPID returns the PID set when performing operations in the semaphore.
+//
+// +checklocksexclude:s.mu
 func (s *Set) GetPID(num int32, creds *auth.Credentials) (int32, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -497,6 +554,10 @@ func (s *Set) GetPID(num int32, creds *auth.Credentials) (int32, error) {
 	return sem.pid, nil
 }
 
+// countWaiters calls pred synchronously under s.mu. pred must not release or
+// reacquire that mutex.
+//
+// +checklocksexclude:s.mu
 func (s *Set) countWaiters(num int32, creds *auth.Credentials, pred func(w *waiter) bool) (uint16, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -520,6 +581,8 @@ func (s *Set) countWaiters(num int32, creds *auth.Credentials, pred func(w *wait
 }
 
 // CountZeroWaiters returns number of waiters waiting for the sem's value to increase.
+//
+// +checklocksexclude:s.mu
 func (s *Set) CountZeroWaiters(num int32, creds *auth.Credentials) (uint16, error) {
 	return s.countWaiters(num, creds, func(w *waiter) bool {
 		return w.value == 0
@@ -527,6 +590,8 @@ func (s *Set) CountZeroWaiters(num int32, creds *auth.Credentials) (uint16, erro
 }
 
 // CountNegativeWaiters returns number of waiters waiting for the sem to go to zero.
+//
+// +checklocksexclude:s.mu
 func (s *Set) CountNegativeWaiters(num int32, creds *auth.Credentials) (uint16, error) {
 	return s.countWaiters(num, creds, func(w *waiter) bool {
 		return w.value < 0
@@ -538,6 +603,8 @@ func (s *Set) CountNegativeWaiters(num int32, creds *auth.Credentials) (uint16, 
 //
 // On failure, it may return an error (retries are hopeless) or it may return
 // a channel that can be waited on before attempting again.
+//
+// +checklocksexclude:s.mu
 func (s *Set) ExecuteOps(ctx context.Context, ops []linux.Sembuf, creds *auth.Credentials, pid int32) (chan struct{}, int32, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -573,6 +640,7 @@ func (s *Set) ExecuteOps(ctx context.Context, ops []linux.Sembuf, creds *auth.Cr
 	return ch, num, nil
 }
 
+// +checklocks:s.mu
 func (s *Set) executeOps(ctx context.Context, ops []linux.Sembuf, pid int32) (chan struct{}, int32, error) {
 	// Changes to semaphores go to this slice temporarily until they all succeed.
 	tmpVals := make([]int16, len(s.sems))
@@ -634,6 +702,8 @@ func (s *Set) executeOps(ctx context.Context, ops []linux.Sembuf, pid int32) (ch
 
 // AbortWait notifies that a waiter is giving up and will not wait on the
 // channel anymore.
+//
+// +checklocksexclude:s.mu
 func (s *Set) AbortWait(num int32, ch chan struct{}) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -650,7 +720,7 @@ func (s *Set) AbortWait(num int32, ch chan struct{}) {
 
 // Destroy implements ipc.Mechanism.Destroy.
 //
-// Preconditions: Caller must hold 's.mu'.
+// +checklocks:s.mu
 func (s *Set) Destroy() {
 	// Notify all waiters. They will fail on the next attempt to execute
 	// operations and return error.
@@ -671,6 +741,8 @@ func abs(val int16) int16 {
 }
 
 // wakeWaiters goes over all waiters and checks which of them can be notified.
+//
+// Preconditions: The owning Set.mu must be held.
 func (s *sem) wakeWaiters() {
 	// Note that this will release all waiters waiting for 0 too.
 	for w := s.waiters.Front(); w != nil; {

--- a/pkg/sentry/kernel/semaphore/semaphore_test.go
+++ b/pkg/sentry/kernel/semaphore/semaphore_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func executeOps(ctx context.Context, t *testing.T, set *Set, ops []linux.Sembuf, block bool) chan struct{} {
+	set.mu.Lock()
 	ch, _, err := set.executeOps(ctx, ops, 123)
+	set.mu.Unlock()
 	if err != nil {
 		t.Fatalf("ExecuteOps(ops) failed, err: %v, ops: %+v", err, ops)
 	}
@@ -124,6 +126,8 @@ func TestNoWait(t *testing.T) {
 
 	ops[0].SemOp = -2
 	ops[0].SemFlg = linux.IPC_NOWAIT
+	set.mu.Lock()
+	defer set.mu.Unlock()
 	if _, _, err := set.executeOps(ctx, ops, 123); err != linuxerr.ErrWouldBlock {
 		t.Fatalf("ExecuteOps(ops) wrong result, got: %v, expected: %v", err, linuxerr.ErrWouldBlock)
 	}
@@ -160,7 +164,10 @@ func TestUnregister(t *testing.T) {
 	if err := r.Remove(set.obj.ID, creds); err != nil {
 		t.Fatalf("Remove(%d) failed, err: %v", set.obj.ID, err)
 	}
-	if !set.dead {
+	set.mu.Lock()
+	dead := set.dead
+	set.mu.Unlock()
+	if !dead {
 		t.Fatalf("set is not dead: %+v", set)
 	}
 	if got := r.FindByID(set.obj.ID); got != nil {

--- a/pkg/sentry/kernel/sessions.go
+++ b/pkg/sentry/kernel/sessions.go
@@ -214,13 +214,14 @@ func (pg *ProcessGroup) handleOrphan() {
 	}
 
 	// Deliver appropriate signals to all thread groups.
-	pg.originator.pidns.owner.forEachThreadGroupLocked(func(tg *ThreadGroup, tgLeader *Task) {
+	pg.originator.pidns.owner.forEachThreadGroupLocked(func(tg *ThreadGroup, _ *Task) {
 		if tg.processGroup != pg {
 			return
 		}
 		tg.signalHandlers.mu.NestedLock(signalHandlersLockTg)
-		tgLeader.sendSignalLocked(SignalInfoPriv(linux.SIGHUP), true /* group */)
-		tgLeader.sendSignalLocked(SignalInfoPriv(linux.SIGCONT), true /* group */)
+		leader := tg.leader
+		_ = leader.sendSignalLocked(SignalInfoPriv(linux.SIGHUP), true /* group */)
+		_ = leader.sendSignalLocked(SignalInfoPriv(linux.SIGCONT), true /* group */)
 		tg.signalHandlers.mu.NestedUnlock(signalHandlersLockTg)
 	})
 

--- a/pkg/sentry/kernel/shm/shm.go
+++ b/pkg/sentry/kernel/shm/shm.go
@@ -66,24 +66,27 @@ type Registry struct {
 
 	// reg defines basic fields and operations needed for all SysV registries.
 	//
-	// Within reg, there are two maps, Objects and KeysToIDs.
+	// Within reg, there are two maps, objects and keysToIDs.
 	//
 	// reg.objects holds all referenced segments, which are removed on the last
 	// DecRef. Thus, it cannot itself hold a reference on the Shm.
 	//
 	// Since removal only occurs after the last (unlocked) DecRef, there
-	// exists a short window during which a Shm still exists in Shm, but is
-	// unreferenced. Users must use TryIncRef to determine if the Shm is
-	// still valid.
+	// exists a short window during which a Shm is still in reg.objects but is
+	// unreferenced. Users must use TryIncRef to determine if the Shm is valid.
 	//
 	// keysToIDs maps segment keys to IDs.
 	//
 	// Shms in keysToIDs are guaranteed to be referenced, as they are
-	// removed by disassociateKey before the last DecRef.
+	// removed by dissociateKey before the last DecRef.
+	//
+	// +checklocks:mu
 	reg *ipc.Registry
 
 	// Sum of the sizes of all existing segments rounded up to page size, in
 	// units of page size.
+	//
+	// +checklocks:mu
 	totalPages uint64
 }
 
@@ -98,6 +101,8 @@ func NewRegistry(userNS *auth.UserNamespace) *Registry {
 // FindByID looks up a segment given an ID.
 //
 // FindByID returns a reference on Shm.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) FindByID(id ipc.ID) *Shm {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -116,10 +121,12 @@ func (r *Registry) FindByID(id ipc.ID) *Shm {
 }
 
 // dissociateKey removes the association between a segment and its key,
-// preventing it from being discovered in the registry. This doesn't necessarily
-// mean the segment is about to be destroyed. This is analogous to unlinking a
-// file; the segment can still be used by a process already referencing it, but
-// cannot be discovered by a new process.
+// preventing it from being found by key. This doesn't necessarily mean the
+// segment is about to be destroyed: it remains accessible by ID while
+// references remain.
+//
+// +checklocksexclude:r.mu
+// +checklocksexclude:s.mu
 func (r *Registry) dissociateKey(s *Shm) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -135,6 +142,8 @@ func (r *Registry) dissociateKey(s *Shm) {
 // analogous to open(2).
 //
 // FindOrCreate returns a reference on Shm.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) FindOrCreate(ctx context.Context, pid int32, key ipc.Key, size uint64, mode linux.FileMode, private, create, exclusive bool) (*Shm, error) {
 	if (create || private) && (size < linux.SHMMIN || size > linux.SHMMAX) {
 		// "A new segment was to be created and size is less than SHMMIN or
@@ -200,7 +209,7 @@ func (r *Registry) FindOrCreate(ctx context.Context, pid int32, key ipc.Key, siz
 
 // newShmLocked creates a new segment in the registry.
 //
-// Precondition: Caller must hold r.mu.
+// +checklocks:r.mu
 func (r *Registry) newShmLocked(ctx context.Context, pid int32, key ipc.Key, creator *auth.Credentials, mode linux.FileMode, size uint64) (*Shm, error) {
 	mf := pgalloc.MemoryFileFromContext(ctx)
 	if mf == nil {
@@ -252,6 +261,8 @@ func (r *Registry) IPCInfo() *linux.ShmParams {
 
 // ShmInfo reports linux-specific global parameters for sysv shared memory
 // segments on this system. See shmctl(SHM_INFO).
+//
+// +checklocksexclude:r.mu
 func (r *Registry) ShmInfo() *linux.ShmInfo {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -268,6 +279,9 @@ func (r *Registry) ShmInfo() *linux.ShmInfo {
 // the segment.
 //
 // Precondition: Must follow a call to r.dissociateKey(s).
+//
+// +checklocksexclude:r.mu
+// +checklocksexclude:s.mu
 func (r *Registry) remove(s *Shm) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -284,6 +298,8 @@ func (r *Registry) remove(s *Shm) {
 
 // Release drops the self-reference of each active shm segment in the registry.
 // It is called when the kernel.IPCNamespace containing r is being destroyed.
+//
+// +checklocksexclude:r.mu
 func (r *Registry) Release(ctx context.Context) {
 	// Because Shm.DecRef() may acquire the same locks, collect the segments to
 	// release first. Note that this should not race with any updates to r, since
@@ -332,6 +348,8 @@ type Shm struct {
 	// via MappingIdentity.
 	ShmRefs
 
+	// mf is initialized during construction or afterLoad, then immutable while
+	// the segment is in use.
 	mf *pgalloc.MemoryFile `state:"nosave"`
 
 	// registry points to the shm registry containing this segment. Immutable.
@@ -350,33 +368,48 @@ type Shm struct {
 	// Invariant: effectiveSize must be a multiple of hostarch.PageSize.
 	effectiveSize uint64
 
-	// fr is the offset into mfp.MemoryFile() that backs this contents of this
-	// segment. Immutable.
+	// fr is the range in mf that backs the contents of this segment. Immutable.
 	fr memmap.FileRange
 
-	// mu protects all fields below.
+	// mu protects mutable state below, including the mutable fields of obj.
 	mu sync.Mutex `state:"nosave"`
 
+	// obj points to common IPC metadata. The pointer is immutable; the ID is
+	// assigned during registration, then immutable. The key, owner IDs, and mode
+	// require mu after initialization.
 	obj *ipc.Object
 
 	// attachTime is updated on every successful shmat.
+	//
+	// +checklocks:mu
 	attachTime ktime.Time
+
 	// detachTime is updated on every successful shmdt.
+	//
+	// +checklocks:mu
 	detachTime ktime.Time
+
 	// changeTime is updated on every successful changes to the segment via
 	// shmctl(IPC_SET).
+	//
+	// +checklocks:mu
 	changeTime ktime.Time
 
-	// creatorPID is the PID of the process that created the segment.
+	// creatorPID is the PID of the process that created the segment. Immutable.
 	creatorPID int32
+
 	// lastAttachDetachPID is the pid of the process that issued the last shmat
 	// or shmdt syscall.
+	//
+	// +checklocks:mu
 	lastAttachDetachPID int32
 
 	// pendingDestruction indicates the segment was marked as destroyed through
-	// shmctl(IPC_RMID). When marked as destroyed, the segment will not be found
-	// in the registry and can no longer be attached. When the last user
-	// detaches from the segment, it is destroyed.
+	// shmctl(IPC_RMID). Its key is dissociated from the registry, but the segment
+	// remains accessible by ID while references remain. It is destroyed when
+	// the last reference is dropped.
+	//
+	// +checklocks:mu
 	pendingDestruction bool
 }
 
@@ -401,24 +434,28 @@ func (s *Shm) Destroy() {
 }
 
 // Lock implements ipc.Mechanism.Lock.
+//
+// +checklocksacquire:s.mu
 func (s *Shm) Lock() {
 	s.mu.Lock()
 }
 
-// Unlock implements ipc.mechanism.Unlock.
+// Unlock implements ipc.Mechanism.Unlock.
 //
-// +checklocksignore
+// +checklocksrelease:s.mu
 func (s *Shm) Unlock() {
 	s.mu.Unlock()
 }
 
-// Precondition: Caller must hold s.mu.
+// +checklocks:s.mu
 func (s *Shm) debugLocked() string {
 	return fmt.Sprintf("Shm{id: %d, key: %d, size: %d bytes, refs: %d, destroyed: %v}",
 		s.obj.ID, s.obj.Key, s.size, s.ReadRefs(), s.pendingDestruction)
 }
 
 // MappedName implements memmap.MappingIdentity.MappedName.
+//
+// +checklocksexclude:s.mu
 func (s *Shm) MappedName(ctx context.Context) string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -437,9 +474,11 @@ func (s *Shm) InodeID() uint64 {
 	return uint64(s.obj.ID)
 }
 
-// DecRef drops a reference on s.
+// DecRef drops a reference on s. The final reference drop acquires the registry
+// and segment mutexes to remove the segment.
 //
-// Precondition: Caller must not hold s.mu.
+// +checklocksexclude:s.mu
+// +checklocksexclude:s.registry.mu
 func (s *Shm) DecRef(ctx context.Context) {
 	s.ShmRefs.DecRef(func() {
 		s.mf.DecRef(s.fr)
@@ -454,6 +493,8 @@ func (s *Shm) Msync(context.Context, memmap.MappableRange) error {
 }
 
 // AddMapping implements memmap.Mappable.AddMapping.
+//
+// +checklocksexclude:s.mu
 func (s *Shm) AddMapping(ctx context.Context, _ memmap.MappingSpace, _ hostarch.AddrRange, _ uint64, _ bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -469,6 +510,8 @@ func (s *Shm) AddMapping(ctx context.Context, _ memmap.MappingSpace, _ hostarch.
 }
 
 // RemoveMapping implements memmap.Mappable.RemoveMapping.
+//
+// +checklocksexclude:s.mu
 func (s *Shm) RemoveMapping(ctx context.Context, _ memmap.MappingSpace, _ hostarch.AddrRange, _ uint64, _ bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -530,6 +573,8 @@ type AttachOpts struct {
 //
 // Postconditions: The returned MMapOpts are valid only as long as a reference
 // continues to be held on s.
+//
+// +checklocksexclude:s.mu
 func (s *Shm) ConfigureAttach(ctx context.Context, addr hostarch.Addr, opts AttachOpts) (memmap.MMapOpts, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -579,6 +624,8 @@ func (s *Shm) EffectiveSize() uint64 {
 }
 
 // IPCStat returns information about a shm. See shmctl(IPC_STAT).
+//
+// +checklocksexclude:s.mu
 func (s *Shm) IPCStat(ctx context.Context) (*linux.ShmidDS, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -635,6 +682,8 @@ func (s *Shm) IPCStat(ctx context.Context) (*linux.ShmidDS, error) {
 }
 
 // Set modifies attributes for a segment. See shmctl(IPC_SET).
+//
+// +checklocksexclude:s.mu
 func (s *Shm) Set(ctx context.Context, ds *linux.ShmidDS) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -651,6 +700,9 @@ func (s *Shm) Set(ctx context.Context, ds *linux.ShmidDS) error {
 // destroyed once it has no references. MarkDestroyed may be called multiple
 // times, and is safe to call after a segment has already been destroyed. See
 // shmctl(IPC_RMID).
+//
+// +checklocksexclude:s.mu
+// +checklocksexclude:s.registry.mu
 func (s *Shm) MarkDestroyed(ctx context.Context) {
 	s.registry.dissociateKey(s)
 

--- a/pkg/sentry/kernel/signal.go
+++ b/pkg/sentry/kernel/signal.go
@@ -35,6 +35,9 @@ const SignalPanic = linux.SIGUSR2
 // context is used only for debugging to differentiate these cases.
 //
 // Preconditions: Kernel must have an init process.
+//
+// +checklocksexclude:k.tasks.mu
+// +checklocksexclude:k.globalInit.signalHandlers.mu
 func (k *Kernel) sendExternalSignal(info *linux.SignalInfo, context string) {
 	switch linux.Signal(info.Signo) {
 	case linux.SIGURG:

--- a/pkg/sentry/kernel/signal_handlers.go
+++ b/pkg/sentry/kernel/signal_handlers.go
@@ -15,6 +15,8 @@
 package kernel
 
 import (
+	"maps"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 )
 
@@ -22,12 +24,14 @@ import (
 //
 // +stateify savable
 type SignalHandlers struct {
-	// mu protects actions, as well as the signal state of all tasks and thread
+	// mu also protects the signal state of all tasks and thread
 	// groups using this SignalHandlers object. (See comment on
 	// ThreadGroup.signalHandlers.)
 	mu signalHandlersMutex `state:"nosave"`
 
 	// actions is the action to be taken upon receiving each signal.
+	//
+	// +checklocks:mu
 	actions map[linux.Signal]linux.SigAction
 }
 
@@ -43,13 +47,12 @@ func NewSignalHandlers() *SignalHandlers {
 //
 // +checklocksexclude:sh.mu
 func (sh *SignalHandlers) Fork() *SignalHandlers {
-	sh2 := NewSignalHandlers()
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
-	for sig, act := range sh.actions {
-		sh2.actions[sig] = act
-	}
-	return sh2
+	// Keep the copy writable even if the source map is nil.
+	actions := make(map[linux.Signal]linux.SigAction, len(sh.actions))
+	maps.Copy(actions, sh.actions)
+	return &SignalHandlers{actions: actions}
 }
 
 // Reset returns a copy of sh with non-ignored handlers reset to SIG_DFL
@@ -57,19 +60,19 @@ func (sh *SignalHandlers) Fork() *SignalHandlers {
 //
 // +checklocksexclude:sh.mu
 func (sh *SignalHandlers) Reset() *SignalHandlers {
-	sh2 := NewSignalHandlers()
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
+	actions := make(map[linux.Signal]linux.SigAction)
 	for sig, act := range sh.actions {
 		newHandler := uint64(linux.SIG_DFL)
 		if act.Handler == linux.SIG_IGN {
 			newHandler = linux.SIG_IGN
 		}
-		sh2.actions[sig] = linux.SigAction{
+		actions[sig] = linux.SigAction{
 			Handler: newHandler,
 		}
 	}
-	return sh2
+	return &SignalHandlers{actions: actions}
 }
 
 // copyForExecLocked returns a copy of sh for a thread group undergoing execve.
@@ -77,15 +80,15 @@ func (sh *SignalHandlers) Reset() *SignalHandlers {
 //
 // +checklocks:sh.mu
 func (sh *SignalHandlers) copyForExecLocked() *SignalHandlers {
-	sh2 := NewSignalHandlers()
+	actions := make(map[linux.Signal]linux.SigAction)
 	for sig, act := range sh.actions {
 		if act.Handler == linux.SIG_IGN {
-			sh2.actions[sig] = linux.SigAction{
+			actions[sig] = linux.SigAction{
 				Handler: linux.SIG_IGN,
 			}
 		}
 	}
-	return sh2
+	return &SignalHandlers{actions: actions}
 }
 
 // IsIgnored returns true if the signal is ignored.

--- a/pkg/sentry/kernel/signal_handlers.go
+++ b/pkg/sentry/kernel/signal_handlers.go
@@ -40,6 +40,8 @@ func NewSignalHandlers() *SignalHandlers {
 }
 
 // Fork returns a copy of sh for a new thread group.
+//
+// +checklocksexclude:sh.mu
 func (sh *SignalHandlers) Fork() *SignalHandlers {
 	sh2 := NewSignalHandlers()
 	sh.mu.Lock()
@@ -50,8 +52,10 @@ func (sh *SignalHandlers) Fork() *SignalHandlers {
 	return sh2
 }
 
-// Reset returns a copy of sh where all non-ignored signal handlers are removed.
-// Used for CLONE_CLEAR_SIGHAND.
+// Reset returns a copy of sh with non-ignored handlers reset to SIG_DFL
+// and all other action fields cleared. Used for CLONE_CLEAR_SIGHAND.
+//
+// +checklocksexclude:sh.mu
 func (sh *SignalHandlers) Reset() *SignalHandlers {
 	sh2 := NewSignalHandlers()
 	sh.mu.Lock()
@@ -68,10 +72,10 @@ func (sh *SignalHandlers) Reset() *SignalHandlers {
 	return sh2
 }
 
-// copyForExecLocked returns a copy of sh for a thread group that is undergoing
-// an execve. (See comments in Task.finishExec.)
+// copyForExecLocked returns a copy of sh for a thread group undergoing execve.
+// Only ignored signals are retained, with all other action fields cleared.
 //
-// Preconditions: sh.mu must be locked.
+// +checklocks:sh.mu
 func (sh *SignalHandlers) copyForExecLocked() *SignalHandlers {
 	sh2 := NewSignalHandlers()
 	for sig, act := range sh.actions {
@@ -85,6 +89,8 @@ func (sh *SignalHandlers) copyForExecLocked() *SignalHandlers {
 }
 
 // IsIgnored returns true if the signal is ignored.
+//
+// +checklocksexclude:sh.mu
 func (sh *SignalHandlers) IsIgnored(sig linux.Signal) bool {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
@@ -92,9 +98,10 @@ func (sh *SignalHandlers) IsIgnored(sig linux.Signal) bool {
 	return ok && sa.Handler == linux.SIG_IGN
 }
 
-// dequeueActionLocked returns the SignalAct that should be used to handle sig.
+// dequeueAction returns the action for sig, resetting it to the default for
+// subsequent signals if SA_RESETHAND is set.
 //
-// Preconditions: sh.mu must be locked.
+// +checklocks:sh.mu
 func (sh *SignalHandlers) dequeueAction(sig linux.Signal) linux.SigAction {
 	act := sh.actions[sig]
 	if act.Flags&linux.SA_RESETHAND != 0 {

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -81,15 +81,17 @@ type Task struct {
 
 	// taskWorkCount represents the current size of the task work queue. It is
 	// used to avoid acquiring taskWorkMu when the queue is empty.
+	//
+	// +checkatomic
+	// +checklocks:taskWorkMu
 	taskWorkCount atomicbitops.Int32
 
-	// taskWorkMu protects taskWork.
 	taskWorkMu taskWorkMutex `state:"nosave"`
 
 	// taskWork is a queue of work to be executed before resuming user execution.
 	// It is similar to the task_work mechanism in Linux.
 	//
-	// taskWork is exclusive to the task goroutine.
+	// +checklocks:taskWorkMu
 	taskWork []TaskWorker
 
 	// haveSyscallReturn is true if image.Arch().Return() represents a value
@@ -258,7 +260,9 @@ type Task struct {
 
 	// exitStatus is the task's exit status.
 	//
-	// exitStatus is protected by the signal mutex.
+	// The task goroutine writes exitStatus under the signal mutex. After
+	// TaskExitZombie it is immutable and may be read with only TaskSet.mu.
+	// checklocks cannot express this lifecycle-dependent locking rule.
 	exitStatus linux.WaitStatus
 
 	// syscallRestartBlock represents a custom restart function to run in
@@ -469,7 +473,7 @@ type Task struct {
 
 	// noNewPrivs determines whether the task is allowed to gain new privileges.
 	//
-	// noNewPrivs is protected by mu.
+	// +checklocks:mu
 	noNewPrivs bool
 
 	// utsns is the task's UTS namespace.
@@ -515,9 +519,9 @@ type Task struct {
 	// don't really control the affinity.
 	//
 	// Invariant: allowedCPUMask.Size() ==
-	// sched.CPUMaskSize(Kernel.applicationCores).
+	// sched.CPUSetSize(Kernel.applicationCores).
 	//
-	// allowedCPUMask is protected by mu.
+	// +checklocks:mu
 	allowedCPUMask sched.CPUSet
 
 	// cpu is the fake cpu number returned by getcpu(2). cpu is ignored
@@ -528,7 +532,7 @@ type Task struct {
 	// It has no effect and is only used to provide a reasonable return value for
 	// sched_getattr() and similar.
 	//
-	// scheduler is protected by mu.
+	// +checklocks:mu
 	scheduler uint
 
 	// This is used to keep track of changes made to a process' priority/niceness.
@@ -538,13 +542,13 @@ type Task struct {
 	// NOTE: This represents the userspace view of priority (nice).
 	// This means that the value should be in the range [-20, 19].
 	//
-	// niceness is protected by mu.
+	// +checklocks:mu
 	niceness int
 
 	// This is used to keep track of a process's IO class and priority.
 	// It is only used to provide a reasonable return value for ioprio_get().
 	//
-	// ioprio is protected by mu.
+	// +checklocks:mu
 	ioprio int
 
 	// This is used to track the numa policy for the current thread. This can be
@@ -556,8 +560,10 @@ type Task struct {
 	// always report a single node so never need to save more than a single
 	// bit.
 	//
-	// numaPolicy and numaNodeMask are protected by mu.
-	numaPolicy   linux.NumaPolicy
+	// +checklocks:mu
+	numaPolicy linux.NumaPolicy
+
+	// +checklocks:mu
 	numaNodeMask uint64
 
 	// netns is the task's network namespace. It has to be changed under mu
@@ -676,7 +682,10 @@ type Task struct {
 	Origin TaskOrigin
 
 	// onDestroyAction is a set of callbacks that are executed when the
-	// task is destroyed.
+	// task is destroyed. The map is detached under mu before callbacks run
+	// asynchronously without mu.
+	//
+	// +checklocks:mu
 	onDestroyAction map[TaskDestroyAction]struct{}
 
 	// Helps serializes an execve(2) with a PTRACE_ATTACH and seccomp tsync. See the comment for
@@ -931,6 +940,8 @@ func (t *Task) SetKcov(k *Kcov) {
 }
 
 // ResetKcov clears the kcov instance associated with t.
+//
+// +checklocksexclude:t.kcov.mu
 func (t *Task) ResetKcov() {
 	if t.kcov != nil {
 		t.kcov.OnTaskExit()

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -872,7 +872,9 @@ func (t *Task) NewFDAt(fd int32, file *vfs.FileDescription, flags FDFlags) (*vfs
 	return t.fdTable.NewFDAt(t, fd, file, flags)
 }
 
-// WithMuLocked executes f with t.mu locked.
+// WithMuLocked acquires t.mu, calls f synchronously, and releases t.mu.
+//
+// +checklocksexclude:t.mu
 func (t *Task) WithMuLocked(f func(*Task)) {
 	t.mu.Lock()
 	f(t)

--- a/pkg/sentry/kernel/task_acct.go
+++ b/pkg/sentry/kernel/task_acct.go
@@ -31,6 +31,9 @@ import (
 // Getitimer implements getitimer(2).
 //
 // Preconditions: The caller must be running on the task goroutine.
+//
+// +checklocksexclude:t.tg.pidns.owner.mu
+// +checklocksexclude:t.tg.signalHandlers.mu
 func (t *Task) Getitimer(id int32) (linux.ItimerVal, error) {
 	var timer ktime.Timer
 	switch id {
@@ -54,6 +57,9 @@ func (t *Task) Getitimer(id int32) (linux.ItimerVal, error) {
 // Setitimer implements setitimer(2).
 //
 // Preconditions: The caller must be running on the task goroutine.
+//
+// +checklocksexclude:t.tg.pidns.owner.mu
+// +checklocksexclude:t.tg.signalHandlers.mu
 func (t *Task) Setitimer(id int32, newitv linux.ItimerVal) (linux.ItimerVal, error) {
 	var (
 		timer ktime.Timer
@@ -117,6 +123,9 @@ type itimerRealListener struct {
 }
 
 // NotifyTimer implements ktime.Listener.NotifyTimer.
+//
+// +checklocksexclude:l.tg.pidns.owner.mu
+// +checklocksexclude:l.tg.signalHandlers.mu
 func (l *itimerRealListener) NotifyTimer(exp uint64) {
 	l.tg.SendSignal(SignalInfoPriv(linux.SIGALRM))
 }

--- a/pkg/sentry/kernel/task_clone.go
+++ b/pkg/sentry/kernel/task_clone.go
@@ -62,6 +62,10 @@ func failCloneAfterTaskCreation(nt *Task) {
 //
 // Preconditions: The caller must be running Task.doSyscallInvoke on the task
 // goroutine.
+//
+// +checklocksexclude:t.mu
+// +checklocksexclude:t.tg.pidns.owner.mu
+// +checklocksexclude:t.tg.signalHandlers.mu
 func (t *Task) Clone(args *linux.CloneArgs) (ThreadID, *SyscallControl, error) {
 	if args.Flags&^SupportedCloneFlags != 0 {
 		return 0, nil, linuxerr.EINVAL

--- a/pkg/sentry/kernel/task_clone.go
+++ b/pkg/sentry/kernel/task_clone.go
@@ -601,6 +601,7 @@ func (nss *namespaceSet) release(t *Task) {
 	}
 }
 
+// +checklocksexclude:target.mu
 func (nss *namespaceSet) initFromTask(t *Task, target *Task, flags int32) error {
 	supported := uint32(linux.CLONE_NEWPID | linux.CLONE_NEWNET | linux.CLONE_NEWUTS | linux.CLONE_NEWIPC | linux.CLONE_NEWNS | linux.CLONE_NEWUSER)
 	if target.k.Cgroup2FS().EverMounted() {
@@ -736,6 +737,9 @@ func (nss *namespaceSet) initFromNS(ns vfs.Namespace, flags int32) error {
 }
 
 // Setns reassociates task t with the specified namespace(s).
+//
+// If fd is a pidfd, callers must not hold the referenced task's mutex.
+// checklocks cannot name that task through fd.
 func (t *Task) Setns(fd *vfs.FileDescription, flags int32) error {
 	if !t.k.Cgroup2FS().EverMounted() && flags&linux.CLONE_NEWCGROUP != 0 {
 		return linuxerr.EINVAL

--- a/pkg/sentry/kernel/task_clone.go
+++ b/pkg/sentry/kernel/task_clone.go
@@ -252,8 +252,12 @@ func (t *Task) Clone(args *linux.CloneArgs) (ThreadID, *SyscallControl, error) {
 
 	mntns := t.mountNamespace
 	if args.Flags&linux.CLONE_NEWNS != 0 {
+		// CLONE_NEWNS forced a private Fork above. checklocks cannot infer
+		// ownership of the returned context before the child is created.
+		root := &fsContext.root // +checklocksignore
+		cwd := &fsContext.cwd   // +checklocksignore
 		var err error
-		mntns, err = t.k.vfs.CloneMountNamespace(t, userns, mntns, &fsContext.root, &fsContext.cwd, t.k)
+		mntns, err = t.k.vfs.CloneMountNamespace(t, userns, mntns, root, cwd, t.k)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -834,12 +838,16 @@ func (t *Task) Setns(fd *vfs.FileDescription, flags int32) error {
 			return linuxerr.EINVAL
 		}
 		nss.fsContext = oldFSContext.Fork()
-		nss.fsContext.root.DecRef(t)
-		nss.fsContext.cwd.DecRef(t)
+		// This Fork remains private until the namespace swap below.
+		// checklocks cannot infer ownership of the returned context.
+		oldRoot := nss.fsContext.root // +checklocksignore
+		oldCwd := nss.fsContext.cwd   // +checklocksignore
+		oldRoot.DecRef(t)
+		oldCwd.DecRef(t)
 		vd := nss.mountNS.Root(t)
-		nss.fsContext.root = vd
+		nss.fsContext.root = vd // +checklocksignore
 		vd.IncRef()
-		nss.fsContext.cwd = vd
+		nss.fsContext.cwd = vd // +checklocksignore
 	}
 
 	// Swap to new namespaces.
@@ -1006,12 +1014,12 @@ func (t *Task) Unshare(flags int32) error {
 		newCgroupNS.SetInode(nsfs.NewInode(t, t.k.nsfsMount, newCgroupNS))
 	}
 	if flags&linux.CLONE_NEWNS != 0 {
-		fsContext := newFSContext
-		if fsContext == nil {
-			fsContext = t.FSContext()
-		}
+		// CLONE_NEWNS forced a private Fork above, not published until
+		// unshareFromTask below. checklocks cannot infer that ownership.
+		root := &newFSContext.root // +checklocksignore
+		cwd := &newFSContext.cwd   // +checklocksignore
 		var err error
-		newMountNS, err = t.k.vfs.CloneMountNamespace(t, creds.UserNamespace, t.mountNamespace, &fsContext.root, &fsContext.cwd, t.k)
+		newMountNS, err = t.k.vfs.CloneMountNamespace(t, creds.UserNamespace, t.mountNamespace, root, cwd, t.k)
 		if err != nil {
 			return err
 		}

--- a/pkg/sentry/kernel/task_exit.go
+++ b/pkg/sentry/kernel/task_exit.go
@@ -661,6 +661,8 @@ func (*runExitNotify) execute(t *Task) taskRunState {
 // termination signal is.
 //
 // Preconditions: The TaskSet mutex must be locked for writing.
+//
+// +checklocksexclude:t.mu
 func (t *Task) exitNotifyLocked(fromPtraceDetach bool) {
 	if t.exitStateLocked() != TaskExitZombie {
 		return
@@ -813,6 +815,8 @@ type TaskDestroyAction interface {
 //
 // It returns true if the action was successfully registered.
 // If the task is already terminated, it returns false.
+//
+// +checklocksexclude:t.mu
 func (t *Task) RegisterOnDestroyAction(act TaskDestroyAction) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -825,12 +829,15 @@ func (t *Task) RegisterOnDestroyAction(act TaskDestroyAction) bool {
 
 // UnregisterOnDestroyAction unregisters an action previously registered with
 // RegisterOnDestroyAction.
+//
+// +checklocksexclude:t.mu
 func (t *Task) UnregisterOnDestroyAction(key TaskDestroyAction) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	delete(t.onDestroyAction, key)
 }
 
+// +checklocksexclude:t.mu
 func (t *Task) execOnDestroyActions() {
 	t.mu.Lock()
 	actions := t.onDestroyAction

--- a/pkg/sentry/kernel/task_identity.go
+++ b/pkg/sentry/kernel/task_identity.go
@@ -473,6 +473,8 @@ func (t *Task) SetSecurebits(arg2 uint64) error {
 }
 
 // SetNoNewPrivs will set the no new privileges flag PR_SET_NO_NEW_PRIVS.
+//
+// +checklocksexclude:t.mu
 func (t *Task) SetNoNewPrivs() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -480,6 +482,8 @@ func (t *Task) SetNoNewPrivs() {
 }
 
 // GetNoNewPrivs returns true if the prctl flag NO_NEW_PRIVS is set.
+//
+// +checklocksexclude:t.mu
 func (t *Task) GetNoNewPrivs() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/pkg/sentry/kernel/task_sched.go
+++ b/pkg/sentry/kernel/task_sched.go
@@ -378,6 +378,8 @@ func (t *Task) StateStatus() string {
 }
 
 // CPUMask returns a copy of t's allowed CPU mask.
+//
+// +checklocksexclude:t.mu
 func (t *Task) CPUMask() sched.CPUSet {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -389,6 +391,9 @@ func (t *Task) CPUMask() sched.CPUSet {
 //
 // Preconditions: mask.Size() ==
 // sched.CPUSetSize(t.Kernel().ApplicationCores()).
+//
+// +checklocksexclude:t.mu
+// +checklocksexclude:t.tg.pidns.owner.mu
 func (t *Task) SetCPUMask(mask sched.CPUSet) error {
 	if want := sched.CPUSetSize(t.k.applicationCores); mask.Size() != want {
 		panic(fmt.Sprintf("Invalid CPUSet %v (expected %d bytes)", mask, want))
@@ -448,6 +453,8 @@ func assignCPU(allowed sched.CPUSet, tid ThreadID) (cpu int32) {
 }
 
 // Niceness returns t's niceness.
+//
+// +checklocksexclude:t.mu
 func (t *Task) Niceness() int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -455,6 +462,8 @@ func (t *Task) Niceness() int {
 }
 
 // Priority returns t's priority.
+//
+// +checklocksexclude:t.mu
 func (t *Task) Priority() int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -463,6 +472,8 @@ func (t *Task) Priority() int {
 
 // SetNiceness sets t's niceness to n.
 // Values outside of [-20, 19] are clamped to fit within the range.
+//
+// +checklocksexclude:t.mu
 func (t *Task) SetNiceness(n int) {
 	if n < -20 {
 		n = -20
@@ -476,6 +487,8 @@ func (t *Task) SetNiceness(n int) {
 }
 
 // SetIOPrio sets t's ioprio.
+//
+// +checklocksexclude:t.mu
 func (t *Task) SetIOPrio(ioprio int) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -483,6 +496,8 @@ func (t *Task) SetIOPrio(ioprio int) {
 }
 
 // GetIOPrio fetches t's ioprio.
+//
+// +checklocksexclude:t.mu
 func (t *Task) GetIOPrio() int {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -490,6 +505,8 @@ func (t *Task) GetIOPrio() int {
 }
 
 // SetScheduler sets t's scheduler.
+//
+// +checklocksexclude:t.mu
 func (t *Task) SetScheduler(scheduler uint) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -497,6 +514,8 @@ func (t *Task) SetScheduler(scheduler uint) {
 }
 
 // GetScheduler fetches t's scheduler.
+//
+// +checklocksexclude:t.mu
 func (t *Task) GetScheduler() uint {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -504,6 +523,8 @@ func (t *Task) GetScheduler() uint {
 }
 
 // NumaPolicy returns t's current numa policy.
+//
+// +checklocksexclude:t.mu
 func (t *Task) NumaPolicy() (policy linux.NumaPolicy, nodeMask uint64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -511,6 +532,8 @@ func (t *Task) NumaPolicy() (policy linux.NumaPolicy, nodeMask uint64) {
 }
 
 // SetNumaPolicy sets t's numa policy.
+//
+// +checklocksexclude:t.mu
 func (t *Task) SetNumaPolicy(policy linux.NumaPolicy, nodeMask uint64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/pkg/sentry/kernel/task_signals.go
+++ b/pkg/sentry/kernel/task_signals.go
@@ -391,6 +391,9 @@ func (t *Task) SendGroupSignal(info *linux.SignalInfo) error {
 
 // SendSignal sends the given signal to tg, using tg's leader to determine if
 // the signal is blocked.
+//
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (tg *ThreadGroup) SendSignal(info *linux.SignalInfo) error {
 	tg.pidns.owner.mu.RLock()
 	defer tg.pidns.owner.mu.RUnlock()

--- a/pkg/sentry/kernel/task_signals.go
+++ b/pkg/sentry/kernel/task_signals.go
@@ -375,14 +375,18 @@ func (t *Task) Sigtimedwait(set linux.SignalSet, timeout time.Duration) (*linux.
 func (t *Task) SendSignal(info *linux.SignalInfo) error {
 	sh := t.tg.signalLock()
 	defer sh.mu.Unlock()
-	return t.sendSignalLocked(info, false /* group */)
+	// signalLock returned t.tg's current handler with sh.mu held;
+	// checklocks does not relate that result to the thread-group field.
+	return t.sendSignalLocked(info, false /* group */) // +checklocksignore
 }
 
 // SendGroupSignal sends the given signal to t's thread group.
 func (t *Task) SendGroupSignal(info *linux.SignalInfo) error {
 	sh := t.tg.signalLock()
 	defer sh.mu.Unlock()
-	return t.sendSignalLocked(info, true /* group */)
+	// signalLock returned t.tg's current handler with sh.mu held;
+	// checklocks does not relate that result to the thread-group field.
+	return t.sendSignalLocked(info, true /* group */) // +checklocksignore
 }
 
 // SendSignal sends the given signal to tg, using tg's leader to determine if
@@ -395,12 +399,12 @@ func (tg *ThreadGroup) SendSignal(info *linux.SignalInfo) error {
 	return tg.leader.sendSignalLocked(info, true /* group */)
 }
 
-// Preconditions: The signal mutex must be locked.
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) sendSignalLocked(info *linux.SignalInfo, group bool) error {
 	return t.sendSignalTimerLocked(info, group, nil)
 }
 
-// Preconditions: The signal mutex must be locked.
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) sendSignalTimerLocked(info *linux.SignalInfo, group bool, timer *IntervalTimer) error {
 	if t.ExitState() == TaskExitDead {
 		return linuxerr.ESRCH
@@ -567,7 +571,7 @@ func (t *Task) forceSignal(sig linux.Signal, unconditional bool) {
 	t.forceSignalLocked(sig, unconditional)
 }
 
-// Preconditions: The signal mutex must be locked.
+// +checklocks:t.tg.signalHandlers.mu
 func (t *Task) forceSignalLocked(sig linux.Signal, unconditional bool) {
 	blocked := linux.SignalSetOf(sig)&linux.SignalSet(t.signalMask.RacyLoad()) != 0
 	act := t.tg.signalHandlers.actions[sig]

--- a/pkg/sentry/kernel/task_start.go
+++ b/pkg/sentry/kernel/task_start.go
@@ -140,6 +140,12 @@ type TaskConfig struct {
 //
 // If successful, NewTask transfers references held by cfg to the new task.
 // Otherwise, NewTask releases them.
+//
+// Preconditions: cfg.Kernel.tasks must be ts. cfg.ThreadGroup and any
+// non-nil cfg.Parent or cfg.InheritParent must belong to ts.
+//
+// +checklocksexclude:ts.mu
+// +checklocksexclude:cfg.ThreadGroup.signalHandlers.mu
 func (ts *TaskSet) NewTask(ctx context.Context, cfg *TaskConfig) (*Task, error) {
 	var err error
 	cleanup := func() {
@@ -170,6 +176,11 @@ func (ts *TaskSet) NewTask(ctx context.Context, cfg *TaskConfig) (*Task, error) 
 
 // newTask is a helper for TaskSet.NewTask that only takes ownership of parts
 // of cfg if it succeeds.
+//
+// Preconditions: As for NewTask.
+//
+// +checklocksexclude:ts.mu
+// +checklocksexclude:cfg.ThreadGroup.signalHandlers.mu
 func (ts *TaskSet) newTask(ctx context.Context, cfg *TaskConfig) (*Task, error) {
 	srcT := TaskFromContext(ctx)
 	tg := cfg.ThreadGroup

--- a/pkg/sentry/kernel/task_stop.go
+++ b/pkg/sentry/kernel/task_stop.go
@@ -187,6 +187,8 @@ func (t *Task) endStopLocked() {
 // BeginExternalStop indicates the start of an external stop that applies to
 // all current and future tasks in ts. BeginExternalStop does not wait for
 // task goroutines to stop.
+//
+// +checklocksexclude:ts.mu
 func (ts *TaskSet) BeginExternalStop() {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
@@ -224,6 +226,8 @@ func (ts *TaskSet) PullFullState() {
 // EndExternalStop indicates the end of an external stop started by a previous
 // call to TaskSet.BeginExternalStop. EndExternalStop does not wait for task
 // goroutines to resume.
+//
+// +checklocksexclude:ts.mu
 func (ts *TaskSet) EndExternalStop() {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()
@@ -243,6 +247,8 @@ func (ts *TaskSet) EndExternalStop() {
 
 // isExternallyStopped returns true if BeginExternalStop() has been called on
 // this TaskSet, without a corresponding call to EndExternalStop().
+//
+// +checklocksexclude:ts.mu
 func (ts *TaskSet) isExternallyStopped() bool {
 	ts.mu.Lock()
 	defer ts.mu.Unlock()

--- a/pkg/sentry/kernel/task_work.go
+++ b/pkg/sentry/kernel/task_work.go
@@ -28,6 +28,8 @@ type TaskWorker interface {
 // RegisterWork can be used to register additional task work that will be
 // performed prior to returning to user space. See TaskWorker.TaskWork for
 // semantics regarding registration.
+//
+// +checklocksexclude:t.taskWorkMu
 func (t *Task) RegisterWork(work TaskWorker) {
 	t.taskWorkMu.Lock()
 	defer t.taskWorkMu.Unlock()

--- a/pkg/sentry/kernel/thread_group.go
+++ b/pkg/sentry/kernel/thread_group.go
@@ -306,6 +306,8 @@ type ThreadGroup struct {
 // thread group leader will send its parent terminationSignal when it exits.
 // The new thread group isn't visible to the system until a task has been
 // created inside of it by a successful call to TaskSet.NewTask.
+//
+// Preconditions: pidns must be non-nil and belong to k.
 func (k *Kernel) NewThreadGroup(pidns *PIDNamespace, sh *SignalHandlers, terminationSignal linux.Signal, limits *limits.LimitSet) *ThreadGroup {
 	pidns.IncRef()
 	tg := &ThreadGroup{

--- a/pkg/sentry/kernel/thread_group.go
+++ b/pkg/sentry/kernel/thread_group.go
@@ -351,6 +351,9 @@ func (tg *ThreadGroup) Limits() *limits.LimitSet {
 }
 
 // Release releases the thread group's resources.
+//
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (tg *ThreadGroup) Release(ctx context.Context) {
 	// Timers must be destroyed without holding the TaskSet or signal mutexes
 	// since timers send signals with Timer.mu locked.
@@ -446,6 +449,10 @@ func (tg *ThreadGroup) GetTTY() *TTY {
 }
 
 // SetControllingTTY sets tty as the controlling terminal of tg.
+//
+// +checklocksexclude:tty.mu
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (tg *ThreadGroup) SetControllingTTY(ctx context.Context, tty *TTY, steal bool, isReadable bool) error {
 	var toDecRef []*TTY
 	defer func() {
@@ -526,6 +533,10 @@ func (tg *ThreadGroup) SetControllingTTY(ctx context.Context, tty *TTY, steal bo
 }
 
 // ReleaseControllingTTY gives up tty as the controlling tty of tg.
+//
+// +checklocksexclude:tty.mu
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (tg *ThreadGroup) ReleaseControllingTTY(ctx context.Context, tty *TTY) error {
 	var toDecRef []*TTY
 	defer func() {
@@ -598,6 +609,10 @@ func (tg *ThreadGroup) ReleaseControllingTTY(ctx context.Context, tty *TTY) erro
 
 // ForegroundProcessGroup returns the foreground process group of the thread
 // group.
+//
+// +checklocksexclude:tty.mu
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (tg *ThreadGroup) ForegroundProcessGroup(tty *TTY) (*ProcessGroup, error) {
 	tty.mu.Lock()
 	defer tty.mu.Unlock()
@@ -618,6 +633,10 @@ func (tg *ThreadGroup) ForegroundProcessGroup(tty *TTY) (*ProcessGroup, error) {
 
 // ForegroundProcessGroupID returns the foreground process group ID of the
 // thread group.
+//
+// +checklocksexclude:tty.mu
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (tg *ThreadGroup) ForegroundProcessGroupID(tty *TTY) (ProcessGroupID, error) {
 	pg, err := tg.ForegroundProcessGroup(tty)
 	if err != nil {
@@ -628,6 +647,10 @@ func (tg *ThreadGroup) ForegroundProcessGroupID(tty *TTY) (ProcessGroupID, error
 
 // SetForegroundProcessGroupID sets the foreground process group of tty to
 // pgid. It corresponds to Linux's drivers/tty/tty_io.c:tiocspgrp().
+//
+// +checklocksexclude:tty.mu
+// +checklocksexclude:tg.pidns.owner.mu
+// +checklocksexclude:tg.signalHandlers.mu
 func (tg *ThreadGroup) SetForegroundProcessGroupID(ctx context.Context, tty *TTY, pgid ProcessGroupID) error {
 	// First check that the change is allowed.
 	if err := tty.CheckChange(ctx, linux.SIGTTOU); err != nil {

--- a/pkg/sentry/kernel/thread_group.go
+++ b/pkg/sentry/kernel/thread_group.go
@@ -34,6 +34,9 @@ import (
 //
 // ThreadGroup is a superset of Linux's struct signal_struct.
 //
+// A nonnil leader always belongs to this thread group.
+//
+// +checklocksalias:leader.tg.signalHandlers.mu=signalHandlers.mu
 // +stateify savable
 type ThreadGroup struct {
 	threadGroupNode

--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -71,19 +71,24 @@ type TaskSet struct {
 
 	// stopCount is the number of active external stops applicable to all tasks
 	// in the TaskSet (calls to TaskSet.BeginExternalStop that have not been
-	// paired with a call to TaskSet.EndExternalStop). stopCount is protected
-	// by mu.
+	// paired with a call to TaskSet.EndExternalStop).
 	//
 	// stopCount is not saved for the same reason as Task.stopCount; it is
 	// always reset to zero after restore.
+	//
+	// +checklocks:mu
 	stopCount int32 `state:"nosave"`
 
 	// liveTasks is the number of tasks in the TaskSet whose goroutines have
-	// not exited. liveTasks is protected by mu.
+	// not exited.
+	//
+	// +checklocks:mu
 	liveTasks uint32
 
 	// If noNewTasksIfZeroLive is true and liveTasks is zero, calls to
-	// Kernel.NewTask() will fail. noNewTasksIfZeroLive is protected by mu.
+	// TaskSet.newTask will fail.
+	//
+	// +checklocks:mu
 	noNewTasksIfZeroLive bool
 
 	// zeroLiveTasksCond is broadcast when liveTasks transitions from non-zero
@@ -132,7 +137,7 @@ func (ts *TaskSet) forEachThreadGroupLocked(f func(tg *ThreadGroup, tgLeader *Ta
 
 // forEachTaskLocked applies f to each Task in ts.
 //
-// Preconditions: ts.mu must be locked (for reading or writing).
+// +checklocksread:ts.mu
 func (ts *TaskSet) forEachTaskLocked(f func(t *Task)) {
 	for t := range ts.Root.tids {
 		f(t)

--- a/pkg/sentry/kernel/tty.go
+++ b/pkg/sentry/kernel/tty.go
@@ -49,7 +49,7 @@ type TTY struct {
 
 	mu sync.Mutex `state:"nosave"`
 
-	// tg is protected by mu.
+	// +checklocks:mu
 	tg *ThreadGroup
 }
 
@@ -67,6 +67,8 @@ func (tty *TTY) Index() uint32 {
 }
 
 // ThreadGroup returns the ThreadGroup this TTY is associated with.
+//
+// +checklocksexclude:tty.mu
 func (tty *TTY) ThreadGroup() *ThreadGroup {
 	tty.mu.Lock()
 	defer tty.mu.Unlock()
@@ -75,6 +77,8 @@ func (tty *TTY) ThreadGroup() *ThreadGroup {
 
 // SignalForegroundProcessGroup sends the signal to the foreground process
 // group of the TTY.
+//
+// +checklocksexclude:tty.mu
 func (tty *TTY) SignalForegroundProcessGroup(info *linux.SignalInfo) {
 	tty.mu.Lock()
 	defer tty.mu.Unlock()
@@ -106,6 +110,8 @@ func (tty *TTY) SignalForegroundProcessGroup(info *linux.SignalInfo) {
 // change the state of the TTY.
 //
 // This corresponds to Linux drivers/tty/tty_io.c:tty_check_change().
+//
+// +checklocksexclude:tty.mu
 func (tty *TTY) CheckChange(ctx context.Context, sig linux.Signal) error {
 	task := TaskFromContext(ctx)
 	if task == nil {
@@ -169,6 +175,8 @@ func (tty *TTY) CheckChange(ctx context.Context, sig linux.Signal) error {
 // the foreground process group. This is called on the replica (slave) TTY
 // when the PTY master is closed, corresponding to Linux's pty_close()
 // calling tty_vhangup(tty->link).
+//
+// +checklocksexclude:tty.mu
 func (tty *TTY) Hangup(ctx context.Context) {
 	tty.mu.Lock()
 	tg := tty.tg

--- a/pkg/sentry/kernel/uts_namespace.go
+++ b/pkg/sentry/kernel/uts_namespace.go
@@ -26,11 +26,15 @@ import (
 //
 // +stateify savable
 type UTSNamespace struct {
-	// mu protects all fields below.
-	mu                sync.Mutex `state:"nosave"`
-	hostName          string
-	hostNameChanged   bool
-	domainName        string
+	mu sync.Mutex `state:"nosave"`
+
+	// +checklocks:mu
+	hostName string
+	// +checklocks:mu
+	hostNameChanged bool
+	// +checklocks:mu
+	domainName string
+	// +checklocks:mu
 	domainNameChanged bool
 
 	// userns is the user namespace associated with the UTSNamespace.
@@ -40,6 +44,7 @@ type UTSNamespace struct {
 	// userns is immutable.
 	userns *auth.UserNamespace
 
+	// +checklocks:mu
 	inode *nsfs.Inode
 }
 
@@ -53,6 +58,8 @@ func NewUTSNamespace(hostName, domainName string, userns *auth.UserNamespace) *U
 }
 
 // UTSNamespace returns the task's UTS namespace.
+//
+// +checklocksexclude:t.mu
 func (t *Task) UTSNamespace() *UTSNamespace {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -61,6 +68,8 @@ func (t *Task) UTSNamespace() *UTSNamespace {
 
 // GetUTSNamespace takes a reference on the task UTS namespace and
 // returns it. It will return nil if the task isn't alive.
+//
+// +checklocksexclude:t.mu
 func (t *Task) GetUTSNamespace() *UTSNamespace {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -71,6 +80,8 @@ func (t *Task) GetUTSNamespace() *UTSNamespace {
 }
 
 // HostName returns the host name of this UTS namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) HostName() string {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -78,6 +89,8 @@ func (u *UTSNamespace) HostName() string {
 }
 
 // SetHostName sets the host name of this UTS namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) SetHostName(ctx context.Context, host string) {
 	u.mu.Lock()
 	u.hostName = host
@@ -88,6 +101,8 @@ func (u *UTSNamespace) SetHostName(ctx context.Context, host string) {
 }
 
 // DomainName returns the domain name of this UTS namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) DomainName() string {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -95,6 +110,8 @@ func (u *UTSNamespace) DomainName() string {
 }
 
 // SetDomainName sets the domain name of this UTS namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) SetDomainName(ctx context.Context, domain string) {
 	u.mu.Lock()
 	u.domainName = domain
@@ -105,6 +122,8 @@ func (u *UTSNamespace) SetDomainName(ctx context.Context, domain string) {
 }
 
 // UserNamespace returns the user namespace associated with this UTS namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) UserNamespace() *auth.UserNamespace {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -120,6 +139,8 @@ func (u *UTSNamespace) Type() string {
 func (u *UTSNamespace) Destroy(ctx context.Context) {}
 
 // SetInode sets the nsfs `inode` to the UTS namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) SetInode(inode *nsfs.Inode) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -127,6 +148,8 @@ func (u *UTSNamespace) SetInode(inode *nsfs.Inode) {
 }
 
 // GetInode returns the nsfs inode associated with the UTS  namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) GetInode() *nsfs.Inode {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -134,6 +157,8 @@ func (u *UTSNamespace) GetInode() *nsfs.Inode {
 }
 
 // IncRef increments the Namespace's refcount.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) IncRef() {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -141,6 +166,8 @@ func (u *UTSNamespace) IncRef() {
 }
 
 // DecRef decrements the namespace's refcount.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) DecRef(ctx context.Context) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -149,6 +176,8 @@ func (u *UTSNamespace) DecRef(ctx context.Context) {
 
 // Clone makes a copy of this UTS namespace, associating the given user
 // namespace.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) Clone(userns *auth.UserNamespace) *UTSNamespace {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -163,6 +192,8 @@ func (u *UTSNamespace) Clone(userns *auth.UserNamespace) *UTSNamespace {
 
 // RestoreSpecValues updates the hostname and domainname if they haven't been
 // explicitly set by the user.
+//
+// +checklocksexclude:u.mu
 func (u *UTSNamespace) RestoreSpecValues(hostName, domainName string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()

--- a/pkg/sentry/syscalls/linux/sys_msgqueue.go
+++ b/pkg/sentry/syscalls/linux/sys_msgqueue.go
@@ -102,9 +102,10 @@ func Msgrcv(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr,
 	return uintptr(len(buf.Text)), nil, nil
 }
 
-// receive returns a message from the queue with the given ID. If msgCopy is
-// true, a message is copied from the queue without being removed. Otherwise,
-// a message is removed from the queue and returned.
+// receive returns a message from the queue with the given ID. If flags includes
+// MSG_COPY, it returns the original message without removing it. Otherwise,
+// the message is removed. Callers must preserve the payload immutability
+// described by msgqueue.Message.
 func receive(t *kernel.Task, id ipc.ID, mType int64, maxSize uint64, flags int32) (*msgqueue.Message, error) {
 	if flags&linux.MSG_COPY != 0 {
 		if flags&(linux.IPC_NOWAIT|linux.MSG_EXCEPT) != linux.IPC_NOWAIT {

--- a/pkg/sentry/syscalls/linux/sys_process_vm.go
+++ b/pkg/sentry/syscalls/linux/sys_process_vm.go
@@ -41,6 +41,8 @@ func ProcessVMWritev(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) 
 	return processVMOp(t, args, processVMOpWrite)
 }
 
+// If pid selects another task, callers must not hold that task's mutex.
+// checklocks cannot name the task returned by PIDNamespace.TaskWithID.
 func processVMOp(t *kernel.Task, args arch.SyscallArguments, op processVMOpType) (uintptr, *kernel.SyscallControl, error) {
 	pid := kernel.ThreadID(args[0].Int())
 	lvec := hostarch.Addr(args[1].Pointer())

--- a/pkg/sentry/syscalls/linux/sys_thread.go
+++ b/pkg/sentry/syscalls/linux/sys_thread.go
@@ -1059,6 +1059,8 @@ func Setpriority(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uin
 }
 
 // Ptrace implements linux system call ptrace(2).
+//
+// +checklocksexclude:t.mu
 func Ptrace(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
 	req := args[0].Int64()
 	pid := kernel.ThreadID(args[1].Int())

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -1071,6 +1071,10 @@ func (cm *containerManager) ListTraceSessions(_ *struct{}, out *[]seccheck.Sessi
 }
 
 // ProcfsDump dumps procfs state of the sandbox.
+//
+// Callers must not hold any thread-group leader's Task.mu in the sandbox.
+// checklocks cannot name the leader mutexes in the slice returned by
+// PIDNamespace.ThreadGroups.
 func (cm *containerManager) ProcfsDump(_ *struct{}, out *[]procfs.ProcessProcfsDump) error {
 	log.Debugf("containerManager.ProcfsDump")
 	ts := cm.l.k.TaskSet()

--- a/runsc/boot/procfs/dump.go
+++ b/runsc/boot/procfs/dump.go
@@ -112,6 +112,8 @@ type ProcessProcfsDump struct {
 // getMM returns t's MemoryManager. On success, the MemoryManager's users count
 // is incremented, and must be decremented by the caller when it is no longer
 // in use.
+//
+// +checklocksexclude:t.mu
 func getMM(t *kernel.Task) *mm.MemoryManager {
 	var mm *mm.MemoryManager
 	t.WithMuLocked(func(*kernel.Task) {
@@ -168,6 +170,7 @@ func getCWD(ctx context.Context, t *kernel.Task, pid kernel.ThreadID) string {
 	return name
 }
 
+// +checklocksexclude:t.mu
 func getFDs(ctx context.Context, t *kernel.Task, pid kernel.ThreadID) []FDInfo {
 	type fdInfo struct {
 		fd *vfs.FileDescription
@@ -289,6 +292,8 @@ func getMappings(ctx context.Context, mm *mm.MemoryManager) []Mapping {
 }
 
 // Dump returns a procfs dump for process pid. t must be a task in process pid.
+//
+// +checklocksexclude:t.mu
 func Dump(t *kernel.Task, pid kernel.ThreadID, pidns *kernel.PIDNamespace) (ProcessProcfsDump, error) {
 	ctx := t.AsyncContext()
 


### PR DESCRIPTION
Annotate existing lock contracts for kernel, namespace, SysV IPC and futex state, including Task.mu exclusions in procfs and tracing callers. Expose private construction and owner aliases to the checker, and replace IPC unlock suppressions with release contracts.

Part of #14349.

Assisted-by: Codex