### PR TITLE
Fix LisaFS socket and node lifetimes

### DIFF
--- a/pkg/lisafs/connection_test.go
+++ b/pkg/lisafs/connection_test.go
@@ -55,6 +55,8 @@ type testConnImpl struct{}
 var _ lisafs.ConnectionImpl = (*testConnImpl)(nil)
 
 // Mount implements lisafs.Mount.
+//
+// +checklocksexclude:mountNode.controlFDsMu
 func (s *testConnImpl) Mount(c *lisafs.Connection, mountNode *lisafs.Node) (*lisafs.ControlFD, lisafs.Statx, int, error) {
 	dummyRoot := &testControlFD{}
 	mountNode.IncRef() // Ref is transferred to ControlFD.

--- a/pkg/lisafs/fd.go
+++ b/pkg/lisafs/fd.go
@@ -87,6 +87,9 @@ var _ genericFD = (*ControlFD)(nil)
 // DecRef implements refs.RefCounter.DecRef. Note that the context
 // parameter should never be used. It exists solely to comply with the
 // refs.RefCounter interface.
+//
+// +checklocksexclude:fd.node.controlFDsMu
+// +checklocksexclude:fd.node.parent.childrenMu
 func (fd *ControlFD) DecRef(context.Context) {
 	fd.controlFDRefs.DecRef(func() {
 		fd.conn.server.renameMu.RLock()
@@ -98,6 +101,9 @@ func (fd *ControlFD) DecRef(context.Context) {
 // decRefLocked is the same as DecRef except the added precondition.
 //
 // Precondition: server's rename mutex must be at least read locked.
+//
+// +checklocksexclude:fd.node.controlFDsMu
+// +checklocksexclude:fd.node.parent.childrenMu
 func (fd *ControlFD) decRefLocked() {
 	fd.controlFDRefs.DecRef(func() {
 		fd.destroyLocked()
@@ -105,6 +111,9 @@ func (fd *ControlFD) decRefLocked() {
 }
 
 // Precondition: server's rename mutex must be at least read locked.
+//
+// +checklocksexclude:fd.node.controlFDsMu
+// +checklocksexclude:fd.node.parent.childrenMu
 func (fd *ControlFD) destroyLocked() {
 	// Update node's control FD list.
 	fd.node.removeFD(fd)
@@ -122,6 +131,8 @@ func (fd *ControlFD) destroyLocked() {
 // Preconditions:
 //   - server's rename mutex must be at least read locked.
 //   - The caller must take a ref on node which is transferred to fd.
+//
+// +checklocksexclude:node.controlFDsMu
 func (fd *ControlFD) Init(c *Connection, node *Node, mode linux.FileMode, impl ControlFDImpl) {
 	fd.conn = c
 	fd.node = node
@@ -175,6 +186,9 @@ func (fd *ControlFD) Node() *Node {
 //   - fd should not have been returned to the client. Otherwise the client can
 //     still refer to it.
 //   - server's rename mutex must at least be read locked.
+//
+// +checklocksexclude:fd.node.controlFDsMu
+// +checklocksexclude:fd.node.parent.childrenMu
 func (fd *ControlFD) RemoveFromConn() {
 	fd.conn.removeControlFDLocked(fd.id)
 }
@@ -257,6 +271,9 @@ func (fd *OpenFD) ControlFD() ControlFDImpl {
 // DecRef implements refs.RefCounter.DecRef. Note that the context
 // parameter should never be used. It exists solely to comply with the
 // refs.RefCounter interface.
+//
+// +checklocksexclude:fd.controlFD.node.controlFDsMu
+// +checklocksexclude:fd.controlFD.node.parent.childrenMu
 func (fd *OpenFD) DecRef(context.Context) {
 	fd.openFDRefs.DecRef(func() {
 		fd.controlFD.openFDsMu.Lock()
@@ -314,6 +331,9 @@ func (fd *BoundSocketFD) ControlFD() ControlFDImpl {
 // DecRef implements refs.RefCounter.DecRef. Note that the context
 // parameter should never be used. It exists solely to comply with the
 // refs.RefCounter interface.
+//
+// +checklocksexclude:fd.controlFD.node.controlFDsMu
+// +checklocksexclude:fd.controlFD.node.parent.childrenMu
 func (fd *BoundSocketFD) DecRef(context.Context) {
 	fd.boundSocketFDRefs.DecRef(func() {
 		fd.controlFD.DecRef(nil) // Drop the ref on the control FD.

--- a/pkg/lisafs/handlers.go
+++ b/pkg/lisafs/handlers.go
@@ -1169,6 +1169,7 @@ func ListenHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 	if err != nil {
 		return 0, err
 	}
+	defer sock.DecRef(nil)
 	if err := sock.controlFD.safelyRead(func() error {
 		if sock.controlFD.node.isDeleted() {
 			return unix.EINVAL
@@ -1190,6 +1191,7 @@ func AcceptHandler(c *Connection, comm Communicator, payloadLen uint32) (uint32,
 	if err != nil {
 		return 0, err
 	}
+	defer sock.DecRef(nil)
 	var (
 		newSock  int
 		peerAddr string

--- a/pkg/lisafs/handlers.go
+++ b/pkg/lisafs/handlers.go
@@ -1389,6 +1389,8 @@ func renameAtCommon(c *Connection, comm Communicator, payloadLen uint32, oldDirF
 	})
 }
 
+// +checklocksexclude:n.controlFDsMu
+// +checklocksexclude:n.childrenMu
 func notifyRenameRecursive(n *Node) {
 	n.forEachFD(func(cfd *ControlFD) {
 		cfd.impl.Renamed()

--- a/pkg/lisafs/node.go
+++ b/pkg/lisafs/node.go
@@ -29,14 +29,15 @@ import (
 // also showed that static arrays are faster than maps for lookups until n=8.
 const numStaticChildren = 5
 
-// Node is a node on the filesystem tree. A Node is shared by all the
-// ControlFDs opened on that position. For a given Server, there will only be
-// one Node for a given filesystem position.
+// Node is a node on the filesystem tree. A Server has one attached Node for
+// each filesystem position, shared by the ControlFDs opened there. An unlinked
+// Node can remain alive while ControlFDs reference it, even after replacement.
 //
 // Reference Model:
 //   - Each node holds a ref on its parent for its entire lifetime.
 type Node struct {
-	// node's ref count is protected by its parent's childrenMu.
+	// References use atomic operations. The parent's childrenMu serializes
+	// lookup with final-reference removal; it is not needed for every ref update.
 	nodeRefs
 
 	// opMu synchronizes high level operations on this path.
@@ -66,25 +67,32 @@ type Node struct {
 	// used to deny operations on FDs on this Node after deletion because it is
 	// not safe for FD implementations to do host walks up to this position
 	// anymore. This node may have been replaced with something hazardous.
-	// deleted is protected by opMu. deleted must only be accessed/mutated using
-	// atomics; see markDeletedRecursive for more details.
+	// Accesses must be atomic because markDeletedRecursive also marks
+	// descendants without holding their opMu.
+	//
+	// +checkatomic
 	deleted atomicbitops.Uint32
 
 	// name is the name of the file represented by this Node in parent. If this
-	// FD represents the root directory, then name is an empty string. name is
-	// protected by the backing server's rename mutex.
+	// Node represents the root directory, then name is an empty string.
+	// Non-root names and parent pointers use the server's rename mutex; root
+	// values are immutable. Node has no server back-reference through which
+	// checklocks could name that mutex.
 	name string
 
-	// parent is this parent node which tracks this node as a child. parent is
-	// protected by the backing server's rename mutex.
+	// parent is held for this node's entire lifetime, even after unlinking.
+	// It is nil for a root and shares name's rename-mutex ownership.
 	parent *Node
+
+	controlFDsMu sync.Mutex
 
 	// controlFDs is a linked list of all the ControlFDs opened on this node.
 	// Prefer this over a slice to avoid additional allocations. Each ControlFD
 	// is an implicit linked list node so there are no additional allocations
 	// needed to maintain the linked list.
-	controlFDsMu sync.Mutex
-	controlFDs   controlFDList
+	//
+	// +checklocks:controlFDsMu
+	controlFDs controlFDList
 
 	// Here is a performance hack. Past experience has shown that map allocations
 	// on each node for tracking children costs a lot of memory. More small
@@ -92,12 +100,15 @@ type Node struct {
 	// upto numStaticChildren children using hardcoded pointers. If more children
 	// are inserted then move to a map. Use dynamicChildren iff it is non-nil.
 
-	// The following fields are protected by childrenMu.
-	childrenMu     sync.Mutex
+	childrenMu sync.Mutex
+
+	// +checklocks:childrenMu
 	staticChildren [numStaticChildren]struct {
 		name string
 		node *Node
 	}
+
+	// +checklocks:childrenMu
 	dynamicChildren map[string]*Node
 }
 
@@ -105,7 +116,10 @@ type Node struct {
 // parameter should never be used. It exists solely to comply with the
 // refs.RefCounter interface.
 //
-// Precondition: server's rename mutex must be at least read locked.
+// Precondition: for a non-root node, the server's rename mutex must be at
+// least read locked. A root's name and parent are immutable.
+//
+// +checklocksexclude:n.parent.childrenMu
 func (n *Node) DecRef(context.Context) {
 	if n.parent == nil {
 		n.nodeRefs.DecRef(nil)
@@ -115,21 +129,26 @@ func (n *Node) DecRef(context.Context) {
 	n.parent.childrenMu.Lock()
 	deleted := false
 	n.nodeRefs.DecRef(func() {
-		n.parent.removeChildLocked(n.name)
 		deleted = true
 	})
+	// An unlinked node may have been replaced under the same name.
+	if deleted && n.parent.LookupChildLocked(n.name) == n {
+		_ = n.parent.removeChildLocked(n.name)
+	}
 	n.parent.childrenMu.Unlock()
 	if deleted {
-		// Drop ref on parent. Keep Decref call lock free for scalability.
+		// Drop the parent reference after releasing its childrenMu.
 		n.parent.DecRef(nil)
 	}
 }
 
-// InitLocked must be called before first use of fd.
+// InitLocked must be called before first use of n.
 //
-// Precondition: parent.childrenMu is locked.
+// Precondition: parent.childrenMu is locked if parent is non-nil.
 //
 // Postconditions: A ref on n is transferred to the caller.
+//
+// +checklocks:parent.childrenMu
 func (n *Node) InitLocked(name string, parent *Node) {
 	n.nodeRefs.InitRefs()
 	n.name = name
@@ -143,7 +162,7 @@ func (n *Node) InitLocked(name string, parent *Node) {
 // LookupChildLocked looks up for a child with given name. Returns nil if child
 // does not exist.
 //
-// Preconditions: childrenMu is locked.
+// +checklocks:n.childrenMu
 func (n *Node) LookupChildLocked(name string) *Node {
 	if n.dynamicChildren != nil {
 		return n.dynamicChildren[name]
@@ -157,7 +176,10 @@ func (n *Node) LookupChildLocked(name string) *Node {
 	return nil
 }
 
-// WithChildrenMu executes fn with n.childrenMu locked.
+// WithChildrenMu executes fn synchronously with n.childrenMu locked.
+// checklocks cannot propagate that lock state into the supplied callback.
+//
+// +checklocksexclude:n.childrenMu
 func (n *Node) WithChildrenMu(fn func()) {
 	n.childrenMu.Lock()
 	defer n.childrenMu.Unlock()
@@ -187,18 +209,26 @@ func (n *Node) isDeleted() bool {
 	return n.deleted.Load() != 0
 }
 
+// +checklocksexclude:n.controlFDsMu
 func (n *Node) removeFD(fd *ControlFD) {
 	n.controlFDsMu.Lock()
 	defer n.controlFDsMu.Unlock()
 	n.controlFDs.Remove(fd)
 }
 
+// +checklocksexclude:n.controlFDsMu
 func (n *Node) insertFD(fd *ControlFD) {
 	n.controlFDsMu.Lock()
 	defer n.controlFDsMu.Unlock()
 	n.controlFDs.PushBack(fd)
 }
 
+// forEachFD calls fn synchronously with n.controlFDsMu held. No reference is
+// transferred to fn; it must not add or remove entries from the list.
+// A listed FD can have zero references while its destructor waits for a lock;
+// list membership alone does not permit IncRef.
+//
+// +checklocksexclude:n.controlFDsMu
 func (n *Node) forEachFD(fn func(*ControlFD)) {
 	n.controlFDsMu.Lock()
 	defer n.controlFDsMu.Unlock()
@@ -210,7 +240,7 @@ func (n *Node) forEachFD(fn func(*ControlFD)) {
 // removeChildLocked removes child with given name from n and returns the
 // removed child. Returns nil if no such child existed.
 //
-// Precondition: childrenMu is locked.
+// +checklocks:n.childrenMu
 func (n *Node) removeChildLocked(name string) *Node {
 	if n.dynamicChildren != nil {
 		toRemove := n.dynamicChildren[name]
@@ -231,7 +261,7 @@ func (n *Node) removeChildLocked(name string) *Node {
 
 // insertChildLocked inserts child into n. It does not check for duplicates.
 //
-// Precondition: childrenMu is locked.
+// +checklocks:n.childrenMu
 func (n *Node) insertChildLocked(name string, child *Node) {
 	// Try to insert statically first if staticChildren is still being used.
 	if n.dynamicChildren == nil {
@@ -257,6 +287,10 @@ func (n *Node) insertChildLocked(name string, child *Node) {
 	n.dynamicChildren[name] = child
 }
 
+// forEachChild calls fn synchronously with n.childrenMu held. No reference is
+// transferred to fn; it must not change n's child collection.
+//
+// +checklocksexclude:n.childrenMu
 func (n *Node) forEachChild(fn func(*Node)) {
 	n.childrenMu.Lock()
 	defer n.childrenMu.Unlock()
@@ -276,7 +310,10 @@ func (n *Node) forEachChild(fn func(*Node)) {
 }
 
 // Precondition: opMu must be locked for writing on the root node being marked
-// as deleted.
+// as deleted. Recursive calls mark children atomically without their opMu;
+// a receiver-wide checklocks requirement would incorrectly require those locks.
+//
+// +checklocksexclude:n.childrenMu
 func (n *Node) markDeletedRecursive() {
 	n.deleted.Store(1)
 

--- a/pkg/lisafs/node_test.go
+++ b/pkg/lisafs/node_test.go
@@ -25,10 +25,12 @@ func TestLookup(t *testing.T) {
 		2 * numStaticChildren, // For dynamic children.
 	} {
 		t.Run(fmt.Sprintf("%dChildren", numChildren), func(t *testing.T) {
-			var root Node
-			root.InitLocked("", nil)
+			s := NewServer()
+			defer s.Destroy()
+			s.renameMu.RLock()
+			defer s.renameMu.RUnlock()
+			root := s.root
 			root.childrenMu.Lock()
-			defer root.childrenMu.Unlock()
 
 			// truth is the source of truth.
 			truth := make(map[string]*Node)
@@ -37,7 +39,7 @@ func TestLookup(t *testing.T) {
 			for i := 0; i < numChildren; i++ {
 				name := fmt.Sprintf("%d", i)
 				var child Node
-				child.InitLocked(name, &root)
+				child.InitLocked(name, root)
 				truth[name] = &child
 			}
 
@@ -47,6 +49,10 @@ func TestLookup(t *testing.T) {
 				if got, want := root.LookupChildLocked(name), truth[name]; got != want {
 					t.Errorf("incorrect child returned by root: want %p, got %p", want, got)
 				}
+			}
+			root.childrenMu.Unlock()
+			for _, child := range truth {
+				child.DecRef(nil)
 			}
 		})
 	}
@@ -58,10 +64,12 @@ func TestDelete(t *testing.T) {
 		2 * numStaticChildren, // For dynamic children.
 	} {
 		t.Run(fmt.Sprintf("%dChildren", numChildren), func(t *testing.T) {
-			var root Node
-			root.InitLocked("", nil)
+			s := NewServer()
+			defer s.Destroy()
+			s.renameMu.RLock()
+			defer s.renameMu.RUnlock()
+			root := s.root
 			root.childrenMu.Lock()
-			defer root.childrenMu.Unlock()
 
 			// truth is the source of truth.
 			truth := make(map[string]*Node)
@@ -70,7 +78,7 @@ func TestDelete(t *testing.T) {
 			for i := 0; i < numChildren; i++ {
 				name := fmt.Sprintf("%d", i)
 				var child Node
-				child.InitLocked(name, &root)
+				child.InitLocked(name, root)
 				truth[name] = &child
 			}
 
@@ -80,6 +88,25 @@ func TestDelete(t *testing.T) {
 				if got, want := root.removeChildLocked(name), truth[name]; got != want {
 					t.Errorf("root deleted incorrect node: want %p, got %p", want, got)
 				}
+			}
+			root.childrenMu.Unlock()
+
+			// Replacing an unlinked node must survive its final DecRef.
+			for name, old := range truth {
+				old.opMu.Lock()
+				old.markDeletedRecursive()
+				old.opMu.Unlock()
+				var replacement Node
+				root.childrenMu.Lock()
+				replacement.InitLocked(name, root)
+				root.childrenMu.Unlock()
+				old.DecRef(nil)
+				root.childrenMu.Lock()
+				if got := root.LookupChildLocked(name); got != &replacement {
+					t.Errorf("final DecRef removed replacement: got %p, want %p", got, &replacement)
+				}
+				root.childrenMu.Unlock()
+				replacement.DecRef(nil)
 			}
 		})
 	}

--- a/pkg/lisafs/server.go
+++ b/pkg/lisafs/server.go
@@ -69,8 +69,9 @@ func NewServer() *Server {
 	var s Server
 	s.handlers = handlers[:]
 	s.root = &Node{}
-	// s owns the ref on s.root.
-	s.root.InitLocked("", nil)
+	// s owns this new root. With no parent, there is no childrenMu to hold;
+	// checklocks cannot express InitLocked's conditional parent requirement.
+	s.root.InitLocked("", nil) // +checklocksignore
 	return &s
 }
 

--- a/pkg/lisafs/testsuite/testsuite.go
+++ b/pkg/lisafs/testsuite/testsuite.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -52,12 +53,30 @@ type Tester interface {
 
 // RunAllLocalFSTests runs all local FS tests as subtests.
 func RunAllLocalFSTests(t *testing.T, tester Tester) {
+	mountRoot := os.Getenv("TEST_TMPDIR")
+	if mountRoot == "" {
+		mountRoot = os.TempDir()
+	}
+	parent, err := os.Open(mountRoot)
+	if err != nil {
+		t.Fatalf("opening temporary directory failed: %v", err)
+	}
+	defer parent.Close()
+
 	for name, testFn := range localFSTests {
-		mountPath, err := os.MkdirTemp(os.Getenv("TEST_TMPDIR"), "")
+		mountPath, err := os.MkdirTemp(mountRoot, "")
 		if err != nil {
 			t.Fatalf("creation of temporary mountpoint failed: %v", err)
 		}
-		RunTest(t, tester, name, testFn, mountPath)
+		serverPath := mountPath
+		if name == "UDS" {
+			// Keep socket paths below UnixPathMax even with a long TEST_TMPDIR.
+			// The final component must remain a directory, not a procfs symlink,
+			// since servers may open the mount point with O_NOFOLLOW. Other tests
+			// require the original path for operations that forbid all symlinks.
+			serverPath = fmt.Sprintf("/proc/self/fd/%d/%s", parent.Fd(), filepath.Base(mountPath))
+		}
+		RunTest(t, tester, name, testFn, serverPath)
 		os.RemoveAll(mountPath)
 	}
 }
@@ -619,7 +638,11 @@ func testUDS(ctx context.Context, t *testing.T, tester Tester, root lisafs.Clien
 	const name = "sock"
 	file, socket, stat := bind(ctx, t, root, name, unix.SOCK_STREAM)
 	defer closeFD(ctx, t, file)
-	defer socket.Close(ctx)
+	defer func() {
+		if socket != nil {
+			socket.Close(ctx)
+		}
+	}()
 
 	if got := stat.Mode & unix.S_IFMT; got != unix.S_IFSOCK {
 		t.Errorf("socket file mode is incorrect: want %#x, got %#x", unix.S_IFSOCK, got)
@@ -645,8 +668,25 @@ func testUDS(ctx context.Context, t *testing.T, tester Tester, root lisafs.Clien
 		t.Errorf("mknod GID is incorrect: want %d, got %d", stat.GID, got.GID)
 	}
 
-	// TODO(b/194709873): Once listen and accept are implemented, test connecting
-	// and accepting a connection using sockF.
+	if err := socket.Listen(ctx, 1); err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	connected, err := file.Connect(ctx, unix.SOCK_STREAM, lisafs.NoUID, lisafs.NoGID)
+	if err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	defer unix.Close(connected)
+	accepted, err := socket.Accept(ctx)
+	if err != nil {
+		t.Fatalf("accept failed: %v", err)
+	}
+	defer unix.Close(accepted)
+
+	// The filesystem descriptor must remain usable after the bound socket
+	// closes. RunTest checks for leaked server references before shutdown.
+	socket.Close(ctx)
+	socket = nil
+	statTo(ctx, t, file, &got)
 }
 
 func testGetdents(ctx context.Context, t *testing.T, tester Tester, root lisafs.ClientFD) {

--- a/runsc/fsgofer/BUILD
+++ b/runsc/fsgofer/BUILD
@@ -34,5 +34,6 @@ go_test(
         "//pkg/lisafs",
         "//pkg/lisafs/testsuite",
         "//pkg/log",
+        "//runsc/config",
     ],
 )

--- a/runsc/fsgofer/lisafs.go
+++ b/runsc/fsgofer/lisafs.go
@@ -116,6 +116,8 @@ type connectionImpl struct {
 var _ lisafs.ConnectionImpl = (*connectionImpl)(nil)
 
 // Mount implements lisafs.ConnectionImpl.Mount.
+//
+// +checklocksexclude:mountNode.controlFDsMu
 func (i *connectionImpl) Mount(c *lisafs.Connection, mountNode *lisafs.Node) (*lisafs.ControlFD, lisafs.Statx, int, error) {
 	mountPath := mountNode.FilePath()
 	rootHostFD, err := tryOpen(func(flags int) (int, error) {
@@ -221,6 +223,7 @@ type controlFDLisa struct {
 
 var _ lisafs.ControlFDImpl = (*controlFDLisa)(nil)
 
+// +checklocksexclude:parent.ControlFD.node.childrenMu
 func newControlFDLisa(hostFD int, parent *controlFDLisa, name string, mode linux.FileMode) *controlFDLisa {
 	var (
 		childFD    *controlFDLisa
@@ -228,7 +231,9 @@ func newControlFDLisa(hostFD int, parent *controlFDLisa, name string, mode linux
 		parentNode = parent.Node()
 	)
 	parentNode.WithChildrenMu(func() {
-		childNode = parentNode.LookupChildLocked(name)
+		// WithChildrenMu runs this callback synchronously under childrenMu;
+		// checklocks cannot propagate that lock through the callback.
+		childNode = parentNode.LookupChildLocked(name) // +checklocksignore
 		if childNode == nil {
 			// Common case. Performance hack which is used to allocate the node and
 			// its control FD together in the heap. For a well-behaving client, there
@@ -241,7 +246,7 @@ func newControlFDLisa(hostFD int, parent *controlFDLisa, name string, mode linux
 			}{}
 			childFD = &temp.fd
 			childNode = &temp.node
-			childNode.InitLocked(name, parentNode)
+			childNode.InitLocked(name, parentNode) // +checklocksignore
 		} else {
 			childNode.IncRef()
 			childFD = &controlFDLisa{}
@@ -426,6 +431,8 @@ func (fd *controlFDLisa) SetStat(stat lisafs.SetStatReq) (failureMask uint32, fa
 }
 
 // Walk implements lisafs.ControlFDImpl.Walk.
+//
+// +checklocksexclude:fd.ControlFD.node.childrenMu
 func (fd *controlFDLisa) Walk(name string) (*lisafs.ControlFD, lisafs.Statx, error) {
 	childHostFD, err := tryOpen(func(flags int) (int, error) {
 		return unix.Openat(fd.hostFD, name, flags, 0)
@@ -580,6 +587,8 @@ func (fd *controlFDLisa) Open(flags uint32) (*lisafs.OpenFD, int, error) {
 }
 
 // OpenCreate implements lisafs.ControlFDImpl.OpenCreate.
+//
+// +checklocksexclude:fd.ControlFD.node.childrenMu
 func (fd *controlFDLisa) OpenCreate(mode linux.FileMode, uid lisafs.UID, gid lisafs.GID, name string, flags uint32) (*lisafs.ControlFD, lisafs.Statx, *lisafs.OpenFD, int, error) {
 	createFlags := unix.O_CREAT | unix.O_EXCL | unix.O_RDONLY | unix.O_NONBLOCK | openFlags
 	childHostFD, err := unix.Openat(fd.hostFD, name, createFlags, uint32(mode&^linux.FileTypeMask))
@@ -631,6 +640,8 @@ func (fd *controlFDLisa) OpenCreate(mode linux.FileMode, uid lisafs.UID, gid lis
 }
 
 // Mkdir implements lisafs.ControlFDImpl.Mkdir.
+//
+// +checklocksexclude:fd.ControlFD.node.childrenMu
 func (fd *controlFDLisa) Mkdir(mode linux.FileMode, uid lisafs.UID, gid lisafs.GID, name string) (*lisafs.ControlFD, lisafs.Statx, error) {
 	if err := unix.Mkdirat(fd.hostFD, name, uint32(mode&^linux.FileTypeMask)); err != nil {
 		return nil, lisafs.Statx{}, err
@@ -667,6 +678,8 @@ func (fd *controlFDLisa) Mkdir(mode linux.FileMode, uid lisafs.UID, gid lisafs.G
 }
 
 // Mknod implements lisafs.ControlFDImpl.Mknod.
+//
+// +checklocksexclude:fd.ControlFD.node.childrenMu
 func (fd *controlFDLisa) Mknod(mode linux.FileMode, uid lisafs.UID, gid lisafs.GID, name string, minor uint32, major uint32) (*lisafs.ControlFD, lisafs.Statx, error) {
 	// Only allow creating regular files or overlayfs whiteouts. Linux's
 	// vfs_mknod() exempts whiteouts from the CAP_MKNOD check, so we do not need
@@ -720,6 +733,8 @@ func (fd *controlFDLisa) Mknod(mode linux.FileMode, uid lisafs.UID, gid lisafs.G
 }
 
 // Symlink implements lisafs.ControlFDImpl.Symlink.
+//
+// +checklocksexclude:fd.ControlFD.node.childrenMu
 func (fd *controlFDLisa) Symlink(name string, target string, uid lisafs.UID, gid lisafs.GID) (*lisafs.ControlFD, lisafs.Statx, error) {
 	if err := unix.Symlinkat(target, fd.hostFD, name); err != nil {
 		return nil, lisafs.Statx{}, err
@@ -752,6 +767,9 @@ func (fd *controlFDLisa) Symlink(name string, target string, uid lisafs.UID, gid
 }
 
 // Link implements lisafs.ControlFDImpl.Link.
+//
+// The destination node's childrenMu must not be held. The destination is
+// supplied through an interface, so checklocks cannot name its node owner.
 func (fd *controlFDLisa) Link(dir lisafs.ControlFDImpl, name string) (*lisafs.ControlFD, lisafs.Statx, error) {
 	// Using linkat(targetFD, "", newdirfd, name, AT_EMPTY_PATH) requires
 	// CAP_DAC_READ_SEARCH in the *root* userns. The gofer process has
@@ -931,6 +949,8 @@ func (fd *controlFDLisa) ConnectWithCreds(sockType uint32, uid lisafs.UID, gid l
 }
 
 // BindAt implements lisafs.ControlFDImpl.BindAt.
+//
+// +checklocksexclude:fd.ControlFD.node.childrenMu
 func (fd *controlFDLisa) BindAt(name string, sockType uint32, mode linux.FileMode, uid lisafs.UID, gid lisafs.GID) (*lisafs.ControlFD, lisafs.Statx, *lisafs.BoundSocketFD, int, error) {
 	if !fd.Conn().Impl().(*connectionImpl).config.HostUDS.AllowCreate() {
 		logRejectedUdsCreateOnce.Do(func() {

--- a/runsc/fsgofer/lisafs.go
+++ b/runsc/fsgofer/lisafs.go
@@ -1008,7 +1008,7 @@ func (fd *controlFDLisa) BindAt(name string, sockType uint32, mode linux.FileMod
 	}
 	cu.Release()
 
-	socketControlFD := newControlFDLisa(sockFD, fd, name, linux.ModeSocket)
+	socketControlFD := newControlFDLisa(sockFileFD, fd, name, linux.ModeSocket)
 	boundSocketFD := &boundSocketFDLisa{
 		sock: os.NewFile(uintptr(sockFD), socketPath),
 	}

--- a/runsc/fsgofer/lisafs_test.go
+++ b/runsc/fsgofer/lisafs_test.go
@@ -20,6 +20,7 @@ import (
 	"gvisor.dev/gvisor/pkg/lisafs"
 	"gvisor.dev/gvisor/pkg/lisafs/testsuite"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/runsc/config"
 	"gvisor.dev/gvisor/runsc/fsgofer"
 )
 
@@ -38,7 +39,7 @@ type tester struct{}
 
 // NewConnImpl implements testsuite.Tester.NewServer.
 func (tester) NewConnImpl(t *testing.T) lisafs.ConnectionImpl {
-	return fsgofer.NewConnectionImpl(&fsgofer.Config{})
+	return fsgofer.NewConnectionImpl(&fsgofer.Config{HostUDS: config.HostUDSAll})
 }
 
 // LinkSupported implements testsuite.Tester.LinkSupported.
@@ -53,9 +54,7 @@ func (tester) SetUserGroupIDSupported() bool {
 
 // BindSupported implements testsuite.Tester.BindSupported.
 func (tester) BindSupported() bool {
-	// In some test environments, the mount path is really large and bind(2)
-	// fails with EINVAL if the path length >= 108.
-	return false
+	return true
 }
 
 func TestFSGofer(t *testing.T) {

--- a/test/syscalls/BUILD
+++ b/test/syscalls/BUILD
@@ -139,8 +139,6 @@ syscall_test(
 syscall_test(
     add_host_connector = True,
     add_hostinet = True,
-    # TODO(b/318948806): lisafs.BoundSocketFD is leaked.
-    leak_check = False,
     one_sandbox = False,
     # Takes too long to run with S/R.
     save = False,
@@ -153,8 +151,6 @@ syscall_test(
 syscall_test(
     add_host_uds = True,
     add_hostinet = True,
-    # TODO(b/318948806): lisafs.BoundSocketFD is leaked.
-    leak_check = False,
     one_sandbox = False,
     # Takes too long to run with S/R.
     save = False,


### PR DESCRIPTION
LisaFS listen and accept requests leak socket references, and bound sockets share a host descriptor with their control FD. Release request references after leaving filesystem locks and give the control FD its own descriptor so it remains usable when the socket closes.

On final release of an unlinked node, remove its parent entry only if it still names that node, preserving replacements at the same path. Document the associated node and FD lock contracts, and restore leak checks in the existing host-socket syscall tests.

Assisted-by: Codex