### PR TITLE
Fix races in shim version queries and RPC shutdown

### DIFF
--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	taskServer "gvisor.dev/gvisor/pkg/shim/v1/taskserver"
 	pb "gvisor.dev/gvisor/pkg/shim/v1/taskserver/task_server_go_proto"
@@ -119,11 +120,9 @@ type runscService struct {
 	// containers maps container id to a container.
 	containers map[string]*Container
 
-	// root is the runsc root directory.
-	root string
-
-	// runtime is runsc runtime configured for sandbox.
-	runtime *runsccmd.Runsc
+	// versionCommand is the runsc executable configured for the sandbox.
+	// A nil pointer or empty command selects the default.
+	versionCommand atomic.Pointer[string]
 
 	shutdown shutdown.Service
 }
@@ -151,8 +150,6 @@ func NewTaskService(ctx context.Context, publisher shim.Publisher, sd shutdown.S
 		ec:         proc.ExitCh,
 		oomPoller:  ep,
 		shutdown:   sd,
-		root:       proc.RunscRoot,
-		runtime:    &runsccmd.Runsc{Root: proc.RunscRoot},
 	}
 	go s.processExits(ctx)
 	runsccmd.Monitor = &runsccmd.LogMonitor{Next: reaper.Default}
@@ -215,8 +212,8 @@ func (s *runscService) CreateWithFSRestore(ctx context.Context, rfs *extension.C
 		return nil, err
 	}
 	if initProcess, ok := p.(*proc.Init); ok && initProcess.Sandbox {
-		s.root = initProcess.Runtime().Root
-		s.runtime = initProcess.Runtime()
+		command := initProcess.Runtime().Command
+		s.versionCommand.Store(&command)
 	}
 
 	// Set up OOM notification on the sandbox's cgroup. This is done on
