### PR TITLE
Fix clock overflow recovery and watchdog timing

### DIFF
--- a/pkg/sentry/time/BUILD
+++ b/pkg/sentry/time/BUILD
@@ -60,6 +60,7 @@ go_test(
     library = ":time",
     deps = [
         "//pkg/abi/linux",
+        "//pkg/sync",
         "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/sentry/time/calibrated_clock.go
+++ b/pkg/sentry/time/calibrated_clock.go
@@ -31,22 +31,30 @@ import (
 // to ensure that the clock does not drift significantly from the reference
 // clock.
 type CalibratedClock struct {
-	// mu protects the fields below.
+	// mu protects ref's mutable sampling state.
 	// TODO(mpratt): consider a sequence counter for read locking.
 	mu sync.RWMutex
 
-	// ref sample the reference clock that this clock is calibrated
-	// against.
+	// ref samples the reference clock that this clock is calibrated against.
+	// The pointer is immutable; its samples and overhead are protected by mu.
+	// The sampler has no link back to this clock, so checklocks cannot name
+	// the owning mutex for the sampler's fields and methods.
 	ref *sampler
 
 	// ready indicates that the fields below are ready for use calculating
 	// time.
+	//
+	// +checklocks:mu
 	ready bool
 
 	// params are the current timekeeping parameters.
+	//
+	// +checklocks:mu
 	params Parameters
 
 	// errorNS is the estimated clock error in nanoseconds.
+	//
+	// +checklocks:mu
 	errorNS ReferenceNS
 }
 
@@ -66,7 +74,7 @@ func (c *CalibratedClock) Debugf(format string, v ...any) {
 	}
 }
 
-// Infof logs at debug level.
+// Infof logs at info level.
 func (c *CalibratedClock) Infof(format string, v ...any) {
 	if log.IsLogging(log.Info) {
 		args := []any{c.ref.clockID}
@@ -75,7 +83,7 @@ func (c *CalibratedClock) Infof(format string, v ...any) {
 	}
 }
 
-// Warningf logs at debug level.
+// Warningf logs at warning level.
 func (c *CalibratedClock) Warningf(format string, v ...any) {
 	if log.IsLogging(log.Warning) {
 		args := []any{c.ref.clockID}
@@ -86,6 +94,8 @@ func (c *CalibratedClock) Warningf(format string, v ...any) {
 
 // reset forces the clock to restart the calibration process, logging the
 // passed message.
+//
+// +checklocksexclude:c.mu
 func (c *CalibratedClock) reset(str string, v ...any) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -93,6 +103,8 @@ func (c *CalibratedClock) reset(str string, v ...any) {
 }
 
 // resetLocked is equivalent to reset with c.mu already held for writing.
+//
+// +checklocks:c.mu
 func (c *CalibratedClock) resetLocked(str string, v ...any) {
 	c.Warningf(str+" Resetting clock; time may jump.", v...)
 	c.ready = false
@@ -106,7 +118,7 @@ func (c *CalibratedClock) resetLocked(str string, v ...any) {
 // actual is the actual estimated timekeeping parameters. The stored parameters
 // may need to be adjusted slightly from these values to compensate for error.
 //
-// Preconditions: c.mu must be held for writing.
+// +checklocks:c.mu
 func (c *CalibratedClock) updateParams(actual Parameters, parked bool) {
 	if !c.ready || parked {
 		// when parked nothing has read the time for a whole interval, so
@@ -154,6 +166,8 @@ func (c *CalibratedClock) updateParams(actual Parameters, parked bool) {
 //
 // The returned timekeeping parameters are invalidated on the next call to
 // Update.
+//
+// +checklocksexclude:c.mu
 func (c *CalibratedClock) Update(parked bool) (Parameters, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -198,6 +212,8 @@ func (c *CalibratedClock) Update(parked bool) (Parameters, bool) {
 }
 
 // GetTime returns the current time based on the clock calibration.
+//
+// +checklocksexclude:c.mu
 func (c *CalibratedClock) GetTime() (int64, error) {
 	c.mu.RLock()
 
@@ -211,11 +227,17 @@ func (c *CalibratedClock) GetTime() (int64, error) {
 	now := c.ref.Cycles()
 	v, ok := c.params.ComputeTime(now)
 	if !ok {
-		// Something is seriously wrong with the clock. Try
-		// again with syscalls.
-		c.resetLocked("Time computation overflowed. params = %+v, now = %v.", c.params, now)
-		now, err := c.ref.Syscall()
+		// The calibrated computation overflowed. Fall back to the reference
+		// clock.
+		params := c.params
 		c.mu.RUnlock()
+		c.mu.Lock()
+		// Reset only if the overflowing calibration is still current.
+		if c.ready && c.params == params {
+			c.resetLocked("Time computation overflowed. params = %+v, now = %v.", params, now)
+		}
+		now, err := c.ref.Syscall()
+		c.mu.Unlock()
 		return int64(now), err
 	}
 
@@ -255,6 +277,10 @@ func NewCalibratedClocks(monotonicRawEnabled bool) *CalibratedClocks {
 }
 
 // Update implements Clocks.Update.
+//
+// +checklocksexclude:c.monotonic.mu
+// +checklocksexclude:c.realtime.mu
+// +checklocksexclude:c.monotonicRaw.mu
 func (c *CalibratedClocks) Update(parked bool) UpdateResult {
 	var res UpdateResult
 	res.Monotonic, res.MonotonicOk = c.monotonic.Update(parked)
@@ -272,6 +298,10 @@ func (c *CalibratedClocks) MonotonicRawEnabled() bool {
 }
 
 // GetTime implements Clocks.GetTime.
+//
+// +checklocksexclude:c.monotonic.mu
+// +checklocksexclude:c.realtime.mu
+// +checklocksexclude:c.monotonicRaw.mu
 func (c *CalibratedClocks) GetTime(id ClockID) (int64, error) {
 	switch id {
 	case Monotonic:

--- a/pkg/sentry/time/calibrated_clock_test.go
+++ b/pkg/sentry/time/calibrated_clock_test.go
@@ -15,8 +15,11 @@
 package time
 
 import (
+	"math"
 	"testing"
 	"time"
+
+	"gvisor.dev/gvisor/pkg/sync"
 )
 
 // newTestCalibratedClock returns a CalibratedClock that collects samples from
@@ -65,6 +68,42 @@ func TestConstantFrequency(t *testing.T) {
 	// next sample.
 	if now < 700 || now > 800 {
 		t.Errorf("now got %v want > 700 && < 800", now)
+	}
+}
+
+func TestGetTimeOverflow(t *testing.T) {
+	c := newTestCalibratedClock([]sample{{ref: 123}}, []TSCValue{math.MaxInt64})
+	c.mu.Lock()
+	c.ready = true
+	c.params = Parameters{Frequency: 1}
+	c.mu.Unlock()
+
+	// Shared reader locks do not order the old reset's write with this read.
+	// An exclusive reset instead waits for this reader to unlock.
+	c.mu.RLock()
+	var got int64
+	var err error
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		got, err = c.GetTime()
+	})
+	readyWhileReadLocked := c.ready
+	c.mu.RUnlock()
+	wg.Wait()
+	if !readyWhileReadLocked {
+		t.Error("clock reset while a reader held the mutex")
+	}
+	if err != nil {
+		t.Fatalf("GetTime: %v", err)
+	}
+	if got != 123 {
+		t.Errorf("GetTime = %d, want 123 from reference clock", got)
+	}
+	c.mu.RLock()
+	ready := c.ready
+	c.mu.RUnlock()
+	if ready {
+		t.Error("clock remains ready after time computation overflow")
 	}
 }
 
@@ -162,26 +201,34 @@ func TestErrorCorrection(t *testing.T) {
 
 			// As the reference clock stabilizes, ensure that the clock error
 			// decreases.
+			c.mu.RLock()
 			initialErr := c.errorNS
+			c.mu.RUnlock()
 			t.Logf("initial error: %v ns", initialErr)
 
 			_, ok = c.Update(false)
 			if !ok {
 				t.Fatalf("Update not ready")
 			}
-			if c.errorNS.Magnitude() > initialErr.Magnitude() {
-				t.Errorf("errorNS increased, got %v want |%v| <= |%v|", c.errorNS, c.errorNS, initialErr)
+			c.mu.RLock()
+			currentErr := c.errorNS
+			c.mu.RUnlock()
+			if currentErr.Magnitude() > initialErr.Magnitude() {
+				t.Errorf("errorNS increased, got %v want |%v| <= |%v|", currentErr, currentErr, initialErr)
 			}
 
 			_, ok = c.Update(false)
 			if !ok {
 				t.Fatalf("Update not ready")
 			}
-			if c.errorNS.Magnitude() > initialErr.Magnitude() {
-				t.Errorf("errorNS increased, got %v want |%v| <= |%v|", c.errorNS, c.errorNS, initialErr)
+			c.mu.RLock()
+			currentErr = c.errorNS
+			c.mu.RUnlock()
+			if currentErr.Magnitude() > initialErr.Magnitude() {
+				t.Errorf("errorNS increased, got %v want |%v| <= |%v|", currentErr, currentErr, initialErr)
 			}
 
-			t.Logf("final error: %v ns", c.errorNS)
+			t.Logf("final error: %v ns", currentErr)
 		})
 	}
 }

--- a/pkg/sentry/watchdog/watchdog.go
+++ b/pkg/sentry/watchdog/watchdog.go
@@ -143,7 +143,12 @@ type Watchdog struct {
 	// spamming the log.
 	lastStackDump time.Time
 
-	// lastRun is set to the last time the watchdog executed a monitoring loop.
+	// lastRun is the CPU-clock time of the last monitoring pass.
+	//
+	// Start initializes it before launching the loop, which then owns it.
+	// Stop holds mu until the loop acknowledges its last access, preventing a
+	// later Start from resetting it concurrently. checklocks cannot express
+	// this ownership handoff.
 	lastRun ktime.Time
 
 	// mu protects the fields below.
@@ -197,7 +202,7 @@ func (w *Watchdog) Start() {
 		log.Infof("Watchdog task timeout disabled")
 		return
 	}
-	w.lastRun = w.k.MonotonicClock().Now()
+	w.lastRun = w.k.CPUClockNow()
 
 	log.Infof("Starting watchdog, period: %v, timeout: %v, action: %v", w.period, w.TaskTimeout, w.TaskTimeoutAction)
 	go w.loop() // S/R-SAFE: watchdog is stopped during save and restarted after restore.

--- a/pkg/sentry/watchdog/watchdog.go
+++ b/pkg/sentry/watchdog/watchdog.go
@@ -369,7 +369,7 @@ func (w *Watchdog) reportStuckWatchdog() {
 	buf.WriteString("Watchdog goroutine is stuck")
 	var stuckTasks map[int64]struct{}
 	forceStackDump := false
-	w.doAction(w.StartupTimeoutAction, forceStackDump, stuckTasks, &buf)
+	w.doAction(w.TaskTimeoutAction, forceStackDump, stuckTasks, &buf)
 }
 
 // doAction will take the given action. If the action is LogWarning, the stack

--- a/pkg/sentry/watchdog/watchdog_test.go
+++ b/pkg/sentry/watchdog/watchdog_test.go
@@ -17,9 +17,24 @@ package watchdog
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestStuckWatchdogUsesTaskAction(t *testing.T) {
+	w := &Watchdog{
+		Opts: Opts{
+			TaskTimeoutAction:    LogWarning,
+			StartupTimeoutAction: Panic,
+		},
+		// Avoid an unrelated stack dump on the logging path.
+		lastStackDump: time.Now(),
+	}
+	// Reporting a stalled monitoring loop must use the task-timeout policy,
+	// not the unrelated policy for failing to start the watchdog.
+	w.reportStuckWatchdog()
+}
 
 func TestStuckGoroutineStacks(t *testing.T) {
 	innocent0 := `goroutine 124 [select, 1 minutes]:


### PR DESCRIPTION
Clock overflow recovery resets calibration while holding only a read lock. Acquire the write lock and recheck the calibration before resetting it.

Initialize watchdog monitoring timestamps from the CPU clock used by monitoring passes, and apply the task-timeout action when a monitoring pass stalls. Annotate the associated clock locking contracts.

Assisted-by: Codex