### PR TITLE
checklocks: annotate network state ownership

### DIFF
--- a/pkg/sentry/socket/hostinet/save_restore.go
+++ b/pkg/sentry/socket/hostinet/save_restore.go
@@ -48,8 +48,12 @@ type listenerState struct {
 	bindToDevice string
 }
 
+// The restore helpers acquire this mutex themselves. checklocks cannot export
+// that exclusion through Stack.Restore's private package-global guard.
 var restoredListeners struct {
-	mu      sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	sockets []*Socket
 }
 
@@ -90,6 +94,8 @@ func (s *Socket) beforeSave() {
 }
 
 // afterLoad is invoked by stateify.
+//
+// +checklocksexclude:restoredListeners.mu
 func (s *Socket) afterLoad(context.Context) {
 	s.fd = -1
 	if s.savedListener != nil {
@@ -100,6 +106,8 @@ func (s *Socket) afterLoad(context.Context) {
 }
 
 // restoreListeners re-creates the host sockets for saved listening sockets.
+//
+// +checklocksexclude:restoredListeners.mu
 func restoreListeners() {
 	restoredListeners.mu.Lock()
 	sockets := restoredListeners.sockets

--- a/pkg/sentry/socket/hostinet/socket.go
+++ b/pkg/sentry/socket/hostinet/socket.go
@@ -129,9 +129,14 @@ type Socket struct {
 	// masks, as when e.g. applications repeatedly call poll() with the same
 	// event mask, or blocking accept() / read() / write() / recvmsg() /
 	// sendmsg() / etc., on the same socket.
-	persistentEventMu   sync.Mutex `state:"nosave"`
+	persistentEventMu sync.Mutex `state:"nosave"`
+
+	// +checklocks:persistentEventMu
+	// +checkatomic
 	persistentEventMask atomicbitops.Uint64
-	persistentEntry     waiter.Entry
+
+	// +checklocks:persistentEventMu
+	persistentEntry waiter.Entry
 
 	// fd is the host socket fd. It must have O_NONBLOCK, so that operations
 	// will return EWOULDBLOCK instead of blocking on the host. This allows us to
@@ -140,9 +145,13 @@ type Socket struct {
 
 	// recvClosed indicates that the socket has been shutdown for reading
 	// (SHUT_RD or SHUT_RDWR).
+	//
+	// +checkatomic
 	recvClosed atomicbitops.Bool
 
 	// listenBacklog is the backlog passed to the most recent listen(2).
+	//
+	// +checkatomic
 	listenBacklog atomicbitops.Int32
 
 	// savedListener is set by beforeSave if this socket is listening.
@@ -337,6 +346,8 @@ func (s *Socket) Readiness(mask waiter.EventMask) waiter.EventMask {
 }
 
 // EventRegister implements waiter.Waitable.EventRegister.
+//
+// +checklocksexclude:s.persistentEventMu
 func (s *Socket) EventRegister(e *waiter.Entry) error {
 	if s.fd < 0 {
 		s.queue.EventRegister(e)
@@ -460,6 +471,8 @@ func (s *Socket) Connect(t *kernel.Task, sockaddr []byte, blocking bool) *syserr
 }
 
 // Accept implements socket.Socket.Accept.
+//
+// +checklocksexclude:s.persistentEventMu
 func (s *Socket) Accept(t *kernel.Task, peerRequested bool, flags int, blocking bool) (int32, linux.SockAddr, uint32, *syserr.Error) {
 	if s.fd < 0 {
 		return 0, nil, 0, syserr.ErrConnectionAborted
@@ -606,6 +619,8 @@ const allowedRecvMsgFlags = unix.MSG_CTRUNC |
 	unix.MSG_WAITALL
 
 // RecvMsg implements socket.Socket.RecvMsg.
+//
+// +checklocksexclude:s.persistentEventMu
 func (s *Socket) RecvMsg(t *kernel.Task, dst usermem.IOSequence, flags int, haveDeadline bool, deadline ktime.Time, senderRequested bool, controlLen uint64) (int, int, linux.SockAddr, uint32, socket.ControlMessages, *syserr.Error) {
 	// Only allow known and safe flags.
 	if flags&^allowedRecvMsgFlags != 0 {
@@ -789,6 +804,8 @@ const allowedSendMsgFlags = unix.MSG_DONTWAIT |
 	unix.MSG_OOB
 
 // SendMsg implements socket.Socket.SendMsg.
+//
+// +checklocksexclude:s.persistentEventMu
 func (s *Socket) SendMsg(t *kernel.Task, src usermem.IOSequence, to []byte, flags int, haveDeadline bool, deadline ktime.Time, controlMessages socket.ControlMessages) (int, *syserr.Error) {
 	if s.family == linux.AF_PACKET {
 		// Don't allow SendMesg for AF_PACKET.

--- a/pkg/sentry/socket/netlink/port/port.go
+++ b/pkg/sentry/socket/netlink/port/port.go
@@ -36,10 +36,11 @@ const maxPorts = 10000
 //
 // +stateify savable
 type Manager struct {
-	// mu protects the fields below.
 	mu sync.Mutex `state:"nosave"`
 
 	// ports contains a map of allocated ports for each protocol.
+	//
+	// +checklocks:mu
 	ports map[int]map[int32]struct{}
 }
 
@@ -52,6 +53,8 @@ func New() *Manager {
 
 // Allocate reserves a new port ID for protocol. hint will be taken if
 // available.
+//
+// +checklocksexclude:m.mu
 func (m *Manager) Allocate(protocol int, hint int32) (int32, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -100,6 +103,8 @@ func (m *Manager) Allocate(protocol int, hint int32) (int32, bool) {
 // Release frees the specified port for protocol.
 //
 // Preconditions: port is already allocated.
+//
+// +checklocksexclude:m.mu
 func (m *Manager) Release(protocol int, port int32) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/sentry/socket/netstack/netstack.go
+++ b/pkg/sentry/socket/netstack/netstack.go
@@ -437,23 +437,32 @@ type sock struct {
 	// +checklocks:mu
 	readWriter usermem.IOSequenceReadWriter `state:"nosave"`
 
-	// readMu protects access to the below fields.
+	// readMu serializes receive metadata and control-message generation.
 	readMu sync.Mutex `state:"nosave"`
 
 	// sockOptTimestamp corresponds to SO_TIMESTAMP. When true, timestamps
 	// of returned messages can be returned via control messages. When
 	// false, the same timestamp is instead stored and can be read via the
-	// SIOCGSTAMP ioctl. It is protected by readMu. See socket(7).
+	// SIOCGSTAMP ioctl. See socket(7).
+	//
+	// +checklocks:readMu
 	sockOptTimestamp bool
-	// timestampValid indicates whether timestamp for SIOCGSTAMP has been
-	// set. It is protected by readMu.
+
+	// timestampValid indicates whether timestamp for SIOCGSTAMP has been set.
+	//
+	// +checklocks:readMu
 	timestampValid bool
-	// timestamp holds the timestamp to use with SIOCTSTAMP. It is only
-	// valid when timestampValid is true. It is protected by readMu.
+
+	// timestamp holds the timestamp to use with SIOCGSTAMP. It is only
+	// valid when timestampValid is true.
+	//
+	// +checklocks:readMu
 	timestamp time.Time `state:".(int64)"`
 
 	// TODO(b/153685824): Move this to SocketOptions.
 	// sockOptInq corresponds to TCP_INQ.
+	//
+	// +checklocks:readMu
 	sockOptInq bool
 }
 
@@ -523,6 +532,9 @@ func (s *sock) Epollable() bool {
 }
 
 // Read implements vfs.FileDescriptionImpl.
+//
+// +checklocksexclude:s.readMu
+// +checklocksexclude:s.mu
 func (s *sock) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	// All flags other than RWF_NOWAIT should be ignored.
 	// TODO(gvisor.dev/issue/2601): Support RWF_NOWAIT.
@@ -544,6 +556,8 @@ func (s *sock) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOp
 }
 
 // Write implements vfs.FileDescriptionImpl.
+//
+// +checklocksexclude:s.mu
 func (s *sock) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
 	// All flags other than RWF_NOWAIT should be ignored.
 	// TODO(gvisor.dev/issue/2601): Support RWF_NOWAIT.
@@ -625,6 +639,8 @@ func (s *sock) Accept(t *kernel.Task, peerRequested bool, flags int, blocking bo
 
 // GetSockOpt implements the linux syscall getsockopt(2) for sockets backed by
 // tcpip.Endpoint.
+//
+// +checklocksexclude:s.readMu
 func (s *sock) GetSockOpt(t *kernel.Task, level, name int, outPtr hostarch.Addr, outLen int) (marshal.Marshallable, *syserr.Error) {
 	// TODO(b/78348848): Unlike other socket options, SO_TIMESTAMP is
 	// implemented specifically for netstack.Socket rather than
@@ -684,6 +700,8 @@ func (s *sock) GetSockOpt(t *kernel.Task, level, name int, outPtr hostarch.Addr,
 
 // SetSockOpt implements the linux syscall setsockopt(2) for sockets backed by
 // tcpip.Endpoint.
+//
+// +checklocksexclude:s.readMu
 func (s *sock) SetSockOpt(t *kernel.Task, level int, name int, optVal []byte) *syserr.Error {
 	// TODO(b/78348848): Unlike other socket options, SO_TIMESTAMP is
 	// implemented specifically for netstack.Socket rather than
@@ -3079,6 +3097,7 @@ func (s *sock) GetPeerCreds(*kernel.Task) (marshal.Marshallable, *syserr.Error) 
 	return nil, syserr.ErrNotSupported
 }
 
+// +checklocks:s.readMu
 func (s *sock) fillCmsgInq(cmsg *socket.ControlMessages) {
 	if !s.sockOptInq {
 		return
@@ -3111,6 +3130,9 @@ func toLinuxPacketType(pktType tcpip.PacketType) uint8 {
 // nonBlockingRead issues a non-blocking read.
 //
 // TODO(b/78348848): Support timestamps for stream sockets.
+//
+// +checklocksexclude:s.readMu
+// +checklocksexclude:s.mu
 func (s *sock) nonBlockingRead(ctx context.Context, dst usermem.IOSequence, peek, trunc, senderRequested bool) (int, int, linux.SockAddr, uint32, socket.ControlMessages, *syserr.Error) {
 	isPacket := s.isPacketBased()
 
@@ -3211,6 +3233,7 @@ func (s *sock) nonBlockingRead(ctx context.Context, dst usermem.IOSequence, peek
 	return res.Count, 0, nil, 0, cmsg, syserr.TranslateNetstackError(err)
 }
 
+// +checklocks:s.readMu
 func (s *sock) netstackToLinuxControlMessages(cm tcpip.ReceivableControlMessages) socket.ControlMessages {
 	readCM := socket.NewIPControlMessages(s.family, cm)
 	return socket.ControlMessages{
@@ -3249,7 +3272,7 @@ func (s *sock) linuxToNetstackControlMessages(cm socket.ControlMessages) tcpip.S
 // updateTimestamp sets the timestamp for SIOCGSTAMP. It should be called after
 // successfully writing packet data out to userspace.
 //
-// Precondition: s.readMu must be locked.
+// +checklocks:s.readMu
 func (s *sock) updateTimestamp(cm tcpip.ReceivableControlMessages) {
 	// Save the SIOCGSTAMP timestamp only if SO_TIMESTAMP is disabled.
 	if !s.sockOptTimestamp {
@@ -3316,6 +3339,9 @@ func (s *sock) recvErr(t *kernel.Task, dst usermem.IOSequence) (int, int, linux.
 
 // RecvMsg implements the linux syscall recvmsg(2) for sockets backed by
 // tcpip.Endpoint.
+//
+// +checklocksexclude:s.readMu
+// +checklocksexclude:s.mu
 func (s *sock) RecvMsg(t *kernel.Task, dst usermem.IOSequence, flags int, haveDeadline bool, deadline ktime.Time, senderRequested bool, _ uint64) (n int, msgFlags int, senderAddr linux.SockAddr, senderAddrLen uint32, controlMessages socket.ControlMessages, err *syserr.Error) {
 	if flags&linux.MSG_ERRQUEUE != 0 {
 		return s.recvErr(t, dst)
@@ -3461,6 +3487,8 @@ func (s *sock) SendMsg(t *kernel.Task, src usermem.IOSequence, to []byte, flags 
 }
 
 // Ioctl implements vfs.FileDescriptionImpl.
+//
+// +checklocksexclude:s.readMu
 func (s *sock) Ioctl(ctx context.Context, uio usermem.IO, sysno uintptr, args arch.SyscallArguments) (uintptr, error) {
 	t := kernel.TaskFromContext(ctx)
 	if t == nil {

--- a/pkg/sentry/socket/netstack/netstack_state.go
+++ b/pkg/sentry/socket/netstack/netstack_state.go
@@ -21,12 +21,14 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
 
+// +checklocksexclude:s.readMu
 func (s *sock) saveTimestamp() int64 {
 	s.readMu.Lock()
 	defer s.readMu.Unlock()
 	return s.timestamp.UnixNano()
 }
 
+// +checklocksexclude:s.readMu
 func (s *sock) loadTimestamp(_ context.Context, nsec int64) {
 	s.readMu.Lock()
 	defer s.readMu.Unlock()

--- a/pkg/tcpip/link/nested/nested.go
+++ b/pkg/tcpip/link/nested/nested.go
@@ -34,8 +34,9 @@ type Endpoint struct {
 	child    stack.LinkEndpoint
 	embedder stack.NetworkDispatcher
 
-	// mu protects dispatcher.
-	mu         sync.RWMutex `state:"nosave"`
+	mu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:mu
 	dispatcher stack.NetworkDispatcher
 }
 
@@ -53,6 +54,8 @@ func (e *Endpoint) Init(child stack.LinkEndpoint, embedder stack.NetworkDispatch
 }
 
 // DeliverNetworkPacket implements stack.NetworkDispatcher.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) DeliverNetworkPacket(protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
 	e.mu.RLock()
 	d := e.dispatcher
@@ -63,6 +66,8 @@ func (e *Endpoint) DeliverNetworkPacket(protocol tcpip.NetworkProtocolNumber, pk
 }
 
 // DeliverLinkPacket implements stack.NetworkDispatcher.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) DeliverLinkPacket(protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
 	e.mu.RLock()
 	d := e.dispatcher
@@ -73,6 +78,8 @@ func (e *Endpoint) DeliverLinkPacket(protocol tcpip.NetworkProtocolNumber, pkt *
 }
 
 // Attach implements stack.LinkEndpoint.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) Attach(dispatcher stack.NetworkDispatcher) {
 	e.mu.Lock()
 	e.dispatcher = dispatcher
@@ -87,6 +94,8 @@ func (e *Endpoint) Attach(dispatcher stack.NetworkDispatcher) {
 }
 
 // IsAttached implements stack.LinkEndpoint.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) IsAttached() bool {
 	e.mu.RLock()
 	isAttached := e.dispatcher != nil
@@ -120,6 +129,8 @@ func (e *Endpoint) LinkAddress() tcpip.LinkAddress {
 }
 
 // SetLinkAddress implements stack.LinkEndpoint.SetLinkAddress.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) SetLinkAddress(addr tcpip.LinkAddress) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/pkg/tcpip/link/qdisc/tbf/tbf_test.go
+++ b/pkg/tcpip/link/qdisc/tbf/tbf_test.go
@@ -40,14 +40,19 @@ type fakeEndpoint struct {
 	gsoMaxSize      uint32
 	supportedGSO    stack.SupportedGSO
 
-	mu             sync.Mutex
-	batchSizes     []int
-	bytesWritten   int
+	mu sync.Mutex
+
+	// +checklocks:mu
+	batchSizes []int
+	// +checklocks:mu
+	bytesWritten int
+	// +checklocks:mu
 	packetsWritten int
 	packetsWanted  int // 0 disables the done signal
 	done           chan struct{}
 }
 
+// +checklocksexclude:e.mu
 func (e *fakeEndpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error) {
 	n := 0
 	bytes := 0
@@ -88,6 +93,8 @@ func (e *fakeEndpoint) GSOMaxSize() uint32                           { return e.
 func (e *fakeEndpoint) SupportedGSO() stack.SupportedGSO             { return e.supportedGSO }
 
 // snapshot returns a copy of stats taken under lock.
+//
+// +checklocksexclude:e.mu
 func (e *fakeEndpoint) snapshot() (packets, bytes int) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -96,6 +103,8 @@ func (e *fakeEndpoint) snapshot() (packets, bytes int) {
 
 // maxBatchSize returns the largest batch ever written to the endpoint, or 0
 // if no writes have been observed.
+//
+// +checklocksexclude:e.mu
 func (e *fakeEndpoint) maxBatchSize() int {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -119,6 +128,8 @@ func newPkt(size int) *stack.PacketBuffer {
 // waitForPackets returns true if ep observed at least n packets within d.
 // Polls instead of relying on the done channel so callers can poll for
 // arbitrary thresholds without re-instrumenting the endpoint.
+//
+// +checklocksexclude:ep.mu
 func waitForPackets(t *testing.T, ep *fakeEndpoint, n int, d time.Duration) bool {
 	t.Helper()
 	deadline := time.Now().Add(d)
@@ -135,6 +146,8 @@ func waitForPackets(t *testing.T, ep *fakeEndpoint, n int, d time.Duration) bool
 // pollMax polls ep over d, returning early as soon as the packet count
 // exceeds limit (the test would fail anyway), otherwise returning the
 // final observed count. Used to assert "no more than `limit` drained".
+//
+// +checklocksexclude:ep.mu
 func pollMax(t *testing.T, ep *fakeEndpoint, limit int, d time.Duration) int {
 	t.Helper()
 	deadline := time.Now().Add(d)

--- a/pkg/tcpip/link/veth/veth.go
+++ b/pkg/tcpip/link/veth/veth.go
@@ -29,13 +29,25 @@ var _ stack.GSOEndpoint = (*Endpoint)(nil)
 
 // +stateify savable
 type veth struct {
-	mu           vethRWMutex `state:"nosave"`
-	closed       bool
+	mu vethRWMutex `state:"nosave"`
+
+	// +checklocks:mu
+	closed bool
+
 	backlogQueue chan vethPacket `state:"nosave"`
-	mtu          uint32
-	endpoints    [2]Endpoint
+
+	// +checklocks:mu
+	mtu uint32
+
+	endpoints [2]Endpoint
 }
 
+// close shuts down both endpoints, invoking close callbacks after unlocking.
+//
+// The caller must not hold either endpoint's mutex. checklocks cannot name
+// those mutexes through the endpoints array.
+//
+// +checklocksexclude:v.mu
 func (v *veth) close() {
 	v.mu.Lock()
 	closed := v.closed
@@ -116,12 +128,18 @@ func NewPair(mtu, backlogQueueSize uint32) (*Endpoint, *Endpoint) {
 
 // Close closes e. Further packet injections will return an error, and all pending
 // packets are discarded. Close may be called concurrently with WritePackets.
+//
+// +checklocksexclude:e.veth.mu
+// +checklocksexclude:e.mu
+// +checklocksexclude:e.peer.mu
 func (e *Endpoint) Close() {
 	e.veth.close()
 }
 
 // InjectInbound injects an inbound packet. If the endpoint is not attached, the
 // packet is not delivered.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) InjectInbound(protocol tcpip.NetworkProtocolNumber, pkt *stack.PacketBuffer) {
 	e.mu.RLock()
 	d := e.dispatcher
@@ -133,6 +151,8 @@ func (e *Endpoint) InjectInbound(protocol tcpip.NetworkProtocolNumber, pkt *stac
 
 // Attach saves the stack network-layer dispatcher for use later when packets
 // are injected.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) Attach(dispatcher stack.NetworkDispatcher) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -140,6 +160,8 @@ func (e *Endpoint) Attach(dispatcher stack.NetworkDispatcher) {
 }
 
 // IsAttached implements stack.LinkEndpoint.IsAttached.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) IsAttached() bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -147,6 +169,8 @@ func (e *Endpoint) IsAttached() bool {
 }
 
 // MTU implements stack.LinkEndpoint.MTU.
+//
+// +checklocksexclude:e.veth.mu
 func (e *Endpoint) MTU() uint32 {
 	e.veth.mu.RLock()
 	defer e.veth.mu.RUnlock()
@@ -154,6 +178,8 @@ func (e *Endpoint) MTU() uint32 {
 }
 
 // SetMTU implements stack.LinkEndpoint.SetMTU.
+//
+// +checklocksexclude:e.veth.mu
 func (e *Endpoint) SetMTU(mtu uint32) {
 	e.veth.mu.Lock()
 	defer e.veth.mu.Unlock()
@@ -182,6 +208,8 @@ func (*Endpoint) MaxHeaderLength() uint16 {
 }
 
 // LinkAddress returns the link address of this endpoint.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) LinkAddress() tcpip.LinkAddress {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -189,6 +217,8 @@ func (e *Endpoint) LinkAddress() tcpip.LinkAddress {
 }
 
 // SetLinkAddress implements stack.LinkEndpoint.SetLinkAddress.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) SetLinkAddress(addr tcpip.LinkAddress) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -197,6 +227,8 @@ func (e *Endpoint) SetLinkAddress(addr tcpip.LinkAddress) {
 
 // WritePackets stores outbound packets into the channel.
 // Multiple concurrent calls are permitted.
+//
+// +checklocksexclude:e.veth.mu
 func (e *Endpoint) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error) {
 	e.veth.mu.RLock()
 	defer e.veth.mu.RUnlock()
@@ -249,6 +281,8 @@ func (e *Endpoint) AddHeader(pkt *stack.PacketBuffer) {}
 func (e *Endpoint) ParseHeader(pkt *stack.PacketBuffer) bool { return true }
 
 // SetOnCloseAction implements stack.LinkEndpoint.
+//
+// +checklocksexclude:e.mu
 func (e *Endpoint) SetOnCloseAction(action func()) {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/pkg/tcpip/ports/ports.go
+++ b/pkg/tcpip/ports/ports.go
@@ -219,18 +219,27 @@ func (ad addrToDevice) isAvailable(res Reservation, portSpecified bool) bool {
 //
 // +stateify savable
 type PortManager struct {
-	// mu protects allocatedPorts.
 	// LOCK ORDERING: mu > ephemeralMu.
 	mu sync.RWMutex `state:"nosave"`
+
 	// allocatedPorts is a nesting of maps that ultimately map Reservations
 	// to FlagCounters describing whether the Reservation is valid and can
 	// be reused.
+	//
+	// mu also protects nested maps reached through allocatedPorts. Their
+	// helper receivers have no reference to this PortManager, so checklocks
+	// cannot express those helpers' owner-lock precondition.
+	//
+	// +checklocks:mu
 	allocatedPorts map[portDescriptor]addrToDevice
 
-	// ephemeralMu protects firstEphemeral and numEphemeral.
-	ephemeralMu    sync.RWMutex `state:"nosave"`
+	ephemeralMu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:ephemeralMu
 	firstEphemeral uint16
-	numEphemeral   uint16
+
+	// +checklocks:ephemeralMu
+	numEphemeral uint16
 }
 
 // NewPortManager creates new PortManager.
@@ -251,6 +260,11 @@ type PortTester func(port uint16) (good bool, err tcpip.Error)
 // possible ephemeral ports, allowing the caller to decide whether a given port
 // is suitable for its needs, and stopping when a port is found or an error
 // occurs.
+//
+// testPort is called synchronously without ephemeralMu held. Locks held by
+// the caller remain held during the callback.
+//
+// +checklocksexclude:pm.ephemeralMu
 func (pm *PortManager) PickEphemeralPort(rng rand.RNG, testPort PortTester) (port uint16, err tcpip.Error) {
 	pm.ephemeralMu.RLock()
 	firstEphemeral := pm.firstEphemeral
@@ -289,6 +303,12 @@ func pickEphemeralPort(offset uint32, first, count uint16, testPort PortTester) 
 // An optional PortTester can be passed in which if provided will be used to
 // test if the picked port can be used. The function should return true if the
 // port is safe to use, false otherwise.
+//
+// testPort is called synchronously with pm.mu held and must not call methods
+// that acquire the same pm.mu.
+//
+// +checklocksexclude:pm.mu
+// +checklocksexclude:pm.ephemeralMu
 func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortTester) (reservedPort uint16, err tcpip.Error) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -313,20 +333,22 @@ func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortT
 		return res.Port, nil
 	}
 
-	// A port wasn't specified, so try to find one.
+	// A port wasn't specified, so try to find one. PickEphemeralPort calls
+	// this callback synchronously with pm.mu still held, but checklocks
+	// analyzes passed callbacks without the caller's lock state.
 	return pm.PickEphemeralPort(rng, func(p uint16) (bool, tcpip.Error) {
 		res.Port = p
-		if !pm.reserveSpecificPortLocked(res, false /* portSpecified */) {
+		if !pm.reserveSpecificPortLocked(res, false /* portSpecified */) { // +checklocksignore
 			return false, nil
 		}
 		if testPort != nil {
 			ok, err := testPort(p)
 			if err != nil {
-				pm.releasePortLocked(res)
+				pm.releasePortLocked(res) // +checklocksignore
 				return false, err
 			}
 			if !ok {
-				pm.releasePortLocked(res)
+				pm.releasePortLocked(res) // +checklocksignore
 				return false, nil
 			}
 		}
@@ -336,6 +358,8 @@ func (pm *PortManager) ReservePort(rng rand.RNG, res Reservation, testPort PortT
 
 // reserveSpecificPortLocked tries to reserve the given port on all given
 // protocols.
+//
+// +checklocks:pm.mu
 func (pm *PortManager) reserveSpecificPortLocked(res Reservation, portSpecified bool) bool {
 	// Make sure the port is available.
 	for _, network := range res.Networks {
@@ -376,6 +400,8 @@ func (pm *PortManager) reserveSpecificPortLocked(res Reservation, portSpecified 
 }
 
 // ReserveTuple adds a port reservation for the tuple on all given protocol.
+//
+// +checklocksexclude:pm.mu
 func (pm *PortManager) ReserveTuple(res Reservation) bool {
 	flagBits := res.Flags.Bits()
 	dst := res.dst()
@@ -428,6 +454,8 @@ func (pm *PortManager) ReserveTuple(res Reservation) bool {
 
 // ReleasePort releases the reservation on a port/IP combination so that it can
 // be reserved by other endpoints.
+//
+// +checklocksexclude:pm.mu
 func (pm *PortManager) ReleasePort(res Reservation) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -435,6 +463,9 @@ func (pm *PortManager) ReleasePort(res Reservation) {
 	pm.releasePortLocked(res)
 }
 
+// releasePortLocked releases a reservation without dropping the caller's lock.
+//
+// +checklocks:pm.mu
 func (pm *PortManager) releasePortLocked(res Reservation) {
 	dst := res.dst()
 	for _, network := range res.Networks {
@@ -478,6 +509,8 @@ func (pm *PortManager) releasePortLocked(res Reservation) {
 
 // PortRange returns the UDP and TCP inclusive range of ephemeral ports used in
 // both IPv4 and IPv6.
+//
+// +checklocksexclude:pm.ephemeralMu
 func (pm *PortManager) PortRange() (uint16, uint16) {
 	pm.ephemeralMu.RLock()
 	defer pm.ephemeralMu.RUnlock()
@@ -486,6 +519,8 @@ func (pm *PortManager) PortRange() (uint16, uint16) {
 
 // SetPortRange sets the UDP and TCP IPv4 and IPv6 ephemeral port range
 // (inclusive).
+//
+// +checklocksexclude:pm.ephemeralMu
 func (pm *PortManager) SetPortRange(start uint16, end uint16) tcpip.Error {
 	if start > end {
 		return &tcpip.ErrInvalidPortRange{}

--- a/pkg/tcpip/socketops.go
+++ b/pkg/tcpip/socketops.go
@@ -142,7 +142,9 @@ type SocketOptions struct {
 	// StackHandler is initialized at the creation time and will not change.
 	stackHandler StackHandler `state:"manual"`
 
-	// These fields are accessed and modified using atomic operations.
+	// The boolean option fields below are accessed atomically. Their setters
+	// pass field addresses through storeAtomicBool; checklocks cannot verify
+	// that helper's atomic operation at those call sites.
 
 	// broadcastEnabled determines whether datagram sockets are allowed to
 	// send packets to a broadcast address.
@@ -230,11 +232,16 @@ type SocketOptions struct {
 	// passing is enabled for IPv6.
 	ipv6RecvErrEnabled atomicbitops.Uint32
 
-	// errQueue is the per-socket error queue. It is protected by errQueueMu.
 	errQueueMu sync.Mutex `state:"nosave"`
-	errQueue   sockErrorList
+
+	// errQueue is the per-socket error queue.
+	//
+	// +checklocks:errQueueMu
+	errQueue sockErrorList
 
 	// bindToDevice determines the device to which the socket is bound.
+	//
+	// +checkatomic
 	bindToDevice atomicbitops.Int32
 
 	// getSendBufferLimits provides the handler to get the min, default and max
@@ -243,6 +250,8 @@ type SocketOptions struct {
 	getSendBufferLimits GetSendBufferLimits `state:"manual"`
 
 	// sendBufferSize determines the send buffer size for this socket.
+	//
+	// +checkatomic
 	sendBufferSize atomicbitops.Int64
 
 	// getReceiveBufferLimits provides the handler to get the min, default and
@@ -251,24 +260,33 @@ type SocketOptions struct {
 	getReceiveBufferLimits GetReceiveBufferLimits `state:"manual"`
 
 	// receiveBufferSize determines the receive buffer size for this socket.
+	//
+	// +checkatomic
 	receiveBufferSize atomicbitops.Int64
 
 	// rcvlowat specifies the minimum number of bytes which should be
 	// received to indicate the socket as readable.
+	//
+	// +checkatomic
 	rcvlowat atomicbitops.Int32
 
 	// experimentOptionValue is the value set for the IP option experiment header
 	// if it is not zero.
+	//
+	// +checkatomic
 	experimentOptionValue atomicbitops.Uint32
 
 	// mark is the mark value set for the socket.
+	//
+	// +checkatomic
 	mark atomicbitops.Uint32
 
-	// mu protects the access to the below fields.
 	mu sync.Mutex `state:"nosave"`
 
 	// linger determines the amount of time the socket should linger before
 	// close. We currently implement this option for TCP socket only.
+	//
+	// +checklocks:mu
 	linger LingerOption
 }
 
@@ -497,6 +515,8 @@ func (so *SocketOptions) GetIPv4RecvError() bool {
 }
 
 // SetIPv4RecvError sets value for IP_RECVERR option.
+//
+// +checklocksexclude:so.errQueueMu
 func (so *SocketOptions) SetIPv4RecvError(v bool) {
 	storeAtomicBool(&so.ipv4RecvErrEnabled, v)
 	if !v {
@@ -510,6 +530,8 @@ func (so *SocketOptions) GetIPv6RecvError() bool {
 }
 
 // SetIPv6RecvError sets value for IPV6_RECVERR option.
+//
+// +checklocksexclude:so.errQueueMu
 func (so *SocketOptions) SetIPv6RecvError(v bool) {
 	storeAtomicBool(&so.ipv6RecvErrEnabled, v)
 	if !v {
@@ -532,6 +554,8 @@ func (*SocketOptions) GetOutOfBandInline() bool {
 func (*SocketOptions) SetOutOfBandInline(bool) {}
 
 // GetLinger gets value for SO_LINGER option.
+//
+// +checklocksexclude:so.mu
 func (so *SocketOptions) GetLinger() LingerOption {
 	so.mu.Lock()
 	linger := so.linger
@@ -540,6 +564,8 @@ func (so *SocketOptions) GetLinger() LingerOption {
 }
 
 // SetLinger sets value for SO_LINGER option.
+//
+// +checklocksexclude:so.mu
 func (so *SocketOptions) SetLinger(linger LingerOption) {
 	so.mu.Lock()
 	so.linger = linger
@@ -643,6 +669,8 @@ type SockError struct {
 }
 
 // pruneErrQueue resets the queue.
+//
+// +checklocksexclude:so.errQueueMu
 func (so *SocketOptions) pruneErrQueue() {
 	so.errQueueMu.Lock()
 	so.errQueue.Reset()
@@ -651,6 +679,8 @@ func (so *SocketOptions) pruneErrQueue() {
 
 // DequeueErr dequeues a socket extended error from the error queue and returns
 // it. Returns nil if queue is empty.
+//
+// +checklocksexclude:so.errQueueMu
 func (so *SocketOptions) DequeueErr() *SockError {
 	so.errQueueMu.Lock()
 	defer so.errQueueMu.Unlock()
@@ -664,6 +694,8 @@ func (so *SocketOptions) DequeueErr() *SockError {
 
 // PeekErr returns the error in the front of the error queue. Returns nil if
 // the error queue is empty.
+//
+// +checklocksexclude:so.errQueueMu
 func (so *SocketOptions) PeekErr() *SockError {
 	so.errQueueMu.Lock()
 	defer so.errQueueMu.Unlock()
@@ -673,6 +705,8 @@ func (so *SocketOptions) PeekErr() *SockError {
 // QueueErr inserts the error at the back of the error queue.
 //
 // Preconditions: so.GetIPv4RecvError() or so.GetIPv6RecvError() is true.
+//
+// +checklocksexclude:so.errQueueMu
 func (so *SocketOptions) QueueErr(err *SockError) {
 	so.errQueueMu.Lock()
 	defer so.errQueueMu.Unlock()
@@ -680,6 +714,8 @@ func (so *SocketOptions) QueueErr(err *SockError) {
 }
 
 // QueueLocalErr queues a local error onto the local queue.
+//
+// +checklocksexclude:so.errQueueMu
 func (so *SocketOptions) QueueLocalErr(err Error, net NetworkProtocolNumber, info uint32, dst FullAddress, payload *buffer.View) {
 	so.QueueErr(&SockError{
 		Err:      err,

--- a/pkg/tcpip/stack/rand.go
+++ b/pkg/tcpip/stack/rand.go
@@ -22,10 +22,13 @@ import (
 
 // lockedRandomSource provides a threadsafe rand.Source.
 type lockedRandomSource struct {
-	mu  sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	src rand.Source
 }
 
+// +checklocksexclude:r.mu
 func (r *lockedRandomSource) Int63() (n int64) {
 	r.mu.Lock()
 	n = r.src.Int63()
@@ -33,6 +36,7 @@ func (r *lockedRandomSource) Int63() (n int64) {
 	return n
 }
 
+// +checklocksexclude:r.mu
 func (r *lockedRandomSource) Seed(seed int64) {
 	r.mu.Lock()
 	r.src.Seed(seed)

--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -760,12 +760,16 @@ func (s *Stack) NICMulticastForwarding(id tcpip.NICID, protocol tcpip.NetworkPro
 
 // PortRange returns the UDP and TCP inclusive range of ephemeral ports used in
 // both IPv4 and IPv6.
+//
+// +checklocksexclude:s.PortManager.ephemeralMu
 func (s *Stack) PortRange() (uint16, uint16) {
 	return s.PortManager.PortRange()
 }
 
 // SetPortRange sets the UDP and TCP IPv4 and IPv6 ephemeral port range
 // (inclusive).
+//
+// +checklocksexclude:s.PortManager.ephemeralMu
 func (s *Stack) SetPortRange(start uint16, end uint16) tcpip.Error {
 	return s.PortManager.SetPortRange(start, end)
 }

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -2857,10 +2857,14 @@ type ProtocolAddress struct {
 }
 
 var (
-	// danglingEndpointsMu protects access to danglingEndpoints.
+	// Public dangling-endpoint helpers acquire this mutex themselves. Their
+	// caller exclusions cannot be exported reliably by checklocks because
+	// the guard is rooted in a private package global.
 	danglingEndpointsMu sync.Mutex
 
 	// danglingEndpoints tracks all dangling endpoints no longer owned by the app.
+	//
+	// +checklocks:danglingEndpointsMu
 	danglingEndpoints = make(map[Endpoint]struct{})
 )
 

--- a/pkg/tcpip/transport/tcp/accept.go
+++ b/pkg/tcpip/transport/tcp/accept.go
@@ -86,9 +86,11 @@ type listenContext struct {
 	// this context. Can be nil if the context is created by the forwarder.
 	listenEP *Endpoint
 
-	// hasherMu protects hasher.
 	hasherMu hasherMutex
+
 	// hasher is the hash function used to generate a SYN cookie.
+	//
+	// +checklocks:hasherMu
 	hasher hash.Hash
 
 	// v6Only is true if listenEP is a dual stack socket and has the
@@ -128,6 +130,8 @@ func newListenContext(stk *stack.Stack, protocol *protocol, listenEP *Endpoint, 
 
 // cookieHash calculates the cookieHash for the given id, timestamp and nonce
 // index. The hash is used to create and validate cookies.
+//
+// +checklocksexclude:l.hasherMu
 func (l *listenContext) cookieHash(id stack.TransportEndpointID, ts uint32, nonceIndex int) uint32 {
 
 	// Initialize block with fixed-size data: local ports and v.
@@ -157,6 +161,8 @@ func (l *listenContext) cookieHash(id stack.TransportEndpointID, ts uint32, nonc
 
 // createCookie creates a SYN cookie for the given id and incoming sequence
 // number.
+//
+// +checklocksexclude:l.hasherMu
 func (l *listenContext) createCookie(id stack.TransportEndpointID, seq seqnum.Value, data uint32) seqnum.Value {
 	ts := timeStamp(l.stack.Clock())
 	v := l.cookieHash(id, 0, 0) + uint32(seq) + (ts << tsOffset)
@@ -167,6 +173,8 @@ func (l *listenContext) createCookie(id stack.TransportEndpointID, seq seqnum.Va
 // isCookieValid checks if the supplied cookie is valid for the given id and
 // sequence number. If it is, it also returns the data originally encoded in the
 // cookie when createCookie was called.
+//
+// +checklocksexclude:l.hasherMu
 func (l *listenContext) isCookieValid(id stack.TransportEndpointID, cookie seqnum.Value, seq seqnum.Value) (uint32, bool) {
 	ts := timeStamp(l.stack.Clock())
 	v := uint32(cookie) - l.cookieHash(id, 0, 0) - uint32(seq)
@@ -434,6 +442,7 @@ func (a *acceptQueue) isFull() bool {
 // and needs to handle it.
 //
 // +checklocks:e.mu
+// +checklocksexclude:ctx.hasherMu
 func (e *Endpoint) handleListenSegment(ctx *listenContext, s *segment) tcpip.Error {
 	e.rcvQueueMu.Lock()
 	rcvClosed := e.RcvClosed

--- a/pkg/tcpip/transport/tcp/connect.go
+++ b/pkg/tcpip/transport/tcp/connect.go
@@ -129,6 +129,9 @@ type handshake struct {
 // processor if there are pending segments that need to be processed.
 //
 // NOTE: e.mu is held for the duration of the call to f().
+// The wrapper does not acquire a sender RTT mutex before calling f. checklocks
+// cannot recover f's captured sender to express that exclusion; the returned
+// callback runs later, so its lock state is not a precondition on timerHandler.
 func timerHandler(e *Endpoint, f func() tcpip.Error) func() {
 	return func() {
 		e.mu.Lock()
@@ -380,6 +383,9 @@ func (h *handshake) synSentState(s *segment) tcpip.Error {
 // synRcvdState handles a segment received when the TCP 3-way handshake is in
 // the SYN-RCVD state.
 // +checklocks:h.ep.mu
+// +checklocksexclude:h.ep.segmentQueue.mu
+// +checklocksexclude:h.ep.pendingProcessingMu
+// +checklocksexclude:h.listenEP.listenCtx.hasherMu
 func (h *handshake) synRcvdState(s *segment) tcpip.Error {
 	if s.flags.Contains(header.TCPFlagRst) {
 		// RFC 793, page 37, states that in the SYN-RCVD state, a reset
@@ -514,6 +520,9 @@ func (h *handshake) synRcvdState(s *segment) tcpip.Error {
 }
 
 // +checklocks:h.ep.mu
+// +checklocksexclude:h.ep.segmentQueue.mu
+// +checklocksexclude:h.ep.pendingProcessingMu
+// +checklocksexclude:h.listenEP.listenCtx.hasherMu
 func (h *handshake) handleSegment(s *segment) tcpip.Error {
 	h.sndWnd = s.window
 	if !s.flags.Contains(header.TCPFlagSyn) && h.sndWndScale > 0 {
@@ -532,6 +541,9 @@ func (h *handshake) handleSegment(s *segment) tcpip.Error {
 // processSegments goes through the segment queue and processes up to
 // maxSegmentsPerWake (if they're available).
 // +checklocks:h.ep.mu
+// +checklocksexclude:h.ep.segmentQueue.mu
+// +checklocksexclude:h.ep.pendingProcessingMu
+// +checklocksexclude:h.listenEP.listenCtx.hasherMu
 func (h *handshake) processSegments() tcpip.Error {
 	for i := 0; i < maxSegmentsPerWake; i++ {
 		s := h.ep.segmentQueue.dequeue()
@@ -981,6 +993,8 @@ func sendTCP(r *stack.Route, tf tcpFields, pkt *stack.PacketBuffer, gso stack.GS
 }
 
 // makeOptions makes an options slice.
+//
+// +checklocks:e.mu
 func (e *Endpoint) makeOptions(sackBlocks []header.SACKBlock) []byte {
 	options := getOptions()
 	offset := 0
@@ -1063,6 +1077,7 @@ func (e *Endpoint) sendRaw(pkt *stack.PacketBuffer, flags header.TCPFlags, seq, 
 }
 
 // +checklocks:e.mu
+// +checklocksexclude:e.snd.rtt.rttMutex
 func (e *Endpoint) sendData(next *segment) {
 	// Initialize the next segment to write if it's currently nil.
 	if e.snd.writeNext == nil {
@@ -1178,6 +1193,8 @@ func (e *Endpoint) tryDeliverSegmentFromClosedEndpoint(s *segment) {
 // Drain segment queue from the endpoint and try to re-match the segment to a
 // different endpoint. This is used when the current endpoint is transitioned to
 // StateClose and has been unregistered from the transport demuxer.
+//
+// +checklocksexclude:e.segmentQueue.mu
 func (e *Endpoint) drainClosingSegmentQueue() {
 	for {
 		s := e.segmentQueue.dequeue()
@@ -1250,6 +1267,8 @@ func (e *Endpoint) handleReset(s *segment) (ok bool, err tcpip.Error) {
 // handleSegments processes all inbound segments.
 //
 // +checklocks:e.mu
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.snd.rtt.rttMutex
 func (e *Endpoint) handleSegmentsLocked() tcpip.Error {
 	sndUna := e.snd.SndUna
 	for i := 0; i < maxSegmentsPerWake; i++ {
@@ -1292,6 +1311,7 @@ func (e *Endpoint) handleSegmentsLocked() tcpip.Error {
 }
 
 // +checklocks:e.mu
+// +checklocksexclude:e.snd.rtt.rttMutex
 func (e *Endpoint) probeSegmentLocked() {
 	if fn := e.probe; fn != nil {
 		var state TCPEndpointState
@@ -1304,6 +1324,7 @@ func (e *Endpoint) probeSegmentLocked() {
 // if the connection should be terminated.
 //
 // +checklocks:e.mu
+// +checklocksexclude:e.snd.rtt.rttMutex
 func (e *Endpoint) handleSegmentLocked(s *segment) (cont bool, err tcpip.Error) {
 	// Invoke the tcp probe if installed. The tcp probe function will update
 	// the TCPEndpointState after the segment is processed.
@@ -1444,6 +1465,8 @@ func (e *Endpoint) resetKeepaliveTimer(receivedData bool) {
 }
 
 // disableKeepaliveTimer stops the keepalive timer.
+//
+// +checklocks:e.mu
 func (e *Endpoint) disableKeepaliveTimer() {
 	e.keepalive.Lock()
 	e.keepalive.timer.disable()
@@ -1480,6 +1503,7 @@ func (e *Endpoint) handshakeFailed(err tcpip.Error) {
 // handleTimeWaitSegments processes segments received during TIME_WAIT
 // state.
 // +checklocks:e.mu
+// +checklocksexclude:e.segmentQueue.mu
 func (e *Endpoint) handleTimeWaitSegments() (extendTimeWait bool, reuseTW func()) {
 	for i := 0; i < maxSegmentsPerWake; i++ {
 		s := e.segmentQueue.dequeue()
@@ -1553,6 +1577,11 @@ func (e *Endpoint) timeWaitTimerExpired() {
 }
 
 // notifyProcessor queues this endpoint for processing to its TCP processor.
+//
+// The caller must not hold the selected processor's queue mutex. checklocks
+// cannot name that mutex through the dispatcher's indexed processor selection.
+//
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) notifyProcessor() {
 	// We use TryLock here to avoid deadlocks in cases where a listening endpoint that is being
 	// closed tries to abort half completed connections which in turn try to queue any segments

--- a/pkg/tcpip/transport/tcp/cubic.go
+++ b/pkg/tcpip/transport/tcp/cubic.go
@@ -209,6 +209,7 @@ func (c *cubicState) updateSlowStart(packetsAcked int) int {
 // Refer: https://tools.ietf.org/html/rfc8312#section-4
 //
 // +checklocks:c.s.ep.mu
+// +checklocksexclude:c.s.rtt.rttMutex
 func (c *cubicState) Update(packetsAcked int, rtt time.Duration, ackTime tcpip.MonotonicTime) {
 	if c.s.Ssthresh == InitialSsthresh && c.s.SndCwnd < c.s.Ssthresh {
 		c.updateHyStart(rtt, ackTime)

--- a/pkg/tcpip/transport/tcp/dispatcher.go
+++ b/pkg/tcpip/transport/tcp/dispatcher.go
@@ -35,11 +35,16 @@ import (
 //
 // +stateify savable
 type epQueue struct {
-	mu   epQueueMutex `state:"nosave"`
+	mu epQueueMutex `state:"nosave"`
+
+	// +checklocks:mu
 	list endpointList `state:"nosave"`
 }
 
 // enqueue adds e to the queue if the endpoint is not already on the queue.
+//
+// +checklocksexclude:q.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (q *epQueue) enqueue(e *Endpoint) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -55,6 +60,11 @@ func (q *epQueue) enqueue(e *Endpoint) {
 
 // dequeue removes and returns the first element from the queue if available,
 // returns nil otherwise.
+//
+// The caller must not hold a queued endpoint's pendingProcessingMu. checklocks
+// cannot name that mutex through the endpoint obtained from the queue.
+//
+// +checklocksexclude:q.mu
 func (q *epQueue) dequeue() *Endpoint {
 	q.mu.Lock()
 	if e := q.list.Front(); e != nil {
@@ -70,6 +80,8 @@ func (q *epQueue) dequeue() *Endpoint {
 }
 
 // empty returns true if the queue is empty, false otherwise.
+//
+// +checklocksexclude:q.mu
 func (q *epQueue) empty() bool {
 	q.mu.Lock()
 	v := q.list.Empty()
@@ -94,6 +106,8 @@ func (p *processor) close() {
 	p.closeWaker.Assert()
 }
 
+// +checklocksexclude:p.epQ.mu
+// +checklocksexclude:ep.pendingProcessingMu
 func (p *processor) queueEndpoint(ep *Endpoint) {
 	// Queue an endpoint for processing by the processor goroutine.
 	p.epQ.enqueue(ep)
@@ -136,6 +150,9 @@ func deliverAccepted(ep *Endpoint) bool {
 
 // handleConnecting is responsible for TCP processing for an endpoint in one of
 // the connecting states.
+//
+// +checklocksexclude:ep.segmentQueue.mu
+// +checklocksexclude:ep.pendingProcessingMu
 func handleConnecting(ep *Endpoint) {
 	if !ep.TryLock() {
 		return
@@ -179,6 +196,8 @@ func handleConnecting(ep *Endpoint) {
 
 // handleConnected is responsible for TCP processing for an endpoint in one of
 // the connected states(StateEstablished, StateFinWait1 etc.)
+//
+// +checklocksexclude:ep.segmentQueue.mu
 func handleConnected(ep *Endpoint) {
 	if !ep.TryLock() {
 		return
@@ -228,6 +247,8 @@ func startTimeWait(ep *Endpoint) {
 
 // handleTimeWait is responsible for TCP processing for an endpoint in TIME-WAIT
 // state.
+//
+// +checklocksexclude:ep.segmentQueue.mu
 func handleTimeWait(ep *Endpoint) {
 	if !ep.TryLock() {
 		return
@@ -260,6 +281,8 @@ var warnRateLimiter = rate.NewLimiter(rate.Every(time.Second), 1)
 
 // handleListen is responsible for TCP processing for an endpoint in LISTEN
 // state.
+//
+// +checklocksexclude:ep.segmentQueue.mu
 func handleListen(ep *Endpoint) {
 	if !ep.TryLock() {
 		return
@@ -438,6 +461,11 @@ func (d *dispatcher) wait() {
 
 // queuePacket queues an incoming packet to the matching tcp endpoint and
 // also queues the endpoint to a processor queue for processing.
+//
+// The caller must not hold the target endpoint's segmentQueue.mu or
+// pendingProcessingMu, or the selected processor's queue mutex. checklocks
+// cannot name these locks through stackEP's interface type and the indexed
+// processor selection.
 func (d *dispatcher) queuePacket(stackEP stack.TransportEndpoint, id stack.TransportEndpointID, clock tcpip.Clock, pkt *stack.PacketBuffer) {
 	d.mu.Lock()
 	closed := d.closed

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -286,6 +286,8 @@ func (*Stats) IsEndpointStats() {}
 // +stateify savable
 type sndQueueInfo struct {
 	sndQueueMu sndQueueMutex `state:"nosave"`
+
+	// +checklocks:sndQueueMu
 	TCPSndBufState
 }
 
@@ -1896,7 +1898,10 @@ func (e *Endpoint) OnSetReceiveBufferSize(rcvBufSz, oldSz int64) (newSz int64, p
 
 // OnSetSendBufferSize implements tcpip.SocketOptionsHandler.OnSetSendBufferSize.
 func (e *Endpoint) OnSetSendBufferSize(sz int64) int64 {
-	e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled.Store(1)
+	// Only this atomic flag is accessed without sndQueueMu; checklocks
+	// cannot express that leaf exception to the enclosing state guard.
+	disabled := &e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled // +checklocksignore
+	disabled.Store(1)
 	return sz
 }
 
@@ -3443,7 +3448,10 @@ func (e *Endpoint) computeTCPSendBufferSize() int64 {
 
 	// Auto tuning is disabled when the user explicitly sets the send
 	// buffer size with SO_SNDBUF option.
-	if disabled := e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled.Load(); disabled == 1 {
+	// Only this atomic flag is accessed without sndQueueMu; checklocks
+	// cannot express that leaf exception to the enclosing state guard.
+	disabled := &e.sndQueueInfo.TCPSndBufState.AutoTuneSndBufDisabled // +checklocksignore
+	if disabled.Load() == 1 {
 		return curSndBufSz
 	}
 

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -599,6 +599,8 @@ type Endpoint struct {
 
 	// listenCtx is used by listening endpoints to store state used while listening for
 	// connections. Nil otherwise.
+	// The context remains fixed while child handshakes run. Restore reinstalls
+	// it before releasing the listenLoading barrier and resuming handshakes.
 	listenCtx *listenContext `state:"nosave"`
 
 	// limRdr is reused to avoid allocations.
@@ -714,6 +716,8 @@ func (e *Endpoint) LockUser() {
 //
 // Precondition: e.LockUser() must have been called before calling e.UnlockUser()
 // +checklocksrelease:e.mu
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) UnlockUser() {
 	// Lock segment queue before checking so that we avoid a race where
 	// segments can be queued between the time we check if queue is empty
@@ -1044,6 +1048,9 @@ func (e *Endpoint) purgeWriteQueue() {
 }
 
 // Abort implements stack.TransportEndpoint.Abort.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Abort() {
 	defer e.drainClosingSegmentQueue()
 	e.LockUser()
@@ -1062,6 +1069,9 @@ func (e *Endpoint) Abort() {
 // Close puts the endpoint in a closed state and frees all resources associated
 // with it. It must be called only once and with no other concurrent calls to
 // the endpoint.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Close() {
 	e.LockUser()
 	if e.closed {
@@ -1297,6 +1307,9 @@ func (e *Endpoint) initialReceiveWindow() int {
 
 // ModerateRecvBuf adjusts the receive buffer and the advertised window
 // based on the number of bytes copied to userspace.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) ModerateRecvBuf(copied int) {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -1396,6 +1409,9 @@ func (e *Endpoint) lastErrorLocked() tcpip.Error {
 }
 
 // LastError implements tcpip.Endpoint.LastError.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) LastError() tcpip.Error {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -1413,6 +1429,9 @@ func (e *Endpoint) LastErrorLocked() tcpip.Error {
 }
 
 // UpdateLastError implements tcpip.SocketOptionsHandler.UpdateLastError.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) UpdateLastError(err tcpip.Error) {
 	e.LockUser()
 	e.lastErrorMu.Lock()
@@ -1422,6 +1441,9 @@ func (e *Endpoint) UpdateLastError(err tcpip.Error) {
 }
 
 // Read implements tcpip.Endpoint.Read.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Read(dst io.Writer, opts tcpip.ReadOptions) (tcpip.ReadResult, tcpip.Error) {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -1576,6 +1598,8 @@ func (e *Endpoint) isEndpointWritableLocked() (int, tcpip.Error) {
 // readFromPayloader reads a slice from the Payloader.
 // +checklocks:e.mu
 // +checklocks:e.sndQueueInfo.sndQueueMu
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) readFromPayloader(p tcpip.Payloader, opts tcpip.WriteOptions, avail int) (buffer.Buffer, tcpip.Error) {
 	// We can release locks while copying data.
 	//
@@ -1613,6 +1637,8 @@ func (e *Endpoint) readFromPayloader(p tcpip.Payloader, opts tcpip.WriteOptions,
 
 // queueSegment reads data from the payloader and returns a segment to be sent.
 // +checklocks:e.mu
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) queueSegment(p tcpip.Payloader, opts tcpip.WriteOptions) (*segment, int, tcpip.Error) {
 	e.sndQueueInfo.sndQueueMu.Lock()
 	defer e.sndQueueInfo.sndQueueMu.Unlock()
@@ -1661,6 +1687,9 @@ func (e *Endpoint) queueSegment(p tcpip.Payloader, opts tcpip.WriteOptions) (*se
 }
 
 // Write writes data to the endpoint's peer.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcpip.Error) {
 	// Linux completely ignores any address passed to sendto(2) for TCP sockets
 	// (without the MSG_FASTOPEN flag). Corking is unimplemented, so opts.More
@@ -1754,6 +1783,9 @@ func (e *Endpoint) windowCrossedACKThresholdLocked(deltaBefore int, rcvBufSize i
 }
 
 // OnReuseAddressSet implements tcpip.SocketOptionsHandler.OnReuseAddressSet.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) OnReuseAddressSet(v bool) {
 	e.LockUser()
 	e.portFlags.TupleOnly = v
@@ -1761,6 +1793,9 @@ func (e *Endpoint) OnReuseAddressSet(v bool) {
 }
 
 // OnReusePortSet implements tcpip.SocketOptionsHandler.OnReusePortSet.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) OnReusePortSet(v bool) {
 	e.LockUser()
 	e.portFlags.LoadBalanced = v
@@ -1768,6 +1803,9 @@ func (e *Endpoint) OnReusePortSet(v bool) {
 }
 
 // OnKeepAliveSet implements tcpip.SocketOptionsHandler.OnKeepAliveSet.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) OnKeepAliveSet(bool) {
 	e.LockUser()
 	e.resetKeepaliveTimer(true /* receivedData */)
@@ -1775,6 +1813,9 @@ func (e *Endpoint) OnKeepAliveSet(bool) {
 }
 
 // OnDelayOptionSet implements tcpip.SocketOptionsHandler.OnDelayOptionSet.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) OnDelayOptionSet(v bool) {
 	if !v {
 		e.LockUser()
@@ -1787,6 +1828,9 @@ func (e *Endpoint) OnDelayOptionSet(v bool) {
 }
 
 // OnCorkOptionSet implements tcpip.SocketOptionsHandler.OnCorkOptionSet.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) OnCorkOptionSet(v bool) {
 	if !v {
 		e.LockUser()
@@ -1806,6 +1850,9 @@ func (e *Endpoint) getSendBufferSize() int {
 }
 
 // OnSetReceiveBufferSize implements tcpip.SocketOptionsHandler.OnSetReceiveBufferSize.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) OnSetReceiveBufferSize(rcvBufSz, oldSz int64) (newSz int64, postSet func()) {
 	e.LockUser()
 
@@ -1854,6 +1901,9 @@ func (e *Endpoint) OnSetSendBufferSize(sz int64) int64 {
 }
 
 // WakeupWriters implements tcpip.SocketOptionsHandler.WakeupWriters.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) WakeupWriters() {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -1869,6 +1919,9 @@ func (e *Endpoint) WakeupWriters() {
 }
 
 // SetSockOptInt sets a socket option.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) SetSockOptInt(opt tcpip.SockOptInt, v int) tcpip.Error {
 	// Lower 2 bits represents ECN bits. RFC 3168, section 23.1
 	const inetECNMask = 3
@@ -1969,6 +2022,9 @@ func (e *Endpoint) HasNIC(id int32) bool {
 }
 
 // SetSockOpt sets a socket option.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) SetSockOpt(opt tcpip.SettableSocketOption) tcpip.Error {
 	switch v := opt.(type) {
 	case *tcpip.KeepaliveIdleOption:
@@ -2062,6 +2118,9 @@ func (e *Endpoint) SetSockOpt(opt tcpip.SettableSocketOption) tcpip.Error {
 }
 
 // readyReceiveSize returns the number of bytes ready to be received.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) readyReceiveSize() (int, tcpip.Error) {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2078,6 +2137,9 @@ func (e *Endpoint) readyReceiveSize() (int, tcpip.Error) {
 }
 
 // GetSockOptInt implements tcpip.Endpoint.GetSockOptInt.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) GetSockOptInt(opt tcpip.SockOptInt) (int, tcpip.Error) {
 	switch opt {
 	case tcpip.KeepaliveCountOption:
@@ -2152,6 +2214,14 @@ func (e *Endpoint) GetSockOptInt(opt tcpip.SockOptInt) (int, tcpip.Error) {
 	}
 }
 
+// getTCPInfo snapshots endpoint state and the selected sender's RTT state.
+//
+// The caller must not hold that sender's RTT mutex. The sender is selected
+// after locking e.mu, so checklocks cannot name it in an entry exclusion
+// through the unlocked e.snd association.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) getTCPInfo() tcpip.TCPInfoOption {
 	info := tcpip.TCPInfoOption{}
 	e.LockUser()
@@ -2181,6 +2251,9 @@ func (e *Endpoint) getTCPInfo() tcpip.TCPInfoOption {
 }
 
 // GetSockOpt implements tcpip.Endpoint.GetSockOpt.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) GetSockOpt(opt tcpip.GettableSocketOption) tcpip.Error {
 	switch o := opt.(type) {
 	case *tcpip.TCPInfoOption:
@@ -2252,6 +2325,9 @@ func (*Endpoint) Disconnect() tcpip.Error {
 }
 
 // Connect connects the endpoint to its peer.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Connect(addr tcpip.FullAddress) tcpip.Error {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2405,6 +2481,7 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 
 // connect connects the endpoint to its peer.
 // +checklocks:e.mu
+// +checklocksexclude:e.segmentQueue.mu
 func (e *Endpoint) connect(addr tcpip.FullAddress, handshake bool) tcpip.Error {
 	connectingAddr := addr.Addr
 
@@ -2535,6 +2612,9 @@ func (*Endpoint) ConnectEndpoint(tcpip.Endpoint) tcpip.Error {
 
 // Shutdown closes the read and/or write end of the endpoint connection to its
 // peer.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Shutdown(flags tcpip.ShutdownFlags) tcpip.Error {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2553,6 +2633,7 @@ func (e *Endpoint) Shutdown(flags tcpip.ShutdownFlags) tcpip.Error {
 }
 
 // +checklocks:e.mu
+// +checklocksexclude:e.snd.rtt.rttMutex
 func (e *Endpoint) shutdownLocked(flags tcpip.ShutdownFlags) tcpip.Error {
 	e.shutdownFlags |= flags
 	switch {
@@ -2644,6 +2725,9 @@ func (e *Endpoint) shutdownLocked(flags tcpip.ShutdownFlags) tcpip.Error {
 
 // Listen puts the endpoint in "listen" mode, which allows it to accept
 // new connections.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Listen(backlog int) tcpip.Error {
 	if err := e.listen(backlog); err != nil {
 		if !err.IgnoreStats() {
@@ -2655,6 +2739,8 @@ func (e *Endpoint) Listen(backlog int) tcpip.Error {
 	return nil
 }
 
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) listen(backlog int) tcpip.Error {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2734,6 +2820,9 @@ func (e *Endpoint) listen(backlog int) tcpip.Error {
 // to an endpoint previously set to listen mode.
 //
 // addr if not-nil will contain the peer address of the returned endpoint.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Accept(peerAddr *tcpip.FullAddress) (tcpip.Endpoint, *waiter.Queue, tcpip.Error) {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2763,6 +2852,9 @@ func (e *Endpoint) Accept(peerAddr *tcpip.FullAddress) (tcpip.Endpoint, *waiter.
 }
 
 // Bind binds the endpoint to a specific local port and optionally address.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Bind(addr tcpip.FullAddress) (err tcpip.Error) {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2856,6 +2948,9 @@ func (e *Endpoint) bindLocked(addr tcpip.FullAddress) (err tcpip.Error) {
 }
 
 // GetLocalAddress returns the address to which the endpoint is bound.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) GetLocalAddress() (tcpip.FullAddress, tcpip.Error) {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2868,6 +2963,9 @@ func (e *Endpoint) GetLocalAddress() (tcpip.FullAddress, tcpip.Error) {
 }
 
 // GetRemoteAddress returns the address to which the endpoint is connected.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) GetRemoteAddress() (tcpip.FullAddress, tcpip.Error) {
 	e.LockUser()
 	defer e.UnlockUser()
@@ -2895,6 +2993,7 @@ func (*Endpoint) HandlePacket(stack.TransportEndpointID, *stack.PacketBuffer) {
 	// based on the state of the endpoint.
 }
 
+// +checklocksexclude:e.segmentQueue.mu
 func (e *Endpoint) enqueueSegment(s *segment) bool {
 	// Send packet to worker goroutine.
 	if !e.segmentQueue.enqueue(s) {
@@ -3177,6 +3276,8 @@ func (e *Endpoint) maybeEnableSACKPermitted(synOpts header.TCPSynOptions) {
 }
 
 // maxOptionSize return the maximum size of TCP options.
+//
+// +checklocks:e.mu
 func (e *Endpoint) maxOptionSize() (size int) {
 	var maxSackBlocks [header.TCPMaxSACKBlocks]header.SACKBlock
 	options := e.makeOptions(maxSackBlocks[:])
@@ -3190,6 +3291,7 @@ func (e *Endpoint) maxOptionSize() (size int) {
 // used before invoking the probe.
 //
 // +checklocks:e.mu
+// +checklocksexclude:e.snd.rtt.rttMutex
 func (e *Endpoint) completeStateLocked(s *TCPEndpointState) {
 	s.TCPEndpointStateInner = e.TCPEndpointStateInner
 	s.ID = TCPEndpointID(e.TransportEndpointInfo.ID)
@@ -3263,6 +3365,9 @@ func (e *Endpoint) State() uint32 {
 }
 
 // Info returns a copy of the endpoint info.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Info() tcpip.EndpointInfo {
 	e.LockUser()
 	// Make a copy of the endpoint info.

--- a/pkg/tcpip/transport/tcp/endpoint_state.go
+++ b/pkg/tcpip/transport/tcp/endpoint_state.go
@@ -37,6 +37,9 @@ func logDisconnect() {
 }
 
 // beforeSave is invoked by stateify.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) beforeSave() {
 	// Stop incoming packets.
 	e.segmentQueue.freeze()
@@ -176,6 +179,9 @@ func (e *Endpoint) closeEndpointAtRestore() {
 }
 
 // Restore implements tcpip.RestoredEndpoint.Restore.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) Restore(s *stack.Stack) {
 	if !e.EndpointState().closed() {
 		e.keepalive.timer.init(s.Clock(), timerHandler(e, e.keepaliveTimerExpired))
@@ -363,12 +369,17 @@ func (e *Endpoint) Restore(s *stack.Stack) {
 }
 
 // Resume implements tcpip.ResumableEndpoint.Resume.
+//
+// +checklocksexclude:e.segmentQueue.mu
 func (e *Endpoint) Resume() {
 	e.segmentQueue.thaw()
 }
 
 // requeueOnRestore re-adds the endpoint to its processor's run-queue if it has
 // queued segments. The run-queue is not saved across checkpoint/restore.
+//
+// +checklocksexclude:e.segmentQueue.mu
+// +checklocksexclude:e.pendingProcessingMu
 func (e *Endpoint) requeueOnRestore() {
 	if e.segmentQueue.empty() || e.isOwnedByUser() {
 		return

--- a/pkg/tcpip/transport/tcp/protocol.go
+++ b/pkg/tcpip/transport/tcp/protocol.go
@@ -89,24 +89,42 @@ const (
 type protocol struct {
 	stack *stack.Stack
 
-	mu                         protocolRWMutex `state:"nosave"`
-	sackEnabled                bool
-	recovery                   tcpip.TCPRecovery
-	delayEnabled               bool
-	alwaysUseSynCookies        bool
-	sendBufferSize             tcpip.TCPSendBufferSizeRangeOption
-	recvBufferSize             tcpip.TCPReceiveBufferSizeRangeOption
-	congestionControl          string
+	mu protocolRWMutex `state:"nosave"`
+
+	// +checklocks:mu
+	sackEnabled bool
+	// +checklocks:mu
+	recovery tcpip.TCPRecovery
+	// +checklocks:mu
+	delayEnabled bool
+	// +checklocks:mu
+	alwaysUseSynCookies bool
+	// +checklocks:mu
+	sendBufferSize tcpip.TCPSendBufferSizeRangeOption
+	// +checklocks:mu
+	recvBufferSize tcpip.TCPReceiveBufferSizeRangeOption
+	// +checklocks:mu
+	congestionControl string
+	// availableCongestionControl is immutable after construction.
 	availableCongestionControl []string
-	moderateReceiveBuffer      bool
-	lingerTimeout              time.Duration
-	timeWaitTimeout            time.Duration
-	timeWaitReuse              tcpip.TCPTimeWaitReuseOption
-	minRTO                     time.Duration
-	maxRTO                     time.Duration
-	maxRetries                 uint32
-	synRetries                 uint8
-	dispatcher                 dispatcher
+	// +checklocks:mu
+	moderateReceiveBuffer bool
+	// +checklocks:mu
+	lingerTimeout time.Duration
+	// +checklocks:mu
+	timeWaitTimeout time.Duration
+	// +checklocks:mu
+	timeWaitReuse tcpip.TCPTimeWaitReuseOption
+	// +checklocks:mu
+	minRTO time.Duration
+	// +checklocks:mu
+	maxRTO time.Duration
+	// +checklocks:mu
+	maxRetries uint32
+	// +checklocks:mu
+	synRetries uint8
+
+	dispatcher dispatcher
 
 	// probe, if not nil, will be invoked any time an endpoint receives a
 	// TCP segment.
@@ -259,6 +277,8 @@ func replyWithReset(st *stack.Stack, s *segment, tos, ipv4TTL uint8, ipv6HopLimi
 }
 
 // SetOption implements stack.TransportProtocol.SetOption.
+//
+// +checklocksexclude:p.mu
 func (p *protocol) SetOption(option tcpip.SettableTransportProtocolOption) tcpip.Error {
 	switch v := option.(type) {
 	case *tcpip.TCPSACKEnabled:
@@ -396,6 +416,8 @@ func (p *protocol) SetOption(option tcpip.SettableTransportProtocolOption) tcpip
 }
 
 // Option implements stack.TransportProtocol.Option.
+//
+// +checklocksexclude:p.mu
 func (p *protocol) Option(option tcpip.GettableTransportProtocolOption) tcpip.Error {
 	switch v := option.(type) {
 	case *tcpip.TCPSACKEnabled:
@@ -500,6 +522,8 @@ func (p *protocol) Option(option tcpip.GettableTransportProtocolOption) tcpip.Er
 }
 
 // SendBufferSize implements stack.SendBufSizeProto.
+//
+// +checklocksexclude:p.mu
 func (p *protocol) SendBufferSize() tcpip.TCPSendBufferSizeRangeOption {
 	p.mu.RLock()
 	defer p.mu.RUnlock()

--- a/pkg/tcpip/transport/tcp/rack.go
+++ b/pkg/tcpip/transport/tcp/rack.go
@@ -77,6 +77,8 @@ func (rc *rackControl) init(snd *sender, iss seqnum.Value) {
 
 // update will update the RACK related fields when an ACK has been received.
 // See: https://tools.ietf.org/html/draft-ietf-tcpm-rack-09#section-6.2
+//
+// +checklocks:rc.snd.ep.mu
 func (rc *rackControl) update(seg *segment, ackSeg *segment) {
 	// Compute the RTT sample against the time the ACK was received at ingress
 	// (ackSeg.rcvdTime), not the current clock. The two differ when the ACK was
@@ -156,6 +158,8 @@ func (rc *rackControl) setDSACKSeen(dsackSeen bool) {
 
 // shouldSchedulePTO dictates whether we should schedule a PTO or not.
 // See https://tools.ietf.org/html/draft-ietf-tcpm-rack-08#section-7.5.1.
+//
+// +checklocks:s.ep.mu
 func (s *sender) shouldSchedulePTO() bool {
 	// Schedule PTO only if RACK loss detection is enabled.
 	return s.ep.tcpRecovery&tcpip.TCPRACKLossDetection != 0 &&
@@ -171,6 +175,7 @@ func (s *sender) shouldSchedulePTO() bool {
 // https://tools.ietf.org/html/draft-ietf-tcpm-rack-08#section-7.5.1.
 //
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) schedulePTO() {
 	pto := time.Second
 	s.rtt.Lock()
@@ -197,6 +202,7 @@ func (s *sender) schedulePTO() {
 // https://tools.ietf.org/html/draft-ietf-tcpm-rack-08#section-7.5.2.
 //
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) probeTimerExpired() tcpip.Error {
 	if s.probeTimer.isUninitialized() || !s.probeTimer.checkExpiration() {
 		return nil
@@ -293,6 +299,7 @@ func (s *sender) detectTLPRecovery(ack seqnum.Value, rcvdSeg *segment) {
 //     DUPACKthreshold.
 //
 // +checklocks:rc.snd.ep.mu
+// +checklocksexclude:rc.snd.rtt.rttMutex
 func (rc *rackControl) updateRACKReorderWindow() {
 	dsackSeen := rc.DSACKSeen
 	snd := rc.snd
@@ -403,6 +410,7 @@ func (rc *rackControl) detectLoss(rcvTime tcpip.MonotonicTime) int {
 // before the reorder timer expired.
 //
 // +checklocks:rc.snd.ep.mu
+// +checklocksexclude:rc.snd.rtt.rttMutex
 func (rc *rackControl) reorderTimerExpired() tcpip.Error {
 	if rc.snd.reorderTimer.isUninitialized() || !rc.snd.reorderTimer.checkExpiration() {
 		return nil
@@ -437,6 +445,7 @@ func (rc *rackControl) reorderTimerExpired() tcpip.Error {
 // DoRecovery implements lossRecovery.DoRecovery.
 //
 // +checklocks:rc.snd.ep.mu
+// +checklocksexclude:rc.snd.rtt.rttMutex
 func (rc *rackControl) DoRecovery(_ *segment, fastRetransmit bool) {
 	snd := rc.snd
 	if fastRetransmit {

--- a/pkg/tcpip/transport/tcp/sack_recovery.go
+++ b/pkg/tcpip/transport/tcp/sack_recovery.go
@@ -104,6 +104,7 @@ func (sr *sackRecovery) handleSACKRecovery(limit int, end seqnum.Value) (dataSen
 }
 
 // +checklocks:sr.s.ep.mu
+// +checklocksexclude:sr.s.rtt.rttMutex
 func (sr *sackRecovery) DoRecovery(rcvdSeg *segment, fastRetransmit bool) {
 	snd := sr.s
 	if fastRetransmit {

--- a/pkg/tcpip/transport/tcp/segment_queue.go
+++ b/pkg/tcpip/transport/tcp/segment_queue.go
@@ -18,19 +18,24 @@ package tcp
 //
 // +stateify savable
 type segmentQueue struct {
-	mu     segmentQueueMutex `state:"nosave"`
-	list   segmentList       `state:"wait"`
-	ep     *Endpoint
+	mu segmentQueueMutex `state:"nosave"`
+	// +checklocks:mu
+	list segmentList `state:"wait"`
+	ep   *Endpoint
+	// +checklocks:mu
 	frozen bool
 }
 
-// emptyLocked determines if the queue is empty.
-// Preconditions: q.mu must be held.
+// emptyLocked is equivalent to empty with q.mu already held.
+//
+// +checklocks:q.mu
 func (q *segmentQueue) emptyLocked() bool {
 	return q.list.Empty()
 }
 
 // empty determines if the queue is empty.
+//
+// +checklocksexclude:q.mu
 func (q *segmentQueue) empty() bool {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -39,13 +44,11 @@ func (q *segmentQueue) empty() bool {
 
 // enqueue adds the given segment to the queue.
 //
-// Returns true when the segment is successfully added to the queue, in which
-// case ownership of the reference is transferred to the queue. And returns
-// false if the queue is full, in which case ownership is retained by the
-// caller.
+// If enqueue succeeds, the queue acquires its own reference and returns true.
+// Otherwise it returns false. The caller retains its reference in either case.
+//
+// +checklocksexclude:q.mu
 func (q *segmentQueue) enqueue(s *segment) bool {
-	// q.ep.receiveBufferParams() must be called without holding q.mu to
-	// avoid lock order inversion.
 	bufSz := q.ep.ops.GetReceiveBufferSize()
 	used := q.ep.receiveMemUsed()
 
@@ -69,6 +72,8 @@ func (q *segmentQueue) enqueue(s *segment) bool {
 // dequeue removes and returns the next segment from queue, if one exists.
 // Ownership is transferred to the caller, who is responsible for decrementing
 // the ref count when done.
+//
+// +checklocksexclude:q.mu
 func (q *segmentQueue) dequeue() *segment {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -84,6 +89,8 @@ func (q *segmentQueue) dequeue() *segment {
 // freeze prevents any more segments from being added to the queue. i.e all
 // future segmentQueue.enqueue will return false and not add the segment to the
 // queue till the queue is unfroze with a corresponding segmentQueue.thaw call.
+//
+// +checklocksexclude:q.mu
 func (q *segmentQueue) freeze() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
@@ -92,6 +99,8 @@ func (q *segmentQueue) freeze() {
 
 // thaw unfreezes a previously frozen queue using segmentQueue.freeze() and
 // allows new segments to be queued again.
+//
+// +checklocksexclude:q.mu
 func (q *segmentQueue) thaw() {
 	q.mu.Lock()
 	defer q.mu.Unlock()

--- a/pkg/tcpip/transport/tcp/snd.go
+++ b/pkg/tcpip/transport/tcp/snd.go
@@ -247,9 +247,14 @@ func (wl *protectedWriteList) InsertAfter(before, seg *segment) {
 type rtt struct {
 	rttMutex `state:"nosave"`
 
+	// +checklocks:rttMutex
 	TCPRTTState
 }
 
+// initSender creates a new sender while the endpoint is locked. Its helpers
+// may acquire the new sender's RTT mutex, which cannot be held by the caller.
+// This imposes no exclusion on the previous ep.snd's RTT mutex.
+//
 // +checklocks:ep.mu
 func initSender(ep *Endpoint, iss, irs seqnum.Value, sndWnd seqnum.Size, mss uint16, sndWndScale int) {
 	// The sender MUST reduce the TCP data length to account for any IP or
@@ -346,6 +351,8 @@ func (s *sender) initCongestionControl(congestionControlName tcpip.CongestionCon
 }
 
 // initLossRecovery initiates the loss recovery algorithm for the sender.
+//
+// +checklocks:s.ep.mu
 func (s *sender) initLossRecovery() lossRecovery {
 	if s.ep.SACKPermitted {
 		return newSACKRecovery(s)
@@ -358,6 +365,7 @@ func (s *sender) initLossRecovery() lossRecovery {
 // by the count argument), it also reduces the number of outstanding packets and
 // attempts to retransmit the first packet above the MTU size.
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) updateMaxPayloadSize(mtu, count int) {
 	m := mtu - header.TCPMinimumSize
 
@@ -433,6 +441,7 @@ func (s *sender) sendAck() {
 // available. This is done in accordance with section 2 of RFC 6298.
 //
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) updateRTO(rtt time.Duration) {
 	// A negative RTT sample is nonsensical and would skew SRTT/RTTVar (and thus
 	// RTO). RTT samples are now anchored to a segment's ingress time, which is
@@ -532,6 +541,7 @@ func (s *sender) resendSegment() {
 // Returns true if the connection is still usable, or false if the connection
 // is deemed lost.
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) retransmitTimerExpired() tcpip.Error {
 	// Check if the timer actually expired or if it's a spurious wake due
 	// to a previously orphaned runtime timer.
@@ -1043,6 +1053,7 @@ func (s *sender) disableZeroWindowProbing() {
 }
 
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) postXmit(dataSent bool, shouldScheduleProbe bool) {
 	if dataSent {
 		// We sent data, so we should stop the keepalive timer to ensure
@@ -1079,6 +1090,7 @@ func (s *sender) postXmit(dataSent bool, shouldScheduleProbe bool) {
 // sendData sends new data segments. It is called when data becomes available or
 // when the send window opens up.
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) sendData() {
 	limit := s.MaxPayloadSize
 	if s.gso {
@@ -1430,6 +1442,7 @@ func checkDSACK(rcvdSeg *segment) bool {
 	return false
 }
 
+// +checklocks:s.ep.mu
 func (s *sender) recordRetransmitTS() {
 	// See: https://datatracker.ietf.org/doc/html/rfc3522#section-3.2
 	//
@@ -1520,6 +1533,7 @@ func (s *sender) inRecovery() bool {
 // handleRcvdSegment is called when a segment is received; it is responsible for
 // updating the send-related state.
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) handleRcvdSegment(rcvdSeg *segment) {
 	bestRTT := unknownRTT
 
@@ -1888,6 +1902,7 @@ func (s *sender) updateWriteNext(seg *segment) {
 
 // corkTimerExpired drains all the segments when TCP_CORK is enabled.
 // +checklocks:s.ep.mu
+// +checklocksexclude:s.rtt.rttMutex
 func (s *sender) corkTimerExpired() tcpip.Error {
 	// Check if the timer actually expired or if it's a spurious wake due
 	// to a previously orphaned runtime timer.

--- a/pkg/tcpip/transport/udp/endpoint.go
+++ b/pkg/tcpip/transport/udp/endpoint.go
@@ -80,17 +80,25 @@ type endpoint struct {
 	rcvClosed bool
 
 	lastErrorMu sync.Mutex `state:"nosave"`
-	lastError   tcpip.Error
+
+	// +checklocks:lastErrorMu
+	lastError tcpip.Error
 
 	// mu protects the endpoint's port and binding state and readShutdown.
-	mu        sync.RWMutex `state:"nosave"`
+	mu sync.RWMutex `state:"nosave"`
+
+	// +checklocks:mu
 	portFlags ports.Flags
 
-	// Values used to reserve a port or register a transport endpoint.
-	// (which ever happens first).
+	// Values used to reserve a port or register a transport endpoint,
+	// whichever happens first.
+	//
+	// +checklocks:mu
 	boundBindToDevice tcpip.NICID
-	boundPortFlags    ports.Flags
+	// +checklocks:mu
+	boundPortFlags ports.Flags
 
+	// +checklocks:mu
 	readShutdown bool
 
 	// effectiveNetProtos contains the network protocols actually in use. In
@@ -99,6 +107,8 @@ type endpoint struct {
 	// protocols (e.g., IPv6 and IPv4) or a single different protocol (e.g.,
 	// IPv4 when IPv6 endpoint is bound or connected to an IPv4 mapped
 	// address).
+	//
+	// +checklocks:mu
 	effectiveNetProtos []tcpip.NetworkProtocolNumber
 
 	// frozen prevents packet delivery during save/restore.
@@ -106,7 +116,9 @@ type endpoint struct {
 	// +checklocks:rcvMu
 	frozen bool
 
-	localPort  uint16
+	// +checklocks:mu
+	localPort uint16
+	// +checklocks:mu
 	remotePort uint16
 }
 
@@ -140,6 +152,9 @@ func (e *endpoint) WakeupWriters() {
 	e.net.MaybeSignalWritable()
 }
 
+// LastError implements tcpip.SocketOptionsHandler.
+//
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) LastError() tcpip.Error {
 	e.lastErrorMu.Lock()
 	defer e.lastErrorMu.Unlock()
@@ -150,6 +165,8 @@ func (e *endpoint) LastError() tcpip.Error {
 }
 
 // UpdateLastError implements tcpip.SocketOptionsHandler.
+//
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) UpdateLastError(err tcpip.Error) {
 	e.lastErrorMu.Lock()
 	e.lastError = err
@@ -159,6 +176,7 @@ func (e *endpoint) UpdateLastError(err tcpip.Error) {
 // Abort implements stack.TransportEndpoint.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) Abort() {
 	e.Close()
 }
@@ -167,6 +185,7 @@ func (e *endpoint) Abort() {
 // associated with it.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) Close() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -227,6 +246,7 @@ func (*endpoint) ModerateRecvBuf(int) {}
 // Read implements tcpip.Endpoint.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) Read(dst io.Writer, opts tcpip.ReadOptions) (tcpip.ReadResult, tcpip.Error) {
 	if err := e.LastError(); err != nil {
 		return tcpip.ReadResult{}, err
@@ -369,6 +389,7 @@ var _ tcpip.EndpointWithPreflight = (*endpoint)(nil)
 // is specified, binds the endpoint to that address.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) Preflight(opts tcpip.WriteOptions) tcpip.Error {
 	var r bytes.Reader
 	udpInfo, err := e.prepareForWrite(&r, opts)
@@ -382,6 +403,8 @@ func (e *endpoint) Preflight(opts tcpip.WriteOptions) tcpip.Error {
 // if the data cannot be written.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) Write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcpip.Error) {
 	n, err := e.write(p, opts)
 	switch err.(type) {
@@ -404,6 +427,7 @@ func (e *endpoint) Write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcp
 }
 
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) prepareForWrite(p tcpip.Payloader, opts tcpip.WriteOptions) (udpPacketInfo, tcpip.Error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -465,17 +489,13 @@ func (e *endpoint) prepareForWrite(p tcpip.Payloader, opts tcpip.WriteOptions) (
 }
 
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcpip.Error) {
-	// Do not hold lock when sending as loopback is synchronous and if the UDP
-	// datagram ends up generating an ICMP response then it can result in a
-	// deadlock where the ICMP response handling ends up acquiring this endpoint's
-	// mutex using e.mu.RLock() in endpoint.HandleControlPacket which can cause a
-	// deadlock if another caller is trying to acquire e.mu in exclusive mode w/
-	// e.mu.Lock(). Since e.mu.Lock() prevents any new read locks to ensure the
-	// lock can be eventually acquired.
-	//
-	// See: https://golang.org/pkg/sync/#RWMutex for details on why recursive read
-	// locking is prohibited.
+	// prepareForWrite releases e.mu before sending. Loopback delivery is
+	// synchronous, so an ICMP response can reenter onICMPError, which takes
+	// e.mu.RLock(). Holding e.mu for a send can deadlock, including if a writer
+	// is waiting when onICMPError tries to take a second read lock.
 
 	if err := e.LastError(); err != nil {
 		return 0, err
@@ -551,6 +571,8 @@ func (e *endpoint) write(p tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcp
 }
 
 // OnReuseAddressSet implements tcpip.SocketOptionsHandler.
+//
+// +checklocksexclude:e.mu
 func (e *endpoint) OnReuseAddressSet(v bool) {
 	e.mu.Lock()
 	e.portFlags.MostRecent = v
@@ -558,6 +580,8 @@ func (e *endpoint) OnReuseAddressSet(v bool) {
 }
 
 // OnReusePortSet implements tcpip.SocketOptionsHandler.
+//
+// +checklocksexclude:e.mu
 func (e *endpoint) OnReusePortSet(v bool) {
 	e.mu.Lock()
 	e.portFlags.LoadBalanced = v
@@ -614,6 +638,8 @@ type udpPacketInfo struct {
 }
 
 // Disconnect implements tcpip.Endpoint.
+//
+// +checklocksexclude:e.mu
 func (e *endpoint) Disconnect() tcpip.Error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -675,12 +701,16 @@ func (e *endpoint) Disconnect() tcpip.Error {
 // Connect connects the endpoint to its peer. Specifying a NIC is optional.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) Connect(addr tcpip.FullAddress) tcpip.Error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	err := e.net.ConnectAndThen(addr, func(netProto tcpip.NetworkProtocolNumber, previousID, nextID stack.TransportEndpointID) tcpip.Error {
-		nextID.LocalPort = e.localPort
+		// ConnectAndThen invokes this callback synchronously while Connect
+		// holds e.mu. checklocks cannot propagate the captured lock into
+		// a passed callback, so only the guarded accesses and call are ignored.
+		nextID.LocalPort = e.localPort // +checklocksignore
 		nextID.RemotePort = addr.Port
 
 		// Even if we're connected, this endpoint can still be used to send
@@ -694,24 +724,24 @@ func (e *endpoint) Connect(addr tcpip.FullAddress) tcpip.Error {
 			}
 		}
 
-		oldPortFlags := e.boundPortFlags
+		oldPortFlags := e.boundPortFlags // +checklocksignore
 
 		// Remove the old registration.
-		if e.localPort != 0 {
-			previousID.LocalPort = e.localPort
-			previousID.RemotePort = e.remotePort
-			e.stack.UnregisterTransportEndpoint(e.effectiveNetProtos, ProtocolNumber, previousID, e, oldPortFlags, e.boundBindToDevice)
+		if e.localPort != 0 { // +checklocksignore
+			previousID.LocalPort = e.localPort                                                                                          // +checklocksignore
+			previousID.RemotePort = e.remotePort                                                                                        // +checklocksignore
+			e.stack.UnregisterTransportEndpoint(e.effectiveNetProtos, ProtocolNumber, previousID, e, oldPortFlags, e.boundBindToDevice) // +checklocksignore
 		}
 
-		nextID, btd, err := e.registerWithStack(netProtos, nextID)
+		nextID, btd, err := e.registerWithStack(netProtos, nextID) // +checklocksignore
 		if err != nil {
 			return err
 		}
 
-		e.localPort = nextID.LocalPort
-		e.remotePort = nextID.RemotePort
-		e.boundBindToDevice = btd
-		e.effectiveNetProtos = netProtos
+		e.localPort = nextID.LocalPort   // +checklocksignore
+		e.remotePort = nextID.RemotePort // +checklocksignore
+		e.boundBindToDevice = btd        // +checklocksignore
+		e.effectiveNetProtos = netProtos // +checklocksignore
 		return nil
 	})
 	if err != nil {
@@ -733,6 +763,7 @@ func (*endpoint) ConnectEndpoint(tcpip.Endpoint) tcpip.Error {
 // to its peer.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) Shutdown(flags tcpip.ShutdownFlags) tcpip.Error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -780,6 +811,9 @@ func (*endpoint) Accept(*tcpip.FullAddress) (tcpip.Endpoint, *waiter.Queue, tcpi
 	return nil, nil, &tcpip.ErrNotSupported{}
 }
 
+// registerWithStack registers id, reserving a port if needed.
+//
+// +checklocks:e.mu
 func (e *endpoint) registerWithStack(netProtos []tcpip.NetworkProtocolNumber, id stack.TransportEndpointID) (stack.TransportEndpointID, tcpip.NICID, tcpip.Error) {
 	bindToDevice := tcpip.NICID(e.ops.GetBindToDevice())
 	if e.localPort == 0 {
@@ -829,6 +863,10 @@ func (e *endpoint) bindLocked(addr tcpip.FullAddress) tcpip.Error {
 	}
 
 	err := e.net.BindAndThen(addr, func(boundNetProto tcpip.NetworkProtocolNumber, boundAddr tcpip.Address) tcpip.Error {
+		// BindAndThen invokes this callback synchronously while bindLocked
+		// holds e.mu. checklocks cannot propagate the captured lock into
+		// a passed callback, so only the guarded accesses and call are ignored.
+
 		// Expand netProtos to include v4 and v6 if the caller is binding to a
 		// wildcard (empty) address, and this is an IPv6 endpoint with v6only
 		// set to false.
@@ -844,14 +882,14 @@ func (e *endpoint) bindLocked(addr tcpip.FullAddress) tcpip.Error {
 			LocalPort:    addr.Port,
 			LocalAddress: boundAddr,
 		}
-		id, btd, err := e.registerWithStack(netProtos, id)
+		id, btd, err := e.registerWithStack(netProtos, id) // +checklocksignore
 		if err != nil {
 			return err
 		}
 
-		e.localPort = id.LocalPort
-		e.boundBindToDevice = btd
-		e.effectiveNetProtos = netProtos
+		e.localPort = id.LocalPort       // +checklocksignore
+		e.boundBindToDevice = btd        // +checklocksignore
+		e.effectiveNetProtos = netProtos // +checklocksignore
 		return nil
 	})
 	if err != nil {
@@ -868,6 +906,7 @@ func (e *endpoint) bindLocked(addr tcpip.FullAddress) tcpip.Error {
 // Specifying a NIC is optional.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) Bind(addr tcpip.FullAddress) tcpip.Error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -881,6 +920,8 @@ func (e *endpoint) Bind(addr tcpip.FullAddress) tcpip.Error {
 }
 
 // GetLocalAddress returns the address to which the endpoint is bound.
+//
+// +checklocksexclude:e.mu
 func (e *endpoint) GetLocalAddress() (tcpip.FullAddress, tcpip.Error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -891,6 +932,8 @@ func (e *endpoint) GetLocalAddress() (tcpip.FullAddress, tcpip.Error) {
 }
 
 // GetRemoteAddress returns the address to which the endpoint is connected.
+//
+// +checklocksexclude:e.mu
 func (e *endpoint) GetRemoteAddress() (tcpip.FullAddress, tcpip.Error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -908,6 +951,7 @@ func (e *endpoint) GetRemoteAddress() (tcpip.FullAddress, tcpip.Error) {
 // waiter.EventIn is set, the endpoint is immediately readable.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) Readiness(mask waiter.EventMask) waiter.EventMask {
 	var result waiter.EventMask
 
@@ -1031,6 +1075,8 @@ func (e *endpoint) HandlePacket(id stack.TransportEndpointID, pkt *stack.PacketB
 	}
 }
 
+// +checklocksexclude:e.mu
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) onICMPError(err tcpip.Error, transErr stack.TransportError, pkt *stack.PacketBuffer) {
 	// Update last error first.
 	e.lastErrorMu.Lock()
@@ -1081,6 +1127,9 @@ func (e *endpoint) onICMPError(err tcpip.Error, transErr stack.TransportError, p
 }
 
 // HandleError implements stack.TransportEndpoint.
+//
+// +checklocksexclude:e.mu
+// +checklocksexclude:e.lastErrorMu
 func (e *endpoint) HandleError(transErr stack.TransportError, pkt *stack.PacketBuffer) {
 	// TODO(gvisor.dev/issues/5270): Handle all transport errors.
 	switch transErr.Kind() {
@@ -1097,6 +1146,8 @@ func (e *endpoint) State() uint32 {
 }
 
 // Info returns a copy of the endpoint info.
+//
+// +checklocksexclude:e.mu
 func (e *endpoint) Info() tcpip.EndpointInfo {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -1120,6 +1171,11 @@ func (e *endpoint) SetOwner(owner tcpip.PacketOwner) {
 }
 
 // SocketOptions implements tcpip.Endpoint.
+//
+// Setting reuse options calls back into this endpoint and requires e.mu to be
+// unlocked. Getting or setting the last error likewise requires e.lastErrorMu
+// to be unlocked. checklocks cannot express these endpoint-specific locks
+// through the SocketOptionsHandler interface stored in the returned options.
 func (e *endpoint) SocketOptions() *tcpip.SocketOptions {
 	return &e.ops
 }

--- a/pkg/tcpip/transport/udp/endpoint_state.go
+++ b/pkg/tcpip/transport/udp/endpoint_state.go
@@ -49,6 +49,7 @@ func (e *endpoint) beforeSave() {
 // Restore implements stack.RestoredEndpoint.Restore.
 //
 // +checklocksexclude:e.rcvMu
+// +checklocksexclude:e.mu
 func (e *endpoint) Restore(s *stack.Stack) {
 	e.mu.Lock()
 	defer e.mu.Unlock()


### PR DESCRIPTION
Annotate existing lock and atomic-access contracts for socket metadata, port reservations, link endpoints and TCP/UDP state. Isolate TCP's unlocked atomic-flag accesses so checklocks can verify the surrounding send-buffer and RTT state.

Part of #14349.

Assisted-by: Codex