### PR TITLE
Fix ARM64 compare-and-swap in race builds

### DIFF
--- a/pkg/sync/gate_test.go
+++ b/pkg/sync/gate_test.go
@@ -37,6 +37,18 @@ func TestGateBasic(t *testing.T) {
 	}
 }
 
+func TestRaceUncheckedAtomicCompareAndSwapUintptr(t *testing.T) {
+	// Gate's park callback needs distinct old and new operands even when the
+	// primitive uses race-detector-free assembly.
+	value := uintptr(1)
+	if swapped := RaceUncheckedAtomicCompareAndSwapUintptr(&value, 1, 2); !swapped || value != 2 {
+		t.Fatalf("CAS(1, 2) = %t, value = %d; want true, 2", swapped, value)
+	}
+	if swapped := RaceUncheckedAtomicCompareAndSwapUintptr(&value, 1, 3); swapped || value != 2 {
+		t.Fatalf("CAS(1, 3) = %t, value = %d; want false, 2", swapped, value)
+	}
+}
+
 func TestGateConcurrent(t *testing.T) {
 	// Each call to testGateConcurrentOnce tests behavior around a single call
 	// to Gate.Close, so run many short tests to increase the probability of

--- a/pkg/sync/race_arm64.s
+++ b/pkg/sync/race_arm64.s
@@ -21,7 +21,7 @@
 TEXT ·RaceUncheckedAtomicCompareAndSwapUintptr(SB),NOSPLIT,$0-25
 	MOVD ptr+0(FP), R0
 	MOVD old+8(FP), R1
-	MOVD new+16(FP), R1
+	MOVD new+16(FP), R2
 again:
 	LDAXR (R0), R3
 	CMP R1, R3


### PR DESCRIPTION
The ARM64 race-build CAS loads the replacement into the expected-value register, breaking gate parking state updates. Load it into the store register instead.

Part of #14349.

Assisted-by: Codex