### PR TITLE
Fix compression cleanup and shared utility races

### DIFF
--- a/pkg/compressio/compressio.go
+++ b/pkg/compressio/compressio.go
@@ -71,6 +71,11 @@ var chunkPool = sync.Pool{
 }
 
 // chunk is a unit of work.
+//
+// Sending a chunk on a worker's input transfers its mutable state and buffers
+// to that worker until the result is received. Inline buffers alias caller
+// storage, so Read and Write must receive their results before returning,
+// including on error. checklocks cannot express this channel-based ownership.
 type chunk struct {
 	// compressed is compressed data.
 	//
@@ -128,12 +133,13 @@ type result struct {
 // The goroutine will exit when input is closed, and the goroutine will close
 // output.
 type worker struct {
+	// These handles are initialized before work starts, then immutable.
 	hashPool *hashPool
 	input    chan *chunk
 	output   chan result
 
 	// scratch is a temporary buffer used for marshalling. This is declared
-	// unfront here to avoid reallocation.
+	// up front here to avoid reallocation. Only this worker's goroutine uses it.
 	scratch [4]byte
 }
 
@@ -209,19 +215,23 @@ func (w *worker) work(compress bool, level int) {
 }
 
 type hashPool struct {
-	// mu protects the hash list.
 	mu sync.Mutex
 
-	// key is the key used to create hash objects.
+	// key is a private copy of the key used to create hash objects. It is
+	// immutable after construction, including during lazy worker setup.
 	key []byte
 
 	// hashes is the hash object free list. Note that this cannot be
 	// globally shared across readers or writers, as it is key-specific.
+	//
+	// +checklocks:mu
 	hashes []hash.Hash
 }
 
 // getHash gets a hash object for the pool. It should only be called when the
-// pool key is non-nil.
+// pool key is non-empty.
+//
+// +checklocksexclude:p.mu
 func (p *hashPool) getHash() hash.Hash {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -235,6 +245,9 @@ func (p *hashPool) getHash() hash.Hash {
 	return h
 }
 
+// putHash resets h and returns it to the free list.
+//
+// +checklocksexclude:p.mu
 func (p *hashPool) putHash(h hash.Hash) {
 	h.Reset()
 
@@ -246,42 +259,63 @@ func (p *hashPool) putHash(h hash.Hash) {
 
 // pool is common functionality for reader/writers.
 type pool struct {
+	// mu serializes construction, Reader.Read, Writer.Write, Writer.Close,
+	// and finalizer cleanup, including synchronous completion callbacks.
+	mu sync.Mutex
+
 	// workers are the compression/decompression workers.
+	//
+	// +checklocks:mu
 	workers []worker
 
 	// chunkSize is the chunk size. This is the first four bytes in the
-	// stream and is shared across both the reader and writer.
+	// stream and is shared across both the reader and writer. It is immutable
+	// after construction.
 	chunkSize uint32
 
-	// mu protects below; it is generally the responsibility of users to
-	// acquire this mutex before calling any methods on the pool.
-	mu sync.Mutex
-
 	// nextInput is the next worker for input (scheduling).
+	//
+	// +checklocks:mu
 	nextInput int
 
 	// nextOutput is the next worker for output (result).
+	//
+	// +checklocks:mu
 	nextOutput int
 
 	// buf is the current active buffer; the exact semantics of this buffer
-	// depending on whether this is a reader or a writer.
+	// depend on whether this is a reader or a writer.
+	//
+	// +checklocks:mu
 	buf *bytes.Buffer
 
-	// lasSum records the hash of the last chunk processed.
+	// err is the first returned terminal Read or Write error. Submitted work is
+	// drained before returning it, so later calls must not schedule more work.
+	//
+	// +checklocks:mu
+	err error
+
+	// lastSum records the hash of the last chunk processed.
+	//
+	// +checklocks:mu
 	lastSum []byte
 
 	// hashPool is the hash object pool. It cannot be embedded into pool
 	// itself as worker refers to it and that would stop pool from being
 	// GCed.
+	//
+	// +checklocks:mu
 	hashPool *hashPool
 }
 
 // init initializes the worker pool.
 //
 // This should only be called once.
+//
+// +checklocks:p.mu
 func (p *pool) init(key []byte, workers int, compress bool, level int) {
 	if len(key) > 0 {
-		p.hashPool = &hashPool{key: key}
+		p.hashPool = &hashPool{key: bytes.Clone(key)}
 	}
 	p.workers = make([]worker, workers)
 	for i := 0; i < len(p.workers); i++ {
@@ -292,19 +326,28 @@ func (p *pool) init(key []byte, workers int, compress bool, level int) {
 		}
 		go p.workers[i].work(compress, level) // S/R-SAFE: In save path only.
 	}
-	runtime.SetFinalizer(p, (*pool).stop)
+	runtime.SetFinalizer(p, func(p *pool) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.stop()
+	})
 }
 
-// stop stops all workers.
+// stop closes worker inputs and drains all submitted work. Worker goroutines
+// may still be exiting when it returns, but no longer access submitted buffers.
+//
+// +checklocks:p.mu
 func (p *pool) stop() {
 	for i := 0; i < len(p.workers); i++ {
 		close(p.workers[i].input)
 	}
-	// Wait for all workers to finish since p.schedule(c=nil) may have returned
+	// Drain outstanding results since p.schedule(c=nil) may have returned
 	// early if any worker emitted an error.
 	if len(p.workers) != 0 {
 		for p.nextOutput < p.nextInput {
-			handleResult(<-p.workers[(p.nextOutput+1)%len(p.workers)].output, func(*chunk) error {
+			// Reclaim completed chunks even if their work failed. No results
+			// are delivered to the caller during cleanup.
+			_ = handleResult(<-p.workers[(p.nextOutput+1)%len(p.workers)].output, func(*chunk) error {
 				return nil
 			})
 			p.nextOutput++
@@ -314,11 +357,15 @@ func (p *pool) stop() {
 	p.hashPool = nil
 }
 
-// handleResult calls the callback.
+// handleResult calls callback synchronously if r.err is nil, then recycles the
+// chunk. callback may retain the uncompressed buffer, but not the chunk itself.
 func handleResult(r result, callback func(*chunk) error) error {
 	defer func() {
 		r.chunk.compressed.Reset()
 		bufPool.Put(r.chunk.compressed)
+		// Inline chunks can reference caller-owned storage. Drop those
+		// references without returning the caller's buffer to bufPool.
+		*r.chunk = chunk{}
 		chunkPool.Put(r.chunk)
 	}()
 	if r.err != nil {
@@ -334,6 +381,12 @@ func handleResult(r result, callback func(*chunk) error) error {
 //
 // If no callback function is provided, then the output channel will be
 // ignored.  You must be sure that the input is schedulable in this case.
+//
+// callback is invoked synchronously with p.mu held. It must preserve that lock
+// and not reenter methods that acquire it. checklocks does not propagate the
+// held lock through this callback parameter.
+//
+// +checklocks:p.mu
 func (p *pool) schedule(c *chunk, callback func(*chunk) error) error {
 	for {
 		var (
@@ -367,17 +420,20 @@ func (p *pool) schedule(c *chunk, callback func(*chunk) error) error {
 type Reader struct {
 	pool
 
-	// in is the source.
+	// in is the source; the interface value is immutable. Read calls it with
+	// mu held, so it must not reenter Reader.Read.
 	in io.ReadCloser
 
 	// scratch is a temporary buffer used for marshalling. This is declared
 	// unfront here to avoid reallocation.
+	//
+	// +checklocks:mu
 	scratch [4]byte
 }
 
 var _ io.Reader = (*Reader)(nil)
 
-// NewReader returns a new compressed reader. If key is non-nil, the data stream
+// NewReader returns a new compressed reader. If key is non-empty, the data stream
 // is assumed to contain expected hash values, which will be compared against
 // hash values computed from the compressed bytes. See package comments for
 // details.
@@ -385,6 +441,10 @@ func NewReader(in io.ReadCloser, key []byte) (*Reader, error) {
 	r := &Reader{
 		in: in,
 	}
+	// init registers a finalizer. Order subsequent initialization before
+	// finalizer cleanup, including when a header read fails.
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	// Use double buffering for read.
 	r.init(key, 2*runtime.GOMAXPROCS(0), false, 0)
@@ -422,13 +482,24 @@ var errNewBuffer = errors.New("buffer ready")
 var ErrHashMismatch = errors.New("hash mismatch")
 
 // Read implements io.Reader.Read.
-func (r *Reader) Read(p []byte) (int, error) {
+//
+// +checklocksexclude:r.mu
+func (r *Reader) Read(p []byte) (done int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Total bytes completed; this is declared up front because it must be
-	// adjustable by the callback below.
-	done := 0
+	if r.err != nil {
+		return 0, r.err
+	}
+	defer func() {
+		if err != nil {
+			r.err = err
+			// Workers may still be writing directly into p, even when an
+			// input read or an earlier worker failed.
+			r.stop()
+			r.buf = nil
+		}
+	}()
 
 	// Total bytes pending in the asynchronous workers for buffers. This is
 	// used to process the proper regions of the input as inline buffers.
@@ -450,11 +521,13 @@ func (r *Reader) Read(p []byte) (int, error) {
 		// return errNewBuffer to ensure that we aren't called a second
 		// time. This error code is handled specially below.
 		//
-		// c.buf will be freed and return to the pool when it is done.
+		// Read returns c.uncompressed to bufPool after consuming it.
 		if pendingPre > 0 {
 			pendingPre--
 		}
-		r.buf = c.uncompressed
+		// schedule invokes this callback with r.mu held, but checklocks does
+		// not propagate the lock state through the callback parameter.
+		r.buf = c.uncompressed // +checklocksignore
 		return errNewBuffer
 	}
 
@@ -471,7 +544,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 				r.buf = nil
 			} else if err != nil {
 				// Should never happen.
-				defer r.stop()
 				return done, err
 			}
 			continue
@@ -489,7 +561,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 			if err := r.schedule(nil, callback); err == nil {
 				// We've actually finished all buffers; this is
 				// the normal EOF exit path.
-				defer r.stop()
 				return done, io.EOF
 			} else if err == errNewBuffer {
 				// A new buffer is now available.
@@ -497,7 +568,6 @@ func (r *Reader) Read(p []byte) (int, error) {
 			} else {
 				// Some other error occurred; we cannot
 				// process any further.
-				defer r.stop()
 				return done, err
 			}
 		}
@@ -547,10 +617,9 @@ func (r *Reader) Read(p []byte) (int, error) {
 			//
 			// It is safe to pass nil as an output function here,
 			// because we know that we just freed up a slot above.
-			r.schedule(c, nil)
+			_ = r.schedule(c, nil)
 		} else if err != nil {
 			// Some other error occurred; see above.
-			defer r.stop()
 			return done, err
 		}
 	}
@@ -563,8 +632,8 @@ func (r *Reader) Read(p []byte) (int, error) {
 				return err
 			}
 			// The nil case means that an inline buffer has
-			// completed. The callback will have already removed
-			// the inline buffer from the map, so we just return an
+			// completed. The callback has already decremented
+			// pendingInline, so we just return an
 			// error to check the top of the loop again.
 			return errNewBuffer
 		}); err != errNewBuffer {
@@ -579,6 +648,9 @@ func (r *Reader) Read(p []byte) (int, error) {
 }
 
 // Close implements io.Closer.Close.
+// It forwards to the source without taking mu, allowing the source to interrupt
+// a blocked Read.
+// Concurrent Read and Close require support from the underlying source.
 func (r *Reader) Close() error {
 	return r.in.Close()
 }
@@ -587,20 +659,26 @@ func (r *Reader) Close() error {
 type Writer struct {
 	pool
 
-	// out is the underlying writer.
+	// out is the underlying writer; the interface value is immutable.
+	// Its Write and Close methods are called with mu held and must not reenter
+	// Writer.Write or Writer.Close.
 	out io.Writer
 
 	// closed indicates whether the file has been closed.
+	//
+	// +checklocks:mu
 	closed bool
 
 	// scratch is a temporary buffer used for marshalling. This is declared
 	// unfront here to avoid reallocation.
+	//
+	// +checklocks:mu
 	scratch [4]byte
 }
 
 var _ io.Writer = (*Writer)(nil)
 
-// NewWriter returns a new compressed writer. If key is non-nil, hash values are
+// NewWriter returns a new compressed writer. If key is non-empty, hash values are
 // generated and written out for compressed bytes. See package comments for
 // details.
 //
@@ -615,6 +693,10 @@ func NewWriter(out io.Writer, key []byte, chunkSize uint32, level int) (*Writer,
 		},
 		out: out,
 	}
+	// init registers a finalizer. Order subsequent initialization before
+	// finalizer cleanup, including when a header write fails.
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	w.init(key, 1+runtime.GOMAXPROCS(0), true, level)
 
 	binary.BigEndian.PutUint32(w.scratch[:], chunkSize)
@@ -637,6 +719,8 @@ func NewWriter(out io.Writer, key []byte, chunkSize uint32, level int) (*Writer,
 }
 
 // flush writes a single buffer.
+//
+// +checklocks:w.mu
 func (w *Writer) flush(c *chunk) error {
 	// Prefix each chunk with a length; this allows the reader to safely
 	// limit reads while buffering.
@@ -667,7 +751,9 @@ func (w *Writer) flush(c *chunk) error {
 }
 
 // Write implements io.Writer.Write.
-func (w *Writer) Write(p []byte) (int, error) {
+//
+// +checklocksexclude:w.mu
+func (w *Writer) Write(p []byte) (done int, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -675,6 +761,19 @@ func (w *Writer) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, io.ErrUnexpectedEOF
 	}
+	if w.err != nil {
+		return 0, w.err
+	}
+	defer func() {
+		if err != nil {
+			w.err = err
+			// Finish all reads from p before the caller can reuse it.
+			w.stop()
+			// buf may be an unsubmitted inline slice of p. Do not return
+			// caller-owned storage to bufPool or submit it on a later call.
+			w.buf = nil
+		}
+	}()
 
 	// See above; we need to track in the same way.
 	var (
@@ -682,29 +781,29 @@ func (w *Writer) Write(p []byte) (int, error) {
 		pendingInline = 0
 	)
 	callback := func(c *chunk) error {
+		// schedule invokes this callback with w.mu held, but checklocks does
+		// not propagate the lock state through the callback parameter.
 		if pendingPre > 0 {
 			pendingPre--
-			err := w.flush(c)
+			err := w.flush(c) // +checklocksignore
 			c.uncompressed.Reset()
 			bufPool.Put(c.uncompressed)
 			return err
 		}
 		if pendingInline > 0 {
 			pendingInline--
-			return w.flush(c)
+			return w.flush(c) // +checklocksignore
 		}
 		panic("both pendingPre and pendingInline exhausted")
 	}
 
-	for done := 0; done < len(p); {
+	for done < len(p) {
 		// Construct an inline buffer if we're doing an inline
 		// encoding; see above regarding the bytes.MinRead constraint.
 		inline := false
 		if w.buf.Len() == 0 && len(p) >= done+int(w.chunkSize) && len(p) >= done+bytes.MinRead {
 			bufPool.Put(w.buf) // Return to the pool; never scheduled.
 			w.buf = bytes.NewBuffer(p[done : done+int(w.chunkSize)])
-			done += int(w.chunkSize)
-			pendingInline++
 			inline = true
 		}
 
@@ -715,7 +814,10 @@ func (w *Writer) Write(p []byte) (int, error) {
 			if err := w.schedule(newChunk(nil, nil, nil, w.buf), callback); err != nil {
 				return done, err
 			}
-			if !inline {
+			if inline {
+				done += int(w.chunkSize)
+				pendingInline++
+			} else {
 				pendingPre++
 			}
 			// Reset the buffer, since this has now been scheduled
@@ -758,7 +860,9 @@ func (w *Writer) Write(p []byte) (int, error) {
 }
 
 // Close implements io.Closer.Close.
-func (w *Writer) Close() error {
+//
+// +checklocksexclude:w.mu
+func (w *Writer) Close() (err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -768,7 +872,19 @@ func (w *Writer) Close() error {
 		return io.ErrUnexpectedEOF
 	}
 	w.closed = true
-	defer w.stop()
+	defer func() {
+		w.stop()
+		// Close the destination even if Write or the final flush failed,
+		// but preserve the earlier error.
+		if closer, ok := w.out.(io.Closer); ok {
+			if closeErr := closer.Close(); err == nil {
+				err = closeErr
+			}
+		}
+	}()
+	if w.err != nil {
+		return w.err
+	}
 
 	// Schedule any remaining partial buffer; we pass w.flush directly here
 	// because the final buffer is guaranteed to not be an inline buffer.
@@ -783,9 +899,5 @@ func (w *Writer) Close() error {
 		return err
 	}
 
-	// Close the underlying writer (if necessary).
-	if closer, ok := w.out.(io.Closer); ok {
-		return closer.Close()
-	}
 	return nil
 }

--- a/pkg/compressio/compressio_test.go
+++ b/pkg/compressio/compressio_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"compress/flate"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -203,6 +204,150 @@ func TestCompress(t *testing.T) {
 			NewReader: func(b *bytes.Buffer) (io.Reader, error) {
 				return flate.NewReader(b), nil
 			},
+		})
+	}
+}
+
+func TestReaderOwnsKey(t *testing.T) {
+	doTest(t, testOpts{
+		Name: "reader owns key",
+		Data: bytes.Repeat([]byte{'a'}, 2*bytes.MinRead),
+		NewWriter: func(b *bytes.Buffer) (io.WriteCloser, error) {
+			return NewWriter(b, hashKey, bytes.MinRead, flate.BestSpeed)
+		},
+		NewReader: func(b *bytes.Buffer) (io.Reader, error) {
+			key := bytes.Clone(hashKey)
+			r, err := NewReader(io.NopCloser(b), key)
+			// Lazy worker HMACs must use the same key as the stream header,
+			// even if the caller reuses the constructor's key buffer.
+			clear(key)
+			return r, err
+		},
+	})
+}
+
+func TestReadErrorReleasesBuffer(t *testing.T) {
+	for _, key := range [][]byte{nil, hashKey} {
+		t.Run(fmt.Sprintf("hash=%t", key != nil), func(t *testing.T) {
+			var compressed bytes.Buffer
+			w, err := NewWriter(&compressed, key, bytes.MinRead, flate.BestSpeed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data := bytes.Repeat([]byte{'a'}, 2*bytes.MinRead)
+			if _, err := w.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatal(err)
+			}
+			// The first chunk can be decoding directly into data when reading
+			// the second chunk's body (or hash) fails.
+			compressed.Truncate(compressed.Len() - 1)
+			r, err := NewReader(io.NopCloser(&compressed), key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				r.mu.Lock()
+				defer r.mu.Unlock()
+				r.stop()
+			})
+			if _, err := r.Read(data); err != io.ErrUnexpectedEOF {
+				t.Fatalf("Read: got %v, want %v", err, io.ErrUnexpectedEOF)
+			}
+			// A Reader must release the caller's buffer even on error. Do not
+			// synchronize with workers before reusing it: that hides the race.
+			// Use instrumented byte accesses; clear is not race-instrumented.
+			for i := range data {
+				data[i]++
+			}
+			if n, err := r.Read(data); n != 0 || err != io.ErrUnexpectedEOF {
+				t.Fatalf("Read after error: got (%d, %v), want (0, %v)", n, err, io.ErrUnexpectedEOF)
+			}
+		})
+	}
+}
+
+type failingWriteCloser struct {
+	err      error
+	closeErr error
+	writes   int
+	closes   int
+}
+
+func (w *failingWriteCloser) Write(p []byte) (int, error) {
+	w.writes++
+	if w.writes == 1 {
+		return len(p), nil // Accept the stream header.
+	}
+	return 0, w.err
+}
+
+func (w *failingWriteCloser) Close() error {
+	w.closes++
+	return w.closeErr
+}
+
+func TestWriteErrorReleasesBuffer(t *testing.T) {
+	out := &failingWriteCloser{
+		err:      errors.New("write failed"),
+		closeErr: errors.New("close failed"),
+	}
+	w, err := NewWriter(out, nil, bytes.MinRead, flate.BestSpeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		w.stop()
+	})
+	data := bytes.Repeat([]byte{'a'}, 2*bytes.MinRead)
+	if _, err := w.Write(data); err != out.err {
+		t.Fatalf("Write: got %v, want %v", err, out.err)
+	}
+	// As with Read, an error must not leave workers using the caller's slice.
+	// Use instrumented byte accesses; clear is not race-instrumented.
+	for i := range data {
+		data[i]++
+	}
+	if n, err := w.Write(nil); n != 0 || err != out.err {
+		t.Errorf("Write after error: got (%d, %v), want (0, %v)", n, err, out.err)
+	}
+	if err := w.Close(); err != out.err {
+		t.Errorf("Close: got %v, want original write error %v", err, out.err)
+	}
+	if out.closes != 1 {
+		t.Errorf("underlying Close called %d times, want 1", out.closes)
+	}
+}
+
+func TestCloseErrorClosesWriter(t *testing.T) {
+	for _, data := range [][]byte{nil, {'a'}} {
+		t.Run(fmt.Sprintf("buffered=%t", len(data) != 0), func(t *testing.T) {
+			out := &failingWriteCloser{
+				err:      errors.New("write failed"),
+				closeErr: errors.New("close failed"),
+			}
+			w, err := NewWriter(out, nil, bytes.MinRead, flate.BestSpeed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A partial chunk is buffered, so the first flush is in Close.
+			if _, err := w.Write(data); err != nil {
+				t.Fatal(err)
+			}
+			want := out.closeErr
+			if len(data) != 0 {
+				want = out.err
+			}
+			if err := w.Close(); err != want {
+				t.Errorf("Close: got %v, want %v", err, want)
+			}
+			if out.closes != 1 {
+				t.Errorf("underlying Close called %d times, want 1", out.closes)
+			}
 		})
 	}
 }

--- a/pkg/compressio/nocompressio.go
+++ b/pkg/compressio/nocompressio.go
@@ -76,7 +76,7 @@ const (
 	defaultBufSize = 256 * 1024
 )
 
-// NewSimpleReader returns a new (uncompressed) reader. If key is non-nil, the
+// NewSimpleReader returns a new (uncompressed) reader. If key is non-empty, the
 // data stream is assumed to contain expected hash values. See package comments
 // for details.
 func NewSimpleReader(in io.ReadCloser, key []byte) *SimpleReader {
@@ -199,8 +199,8 @@ type SimpleWriter struct {
 var _ io.Writer = (*SimpleWriter)(nil)
 var _ io.Closer = (*SimpleWriter)(nil)
 
-// NewSimpleWriter returns a new non-compressing writer. If key is non-nil,
-// hash values are generated and written out for compressed bytes. See package
+// NewSimpleWriter returns a new non-compressing writer. If key is non-empty,
+// hash values are generated and written out for data. See package
 // comments for details. chunkSize is the buffer size used for buffering. Large
 // writes are not buffered and written out directly as a single chunk.
 func NewSimpleWriter(out io.Writer, key []byte, chunkSize uint32) *SimpleWriter {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -195,7 +195,12 @@ type Logger interface {
 
 // BasicLogger is the default implementation of Logger.
 type BasicLogger struct {
+	// +checkatomic
 	Level
+
+	// Emitter receives enabled log messages. BasicLogger does not synchronize
+	// access to it. Callers must synchronize field replacement with logging
+	// calls and provide any synchronization needed for concurrent Emit calls.
 	Emitter
 }
 
@@ -257,17 +262,19 @@ func Log() *BasicLogger {
 	return log.Load()
 }
 
-// SetTarget sets the log target.
+// SetTarget atomically replaces the default logger, using target and a snapshot
+// of the previous logger's level. Existing loggers returned by Log retain their
+// target; a concurrent SetLevel may affect only the previous logger.
 //
-// This is not thread safe and shouldn't be called concurrently with any
-// logging calls.
-//
-// SetTarget should be called before any instances of log.Log() to avoid race conditions
+// Set the target before creating loggers that should use it. Callers remain
+// responsible for emitter synchronization and for keeping old targets usable
+// while loggers may still use them.
 func SetTarget(target Emitter) {
 	logMu.Lock()
 	defer logMu.Unlock()
 	oldLog := Log()
-	log.Store(&BasicLogger{Level: oldLog.Level, Emitter: target})
+	level := Level(atomic.LoadUint32((*uint32)(&oldLog.Level)))
+	log.Store(&BasicLogger{Level: level, Emitter: target})
 }
 
 // SetLevel sets the log level.

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -56,25 +57,18 @@ func TestDropMessages(t *testing.T) {
 		t.Fatalf("Write should have failed")
 	}
 
-	fmt.Printf("writer: %#v\n", &w)
-
 	tw.fail = false
 	if _, err := w.Write([]byte("line 2\n")); err != nil {
 		t.Fatalf("Write failed, err: %v", err)
 	}
 
 	expected := []string{
-		"line1\n",
-		"\n*** Dropped %d log messages ***\n",
+		"line 1\n",
 		"line 2\n",
+		"\n*** Dropped 2 log messages ***\n",
 	}
-	if len(tw.lines) != len(expected) {
-		t.Fatalf("Writer should have logged %d lines, got: %v, expected: %v", len(expected), tw.lines, expected)
-	}
-	for i, l := range tw.lines {
-		if l == expected[i] {
-			t.Fatalf("line %d doesn't match, got: %v, expected: %v", i, l, expected[i])
-		}
+	if !slices.Equal(tw.lines, expected) {
+		t.Fatalf("Writer output = %q, want %q", tw.lines, expected)
 	}
 }
 

--- a/pkg/sentry/platform/interrupt/interrupt.go
+++ b/pkg/sentry/platform/interrupt/interrupt.go
@@ -15,15 +15,16 @@
 // Package interrupt provides an interrupt helper.
 package interrupt
 
-import (
-	"fmt"
-
-	"gvisor.dev/gvisor/pkg/sync"
-)
+import "gvisor.dev/gvisor/pkg/sync"
 
 // Receiver receives interrupt notifications from a Forwarder.
 type Receiver interface {
 	// NotifyInterrupt is called when the Receiver receives an interrupt.
+	//
+	// Forwarder calls this synchronously with its mutex held. It must not
+	// synchronously call back into that Forwarder. This interface does not
+	// identify the calling Forwarder, so checklocks cannot express the
+	// nonreentry requirement here.
 	NotifyInterrupt()
 }
 
@@ -31,13 +32,17 @@ type Receiver interface {
 //
 // This helps platform implementations with Interrupt semantics.
 type Forwarder struct {
-	// mu protects the below.
 	mu sync.Mutex
 
-	// dst is the function to be called when NotifyInterrupt() is called. If
-	// dst is nil, pending will be set instead, causing the next call to
-	// Enable() to return false.
-	dst     Receiver
+	// dst receives forwarded interrupts. It is nil while forwarding is disabled.
+	//
+	// +checklocks:mu
+	dst Receiver
+
+	// pending records an interrupt received while forwarding was disabled.
+	// The next Enable consumes it and returns false.
+	//
+	// +checklocks:mu
 	pending bool
 }
 
@@ -58,6 +63,8 @@ type Forwarder struct {
 // Preconditions:
 //   - r must not be nil.
 //   - f must not already be forwarding interrupts to a Receiver.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) Enable(r Receiver) bool {
 	if r == nil {
 		panic("nil Receiver")
@@ -65,7 +72,7 @@ func (f *Forwarder) Enable(r Receiver) bool {
 	f.mu.Lock()
 	if f.dst != nil {
 		f.mu.Unlock()
-		panic(fmt.Sprintf("already forwarding interrupts to %+v", f.dst))
+		panic("already forwarding interrupts")
 	}
 	if f.pending {
 		f.pending = false
@@ -79,6 +86,8 @@ func (f *Forwarder) Enable(r Receiver) bool {
 
 // Disable stops interrupt forwarding. If interrupt forwarding is already
 // disabled, Disable is a no-op.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) Disable() {
 	f.mu.Lock()
 	f.dst = nil
@@ -88,6 +97,8 @@ func (f *Forwarder) Disable() {
 // NotifyInterrupt implements Receiver.NotifyInterrupt. If interrupt forwarding
 // is enabled, the configured Receiver will be notified. Otherwise the
 // interrupt will be delivered to the next call to Enable.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) NotifyInterrupt() {
 	f.mu.Lock()
 	if f.dst != nil {
@@ -101,6 +112,8 @@ func (f *Forwarder) NotifyInterrupt() {
 // Preempt preempts the running context. Preempt is a weaker version of
 // NotifyInterrupt, it doesn't set the pending flag which is set when a context
 // isn't actually running at this moment.
+//
+// +checklocksexclude:f.mu
 func (f *Forwarder) Preempt() {
 	f.mu.Lock()
 	if f.dst != nil {


### PR DESCRIPTION
Compression errors can leave workers accessing caller buffers after Read or Write returns. Drain submitted work before returning, preserve terminal errors, copy hash keys, and discard references when recycling chunks. Always close the destination after a failed write or final flush while preserving the original error.

Read logger levels atomically when replacing the target, avoid formatting mutable interrupt receivers in panic messages, and repair the existing dropped-message assertion.

Assisted-by: Codex