### PR TITLE
Fix checkpoint and restore synchronization

### DIFF
--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -435,6 +435,7 @@ go_test(
     size = "small",
     srcs = [
         "fd_table_test.go",
+        "kernel_restore_test.go",
         "table_test.go",
         "task_syscall_benchmark_test.go",
         "task_test.go",
@@ -455,6 +456,7 @@ go_test(
         "//pkg/sentry/pgalloc",
         "//pkg/sentry/seccheck",
         "//pkg/sentry/seccheck/points:points_go_proto",
+        "//pkg/sentry/state/stateio",
         "//pkg/sentry/time",
         "//pkg/sentry/usage",
         "//pkg/sentry/vfs",

--- a/pkg/sentry/kernel/fscheckpoint.go
+++ b/pkg/sentry/kernel/fscheckpoint.go
@@ -57,6 +57,8 @@ type FSSaveOpts struct {
 
 // FSSave collects a filesystem checkpoint as specified by the fscheckpoint
 // package. FSSave takes ownership of resources in opts.
+//
+// +checklocksexclude:k.fsSaveMu
 func (k *Kernel) FSSave(ctx context.Context, opts *FSSaveOpts) error {
 	defer func() {
 		if opts.ManifestFile != nil {
@@ -202,7 +204,10 @@ func (k *Kernel) FSSave(ctx context.Context, opts *FSSaveOpts) error {
 				PagesStart:         prevPagesOffset,
 			})
 			prevPagesMetadataOffset = pagesMetadataWriter.count
-			prevPagesOffset = apfs.PagesFileOffset()
+			// This callback serializes all SaveTo calls using apfs. Only those
+			// calls write saveOff; the background saver only reads it.
+			// checklocks cannot express the absence of a concurrent writer here.
+			prevPagesOffset = apfs.PagesFileOffset() // +checklocksignore
 			if err := tmpfs.FSCheckpointWrite(ctx, fs, multiTarWriter); err != nil {
 				return fmt.Errorf("failed to write tmpfs with resourceID %s to multi-tar file: %w", resourceID, err)
 			}
@@ -274,6 +279,8 @@ func (cw *countingWriter) Write(src []byte) (int, error) {
 //
 // This API is difficult to use without races, but is consistent with
 // k.WaitForCheckpoint().
+//
+// +checklocksexclude:k.fsSaveMu
 func (k *Kernel) WaitForFSSave() error {
 	c := make(chan error, 1)
 	k.fsSaveMu.Lock()
@@ -283,6 +290,8 @@ func (k *Kernel) WaitForFSSave() error {
 }
 
 // SignalAllFSSaveWaiters signals all FS save waiters with err.
+//
+// +checklocksexclude:k.fsSaveMu
 func (k *Kernel) SignalAllFSSaveWaiters(err error) {
 	k.fsSaveMu.Lock()
 	defer k.fsSaveMu.Unlock()

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -146,6 +146,7 @@ type SaveRestoreExecConfig struct {
 // Init() or LoadFrom().
 //
 // +stateify savable
+// +checklocksalias:CheckpointWait.k.checkpointMu=checkpointMu
 type Kernel struct {
 	// extMu serializes external changes to the Kernel with calls to
 	// Kernel.SaveTo. (Kernel.SaveTo requires that the state of the Kernel
@@ -401,23 +402,28 @@ type Kernel struct {
 	// It's protected by extMu.
 	containerNames map[string]string
 
-	// checkpointMu is used to protect the checkpointing related fields below.
+	// Lock order: checkpointMu precedes CheckpointWait.mu.
 	checkpointMu sync.Mutex `state:"nosave"`
 
 	// additionalCheckpointState stores additional state that needs
-	// to be checkpointed. It's protected by checkpointMu.
+	// to be checkpointed.
+	//
+	// +checklocks:checkpointMu
 	additionalCheckpointState map[any]any
 
 	// saver implements the Saver interface, which (as of writing) supports
-	// asynchronous checkpointing. It's protected by checkpointMu.
+	// asynchronous checkpointing.
+	//
+	// +checklocks:checkpointMu
 	saver Saver `state:"nosave"`
 
 	// CheckpointWait is used to wait for a checkpoint to complete.
 	CheckpointWait CheckpointWaitable
 
-	// checkpointGen aims to track the number of times the kernel has been
-	// successfully checkpointed. Callers of checkpoint must notify the kernel
-	// when checkpoint/restore are done. It's protected by checkpointMu.
+	// checkpointGen describes the latest checkpoint attempt or restore.
+	// Callers must notify the kernel when checkpoint/restore are done.
+	//
+	// +checklocks:checkpointMu
 	checkpointGen CheckpointGeneration
 
 	// SaveRestoreExecConfig stores configuration options for the save/restore

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -443,9 +443,11 @@ type Kernel struct {
 	// MaxKeySetSize is the maximum number of keys in a key set.
 	MaxKeySetSize atomicbitops.Int32
 
-	// fsSaveWaiters holds waiters for Kernel.WaitForFSSave. fsSaveWaiters is
-	// protected by fsSaveMu.
-	fsSaveMu      fsSaveMutex  `state:"nosave"`
+	fsSaveMu fsSaveMutex `state:"nosave"`
+
+	// fsSaveWaiters holds waiters for Kernel.WaitForFSSave.
+	//
+	// +checklocks:fsSaveMu
 	fsSaveWaiters []chan error `state:"nosave"`
 
 	// HostNamePoller is notified when the system hostname changes in *any*

--- a/pkg/sentry/kernel/kernel_restore.go
+++ b/pkg/sentry/kernel/kernel_restore.go
@@ -266,6 +266,9 @@ func (w *CheckpointWaitable) signal(gen CheckpointGeneration, err error) {
 // loadPrivateMemoryFiles loads the private MemoryFiles from mfmap and it reads
 // private MemoryFile metadata from `r`. This consumes bytes from `r`, so this
 // must be called only once.
+//
+// +checklocksexclude:opts.PagesFile.amflsMu
+// +checklocksexclude:opts.PagesFile.mu
 func loadPrivateMemoryFiles(ctx context.Context, r io.Reader, mfmap map[checkpoint.ResourceID]*pgalloc.MemoryFile, opts *pgalloc.LoadOpts) error {
 	// Load the metadata.
 	var meta privateMemoryFileMetadata

--- a/pkg/sentry/kernel/kernel_restore.go
+++ b/pkg/sentry/kernel/kernel_restore.go
@@ -262,6 +262,10 @@ type AsyncMFLoader struct {
 	// MemoryFiles, once they are known. This channel is written to exactly once.
 	privateMFsChan chan map[checkpoint.ResourceID]*pgalloc.MemoryFile
 
+	// Error fields are published by WaitGroup completion rather than a mutex:
+	// mainMFStartWg publishes mainMetadataErr, metadataWg publishes metadataErr,
+	// and loadWg publishes loadErr. Readers wait for the corresponding group.
+	// checklocks cannot express these completion-based publication boundaries.
 	mainMFStartWg   sync.WaitGroup
 	mainMetadataErr error
 
@@ -306,6 +310,9 @@ func (mfl *AsyncMFLoader) backgroundGoroutine(pagesMetadata io.ReadCloser, pages
 	}, timeline) // transfers ownership of pagesFile
 	if err != nil {
 		mfl.loadWg.Done()
+		mfl.mainMetadataErr = err
+		mfl.metadataErr = err
+		mfl.mainMFStartWg.Done()
 		log.Warningf("Failed to start async page loading: %v", err)
 		return
 	}

--- a/pkg/sentry/kernel/kernel_restore.go
+++ b/pkg/sentry/kernel/kernel_restore.go
@@ -37,12 +37,12 @@ type Saver interface {
 	FSSave() error
 }
 
-// CheckpointGeneration stores information about the last checkpoint taken.
+// CheckpointGeneration describes the latest checkpoint attempt or restore.
 //
 // +stateify savable
 type CheckpointGeneration struct {
-	// Count is incremented every time a checkpoint is triggered, even if the
-	// checkpoint failed.
+	// Count is incremented after each checkpoint attempt, including failures,
+	// and on restore.
 	Count uint32
 	// Restore indicates if the current instance resumed after the checkpoint or
 	// it was restored from a checkpoint.
@@ -50,6 +50,9 @@ type CheckpointGeneration struct {
 }
 
 // AddStateToCheckpoint adds a key-value pair to be additionally checkpointed.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) AddStateToCheckpoint(key, v any) {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -61,6 +64,9 @@ func (k *Kernel) AddStateToCheckpoint(key, v any) {
 
 // PopCheckpointState pops a key-value pair from the additional checkpoint
 // state. If the key doesn't exist, nil is returned.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) PopCheckpointState(key any) any {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -73,6 +79,9 @@ func (k *Kernel) PopCheckpointState(key any) any {
 
 // SetSaver sets the kernel's Saver.
 // Thread-compatible.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) SetSaver(s Saver) {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -81,6 +90,9 @@ func (k *Kernel) SetSaver(s Saver) {
 
 // Saver returns the kernel's Saver.
 // Thread-compatible.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) Saver() Saver {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -88,6 +100,9 @@ func (k *Kernel) Saver() Saver {
 }
 
 // CheckpointGen returns the current checkpoint generation.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) CheckpointGen() CheckpointGeneration {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -96,6 +111,9 @@ func (k *Kernel) CheckpointGen() CheckpointGeneration {
 }
 
 // IncCheckpointGenOnRestore increments the checkpoint generation upon restore.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) IncCheckpointGenOnRestore() {
 	k.checkpointMu.Lock()
 	defer k.checkpointMu.Unlock()
@@ -108,6 +126,9 @@ func (k *Kernel) IncCheckpointGenOnRestore() {
 
 // OnCheckpointAttempt is called when a checkpoint attempt is completed. err is
 // any checkpoint errors that may have occurred.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) OnCheckpointAttempt(err error) {
 	if err == nil {
 		log.Infof("Checkpoint completed successfully.")
@@ -124,7 +145,11 @@ func (k *Kernel) OnCheckpointAttempt(err error) {
 	k.CheckpointWait.signal(k.checkpointGen, err)
 }
 
-// WaitForCheckpoint waits for the Kernel to have been successfully checkpointed.
+// WaitForCheckpoint waits for the next checkpoint generation or an error
+// notification, and returns the reported error.
+//
+// +checklocksexclude:k.checkpointMu
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) WaitForCheckpoint() error {
 	// Send checkpoint result to a channel and wait on it.
 	ch := make(chan error, 1)
@@ -136,6 +161,8 @@ func (k *Kernel) WaitForCheckpoint() error {
 }
 
 // SignalAllCheckpointWaiters signals all checkpoint waiters with err.
+//
+// +checklocksexclude:k.CheckpointWait.mu
 func (k *Kernel) SignalAllCheckpointWaiters(err error) {
 	k.CheckpointWait.signal(CheckpointGeneration{Count: math.MaxUint32}, err)
 }
@@ -145,6 +172,9 @@ type checkpointWaiter struct {
 	count uint32
 	// callback is the function that will be called when the checkpoint generation
 	// reaches the desired count. It is set to nil after the callback is called.
+	//
+	// It is protected by the owning CheckpointWaitable's mu. The waiter has
+	// no reference to that owner, so checklocks cannot name the mutex here.
 	callback func(CheckpointGeneration, error)
 }
 
@@ -152,22 +182,32 @@ type checkpointWaiter struct {
 // checkpoint to complete.
 //
 // +stateify savable
+// +checklocksalias:k.CheckpointWait.mu=mu
 type CheckpointWaitable struct {
+	// k contains this waitable in k.CheckpointWait. It is set before the
+	// waitable is used and remains unchanged.
 	k *Kernel
 
 	mu sync.Mutex `state:"nosave"`
 
 	// Don't save the waiters, because they are repopulated after restore. It also
 	// allows for external entities to wait for the checkpoint.
+	//
+	// +checklocks:mu
 	waiters map[*checkpointWaiter]struct{} `state:"nosave"`
 }
 
-// Register registers a callback that is notified when the checkpoint generation count is higher
-// than the desired count.
+// Register registers a callback that is notified when the checkpoint generation
+// reaches the desired count.
+//
+// cb runs with mu held and may also run with the kernel's checkpoint mutex
+// held. It must not call methods that acquire either mutex. checklocks cannot
+// attach these owner-lock requirements to the supplied function value.
+//
+// +checklocksexclude:w.mu
+// +checklocksexclude:w.k.checkpointMu
 func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), count uint32) any {
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	waiter := &checkpointWaiter{
 		count:    count,
 		callback: cb,
@@ -176,8 +216,17 @@ func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), coun
 		w.waiters = make(map[*checkpointWaiter]struct{})
 	}
 	w.waiters[waiter] = struct{}{}
+	w.mu.Unlock()
 
-	if gen := w.k.CheckpointGen(); count <= gen.Count {
+	// Publish the waiter before reading the generation to avoid missing a
+	// checkpoint. Do not hold mu while acquiring checkpointMu: notification
+	// holds checkpointMu while acquiring mu.
+	gen := w.k.CheckpointGen()
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	// Notification may have already delivered the checkpoint's error.
+	if waiter.callback != nil && count <= gen.Count {
 		// The checkpoint has already occurred. Signal immediately.
 		waiter.callback(gen, nil)
 		waiter.callback = nil
@@ -185,8 +234,10 @@ func (w *CheckpointWaitable) Register(cb func(CheckpointGeneration, error), coun
 	return waiter
 }
 
-// Unregister unregisters a waiter. It must be called even if the channel
-// was signalled.
+// Unregister unregisters a waiter. It must be called even if the callback
+// has already run.
+//
+// +checklocksexclude:w.mu
 func (w *CheckpointWaitable) Unregister(key any) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -197,6 +248,9 @@ func (w *CheckpointWaitable) Unregister(key any) {
 	}
 }
 
+// signal notifies waiters whose desired generation has been reached.
+//
+// +checklocksexclude:w.mu
 func (w *CheckpointWaitable) signal(gen CheckpointGeneration, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/pkg/sentry/kernel/kernel_restore_test.go
+++ b/pkg/sentry/kernel/kernel_restore_test.go
@@ -16,9 +16,12 @@ package kernel
 
 import (
 	"bytes"
+	"errors"
 	"io"
+	"runtime"
 	"testing"
 	"testing/synctest"
+	"time"
 
 	"gvisor.dev/gvisor/pkg/sentry/state/stateio"
 )
@@ -43,4 +46,67 @@ func TestAsyncMFLoaderStartupError(t *testing.T) {
 			t.Errorf("Wait() = %v, want %v", err, startErr)
 		}
 	})
+}
+
+func TestCheckpointRegistrationDuringNotification(t *testing.T) {
+	var k Kernel
+	w := &k.CheckpointWait
+	w.k = &k
+	gen := CheckpointGeneration{Count: 1}
+	wantErr := errors.New("checkpoint failed")
+	type result struct {
+		gen CheckpointGeneration
+		err error
+	}
+	results := make(chan result, 2)
+	registered := make(chan any, 1)
+	notified := make(chan struct{})
+
+	// Hold the generation lock as a checkpoint producer does. Registration
+	// must not hold the waiters lock while waiting to read this generation.
+	k.checkpointMu.Lock()
+	k.checkpointGen = gen
+	go func() {
+		registered <- w.Register(func(gen CheckpointGeneration, err error) {
+			results <- result{gen, err}
+		}, gen.Count)
+	}()
+	go func() {
+		for {
+			w.mu.Lock()
+			pending := len(w.waiters) != 0
+			w.mu.Unlock()
+			if pending {
+				break
+			}
+			runtime.Gosched()
+		}
+		w.signal(gen, wantErr)
+		close(notified)
+	}()
+
+	// Mutex contention is not durably blocking in synctest, so its clock
+	// cannot advance a watchdog when the original lock inversion occurs.
+	// Use a real-time deadline to release both goroutines on that failure.
+	var blocked bool
+	select {
+	case <-notified:
+	case <-time.After(5 * time.Second):
+		blocked = true
+	}
+	// Release the generation lock even on failure, so the original lock
+	// inversion cannot strand either goroutine during test cleanup.
+	k.checkpointMu.Unlock()
+	key := <-registered
+	<-notified
+	w.Unregister(key)
+	if blocked {
+		t.Fatal("checkpoint notification blocked on registration")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d callbacks, want 1", len(results))
+	}
+	if got := <-results; got.gen != gen || got.err != wantErr {
+		t.Fatalf("callback = (%+v, %v), want (%+v, %v)", got.gen, got.err, gen, wantErr)
+	}
 }

--- a/pkg/sentry/kernel/kernel_restore_test.go
+++ b/pkg/sentry/kernel/kernel_restore_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"testing/synctest"
+
+	"gvisor.dev/gvisor/pkg/sentry/state/stateio"
+)
+
+func TestAsyncMFLoaderStartupError(t *testing.T) {
+	// The bubble detects a missing mainMFStartWg completion as a deadlock,
+	// without a timeout. This test does not depend on virtual time.
+	synctest.Test(t, func(t *testing.T) {
+		// A sub-page read limit fails before metadata or mainMF is loaded.
+		pages := stateio.NewIOReader(bytes.NewReader(nil), 1, 1, 1)
+		metadata := io.NopCloser(bytes.NewReader(nil))
+		loader := NewAsyncMFLoader(metadata, pages, nil, nil)
+
+		startErr := loader.WaitMainMFStart()
+		if startErr == nil {
+			t.Fatal("WaitMainMFStart() succeeded with a sub-page read limit")
+		}
+		if err := loader.WaitMetadata(); err != startErr {
+			t.Errorf("WaitMetadata() = %v, want %v", err, startErr)
+		}
+		if err := loader.Wait(); err != startErr {
+			t.Errorf("Wait() = %v, want %v", err, startErr)
+		}
+	})
+}

--- a/pkg/sentry/pgalloc/BUILD
+++ b/pkg/sentry/pgalloc/BUILD
@@ -212,8 +212,13 @@ go_test(
     ],
     library = ":pgalloc",
     deps = [
+        "//pkg/context",
         "//pkg/hostarch",
+        "//pkg/memutil",
         "//pkg/sentry/memmap",
+        "//pkg/sentry/usage",
+        "//pkg/state",
+        "//pkg/state/wire",
     ],
 )
 

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -212,7 +212,11 @@ type MemoryFile struct {
 	// quiet cache line, since MapInternal() is by far the hottest path through
 	// pgalloc.
 	//
-	// chunks is protected by mu. chunks slices are immutable.
+	// After construction, stores to chunks require mu. Published slice headers
+	// and membership are immutable; chunk mappings follow the lifecycle below.
+	//
+	// The current checker cannot validate this field's generic atomic.Pointer
+	// operations.
 	chunks atomic.Pointer[[]chunkInfo]
 }
 
@@ -229,7 +233,13 @@ const (
 type chunkInfo struct {
 	// mapping is the start address of a mapping of the chunk.
 	//
-	// mapping is immutable.
+	// mapping is initialized before a new chunk is published. LoadFrom
+	// initializes restored mappings and destruction clears them with the
+	// owning MemoryFile.mu held. Commitment scans read mapping under that
+	// mutex. Other readers are ordered after initialization and exclude
+	// destruction through page references or MemoryFile lifecycle ownership.
+	//
+	// chunkInfo has no pointer to its MemoryFile for checklocks to use.
 	mapping uintptr `state:"nosave"`
 
 	// huge is true if this chunk is expected to be hugepage-backed and false if
@@ -1677,7 +1687,9 @@ func (f *MemoryFile) updateUsageLocked(memCgIDs map[uint32]struct{}) error {
 	// Track if anything changed to elide the merge.
 	changedAny := false
 	defer func() {
-		if changedAny {
+		// SaveTo may have started while mincore released f.mu, and may
+		// retain accounting iterators across its own unlocks.
+		if changedAny && !f.isSaving {
 			f.memAcct.MergeAll()
 		}
 	}()

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -108,18 +108,25 @@ type MemoryFile struct {
 	// are *not* waste, allowing use of segment.Set gap-tracking to efficiently
 	// find ranges for both release and recycling allocations.
 	//
-	// unwasteSmall and unwasteHuge are protected by mu.
+	// +checklocks:mu
 	unwasteSmall unwasteSet
-	unwasteHuge  unwasteSet
+
+	// +checklocks:mu
+	unwasteHuge unwasteSet
 
 	// haveWaste is true if there may be at least one waste page in the
 	// MemoryFile.
 	//
-	// haveWaste is protected by mu.
+	// +checklocks:mu
 	haveWaste bool
 
 	// releaseCond is signaled (with mu locked) when haveWaste or destroyed
 	// transitions from false to true.
+	//
+	// Its Locker is set to &mu before publication and does not change. Wait
+	// requires mu and temporarily releases it; the queue is synchronized
+	// internally. checklocks cannot express Wait's requirement on the mutex
+	// selected by the Locker interface.
 	releaseCond sync.Cond
 
 	// unfreeSmall and unfreeHuge track information for non-free ranges backed
@@ -129,13 +136,16 @@ type MemoryFile struct {
 	// allowing use of segment.Set gap-tracking to efficiently find free ranges
 	// for allocation.
 	//
-	// unfreeSmall and unfreeHuge are protected by mu.
+	// +checklocks:mu
 	unfreeSmall unfreeSet
-	unfreeHuge  unfreeSet
+
+	// +checklocks:mu
+	unfreeHuge unfreeSet
 
 	// subreleased maps hugepage-aligned file offsets to the number of
 	// sub-released small pages within the hugepage beginning at that offset.
-	// subreleased is protected by mu.
+	//
+	// +checklocks:mu
 	subreleased map[uint64]uint64
 
 	// These fields are used for memory accounting.
@@ -151,33 +161,43 @@ type MemoryFile struct {
 	// each page. Non-empty gaps in memAcct represent pages known to be
 	// uncommitted (void, free, and sub-released pages).
 	//
+	// +checklocks:mu
+	memAcct memAcctSet
+
 	// knownCommittedBytes is the number of bytes in the file known to be
 	// committed, i.e. the span of all segments in memAcct for which
 	// knownCommitted is true.
 	//
+	// +checklocks:mu
+	knownCommittedBytes uint64
+
 	// commitSeq is a sequence counter used to detect races between scans for
 	// committed pages and concurrent decommitment.
 	//
+	// +checklocks:mu
+	commitSeq uint64
+
 	// nextCommitScan is the next time at which UpdateUsage(nil) may scan the
 	// backing file for commitment information.
 	//
-	// ongoingCommitScan is true while UpdateUsage(nil) is in progress. Writing
-	// to it requires f.mu to be locked, but reading it does not.
+	// +checklocks:mu
+	nextCommitScan time.Time
+
+	// ongoingCommitScan is true while UpdateUsage(nil) is in progress.
 	//
+	// +checkatomic
+	// +checklocks:mu
+	ongoingCommitScan atomic.Bool
+
 	// isSaving is true during f.SaveTo() to prevent concurrent calls to
 	// f.UpdateUsage() from marking pages as committed.
 	//
-	// All of these fields are protected by mu.
-	memAcct             memAcctSet
-	knownCommittedBytes uint64
-	commitSeq           uint64
-	nextCommitScan      time.Time
-	ongoingCommitScan   atomic.Bool
-	isSaving            bool
+	// +checklocks:mu
+	isSaving bool
 
 	// evictable maps EvictableMemoryUsers to eviction state.
 	//
-	// evictable is protected by mu.
+	// +checklocks:mu
 	evictable map[EvictableMemoryUser]*evictableMemoryUserInfo
 
 	// evictionWG counts the number of goroutines currently performing evictions.
@@ -187,11 +207,15 @@ type MemoryFile struct {
 	opts MemoryFileOpts
 
 	// savable is true if this MemoryFile will be saved via SaveTo() during
-	// the kernel's SaveTo operation. savable is protected by mu.
+	// the kernel's SaveTo operation.
+	//
+	// +checklocks:mu
 	savable bool
 
 	// destroyed is set by Destroy to instruct the releaser goroutine to
-	// release all MemoryFile resources and exit. destroyed is protected by mu.
+	// release all MemoryFile resources and exit.
+	//
+	// +checklocks:mu
 	destroyed bool
 
 	// stopNotifyPressure stops memory cgroup pressure level
@@ -278,6 +302,10 @@ type unwasteInfo struct{}
 
 // unfreeInfo is the value type of MemoryFile.unfreeSmall/Huge.
 //
+// Stored values are protected by the owning MemoryFile's mu. Values and
+// generated iterators have no owner back-reference for checklocks to use;
+// Merge and Split also operate on copied values.
+//
 // +stateify savable
 type unfreeInfo struct {
 	// refs is the per-page reference count. refs is non-zero for used pages,
@@ -287,6 +315,10 @@ type unfreeInfo struct {
 }
 
 // memAcctInfo is the value type of MemoryFile.memAcct.
+//
+// Values share the owning MemoryFile's mutex.
+// Values and generated iterators have no MemoryFile back-reference through
+// which checklocks could name that owner; Merge and Split operate on copies.
 //
 // +stateify savable
 type memAcctInfo struct {
@@ -344,6 +376,9 @@ type EvictableMemoryUser interface {
 // type EvictableRange <generated using go_generics>
 
 // evictableMemoryUserInfo is the value type of MemoryFile.evictable.
+//
+// Both fields are protected by the owning MemoryFile's mu. Entries have no
+// back-reference to that MemoryFile, so checklocks cannot name the mutex here.
 type evictableMemoryUserInfo struct {
 	// ranges tracks all evictable ranges for the given user.
 	ranges evictableRangeSet
@@ -454,7 +489,9 @@ func NewMemoryFile(file *os.File, opts MemoryFileOpts) (*MemoryFile, error) {
 		opts: opts,
 		file: file,
 	}
-	f.initFields()
+	// f was just allocated; no callback or releaser can access it yet.
+	// checklocks cannot substitute this ownership for initFields' mutex contract.
+	f.initFields() // +checklocksignore
 
 	if f.opts.DelayedEviction == DelayedEvictionEnabled && f.opts.UseHostMemcgPressure {
 		stop, err := hostmm.NotifyCurrentMemcgPressureCallback(func() {
@@ -479,6 +516,11 @@ func NewMemoryFile(file *os.File, opts MemoryFileOpts) (*MemoryFile, error) {
 	return f, nil
 }
 
+// initFields initializes f's bookkeeping before publication.
+//
+// Preconditions: f has not been initialized or shared with other goroutines.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) initFields() {
 	// Initially, all pages are void.
 	fullFR := memmap.FileRange{0, math.MaxUint64}
@@ -533,6 +575,8 @@ func IMAWorkAroundForMemFile(fd uintptr) {
 // Preconditions: All pages allocated by f have been freed.
 //
 // Postconditions: None of f's methods may be called after Destroy.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) Destroy() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -540,7 +584,9 @@ func (f *MemoryFile) Destroy() {
 	f.releaseCond.Signal()
 }
 
-// Preconditions: f.mu must be locked.
+// releaserDestroyLocked releases the backing file and chunk mappings.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) releaserDestroyLocked() {
 	if !f.destroyed {
 		panic("destroyed is no longer set")
@@ -660,6 +706,8 @@ type allocState struct {
 //   - length > 0.
 //   - length must be page-aligned.
 //   - If opts.Hugepage == true, length must be hugepage-aligned.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) Allocate(length uint64, opts AllocOpts) (memmap.FileRange, error) {
 	if length == 0 || !hostarch.IsPageAligned(length) || (opts.Huge && !hostarch.IsHugePageAligned(length)) {
 		panic(fmt.Sprintf("invalid allocation length: %#x", length))
@@ -783,16 +831,17 @@ func (f *MemoryFile) Allocate(length uint64, opts AllocOpts) (memmap.FileRange, 
 	return fr, nil
 }
 
+// +checklocksexclude:f.mu
 func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.FileRange, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	unwaste := &f.unwasteSmall
 	unfree := &f.unfreeSmall
 	if alloc.huge {
 		unwaste = &f.unwasteHuge
 		unfree = &f.unfreeHuge
 	}
-
-	f.mu.Lock()
-	defer f.mu.Unlock()
 
 	if alloc.willCommit {
 		// Try to recycle waste pages, since this avoids the overhead of
@@ -818,10 +867,12 @@ func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.Fi
 			}
 			unwaste.Insert(uwgap, fr, unwasteInfo{})
 			// Update reference count for these pages from 0 to 1.
+			// MutateFullRange calls back synchronously with f.mu held, but
+			// checklocks does not propagate that lock state into the callback.
 			unfree.MutateFullRange(fr, func(ufseg unfreeIterator) bool {
 				uf := ufseg.ValuePtr()
 				if uf.refs != 0 {
-					panic(fmt.Sprintf("waste pages %v have unexpected refcount %d during recycling of %v\n%s", ufseg.Range(), uf.refs, fr, f.stringLocked()))
+					panic(fmt.Sprintf("waste pages %v have unexpected refcount %d during recycling of %v\n%s", ufseg.Range(), uf.refs, fr, f.stringLocked())) // +checklocksignore
 				}
 				uf.refs = 1
 				return true
@@ -829,16 +880,19 @@ func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.Fi
 			// These pages should all be unknown-commitment or known-committed;
 			// mark them unknown-commitment, for consistency with non-recycling
 			// allocations (below).
+			//
+			// MutateFullRange is synchronous; checklocks does not carry the held
+			// f.mu into the callback.
 			f.memAcct.MutateFullRange(fr, func(maseg memAcctIterator) bool {
 				ma := maseg.ValuePtr()
 				malen := maseg.Range().Length()
 				if ma.knownCommitted {
 					if ma.kind != usage.System {
-						panic(fmt.Sprintf("waste pages %v have unexpected kind %v\n%s", maseg.Range(), ma.kind, f.stringLocked()))
+						panic(fmt.Sprintf("waste pages %v have unexpected kind %v\n%s", maseg.Range(), ma.kind, f.stringLocked())) // +checklocksignore
 					}
 					ma.knownCommitted = false
-					ma.commitSeq = f.commitSeq
-					f.knownCommittedBytes -= malen
+					ma.commitSeq = f.commitSeq     // +checklocksignore
+					f.knownCommittedBytes -= malen // +checklocksignore
 					if !f.opts.DisableMemoryAccounting {
 						usage.MemoryAccounting.Dec(malen, usage.System, ma.memCgID)
 					}
@@ -899,7 +953,9 @@ retryFree:
 	return
 }
 
-// Preconditions: f.mu must be locked.
+// extendChunksLocked grows the backing file and publishes its new chunks.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) extendChunksLocked(alloc *allocState) error {
 	unfree := &f.unfreeSmall
 	if alloc.huge {
@@ -1092,6 +1148,8 @@ func tryPopulate(b safemem.Block) bool {
 //   - fr.Start and fr.End must be page-aligned.
 //   - fr.Length() > 0.
 //   - At least one reference must be held on all pages in fr.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) Decommit(fr memmap.FileRange) {
 	if !fr.WellFormed() || fr.Length() == 0 || fr.Start%hostarch.PageSize != 0 || fr.End%hostarch.PageSize != 0 {
 		panic(fmt.Sprintf("invalid range: %v", fr))
@@ -1101,19 +1159,21 @@ func (f *MemoryFile) Decommit(fr memmap.FileRange) {
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// MutateFullRange is synchronous; checklocks does not carry the held
+	// f.mu into the callback.
 	f.memAcct.MutateFullRange(fr, func(maseg memAcctIterator) bool {
 		ma := maseg.ValuePtr()
 		if ma.knownCommitted {
 			ma.knownCommitted = false
 			malen := maseg.Range().Length()
-			f.knownCommittedBytes -= malen
+			f.knownCommittedBytes -= malen // +checklocksignore
 			if !f.opts.DisableMemoryAccounting {
 				usage.MemoryAccounting.Dec(malen, ma.kind, ma.memCgID)
 			}
 		}
 		// Update commitSeq to invalidate any observations made by
 		// concurrent calls to f.updateUsageLocked().
-		ma.commitSeq = f.commitSeq
+		ma.commitSeq = f.commitSeq // +checklocksignore
 		return true
 	})
 }
@@ -1160,14 +1220,18 @@ func (f *MemoryFile) decommitOrManuallyZero(fr memmap.FileRange) {
 // copying it, then a return value of true is not racy.
 //
 // Preconditions: At least one reference must be held on all pages in fr.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) HasUniqueRef(fr memmap.FileRange) bool {
 	hasUniqueRef := true
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// forEachChunk invokes this callback synchronously with f.mu held.
+	// checklocks does not propagate that lock state into the callback.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unfree := &f.unfreeSmall
+		unfree := &f.unfreeSmall // +checklocksignore
 		if chunk.huge {
-			unfree = &f.unfreeHuge
+			unfree = &f.unfreeHuge // +checklocksignore
 		}
 		unfree.VisitFullRange(fr, func(ufseg unfreeIterator) bool {
 			if ufseg.ValuePtr().refs != 1 {
@@ -1188,14 +1252,18 @@ func (f *MemoryFile) HasUniqueRef(fr memmap.FileRange) bool {
 // contained in the returned range) are not racy.
 //
 // Preconditions: At least one reference must be held on all pages in fr.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) FirstSharedRange(fr memmap.FileRange) (memmap.FileRange, bool) {
 	var sr memmap.FileRange
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// forEachChunk invokes this callback synchronously with f.mu held.
+	// checklocks does not propagate that lock state into the callback.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unfree := &f.unfreeSmall
+		unfree := &f.unfreeSmall // +checklocksignore
 		if chunk.huge {
-			unfree = &f.unfreeHuge
+			unfree = &f.unfreeHuge // +checklocksignore
 		}
 		cont := true
 		unfree.VisitFullRange(chunkFR, func(ufseg unfreeIterator) bool {
@@ -1221,6 +1289,8 @@ func (f *MemoryFile) FirstSharedRange(fr memmap.FileRange) (memmap.FileRange, bo
 }
 
 // IncRef implements memmap.File.IncRef.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) IncRef(fr memmap.FileRange, memCgID uint32) {
 	if !fr.WellFormed() || fr.Length() == 0 || !hostarch.IsPageAligned(fr.Start) || !hostarch.IsPageAligned(fr.End) {
 		panic(fmt.Sprintf("invalid range: %v", fr))
@@ -1231,12 +1301,16 @@ func (f *MemoryFile) IncRef(fr memmap.FileRange, memCgID uint32) {
 	f.incRefLocked(fr)
 }
 
-// Preconditions: f.mu must be locked.
+// incRefLocked increments reference counts for pages in fr with f.mu held.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) incRefLocked(fr memmap.FileRange) {
+	// forEachChunk invokes this callback synchronously with f.mu held.
+	// checklocks does not propagate that lock state into the callback.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unfree := &f.unfreeSmall
+		unfree := &f.unfreeSmall // +checklocksignore
 		if chunk.huge {
-			unfree = &f.unfreeHuge
+			unfree = &f.unfreeHuge // +checklocksignore
 		}
 		unfree.MutateFullRange(chunkFR, func(ufseg unfreeIterator) bool {
 			uf := ufseg.ValuePtr()
@@ -1251,6 +1325,8 @@ func (f *MemoryFile) incRefLocked(fr memmap.FileRange) {
 }
 
 // DecRef implements memmap.File.DecRef.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) DecRef(fr memmap.FileRange) {
 	if !fr.WellFormed() || fr.Length() == 0 || !hostarch.IsPageAligned(fr.Start) || !hostarch.IsPageAligned(fr.End) {
 		panic(fmt.Sprintf("invalid range: %v", fr))
@@ -1260,12 +1336,14 @@ func (f *MemoryFile) DecRef(fr memmap.FileRange) {
 	defer f.mu.Unlock()
 
 	haveWaste := false
+	// forEachChunk is synchronous; checklocks cannot carry the held f.mu
+	// into this callback or its nested range callbacks.
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-		unwaste := &f.unwasteSmall
-		unfree := &f.unfreeSmall
+		unwaste := &f.unwasteSmall // +checklocksignore
+		unfree := &f.unfreeSmall   // +checklocksignore
 		if chunk.huge {
-			unwaste = &f.unwasteHuge
-			unfree = &f.unfreeHuge
+			unwaste = &f.unwasteHuge // +checklocksignore
+			unfree = &f.unfreeHuge   // +checklocksignore
 		}
 		unfree.MutateFullRange(chunkFR, func(ufseg unfreeIterator) bool {
 			uf := ufseg.ValuePtr()
@@ -1280,7 +1358,7 @@ func (f *MemoryFile) DecRef(fr memmap.FileRange) {
 				haveWaste = true
 				// Reclassify waste memory as System until it's recycled or
 				// released.
-				f.memAcct.MutateFullRange(wasteFR, func(maseg memAcctIterator) bool {
+				f.memAcct.MutateFullRange(wasteFR, func(maseg memAcctIterator) bool { // +checklocksignore
 					ma := maseg.ValuePtr()
 					if !f.opts.DisableMemoryAccounting && ma.knownCommitted {
 						usage.MemoryAccounting.Move(maseg.Range().Length(), usage.System, ma.kind, ma.memCgID)
@@ -1291,7 +1369,10 @@ func (f *MemoryFile) DecRef(fr memmap.FileRange) {
 				})
 				// Cancel any pending async load on waste pages.
 				if apl := f.asyncPageLoad.Load(); apl != nil {
-					apl.cancelWasteLoad(wasteFR)
+					// DecRef holds f.mu across both synchronous callbacks;
+					// apl came from f.asyncPageLoad, so apl.f is f. checklocks
+					// loses that lock state and owner identity in this callback.
+					apl.cancelWasteLoad(wasteFR) // +checklocksignore
 				}
 			}
 			return true
@@ -1358,7 +1439,10 @@ MainLoop:
 	}
 }
 
-// Preconditions: f.mu must be locked; it may be unlocked and reacquired.
+// releaseLocked releases fr, temporarily dropping f.mu while decommitting
+// pages.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) releaseLocked(fr memmap.FileRange, huge bool) {
 	defer func() {
 		maseg := f.memAcct.LowerBoundSegmentSplitBefore(fr.Start)
@@ -1484,6 +1568,10 @@ func (f *MemoryFile) releaseLocked(fr memmap.FileRange, huge bool) {
 }
 
 // MapInternal implements memmap.File.MapInternal.
+//
+// If asynchronous page loading is active, the caller must not hold that
+// loader's mu. checklocks cannot name this mutex through the atomic
+// f.asyncPageLoad.Load() result in an entry contract.
 func (f *MemoryFile) MapInternal(fr memmap.FileRange, at hostarch.AccessType) (safemem.BlockSeq, error) {
 	if !fr.WellFormed() || fr.Length() == 0 {
 		panic(fmt.Sprintf("invalid range: %v", fr))
@@ -1527,6 +1615,8 @@ func (f *MemoryFile) forEachMappingSlice(fr memmap.FileRange, fn func([]byte)) {
 // user.Evict(er) in the future.
 //
 // Redundantly marking an already-evictable range as evictable has no effect.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) MarkEvictable(user EvictableMemoryUser, er EvictableRange) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -1567,6 +1657,8 @@ func (f *MemoryFile) MarkEvictable(user EvictableMemoryUser, er EvictableRange) 
 //
 // Redundantly marking an already-unevictable range as unevictable has no
 // effect.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) MarkUnevictable(user EvictableMemoryUser, er EvictableRange) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -1584,6 +1676,8 @@ func (f *MemoryFile) MarkUnevictable(user EvictableMemoryUser, er EvictableRange
 
 // MarkAllUnevictable informs f that user no longer considers any offsets to be
 // evictable. It otherwise has the same semantics as MarkUnevictable.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) MarkAllUnevictable(user EvictableMemoryUser) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -1624,6 +1718,8 @@ const commitScanIntervalRatio = 8
 // Scanning is throttled, so statistics may lag page commitment by an
 // unbounded amount; only callers that tolerate stale statistics may use
 // UpdateUsage.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) UpdateUsage(memCgIDs map[uint32]struct{}) error {
 	if memCgIDs == nil && f.ongoingCommitScan.Load() {
 		return nil
@@ -1681,7 +1777,8 @@ func (f *MemoryFile) UpdateUsage(memCgIDs map[uint32]struct{}) error {
 // updateUsageLocked attempts to detect commitment of previously-uncommitted
 // pages, and updates memory accounting to reflect newly-committed pages.
 //
-// Precondition: f.mu must be held; it may be unlocked and reacquired.
+// The mutex may be temporarily released while querying page commitment.
+//
 // +checklocks:f.mu
 func (f *MemoryFile) updateUsageLocked(memCgIDs map[uint32]struct{}) error {
 	// Track if anything changed to elide the merge.
@@ -1746,9 +1843,11 @@ func (f *MemoryFile) updateUsageLocked(memCgIDs map[uint32]struct{}) error {
 			// Query for new pages in core.
 			// NOTE(b/165896008): mincore might take a really long time. So
 			// unlock f.mu while mincore runs.
-			lastCommitSeq := f.commitSeq
-			f.commitSeq++
-			f.mu.Unlock() // +checklocksforce
+			// forEachChunk calls back with f.mu held, but checklocks cannot
+			// infer that incoming lock state. The reacquisition below is checked.
+			lastCommitSeq := f.commitSeq // +checklocksignore
+			f.commitSeq++                // +checklocksignore
+			f.mu.Unlock()                // +checklocksforce
 			err := mincore(s, buf)
 			f.mu.Lock()
 			if err != nil {
@@ -1857,6 +1956,10 @@ func (f *MemoryFile) File() *os.File {
 }
 
 // DataFD implements memmap.File.DataFD.
+//
+// If asynchronous page loading is active, the caller must not hold that
+// loader's mu. checklocks cannot name this mutex through the atomic
+// f.asyncPageLoad.Load() result in an entry contract.
 func (f *MemoryFile) DataFD(fr memmap.FileRange) (int, error) {
 	if amfl := f.asyncPageLoad.Load(); amfl != nil {
 		if err := amfl.awaitLoad(fr); err != nil {
@@ -1883,13 +1986,17 @@ func (f *MemoryFile) HugepagesEnabled() bool {
 }
 
 // String implements fmt.Stringer.String.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) String() string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.stringLocked()
 }
 
-// Preconditions: f.mu must be locked.
+// stringLocked formats f's allocation state with f.mu held.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) stringLocked() string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "unwasteSmall:\n%s", &f.unwasteSmall)
@@ -1910,13 +2017,17 @@ func (f *MemoryFile) stringLocked() string {
 
 // StartEvictions requests that f evict all evictable allocations. It does not
 // wait for eviction to complete; for this, see MemoryFile.WaitForEvictions.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) StartEvictions() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.startEvictionsLocked()
 }
 
-// Preconditions: f.mu must be locked.
+// startEvictionsLocked starts eviction workers and reports whether any started.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) startEvictionsLocked() bool {
 	startedAny := false
 	for user, info := range f.evictable {
@@ -1933,7 +2044,8 @@ func (f *MemoryFile) startEvictionsLocked() bool {
 // Preconditions:
 //   - info == f.evictable[user].
 //   - !info.evicting.
-//   - f.mu must be locked.
+//
+// +checklocks:f.mu
 func (f *MemoryFile) startEvictionGoroutineLocked(user EvictableMemoryUser, info *evictableMemoryUserInfo) {
 	info.evicting = true
 	f.evictionWG.Add(1)
@@ -1969,7 +2081,10 @@ func (f *MemoryFile) startEvictionGoroutineLocked(user EvictableMemoryUser, info
 }
 
 // WaitForEvictions blocks until f is no longer evicting any evictable
-// allocations.
+// allocations. The caller must not hold f.mu, which eviction workers need
+// to finish.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) WaitForEvictions() {
 	f.evictionWG.Wait()
 }

--- a/pkg/sentry/pgalloc/pgalloc_64k_test.go
+++ b/pkg/sentry/pgalloc/pgalloc_64k_test.go
@@ -404,23 +404,27 @@ func TestFindAllocatable64K(t *testing.T) {
 					DisableMemoryAccounting: true,
 				},
 			}
-			f.initFields()
+			// f is a local fixture with no releaser or published references.
+			// checklocks cannot substitute this ownership for the mutex contract.
+			f.initFields() // +checklocksignore
 			chunks := make([]chunkInfo, len(test.chunkHuge))
 			for i, huge := range test.chunkHuge {
 				chunks[i].huge = huge
 				chunkFR := memmap.FileRange{uint64(i) * chunkSize, uint64(i+1) * chunkSize}
 				if huge {
-					f.unfreeHuge.RemoveRange(chunkFR)
+					f.unfreeHuge.RemoveRange(chunkFR) // +checklocksignore
 				} else {
-					f.unfreeSmall.RemoveRange(chunkFR)
+					f.unfreeSmall.RemoveRange(chunkFR) // +checklocksignore
 				}
 			}
 			f.chunks.Store(&chunks)
+			// The synchronous callbacks below only initialize this private
+			// fixture; checklocks cannot track that ownership into them.
 			for _, es := range test.existing {
 				f.forEachChunk(memmap.FileRange{es.start, es.end}, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall
+					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall // +checklocksignore
 					if chunk.huge {
-						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge
+						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge // +checklocksignore
 					}
 					switch es.state {
 					case existingUsed:
@@ -433,7 +437,7 @@ func TestFindAllocatable64K(t *testing.T) {
 					default:
 						t.Fatalf("existingSegment %+v has unknown state", es)
 					}
-					f.memAcct.InsertRange(chunkFR, memAcctInfo{
+					f.memAcct.InsertRange(chunkFR, memAcctInfo{ // +checklocksignore
 						wasteOrReleasing: es.state != existingUsed,
 					})
 					return true

--- a/pkg/sentry/pgalloc/pgalloc_test.go
+++ b/pkg/sentry/pgalloc/pgalloc_test.go
@@ -17,10 +17,21 @@
 package pgalloc
 
 import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
+	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/memutil"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
+	"gvisor.dev/gvisor/pkg/state"
+	"gvisor.dev/gvisor/pkg/state/wire"
 )
 
 const (
@@ -583,5 +594,154 @@ func TestFindAllocatable(t *testing.T) {
 				t.Errorf("findAllocatableAndMarkUsed(%+v): got: end=%#x, want: %#x\n%v", alloc, fr.End, wantEnd, f)
 			}
 		})
+	}
+}
+
+// readFunc lets the restore test intervene after a page reaches its mapping.
+type readFunc func([]byte) (int, error)
+
+// Read implements io.Reader.
+func (f readFunc) Read(p []byte) (int, error) {
+	return f(p)
+}
+
+func TestLoadFromWithUpdateUsage(t *testing.T) {
+	newMemoryFile := func() *MemoryFile {
+		t.Helper()
+		memfd, err := memutil.CreateMemFD("pgalloc-test", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		file := os.NewFile(uintptr(memfd), "pgalloc-test")
+		f, err := NewMemoryFile(file, MemoryFileOpts{
+			DisableMemoryAccounting: true,
+		})
+		if err != nil {
+			_ = file.Close()
+			t.Fatal(err)
+		}
+		t.Cleanup(f.Destroy)
+		return f
+	}
+
+	ctx := context.Background()
+	src := newMemoryFile()
+	fr, err := src.Allocate(3*page, AllocOpts{Kind: usage.Anonymous})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { src.DecRef(fr) })
+
+	want := make([]byte, 3*page)
+	want[0], want[2*page] = 1, 2
+	// The first three-page allocation fits in one chunk.
+	src.forEachMappingSlice(fr, func(bs []byte) {
+		bs[0], bs[2*page] = want[0], want[2*page]
+	})
+	var saved bytes.Buffer
+	if err := src.SaveTo(ctx, &saved, &SaveOpts{
+		ExcludeCommittedZeroPages: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	data := saved.Bytes()
+	metadataEnd := 8 + int(binary.LittleEndian.Uint64(data[:8]))
+	probe := bytes.NewReader(data[metadataEnd:])
+	length, object, err := state.ReadHeader(&wire.Reader{Reader: probe})
+	if err != nil || object || length != page {
+		t.Fatalf("first page header: length=%d object=%t err=%v",
+			length, object, err)
+	}
+	firstPayloadEnd := len(data) - probe.Len() + int(length)
+
+	dst := newMemoryFile()
+	t.Cleanup(func() {
+		// LoadFrom may fail before or after importing this reference.
+		dst.mu.Lock()
+		seg := dst.unfreeSmall.FindSegment(fr.Start)
+		hasRef := seg.Ok() && seg.Value().refs != 0
+		dst.mu.Unlock()
+		if hasRef {
+			dst.DecRef(fr)
+		}
+	})
+
+	stop := make(chan struct{})
+	scanned := make(chan error, 1)
+	var scanWG sync.WaitGroup
+	scanWG.Go(func() {
+		// Observe host commitment without synchronizing with LoadFrom. A
+		// signal from the reader would hide missing mapping publication.
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			committed, err := dst.TotalUsage()
+			if err != nil {
+				scanned <- err
+				return
+			}
+			if committed >= 2*page {
+				scanned <- dst.UpdateUsage(nil)
+				return
+			}
+			runtime.Gosched()
+		}
+	})
+	t.Cleanup(func() {
+		close(stop)
+		scanWG.Wait()
+	})
+
+	input := bytes.NewReader(data)
+	updated := false
+	reader := readFunc(func(p []byte) (int, error) {
+		n, err := input.Read(p)
+		if !updated && len(data)-input.Len() >= firstPayloadEnd {
+			updated = true
+			// Model neighboring-page commitment without requiring THP.
+			// This preserves the omitted page's zero contents.
+			dst.forEachMappingSlice(memmap.FileRange{
+				Start: fr.Start + page,
+				End:   fr.Start + 2*page,
+			}, func(bs []byte) {
+				clear(bs)
+			})
+			select {
+			case err := <-scanned:
+				if err != nil {
+					t.Fatalf("UpdateUsage during restore: %v", err)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("usage scan did not complete during restore")
+			}
+		}
+		return n, err
+	})
+	if err := dst.LoadFrom(ctx, reader, &LoadOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	if !updated {
+		t.Fatal("restore never reached the accounting update")
+	}
+	dst.forEachMappingSlice(fr, func(bs []byte) {
+		if !bytes.Equal(bs, want) {
+			t.Error("restored pages differ from saved pages")
+		}
+	})
+	if input.Len() != 0 {
+		t.Errorf("restore left %d bytes unread", input.Len())
+	}
+
+	// Count both restored pages and the zero page committed during loading.
+	dst.mu.Lock()
+	committed := dst.knownCommittedBytes
+	dst.mu.Unlock()
+	if committed != 3*page {
+		t.Errorf("committed bytes after restore: got %d, want %d",
+			committed, 3*page)
 	}
 }

--- a/pkg/sentry/pgalloc/pgalloc_test.go
+++ b/pkg/sentry/pgalloc/pgalloc_test.go
@@ -534,23 +534,27 @@ func TestFindAllocatable(t *testing.T) {
 					DisableMemoryAccounting: true,
 				},
 			}
-			f.initFields()
+			// f is a local fixture with no releaser or published references.
+			// checklocks cannot substitute this ownership for the mutex contract.
+			f.initFields() // +checklocksignore
 			chunks := make([]chunkInfo, len(test.chunkHuge))
 			for i, huge := range test.chunkHuge {
 				chunks[i].huge = huge
 				chunkFR := memmap.FileRange{uint64(i) * chunkSize, uint64(i+1) * chunkSize}
 				if huge {
-					f.unfreeHuge.RemoveRange(chunkFR)
+					f.unfreeHuge.RemoveRange(chunkFR) // +checklocksignore
 				} else {
-					f.unfreeSmall.RemoveRange(chunkFR)
+					f.unfreeSmall.RemoveRange(chunkFR) // +checklocksignore
 				}
 			}
 			f.chunks.Store(&chunks)
+			// The synchronous callbacks below only initialize this private
+			// fixture; checklocks cannot track that ownership into them.
 			for _, es := range test.existing {
 				f.forEachChunk(memmap.FileRange{es.start, es.end}, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
-					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall
+					unwaste, unfree := &f.unwasteSmall, &f.unfreeSmall // +checklocksignore
 					if chunk.huge {
-						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge
+						unwaste, unfree = &f.unwasteHuge, &f.unfreeHuge // +checklocksignore
 					}
 					switch es.state {
 					case existingUsed:
@@ -563,7 +567,7 @@ func TestFindAllocatable(t *testing.T) {
 					default:
 						t.Fatalf("existingSegment %+v has unknown state", es)
 					}
-					f.memAcct.InsertRange(chunkFR, memAcctInfo{
+					f.memAcct.InsertRange(chunkFR, memAcctInfo{ // +checklocksignore
 						wasteOrReleasing: es.state != existingUsed,
 					})
 					return true

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -48,6 +48,8 @@ import (
 )
 
 // MarkSavable marks f as savable.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) MarkSavable() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -55,6 +57,8 @@ func (f *MemoryFile) MarkSavable() {
 }
 
 // IsSavable returns true if f is savable.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) IsSavable() bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -66,6 +70,7 @@ func (f *MemoryFile) ResourceID() checkpoint.ResourceID {
 	return f.opts.ResourceID
 }
 
+// +checklocks:f.mu
 func (f *MemoryFile) exportMetadataProto() *pgallocpb.MemoryFileMetadataProto {
 	pb := &pgallocpb.MemoryFileMetadataProto{
 		Version:     1,
@@ -194,6 +199,13 @@ type SaveOpts struct {
 }
 
 // SaveTo writes f's state to the given stream.
+//
+// If asynchronous page loading is active, the caller must not hold that
+// loader's mu. checklocks cannot name this mutex through the atomic
+// f.asyncPageLoad.Load() result in an entry contract.
+//
+// +checklocksexclude:f.mu
+// +checklocksexclude:opts.PagesFile.mu
 func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) error {
 	if err := f.AwaitLoadAll(); err != nil {
 		return fmt.Errorf("previous async page loading failed: %w", err)
@@ -326,30 +338,32 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 		updatePendingWasCommitted bool
 		updatePendingNowCommitted bool
 	)
+	// These local batching callbacks run synchronously while SaveTo holds
+	// f.mu. checklocks does not propagate the caller's lock state through them.
 	updateNow := func(maseg memAcctIterator, fr memmap.FileRange, wasCommitted, nowCommitted bool) memAcctIterator {
 		amount := fr.Length()
 		if amount == 0 {
 			return maseg
 		}
 		if wasCommitted != nowCommitted {
-			maseg = f.memAcct.Isolate(maseg, fr)
+			maseg = f.memAcct.Isolate(maseg, fr) // +checklocksignore
 			ma := maseg.ValuePtr()
 			if nowCommitted {
 				ma.knownCommitted = true
 				ma.commitSeq = 0
-				f.knownCommittedBytes += amount
+				f.knownCommittedBytes += amount // +checklocksignore
 				if !f.opts.DisableMemoryAccounting {
 					usage.MemoryAccounting.Inc(amount, ma.kind, ma.memCgID)
 				}
 			} else {
 				ma.knownCommitted = false
-				ma.commitSeq = f.commitSeq
-				f.knownCommittedBytes -= amount
+				ma.commitSeq = f.commitSeq      // +checklocksignore
+				f.knownCommittedBytes -= amount // +checklocksignore
 				if !f.opts.DisableMemoryAccounting {
 					usage.MemoryAccounting.Dec(amount, ma.kind, ma.memCgID)
 				}
 			}
-			maseg = f.memAcct.Unisolate(maseg)
+			maseg = f.memAcct.Unisolate(maseg) // +checklocksignore
 		}
 		if nowCommitted {
 			asyncWritePages(fr)
@@ -537,10 +551,15 @@ type AsyncPagesFileSave struct {
 	mu apfsMutex
 
 	// saveOff is the offset in the pages file at which the next page to be
-	// inserted into unsaved will be saved. saveOff is protected by mu.
+	// inserted into unsaved will be saved. PagesFileOffset may read it
+	// between MemoryFile.SaveTo calls using this pages file.
+	//
+	// +checklocks:mu
 	saveOff uint64
 
-	// unsaved tracks pages that have not been saved. unsaved is protected by mu.
+	// unsaved tracks pages that have not been saved.
+	//
+	// +checklocks:mu
 	unsaved ringdeque.Deque[apsRange]
 
 	// stStatus communicates state from MemoryFile.SaveTo() and its callers to
@@ -550,8 +569,9 @@ type AsyncPagesFileSave struct {
 	// Padding before fields used mostly by the async page saver goroutine:
 	_ [hostarch.CacheLineSize]byte
 
-	// bytesSaved is the number of write-completed bytes. bytesSaved is
-	// protected by statsMu.
+	// bytesSaved is the number of write-completed bytes.
+	//
+	// +checklocks:mu
 	bytesSaved uint64
 
 	// When async page saving is enabled, MemoryFile.SaveTo() enqueues writes
@@ -566,11 +586,16 @@ type AsyncPagesFileSave struct {
 	// full. timeFullStart was the value of gohacks.Nanotime() when the I/O
 	// queue last became full; if it is currently not full, timeFullStart is
 	// MaxInt64. durFull is the duration elapsed while the I/O queue was full,
-	// not counting time elapsed since timeFullStart. These fields are
-	// protected by statsMu.
-	bytesFull     uint64
+	// not counting time elapsed since timeFullStart.
+	//
+	// +checklocks:mu
+	bytesFull uint64
+
+	// +checklocks:mu
 	timeFullStart int64
-	durFull       time.Duration
+
+	// +checklocks:mu
+	durFull time.Duration
 
 	// Following fields are exclusive to the async page saver goroutine.
 
@@ -687,6 +712,10 @@ func (apfs *AsyncPagesFileSave) MemoryFilesDone() {
 
 // PagesFileOffset returns the offset into the pages file of the next page to
 // be written.
+//
+// Preconditions: MemoryFile.SaveTo must not run concurrently using apfs.
+//
+// +checklocks:apfs.mu
 func (apfs *AsyncPagesFileSave) PagesFileOffset() uint64 {
 	return apfs.saveOff
 }
@@ -1010,6 +1039,11 @@ type LoadOpts struct {
 	// MemoryFile completes. DoneCallback will be called whether or not
 	// LoadFrom returns a non-nil error.
 	//
+	// DoneCallback may run with PagesFile.amflsMu and PagesFile.mu held. It
+	// must not reacquire them or locks that precede them in pgalloc's lock
+	// order, including MemoryFile.mu. checklocks cannot pass the incoming
+	// lock state through this function value.
+	//
 	// Invariant: PagesFileOffset must be page-aligned.
 	PagesFile       *AsyncPagesFileLoad
 	PagesFileOffset uint64
@@ -1031,6 +1065,8 @@ type LoadOpts struct {
 // concurrently and may continue after it returns.
 //
 // +checklocksexclude:f.mu
+// +checklocksexclude:opts.PagesFile.amflsMu
+// +checklocksexclude:opts.PagesFile.mu
 func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) (err error) {
 	mfTimeline := opts.Timeline.Fork(fmt.Sprintf("mf:%p", f)).Lease()
 	defer mfTimeline.End()
@@ -1249,11 +1285,15 @@ type AsyncPagesFileLoad struct {
 	// If errVal is not nil, it is an error that has terminated asynchronous
 	// page loading. errVal can only be set by the async page loader goroutine,
 	// and can only transition from nil to non-nil once, after which it is
-	// immutable. errVal is stored with mu locked.
+	// immutable.
+	//
+	// +checkatomic
+	// +checklocks:mu
 	errVal atomic.Value
 
 	// priority contains possibly-unstarted ranges with at least one waiter.
-	// priority is protected by mu.
+	//
+	// +checklocks:mu
 	priority ringdeque.Deque[aplFileRange]
 
 	// lfStatus communicates MemoryFile.LoadFrom() state to the async page
@@ -1263,34 +1303,51 @@ type AsyncPagesFileLoad struct {
 	// Padding before state used mostly by the async page loader goroutine:
 	_ [hostarch.CacheLineSize]byte
 
-	// amfls tracks MemoryFiles that are currently loading from the pages file.
-	// amfls is protected by amflsMu.
 	amflsMu amflsMutex
-	amfls   asyncMemoryFileLoadList
 
-	// numWaiters is the current number of waiting waiters. numWaiters is
-	// protected by mu.
+	// amfls tracks MemoryFiles that are currently loading from the pages file.
+	//
+	// +checklocks:amflsMu
+	amfls asyncMemoryFileLoadList
+
+	// numWaiters is the current number of waiting waiters.
+	//
+	// +checklocks:mu
 	numWaiters int
 
 	// totalWaiters is the number of waiters that have ever waited for pages
-	// from this pages file. totalWaiters is protected by mu.
+	// from this pages file.
+	//
+	// +checklocks:mu
 	totalWaiters int
 
 	// timeStartWaiters was the value of gohacks.Nanotime() when numWaiters
 	// most recently transitioned from 0 to 1. If numWaiters is 0,
-	// timeStartWaiters is MaxInt64. timeStartWaiters is protected by mu.
+	// timeStartWaiters is MaxInt64.
+	//
+	// +checklocks:mu
 	timeStartWaiters int64
 
-	// nsWaitedOne is the duration for which at least one waiter was waiting
-	// for a load. nsWaitedTotal is the duration for which waiters were waiting
-	// for loads, summed across all waiters. bytesWaited is the number of bytes
-	// for which at least one waiter waited. These fields are protected by mu.
-	durWaitedOne   time.Duration
+	// durWaitedOne is the duration for which at least one waiter was waiting
+	// for a load.
+	//
+	// +checklocks:mu
+	durWaitedOne time.Duration
+
+	// durWaitedTotal is the duration for which waiters were waiting for loads,
+	// summed across all waiters.
+	//
+	// +checklocks:mu
 	durWaitedTotal time.Duration
-	bytesWaited    uint64
+
+	// bytesWaited is the number of bytes for which at least one waiter waited.
+	//
+	// +checklocks:mu
+	bytesWaited uint64
 
 	// bytesLoaded is the number of bytes that have been loaded so far.
-	// bytesLoaded is protected by mu.
+	//
+	// +checklocks:mu
 	bytesLoaded uint64
 
 	// Following fields are exclusive to the async page loader goroutine.
@@ -1345,26 +1402,42 @@ func (apfl *AsyncPagesFileLoad) err() error {
 
 // asyncMemoryFileLoad holds async page loading state for a single MemoryFile.
 type asyncMemoryFileLoad struct {
-	// Immutable fields:
-	f            *MemoryFile
-	pf           *AsyncPagesFileLoad
-	df           stateio.DestinationFile
+	// f, pf, and df are immutable.
+	f  *MemoryFile
+	pf *AsyncPagesFileLoad
+	df stateio.DestinationFile
+
+	// doneCallback is called and cleared when loading completes or fails.
+	//
+	// +checklocks:pf.amflsMu
+	// +checklocks:pf.mu
 	doneCallback func(error)
-	timeline     *timing.Timeline
+
+	// timeline is an immutable pointer to the async load timeline.
+	timeline *timing.Timeline
 
 	// minUnloaded is the MemoryFile offset of the first unloaded byte.
+	//
+	// +checkatomic
 	minUnloaded atomicbitops.Uint64
 
 	// unloaded tracks pages in the MemoryFile that have not been loaded.
-	// unloaded is protected by pf.mu.
+	//
+	// +checklocks:pf.mu
 	unloaded aplUnloadedSet
 
 	// lfDone is true if MemoryFile.LoadFrom() has finished inserting into
-	// unloaded. lfDone is protected by pf.mu.
+	// unloaded.
+	//
+	// +checklocks:pf.mu
 	lfDone bool
 
 	// asyncMemoryFileLoadEntry links into pf.amfls. asyncMemoryFileLoadEntry
 	// is protected by pf.amflsMu.
+	//
+	// Generated list methods access the links without a parent-lock
+	// precondition, so checklocks cannot verify that their callers hold
+	// pf.amflsMu.
 	asyncMemoryFileLoadEntry
 
 	// Padding before state exclusive to the async page loader goroutine:
@@ -1376,6 +1449,11 @@ type asyncMemoryFileLoad struct {
 }
 
 // aplUnloadedInfo is the value type of asyncMemoryFileLoad.unloaded.
+//
+// Stored values are protected by the owning asyncMemoryFileLoad.pf.mu.
+// Values and generated iterators have no back-reference to that owner, so
+// checklocks cannot resolve its mutex. Merge and Split also operate on
+// copied values.
 type aplUnloadedInfo struct {
 	// off is the offset into the pages file at which the represented pages
 	// begin.
@@ -1389,18 +1467,21 @@ type aplUnloadedInfo struct {
 }
 
 type aplWaiter struct {
-	// wakeup is used by a caller of MemoryFile.awaitLoad() to block until all
-	// pages in fr are loaded. wakeup is internally synchronized. fr is
-	// immutable after initialization.
+	// wakeup is used by asyncMemoryFileLoad.awaitLoad() to block until all pages
+	// in fr are loaded. wakeup is internally synchronized. fr is
+	// immutable until the waiter is returned to aplWaiterPool.
 	wakeup syncevent.Waiter
 	fr     memmap.FileRange
 
 	// timeStart was the value of gohacks.Nanotime() when this waiter started
-	// waiting. timeStart is immutable after initialization.
+	// waiting. It is immutable until the waiter is returned to aplWaiterPool.
 	timeStart int64
 
 	// pending is the number of unloaded bytes that this waiter is waiting for.
-	// pending is protected by aplShared.mu.
+	// pending is protected by the owning AsyncPagesFileLoad.mu.
+	//
+	// The owner is determined by the unloaded segments containing this
+	// waiter; aplWaiter has no pointer to that loader for checklocks to use.
 	pending uint64
 }
 
@@ -1490,6 +1571,10 @@ func (f *MemoryFile) IsAsyncLoading() bool {
 
 // AwaitLoadAll blocks until async page loading has completed. If async page
 // loading is not in progress, AwaitLoadAll returns immediately.
+//
+// If asynchronous page loading is active, the caller must not hold that
+// loader's mu. checklocks cannot name this mutex through the atomic
+// f.asyncPageLoad.Load() result in an entry contract.
 func (f *MemoryFile) AwaitLoadAll() error {
 	if amfl := f.asyncPageLoad.Load(); amfl != nil {
 		return amfl.awaitLoad(memmap.FileRange{0, hostarch.PageRoundDown(uint64(math.MaxUint64))})
@@ -1501,6 +1586,8 @@ func (f *MemoryFile) AwaitLoadAll() error {
 //
 // Preconditions: At least one reference must be held on all unloaded pages in
 // fr.
+//
+// +checklocksexclude:amfl.pf.mu
 func (amfl *asyncMemoryFileLoad) awaitLoad(fr memmap.FileRange) error {
 	// Lockless fast path:
 	if fr.End <= amfl.minUnloaded.Load() {
@@ -1532,10 +1619,12 @@ func (amfl *asyncMemoryFileLoad) awaitLoad(fr memmap.FileRange) error {
 		ul := ulseg.ValuePtr()
 		ulFR := ulseg.Range()
 		ullen := ulFR.Length()
+		// MutateRange invokes this callback synchronously with apfl.mu held.
+		// checklocks does not propagate the caller's lock state into it.
 		if len(ul.waiters) == 0 {
-			apfl.bytesWaited += ullen
+			apfl.bytesWaited += ullen // +checklocksignore
 			if !ul.started {
-				apfl.priority.PushBack(aplFileRange{amfl, ulFR})
+				apfl.priority.PushBack(aplFileRange{amfl, ulFR}) // +checklocksignore
 			}
 			if logAwaitedLoads {
 				log.Infof("MemoryFile(%p): prioritize %v", amfl.f, ulFR)
@@ -1726,8 +1815,10 @@ func (apfl *AsyncPagesFileLoad) main() {
 		// unloaded) segments.
 		apfl.amflsMu.Lock()
 		apfl.mu.Lock()
+		// Each entry in apfl.amfls belongs to apfl. checklocks cannot prove
+		// amfl.pf == apfl after the list lookup.
 		for amfl := apfl.amfls.Front(); amfl != nil; amfl = amfl.Next() {
-			for ulseg := amfl.unloaded.FirstSegment(); ulseg.Ok(); ulseg = ulseg.NextSegment() {
+			for ulseg := amfl.unloaded.FirstSegment(); ulseg.Ok(); ulseg = ulseg.NextSegment() { // +checklocksignore
 				ul := ulseg.ValuePtr()
 				ullen := ulseg.Range().Length()
 				for _, w := range ul.waiters {
@@ -1739,9 +1830,9 @@ func (apfl *AsyncPagesFileLoad) main() {
 				ul.started = false
 				ul.waiters = nil
 			}
-			if amfl.doneCallback != nil {
-				amfl.doneCallback(apfl.err())
-				amfl.doneCallback = nil
+			if amfl.doneCallback != nil { // +checklocksignore
+				amfl.doneCallback(apfl.err()) // +checklocksignore
+				amfl.doneCallback = nil       // +checklocksignore
 			}
 		}
 		apfl.mu.Unlock()
@@ -1823,12 +1914,15 @@ func (apfl *AsyncPagesFileLoad) main() {
 		apfl.mu.Lock()
 		for apfl.canEnqueue() && !apfl.priority.Empty() {
 			fr := apfl.priority.PopFront()
+			// awaitLoad queued this range on its own pages-file loader, so
+			// fr.amfl.pf == apfl. checklocks cannot recover that identity here.
+			//
 			// All pages in apfl.priority have non-zero waiters and were split
 			// around fr by fr.amfl.awaitLoad(), and fr.amfl.unloaded never
 			// merges segments with waiters. Thus, we don't need to split
 			// around fr again, and fr.Intersect(ulseg.Range()) ==
 			// ulseg.Range().
-			ulseg := fr.amfl.unloaded.LowerBoundSegment(fr.Start)
+			ulseg := fr.amfl.unloaded.LowerBoundSegment(fr.Start) // +checklocksignore
 			for ulseg.Ok() && ulseg.Start() < fr.End {
 				ul := ulseg.ValuePtr()
 				ulFR := ulseg.Range()
@@ -1849,7 +1943,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 					break
 				}
 				ulFR.End = ulFR.Start + n
-				ulseg = fr.amfl.unloaded.SplitAfter(ulseg, ulFR.End)
+				ulseg = fr.amfl.unloaded.SplitAfter(ulseg, ulFR.End) // +checklocksignore
 				ulseg.ValuePtr().started = true
 				fr.Start = ulFR.End
 				if fr.Length() > 0 {
@@ -1880,7 +1974,9 @@ func (apfl *AsyncPagesFileLoad) main() {
 			for amfl := apfl.amfls.Front(); amfl != nil; amfl = amfl.Next() {
 				amfl.f.mu.Lock()
 				apfl.mu.Lock()
-				ulseg := amfl.unloaded.LowerBoundSegment(amfl.minUnstarted)
+				// Membership in apfl.amfls establishes amfl.pf == apfl,
+				// which checklocks cannot infer from this iterator.
+				ulseg := amfl.unloaded.LowerBoundSegment(amfl.minUnstarted) // +checklocksignore
 				for ulseg.Ok() {
 					ul := ulseg.ValuePtr()
 					ulFR := ulseg.Range()
@@ -1899,7 +1995,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 						break amflsLoop
 					}
 					ulFR.End = ulFR.Start + n
-					ulseg = amfl.unloaded.SplitAfter(ulseg, ulFR.End)
+					ulseg = amfl.unloaded.SplitAfter(ulseg, ulFR.End) // +checklocksignore
 					ulseg.ValuePtr().started = true
 					amfl.minUnstarted = ulFR.End
 					amfl.f.incRefLocked(ulFR)
@@ -1976,6 +2072,8 @@ func (apfl *AsyncPagesFileLoad) main() {
 			}
 			apfl.bytesLoaded += op.total
 			amfl := op.amfl
+			// enqueueRange records only MemoryFiles belonging to apfl in ops.
+			// checklocks cannot recover amfl.pf == apfl from the completed op.
 			haveWaiters := false
 			now := int64(0)
 			for _, fr := range op.frs {
@@ -1983,7 +2081,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 				// when they were started (above), and fr.amfl.unloaded never
 				// merges started segments. Thus, we don't need to split around
 				// fr again, and fr.Intersect(ulseg.Range()) == ulseg.Range().
-				for ulseg := amfl.unloaded.FindSegment(fr.Start); ulseg.Ok() && ulseg.Start() < fr.End; ulseg = amfl.unloaded.Remove(ulseg).NextSegment() {
+				for ulseg := amfl.unloaded.FindSegment(fr.Start); ulseg.Ok() && ulseg.Start() < fr.End; ulseg = amfl.unloaded.Remove(ulseg).NextSegment() { // +checklocksignore
 					ul := ulseg.ValuePtr()
 					ullen := ulseg.Range().Length()
 					if !ul.started {
@@ -1999,7 +2097,7 @@ func (apfl *AsyncPagesFileLoad) main() {
 							}
 							// This definition of "wait time" skips the time
 							// taken for w to wake up (bad), but avoids having
-							// to lock apfl.mu again in apfl.awaitLoad()
+							// to lock apfl.mu again in asyncMemoryFileLoad.awaitLoad()
 							// (good).
 							apfl.durWaitedTotal += time.Duration(now - w.timeStart)
 							apfl.numWaiters--
@@ -2016,18 +2114,19 @@ func (apfl *AsyncPagesFileLoad) main() {
 			}
 			// Keep amfl.minUnloaded up to date. We can only determine this
 			// accurately if insertions into amfl.unloaded are complete.
-			if amfl.lfDone {
-				if amfl.unloaded.IsEmpty() {
+			if amfl.lfDone { // +checklocksignore
+				if amfl.unloaded.IsEmpty() { // +checklocksignore
 					amfl.minUnloaded.Store(math.MaxUint64)
 					apfl.amfls.Remove(amfl)
 					amfl.f.asyncPageLoad.Store(nil)
 					amfl.timeline.End()
-					if amfl.doneCallback != nil {
-						amfl.doneCallback(nil)
-						amfl.doneCallback = nil
+					if amfl.doneCallback != nil { // +checklocksignore
+						amfl.doneCallback(nil)  // +checklocksignore
+						amfl.doneCallback = nil // +checklocksignore
 					}
 				} else {
-					amfl.minUnloaded.Store(amfl.unloaded.FirstSegment().Start())
+					minUnloaded := amfl.unloaded.FirstSegment().Start() // +checklocksignore
+					amfl.minUnloaded.Store(minUnloaded)
 				}
 			}
 		}
@@ -2041,9 +2140,14 @@ func (apfl *AsyncPagesFileLoad) main() {
 	}
 }
 
+// cancelWasteLoad cancels unstarted loads for pages becoming waste.
+//
 // Preconditions:
-// - All pages in fr must be becoming waste pages.
-// - fr must be page-aligned.
+//   - All pages in fr must be becoming waste pages.
+//   - fr must be page-aligned.
+//
+// +checklocks:amfl.f.mu
+// +checklocksexclude:amfl.pf.mu
 func (amfl *asyncMemoryFileLoad) cancelWasteLoad(fr memmap.FileRange) {
 	// Lockless fast path:
 	if fr.End <= amfl.minUnloaded.Load() {
@@ -2056,7 +2160,7 @@ func (amfl *asyncMemoryFileLoad) cancelWasteLoad(fr memmap.FileRange) {
 		ul := ulseg.ValuePtr()
 		if ul.started {
 			// This shouldn't be possible since page references are held while
-			// reading (see MemoryFile.asyncPageLoadMain()).
+			// reading (see AsyncPagesFileLoad.main()).
 			panic(fmt.Sprintf("pages %v becoming waste during inflight read from async loading", ulseg.Range()))
 		}
 		if n := len(ul.waiters); n != 0 {

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -122,7 +122,16 @@ func (f *MemoryFile) exportMetadataProto() *pgallocpb.MemoryFileMetadataProto {
 	return pb
 }
 
+// importMetadataProto restores f's bookkeeping before its mappings are loaded.
+//
+// Preconditions: f is newly created and has not been used for allocations or
+// registered with async page loading.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) importMetadataProto(pb *pgallocpb.MemoryFileMetadataProto) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	if pb.Version != 1 {
 		return fmt.Errorf("unsupported MemoryFileMetadataProto version %d", pb.Version)
 	}
@@ -1014,6 +1023,14 @@ type LoadOpts struct {
 }
 
 // LoadFrom loads MemoryFile state from the given stream.
+//
+// Preconditions: f is newly created and has not been used for allocations.
+// UpdateUsage may run concurrently, but the caller must exclude operations
+// that allocate, release, or save memory and other calls to LoadFrom until it
+// returns. Asynchronous page loading started by LoadFrom may proceed
+// concurrently and may continue after it returns.
+//
+// +checklocksexclude:f.mu
 func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) (err error) {
 	mfTimeline := opts.Timeline.Fork(fmt.Sprintf("mf:%p", f)).Lease()
 	defer mfTimeline.End()
@@ -1069,11 +1086,14 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 			return fmt.Errorf("failed to mmap MemoryFile: %w", errno)
 		}
 		mfTimeline.Reached("mmaped chunks")
+		// Publish mappings to commitment scans before loading page contents.
+		f.mu.Lock()
 		for i := range chunks {
 			chunk := &chunks[i]
 			chunk.mapping = m
 			m += chunkSize
 		}
+		f.mu.Unlock()
 		madviseWG.Add(1)
 		go func() {
 			defer madviseWG.Done()
@@ -1147,11 +1167,13 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 	wr := wire.Reader{Reader: r}
 	timePagesStart := gohacks.Nanotime()
 	minUnloadedInit := false
-	for maseg := f.memAcct.FirstSegment(); maseg.Ok(); maseg = maseg.NextSegment() {
-		if !maseg.ValuePtr().knownCommitted {
+	// Saved ranges define the stream layout. Live accounting may merge ranges
+	// during import or while UpdateUsage observes restored pages.
+	for _, ma := range pb.MemAcct {
+		if !ma.KnownCommitted {
 			continue
 		}
-		maFR := maseg.Range()
+		maFR := memmap.FileRange{Start: ma.Start, End: ma.End}
 		amount := maFR.Length()
 		// Wait for all chunks spanned by this segment to be madvised.
 		for madviseEnd.Load() < maFR.End {
@@ -1200,16 +1222,21 @@ func (f *MemoryFile) LoadFrom(ctx context.Context, r io.Reader, opts *LoadOpts) 
 		// Update accounting for restored pages. We need to do this here since
 		// these segments are marked as "known committed", and will be skipped
 		// over on accounting scans.
+		f.mu.Lock()
 		f.knownCommittedBytes += amount
 		if !f.opts.DisableMemoryAccounting {
-			usage.MemoryAccounting.Inc(amount, maseg.ValuePtr().kind, maseg.ValuePtr().memCgID)
+			usage.MemoryAccounting.Inc(amount, usage.MemoryKind(ma.Kind), ma.MemCgId)
 		}
+		f.mu.Unlock()
 	}
 	durPages := time.Duration(gohacks.Nanotime() - timePagesStart)
+	f.mu.Lock()
+	knownCommittedBytes := f.knownCommittedBytes
+	f.mu.Unlock()
 	if amfl != nil {
-		log.Infof("MemoryFile(%p): loaded page file offsets in %s; async loading %d bytes", f, durPages, f.knownCommittedBytes)
+		log.Infof("MemoryFile(%p): loaded page file offsets in %s; async loading %d bytes", f, durPages, knownCommittedBytes)
 	} else {
-		log.Infof("MemoryFile(%p): loaded pages in %s (%d bytes, %.3f MB/s)", f, durPages, f.knownCommittedBytes, float64(f.knownCommittedBytes)*1e-6/durPages.Seconds())
+		log.Infof("MemoryFile(%p): loaded pages in %s (%d bytes, %.3f MB/s)", f, durPages, knownCommittedBytes, float64(knownCommittedBytes)*1e-6/durPages.Seconds())
 	}
 
 	return nil

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -294,6 +294,9 @@ type containerManager struct {
 }
 
 // StartRoot will start the root container process.
+//
+// +checklocksexclude:cm.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:cm.l.fsRestore.apfl.mu
 func (cm *containerManager) StartRoot(cid *string, _ *struct{}) error {
 	log.Debugf("containerManager.StartRoot, cid: %s", *cid)
 	cm.l.mu.Lock()
@@ -306,7 +309,11 @@ func (cm *containerManager) StartRoot(cid *string, _ *struct{}) error {
 	return cm.onStart()
 }
 
-// onStart notifies that sandbox is ready to start and wait for the result.
+// onStart tells Loader.Run to start the sandbox and waits for its result.
+// Loader.Run may acquire the filesystem-restore loader's locks.
+//
+// +checklocksexclude:cm.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:cm.l.fsRestore.apfl.mu
 func (cm *containerManager) onStart() error {
 	cm.startChan <- struct{}{}
 	if err := <-cm.startResultChan; err != nil {
@@ -383,6 +390,9 @@ type StartArgs struct {
 }
 
 // StartSubcontainer runs a created container within a sandbox.
+//
+// +checklocksexclude:cm.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:cm.l.fsRestore.apfl.mu
 func (cm *containerManager) StartSubcontainer(args *StartArgs, _ *struct{}) error {
 	// Validate arguments.
 	if args == nil {
@@ -950,6 +960,7 @@ func (cm *containerManager) WaitRestore(*struct{}, *struct{}) error {
 	return err
 }
 
+// +checklocksexclude:cm.l.k.fsSaveMu
 func (cm *containerManager) WaitFSCheckpoint(*struct{}, *struct{}) error {
 	log.Debugf("containerManager.WaitFSCheckpoint")
 	err := cm.l.k.WaitForFSSave()
@@ -1212,6 +1223,8 @@ type FSSaveArgs struct {
 }
 
 // FSSave collects a filesystem checkpoint.
+//
+// +checklocksexclude:cm.l.k.fsSaveMu
 func (cm *containerManager) FSSave(args *FSSaveArgs, _ *struct{}) error {
 	log.Debugf("containerManager.FSSave")
 	kopts, err := convertToKernelFSSaveOpts(args)

--- a/runsc/boot/fscheckpoint.go
+++ b/runsc/boot/fscheckpoint.go
@@ -88,6 +88,8 @@ func GetAnnotationFSCheckpointDirect(spec *specs.Spec) bool {
 }
 
 // FSSave implements kernel.Saver.FSSave.
+//
+// +checklocksexclude:l.k.fsSaveMu
 func (l *Loader) FSSave() error {
 	l.mu.Lock()
 	fsSaveFDs := l.fsSaveFDs

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -1025,6 +1025,8 @@ func createProcessArgs(id string, spec *specs.Spec, conf *config.Config, creds *
 // Note that this will block until all open control server connections have
 // been closed. For that reason, this should NOT be called in a defer, because
 // a panic in a control server rpc would then hang forever.
+//
+// +checklocksexclude:l.k.fsSaveMu
 func (l *Loader) Destroy() {
 	if l.stopSignalForwarding != nil {
 		l.stopSignalForwarding()
@@ -1213,6 +1215,9 @@ func (l *Loader) installSeccompFilters() error {
 }
 
 // Run runs the root container.
+//
+// +checklocksexclude:l.fsRestore.apfl.amflsMu
+// +checklocksexclude:l.fsRestore.apfl.mu
 func (l *Loader) Run() error {
 	err := l.run()
 	l.ctrl.manager.startResultChan <- err
@@ -1227,6 +1232,8 @@ func (l *Loader) Run() error {
 	return nil
 }
 
+// +checklocksexclude:l.fsRestore.apfl.amflsMu
+// +checklocksexclude:l.fsRestore.apfl.mu
 func (l *Loader) run() error {
 	if l.root.conf.Network == config.NetworkHost {
 		// Delay host network configuration to this point because network namespace
@@ -1373,6 +1380,9 @@ func (l *Loader) createSubcontainer(cid string, tty *fd.FD) error {
 // startSubcontainer starts a child container. It returns the thread group ID of
 // the newly created process. Used FDs are either closed or released. It's safe
 // for the caller to close any remaining files upon return.
+//
+// +checklocksexclude:l.fsRestore.apfl.amflsMu
+// +checklocksexclude:l.fsRestore.apfl.mu
 func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid string, stdioFDs, goferFDs, goferFilestoreFDs []*fd.FD, devGoferFD *fd.FD, goferMountConfs []specutils.GoferMountConf, rootfsUpperTarFD *fd.FD) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -1491,6 +1501,8 @@ func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid st
 }
 
 // +checklocks:l.mu
+// +checklocksexclude:l.fsRestore.apfl.amflsMu
+// +checklocksexclude:l.fsRestore.apfl.mu
 func (l *Loader) createContainerProcess(info *containerInfo) (*kernel.ThreadGroup, *host.TTYFileDescription, error) {
 	// Create the FD map, which will set stdin, stdout, and stderr.
 	ctx := info.procArgs.NewContext(l.k)

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -270,6 +270,8 @@ func rdmaproxyRegisterDevices(info *containerInfo, vfsObj *vfs.VirtualFilesystem
 	return nil
 }
 
+// +checklocksexclude:mntr.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:mntr.l.fsRestore.apfl.mu
 func setupContainerVFS(ctx context.Context, info *containerInfo, mntr *containerMounter, procArgs *kernel.CreateProcessArgs) error {
 	// Create context with root credentials to mount the filesystem (the current
 	// user may not be privileged enough).
@@ -565,6 +567,8 @@ func getMountAccessType(conf *config.Config, hint *MountHint) config.FileAccessT
 	return conf.FileAccessMounts
 }
 
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) mountAll(rootCtx context.Context, rootCreds *auth.Credentials, spec *specs.Spec, conf *config.Config, rootProcArgs *kernel.CreateProcessArgs) (*vfs.MountNamespace, error) {
 	log.Infof("Configuring container's file system")
 
@@ -600,6 +604,9 @@ func (c *containerMounter) mountAll(rootCtx context.Context, rootCreds *auth.Cre
 }
 
 // createMountNamespace creates the container's root mount and namespace.
+//
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) createMountNamespace(ctx context.Context, spec *specs.Spec, conf *config.Config, creds *auth.Credentials) (*vfs.MountNamespace, error) {
 	ioFD := c.goferFDs.remove()
 	rootfsConf := c.goferMountConfs[0]
@@ -719,6 +726,9 @@ func (c *containerMounter) createMountNamespace(ctx context.Context, spec *specs
 // layer using tmpfs, and return overlay mount options. "cleanup" must be called
 // after the options have been used to mount the overlay, to release refs on
 // lower and upper mounts.
+//
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) configureOverlay(ctx context.Context, conf *config.Config, creds *auth.Credentials, lowerOpts *vfs.MountOptions, lowerFSName string, filestoreFD *fd.FD, mountConf specutils.GoferMountConf, dst string, rootfsUpperTarFD *fd.FD) (*vfs.MountOptions, func(), error) {
 	// First copy options from lower layer to upper layer and overlay. Clear
 	// filesystem specific options.
@@ -865,6 +875,8 @@ func (c *containerMounter) configureOverlay(ctx context.Context, conf *config.Co
 	return &overlayOpts, cu.Release(), nil
 }
 
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) mountSubmounts(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, timeline *timing.Timeline) error {
 	mounts, err := c.prepareMounts()
 	if err != nil {
@@ -1007,6 +1019,8 @@ func (c *containerMounter) getPathMode(ctx context.Context, creds *auth.Credenti
 	return linux.FileMode(stat.Mode), nil
 }
 
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) (*vfs.Mount, error) {
 	fsName, opts, err := getMountNameAndOptions(spec, conf, submount, c.l.productName, c.containerName, c.containerID, c.l.fsRestore, c.l.rdmaSysfs)
 	if err != nil {
@@ -1071,6 +1085,9 @@ func (c *containerMounter) mountSubmount(ctx context.Context, spec *specs.Spec, 
 
 // getMountNameAndOptions retrieves the fsName, opts, and useOverlay values
 // used for mounts.
+//
+// +checklocksexclude:fsr.apfl.amflsMu
+// +checklocksexclude:fsr.apfl.mu
 func getMountNameAndOptions(spec *specs.Spec, conf *config.Config, m *mountInfo, productName, containerName, containerID string, fsr *fsRestore, rdmaSysfs *rdma.Snapshot) (string, *vfs.MountOptions, error) {
 	fsName := m.mount.Type
 	var (
@@ -1220,6 +1237,8 @@ func parseKeyValue(s string) (string, string, bool) {
 	return strings.TrimSpace(tokens[0]), strings.TrimSpace(tokens[1]), true
 }
 
+// +checklocksexclude:fsr.apfl.amflsMu
+// +checklocksexclude:fsr.apfl.mu
 func createPrivateMemoryFile(file *os.File, resourceID checkpoint.ResourceID, cid string, fsr *fsRestore) (*pgalloc.MemoryFile, error) {
 	pagesMetadataReader, pagesFileOffset, onLoadEnd, err := fsr.memoryFileLoadArgs(resourceID, cid)
 	if err != nil {
@@ -1266,6 +1285,9 @@ func createPrivateMemoryFile(file *os.File, resourceID checkpoint.ResourceID, ci
 //
 // Note that when there are submounts inside of '/tmp', directories for the
 // mount points must be present, making '/tmp' not empty anymore.
+//
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) mountTmp(ctx context.Context, spec *specs.Spec, conf *config.Config, creds *auth.Credentials, mns *vfs.MountNamespace) error {
 	for _, m := range c.mounts {
 		// m.Destination has been cleaned, so it's to use equality here.
@@ -1330,6 +1352,8 @@ func (c *containerMounter) mountTmp(ctx context.Context, spec *specs.Spec, conf 
 	}
 }
 
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) getSharedMount(ctx context.Context, spec *specs.Spec, conf *config.Config, mount *mountInfo, creds *auth.Credentials) (*vfs.Mount, error) {
 	sharedMount, ok := c.sharedMounts[mount.hint.Mount.Source]
 	if ok {
@@ -1593,6 +1617,9 @@ func (l *Loader) mountCgroupMounts(conf *config.Config, creds *auth.Credentials)
 // container. The cgroup submounts are created under the root controller mount
 // with containerID as the directory name and then bind mounts this directory
 // inside the container's mount namespace.
+//
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) mountCgroupSubmounts(ctx context.Context, spec *specs.Spec, conf *config.Config, mns *vfs.MountNamespace, creds *auth.Credentials, submount *mountInfo) error {
 	root := mns.Root(ctx)
 	defer root.DecRef(ctx)
@@ -1662,6 +1689,9 @@ func (c *containerMounter) mountCgroupSubmounts(ctx context.Context, spec *specs
 
 // mountSharedMaster mounts the master of a volume that is shared among
 // containers in a pod.
+//
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) mountSharedMaster(ctx context.Context, spec *specs.Spec, conf *config.Config, mntInfo *mountInfo, creds *auth.Credentials) (*vfs.Mount, error) {
 	// Mount the master using the options from the hint (mount annotations).
 	origOpts := mntInfo.mount.Options
@@ -1788,6 +1818,9 @@ func (c *containerMounter) makeMountPoint(
 
 // configureRestore returns an updated context.Context including filesystem
 // state used by restore defined by conf.
+//
+// +checklocksexclude:c.l.fsRestore.apfl.amflsMu
+// +checklocksexclude:c.l.fsRestore.apfl.mu
 func (c *containerMounter) configureRestore(restoreMnts *restoreMounts) error {
 	// Compare createMountNamespace(); rootfs always consumes a gofer FD and a
 	// filestore FD is consumed if the rootfs GoferMountConf indicates so.


### PR DESCRIPTION
Async-loader startup failures can leave the main-file waiter blocked and other waiters reporting success. Publish the error to every waiter. Remove the checkpoint-registration lock inversion and prevent concurrent notification from invoking a callback twice or losing its error.

Use saved metadata to define restore page boundaries so live accounting merges cannot change the input layout. Synchronize restored mappings and accounting with usage scans, preserve save iterators during scans, and document allocator and save/restore lock contracts.

Assisted-by: Codex