### PR TITLE
Fix mountinfo option races during remount

### DIFF
--- a/pkg/sentry/vfs/mount.go
+++ b/pkg/sentry/vfs/mount.go
@@ -1785,20 +1785,21 @@ func (vfs *VirtualFilesystem) GenerateProcMountInfo(ctx context.Context, taskRoo
 		fmt.Fprintf(buf, "%s ", manglePath(pathFromRoot))
 
 		// (6) Mount options.
+		mntOpts := mnt.Options()
 		opts := "rw"
-		if mnt.ReadOnly() {
+		if mntOpts.ReadOnly {
 			opts = "ro"
 		}
-		if mnt.flags.NoSUID {
+		if mntOpts.Flags.NoSUID {
 			opts += ",nosuid"
 		}
-		if mnt.flags.NoDev {
+		if mntOpts.Flags.NoDev {
 			opts += ",nodev"
 		}
-		if mnt.flags.NoExec {
+		if mntOpts.Flags.NoExec {
 			opts += ",noexec"
 		}
-		if mnt.flags.NoATime {
+		if mntOpts.Flags.NoATime {
 			opts += ",noatime"
 		}
 		fmt.Fprintf(buf, "%s ", opts)


### PR DESCRIPTION
Reading /proc/[pid]/mountinfo races with remount because mount flags are read without mountMu. Reading the read-only bit separately can also produce mixed mount options.

Use the existing Mount.Options snapshot for read-only state and flags, matching GenerateProcMounts.

Assisted-by: Codex