### PR TITLE
checklocks: fix TCP state races

### DIFF
--- a/pkg/tcpip/transport/tcp/BUILD
+++ b/pkg/tcpip/transport/tcp/BUILD
@@ -217,6 +217,7 @@ go_test(
     size = "small",
     srcs = [
         "cubic_test.go",
+        "endpoint_test.go",
         "main_test.go",
         "sack_scoreboard_test.go",
         "segment_test.go",
@@ -227,6 +228,7 @@ go_test(
         "//pkg/buffer",
         "//pkg/refs",
         "//pkg/sleep",
+        "//pkg/sync",
         "//pkg/tcpip",
         "//pkg/tcpip/faketime",
         "//pkg/tcpip/header",

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -2361,9 +2361,12 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 				}
 			}
 
-			id := e.TransportEndpointInfo.ID
-			id.LocalPort = p
-			if err := e.stack.RegisterTransportEndpoint(netProtos, ProtocolNumber, id, e, e.portFlags, bindToDevice); err != nil {
+			// Initialize the ID before publishing the endpoint: ICMP error
+			// delivery reads it without acquiring e.mu.
+			oldID := e.TransportEndpointInfo.ID
+			e.TransportEndpointInfo.ID.LocalPort = p
+			if err := e.stack.RegisterTransportEndpoint(netProtos, ProtocolNumber, e.TransportEndpointInfo.ID, e, e.portFlags, bindToDevice); err != nil {
+				e.TransportEndpointInfo.ID = oldID
 				portRes := ports.Reservation{
 					Networks:     netProtos,
 					Transport:    ProtocolNumber,
@@ -2382,7 +2385,6 @@ func (e *Endpoint) registerEndpoint(addr tcpip.FullAddress, netProto tcpip.Netwo
 
 			// Port picking successful. Save the details of
 			// the selected port.
-			e.TransportEndpointInfo.ID = id
 			e.isPortReserved = true
 			e.boundBindToDevice = bindToDevice
 			e.boundPortFlags = e.portFlags

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -289,14 +289,18 @@ type sndQueueInfo struct {
 	TCPSndBufState
 }
 
-// CloneState clones sq into other. It is not thread safe
+// CloneState clones sq into other. The caller must exclusively own other.
+// other is a standalone snapshot without an owning mutex; the source-lock
+// contract does not establish the caller's exclusive ownership of other.
+//
+// +checklocks:sq.sndQueueMu
 func (sq *sndQueueInfo) CloneState(other *TCPSndBufState) {
 	other.SndBufSize = sq.SndBufSize
 	other.SndBufUsed = sq.SndBufUsed
 	other.SndClosed = sq.SndClosed
 	other.PacketTooBigCount = sq.PacketTooBigCount
 	other.SndMTU = sq.SndMTU
-	other.AutoTuneSndBufDisabled = atomicbitops.FromUint32(sq.AutoTuneSndBufDisabled.RacyLoad())
+	other.AutoTuneSndBufDisabled.Store(sq.AutoTuneSndBufDisabled.Load())
 }
 
 // Endpoint represents a TCP endpoint. This struct serves as the interface

--- a/pkg/tcpip/transport/tcp/endpoint.go
+++ b/pkg/tcpip/transport/tcp/endpoint.go
@@ -409,8 +409,9 @@ type Endpoint struct {
 	// methods.
 	state atomicbitops.Uint32 `state:".(EndpointState)"`
 
-	// connectionDirectionState holds current state of send and receive,
-	// accessed atomically
+	// connectionDirectionState records whether sending and receiving are closed.
+	//
+	// +checkatomic
 	connectionDirectionState atomicbitops.Uint32
 
 	// origEndpointState is only used during a restore phase to save the
@@ -3097,14 +3098,15 @@ func (e *Endpoint) maxReceiveBufferSize() int {
 	return rs.Max
 }
 
-// directionState returns the close state of send and receive part of the endpoint
+// connDirectionState returns the send and receive close state of the endpoint.
 func (e *Endpoint) connDirectionState() connDirectionState {
 	return connDirectionState(e.connectionDirectionState.Load())
 }
 
-// updateDirectionState updates the close state of send and receive part of the endpoint
-func (e *Endpoint) updateConnDirectionState(state connDirectionState) connDirectionState {
-	return connDirectionState(e.connectionDirectionState.Swap(uint32(e.connDirectionState() | state)))
+// updateConnDirectionState adds closed directions to the endpoint's state.
+// Passing connDirectionStateOpen leaves the state unchanged.
+func (e *Endpoint) updateConnDirectionState(state connDirectionState) {
+	atomicbitops.OrUint32(&e.connectionDirectionState, uint32(state))
 }
 
 // rcvWndScaleForHandshake computes the receive window scale to offer to the

--- a/pkg/tcpip/transport/tcp/endpoint_test.go
+++ b/pkg/tcpip/transport/tcp/endpoint_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcp
+
+import (
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/sync"
+)
+
+func TestSendBufferStateSnapshot(t *testing.T) {
+	var ep Endpoint
+	var snapshot TCPSndBufState
+	// Neither the initial nor updated endpoint state contains this value.
+	snapshot.AutoTuneSndBufDisabled.Store(2)
+
+	// The socket option callback does not take sndQueueMu. Join only after
+	// both accesses so that the wait group cannot serialize them.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		_ = ep.OnSetSendBufferSize(4096)
+	})
+	wg.Go(func() {
+		ep.sndQueueInfo.sndQueueMu.Lock()
+		ep.sndQueueInfo.CloneState(&snapshot)
+		ep.sndQueueInfo.sndQueueMu.Unlock()
+	})
+	wg.Wait()
+
+	ep.sndQueueInfo.sndQueueMu.Lock()
+	sourceDisabled := ep.sndQueueInfo.AutoTuneSndBufDisabled.Load()
+	ep.sndQueueInfo.sndQueueMu.Unlock()
+	if sourceDisabled != 1 {
+		t.Errorf("source AutoTuneSndBufDisabled = %d, want 1", sourceDisabled)
+	}
+	if got := snapshot.AutoTuneSndBufDisabled.Load(); got > 1 {
+		t.Errorf("snapshot AutoTuneSndBufDisabled = %d, want 0 or 1", got)
+	}
+}

--- a/pkg/tcpip/transport/tcp/state.go
+++ b/pkg/tcpip/transport/tcp/state.go
@@ -417,6 +417,8 @@ type TCPSndBufState struct {
 
 	// AutoTuneSndBufDisabled indicates that the auto tuning of send buffer
 	// is disabled.
+	//
+	// +checkatomic
 	AutoTuneSndBufDisabled atomicbitops.Uint32
 }
 

--- a/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
+++ b/pkg/tcpip/transport/tcp/test/e2e/tcp_test.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -153,9 +154,34 @@ func TestGiveUpConnect(t *testing.T) {
 	}
 }
 
+type handshakeClock struct {
+	tcpip.Clock
+	arm    <-chan struct{}
+	resume <-chan struct{}
+}
+
+func (c *handshakeClock) NowMonotonic() tcpip.MonotonicTime {
+	select {
+	case <-c.arm:
+		<-c.resume
+	default:
+	}
+	return c.Clock.NowMonotonic()
+}
+
 // Test for ICMP error handling without completing handshake.
 func TestConnectICMPError(t *testing.T) {
-	c := context.New(t, e2e.DefaultMTU)
+	arm, resume := make(chan struct{}), make(chan struct{})
+	c := context.NewWithOpts(t, context.Options{
+		EnableV4: true,
+		EnableV6: true,
+		MTU:      e2e.DefaultMTU,
+		Clock: &handshakeClock{
+			Clock:  faketime.NewManualClock(),
+			arm:    arm,
+			resume: resume,
+		},
+	})
 	defer c.Cleanup()
 
 	var wq waiter.Queue
@@ -163,16 +189,79 @@ func TestConnectICMPError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEndpoint failed: %s", err)
 	}
+	c.EP = ep
+	ep.SocketOptions().SetIPv4RecvError(true)
+	if err := c.Stack().SetPortRange(context.StackPort, context.StackPort); err != nil {
+		t.Fatalf("SetPortRange failed: %s", err)
+	}
 
 	waitEntry, notifyCh := waiter.NewChannelEntry(waiter.EventHUp)
 	wq.EventRegister(&waitEntry)
 	defer wq.EventUnregister(&waitEntry)
 
-	{
+	quoted := c.BuildSegmentWithAddrs(nil, &context.Headers{
+		SrcPort: context.StackPort,
+		DstPort: context.TestPort,
+		Flags:   header.TCPFlagSyn,
+	}, context.StackAddr, context.TestAddr)
+	defer quoted.Release()
+	quote := buffer.NewViewWithData(quoted.Flatten())
+	defer quote.Release()
+
+	var wg sync.WaitGroup
+	resumeHandshake := sync.OnceFunc(func() { close(resume) })
+	defer func() {
+		resumeHandshake()
+		wg.Wait()
+		for err := ep.SocketOptions().DequeueErr(); err != nil; err = ep.SocketOptions().DequeueErr() {
+			err.Payload.Release()
+		}
+	}()
+
+	// Pause the first handshake clock read, after registration but before SYN
+	// allocation and route cleanup can synchronize with ICMP delivery. Observe
+	// only the registry, not a signal from Connect after its ID assignment.
+	close(arm)
+	wg.Go(func() {
 		err := ep.Connect(tcpip.FullAddress{Addr: context.TestAddr, Port: context.TestPort})
 		if d := cmp.Diff(&tcpip.ErrConnectStarted{}, err); d != "" {
-			t.Fatalf("ep.Connect(...) mismatch (-want +got):\n%s", d)
+			t.Errorf("ep.Connect(...) mismatch (-want +got):\n%s", d)
 		}
+	})
+	waitFor := func(what string, ready func() bool) {
+		t.Helper()
+		deadline := time.Now().Add(5 * time.Second)
+		for !ready() {
+			if time.Now().After(deadline) {
+				t.Fatalf("timed out waiting for %s", what)
+			}
+			runtime.Gosched()
+		}
+	}
+	id := stack.TransportEndpointID{
+		LocalAddress:  context.StackAddr,
+		LocalPort:     context.StackPort,
+		RemoteAddress: context.TestAddr,
+		RemotePort:    context.TestPort,
+	}
+	waitFor("endpoint registration", func() bool {
+		return c.Stack().FindTransportEndpoint(ipv4.ProtocolNumber, tcp.ProtocolNumber, id, 1) != nil
+	})
+	wg.Go(func() {
+		c.SendICMPPacket(header.ICMPv4DstUnreachable, header.ICMPv4HostUnreachable, nil, quote, e2e.DefaultMTU)
+	})
+	waitFor("queued ICMP error", func() bool { return ep.SocketOptions().PeekErr() != nil })
+	resumeHandshake()
+	wg.Wait()
+	sockErr := ep.SocketOptions().DequeueErr()
+	defer sockErr.Payload.Release()
+	if got, want := sockErr.Offender.Port, uint16(context.StackPort); got != want {
+		t.Errorf("ICMP error local port = %d, want %d", got, want)
+	}
+	// GetPacket may call FailNow before returning ownership of its allocated
+	// view. Avoid entering it after a failure that would bypass our Release.
+	if t.Failed() {
+		return
 	}
 
 	syn := c.GetPacket()
@@ -183,19 +272,15 @@ func TestConnectICMPError(t *testing.T) {
 		LastErrorLocked() tcpip.Error
 	})
 
-	c.SendICMPPacket(header.ICMPv4DstUnreachable, header.ICMPv4HostUnreachable, nil, syn, e2e.DefaultMTU)
-
-	for {
-		if err := wep.LastErrorLocked(); err != nil {
-			if d := cmp.Diff(&tcpip.ErrHostUnreachable{}, err); d != "" {
-				t.Errorf("ep.LastErrorLocked() mismatch (-want +got):\n%s", d)
-			}
-			break
-		}
-		time.Sleep(time.Millisecond)
+	if d := cmp.Diff(&tcpip.ErrHostUnreachable{}, wep.LastErrorLocked()); d != "" {
+		t.Errorf("ep.LastErrorLocked() mismatch (-want +got):\n%s", d)
 	}
 
-	<-notifyCh
+	select {
+	case <-notifyCh:
+	default:
+		t.Fatal("ICMP error did not notify the endpoint")
+	}
 
 	// The stack would have unregistered the endpoint because of the ICMP error.
 	// Expect a RST for any subsequent packets sent to the endpoint.


### PR DESCRIPTION
ICMP delivery can read an endpoint's ID immediately after registration, readiness paths can concurrently add closed directions, and socket options can change the send-buffer flag during a probe snapshot. Initialize the local port before registration, merge closed directions with atomic OR, and copy the probe flag atomically.

Add ownership contracts and regressions that exercise the registry publication window and the actual option-callback/probe overlap.

Part of #14349.

Assisted-by: Codex