@@ -921,10 +918,11 @@ func (g *GvisorTaskServer) State(ctx context.Context, req *pb.StateRequest) (*pb
 
 // Version implements taskServer.GvisorTaskServiceExt.
 func (g *GvisorTaskServer) Version(ctx context.Context, req *pb.VersionRequest) (*pb.VersionResponse, error) {
-	cmd := exec.Command("runsc", "-version")
-	if g.s.runtime.Command != "" {
-		cmd = exec.Command(g.s.runtime.Command, "-version")
+	command := runsccmd.DefaultCommand
+	if configured := g.s.versionCommand.Load(); configured != nil && *configured != "" {
+		command = *configured
 	}
+	cmd := exec.Command(command, "-version")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get runsc version: %w, output: %s", err, string(out))

--- a/pkg/urpc/urpc.go
+++ b/pkg/urpc/urpc.go
@@ -172,6 +172,8 @@ type Server struct {
 	methods map[string]registeredMethod
 
 	// stoppers are all registered stoppers.
+	//
+	// +checklocks:mu
 	stoppers []Stopper
 
 	// clients is a map of clients.
@@ -485,9 +487,15 @@ func (s *Server) StartHandling(client *unet.Socket) {
 // expires, all clients are drained (i.e. their ongoing RPC is allowed to
 // complete) and closed. Any new RPCs will not be processed. Note that ongoing
 // RPCs are *not* interrupted or cancelled.
+//
+// +checklocksexclude:s.mu
 func (s *Server) Stop(timeout time.Duration) {
-	// Call any Stop callbacks.
-	for _, stopper := range s.stoppers {
+	// Snapshot the append-only list. Existing entries never change, so
+	// callbacks can run without mu while registration continues.
+	s.mu.Lock()
+	stoppers := s.stoppers
+	s.mu.Unlock()
+	for _, stopper := range stoppers {
 		stopper.Stop()
 	}
 

--- a/runsc/boot/portforward/BUILD
+++ b/runsc/boot/portforward/BUILD
@@ -51,7 +51,6 @@ go_test(
         "//pkg/buffer",
         "//pkg/context",
         "//pkg/errors/linuxerr",
-        "//pkg/sentry/contexttest",
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/vfs",
         "//pkg/tcpip",

--- a/runsc/boot/portforward/portforward_fd_rw_test.go
+++ b/runsc/boot/portforward/portforward_fd_rw_test.go
@@ -21,76 +21,42 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
-	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/pkg/usermem"
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
-// mockFileDescriptionRWImpl implements all vfs.FileDescriptionImpl methods used in
-// fileDescriptionReaderWriter for a mockFileDescription.
-type mockFileDescriptionRWImpl interface {
-	Read(context.Context, usermem.IOSequence, vfs.ReadOptions) (int64, error)
-	Write(context.Context, usermem.IOSequence, vfs.WriteOptions) (int64, error)
-	EventRegister(*waiter.Entry) error
-	EventUnregister(*waiter.Entry)
-	Release(context.Context)
-}
-
-// mockFileDescription implements vfs.FileDescriptionImpl for portforward tests.
-type mockFileDescription struct {
-	vfsfd  vfs.FileDescription
-	impl   vfs.FileDescriptionImpl
-	vfsObj *vfs.VirtualFilesystem
-}
-
-// Read implements FileDescriptionImpl.Read.
-func (m *mockFileDescription) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
-	return m.impl.Read(ctx, dst, opts)
-}
-
-// Write implements vfs.FileDescriptionImpl.Write.
-func (m *mockFileDescription) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
-	return m.impl.Write(ctx, src, opts)
-}
-
-// EventRegister implements vfs.FileDescriptionImpl.EventRegister.
-func (m *mockFileDescription) EventRegister(waitEntry *waiter.Entry) error {
-	return m.impl.EventRegister(waitEntry)
-}
-
-// EventUnregister implements vfs.FileDescriptionImpl.EventUnregister.
-func (m *mockFileDescription) EventUnregister(waitEntry *waiter.Entry) {
-	m.impl.EventUnregister(waitEntry)
-}
-
-// Release implements vfs.FileDescriptionImpl.Release.
-func (m *mockFileDescription) Release(ctx context.Context) { m.impl.Release(ctx) }
-
-func newMockFileDescription(ctx context.Context, fdImpl vfs.FileDescriptionImpl) (*vfs.FileDescription, error) {
+// newMockFileDescriptionConn takes ownership of impl, including on failure.
+func newMockFileDescriptionConn(t *testing.T, ctx context.Context, impl vfs.FileDescriptionImpl) *fileDescriptionConn {
+	t.Helper()
 	vfsObj := &vfs.VirtualFilesystem{}
 	if err := vfsObj.Init(ctx); err != nil {
-		return nil, fmt.Errorf("vfsObj.Init: %v", err)
+		impl.Release(ctx)
+		t.Fatalf("VirtualFilesystem.Init: %v", err)
 	}
+	t.Cleanup(func() { vfsObj.Release(ctx) })
 	vd := vfsObj.NewAnonVirtualDentry("mock_app")
 	defer vd.DecRef(ctx)
-	fd := mockFileDescription{
-		impl:   fdImpl,
-		vfsObj: vfsObj,
+	var fd vfs.FileDescription
+	if err := fd.Init(impl, linux.O_RDWR, auth.CredentialsFromContext(ctx), vd.Mount(), vd.Dentry(), &vfs.FileDescriptionOptions{}); err != nil {
+		impl.Release(ctx)
+		t.Fatalf("FileDescription.Init: %v", err)
 	}
-	fd.vfsfd.Init(fd.impl, linux.O_RDWR, auth.CredentialsFromContext(ctx), vd.Mount(), vd.Dentry(), &vfs.FileDescriptionOptions{})
-	fd.vfsObj = vfsObj
-	return &fd.vfsfd, nil
+	conn := &fileDescriptionConn{file: &fd}
+	// The proxy and cleanup must share the same Once-protected close.
+	t.Cleanup(func() { conn.Close(ctx) })
+	return conn
 }
 
-// readerWriter implements mockFileDescriptionRWImpl. On write, it appends given data to a buffer.
-// On reads it pops the requested amount of data off the buffer.
+// readerWriter is a synchronous in-memory FileDescriptionImpl for
+// TestReaderWriter. Writes append to its buffer; reads consume buffered data.
 type readerWriter struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.NoLockFD
@@ -101,21 +67,21 @@ type readerWriter struct {
 
 var _ vfs.FileDescriptionImpl = (*readerWriter)(nil)
 
-// Read implements vfs.FileDescriptionImpl.Read details for the parent mockFileDescription.
+// Read implements vfs.FileDescriptionImpl.Read.
 func (rw *readerWriter) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	if rw.released {
 		return 0, io.EOF
 	}
 	buf := make([]byte, dst.NumBytes())
-	_, err := rw.buf.Read(buf)
+	n, err := rw.buf.Read(buf)
 	if err != nil {
 		return 0, nil
 	}
-	n, err := dst.CopyOut(ctx, buf)
+	n, err = dst.CopyOut(ctx, buf[:n])
 	return int64(n), err
 }
 
-// Write implements vfs.FileDescriptionImpl.Write details for the parent mockFileDescription.
+// Write implements vfs.FileDescriptionImpl.Write.
 func (rw *readerWriter) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
 	if rw.released {
 		return 0, io.EOF
@@ -129,29 +95,38 @@ func (rw *readerWriter) Write(ctx context.Context, src usermem.IOSequence, opts 
 	return int64(n), err
 }
 
-// EventRegister implements vfs.FileDescriptionImpl.EventRegister details for the parent mockFileDescription.
+// EventRegister implements vfs.FileDescriptionImpl.EventRegister.
 func (rw *readerWriter) EventRegister(we *waiter.Entry) error { return fmt.Errorf("not implemented") }
 
-// EventUnregister implements vfs.FileDescriptionImpl.Unregister details for the parent mockFileDescription.
+// EventUnregister implements vfs.FileDescriptionImpl.EventUnregister.
 func (rw *readerWriter) EventUnregister(we *waiter.Entry) { panic("not implemented") }
 
-// Release implements vfs.FileDescriptionImpl.Release details for the parent mockFileDescription.
+// Release implements vfs.FileDescriptionImpl.Release.
 func (rw *readerWriter) Release(context.Context) {
 	rw.released = true
 }
 
-// waiterRW implements mockFileDescriptionRWImpl. waiterRW works the same way as readerWriter above,
-// but it interleaves blocks in between Read and Write calls.
+// waiterRW is like readerWriter, but blocks between Read and Write calls.
 type waiterRW struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.NoLockFD
 	vfs.DentryMetadataFileDescriptionImpl
-	buf        bytes.Buffer
-	waitMu     sync.Mutex
-	entries    []*waiter.Entry
+
+	waitMu sync.Mutex
+
+	// +checklocks:waitMu
+	buf bytes.Buffer
+
+	// +checklocks:waitMu
+	entries []*waiter.Entry
+
+	// +checklocks:waitMu
 	shouldWait bool
-	quit       chan bool
-	closed     bool
+
+	quit chan bool
+
+	// +checklocks:waitMu
+	closed bool
 }
 
 var _ vfs.FileDescriptionImpl = (*waiterRW)(nil)
@@ -166,7 +141,9 @@ func newWaiterReaderWriter() *waiterRW {
 	return ret
 }
 
-// Read implements vfs.FileDescriptionImpl.Read details for the parent mockFileDescription.
+// Read implements vfs.FileDescriptionImpl.Read.
+//
+// +checklocksexclude:w.waitMu
 func (w *waiterRW) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	w.waitMu.Lock()
 	defer w.waitMu.Unlock()
@@ -177,16 +154,18 @@ func (w *waiterRW) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.Re
 		return 0, linuxerr.ErrWouldBlock
 	}
 	buf := make([]byte, dst.NumBytes())
-	_, err := w.buf.Read(buf)
+	n, err := w.buf.Read(buf)
 	if err != nil {
 		return 0, err
 	}
-	n, err := dst.CopyOut(ctx, buf)
+	n, err = dst.CopyOut(ctx, buf[:n])
 	w.shouldWait = true
 	return int64(n), err
 }
 
-// Write implements vfs.FileDescriptionImpl.Write details for the parent mockFileDescription.
+// Write implements vfs.FileDescriptionImpl.Write.
+//
+// +checklocksexclude:w.waitMu
 func (w *waiterRW) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
 	w.waitMu.Lock()
 	defer w.waitMu.Unlock()
@@ -209,30 +188,30 @@ func (w *waiterRW) Write(ctx context.Context, src usermem.IOSequence, opts vfs.W
 	return int64(n), err
 }
 
-// EventRegister implements vfs.FileDescriptionImpl.EventRegister details for the parent mockFileDescription.
+// EventRegister implements vfs.FileDescriptionImpl.EventRegister.
+//
+// +checklocksexclude:w.waitMu
 func (w *waiterRW) EventRegister(we *waiter.Entry) error {
 	w.waitMu.Lock()
 	defer w.waitMu.Unlock()
 	w.entries = append(w.entries, we)
-	for _, e := range w.entries {
-		if e == we {
-			return nil
-		}
-	}
-	w.entries = append(w.entries, we)
 	return nil
 }
 
-// EventUnregister implements vfs.FileDescriptionImpl.Unregister details for the parent mockFileDescription.
+// EventUnregister implements vfs.FileDescriptionImpl.EventUnregister.
+//
+// +checklocksexclude:w.waitMu
 func (w *waiterRW) EventUnregister(we *waiter.Entry) {
-	for i, e := range w.entries {
-		if e == we {
-			w.entries = append(w.entries[:i], w.entries[i+1:]...)
-		}
+	w.waitMu.Lock()
+	defer w.waitMu.Unlock()
+	if i := slices.Index(w.entries, we); i >= 0 {
+		w.entries = slices.Delete(w.entries, i, i+1)
 	}
 }
 
-// Release implements vfs.FileDescriptionImpl.Release details for the parent mockFileDescription.
+// Release implements vfs.FileDescriptionImpl.Release.
+//
+// +checklocksexclude:w.waitMu
 func (w *waiterRW) Release(context.Context) {
 	w.quit <- true
 }
@@ -251,54 +230,50 @@ func (w *waiterRW) doNotify() {
 				we.NotifyEvent(waiter.ReadableEvents | waiter.WritableEvents)
 			}
 			w.waitMu.Unlock()
+			// Keep a real clock so notifications can overlap waiter registration
+			// and removal. A synctest clock would wait for the I/O goroutine to
+			// block again.
 			time.Sleep(100 * time.Millisecond)
 		}
 	}
 }
 
 func TestReaderWriter(t *testing.T) {
-	ctx := contexttest.Context(t)
+	ctx := context.Background()
 	for _, tc := range []struct {
-		name       string
-		mockFDImpl vfs.FileDescriptionImpl
+		name    string
+		newImpl func() vfs.FileDescriptionImpl
 	}{
 		{
-			name:       "readerWriter",
-			mockFDImpl: &readerWriter{},
+			name:    "readerWriter",
+			newImpl: func() vfs.FileDescriptionImpl { return &readerWriter{} },
 		},
 		{
-			name:       "waiter",
-			mockFDImpl: newWaiterReaderWriter(),
+			name:    "waiter",
+			newImpl: func() vfs.FileDescriptionImpl { return newWaiterReaderWriter() },
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			fd, err := newMockFileDescription(ctx, tc.mockFDImpl)
-			if err != nil {
-				tc.mockFDImpl.Release(ctx)
-				t.Fatal(err)
-			}
-			readerWriter := fileDescriptionConn{
-				file: fd,
-			}
-			sendBytes := []([]byte){
-				[]byte{'a', 'b', 'c'},
-				[]byte{'1', '2', '3'},
-				[]byte{'a', 'b', 'c', '1', '2', '3'},
-				[]byte{'y', 'o', 'u', 'a', 'n', 'd', 'm', 'e'},
+			readerWriter := newMockFileDescriptionConn(t, ctx, tc.newImpl())
+			// The total is not a multiple of the read buffer size, so the last
+			// read must not copy or report unused buffer bytes.
+			sendBytes := [][]byte{
+				[]byte("abc"),
+				[]byte("123"),
+				[]byte("abc123"),
+				[]byte("youandme!"),
 			}
 			for _, buf := range sendBytes {
 				n, err := readerWriter.Write(ctx, buf, nil)
 				if err != nil {
-					tc.mockFDImpl.Release(ctx)
 					t.Fatalf("write failed: %v", err)
 				}
 				if n != len(buf) {
-					tc.mockFDImpl.Release(ctx)
 					t.Fatalf("failed to write buf: %s", string(buf))
 				}
 			}
 
-			got := []byte{}
+			var got []byte
 			buf := make([]byte, 4)
 			for {
 				n, err := readerWriter.Read(ctx, buf, nil)
@@ -311,45 +286,33 @@ func TestReaderWriter(t *testing.T) {
 				if n == 0 {
 					break
 				}
-				got = append(got, buf...)
-				buf = buf[0:]
+				got = append(got, buf[:n]...)
 			}
-			tc.mockFDImpl.Release(ctx)
-
-			want := []byte{}
-			for _, buf := range sendBytes {
-				want = append(want, buf...)
-			}
-
-			if !slices.Equal(got, want) {
-				t.Fatalf("mismatch types: got: %q want: %q", string(got), string(want))
-			}
-
-			_, err = readerWriter.Read(ctx, buf[0:], nil)
-			if err != io.EOF {
-				t.Fatalf("expected end of file: got: %v", err)
+			if want := slices.Concat(sendBytes...); !slices.Equal(got, want) {
+				t.Fatalf("mismatch data: got: %q want: %q", got, want)
 			}
 		})
 	}
 }
 
 type blockingConn struct {
-	name                 string
-	inRead               chan struct{}
-	mu                   sync.Mutex
-	readExited           bool
+	name        string
+	releaseRead <-chan struct{}
+	mu          sync.Mutex
+
+	// +checklocks:mu
+	readExited bool
+
+	// +checklocks:mu
 	closedBeforeReadExit bool
 }
 
 func (b *blockingConn) Name() string { return b.name }
 
+// +checklocksexclude:b.mu
 func (b *blockingConn) Read(ctx context.Context, buf []byte, cancel <-chan struct{}) (int, error) {
-	select {
-	case b.inRead <- struct{}{}:
-	default:
-	}
 	<-cancel
-	time.Sleep(10 * time.Millisecond)
+	<-b.releaseRead
 	b.mu.Lock()
 	b.readExited = true
 	b.mu.Unlock()
@@ -361,6 +324,7 @@ func (b *blockingConn) Write(ctx context.Context, buf []byte, cancel <-chan stru
 	return 0, io.EOF
 }
 
+// +checklocksexclude:b.mu
 func (b *blockingConn) Close(ctx context.Context) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -370,28 +334,40 @@ func (b *blockingConn) Close(ctx context.Context) {
 }
 
 func TestProxyCloseOrdersCancellationBeforeCleanup(t *testing.T) {
-	ctx := contexttest.Context(t)
-	to := &blockingConn{name: "to", inRead: make(chan struct{}, 1)}
-	from := &blockingConn{name: "from", inRead: make(chan struct{}, 1)}
+	ctx := context.Background()
+	synctest.Test(t, func(t *testing.T) {
+		releaseRead := make(chan struct{})
+		to := &blockingConn{name: "to", releaseRead: releaseRead}
+		from := &blockingConn{name: "from", releaseRead: releaseRead}
+		proxy := NewProxy(ProxyPair{To: to, From: from}, "test-cid")
+		unblock := sync.OnceFunc(func() { close(releaseRead) })
+		t.Cleanup(func() {
+			unblock()
+			proxy.Close()
+			synctest.Wait()
+		})
+		proxy.Start(ctx)
 
-	proxy := NewProxy(ProxyPair{To: to, From: from}, "test-cid")
-	proxy.Start(ctx)
+		// Both reads must block on cancellation before Close starts.
+		synctest.Wait()
+		go proxy.Close()
 
-	// Wait until both proxy goroutines have entered Read.
-	<-to.inRead
-	<-from.inRead
+		// Keep the canceled reads blocked so cleanup cannot run early without
+		// being observed. This uses durable blocking, not simulated time.
+		synctest.Wait()
+		unblock()
+		synctest.Wait()
 
-	proxy.Close()
+		to.mu.Lock()
+		defer to.mu.Unlock()
+		if to.closedBeforeReadExit {
+			t.Errorf("Proxy.Close invoked to.Close() before to.Read() exited")
+		}
 
-	to.mu.Lock()
-	defer to.mu.Unlock()
-	if to.closedBeforeReadExit {
-		t.Errorf("Proxy.Close invoked to.Close() before to.Read() exited")
-	}
-
-	from.mu.Lock()
-	defer from.mu.Unlock()
-	if from.closedBeforeReadExit {
-		t.Errorf("Proxy.Close invoked from.Close() before from.Read() exited")
-	}
+		from.mu.Lock()
+		defer from.mu.Unlock()
+		if from.closedBeforeReadExit {
+			t.Errorf("Proxy.Close invoked from.Close() before from.Read() exited")
+		}
+	})
 }

--- a/runsc/boot/portforward/portforward_hostinet_test.go
+++ b/runsc/boot/portforward/portforward_hostinet_test.go
@@ -26,11 +26,10 @@ import (
 	"golang.org/x/sync/errgroup"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
-	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 )
 
 func TestLocalHostSocket(t *testing.T) {
-	ctx := contexttest.Context(t)
+	ctx := context.Background()
 	clientData := append(
 		[]byte("do what must be done\n"),
 		[]byte("do not hesitate\n")...,
@@ -84,6 +83,7 @@ func TestLocalHostSocket(t *testing.T) {
 		if err != nil {
 			t.Fatalf("could not create local host socket: %v", err)
 		}
+		defer sock.Close(ctx)
 		for i := 0; i < len(clientData); {
 			n, err := sock.Write(ctx, clientData[i:], nil)
 			if err != nil {
@@ -119,6 +119,8 @@ type netConnMockEndpoint struct {
 }
 
 // read implements portforwarderTestHarness.read.
+//
+// +checklocksexclude:nc.mu
 func (nc *netConnMockEndpoint) read(n int) ([]byte, error) {
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
@@ -133,6 +135,8 @@ func (nc *netConnMockEndpoint) read(n int) ([]byte, error) {
 }
 
 // write implements portforwarderTestHarness write.
+//
+// +checklocksexclude:nc.mu
 func (nc *netConnMockEndpoint) write(buf []byte) (int, error) {
 	nc.mu.Lock()
 	defer nc.mu.Unlock()
@@ -186,10 +190,7 @@ func TestHostInetProxy(t *testing.T) {
 func doHostinetTest(t *testing.T, name string, requests map[string]string) {
 	ctx := context.Background()
 	appEndpoint := newMockApplicationFDImpl()
-	client, err := newMockFileDescription(ctx, appEndpoint)
-	if err != nil {
-		t.Fatalf("newMockFileDescription: %v", err)
-	}
+	client := newMockFileDescriptionConn(t, ctx, appEndpoint)
 
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -202,9 +203,10 @@ func doHostinetTest(t *testing.T, name string, requests map[string]string) {
 		t.Fatalf("could not create local host socket: %v", err)
 	}
 
-	proxy := NewProxy(ProxyPair{To: sock, From: &fileDescriptionConn{file: client}}, name)
+	proxy := NewProxy(ProxyPair{To: sock, From: client}, name)
 
 	proxy.Start(ctx)
+	defer proxy.Close()
 
 	shim, err := l.Accept()
 	if err != nil {

--- a/runsc/boot/portforward/portforward_netstack_test.go
+++ b/runsc/boot/portforward/portforward_netstack_test.go
@@ -22,31 +22,40 @@ import (
 
 	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/context"
-	"gvisor.dev/gvisor/pkg/sentry/contexttest"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 	"gvisor.dev/gvisor/pkg/waiter"
 )
 
 type baseTCPEndpointImpl struct {
-	closed   bool
-	readBuf  bytes.Buffer
+	mu sync.Mutex
+
+	// +checklocks:mu
+	closed bool
+
+	// +checklocks:mu
+	readBuf bytes.Buffer
+
+	// +checklocks:mu
 	writeBuf bytes.Buffer
-	mu       sync.Mutex
 }
 
 // read reads data from the buffer that "Write" writes to.
+//
+// +checklocksexclude:b.mu
 func (b *baseTCPEndpointImpl) read(n int) ([]byte, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closed {
 		return nil, io.EOF
 	}
-	ret := b.writeBuf.Next(n)
-	return ret, nil
+	// The caller consumes the data after mu is released.
+	return bytes.Clone(b.writeBuf.Next(n)), nil
 }
 
 // write writes data to the read buffer that "Read" reads from.
+//
+// +checklocksexclude:b.mu
 func (b *baseTCPEndpointImpl) write(buf []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -57,12 +66,14 @@ func (b *baseTCPEndpointImpl) write(buf []byte) (int, error) {
 	return n, err
 }
 
+// +checklocksexclude:b.mu
 func (b *baseTCPEndpointImpl) Close() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.closed = true
 }
 
+// +checklocksexclude:b.mu
 func (b *baseTCPEndpointImpl) Read(w io.Writer, _ tcpip.ReadOptions) (tcpip.ReadResult, tcpip.Error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -83,6 +94,7 @@ func (b *baseTCPEndpointImpl) Read(w io.Writer, _ tcpip.ReadOptions) (tcpip.Read
 	}, nil
 }
 
+// +checklocksexclude:b.mu
 func (b *baseTCPEndpointImpl) Write(payload tcpip.Payloader, _ tcpip.WriteOptions) (int64, tcpip.Error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -101,6 +113,7 @@ func (b *baseTCPEndpointImpl) Write(payload tcpip.Payloader, _ tcpip.WriteOption
 	return int64(n), nil
 }
 
+// +checklocksexclude:b.mu
 func (b *baseTCPEndpointImpl) Shutdown(shutdown tcpip.ShutdownFlags) tcpip.Error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -143,12 +156,9 @@ func TestNetstackProxy(t *testing.T) {
 }
 
 func doNetstackTest(t *testing.T, name string, responses map[string]string) {
-	ctx := contexttest.Context(t)
+	ctx := context.Background()
 	appEndpoint := newMockApplicationFDImpl()
-	fd, err := newMockFileDescription(ctx, appEndpoint)
-	if err != nil {
-		t.Fatalf("newMockFileDescription: %v", err)
-	}
+	fd := newMockFileDescriptionConn(t, ctx, appEndpoint)
 
 	wq := &waiter.Queue{}
 	impl := &baseTCPEndpointImpl{}
@@ -158,7 +168,7 @@ func doNetstackTest(t *testing.T, name string, responses map[string]string) {
 		wq: wq,
 	}
 
-	proxy := NewProxy(ProxyPair{To: sock, From: &fileDescriptionConn{file: fd}}, name)
+	proxy := NewProxy(ProxyPair{To: sock, From: fd}, name)
 	proxy.Start(ctx)
 	defer proxy.Close()
 
@@ -198,12 +208,18 @@ func doNetstackTest(t *testing.T, name string, responses map[string]string) {
 
 // tcpErrImpl blocks on the first Read/Write and then throws an error afterwards.
 type tcpErrImpl struct {
-	mu     sync.Mutex
-	reads  bool
+	mu sync.Mutex
+
+	// +checklocks:mu
+	reads bool
+
+	// +checklocks:mu
 	writes bool
 }
 
 // Read implements mockTCPEndpointImpl.Read.
+//
+// +checklocksexclude:e.mu
 func (e *tcpErrImpl) Read(w io.Writer, _ tcpip.ReadOptions) (tcpip.ReadResult, tcpip.Error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -215,6 +231,8 @@ func (e *tcpErrImpl) Read(w io.Writer, _ tcpip.ReadOptions) (tcpip.ReadResult, t
 }
 
 // Write implements mockTCPEndpointImpl.Write.
+//
+// +checklocksexclude:e.mu
 func (e *tcpErrImpl) Write(payload tcpip.Payloader, _ tcpip.WriteOptions) (int64, tcpip.Error) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -236,7 +254,7 @@ func (e *tcpErrImpl) Close() {}
 // TestNTestNestackReadsWrites checks that reads/writes check errors from the underlying endpoint
 // multiple times.
 func TestNestackReadsWrites(t *testing.T) {
-	ctx := contexttest.Context(t)
+	ctx := context.Background()
 	wq := &waiter.Queue{}
 	ep := newMockTCPEndpoint(&tcpErrImpl{}, wq)
 	cancel := make(chan struct{})
@@ -266,6 +284,7 @@ func (p *packetReadImpl) Read(w io.Writer, _ tcpip.ReadOptions) (tcpip.ReadResul
 	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 		Payload: buffer.MakeWithData(payload),
 	})
+	defer pkt.DecRef()
 	n, err := pkt.Data().ReadTo(w, false)
 	if err != nil && n == 0 {
 		return tcpip.ReadResult{}, &tcpip.ErrBadBuffer{}
@@ -288,7 +307,7 @@ func TestNetstackConnReadHandlesShortWrite(t *testing.T) {
 	const bufLen = 1024
 	const payloadLen = bufLen + 512
 
-	ctx := contexttest.Context(t)
+	ctx := context.Background()
 	wq := &waiter.Queue{}
 	ep := newMockTCPEndpoint(&packetReadImpl{payloadSize: payloadLen}, wq)
 	conn := netstackConn{ep: ep, wq: wq}
@@ -306,12 +325,15 @@ func TestNetstackConnReadHandlesShortWrite(t *testing.T) {
 }
 
 type chunkedPacketReadImpl struct {
-	mu   sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	data []byte
 }
 
 func (c *chunkedPacketReadImpl) Close() {}
 
+// +checklocksexclude:c.mu
 func (c *chunkedPacketReadImpl) Read(w io.Writer, _ tcpip.ReadOptions) (tcpip.ReadResult, tcpip.Error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -321,6 +343,7 @@ func (c *chunkedPacketReadImpl) Read(w io.Writer, _ tcpip.ReadOptions) (tcpip.Re
 	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 		Payload: buffer.MakeWithData(c.data),
 	})
+	defer pkt.DecRef()
 	n, err := pkt.Data().ReadTo(w, false)
 	if err != nil && n == 0 {
 		return tcpip.ReadResult{}, &tcpip.ErrBadBuffer{}
@@ -343,13 +366,16 @@ func (c *chunkedPacketReadImpl) Shutdown(tcpip.ShutdownFlags) tcpip.Error {
 type bufferConn struct {
 	name string
 	mu   sync.Mutex
-	buf  bytes.Buffer
+
+	// +checklocks:mu
+	buf bytes.Buffer
 }
 
 func (b *bufferConn) Name() string {
 	return b.name
 }
 
+// +checklocksexclude:b.mu
 func (b *bufferConn) Write(_ context.Context, p []byte, _ <-chan struct{}) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -367,7 +393,7 @@ func TestDoCopyDrainsLargeRead(t *testing.T) {
 	payloadLen := bufLen*3 + 123
 	payload := bytes.Repeat([]byte{'v'}, payloadLen)
 
-	ctx := contexttest.Context(t)
+	ctx := context.Background()
 	wq := &waiter.Queue{}
 	ep := newMockTCPEndpoint(&chunkedPacketReadImpl{data: payload}, wq)
 	src := &netstackConn{ep: ep, wq: wq}
@@ -384,7 +410,7 @@ func TestDoCopyDrainsLargeRead(t *testing.T) {
 	}
 
 	dst.mu.Lock()
-	got := append([]byte(nil), dst.buf.Bytes()...)
+	got := bytes.Clone(dst.buf.Bytes())
 	dst.mu.Unlock()
 	if len(got) != payloadLen {
 		t.Fatalf("copied %d bytes, want %d", len(got), payloadLen)

--- a/runsc/boot/portforward/portforward_test_util.go
+++ b/runsc/boot/portforward/portforward_test_util.go
@@ -77,10 +77,17 @@ type mockApplicationFDImpl struct {
 	vfs.FileDescriptionDefaultImpl
 	vfs.NoLockFD
 	vfs.DentryMetadataFileDescriptionImpl
-	mu         sync.Mutex
-	readBuf    bytes.Buffer
-	writeBuf   bytes.Buffer
-	released   bool
+	mu sync.Mutex
+
+	// +checklocks:mu
+	readBuf bytes.Buffer
+
+	// +checklocks:mu
+	writeBuf bytes.Buffer
+
+	// +checklocks:mu
+	released bool
+
 	queue      waiter.Queue
 	notifyStop chan struct{}
 }
@@ -93,7 +100,9 @@ func newMockApplicationFDImpl() *mockApplicationFDImpl {
 	return app
 }
 
-// Read implements vfs.FileDescriptionImpl.Read details for the parent mockFileDescription.
+// Read implements vfs.FileDescriptionImpl.Read.
+//
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) Read(ctx context.Context, dst usermem.IOSequence, opts vfs.ReadOptions) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -108,7 +117,9 @@ func (s *mockApplicationFDImpl) Read(ctx context.Context, dst usermem.IOSequence
 	return int64(n), err
 }
 
-// Write implements vfs.FileDescriptionImpl.Write details for the parent mockFileDescription.
+// Write implements vfs.FileDescriptionImpl.Write.
+//
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) Write(ctx context.Context, src usermem.IOSequence, opts vfs.WriteOptions) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -123,6 +134,8 @@ func (s *mockApplicationFDImpl) Write(ctx context.Context, src usermem.IOSequenc
 }
 
 // write implements mockEndpoint.write.
+//
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) write(buf []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -134,6 +147,8 @@ func (s *mockApplicationFDImpl) write(buf []byte) (int, error) {
 }
 
 // read implements mockEndpoint.read.
+//
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) read(n int) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -143,8 +158,8 @@ func (s *mockApplicationFDImpl) read(n int) ([]byte, error) {
 	if s.writeBuf.Len() == 0 {
 		return nil, linuxerr.ErrWouldBlock
 	}
-	ret := s.writeBuf.Next(n)
-	return ret, nil
+	// The caller consumes the data after mu is released.
+	return bytes.Clone(s.writeBuf.Next(n)), nil
 }
 
 func (s *mockApplicationFDImpl) doNotify() {
@@ -159,6 +174,7 @@ func (s *mockApplicationFDImpl) doNotify() {
 	}
 }
 
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) IsReadable() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -168,13 +184,16 @@ func (s *mockApplicationFDImpl) IsReadable() bool {
 	return s.readBuf.Len() > 0
 }
 
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) IsWritable() bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return !s.released
 }
 
-// EventRegister implements vfs.FileDescriptionImpl.EventRegister details for the parent mockFileDescription.
+// EventRegister implements vfs.FileDescriptionImpl.EventRegister.
+//
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) EventRegister(we *waiter.Entry) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -182,14 +201,18 @@ func (s *mockApplicationFDImpl) EventRegister(we *waiter.Entry) error {
 	return nil
 }
 
-// EventUnregister implements vfs.FileDescriptionImpl.Unregister details for the parent mockFileDescription.
+// EventUnregister implements vfs.FileDescriptionImpl.EventUnregister.
+//
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) EventUnregister(we *waiter.Entry) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.queue.EventUnregister(we)
 }
 
-// Release implements vfs.FileDescriptionImpl.Release details for the parent mockFileDescription.
+// Release implements vfs.FileDescriptionImpl.Release.
+//
+// +checklocksexclude:s.mu
 func (s *mockApplicationFDImpl) Release(context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Version needs the configured runsc binary while sandbox creation is in progress. Publish a copy of the command through an atomic pointer so the version probe neither races with updates nor waits for the service mutex held during creation. Use the default binary when the command is unset or empty, and remove the unused shim root field.

Snapshot registered RPC stoppers under their mutex, then invoke callbacks after unlocking so callbacks can reenter the server.

Repair port-forward fixture synchronization, buffer ownership, short-read handling, and cleanup. Replace the close-order test's sleep with explicit synchronization.

Assisted-by: Codex