### PR TITLE
checklocks: unlock fragment processing on error

### DIFF
--- a/pkg/tcpip/network/internal/fragmentation/fragmentation.go
+++ b/pkg/tcpip/network/internal/fragmentation/fragmentation.go
@@ -83,12 +83,19 @@ type FragmentID struct {
 //
 // +stateify savable
 type Fragmentation struct {
-	mu             sync.Mutex `state:"nosave"`
-	highLimit      int
-	lowLimit       int
-	reassemblers   map[FragmentID]*reassembler
-	rList          reassemblerList
-	memSize        int
+	mu        sync.Mutex `state:"nosave"`
+	highLimit int
+	lowLimit  int
+
+	// +checklocks:mu
+	reassemblers map[FragmentID]*reassembler
+
+	// +checklocks:mu
+	rList reassemblerList
+
+	// +checklocks:mu
+	memSize int
+
 	timeout        time.Duration
 	blockSize      uint16
 	clock          tcpip.Clock
@@ -101,6 +108,14 @@ type TimeoutHandler interface {
 	// OnReassemblyTimeout will be called with the first fragment (or nil, if the
 	// first fragment has not been received) of a packet whose reassembly has
 	// timed out.
+	//
+	// The packet is borrowed for the duration of the call; a handler that
+	// retains it must take its own reference.
+	//
+	// The call is synchronous with the owning Fragmentation's mutex held.
+	// The handler must not reenter that Fragmentation's Process or Release.
+	// checklocks cannot name that mutex because TimeoutHandler does not
+	// expose the owning Fragmentation.
 	OnReassemblyTimeout(pkt *stack.PacketBuffer)
 }
 
@@ -116,8 +131,7 @@ type TimeoutHandler interface {
 // fragments after reaching highMemoryLimit.
 //
 // reassemblingTimeout specifies the maximum time allowed to reassemble a packet.
-// Fragments are lazily evicted only when a new a packet with an
-// already existing fragmentation-id arrives after the timeout.
+// Incomplete reassemblies are released once this timeout elapses.
 func NewFragmentation(blockSize uint16, highMemoryLimit, lowMemoryLimit int, reassemblingTimeout time.Duration, clock tcpip.Clock, timeoutHandler TimeoutHandler) *Fragmentation {
 	if lowMemoryLimit >= highMemoryLimit {
 		lowMemoryLimit = highMemoryLimit
@@ -140,6 +154,8 @@ func NewFragmentation(blockSize uint16, highMemoryLimit, lowMemoryLimit int, rea
 		clock:          clock,
 		timeoutHandler: timeoutHandler,
 	}
+	// Job locks f.mu before invoking this callback; checklocks cannot carry
+	// that lock through the stored function value.
 	f.releaseJob = tcpip.NewJob(f.clock, &f.mu, f.releaseReassemblersLocked)
 
 	return f
@@ -158,6 +174,8 @@ func NewFragmentation(blockSize uint16, highMemoryLimit, lowMemoryLimit int, rea
 // proto is the protocol number marked in the fragment being processed. It has
 // to be given here outside of the FragmentID struct because IPv6 should not use
 // the protocol to identify a fragment.
+//
+// +checklocksexclude:f.mu
 func (f *Fragmentation) Process(
 	id FragmentID, first, last uint16, more bool, proto uint8, pkt *stack.PacketBuffer) (
 	*stack.PacketBuffer, uint8, bool, error) {
@@ -180,6 +198,7 @@ func (f *Fragmentation) Process(
 
 	f.mu.Lock()
 	if f.reassemblers == nil {
+		f.mu.Unlock()
 		return nil, 0, false, fmt.Errorf("Release() called before fragmentation processing could finish")
 	}
 
@@ -228,6 +247,8 @@ func (f *Fragmentation) Process(
 }
 
 // Release releases all underlying resources.
+//
+// +checklocksexclude:f.mu
 func (f *Fragmentation) Release() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -237,40 +258,52 @@ func (f *Fragmentation) Release() {
 	f.reassemblers = nil
 }
 
+// release releases r if it has not already been marked done.
+// r must belong to f.
+//
+// +checklocks:f.mu
+// +checklocksexclude:r.mu
 func (f *Fragmentation) release(r *reassembler, timedOut bool) {
 	// Before releasing a fragment we need to check if r is already marked as done.
 	// Otherwise, we would delete it twice.
 	if r.checkDoneOrMark() {
 		return
 	}
+	// checkDoneOrMark waited for active processing under r.mu. Since it
+	// returned false, this call marked r done, so subsequent process calls
+	// return before accessing r.memSize, r.pkt, or r.holes. This call now
+	// owns those fields exclusively without r.mu. checklocks cannot model
+	// this ownership transfer.
 
 	delete(f.reassemblers, r.id)
 	f.rList.Remove(r)
-	f.memSize -= r.memSize
+	f.memSize -= r.memSize // +checklocksignore
 	if f.memSize < 0 {
 		log.Warningf("memory counter < 0 (%d), this is an accounting bug that requires investigation", f.memSize)
 		f.memSize = 0
 	}
 
 	if h := f.timeoutHandler; timedOut && h != nil {
-		h.OnReassemblyTimeout(r.pkt)
+		h.OnReassemblyTimeout(r.pkt) // +checklocksignore
 	}
-	if r.pkt != nil {
-		r.pkt.DecRef()
-		r.pkt = nil
+	if r.pkt != nil { // +checklocksignore
+		r.pkt.DecRef() // +checklocksignore
+		r.pkt = nil    // +checklocksignore
 	}
-	for _, h := range r.holes {
+	for _, h := range r.holes { // +checklocksignore
 		if h.pkt != nil {
 			h.pkt.DecRef()
 			h.pkt = nil
 		}
 	}
-	r.holes = nil
+	r.holes = nil // +checklocksignore
 }
 
 // releaseReassemblersLocked releases already-expired reassemblers, then
 // schedules the job to call back itself for the remaining reassemblers if
-// any. This function must be called with f.mu locked.
+// any.
+//
+// +checklocks:f.mu
 func (f *Fragmentation) releaseReassemblersLocked() {
 	now := f.clock.NowMonotonic()
 	for {

--- a/pkg/tcpip/network/internal/fragmentation/fragmentation_test.go
+++ b/pkg/tcpip/network/internal/fragmentation/fragmentation_test.go
@@ -49,6 +49,38 @@ func pkt(size int, pieces ...string) *stack.PacketBuffer {
 	})
 }
 
+func TestProcessAfterRelease(t *testing.T) {
+	f := NewFragmentation(minBlockSize, HighFragThreshold, LowFragThreshold, reassembleTimeout, &faketime.NullClock{}, nil)
+	f.Release()
+
+	done := make(chan error, 1)
+	go func() {
+		p := pkt(1, "x")
+		out, _, _, err := f.Process(FragmentID{}, 0, 0, false, 0, p)
+		p.DecRef()
+		if out != nil {
+			out.DecRef()
+		}
+		if err == nil {
+			done <- errors.New("Process succeeded after Release")
+			return
+		}
+		f.Release()
+		done <- nil
+	}()
+
+	// Keep a real-time watchdog: the regression blocks on f.mu, and mutex
+	// waits are not durably blocked in synctest, so its clock would not advance.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Process after Release or subsequent Release blocked")
+	}
+}
+
 type processInput struct {
 	id    FragmentID
 	first uint16
@@ -137,6 +169,7 @@ func TestFragmentationProcess(t *testing.T) {
 						t.Errorf("got Process(%+v, %d, %d, %t, %d, _) = (_, %d, _, _), want = (_, %d, _, _)",
 							in.id, in.first, in.last, in.more, in.proto, proto, firstFragmentProto)
 					}
+					f.mu.Lock()
 					if _, ok := f.reassemblers[in.id]; ok {
 						t.Errorf("Process(%d) did not remove buffer from reassemblers", i)
 					}
@@ -145,6 +178,7 @@ func TestFragmentationProcess(t *testing.T) {
 							t.Errorf("Process(%d) did not remove buffer from rList", i)
 						}
 					}
+					f.mu.Unlock()
 				}
 			}
 		})
@@ -277,7 +311,10 @@ func TestReassemblingTimeout(t *testing.T) {
 						t.Fatalf("%s: got done = %t, want = %t", event.name, done, event.expectDone)
 					}
 				}
-				if got, want := f.memSize, event.memSizeAfterEvent; got != want {
+				f.mu.Lock()
+				gotMemSize := f.memSize
+				f.mu.Unlock()
+				if got, want := gotMemSize, event.memSizeAfterEvent; got != want {
 					t.Errorf("%s: got f.memSize = %d, want = %d", event.name, got, want)
 				}
 			}
@@ -324,6 +361,7 @@ func TestMemoryLimits(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	f.mu.Lock()
 	if _, ok := f.reassemblers[FragmentID{ID: 0}]; ok {
 		t.Errorf("Memory limits are not respected: id=0 has not been evicted.")
 	}
@@ -333,6 +371,7 @@ func TestMemoryLimits(t *testing.T) {
 	if _, ok := f.reassemblers[FragmentID{ID: 3}]; !ok {
 		t.Errorf("Implementation of memory limits is wrong: id=3 is not present.")
 	}
+	f.mu.Unlock()
 }
 
 func TestMemoryLimitsIgnoresDuplicates(t *testing.T) {
@@ -355,7 +394,10 @@ func TestMemoryLimitsIgnoresDuplicates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := f.memSize, memSize; got != want {
+	f.mu.Lock()
+	gotMemSize := f.memSize
+	f.mu.Unlock()
+	if got, want := gotMemSize, memSize; got != want {
 		t.Errorf("Wrong size, duplicates are not handled correctly: got=%d, want=%d.", got, want)
 	}
 }
@@ -693,11 +735,15 @@ func TestTimeoutHandler(t *testing.T) {
 				}
 			}
 			if !test.wantError {
+				f.mu.Lock()
 				r, ok := f.reassemblers[id]
+				if ok {
+					f.release(r, true)
+				}
+				f.mu.Unlock()
 				if !ok {
 					t.Fatal("Reassembler not found")
 				}
-				f.release(r, true)
 			}
 			switch {
 			case handler.pkt != nil && test.wantPkt == nil:

--- a/pkg/tcpip/network/internal/fragmentation/reassembler.go
+++ b/pkg/tcpip/network/internal/fragmentation/reassembler.go
@@ -15,14 +15,21 @@
 package fragmentation
 
 import (
+	"cmp"
 	"math"
-	"sort"
+	"slices"
 
 	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )
 
+// hole describes a missing or received range in a reassembler.
+//
+// Holes stored in reassembler.holes are protected by that reassembler's mu
+// until release takes exclusive ownership. A hole has no reference to its
+// reassembler, so checklocks cannot name the owning mutex.
+//
 // +stateify savable
 type hole struct {
 	first  uint16
@@ -34,18 +41,34 @@ type hole struct {
 	pkt *stack.PacketBuffer
 }
 
+// reassembler holds a packet's fragments until reassembly or release.
+//
+// Fragmentation.release claims exclusive ownership of memSize, holes, and
+// pkt by marking reassembly done under mu. Those cleanup accesses need
+// exceptions because checklocks cannot model the ownership transfer.
+//
 // +stateify savable
 type reassembler struct {
+	// reassemblerEntry is protected by the owning Fragmentation.mu. There
+	// is no reference back to that Fragmentation, so checklocks cannot name
+	// its mutex here.
 	reassemblerEntry
-	id        FragmentID
-	memSize   int
-	proto     uint8
-	mu        sync.Mutex `state:"nosave"`
-	holes     []hole
-	filled    int
+	id FragmentID
+	// +checklocks:mu
+	memSize int
+	// +checklocks:mu
+	proto uint8
+	// mu follows the owning Fragmentation.mu in lock order.
+	mu sync.Mutex `state:"nosave"`
+	// +checklocks:mu
+	holes []hole
+	// +checklocks:mu
+	filled int
+	// +checklocks:mu
 	done      bool
 	createdAt tcpip.MonotonicTime
-	pkt       *stack.PacketBuffer
+	// +checklocks:mu
+	pkt *stack.PacketBuffer
 }
 
 func newReassembler(id FragmentID, clock tcpip.Clock) *reassembler {
@@ -62,6 +85,7 @@ func newReassembler(id FragmentID, clock tcpip.Clock) *reassembler {
 	return r
 }
 
+// +checklocksexclude:r.mu
 func (r *reassembler) process(first, last uint16, more bool, proto uint8, pkt *stack.PacketBuffer) (*stack.PacketBuffer, uint8, bool, int, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -178,8 +202,8 @@ func (r *reassembler) process(first, last uint16, more bool, proto uint8, pkt *s
 		return nil, 0, false, memConsumed, nil
 	}
 
-	sort.Slice(r.holes, func(i, j int) bool {
-		return r.holes[i].first < r.holes[j].first
+	slices.SortFunc(r.holes, func(a, b hole) int {
+		return cmp.Compare(a.first, b.first)
 	})
 
 	resPkt := r.holes[0].pkt.Clone()
@@ -189,6 +213,7 @@ func (r *reassembler) process(first, last uint16, more bool, proto uint8, pkt *s
 	return resPkt, r.proto, true /* done */, memConsumed, nil
 }
 
+// +checklocksexclude:r.mu
 func (r *reassembler) checkDoneOrMark() bool {
 	r.mu.Lock()
 	prev := r.done

--- a/pkg/tcpip/network/internal/fragmentation/reassembler_test.go
+++ b/pkg/tcpip/network/internal/fragmentation/reassembler_test.go
@@ -188,6 +188,8 @@ func TestReassemblerProcess(t *testing.T) {
 			// after reassembler error or completion. Without release(), the
 			// reassembler will leak PacketBuffers.
 			defer func() {
+				r.mu.Lock()
+				defer r.mu.Unlock()
 				for _, h := range r.holes {
 					if h.pkt != nil {
 						h.pkt.DecRef()
@@ -221,6 +223,8 @@ func TestReassemblerProcess(t *testing.T) {
 				return bytes.Equal(a.Data().AsRange().ToSlice(), b.Data().AsRange().ToSlice())
 			}
 
+			r.mu.Lock()
+			defer r.mu.Unlock()
 			if isDone {
 				if diff := cmp.Diff(
 					test.want, r.holes,


### PR DESCRIPTION
Processing a fragment after Release returns an error without unlocking the fragmentation mutex, blocking later processing and cleanup. Unlock on that path.

Annotate reassembler locking and the handoff to exclusive cleanup. Sort holes with a value comparator so the callback no longer accesses guarded state.

Part of #14349.

Assisted-by: Codex