### PR TITLE
checklocks: annotate filesystem lock ownership

### DIFF
--- a/pkg/fdnotifier/fdnotifier.go
+++ b/pkg/fdnotifier/fdnotifier.go
@@ -30,7 +30,12 @@ import (
 )
 
 type fdInfo struct {
-	queue   *waiter.Queue
+	// queue is immutable after registration. waiter.Queue.mu protects entry
+	// membership and queued event masks.
+	queue *waiter.Queue
+
+	// waiting is protected by the owning notifier's mu. fdInfo does not retain
+	// a pointer to that owner for a checklocks annotation.
 	waiting bool
 }
 
@@ -42,13 +47,15 @@ type notifier struct {
 	epFD int
 
 	// pauseMu synchronizes notifications with save/restore.
+	// It precedes mu in lock order.
 	pauseMu sync.Mutex
 
-	// mu protects fdMap.
 	mu sync.Mutex
 
 	// fdMap maps file descriptors to their notification queues and waiting
 	// status.
+	//
+	// +checklocks:mu
 	fdMap map[int32]*fdInfo
 }
 
@@ -69,7 +76,9 @@ func newNotifier() (*notifier, error) {
 	return w, nil
 }
 
-// waitFD waits on mask for fd. The fdMap mutex must be hold.
+// waitFD waits on mask for fd.
+//
+// +checklocks:n.mu
 func (n *notifier) waitFD(fd int32, fi *fdInfo, mask waiter.EventMask) error {
 	if !fi.waiting && mask == 0 {
 		return nil
@@ -99,6 +108,9 @@ func (n *notifier) waitFD(fd int32, fi *fdInfo, mask waiter.EventMask) error {
 }
 
 // addFD adds an FD to the list of FDs observed by n.
+//
+// +checklocksexclude:n.mu
+// +checklocksexclude:queue.mu
 func (n *notifier) addFD(fd int32, queue *waiter.Queue) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -119,6 +131,11 @@ func (n *notifier) addFD(fd int32, queue *waiter.Queue) error {
 }
 
 // updateFD updates the set of events the fd needs to be notified on.
+//
+// The caller must not hold the registered waiter's queue mutex. checklocks
+// cannot name that queue through the FD's entry in fdMap.
+//
+// +checklocksexclude:n.mu
 func (n *notifier) updateFD(fd int32) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -131,6 +148,8 @@ func (n *notifier) updateFD(fd int32) error {
 }
 
 // RemoveFD removes an FD from the list of FDs observed by n.
+//
+// +checklocksexclude:n.mu
 func (n *notifier) removeFD(fd int32) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -141,6 +160,8 @@ func (n *notifier) removeFD(fd int32) {
 }
 
 // hasFD returns true if the fd is in the list of observed FDs.
+//
+// +checklocksexclude:n.mu
 func (n *notifier) hasFD(fd int32) bool {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -193,6 +214,13 @@ func (n *notifier) resume() {
 	n.pauseMu.Unlock()
 }
 
+// once publishes notifier and initErr; checklocks does not model sync.Once
+// publication. Public FD helpers acquire notifier.mu themselves, but their
+// exclusions cannot be exported reliably through this private package global.
+// Pause/Resume have the same private-global limitation for their lock effects.
+//
+// Notifications call waiter callbacks with pauseMu and mu held. Callbacks must
+// not reenter the FD helpers or Pause/Resume on the same notifier.
 var shared struct {
 	notifier *notifier
 	once     sync.Once
@@ -206,6 +234,8 @@ func ensureSharedNotifier() {
 }
 
 // AddFD adds an FD to the list of observed FDs.
+//
+// +checklocksexclude:queue.mu
 func AddFD(fd int32, queue *waiter.Queue) error {
 	ensureSharedNotifier()
 	if shared.initErr != nil {

--- a/pkg/lisafs/channel.go
+++ b/pkg/lisafs/channel.go
@@ -98,6 +98,8 @@ func (ch *channel) destroy() {
 
 // createChannel creates a server side channel. It returns a packet window
 // descriptor (for the data channel) and an open socket for the FD channel.
+//
+// +checklocksexclude:c.channelsMu
 func (c *Connection) createChannel(maxMessageSize uint32) (*channel, flipcall.PacketWindowDescriptor, int, error) {
 	c.channelsMu.Lock()
 	defer c.channelsMu.Unlock()

--- a/pkg/lisafs/client.go
+++ b/pkg/lisafs/client.go
@@ -41,12 +41,18 @@ type Client struct {
 	sockMu   sync.Mutex
 	sockComm *sockCommunicator
 
-	// channelsMu protects channels and availableChannels.
 	channelsMu sync.Mutex
+
 	// channels tracks all the channels.
+	//
+	// +checklocks:channelsMu
 	channels []*channel
+
 	// availableChannels is a LIFO (stack) of channels available to be used.
+	//
+	// +checklocks:channelsMu
 	availableChannels []*channel
+
 	// activeWg represents active channels.
 	activeWg sync.WaitGroup
 
@@ -61,10 +67,13 @@ type Client struct {
 	// It is initialized on Mount and is immutable.
 	maxMessageSize uint32
 
+	fdsMu sync.Mutex
+
 	// fdsToClose tracks the FDs to close. It caches the FDs no longer being used
 	// by the client and closes them in one shot. It is not preserved across
 	// checkpoint/restore as FDIDs are not preserved.
-	fdsMu      sync.Mutex
+	//
+	// +checklocks:fdsMu
 	fdsToClose []FDID
 }
 
@@ -108,6 +117,10 @@ func NewClient(sock *unet.Socket) (*Client, Inode, int, error) {
 }
 
 // StartChannels starts maxChannels() channel communicators.
+// It waits for bootstrap RPCs, which may need the main socket's mutex.
+//
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.sockMu
 func (c *Client) StartChannels() error {
 	maxChans := maxChannels()
 	c.channelsMu.Lock()
@@ -191,6 +204,7 @@ func (c *Client) watchdog() {
 	c.sockComm.destroy()
 }
 
+// +checklocksexclude:c.channelsMu
 func (c *Client) shutdownActiveChans() {
 	c.channelsMu.Lock()
 	defer c.channelsMu.Unlock()
@@ -212,6 +226,9 @@ func (c *Client) shutdownActiveChans() {
 }
 
 // Close shuts down the main socket and waits for the watchdog to clean up.
+// The watchdog acquires channelsMu while shutting down and destroying channels.
+//
+// +checklocksexclude:c.channelsMu
 func (c *Client) Close() {
 	// This shutdown has no effect if the watchdog has already fired and closed
 	// the main socket.
@@ -219,6 +236,8 @@ func (c *Client) Close() {
 	c.watchdogWg.Wait()
 }
 
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.sockMu
 func (c *Client) createChannel() (*channel, error) {
 	var (
 		chanReq  ChannelReq
@@ -264,6 +283,10 @@ func (c *Client) IsSupported(m MID) bool {
 // CloseFD either queues the passed FD to be closed or makes a batch
 // RPC to close all the accumulated FDs-to-close. If flush is true, the RPC
 // is made immediately.
+//
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.sockMu
+// +checklocksexclude:c.fdsMu
 func (c *Client) CloseFD(ctx context.Context, fd FDID, flush bool) {
 	c.fdsMu.Lock()
 	c.fdsToClose = append(c.fdsToClose, fd)
@@ -294,6 +317,9 @@ func (c *Client) CloseFD(ctx context.Context, fd FDID, flush bool) {
 }
 
 // SyncFDs makes a Fsync RPC to sync multiple FDs.
+//
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.sockMu
 func (c *Client) SyncFDs(ctx context.Context, fds []FDID) error {
 	if len(fds) == 0 {
 		return nil
@@ -315,6 +341,9 @@ func (c *Client) SyncFDs(ctx context.Context, fds []FDID) error {
 // combining these functions into an interface type.
 //
 // Precondition: function arguments must be non-nil.
+//
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.sockMu
 func (c *Client) SndRcvMessage(m MID, payloadLen uint32, reqMarshal marshalFunc, respUnmarshal unmarshalFunc, respFDs []int, reqString debugStringer, respString debugStringer) error {
 	if !c.IsSupported(m) {
 		return unix.EOPNOTSUPP
@@ -396,7 +425,14 @@ func debugf(action string, comm Communicator, debugMsg debugStringer) {
 	}
 }
 
-// Postcondition: releaseCommunicator() must be called on the returned value.
+// acquireCommunicator borrows a channel or locks the main socket. It holds
+// sockMu on return only for a *sockCommunicator; checklocks cannot express
+// a lock effect conditional on the returned interface's dynamic type.
+//
+// Postcondition: c.releaseCommunicator must be called on the returned value.
+//
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.sockMu
 func (c *Client) acquireCommunicator() Communicator {
 	// Prefer using channel over socket because:
 	//	- Channel uses a shared memory region for passing messages. IO from shared
@@ -411,7 +447,12 @@ func (c *Client) acquireCommunicator() Communicator {
 	return c.sockComm
 }
 
-// Precondition: comm must have been acquired via acquireCommunicator().
+// releaseCommunicator ends a use begun by c.acquireCommunicator.
+//
+// Precondition: comm was returned by this c's acquireCommunicator and has
+// not yet been released. For a *sockCommunicator, c.sockMu is still held.
+//
+// +checklocksexclude:c.channelsMu
 func (c *Client) releaseCommunicator(comm Communicator) {
 	switch t := comm.(type) {
 	case *sockCommunicator:
@@ -425,6 +466,8 @@ func (c *Client) releaseCommunicator(comm Communicator) {
 
 // getChannel pops a channel from the available channels stack. The caller must
 // release the channel after use.
+//
+// +checklocksexclude:c.channelsMu
 func (c *Client) getChannel() *channel {
 	c.channelsMu.Lock()
 	defer c.channelsMu.Unlock()
@@ -439,8 +482,10 @@ func (c *Client) getChannel() *channel {
 	return ch
 }
 
-// releaseChannel pushes the passed channel onto the available channel stack if
-// reinsert is true.
+// releaseChannel ends a channel use and makes the channel available again
+// unless the channel is dead or the client is shutting down.
+//
+// +checklocksexclude:c.channelsMu
 func (c *Client) releaseChannel(ch *channel) {
 	c.channelsMu.Lock()
 	defer c.channelsMu.Unlock()

--- a/pkg/lisafs/connection.go
+++ b/pkg/lisafs/connection.go
@@ -69,9 +69,11 @@ type Connection struct {
 	// sockComm is the main socket by which this connections is established.
 	sockComm *sockCommunicator
 
-	// channelsMu protects channels.
 	channelsMu sync.Mutex
+
 	// channels keeps track of all open channels.
+	//
+	// +checklocks:channelsMu
 	channels []*channel
 
 	// activeWg represents active channels.
@@ -84,9 +86,14 @@ type Connection struct {
 	channelAlloc *flipcall.PacketWindowAllocator
 
 	fdsMu sync.RWMutex
-	// fds keeps tracks of open FDs on this server. It is protected by fdsMu.
+
+	// fds tracks this connection's open FDs.
+	//
+	// +checklocks:fdsMu
 	fds map[FDID]genericFD
-	// nextFDID is the next available FDID. It is protected by fdsMu.
+	// nextFDID is the next available FDID.
+	//
+	// +checklocks:fdsMu
 	nextFDID FDID
 }
 
@@ -140,6 +147,10 @@ func (c *Connection) Impl() ConnectionImpl {
 }
 
 // Run defines the lifecycle of a connection.
+//
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) Run() {
 	defer c.close()
 
@@ -193,6 +204,9 @@ func (c *Connection) respondError(comm Communicator, err unix.Errno) (MID, uint3
 	return Error, respLen, nil
 }
 
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) handleMsg(comm Communicator, m MID, payloadLen uint32) (retM MID, retPayloadLen uint32, retFDs []int) {
 	if payloadLen > c.maxMessageSize {
 		log.Warningf("received payload is too large: %d bytes", payloadLen)
@@ -245,6 +259,9 @@ func (c *Connection) handleMsg(comm Communicator, m MID, payloadLen uint32) (ret
 	return m, respPayloadLen, fds
 }
 
+// +checklocksexclude:c.channelsMu
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) close() {
 	// Wait for completion of all inflight requests. This is mostly so that if
 	// a request is stuck, the sandbox supervisor has the opportunity to kill
@@ -282,6 +299,8 @@ func (c *Connection) close() {
 }
 
 // Postcondition: The caller gains a ref on the FD on success.
+//
+// +checklocksexclude:c.fdsMu
 func (c *Connection) lookupFD(id FDID) (genericFD, error) {
 	c.fdsMu.RLock()
 	defer c.fdsMu.RUnlock()
@@ -296,6 +315,9 @@ func (c *Connection) lookupFD(id FDID) (genericFD, error) {
 
 // lookupControlFD retrieves the control FD identified by id on this
 // connection. On success, the caller gains a ref on the FD.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) lookupControlFD(id FDID) (*ControlFD, error) {
 	fd, err := c.lookupFD(id)
 	if err != nil {
@@ -312,6 +334,9 @@ func (c *Connection) lookupControlFD(id FDID) (*ControlFD, error) {
 
 // lookupOpenFD retrieves the open FD identified by id on this
 // connection. On success, the caller gains a ref on the FD.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) lookupOpenFD(id FDID) (*OpenFD, error) {
 	fd, err := c.lookupFD(id)
 	if err != nil {
@@ -328,6 +353,9 @@ func (c *Connection) lookupOpenFD(id FDID) (*OpenFD, error) {
 
 // lookupBoundSocketFD retrieves the boundSockedFD identified by id on this
 // connection. On success, the caller gains a ref on the FD.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) lookupBoundSocketFD(id FDID) (*BoundSocketFD, error) {
 	fd, err := c.lookupFD(id)
 	if err != nil {
@@ -344,6 +372,8 @@ func (c *Connection) lookupBoundSocketFD(id FDID) (*BoundSocketFD, error) {
 
 // insertFD inserts the passed fd into the internal data structure to track FDs.
 // The caller must hold a ref on fd which is transferred to the connection.
+//
+// +checklocksexclude:c.fdsMu
 func (c *Connection) insertFD(fd genericFD) FDID {
 	c.fdsMu.Lock()
 	defer c.fdsMu.Unlock()
@@ -358,6 +388,9 @@ func (c *Connection) insertFD(fd genericFD) FDID {
 }
 
 // removeFD makes c stop tracking the passed FDID and drops its ref on it.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) removeFD(id FDID) {
 	c.fdsMu.Lock()
 	fd := c.stopTrackingFD(id)
@@ -369,11 +402,14 @@ func (c *Connection) removeFD(id FDID) {
 	}
 }
 
-// removeControlFDLocked is the same as removeFD with added preconditions.
+// removeControlFDLocked removes a control FD with the server's rename mutex
+// already held at least for reading, avoiding its reacquisition during
+// destruction.
 //
-// Preconditions:
-//   - server's rename mutex must at least be read locked.
-//   - id must be pointing to a control FD.
+// Precondition: id must point to a control FD.
+//
+// +checklocksread:c.server.renameMu
+// +checklocksexclude:c.fdsMu
 func (c *Connection) removeControlFDLocked(id FDID) {
 	c.fdsMu.Lock()
 	fd := c.stopTrackingFD(id)
@@ -381,14 +417,16 @@ func (c *Connection) removeControlFDLocked(id FDID) {
 	if fd != nil {
 		// Drop the ref held by c. This can take arbitrarily long. So do not hold
 		// c.fdsMu while calling it.
-		fd.(*ControlFD).decRefLocked()
+		// The removed FD belongs to c, whose server.renameMu is held.
+		// checklocks cannot recover its owner through the connection map.
+		fd.(*ControlFD).decRefLocked() // +checklocksignore
 	}
 }
 
 // stopTrackingFD makes c stop tracking the passed FDID. Note that the caller
 // must drop ref on the returned fd (preferably without holding c.fdsMu).
 //
-// Precondition: c.fdsMu is locked.
+// +checklocks:c.fdsMu
 func (c *Connection) stopTrackingFD(id FDID) genericFD {
 	fd := c.fds[id]
 	if fd == nil {

--- a/pkg/lisafs/connection_test.go
+++ b/pkg/lisafs/connection_test.go
@@ -54,7 +54,10 @@ type testConnImpl struct{}
 
 var _ lisafs.ConnectionImpl = (*testConnImpl)(nil)
 
-// Mount implements lisafs.Mount.
+// Mount implements lisafs.ConnectionImpl.Mount.
+//
+// +checklocksread:c.server.renameMu
+// +checklocksexclude:c.fdsMu
 func (s *testConnImpl) Mount(c *lisafs.Connection, mountNode *lisafs.Node) (*lisafs.ControlFD, lisafs.Statx, int, error) {
 	dummyRoot := &testControlFD{}
 	mountNode.IncRef() // Ref is transferred to ControlFD.

--- a/pkg/lisafs/fd.go
+++ b/pkg/lisafs/fd.go
@@ -56,15 +56,20 @@ type genericFD interface {
 //   - Each control FD holds a ref on its Node for its entire lifetime.
 type ControlFD struct {
 	controlFDRefs
+	// These generated links use the associated node.controlFDsMu. Their
+	// generic accessors cannot express the enclosing ControlFD's node owner.
 	controlFDEntry
 
 	// node is the filesystem node this FD is immutably associated with.
 	node *Node
 
+	openFDsMu sync.RWMutex
+
 	// openFDs is a linked list of all FDs opened on this FD. As per reference
 	// model, all open FDs hold a ref on this FD.
-	openFDsMu sync.RWMutex
-	openFDs   openFDList
+	//
+	// +checklocks:openFDsMu
+	openFDs openFDList
 
 	// All the following fields are immutable.
 
@@ -87,6 +92,8 @@ var _ genericFD = (*ControlFD)(nil)
 // DecRef implements refs.RefCounter.DecRef. Note that the context
 // parameter should never be used. It exists solely to comply with the
 // refs.RefCounter interface.
+//
+// +checklocksexclude:fd.conn.server.renameMu
 func (fd *ControlFD) DecRef(context.Context) {
 	fd.controlFDRefs.DecRef(func() {
 		fd.conn.server.renameMu.RLock()
@@ -95,16 +102,21 @@ func (fd *ControlFD) DecRef(context.Context) {
 	})
 }
 
-// decRefLocked is the same as DecRef except the added precondition.
+// decRefLocked drops a reference with the server's rename mutex already held
+// at least for reading, avoiding DecRef's acquisition of that mutex.
 //
-// Precondition: server's rename mutex must be at least read locked.
+// +checklocksread:fd.conn.server.renameMu
 func (fd *ControlFD) decRefLocked() {
 	fd.controlFDRefs.DecRef(func() {
-		fd.destroyLocked()
+		// The destructor runs synchronously with the required rename lock held;
+		// checklocks does not propagate that lock into the callback.
+		fd.destroyLocked() // +checklocksignore
 	})
 }
 
-// Precondition: server's rename mutex must be at least read locked.
+// destroyLocked releases fd's node and implementation under the rename mutex.
+//
+// +checklocksread:fd.conn.server.renameMu
 func (fd *ControlFD) destroyLocked() {
 	// Update node's control FD list.
 	fd.node.removeFD(fd)
@@ -119,9 +131,10 @@ func (fd *ControlFD) destroyLocked() {
 // Init must be called before first use of fd. It inserts fd into the
 // filesystem tree.
 //
-// Preconditions:
-//   - server's rename mutex must be at least read locked.
-//   - The caller must take a ref on node which is transferred to fd.
+// Precondition: The caller must take a ref on node which is transferred to fd.
+//
+// +checklocksread:c.server.renameMu
+// +checklocksexclude:c.fdsMu
 func (fd *ControlFD) Init(c *Connection, node *Node, mode linux.FileMode, impl ControlFDImpl) {
 	fd.conn = c
 	fd.node = node
@@ -171,16 +184,20 @@ func (fd *ControlFD) Node() *Node {
 
 // RemoveFromConn removes this control FD from its owning connection.
 //
-// Preconditions:
-//   - fd should not have been returned to the client. Otherwise the client can
-//     still refer to it.
-//   - server's rename mutex must at least be read locked.
+// Precondition: fd must not have been returned to the client. Otherwise the
+// client can still refer to it.
+//
+// +checklocksread:fd.conn.server.renameMu
+// +checklocksexclude:fd.conn.fdsMu
 func (fd *ControlFD) RemoveFromConn() {
 	fd.conn.removeControlFDLocked(fd.id)
 }
 
 // safelyRead executes the given operation with the local path node locked.
-// This guarantees that fd's path will not change. fn may not any change paths.
+// This guarantees that fd's path will not change. fn must not change paths.
+//
+// +checklocksexclude:fd.conn.server.renameMu
+// +checklocksexclude:fd.node.opMu
 func (fd *ControlFD) safelyRead(fn func() error) error {
 	fd.conn.server.renameMu.RLock()
 	defer fd.conn.server.renameMu.RUnlock()
@@ -192,6 +209,9 @@ func (fd *ControlFD) safelyRead(fn func() error) error {
 // safelyWrite executes the given operation with the local path node locked in
 // a writable fashion. This guarantees that no other operation is executing on
 // this path node. fn may change paths inside fd.node.
+//
+// +checklocksexclude:fd.conn.server.renameMu
+// +checklocksexclude:fd.node.opMu
 func (fd *ControlFD) safelyWrite(fn func() error) error {
 	fd.conn.server.renameMu.RLock()
 	defer fd.conn.server.renameMu.RUnlock()
@@ -203,13 +223,21 @@ func (fd *ControlFD) safelyWrite(fn func() error) error {
 // safelyGlobal executes the given operation with the global path lock held.
 // This guarantees that no other operations is executing concurrently on this
 // server. fn may change any path.
+//
+// +checklocksexclude:fd.conn.server.renameMu
 func (fd *ControlFD) safelyGlobal(fn func() error) (err error) {
 	fd.conn.server.renameMu.Lock()
 	defer fd.conn.server.renameMu.Unlock()
 	return fn()
 }
 
-// forEachOpenFD executes fn on each FD opened on fd.
+// forEachOpenFD executes fn synchronously on each FD opened on fd while holding
+// fd.openFDsMu for reading. No reference is transferred to fn. It must not add
+// or remove open FDs, or drop an open FD's last reference; those operations
+// acquire the same mutex for writing. checklocks does not propagate the held
+// lock through fn.
+//
+// +checklocksexclude:fd.openFDsMu
 func (fd *ControlFD) forEachOpenFD(fn func(ofd *OpenFD)) {
 	fd.openFDsMu.RLock()
 	defer fd.openFDsMu.RUnlock()
@@ -227,6 +255,8 @@ func (fd *ControlFD) forEachOpenFD(fn func(ofd *OpenFD)) {
 //   - An OpenFD takes a reference on the control FD it was opened on.
 type OpenFD struct {
 	openFDRefs
+	// These generated links use controlFD.openFDsMu. Entry accessors have
+	// no back-reference to the enclosing OpenFD to name that owner lock.
 	openFDEntry
 
 	// All the following fields are immutable.
@@ -257,6 +287,9 @@ func (fd *OpenFD) ControlFD() ControlFDImpl {
 // DecRef implements refs.RefCounter.DecRef. Note that the context
 // parameter should never be used. It exists solely to comply with the
 // refs.RefCounter interface.
+//
+// +checklocksexclude:fd.controlFD.openFDsMu
+// +checklocksexclude:fd.controlFD.conn.server.renameMu
 func (fd *OpenFD) DecRef(context.Context) {
 	fd.openFDRefs.DecRef(func() {
 		fd.controlFD.openFDsMu.Lock()
@@ -268,6 +301,9 @@ func (fd *OpenFD) DecRef(context.Context) {
 }
 
 // Init must be called before first use of fd.
+//
+// +checklocksexclude:cfd.conn.fdsMu
+// +checklocksexclude:cfd.openFDsMu
 func (fd *OpenFD) Init(cfd *ControlFD, flags uint32, impl OpenFDImpl) {
 	// Initialize fd with 1 ref which is transferred to c via c.insertFD().
 	fd.openFDRefs.InitRefs()
@@ -314,6 +350,8 @@ func (fd *BoundSocketFD) ControlFD() ControlFDImpl {
 // DecRef implements refs.RefCounter.DecRef. Note that the context
 // parameter should never be used. It exists solely to comply with the
 // refs.RefCounter interface.
+//
+// +checklocksexclude:fd.controlFD.conn.server.renameMu
 func (fd *BoundSocketFD) DecRef(context.Context) {
 	fd.boundSocketFDRefs.DecRef(func() {
 		fd.controlFD.DecRef(nil) // Drop the ref on the control FD.
@@ -322,6 +360,8 @@ func (fd *BoundSocketFD) DecRef(context.Context) {
 }
 
 // Init must be called before first use of fd.
+//
+// +checklocksexclude:cfd.conn.fdsMu
 func (fd *BoundSocketFD) Init(cfd *ControlFD, impl BoundSocketFDImpl) {
 	// Initialize fd with 1 ref which is transferred to c via c.insertFD().
 	fd.boundSocketFDRefs.InitRefs()
@@ -349,6 +389,13 @@ func (fd *BoundSocketFD) Init(cfd *ControlFD, impl BoundSocketFDImpl) {
 //
 // global: The method is guaranteed to be exclusive of any read, write or
 // global operation.
+//
+// Read and write operations run synchronously with the associated ControlFD's
+// server.renameMu held for reading and node.opMu held for reading or writing,
+// respectively. Global operations hold server.renameMu for writing. These
+// guarantees also apply through the associated ControlFD of an OpenFD or
+// BoundSocketFD. checklocks does not transfer concrete method contracts
+// through interface dispatch. Per-method exceptions are described below.
 
 // ControlFDImpl contains implementation details for a ControlFD.
 // Implementations of ControlFDImpl should contain their associated ControlFD

--- a/pkg/lisafs/handlers.go
+++ b/pkg/lisafs/handlers.go
@@ -44,6 +44,10 @@ const (
 //   - Marshalling the response into the communicator's payload buffer.
 //   - Return the number of payload bytes written.
 //   - Donate any FDs (if needed) to comm which will in turn donate it to client.
+//
+// Handlers run without the connection's channelsMu, fdsMu, or server.renameMu
+// held. checklocks does not transfer concrete handler contracts through this
+// function type.
 type RPCHandler func(c *Connection, comm Communicator, payloadLen uint32) (uint32, error)
 
 var handlers = [...]RPCHandler{
@@ -93,6 +97,9 @@ func ErrorHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 // executions of MountHandler on a connection because the connection enforces
 // that Mount is the first message on the connection. Only after the connection
 // has been successfully mounted can other channels be created.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func MountHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var (
 		mountPointFD     *ControlFD
@@ -166,6 +173,8 @@ func MountHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 }
 
 // ChannelHandler handles the Channel RPC.
+//
+// +checklocksexclude:c.channelsMu
 func ChannelHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	ch, desc, fdSock, err := c.createChannel(c.maxMessageSize)
 	if err != nil {
@@ -204,6 +213,9 @@ func ChannelHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32
 }
 
 // FStatHandler handles the FStat RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req StatReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -240,6 +252,9 @@ func FStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 }
 
 // SetStatHandler handles the SetStat RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func SetStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -280,6 +295,9 @@ func SetStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32
 }
 
 // WalkHandler handles the Walk RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func WalkHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req WalkReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -318,7 +336,9 @@ func WalkHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, e
 			var curIno Inode
 			for i := 0; i < int(numInodes); i++ {
 				buf = curIno.UnmarshalBytes(buf)
-				c.removeControlFDLocked(curIno.ControlFD)
+				// Cleanup runs before withRenameReadLock releases the mutex;
+				// checklocks cannot propagate it into these passed callbacks.
+				c.removeControlFDLocked(curIno.ControlFD) // +checklocksignore
 			}
 		})
 		defer cu.Clean()
@@ -371,6 +391,9 @@ func WalkHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, e
 }
 
 // WalkStatHandler handles the WalkStat RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func WalkStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req WalkReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -444,7 +467,9 @@ func WalkStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint3
 		parent := startDir
 		closeParent := func() {
 			if parent != startDir {
-				c.removeControlFDLocked(parent.id)
+				// Both direct and deferred cleanup run inside withRenameReadLock;
+				// checklocks does not retain that callback's lock state.
+				c.removeControlFDLocked(parent.id) // +checklocksignore
 			}
 		}
 		defer closeParent()
@@ -492,6 +517,9 @@ func WalkStatHandler(c *Connection, comm Communicator, payloadLen uint32) (uint3
 }
 
 // OpenAtHandler handles the OpenAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func OpenAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req OpenAtReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -549,6 +577,9 @@ func OpenAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 }
 
 // OpenCreateAtHandler handles the OpenCreateAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func OpenCreateAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -610,6 +641,9 @@ func OpenCreateAtHandler(c *Connection, comm Communicator, payloadLen uint32) (u
 }
 
 // CloseHandler handles the Close RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func CloseHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req CloseReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -624,6 +658,9 @@ func CloseHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 }
 
 // FSyncHandler handles the FSync RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FSyncHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req FsyncReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -643,6 +680,8 @@ func FSyncHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 	return 0, retErr
 }
 
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func (c *Connection) fsyncFD(id FDID) error {
 	fd, err := c.lookupOpenFD(id)
 	if err != nil {
@@ -655,6 +694,9 @@ func (c *Connection) fsyncFD(id FDID) error {
 }
 
 // PWriteHandler handles the PWrite RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func PWriteHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -689,6 +731,9 @@ func PWriteHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 }
 
 // PReadHandler handles the PRead RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func PReadHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req PReadReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -729,6 +774,9 @@ func PReadHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 }
 
 // MkdirAtHandler handles the MkdirAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func MkdirAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -777,6 +825,9 @@ func MkdirAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32
 }
 
 // MknodAtHandler handles the MknodAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func MknodAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -824,6 +875,9 @@ func MknodAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32
 }
 
 // SymlinkAtHandler handles the SymlinkAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func SymlinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -871,6 +925,9 @@ func SymlinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint
 }
 
 // LinkAtHandler handles the LinkAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func LinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -937,6 +994,9 @@ func LinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 }
 
 // FStatFSHandler handles the FStatFS RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FStatFSHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req FStatFSReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -961,6 +1021,9 @@ func FStatFSHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32
 }
 
 // FAllocateHandler handles the FAllocate RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FAllocateHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -988,6 +1051,9 @@ func FAllocateHandler(c *Connection, comm Communicator, payloadLen uint32) (uint
 }
 
 // ReadLinkAtHandler handles the ReadLinkAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func ReadLinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req ReadLinkAtReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1028,6 +1094,9 @@ func ReadLinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uin
 }
 
 // FlushHandler handles the Flush RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FlushHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req FlushReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1046,6 +1115,9 @@ func FlushHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, 
 }
 
 // ConnectHandler handles the Connect RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func ConnectHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req ConnectReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1076,6 +1148,9 @@ func ConnectHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32
 }
 
 // ConnectWithCredsHandler handles the ConnectWithCreds RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func ConnectWithCredsHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req ConnectWithCredsReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1106,6 +1181,9 @@ func ConnectWithCredsHandler(c *Connection, comm Communicator, payloadLen uint32
 }
 
 // BindAtHandler handles the BindAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func BindAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -1160,6 +1238,9 @@ func BindAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 }
 
 // ListenHandler handles the Listen RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func ListenHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req ListenReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1181,6 +1262,9 @@ func ListenHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 }
 
 // AcceptHandler handles the Accept RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func AcceptHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req AcceptReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1214,6 +1298,9 @@ func AcceptHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 }
 
 // UnlinkAtHandler handles the UnlinkAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func UnlinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -1270,6 +1357,9 @@ func UnlinkAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint3
 }
 
 // RenameAt2Handler handles the RenameAt2 RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func RenameAt2Handler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -1282,6 +1372,9 @@ func RenameAt2Handler(c *Connection, comm Communicator, payloadLen uint32) (uint
 }
 
 // RenameAtHandler handles the RenameAt RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func RenameAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -1294,6 +1387,9 @@ func RenameAtHandler(c *Connection, comm Communicator, payloadLen uint32) (uint3
 }
 
 // renameAtCommon is the common implementation for RenameAt and RenameAt2.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func renameAtCommon(c *Connection, comm Communicator, payloadLen uint32, oldDirFD, newDirFD FDID, oldName, newName string, flags uint32) (uint32, error) {
 	if err := checkSafeName(oldName); err != nil {
 		return 0, err
@@ -1401,6 +1497,9 @@ func notifyRenameRecursive(n *Node) {
 }
 
 // Getdents64Handler handles the Getdents64 RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func Getdents64Handler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req Getdents64Req
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1457,6 +1556,9 @@ func Getdents64Handler(c *Connection, comm Communicator, payloadLen uint32) (uin
 }
 
 // FGetXattrHandler handles the FGetXattr RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FGetXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req FGetXattrReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1492,6 +1594,9 @@ func FGetXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (uint
 }
 
 // FSetXattrHandler handles the FSetXattr RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FSetXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS
@@ -1515,6 +1620,9 @@ func FSetXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (uint
 }
 
 // FListXattrHandler handles the FListXattr RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FListXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	var req FListXattrReq
 	if _, ok := req.CheckedUnmarshal(comm.PayloadBuf(payloadLen)); !ok {
@@ -1543,6 +1651,9 @@ func FListXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (uin
 }
 
 // FRemoveXattrHandler handles the FRemoveXattr RPC.
+//
+// +checklocksexclude:c.fdsMu
+// +checklocksexclude:c.server.renameMu
 func FRemoveXattrHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32, error) {
 	if c.opts.Readonly {
 		return 0, unix.EROFS

--- a/pkg/lisafs/server.go
+++ b/pkg/lisafs/server.go
@@ -82,6 +82,8 @@ func (s *Server) SetHandlers(handlers []RPCHandler) {
 
 // withRenameReadLock invokes fn with the server's rename mutex locked for
 // reading. This ensures that no rename operations occur concurrently.
+//
+// +checklocksexclude:s.renameMu
 func (s *Server) withRenameReadLock(fn func() error) error {
 	s.renameMu.RLock()
 	defer s.renameMu.RUnlock()
@@ -98,6 +100,9 @@ func (s *Server) StartConnection(c *Connection) {
 }
 
 // Wait waits for all connections started via StartConnection() to terminate.
+// Connections may acquire renameMu while handling requests or during cleanup.
+//
+// +checklocksexclude:s.renameMu
 func (s *Server) Wait() {
 	s.connWg.Wait()
 }

--- a/pkg/sentry/fsimpl/devpts/devpts.go
+++ b/pkg/sentry/fsimpl/devpts/devpts.go
@@ -237,19 +237,24 @@ type rootInode struct {
 	// master is the master pty inode. Immutable.
 	master *masterInode
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// replicas maps pty ids to replica inodes.
+	//
+	// +checklocks:mu
 	replicas map[uint32]*replicaInode
 
-	// nextIdx is the next pty index to use. Must be accessed atomically.
+	// nextIdx is the next pty index to use.
+	//
+	// +checklocks:mu
 	nextIdx uint32
 }
 
 var _ kernfs.Inode = (*rootInode)(nil)
 
 // allocateTerminal creates a new Terminal and installs a pts node for it.
+//
+// +checklocksexclude:i.mu
 func (i *rootInode) allocateTerminal(ctx context.Context, creds *auth.Credentials) (*Terminal, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -285,6 +290,8 @@ func (i *rootInode) allocateTerminal(ctx context.Context, creds *auth.Credential
 }
 
 // masterClose is called when the master end of t is closed.
+//
+// +checklocksexclude:i.mu
 func (i *rootInode) masterClose(ctx context.Context, t *Terminal) {
 	// When the master is closed, hang up the slave (replica) side.
 	// This corresponds to Linux's pty_close() calling tty_vhangup(tty->link).
@@ -318,6 +325,8 @@ func (i *rootInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernfs.D
 }
 
 // Lookup implements kernfs.Inode.Lookup.
+//
+// +checklocksexclude:i.mu
 func (i *rootInode) Lookup(ctx context.Context, name string) (kernfs.Inode, error) {
 	// Check if a static entry was looked up.
 	if d, err := i.OrderedChildren.Lookup(ctx, name); err == nil {
@@ -340,6 +349,11 @@ func (i *rootInode) Lookup(ctx context.Context, name string) (kernfs.Inode, erro
 }
 
 // IterDirents implements kernfs.Inode.IterDirents.
+//
+// cb runs with i.mu held and must not call methods that acquire the same mutex.
+// checklocks cannot convey this receiver's lock through the callback interface.
+//
+// +checklocksexclude:i.mu
 func (i *rootInode) IterDirents(ctx context.Context, mnt *vfs.Mount, cb vfs.IterDirentsCallback, offset, relOffset int64) (int64, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()

--- a/pkg/sentry/fsimpl/devpts/devpts_test.go
+++ b/pkg/sentry/fsimpl/devpts/devpts_test.go
@@ -64,7 +64,10 @@ func TestEchoDeadlock(t *testing.T) {
 	outBytes := make([]byte, 32)
 	dst := usermem.BytesIOSequence(outBytes)
 	entry := waiter.NewFunctionEntry(waiter.ReadableEvents, func(waiter.EventMask) {
-		ld.inputQueueRead(ctx, dst)
+		// Read synchronously without notifying this waiter queue again.
+		ld.termiosMu.RLock()
+		defer ld.termiosMu.RUnlock()
+		_, _, _, _ = ld.inQueue.read(ctx, dst, ld, false /* packet */)
 	})
 	ld.masterWaiter.EventRegister(&entry)
 	defer ld.masterWaiter.EventUnregister(&entry)

--- a/pkg/sentry/fsimpl/devpts/line_discipline.go
+++ b/pkg/sentry/fsimpl/devpts/line_discipline.go
@@ -85,10 +85,11 @@ const (
 //
 // +stateify savable
 type lineDiscipline struct {
-	// sizeMu protects size.
 	sizeMu sync.Mutex `state:"nosave"`
 
 	// size is the terminal size (width and height).
+	//
+	// +checklocks:sizeMu
 	size linux.Winsize
 
 	// inQueue is the input queue of the terminal.
@@ -101,13 +102,19 @@ type lineDiscipline struct {
 	termiosMu sync.RWMutex `state:"nosave"`
 
 	// termios is the terminal configuration used by the lineDiscipline.
+	//
+	// +checklocks:termiosMu
 	termios linux.KernelTermios
 
 	// column is the location in a row of the cursor. This is important for
 	// handling certain special characters like backspace.
+	//
+	// +checklocks:outQueue.mu
 	column int
 
 	// numReplicas is the number of replica file descriptors.
+	//
+	// +checklocks:termiosMu
 	numReplicas int
 
 	// masterWaiter is used to wait on the master end of the TTY.
@@ -120,6 +127,8 @@ type lineDiscipline struct {
 	terminal *Terminal
 
 	// packet indicates the master is in packet mode.
+	//
+	// +checklocks:termiosMu
 	packet bool
 
 	// packetStatus contains pending TIOCPKT_* status bits for the next master
@@ -127,6 +136,8 @@ type lineDiscipline struct {
 	//
 	// Currently only TIOCPKT_FLUSHREAD and TIOCPKT_FLUSHWRITE are emitted
 	// through packetStatus.
+	//
+	// +checklocks:termiosMu
 	packetStatus uint8
 }
 
@@ -148,6 +159,8 @@ const (
 )
 
 // getTermios gets the linux.Termios for the tty.
+//
+// +checklocksexclude:l.termiosMu
 func (l *lineDiscipline) getTermios(task *kernel.Task, args arch.SyscallArguments) (uintptr, error) {
 	l.termiosMu.RLock()
 	defer l.termiosMu.RUnlock()
@@ -158,6 +171,8 @@ func (l *lineDiscipline) getTermios(task *kernel.Task, args arch.SyscallArgument
 }
 
 // getTermios2 gets the linux.KernelTermios for the tty.
+//
+// +checklocksexclude:l.termiosMu
 func (l *lineDiscipline) getTermios2(task *kernel.Task, args arch.SyscallArguments) (uintptr, error) {
 	l.termiosMu.RLock()
 	defer l.termiosMu.RUnlock()
@@ -166,6 +181,11 @@ func (l *lineDiscipline) getTermios2(task *kernel.Task, args arch.SyscallArgumen
 }
 
 // setTermios2 sets a linux.KernelTermios for the tty.
+//
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.inQueue.mu
+// +checklocksexclude:l.outQueue.mu
+// +checklocksexclude:l.replicaWaiter.mu
 func (l *lineDiscipline) setTermios2(task *kernel.Task, args arch.SyscallArguments) (uintptr, error) {
 	var t linux.KernelTermios
 	if _, err := t.CopyIn(task, args[2].Pointer()); err != nil {
@@ -194,6 +214,11 @@ func (l *lineDiscipline) setTermios2(task *kernel.Task, args arch.SyscallArgumen
 }
 
 // setTermios sets a linux.Termios for the tty.
+//
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.inQueue.mu
+// +checklocksexclude:l.outQueue.mu
+// +checklocksexclude:l.replicaWaiter.mu
 func (l *lineDiscipline) setTermios(task *kernel.Task, args arch.SyscallArguments) (uintptr, error) {
 	// We must copy a Termios struct, not KernelTermios.
 	var t linux.Termios
@@ -222,6 +247,7 @@ func (l *lineDiscipline) setTermios(task *kernel.Task, args arch.SyscallArgument
 	return 0, nil
 }
 
+// +checklocksexclude:l.sizeMu
 func (l *lineDiscipline) windowSize(t *kernel.Task, args arch.SyscallArguments) error {
 	l.sizeMu.Lock()
 	defer l.sizeMu.Unlock()
@@ -229,6 +255,7 @@ func (l *lineDiscipline) windowSize(t *kernel.Task, args arch.SyscallArguments) 
 	return err
 }
 
+// +checklocksexclude:l.sizeMu
 func (l *lineDiscipline) setWindowSize(t *kernel.Task, args arch.SyscallArguments) error {
 	l.sizeMu.Lock()
 	defer l.sizeMu.Unlock()
@@ -243,6 +270,9 @@ func (l *lineDiscipline) setWindowSize(t *kernel.Task, args arch.SyscallArgument
 	return nil
 }
 
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.inQueue.mu
+// +checklocksexclude:l.outQueue.mu
 func (l *lineDiscipline) masterReadiness() waiter.EventMask {
 	// The master termios is immutable so termiosMu is not needed.
 	res := l.inQueue.writeReadiness(&linux.MasterTermios) | l.outQueue.readReadiness(&linux.MasterTermios)
@@ -257,16 +287,25 @@ func (l *lineDiscipline) masterReadiness() waiter.EventMask {
 	return res
 }
 
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.inQueue.mu
+// +checklocksexclude:l.outQueue.mu
 func (l *lineDiscipline) replicaReadiness() waiter.EventMask {
 	l.termiosMu.RLock()
 	defer l.termiosMu.RUnlock()
 	return l.outQueue.writeReadiness(&l.termios) | l.inQueue.readReadiness(&l.termios)
 }
 
+// +checklocksexclude:l.inQueue.mu
 func (l *lineDiscipline) inputQueueReadSize(t *kernel.Task, io usermem.IO, args arch.SyscallArguments) error {
 	return l.inQueue.readableSize(t, io, args)
 }
 
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.inQueue.mu
+// +checklocksexclude:l.outQueue.mu
+// +checklocksexclude:l.masterWaiter.mu
+// +checklocksexclude:l.replicaWaiter.mu
 func (l *lineDiscipline) inputQueueRead(ctx context.Context, dst usermem.IOSequence) (int64, error) {
 	l.termiosMu.RLock()
 	// Replica never reads in packet mode.
@@ -297,6 +336,11 @@ func (l *lineDiscipline) inputQueueRead(ctx context.Context, dst usermem.IOSeque
 	return 0, linuxerr.ErrWouldBlock
 }
 
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.inQueue.mu
+// +checklocksexclude:l.outQueue.mu
+// +checklocksexclude:l.masterWaiter.mu
+// +checklocksexclude:l.replicaWaiter.mu
 func (l *lineDiscipline) inputQueueWrite(ctx context.Context, src usermem.IOSequence) (int64, error) {
 	l.termiosMu.RLock()
 	n, notifyEcho, err := l.inQueue.write(ctx, src, l)
@@ -314,10 +358,15 @@ func (l *lineDiscipline) inputQueueWrite(ctx context.Context, src usermem.IOSequ
 	return 0, linuxerr.ErrWouldBlock
 }
 
+// +checklocksexclude:l.outQueue.mu
 func (l *lineDiscipline) outputQueueReadSize(t *kernel.Task, io usermem.IO, args arch.SyscallArguments) error {
 	return l.outQueue.readableSize(t, io, args)
 }
 
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.outQueue.mu
+// +checklocksexclude:l.masterWaiter.mu
+// +checklocksexclude:l.replicaWaiter.mu
 func (l *lineDiscipline) outputQueueRead(ctx context.Context, dst usermem.IOSequence) (int64, error) {
 	if dst.NumBytes() == 0 {
 		return 0, nil
@@ -343,6 +392,9 @@ func (l *lineDiscipline) outputQueueRead(ctx context.Context, dst usermem.IOSequ
 	return 0, linuxerr.ErrWouldBlock
 }
 
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.outQueue.mu
+// +checklocksexclude:l.masterWaiter.mu
 func (l *lineDiscipline) outputQueueWrite(ctx context.Context, src usermem.IOSequence) (int64, error) {
 	l.termiosMu.RLock()
 	// Ignore notifyEcho, as it cannot happen when writing to the output queue.
@@ -356,6 +408,8 @@ func (l *lineDiscipline) outputQueueWrite(ctx context.Context, src usermem.IOSeq
 }
 
 // replicaOpen is called when a replica file descriptor is opened.
+//
+// +checklocksexclude:l.termiosMu
 func (l *lineDiscipline) replicaOpen() {
 	l.termiosMu.Lock()
 	defer l.termiosMu.Unlock()
@@ -363,6 +417,9 @@ func (l *lineDiscipline) replicaOpen() {
 }
 
 // replicaClose is called when a replica file descriptor is closed.
+//
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.masterWaiter.mu
 func (l *lineDiscipline) replicaClose() {
 	l.termiosMu.Lock()
 	l.numReplicas--
@@ -375,8 +432,12 @@ func (l *lineDiscipline) replicaClose() {
 
 // transformer is a helper interface to make it easier to stateify queue.
 type transformer interface {
-	// transform functions require queue's mutex to be held.
-	// The boolean indicates whether there was any echoed bytes.
+	// transform requires the line discipline's termiosMu to be held for reading
+	// and the queue's mu to be held. checklocks does not propagate these lock
+	// contracts through this interface.
+	//
+	// The boolean indicates whether to notify master readers of possible echo
+	// output.
 	transform(*lineDiscipline, *queue, []byte) (int, bool)
 }
 
@@ -389,9 +450,12 @@ type outputQueueTransformer struct{}
 // transform does output processing for one end of the pty. See
 // drivers/tty/n_tty.c:do_output_char for an analogous kernel function.
 //
-// Preconditions:
-//   - l.termiosMu must be held for reading.
-//   - q.mu must be held.
+// q must be &l.outQueue. checklocks does not infer that identity from the
+// queue's transformer, so both mutex paths are annotated below.
+//
+// +checklocksread:l.termiosMu
+// +checklocks:q.mu
+// +checklocks:l.outQueue.mu
 func (*outputQueueTransformer) transform(l *lineDiscipline, q *queue, buf []byte) (int, bool) {
 	// transformOutput is effectively always in noncanonical mode, as the
 	// master termios never has ICANON set.
@@ -486,12 +550,15 @@ type inputQueueTransformer struct{}
 // transformed according to flags set in the termios struct. See
 // drivers/tty/n_tty.c:n_tty_receive_char_special for an analogous kernel
 // function.
-// It returns an extra boolean indicating whether any characters need to be
-// echoed, in which case we need to notify readers.
 //
-// Preconditions:
-//   - l.termiosMu must be held for reading.
-//   - q.mu must be held.
+// It returns an extra boolean indicating whether to notify master readers of
+// possible echo output.
+//
+// q must be &l.inQueue; echo processing acquires l.outQueue.mu separately.
+//
+// +checklocksread:l.termiosMu
+// +checklocks:q.mu
+// +checklocksexclude:l.outQueue.mu
 func (*inputQueueTransformer) transform(l *lineDiscipline, q *queue, buf []byte) (int, bool) {
 	// If there's a line waiting to be read in canonical mode, don't write
 	// anything else to the read buffer.
@@ -685,15 +752,16 @@ func (*inputQueueTransformer) transform(l *lineDiscipline, q *queue, buf []byte)
 // too many bytes are enqueued, we keep reading input and discarding it until
 // we find a terminating character. Signal/echo processing still occurs.
 //
-// Precondition:
-//   - l.termiosMu must be held for reading.
-//   - q.mu must be held.
+// +checklocksread:l.termiosMu
+// +checklocks:q.mu
 func (l *lineDiscipline) shouldDiscard(q *queue, cBytes []byte) bool {
 	return l.termios.LEnabled(linux.ICANON) && len(q.readBuf)+len(cBytes) >= canonMaxBytes && !l.termios.IsTerminating(cBytes)
 }
 
 // peek returns the size in bytes of the next character to process. As long as
 // b isn't empty, peek returns a value of at least 1.
+//
+// +checklocksread:l.termiosMu
 func (l *lineDiscipline) peek(b []byte) int {
 	size := 1
 	// If UTF-8 support is enabled, runes might be multiple bytes.
@@ -703,6 +771,7 @@ func (l *lineDiscipline) peek(b []byte) int {
 	return size
 }
 
+// +checklocksexclude:l.termiosMu
 func (l *lineDiscipline) setPacketMode(mode int) {
 	l.termiosMu.Lock()
 	defer l.termiosMu.Unlock()
@@ -716,6 +785,7 @@ func (l *lineDiscipline) setPacketMode(mode int) {
 	l.packet = true
 }
 
+// +checklocksexclude:l.termiosMu
 func (l *lineDiscipline) getPacketMode() int {
 	l.termiosMu.RLock()
 	defer l.termiosMu.RUnlock()
@@ -725,6 +795,7 @@ func (l *lineDiscipline) getPacketMode() int {
 	return 0
 }
 
+// +checklocksexclude:l.termiosMu
 func (l *lineDiscipline) consumePacketStatus() (byte, bool) {
 	l.termiosMu.Lock()
 	defer l.termiosMu.Unlock()
@@ -752,6 +823,8 @@ func (l *lineDiscipline) packetStatusForFlush(endpoint ptyEndpoint, arg uint32) 
 	}
 }
 
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.masterWaiter.mu
 func (l *lineDiscipline) notifyPacketStatus(status uint8) {
 	if status == 0 {
 		return
@@ -780,6 +853,8 @@ func (l *lineDiscipline) outputQueueForEndpoint(endpoint ptyEndpoint) *queue {
 	return &l.outQueue
 }
 
+// +checklocksexclude:l.masterWaiter.mu
+// +checklocksexclude:l.replicaWaiter.mu
 func (l *lineDiscipline) notifyWritableForFlushedQueue(q *queue) {
 	switch q {
 	case &l.inQueue:
@@ -792,6 +867,12 @@ func (l *lineDiscipline) notifyWritableForFlushedQueue(q *queue) {
 // tcFlush handles the TCFLSH ioctl from the perspective of the calling PTY
 // endpoint. Linux interprets TCIFLUSH/TCOFLUSH relative to the fd that issued
 // the ioctl, not relative to the internal queue names.
+//
+// +checklocksexclude:l.termiosMu
+// +checklocksexclude:l.inQueue.mu
+// +checklocksexclude:l.outQueue.mu
+// +checklocksexclude:l.masterWaiter.mu
+// +checklocksexclude:l.replicaWaiter.mu
 func (l *lineDiscipline) tcFlush(endpoint ptyEndpoint, arg uint32) error {
 	inputQueue := l.inputQueueForEndpoint(endpoint)
 	outputQueue := l.outputQueueForEndpoint(endpoint)

--- a/pkg/sentry/fsimpl/devpts/queue.go
+++ b/pkg/sentry/fsimpl/devpts/queue.go
@@ -40,31 +40,43 @@ const waitBufMaxBytes = 131072
 //
 // +stateify savable
 type queue struct {
-	// mu protects everything in queue.
 	mu sync.Mutex `state:"nosave"`
 
 	// readBuf is buffer of data ready to be read when readable is true.
 	// This data has been processed.
+	//
+	// +checklocks:mu
 	readBuf []byte
 
 	// waitBuf contains data that can't fit into readBuf. It is put here
 	// until it can be loaded into the read buffer. waitBuf contains data
 	// that hasn't been processed.
-	waitBuf    [][]byte
+	//
+	// +checklocks:mu
+	waitBuf [][]byte
+
+	// waitBufLen is the number of bytes in waitBuf.
+	//
+	// +checklocks:mu
 	waitBufLen uint64
 
 	// readable indicates whether the read buffer can be read from.  In
 	// canonical mode, there can be an unterminated line in the read buffer,
 	// so readable must be checked.
+	//
+	// +checklocks:mu
 	readable bool
 
-	// transform is the queue's function for transforming bytes
-	// entering the queue. For example, transform might convert all '\r's
-	// entering the queue to '\n's.
+	// transformer processes bytes entering the queue. For example, its
+	// transform method might convert '\r' to '\n'.
+	//
+	// It is immutable after initialization.
 	transformer
 }
 
 // readReadiness returns whether q is ready to be read from.
+//
+// +checklocksexclude:q.mu
 func (q *queue) readReadiness(t *linux.KernelTermios) waiter.EventMask {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -75,6 +87,8 @@ func (q *queue) readReadiness(t *linux.KernelTermios) waiter.EventMask {
 }
 
 // writeReadiness returns whether q is ready to be written to.
+//
+// +checklocksexclude:q.mu
 func (q *queue) writeReadiness(t *linux.KernelTermios) waiter.EventMask {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -85,6 +99,8 @@ func (q *queue) writeReadiness(t *linux.KernelTermios) waiter.EventMask {
 }
 
 // readableSize writes the number of readable bytes to userspace.
+//
+// +checklocksexclude:q.mu
 func (q *queue) readableSize(t *kernel.Task, io usermem.IO, args arch.SyscallArguments) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -100,11 +116,12 @@ func (q *queue) readableSize(t *kernel.Task, io usermem.IO, args arch.SyscallArg
 
 // read reads from q to userspace. It returns:
 //   - The number of bytes read
-//   - Whether the read caused more readable data to become available (whether
-//     data was pushed from the wait buffer to the read buffer).
-//   - Whether any data was echoed back (need to notify readers).
+//   - Whether any bytes were processed from the wait buffer.
+//   - Whether to notify master readers of possible echo output.
 //
-// Preconditions: l.termiosMu must be held for reading.
+// +checklocksread:l.termiosMu
+// +checklocksexclude:q.mu
+// +checklocksexclude:l.outQueue.mu
 func (q *queue) read(ctx context.Context, dst usermem.IOSequence, l *lineDiscipline, packet bool) (int64, bool, bool, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -133,16 +150,18 @@ func (q *queue) read(ctx context.Context, dst usermem.IOSequence, l *lineDiscipl
 	}
 
 	n, err := dst.CopyOutFrom(ctx, safemem.ReaderFunc(func(dst safemem.BlockSeq) (uint64, error) {
-		src := safemem.BlockSeqOf(safemem.BlockFromSafeSlice(q.readBuf))
+		// CopyOutFrom invokes this callback synchronously with q.mu held.
+		// checklocks does not propagate that lock state into a passed callback.
+		src := safemem.BlockSeqOf(safemem.BlockFromSafeSlice(q.readBuf)) // +checklocksignore
 		n, err := safemem.CopySeq(dst, src)
 		if err != nil {
 			return 0, err
 		}
-		q.readBuf = q.readBuf[n:]
+		q.readBuf = q.readBuf[n:] // +checklocksignore
 
 		// If we read everything, this queue is no longer readable.
-		if len(q.readBuf) == 0 {
-			q.readable = false
+		if len(q.readBuf) == 0 { // +checklocksignore
+			q.readable = false // +checklocksignore
 		}
 
 		return n, nil
@@ -158,17 +177,23 @@ func (q *queue) read(ctx context.Context, dst usermem.IOSequence, l *lineDiscipl
 }
 
 // write writes to q from userspace.
-// The returned boolean indicates whether any data was echoed back.
 //
-// Preconditions: l.termiosMu must be held for reading.
+// The returned boolean indicates whether to notify master readers of possible
+// echo output.
+//
+// +checklocksread:l.termiosMu
+// +checklocksexclude:q.mu
+// +checklocksexclude:l.outQueue.mu
 func (q *queue) write(ctx context.Context, src usermem.IOSequence, l *lineDiscipline) (int64, bool, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
 	// Copy data into the wait buffer.
 	n, err := src.CopyInTo(ctx, safemem.WriterFunc(func(src safemem.BlockSeq) (uint64, error) {
+		// CopyInTo invokes this callback synchronously with q.mu held.
+		// checklocks does not propagate that lock state into a passed callback.
 		copyLen := src.NumBytes()
-		room := waitBufMaxBytes - q.waitBufLen
+		room := waitBufMaxBytes - q.waitBufLen // +checklocksignore
 		// If out of room, return EAGAIN.
 		if room == 0 && copyLen > 0 {
 			return 0, linuxerr.ErrWouldBlock
@@ -186,7 +211,7 @@ func (q *queue) write(ctx context.Context, src usermem.IOSequence, l *lineDiscip
 		if err != nil {
 			return 0, err
 		}
-		q.waitBufAppend(buf)
+		q.waitBufAppend(buf) // +checklocksignore
 
 		return n, nil
 	}))
@@ -201,9 +226,13 @@ func (q *queue) write(ctx context.Context, src usermem.IOSequence, l *lineDiscip
 }
 
 // writeBytes writes to q from b.
-// The returned boolean indicates whether any data was echoed back.
 //
-// Preconditions: l.termiosMu must be held for reading.
+// The returned boolean indicates whether to notify master readers of possible
+// echo output.
+//
+// +checklocksread:l.termiosMu
+// +checklocksexclude:q.mu
+// +checklocksexclude:l.outQueue.mu
 func (q *queue) writeBytes(b []byte, l *lineDiscipline) bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -216,11 +245,16 @@ func (q *queue) writeBytes(b []byte, l *lineDiscipline) bool {
 
 // pushWaitBufLocked fills the queue's read buffer with data from the wait
 // buffer.
-// The returned boolean indicates whether any data was echoed back.
 //
-// Preconditions:
-//   - l.termiosMu must be held for reading.
-//   - q.mu must be locked.
+// The returned boolean indicates whether to notify master readers of possible
+// echo output.
+//
+// q must be one of l's queues. Input processing requires l.outQueue.mu to be
+// unlocked for echo; output processing already holds that mutex as q.mu.
+// checklocks cannot express the exclusion conditional on which queue q is.
+//
+// +checklocksread:l.termiosMu
+// +checklocks:q.mu
 func (q *queue) pushWaitBufLocked(l *lineDiscipline) (int, bool) {
 	if q.waitBufLen == 0 {
 		return 0, false
@@ -249,7 +283,9 @@ func (q *queue) pushWaitBufLocked(l *lineDiscipline) (int, bool) {
 	return total, notifyEcho
 }
 
-// Precondition: q.mu must be locked.
+// waitBufAppend appends unprocessed data to the wait buffer.
+//
+// +checklocks:q.mu
 func (q *queue) waitBufAppend(b []byte) {
 	q.waitBuf = append(q.waitBuf, b)
 	q.waitBufLen += uint64(len(b))
@@ -258,6 +294,8 @@ func (q *queue) waitBufAppend(b []byte) {
 // flush discards all pending data in both the read buffer and the wait
 // buffer. This implements the TCFLSH ioctl behavior for clearing a
 // queue's data, analogous to __tty_perform_flush in Linux.
+//
+// +checklocksexclude:q.mu
 func (q *queue) flush() {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/pkg/sentry/fsimpl/eventfd/eventfd.go
+++ b/pkg/sentry/fsimpl/eventfd/eventfd.go
@@ -48,22 +48,32 @@ type EventFileDescription struct {
 	// becomes readable or writable.
 	queue waiter.Queue
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// val is the current value of the event counter.
+	//
+	// +checklocks:mu
 	val uint64
 
-	// semMode specifies whether the event is in "semaphore" mode.
+	// semMode specifies whether the event is in "semaphore" mode and is
+	// immutable after construction.
 	semMode bool
 
-	// hostfd indicates whether this eventfd is passed through to the host.
+	// hostfd is the backing host eventfd, or -1 if none is installed.
+	//
+	// +checklocks:mu
 	hostfd int
 
-	// sentryOwnedHostfd indicates whether the sentry owns the hostfd.
+	// sentryOwnedHostfd indicates that HostFD created hostfd rather than
+	// NewFromHost importing it. Only sentry-created host FDs support
+	// save/restore.
+	//
+	// +checklocks:mu
 	sentryOwnedHostfd bool
 
-	// hostfdState is the state of the hostfd during save/restore.
+	// hostfdState contains the counter bytes captured by beforeSave and
+	// consumed by afterLoad while ordinary Sentry execution is excluded.
+	// checklocks cannot express this checkpoint-owned lifecycle phase.
 	hostfdState [8]byte
 }
 
@@ -101,14 +111,21 @@ func NewFromHost(ctx context.Context, vfsObj *vfs.VirtualFilesystem, hostfd int,
 		return nil, err
 	}
 	efd := fd.Impl().(*EventFileDescription)
-	efd.hostfd = hostfd
+	// New returned an unshared file. checklocks cannot recover that private
+	// ownership through the returned FileDescription and its Impl accessor.
+	efd.hostfd = hostfd // +checklocksignore
 	if err := fdnotifier.AddFD(int32(hostfd), &efd.queue); err != nil {
 		return nil, err
 	}
 	return fd, nil
 }
 
-// HostFD returns the host eventfd associated with this event.
+// HostFD returns the host eventfd associated with this event. The descriptor
+// is borrowed, not duplicated; callers must retain a reference to the
+// associated vfs.FileDescription while using it.
+//
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) HostFD() (int, error) {
 	efd.mu.Lock()
 	defer efd.mu.Unlock()
@@ -139,6 +156,8 @@ func (efd *EventFileDescription) HostFD() (int, error) {
 }
 
 // Release implements vfs.FileDescriptionImpl.Release.
+//
+// +checklocksexclude:efd.mu
 func (efd *EventFileDescription) Release(context.Context) {
 	efd.mu.Lock()
 	defer efd.mu.Unlock()
@@ -153,6 +172,9 @@ func (efd *EventFileDescription) Release(context.Context) {
 }
 
 // Read implements vfs.FileDescriptionImpl.Read.
+//
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) Read(ctx context.Context, dst usermem.IOSequence, _ vfs.ReadOptions) (int64, error) {
 	if dst.NumBytes() < 8 {
 		return 0, unix.EINVAL
@@ -164,6 +186,9 @@ func (efd *EventFileDescription) Read(ctx context.Context, dst usermem.IOSequenc
 }
 
 // Write implements vfs.FileDescriptionImpl.Write.
+//
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) Write(ctx context.Context, src usermem.IOSequence, _ vfs.WriteOptions) (int64, error) {
 	if src.NumBytes() != 8 {
 		return 0, unix.EINVAL
@@ -174,7 +199,7 @@ func (efd *EventFileDescription) Write(ctx context.Context, src usermem.IOSequen
 	return 8, nil
 }
 
-// Preconditions: Must be called with efd.mu locked.
+// +checklocks:efd.mu
 func (efd *EventFileDescription) hostReadLocked(ctx context.Context, dst usermem.IOSequence) error {
 	var buf [8]byte
 	if _, err := unix.Read(efd.hostfd, buf[:]); err != nil {
@@ -187,6 +212,8 @@ func (efd *EventFileDescription) hostReadLocked(ctx context.Context, dst usermem
 	return err
 }
 
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) read(ctx context.Context, dst usermem.IOSequence) error {
 	efd.mu.Lock()
 	if efd.hostfd >= 0 {
@@ -224,7 +251,7 @@ func (efd *EventFileDescription) read(ctx context.Context, dst usermem.IOSequenc
 	return err
 }
 
-// Preconditions: Must be called with efd.mu locked.
+// +checklocks:efd.mu
 func (efd *EventFileDescription) hostWriteLocked(val uint64) error {
 	var buf [8]byte
 	hostarch.ByteOrder.PutUint64(buf[:], val)
@@ -235,6 +262,8 @@ func (efd *EventFileDescription) hostWriteLocked(val uint64) error {
 	return err
 }
 
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) write(ctx context.Context, src usermem.IOSequence) error {
 	var buf [8]byte
 	if _, err := src.CopyIn(ctx, buf[:]); err != nil {
@@ -246,6 +275,9 @@ func (efd *EventFileDescription) write(ctx context.Context, src usermem.IOSequen
 }
 
 // Signal is an internal function to signal the event fd.
+//
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) Signal(val uint64) error {
 	if val == math.MaxUint64 {
 		return unix.EINVAL
@@ -275,6 +307,8 @@ func (efd *EventFileDescription) Signal(val uint64) error {
 }
 
 // Readiness implements waiter.Waitable.Readiness.
+//
+// +checklocksexclude:efd.mu
 func (efd *EventFileDescription) Readiness(mask waiter.EventMask) waiter.EventMask {
 	efd.mu.Lock()
 	defer efd.mu.Unlock()
@@ -296,6 +330,9 @@ func (efd *EventFileDescription) Readiness(mask waiter.EventMask) waiter.EventMa
 }
 
 // EventRegister implements waiter.Waitable.EventRegister.
+//
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) EventRegister(entry *waiter.Entry) error {
 	efd.queue.EventRegister(entry)
 
@@ -311,6 +348,9 @@ func (efd *EventFileDescription) EventRegister(entry *waiter.Entry) error {
 }
 
 // EventUnregister implements waiter.Waitable.EventUnregister.
+//
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) EventUnregister(entry *waiter.Entry) {
 	efd.queue.EventUnregister(entry)
 

--- a/pkg/sentry/fsimpl/eventfd/save_restore.go
+++ b/pkg/sentry/fsimpl/eventfd/save_restore.go
@@ -21,6 +21,11 @@ import (
 	"gvisor.dev/gvisor/pkg/log"
 )
 
+// beforeSave runs during paused Sentry serialization with fdnotifier paused.
+// The generated StateSave caller exempts this call: serialization supplies
+// quiescence instead of an actual held mutex.
+//
+// +checklocks:efd.mu
 func (efd *EventFileDescription) beforeSave() {
 	if efd.hostfd < 0 {
 		return
@@ -36,16 +41,22 @@ func (efd *EventFileDescription) beforeSave() {
 	copy(efd.hostfdState[:], buf[:])
 }
 
+// afterLoad runs before the restored graph is used, while fdnotifier remains
+// paused. checklocks does not model this framework-owned initialization phase.
+//
+// +checklocksexclude:efd.mu
+// +checklocksexclude:efd.queue.mu
 func (efd *EventFileDescription) afterLoad(ctx context.Context) {
-	if efd.hostfd < 0 {
+	if efd.hostfd < 0 { // +checklocksignore
 		return
 	}
-	efd.hostfd = -1
-	if _, err := efd.HostFD(); err != nil {
+	efd.hostfd = -1 // +checklocksignore
+	hostfd, err := efd.HostFD()
+	if err != nil {
 		log.Warningf("Failed to create host fd for eventfd: %v", err)
 		return
 	}
-	if _, err := unix.Write(efd.hostfd, efd.hostfdState[:]); err != nil {
+	if _, err := unix.Write(hostfd, efd.hostfdState[:]); err != nil {
 		log.Warningf("Failed to write host fd for eventfd: %v", err)
 	}
 }

--- a/pkg/sentry/fsimpl/host/host.go
+++ b/pkg/sentry/fsimpl/host/host.go
@@ -166,33 +166,43 @@ type inode struct {
 	queue waiter.Queue
 
 	// virtualOwner caches ownership and permission information to override the
-	// underlying file owner and permission. This is used to allow the unstrusted
+	// underlying file owner and permission. This is used to allow the untrusted
 	// application to change these fields without affecting the host.
 	virtualOwner virtualOwner
 
-	// maps holds application memory mappings of the inode. maps is protected
-	// by mapsMu.
-	mapsMu   sync.Mutex `state:"nosave"`
+	mapsMu sync.Mutex `state:"nosave"`
+
+	// mappings holds application memory mappings of the inode.
+	//
+	// +checklocks:mapsMu
 	mappings memmap.MappingSet
 
 	// mmapFile implements memmap.File for hostFD.
 	mmapFile fsutil.MmapCachedFile
 
+	bufMu sync.Mutex `state:"nosave"`
+
 	// If haveBuf is non-zero, hostFD represents a pipe, and buf contains data
-	// read from the pipe from previous calls to inode.beforeSave(). haveBuf
-	// and buf are protected by bufMu.
-	bufMu   sync.Mutex `state:"nosave"`
+	// read from the pipe from previous calls to inode.beforeSave().
+	//
+	// +checklocks:bufMu
+	// +checkatomic
 	haveBuf atomicbitops.Uint32
-	buf     []byte
+
+	// +checklocks:bufMu
+	buf []byte
 
 	// If the inode corresponds to a TTY, tty is the kernel.TTY.
 	//
 	// This pointer is initialized at creation time and is immutable.
 	tty *kernel.TTY
-	// If the inode corresponds to a TTY, termios is the cached termios
-	// struct. It is protected by termiosMu.
+
 	termiosMu sync.Mutex `state:"nosave"`
-	termios   linux.KernelTermios
+
+	// If the inode corresponds to a TTY, termios is the cached termios struct.
+	//
+	// +checklocks:termiosMu
+	termios linux.KernelTermios
 }
 
 func newInode(ctx context.Context, fs *filesystem, hostFD int, savable bool, restoreKey checkpoint.ResourceID, fileType linux.FileMode, isTTY bool, readonly bool) (*inode, error) {
@@ -666,6 +676,8 @@ func (i *inode) SetStat(ctx context.Context, fs *vfs.Filesystem, creds *auth.Cre
 }
 
 // DecRef implements kernfs.Inode.DecRef.
+//
+// +checklocksexclude:i.queue.mu
 func (i *inode) DecRef(ctx context.Context) {
 	i.inodeRefs.DecRef(func() {
 		if i.hostFD >= 0 {
@@ -789,11 +801,12 @@ type fileDescription struct {
 	// inode is immutable after fileDescription creation.
 	inode *inode
 
-	// offsetMu protects offset.
 	offsetMu sync.Mutex `state:"nosave"`
 
 	// offset specifies the current file offset. It is only meaningful when
 	// inode.seekable is true.
+	//
+	// +checklocks:offsetMu
 	offset int64
 }
 
@@ -849,6 +862,9 @@ func (f *fileDescription) PRead(ctx context.Context, dst usermem.IOSequence, off
 }
 
 // Read implements vfs.FileDescriptionImpl.Read.
+//
+// +checklocksexclude:f.offsetMu
+// +checklocksexclude:f.inode.bufMu
 func (f *fileDescription) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	// Check that flags are supported.
 	//
@@ -884,6 +900,7 @@ func (f *fileDescription) Read(ctx context.Context, dst usermem.IOSequence, opts
 	return n, err
 }
 
+// +checklocksexclude:i.bufMu
 func (i *inode) readFromBuf(ctx context.Context, dst *usermem.IOSequence) (int64, error) {
 	if i.haveBuf.Load() == 0 {
 		return 0, nil
@@ -920,6 +937,8 @@ func (f *fileDescription) PWrite(ctx context.Context, src usermem.IOSequence, of
 }
 
 // Write implements vfs.FileDescriptionImpl.Write.
+//
+// +checklocksexclude:f.offsetMu
 func (f *fileDescription) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
 	i := f.inode
 	if !i.seekable {
@@ -980,6 +999,8 @@ func (f *fileDescription) writeToHostFD(ctx context.Context, src usermem.IOSeque
 //
 // Note that we do not support seeking on directories, since we do not even
 // allow directory fds to be imported at all.
+//
+// +checklocksexclude:f.offsetMu
 func (f *fileDescription) Seek(_ context.Context, offset int64, whence int32) (int64, error) {
 	i := f.inode
 	if !i.seekable {
@@ -1063,6 +1084,8 @@ func (f *fileDescription) ConfigureMMap(_ context.Context, opts *memmap.MMapOpts
 }
 
 // AddMapping implements memmap.Mappable.AddMapping.
+//
+// +checklocksexclude:i.mapsMu
 func (i *inode) AddMapping(ctx context.Context, ms memmap.MappingSpace, ar hostarch.AddrRange, offset uint64, writable bool) error {
 	i.mmapFile.AddMapping(ar, offset)
 	i.mapsMu.Lock()
@@ -1072,6 +1095,8 @@ func (i *inode) AddMapping(ctx context.Context, ms memmap.MappingSpace, ar hosta
 }
 
 // RemoveMapping implements memmap.Mappable.RemoveMapping.
+//
+// +checklocksexclude:i.mapsMu
 func (i *inode) RemoveMapping(ctx context.Context, ms memmap.MappingSpace, ar hostarch.AddrRange, offset uint64, writable bool) {
 	i.mmapFile.RemoveMapping(ar, offset)
 	i.mapsMu.Lock()
@@ -1080,6 +1105,8 @@ func (i *inode) RemoveMapping(ctx context.Context, ms memmap.MappingSpace, ar ho
 }
 
 // CopyMapping implements memmap.Mappable.CopyMapping.
+//
+// +checklocksexclude:i.mapsMu
 func (i *inode) CopyMapping(ctx context.Context, ms memmap.MappingSpace, srcAR, dstAR hostarch.AddrRange, offset uint64, writable bool) error {
 	return i.AddMapping(ctx, ms, dstAR, offset, writable)
 }
@@ -1105,6 +1132,8 @@ func (i *inode) InvalidateUnsavable(ctx context.Context) error {
 }
 
 // EventRegister implements waiter.Waitable.EventRegister.
+//
+// +checklocksexclude:f.inode.queue.mu
 func (f *fileDescription) EventRegister(e *waiter.Entry) error {
 	f.inode.queue.EventRegister(e)
 	if f.inode.epollable {
@@ -1117,6 +1146,8 @@ func (f *fileDescription) EventRegister(e *waiter.Entry) error {
 }
 
 // EventUnregister implements waiter.Waitable.EventUnregister.
+//
+// +checklocksexclude:f.inode.queue.mu
 func (f *fileDescription) EventUnregister(e *waiter.Entry) {
 	f.inode.queue.EventUnregister(e)
 	if f.inode.epollable {

--- a/pkg/sentry/fsimpl/host/save_restore.go
+++ b/pkg/sentry/fsimpl/host/save_restore.go
@@ -42,6 +42,8 @@ func MakeResourceID(containerName string, fd int) checkpoint.ResourceID {
 }
 
 // beforeSave is invoked by stateify.
+//
+// +checklocksexclude:i.bufMu
 func (i *inode) beforeSave() {
 	if !i.savable {
 		panic("host.inode is not savable")

--- a/pkg/sentry/fsimpl/host/tty.go
+++ b/pkg/sentry/fsimpl/host/tty.go
@@ -40,6 +40,8 @@ type TTYFileDescription struct {
 // Release implements vfs.FileDescriptionImpl.Release.
 //
 // It drops the inode reference taken in inode.OpenTTY.
+//
+// +checklocksexclude:t.inode.queue.mu
 func (t *TTYFileDescription) Release(ctx context.Context) {
 	t.inode.DecRef(ctx)
 }
@@ -73,6 +75,9 @@ func (t *TTYFileDescription) PRead(ctx context.Context, dst usermem.IOSequence, 
 //
 // Reading from a TTY is only allowed for foreground process groups. Background
 // process groups will either get EIO or a SIGTTIN.
+//
+// +checklocksexclude:t.fileDescription.offsetMu
+// +checklocksexclude:t.inode.bufMu
 func (t *TTYFileDescription) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	// Are we allowed to do the read?
 	// drivers/tty/n_tty.c:n_tty_read()=>job_control()=>tty_check_change().
@@ -85,6 +90,8 @@ func (t *TTYFileDescription) Read(ctx context.Context, dst usermem.IOSequence, o
 }
 
 // PWrite implements vfs.FileDescriptionImpl.PWrite.
+//
+// +checklocksexclude:t.inode.termiosMu
 func (t *TTYFileDescription) PWrite(ctx context.Context, src usermem.IOSequence, offset int64, opts vfs.WriteOptions) (int64, error) {
 	t.inode.termiosMu.Lock()
 	defer t.inode.termiosMu.Unlock()
@@ -99,6 +106,9 @@ func (t *TTYFileDescription) PWrite(ctx context.Context, src usermem.IOSequence,
 }
 
 // Write implements vfs.FileDescriptionImpl.Write.
+//
+// +checklocksexclude:t.inode.termiosMu
+// +checklocksexclude:t.fileDescription.offsetMu
 func (t *TTYFileDescription) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
 	t.inode.termiosMu.Lock()
 	defer t.inode.termiosMu.Unlock()
@@ -113,6 +123,8 @@ func (t *TTYFileDescription) Write(ctx context.Context, src usermem.IOSequence, 
 }
 
 // Ioctl implements vfs.FileDescriptionImpl.Ioctl.
+//
+// +checklocksexclude:t.inode.termiosMu
 func (t *TTYFileDescription) Ioctl(ctx context.Context, io usermem.IO, sysno uintptr, args arch.SyscallArguments) (uintptr, error) {
 	task := kernel.TaskFromContext(ctx)
 	if task == nil {

--- a/pkg/sentry/fsimpl/kernfs/fd_impl_util.go
+++ b/pkg/sentry/fsimpl/kernfs/fd_impl_util.go
@@ -51,10 +51,9 @@ type GenericDirectoryFDOptions struct {
 // GenericDirectoryFD implements vfs.FileDescriptionImpl for a generic directory
 // inode that uses OrderChildren to track child nodes.
 //
-// Note that GenericDirectoryFD holds a lock over OrderedChildren while calling
-// IterDirents callback. The IterDirents callback therefore cannot hash or
-// unhash children, or recursively call IterDirents on the same underlying
-// inode.
+// IterDirents holds mu throughout iteration and children.mu while visiting
+// children. Its callback must not reacquire either mutex, including through
+// Seek, IterDirents, or operations on the same OrderedChildren.
 //
 // Must be initialize with Init before first use.
 //
@@ -72,10 +71,11 @@ type GenericDirectoryFD struct {
 	vfsfd    vfs.FileDescription
 	children *OrderedChildren
 
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
-	// off is the current directory offset. Protected by "mu".
+	// off is the current directory offset.
+	//
+	// +checklocks:mu
 	off int64
 }
 
@@ -152,8 +152,13 @@ func (fd *GenericDirectoryFD) inode() Inode {
 	return fd.dentry().inode
 }
 
-// IterDirents implements vfs.FileDescriptionImpl.IterDirents. IterDirents holds
-// o.mu when calling cb.
+// IterDirents implements vfs.FileDescriptionImpl.IterDirents. Callbacks run
+// with fd.mu held, and with fd.children.mu held for reading during the child
+// walk. They must not seek or iterate this FD, or mutate or iterate its children.
+// checklocks does not propagate these lock states through cb.Handle.
+//
+// +checklocksexclude:fd.mu
+// +checklocksexclude:fd.children.mu
 func (fd *GenericDirectoryFD) IterDirents(ctx context.Context, cb vfs.IterDirentsCallback) error {
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
@@ -226,6 +231,9 @@ func (fd *GenericDirectoryFD) IterDirents(ctx context.Context, cb vfs.IterDirent
 }
 
 // Seek implements vfs.FileDescriptionImpl.Seek.
+//
+// +checklocksexclude:fd.mu
+// +checklocksexclude:fd.children.mu
 func (fd *GenericDirectoryFD) Seek(ctx context.Context, offset int64, whence int32) (int64, error) {
 	fd.mu.Lock()
 	defer fd.mu.Unlock()

--- a/pkg/sentry/fsimpl/proc/subtasks.go
+++ b/pkg/sentry/fsimpl/proc/subtasks.go
@@ -124,6 +124,8 @@ type subtasksFD struct {
 	task *kernel.Task
 }
 
+// +checklocksexclude:fd.GenericDirectoryFD.mu
+// +checklocksexclude:fd.GenericDirectoryFD.children.mu
 func (fd *subtasksFD) IterDirents(ctx context.Context, cb vfs.IterDirentsCallback) error {
 	if fd.task.ExitState() >= kernel.TaskExitZombie {
 		return linuxerr.ENOENT
@@ -132,6 +134,9 @@ func (fd *subtasksFD) IterDirents(ctx context.Context, cb vfs.IterDirentsCallbac
 }
 
 // Seek implements vfs.FileDescriptionImpl.Seek.
+//
+// +checklocksexclude:fd.GenericDirectoryFD.mu
+// +checklocksexclude:fd.GenericDirectoryFD.children.mu
 func (fd *subtasksFD) Seek(ctx context.Context, offset int64, whence int32) (int64, error) {
 	if fd.task.ExitState() >= kernel.TaskExitZombie {
 		return 0, linuxerr.ENOENT

--- a/pkg/sentry/fsimpl/proc/task.go
+++ b/pkg/sentry/fsimpl/proc/task.go
@@ -48,6 +48,8 @@ type taskInode struct {
 
 	dentriesMu dentriesRWMutex `state:"nosave"`
 	// dentries is a list of dentries to be invalidated when the task is destroyed.
+	//
+	// +checklocks:dentriesMu
 	dentries map[*kernfs.Dentry]struct{}
 }
 
@@ -127,9 +129,12 @@ func (fs *filesystem) newTaskInode(ctx context.Context, task *kernel.Task, pidns
 	return inode, nil
 }
 
+// +checklocksexclude:i.dentriesMu
 func (i *taskInode) TaskDestroyAction(ctx context.Context) {
 	i.dentriesMu.Lock()
 	dentries := i.dentries
+	// Detach the map before invalidation callbacks run. RegisterDentry cannot
+	// repopulate a nil map, so this loop exclusively owns the old entries.
 	i.dentries = nil
 	i.dentriesMu.Unlock()
 
@@ -139,6 +144,8 @@ func (i *taskInode) TaskDestroyAction(ctx context.Context) {
 }
 
 // RegisterDentry implements kernfs.Inode.RegisterDentry.
+//
+// +checklocksexclude:i.dentriesMu
 func (i *taskInode) RegisterDentry(d *kernfs.Dentry) {
 	i.dentriesMu.Lock()
 	defer i.dentriesMu.Unlock()
@@ -155,6 +162,8 @@ func (i *taskInode) RegisterDentry(d *kernfs.Dentry) {
 }
 
 // UnregisterDentry implements kernfs.Inode.RegisterDentry.
+//
+// +checklocksexclude:i.dentriesMu
 func (i *taskInode) UnregisterDentry(d *kernfs.Dentry) {
 	i.dentriesMu.Lock()
 	defer i.dentriesMu.Unlock()
@@ -193,6 +202,7 @@ func (i *taskInode) DecRef(ctx context.Context) {
 	i.taskInodeRefs.DecRef(func() { i.Destroy(ctx) })
 }
 
+// +checklocksexclude:i.dentriesMu
 func (i *taskInode) Lookup(ctx context.Context, name string) (kernfs.Inode, error) {
 	i.dentriesMu.RLock()
 	if i.dentries == nil {

--- a/pkg/sentry/fsimpl/proc/task_files.go
+++ b/pkg/sentry/fsimpl/proc/task_files.go
@@ -544,8 +544,9 @@ type memFD struct {
 
 	inode *memInode
 	mm    *mm.MemoryManager
-	// mu guards the fields below.
-	mu     sync.Mutex `state:"nosave"`
+	mu    sync.Mutex `state:"nosave"`
+
+	// +checklocks:mu
 	offset int64
 }
 
@@ -560,6 +561,8 @@ func (fd *memFD) Init(m *vfs.Mount, d *kernfs.Dentry, inode *memInode, flags uin
 }
 
 // Seek implements vfs.FileDescriptionImpl.Seek.
+//
+// +checklocksexclude:fd.mu
 func (fd *memFD) Seek(ctx context.Context, offset int64, whence int32) (int64, error) {
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
@@ -630,6 +633,8 @@ func (fd *memFD) PRead(ctx context.Context, dst usermem.IOSequence, offset int64
 }
 
 // Write implements vfs.FileDescriptionImpl.Write.
+//
+// +checklocksexclude:fd.mu
 func (fd *memFD) Write(ctx context.Context, dst usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
 	fd.mu.Lock()
 	n, err := fd.PWrite(ctx, dst, fd.offset, opts)
@@ -639,6 +644,8 @@ func (fd *memFD) Write(ctx context.Context, dst usermem.IOSequence, opts vfs.Wri
 }
 
 // Read implements vfs.FileDescriptionImpl.Read.
+//
+// +checklocksexclude:fd.mu
 func (fd *memFD) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	fd.mu.Lock()
 	n, err := fd.PRead(ctx, dst, fd.offset, opts)

--- a/pkg/sentry/vfs/memxattr/xattr.go
+++ b/pkg/sentry/vfs/memxattr/xattr.go
@@ -35,12 +35,15 @@ import (
 //
 // +stateify savable
 type SimpleExtendedAttributes struct {
-	// mu protects the below fields.
-	mu     sync.RWMutex `state:"nosave"`
+	mu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:mu
 	xattrs map[string]string
 }
 
 // GetXattr returns the value at 'name'.
+//
+// +checklocksexclude:x.mu
 func (x *SimpleExtendedAttributes) GetXattr(creds *auth.Credentials, mode linux.FileMode, kuid auth.KUID, opts *vfs.GetXattrOptions) (string, error) {
 	if err := vfs.CheckXattrPermissions(creds, vfs.MayRead, mode, kuid, opts.Name); err != nil {
 		return "", err
@@ -64,6 +67,8 @@ func (x *SimpleExtendedAttributes) GetXattr(creds *auth.Credentials, mode linux.
 }
 
 // SetXattr sets 'value' at 'name'.
+//
+// +checklocksexclude:x.mu
 func (x *SimpleExtendedAttributes) SetXattr(creds *auth.Credentials, mode linux.FileMode, kuid auth.KUID, kgid auth.KGID, opts *vfs.SetXattrOptions) error {
 	if err := vfs.CheckXattrPermissions(creds, vfs.MayWrite, mode, kuid, opts.Name); err != nil {
 		return err
@@ -98,6 +103,8 @@ func (x *SimpleExtendedAttributes) SetXattr(creds *auth.Credentials, mode linux.
 }
 
 // ListXattr returns all names in xattrs.
+//
+// +checklocksexclude:x.mu
 func (x *SimpleExtendedAttributes) ListXattr(creds *auth.Credentials, size uint64) ([]string, error) {
 	// Keep track of the size of the buffer needed in listxattr(2) for the list.
 	listSize := 0
@@ -125,6 +132,8 @@ func (x *SimpleExtendedAttributes) ListXattr(creds *auth.Credentials, size uint6
 // KillPriv removes the "security.capability" xattr if present. No permission
 // check is needed because the caller is removing privileges on behalf of the
 // kernel, not userspace.
+//
+// +checklocksexclude:x.mu
 func (x *SimpleExtendedAttributes) KillPriv() {
 	x.mu.Lock()
 	delete(x.xattrs, linux.XATTR_SECURITY_CAPABILITY)
@@ -132,6 +141,8 @@ func (x *SimpleExtendedAttributes) KillPriv() {
 }
 
 // RemoveXattr removes the xattr at 'name'.
+//
+// +checklocksexclude:x.mu
 func (x *SimpleExtendedAttributes) RemoveXattr(creds *auth.Credentials, mode linux.FileMode, kuid auth.KUID, name string) error {
 	if err := vfs.CheckXattrPermissions(creds, vfs.MayWrite, mode, kuid, name); err != nil {
 		return err
@@ -148,6 +159,8 @@ func (x *SimpleExtendedAttributes) RemoveXattr(creds *auth.Credentials, mode lin
 
 // RawXattrs returns a copy of the underlying xattr map for serialization.
 // No permission checks are performed.
+//
+// +checklocksexclude:x.mu
 func (x *SimpleExtendedAttributes) RawXattrs() map[string]string {
 	x.mu.RLock()
 	defer x.mu.RUnlock()
@@ -156,6 +169,11 @@ func (x *SimpleExtendedAttributes) RawXattrs() map[string]string {
 
 // SetRawXattrs sets the underlying xattr map from deserialized data.
 // No permission checks are performed.
+//
+// SetRawXattrs takes ownership of xattrs; the caller must not access the map
+// afterward. checklocks cannot track ownership through retained map aliases.
+//
+// +checklocksexclude:x.mu
 func (x *SimpleExtendedAttributes) SetRawXattrs(xattrs map[string]string) {
 	x.mu.Lock()
 	defer x.mu.Unlock()

--- a/pkg/waiter/waiter.go
+++ b/pkg/waiter/waiter.go
@@ -142,7 +142,10 @@ type Entry struct {
 	// eventListener receives the notification.
 	eventListener EventListener
 
-	// mask should be immutable once queued.
+	// mask is initialized before registration. While queued, SetQueuedMask
+	// updates it under the owning queue's mu. Calls to Mask or NotifyEvent
+	// must not race with mask updates. The queue is not stored in Entry, so
+	// its lock cannot be named by a field annotation.
 	mask EventMask
 }
 
@@ -157,6 +160,8 @@ func (e *Entry) Init(eventListener EventListener, mask EventMask) {
 // SetQueuedMask changes the entry mask.
 //
 // Preconditions: The Entry must be registered to the given Queue.
+//
+// +checklocksexclude:q.mu
 func (e *Entry) SetQueuedMask(q *Queue, mask EventMask) {
 	q.mu.Lock()
 	e.mask = mask
@@ -225,11 +230,14 @@ func (NoopListener) NotifyEvent(mask EventMask) {}
 //
 // +stateify savable
 type Queue struct {
+	// +checklocks:mu
 	list waiterList
 	mu   sync.RWMutex `state:"nosave"`
 }
 
 // EventRegister adds a waiter to the wait queue.
+//
+// +checklocksexclude:q.mu
 func (q *Queue) EventRegister(e *Entry) {
 	q.mu.Lock()
 	q.list.PushBack(e)
@@ -237,6 +245,8 @@ func (q *Queue) EventRegister(e *Entry) {
 }
 
 // EventUnregister removes the given waiter entry from the wait queue.
+//
+// +checklocksexclude:q.mu
 func (q *Queue) EventUnregister(e *Entry) {
 	q.mu.Lock()
 	q.list.Remove(e)
@@ -245,6 +255,11 @@ func (q *Queue) EventUnregister(e *Entry) {
 
 // Notify notifies all waiters in the queue whose masks have at least one bit
 // in common with the notification mask.
+//
+// Callbacks run with q.mu read-locked and must not call methods that acquire
+// the same mutex. checklocks cannot convey that owner through EventListener.
+//
+// +checklocksexclude:q.mu
 func (q *Queue) Notify(mask EventMask) {
 	q.mu.RLock()
 	for e := q.list.Front(); e != nil; e = e.Next() {
@@ -259,6 +274,8 @@ func (q *Queue) Notify(mask EventMask) {
 
 // Events returns the set of events being waited on. It is the union of the
 // masks of all registered entries.
+//
+// +checklocksexclude:q.mu
 func (q *Queue) Events() EventMask {
 	q.mu.RLock()
 	defer q.mu.RUnlock()
@@ -270,6 +287,8 @@ func (q *Queue) Events() EventMask {
 }
 
 // IsEmpty returns if the wait queue is empty or not.
+//
+// +checklocksexclude:q.mu
 func (q *Queue) IsEmpty() bool {
 	q.mu.RLock()
 	defer q.mu.RUnlock()

--- a/runsc/fsgofer/lisafs.go
+++ b/runsc/fsgofer/lisafs.go
@@ -116,6 +116,9 @@ type connectionImpl struct {
 var _ lisafs.ConnectionImpl = (*connectionImpl)(nil)
 
 // Mount implements lisafs.ConnectionImpl.Mount.
+//
+// +checklocksread:c.server.renameMu
+// +checklocksexclude:c.fdsMu
 func (i *connectionImpl) Mount(c *lisafs.Connection, mountNode *lisafs.Node) (*lisafs.ControlFD, lisafs.Statx, int, error) {
 	mountPath := mountNode.FilePath()
 	rootHostFD, err := tryOpen(func(flags int) (int, error) {
@@ -221,6 +224,10 @@ type controlFDLisa struct {
 
 var _ lisafs.ControlFDImpl = (*controlFDLisa)(nil)
 
+// newControlFDLisa creates a child FD while its server excludes renames.
+//
+// +checklocksread:parent.ControlFD.conn.server.renameMu
+// +checklocksexclude:parent.ControlFD.conn.fdsMu
 func newControlFDLisa(hostFD int, parent *controlFDLisa, name string, mode linux.FileMode) *controlFDLisa {
 	var (
 		childFD    *controlFDLisa
@@ -249,7 +256,9 @@ func newControlFDLisa(hostFD int, parent *controlFDLisa, name string, mode linux
 	})
 	childFD.hostFD = hostFD
 	childFD.writableHostFD = atomicbitops.FromInt32(-1)
-	childFD.ControlFD.Init(parent.Conn(), childNode, mode, childFD)
+	// Conn returns parent.ControlFD.conn, whose server rename lock is required
+	// on entry. checklocks does not retain that identity across the accessor.
+	childFD.ControlFD.Init(parent.Conn(), childNode, mode, childFD) // +checklocksignore
 	return childFD
 }
 
@@ -270,6 +279,9 @@ func (fd *controlFDLisa) getWritableFD() (int, error) {
 	return writableFD, nil
 }
 
+// getParentFD opens the parent directory while the server excludes renames.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
 func (fd *controlFDLisa) getParentFD() (int, string, error) {
 	filePath := fd.Node().FilePath()
 	if filePath == "/" {
@@ -312,6 +324,8 @@ func (fd *controlFDLisa) Stat() (lisafs.Statx, error) {
 }
 
 // SetStat implements lisafs.ControlFDImpl.SetStat.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
 func (fd *controlFDLisa) SetStat(stat lisafs.SetStatReq) (failureMask uint32, failureErr error) {
 	if stat.Mask&unix.STATX_MODE != 0 {
 		switch fd.FileType() {
@@ -426,6 +440,9 @@ func (fd *controlFDLisa) SetStat(stat lisafs.SetStatReq) (failureMask uint32, fa
 }
 
 // Walk implements lisafs.ControlFDImpl.Walk.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
 func (fd *controlFDLisa) Walk(name string) (*lisafs.ControlFD, lisafs.Statx, error) {
 	childHostFD, err := tryOpen(func(flags int) (int, error) {
 		return unix.Openat(fd.hostFD, name, flags, 0)
@@ -520,6 +537,9 @@ var (
 )
 
 // Open implements lisafs.ControlFDImpl.Open.
+//
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
+// +checklocksexclude:fd.ControlFD.openFDsMu
 func (fd *controlFDLisa) Open(flags uint32) (*lisafs.OpenFD, int, error) {
 	ftype := fd.FileType()
 	impl := fd.Conn().Impl().(*connectionImpl)
@@ -580,6 +600,9 @@ func (fd *controlFDLisa) Open(flags uint32) (*lisafs.OpenFD, int, error) {
 }
 
 // OpenCreate implements lisafs.ControlFDImpl.OpenCreate.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
 func (fd *controlFDLisa) OpenCreate(mode linux.FileMode, uid lisafs.UID, gid lisafs.GID, name string, flags uint32) (*lisafs.ControlFD, lisafs.Statx, *lisafs.OpenFD, int, error) {
 	createFlags := unix.O_CREAT | unix.O_EXCL | unix.O_RDONLY | unix.O_NONBLOCK | openFlags
 	childHostFD, err := unix.Openat(fd.hostFD, name, createFlags, uint32(mode&^linux.FileTypeMask))
@@ -631,6 +654,9 @@ func (fd *controlFDLisa) OpenCreate(mode linux.FileMode, uid lisafs.UID, gid lis
 }
 
 // Mkdir implements lisafs.ControlFDImpl.Mkdir.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
 func (fd *controlFDLisa) Mkdir(mode linux.FileMode, uid lisafs.UID, gid lisafs.GID, name string) (*lisafs.ControlFD, lisafs.Statx, error) {
 	if err := unix.Mkdirat(fd.hostFD, name, uint32(mode&^linux.FileTypeMask)); err != nil {
 		return nil, lisafs.Statx{}, err
@@ -667,6 +693,9 @@ func (fd *controlFDLisa) Mkdir(mode linux.FileMode, uid lisafs.UID, gid lisafs.G
 }
 
 // Mknod implements lisafs.ControlFDImpl.Mknod.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
 func (fd *controlFDLisa) Mknod(mode linux.FileMode, uid lisafs.UID, gid lisafs.GID, name string, minor uint32, major uint32) (*lisafs.ControlFD, lisafs.Statx, error) {
 	// Only allow creating regular files or overlayfs whiteouts. Linux's
 	// vfs_mknod() exempts whiteouts from the CAP_MKNOD check, so we do not need
@@ -720,6 +749,9 @@ func (fd *controlFDLisa) Mknod(mode linux.FileMode, uid lisafs.UID, gid lisafs.G
 }
 
 // Symlink implements lisafs.ControlFDImpl.Symlink.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
 func (fd *controlFDLisa) Symlink(name string, target string, uid lisafs.UID, gid lisafs.GID) (*lisafs.ControlFD, lisafs.Statx, error) {
 	if err := unix.Symlinkat(target, fd.hostFD, name); err != nil {
 		return nil, lisafs.Statx{}, err
@@ -752,6 +784,9 @@ func (fd *controlFDLisa) Symlink(name string, target string, uid lisafs.UID, gid
 }
 
 // Link implements lisafs.ControlFDImpl.Link.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
 func (fd *controlFDLisa) Link(dir lisafs.ControlFDImpl, name string) (*lisafs.ControlFD, lisafs.Statx, error) {
 	// Using linkat(targetFD, "", newdirfd, name, AT_EMPTY_PATH) requires
 	// CAP_DAC_READ_SEARCH in the *root* userns. The gofer process has
@@ -786,7 +821,10 @@ func (fd *controlFDLisa) Link(dir lisafs.ControlFDImpl, name string) (*lisafs.Co
 		return nil, lisafs.Statx{}, err
 	}
 	cu.Release()
-	return newControlFDLisa(linkFD, dirFD, name, linux.FileMode(linkStat.Mode)).FD(), linkStat, nil
+	// LinkAtHandler obtains source and destination from the same connection.
+	// Its rename lock is held; checklocks loses the destination owner through
+	// the ControlFDImpl interface and this type assertion.
+	return newControlFDLisa(linkFD, dirFD, name, linux.FileMode(linkStat.Mode)).FD(), linkStat, nil // +checklocksignore
 }
 
 // StatFS implements lisafs.ControlFDImpl.StatFS.
@@ -931,6 +969,9 @@ func (fd *controlFDLisa) ConnectWithCreds(sockType uint32, uid lisafs.UID, gid l
 }
 
 // BindAt implements lisafs.ControlFDImpl.BindAt.
+//
+// +checklocksread:fd.ControlFD.conn.server.renameMu
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
 func (fd *controlFDLisa) BindAt(name string, sockType uint32, mode linux.FileMode, uid lisafs.UID, gid lisafs.GID) (*lisafs.ControlFD, lisafs.Statx, *lisafs.BoundSocketFD, int, error) {
 	if !fd.Conn().Impl().(*connectionImpl).config.HostUDS.AllowCreate() {
 		logRejectedUdsCreateOnce.Do(func() {
@@ -1130,6 +1171,8 @@ type openFDLisa struct {
 
 var _ lisafs.OpenFDImpl = (*openFDLisa)(nil)
 
+// +checklocksexclude:fd.ControlFD.conn.fdsMu
+// +checklocksexclude:fd.ControlFD.openFDsMu
 func (fd *controlFDLisa) newOpenFDLisa(hostFD int, flags uint32) *openFDLisa {
 	newFD := &openFDLisa{
 		hostFD: hostFD,


### PR DESCRIPTION
Add lock contracts for LisaFS, notification queues, PTYs and file descriptions. Use HostFD's returned descriptor during eventfd restore instead of rereading its guarded field.

Read the PTY echo test's input queue under termiosMu without recursively notifying its waiter queue.

Part of #14349.

Assisted-by: Codex