### PR TITLE
Fix IPC removal error handling

### DIFF
--- a/pkg/sentry/kernel/msgqueue/msgqueue.go
+++ b/pkg/sentry/kernel/msgqueue/msgqueue.go
@@ -190,8 +190,7 @@ func (r *Registry) Remove(id ipc.ID, creds *auth.Credentials) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.reg.Remove(id, creds)
-	return nil
+	return r.reg.Remove(id, creds)
 }
 
 // FindByID returns the queue with the specified ID and an error if the ID

--- a/pkg/sentry/kernel/semaphore/semaphore.go
+++ b/pkg/sentry/kernel/semaphore/semaphore.go
@@ -217,9 +217,10 @@ func (r *Registry) Remove(id ipc.ID, creds *auth.Credentials) error {
 	if !found {
 		return linuxerr.EINVAL
 	}
+	if err := r.reg.Remove(id, creds); err != nil {
+		return err
+	}
 	delete(r.indexes, index)
-
-	r.reg.Remove(id, creds)
 
 	return nil
 }

--- a/test/syscalls/linux/msgqueue.cc
+++ b/test/syscalls/linux/msgqueue.cc
@@ -17,7 +17,9 @@
 #include <string.h>
 #include <sys/ipc.h>
 #include <sys/msg.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include <cstdint>
 #include <map>
@@ -841,6 +843,33 @@ TEST(MsgqueueTest, MsgCtlIpcStatWriteOnly) {
   struct msqid_ds ds;
   ASSERT_THAT(msgctl(queue.get(), IPC_STAT, &ds),
               SyscallFailsWithErrno(EACCES));
+}
+
+TEST(MsgqueueTest, MsgCtlIpcRmid) {
+  Queue queue = ASSERT_NO_ERRNO_AND_VALUE(Msgget(IPC_PRIVATE, 0600));
+  const int id = queue.get();
+  ASSERT_THAT(msgctl(id, IPC_RMID, nullptr), SyscallSucceeds());
+  queue.release();
+  EXPECT_THAT(msgctl(id, IPC_RMID, nullptr), SyscallFailsWithErrno(EINVAL));
+}
+
+TEST(MsgqueueTest, MsgCtlIpcRmidPermission) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  Queue queue = ASSERT_NO_ERRNO_AND_VALUE(Msgget(IPC_PRIVATE, 0600));
+  const uid_t other_uid = geteuid() == 0 ? 1 : 0;
+  ScopedThread([&] {
+    // Change only this thread's credentials, leaving the owner able to remove
+    // the queue after the denied attempt.
+    ASSERT_THAT(syscall(SYS_setresuid, -1, other_uid, -1), SyscallSucceeds());
+    ASSERT_NO_ERRNO(SetCapability(CAP_SYS_ADMIN, false));
+    EXPECT_THAT(msgctl(queue.get(), IPC_RMID, nullptr),
+                SyscallFailsWithErrno(EPERM));
+  });
+
+  struct msqid_ds ds = {};
+  EXPECT_THAT(msgctl(queue.get(), IPC_STAT, &ds), SyscallSucceeds());
+  // Queue's destructor checks that removal by the owner still succeeds.
 }
 
 // Test msgctl with IPC_SET option.

--- a/test/syscalls/linux/semaphore.cc
+++ b/test/syscalls/linux/semaphore.cc
@@ -16,7 +16,9 @@
 #include <signal.h>
 #include <sys/ipc.h>
 #include <sys/sem.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include <atomic>
 #include <cerrno>
@@ -1027,6 +1029,24 @@ TEST(SemaphoreTest, SemInfo) {
   // semaem range from 0 to a random number. Since the numbers are always
   // non-negative, the test will not check the results of semusz and semaem.
   EXPECT_EQ(info.semvmx, kSemVmx);
+}
+
+TEST(SemaphoreTest, RemoveWithoutPermission) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  AutoSem sem(semget(IPC_PRIVATE, 1, 0600));
+  ASSERT_THAT(sem.get(), SyscallSucceeds());
+  const uid_t other_uid = geteuid() == 0 ? 1 : 0;
+  ScopedThread([&] {
+    // Change only this thread's credentials so the owner can remove the set.
+    ASSERT_THAT(syscall(SYS_setresuid, -1, other_uid, -1), SyscallSucceeds());
+    ASSERT_NO_ERRNO(SetCapability(CAP_SYS_ADMIN, false));
+    EXPECT_THAT(semctl(sem.get(), 0, IPC_RMID), SyscallFailsWithErrno(EPERM));
+  });
+
+  struct semid_ds ds = {};
+  EXPECT_THAT(semctl(sem.get(), 0, IPC_STAT, &ds), SyscallSucceeds());
+  // AutoSem's destructor checks that removal by the owner still succeeds.
 }
 
 TEST(SempahoreTest, RemoveNonExistentSemaphore) {


### PR DESCRIPTION
Message-queue and semaphore removal discard IPC registry errors, reporting success when permission is denied. Semaphore removal also deletes its index entry before checking ownership, preventing later removal by the owner.

Propagate the registry errors and delete the semaphore index only after removal succeeds.

Assisted-by: Codex