### PR TITLE
checklocks: guard gonet, FIFO and TUN state

### DIFF
--- a/pkg/tcpip/adapters/gonet/BUILD
+++ b/pkg/tcpip/adapters/gonet/BUILD
@@ -25,7 +25,6 @@ go_test(
     srcs = ["gonet_test.go"],
     library = ":gonet",
     deps = [
-        "//pkg/sync",
         "//pkg/tcpip",
         "//pkg/tcpip/header",
         "//pkg/tcpip/link/loopback",

--- a/pkg/tcpip/adapters/gonet/gonet.go
+++ b/pkg/tcpip/adapters/gonet/gonet.go
@@ -128,26 +128,34 @@ func (l *TCPListener) Addr() net.Addr {
 }
 
 type deadlineTimer struct {
-	// mu protects the fields below.
 	mu sync.Mutex
 
-	readTimer     *time.Timer
-	readCancelCh  chan struct{}
-	writeTimer    *time.Timer
+	// +checklocks:mu
+	readTimer *time.Timer
+	// +checklocks:mu
+	readCancelCh chan struct{}
+	// +checklocks:mu
+	writeTimer *time.Timer
+	// +checklocks:mu
 	writeCancelCh chan struct{}
 }
 
-func (d *deadlineTimer) init() {
-	d.readCancelCh = make(chan struct{})
-	d.writeCancelCh = make(chan struct{})
+func newDeadlineTimer() deadlineTimer {
+	return deadlineTimer{
+		readCancelCh:  make(chan struct{}),
+		writeCancelCh: make(chan struct{}),
+	}
 }
 
+// +checklocksexclude:d.mu
 func (d *deadlineTimer) readCancel() <-chan struct{} {
 	d.mu.Lock()
 	c := d.readCancelCh
 	d.mu.Unlock()
 	return c
 }
+
+// +checklocksexclude:d.mu
 func (d *deadlineTimer) writeCancel() <-chan struct{} {
 	d.mu.Lock()
 	c := d.writeCancelCh
@@ -157,11 +165,11 @@ func (d *deadlineTimer) writeCancel() <-chan struct{} {
 
 // setDeadline contains the shared logic for setting a deadline.
 //
-// cancelCh and timer must be pointers to deadlineTimer.readCancelCh and
-// deadlineTimer.readTimer or deadlineTimer.writeCancelCh and
-// deadlineTimer.writeTimer.
+// cancelCh and timer must point to d.readCancelCh and d.readTimer, or to
+// d.writeCancelCh and d.writeTimer. checklocks verifies that d.mu is held,
+// but cannot prove that the arguments identify the matching fields of d.
 //
-// setDeadline must only be called while holding d.mu.
+// +checklocks:d.mu
 func (d *deadlineTimer) setDeadline(cancelCh *chan struct{}, timer **time.Timer, t time.Time) {
 	if *timer != nil && !(*timer).Stop() {
 		*cancelCh = make(chan struct{})
@@ -201,6 +209,8 @@ func (d *deadlineTimer) setDeadline(cancelCh *chan struct{}, timer **time.Timer,
 
 // SetReadDeadline implements net.Conn.SetReadDeadline and
 // net.PacketConn.SetReadDeadline.
+//
+// +checklocksexclude:d.mu
 func (d *deadlineTimer) SetReadDeadline(t time.Time) error {
 	d.mu.Lock()
 	d.setDeadline(&d.readCancelCh, &d.readTimer, t)
@@ -210,6 +220,8 @@ func (d *deadlineTimer) SetReadDeadline(t time.Time) error {
 
 // SetWriteDeadline implements net.Conn.SetWriteDeadline and
 // net.PacketConn.SetWriteDeadline.
+//
+// +checklocksexclude:d.mu
 func (d *deadlineTimer) SetWriteDeadline(t time.Time) error {
 	d.mu.Lock()
 	d.setDeadline(&d.writeCancelCh, &d.writeTimer, t)
@@ -218,6 +230,8 @@ func (d *deadlineTimer) SetWriteDeadline(t time.Time) error {
 }
 
 // SetDeadline implements net.Conn.SetDeadline and net.PacketConn.SetDeadline.
+//
+// +checklocksexclude:d.mu
 func (d *deadlineTimer) SetDeadline(t time.Time) error {
 	d.mu.Lock()
 	d.setDeadline(&d.readCancelCh, &d.readTimer, t)
@@ -234,7 +248,7 @@ type TCPConn struct {
 	wq *waiter.Queue
 	ep tcpip.Endpoint
 
-	// readMu serializes reads and implicitly protects read.
+	// readMu serializes reads.
 	//
 	// Lock ordering:
 	// If both readMu and deadlineTimer.mu are to be used in a single
@@ -243,17 +257,18 @@ type TCPConn struct {
 
 	// read contains bytes that have been read from the endpoint,
 	// but haven't yet been returned.
+	//
+	// +checklocks:readMu
 	read []byte
 }
 
 // NewTCPConn creates a new TCPConn.
 func NewTCPConn(wq *waiter.Queue, ep tcpip.Endpoint) *TCPConn {
-	c := &TCPConn{
-		wq: wq,
-		ep: ep,
+	return &TCPConn{
+		deadlineTimer: newDeadlineTimer(),
+		wq:            wq,
+		ep:            ep,
 	}
-	c.deadlineTimer.init()
-	return c
 }
 
 // Accept implements net.Conn.Accept.
@@ -343,6 +358,9 @@ func commonRead(b []byte, ep tcpip.Endpoint, wq *waiter.Queue, deadline <-chan s
 }
 
 // Read implements net.Conn.Read.
+//
+// +checklocksexclude:c.readMu
+// +checklocksexclude:c.deadlineTimer.mu
 func (c *TCPConn) Read(b []byte) (int, error) {
 	c.readMu.Lock()
 	defer c.readMu.Unlock()
@@ -357,6 +375,8 @@ func (c *TCPConn) Read(b []byte) (int, error) {
 }
 
 // Write implements net.Conn.Write.
+//
+// +checklocksexclude:c.deadlineTimer.mu
 func (c *TCPConn) Write(b []byte) (int, error) {
 	deadline := c.writeCancel()
 
@@ -553,12 +573,11 @@ type UDPConn struct {
 
 // NewUDPConn creates a new UDPConn.
 func NewUDPConn(wq *waiter.Queue, ep tcpip.Endpoint) *UDPConn {
-	c := &UDPConn{
-		ep: ep,
-		wq: wq,
+	return &UDPConn{
+		deadlineTimer: newDeadlineTimer(),
+		ep:            ep,
+		wq:            wq,
 	}
-	c.deadlineTimer.init()
-	return c
 }
 
 // DialUDP creates a new UDPConn.
@@ -626,12 +645,16 @@ func (c *UDPConn) RemoteAddr() net.Addr {
 }
 
 // Read implements net.Conn.Read
+//
+// +checklocksexclude:c.deadlineTimer.mu
 func (c *UDPConn) Read(b []byte) (int, error) {
 	bytesRead, _, err := c.ReadFrom(b)
 	return bytesRead, err
 }
 
 // ReadFrom implements net.PacketConn.ReadFrom.
+//
+// +checklocksexclude:c.deadlineTimer.mu
 func (c *UDPConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	deadline := c.readCancel()
 
@@ -643,11 +666,16 @@ func (c *UDPConn) ReadFrom(b []byte) (int, net.Addr, error) {
 	return n, fullToUDPAddr(addr), nil
 }
 
+// Write implements net.Conn.Write.
+//
+// +checklocksexclude:c.deadlineTimer.mu
 func (c *UDPConn) Write(b []byte) (int, error) {
 	return c.WriteTo(b, nil)
 }
 
 // WriteTo implements net.PacketConn.WriteTo.
+//
+// +checklocksexclude:c.deadlineTimer.mu
 func (c *UDPConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 	deadline := c.writeCancel()
 

--- a/pkg/tcpip/adapters/gonet/gonet_test.go
+++ b/pkg/tcpip/adapters/gonet/gonet_test.go
@@ -22,10 +22,10 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"golang.org/x/net/nettest"
-	"gvisor.dev/gvisor/pkg/sync"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/header"
 	"gvisor.dev/gvisor/pkg/tcpip/link/loopback"
@@ -764,18 +764,11 @@ func makePipe() (c1, c2 net.Conn, stop func(), err error) {
 }
 
 func TestTCPConnTransfer(t *testing.T) {
-	c1, c2, _, err := makePipe()
+	c1, c2, stop, err := makePipe()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		if err := c1.Close(); err != nil {
-			t.Error("c1.Close():", err)
-		}
-		if err := c2.Close(); err != nil {
-			t.Error("c2.Close():", err)
-		}
-	}()
+	t.Cleanup(stop)
 
 	c1.SetDeadline(time.Now().Add(time.Second))
 	c2.SetDeadline(time.Now().Add(time.Second))
@@ -1011,22 +1004,19 @@ func TestNetTest(t *testing.T) {
 
 // NOTE(gvisor.dev/issue/9885): Regression test.
 func TestDeadlineTimerAfterZeroValue(t *testing.T) {
-	timer := &deadlineTimer{}
-	timer.init()
-
-	wg := sync.WaitGroup{}
-	ch := timer.readCancel()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	synctest.Test(t, func(t *testing.T) {
+		timer := newDeadlineTimer()
+		ch := timer.readCancel()
+		// Keep the future timer pending even if the host deschedules this test.
+		for _, deadline := range []time.Time{time.Now().Add(10 * time.Second), {}, time.Unix(1, 0)} {
+			if err := timer.SetReadDeadline(deadline); err != nil {
+				t.Fatalf("SetReadDeadline(%v): %v", deadline, err)
+			}
+		}
 		select {
 		case <-ch:
-		case <-time.After(1 * time.Second):
-			t.Fail()
+		default:
+			t.Fatal("original cancellation channel was not closed")
 		}
-	}()
-	timer.SetReadDeadline(time.Now().Add(10 * time.Second))
-	timer.SetReadDeadline(time.Time{})
-	timer.SetReadDeadline(time.Unix(1, 0))
-	wg.Wait()
+	})
 }

--- a/pkg/tcpip/link/qdisc/fifo/qdisc_test.go
+++ b/pkg/tcpip/link/qdisc/fifo/qdisc_test.go
@@ -33,12 +33,17 @@ var _ stack.LinkWriter = (*countWriter)(nil)
 
 // countWriter implements LinkWriter.
 type countWriter struct {
-	mu             sync.Mutex
+	mu sync.Mutex
+
+	// +checklocks:mu
 	packetsWritten int
-	packetsWanted  int
-	done           chan struct{}
+
+	// packetsWanted and done are initialized before publication to the dispatcher.
+	packetsWanted int
+	done          chan struct{}
 }
 
+// +checklocksexclude:cw.mu
 func (cw *countWriter) WritePackets(pkts stack.PacketBufferList) (int, tcpip.Error) {
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
@@ -99,6 +104,9 @@ func TestWriteMorePacketsThanBatchSize(t *testing.T) {
 		done := make(chan struct{})
 		lower := &countWriter{done: done, packetsWanted: want}
 		linkEp := fifo.New(lower, 1, 1000)
+		// Close each iteration promptly below; this idempotent fallback
+		// also joins the dispatcher if the test fails first.
+		t.Cleanup(linkEp.Close)
 		for i := 0; i < want; i++ {
 			pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 				Payload: buffer.MakeWithData(v),
@@ -109,7 +117,10 @@ func TestWriteMorePacketsThanBatchSize(t *testing.T) {
 		select {
 		case <-done:
 		case <-time.After(1 * time.Second):
-			t.Fatalf("expected %d packets, but got only %d", want, lower.packetsWritten)
+			lower.mu.Lock()
+			packetsWritten := lower.packetsWritten
+			lower.mu.Unlock()
+			t.Fatalf("expected %d packets, but got only %d", want, packetsWritten)
 		}
 		linkEp.Close()
 	}

--- a/pkg/tcpip/link/tun/device.go
+++ b/pkg/tcpip/link/tun/device.go
@@ -41,14 +41,23 @@ var zeroMAC [6]byte
 
 // Device is an opened /dev/net/tun device.
 //
+// File lifetime must exclude final Release from concurrent file operations.
+// Capturing the endpoint under mu does not take an additional reference.
+//
 // +stateify savable
 type Device struct {
 	waiter.Queue
 
-	mu           deviceRWMutex `state:"nosave"`
-	endpoint     *tunEndpoint
+	mu deviceRWMutex `state:"nosave"`
+	// +checklocks:mu
+	endpoint *tunEndpoint
+	// +checklocks:mu
 	notifyHandle *channel.NotificationHandle
-	flags        Flags
+
+	// flags is set by SetIff and immutable for that association.
+	//
+	// +checklocks:mu
+	flags Flags
 }
 
 // Flags set properties of a Device
@@ -62,6 +71,8 @@ type Flags struct {
 }
 
 // beforeSave is invoked by stateify.
+//
+// +checklocksexclude:d.mu
 func (d *Device) beforeSave() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -72,6 +83,10 @@ func (d *Device) beforeSave() {
 	}
 }
 
+// SetPersistent sets whether the attached interface persists without open files.
+//
+// +checklocksexclude:d.mu
+// +checklocksexclude:d.endpoint.mu
 func (d *Device) SetPersistent(v bool) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -85,7 +100,9 @@ func (d *Device) SetPersistent(v bool) error {
 	return nil
 }
 
-// Release implements fs.FileOperations.Release.
+// Release releases the device's reference to its attached endpoint.
+//
+// +checklocksexclude:d.mu
 func (d *Device) Release(ctx context.Context) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -100,6 +117,8 @@ func (d *Device) Release(ctx context.Context) {
 }
 
 // SetIff services TUNSETIFF ioctl(2) request.
+//
+// +checklocksexclude:d.mu
 func (d *Device) SetIff(ctx context.Context, s *stack.Stack, name string, flags Flags) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -192,6 +211,8 @@ func attachOrCreateNIC(ctx context.Context, s *stack.Stack, name, prefix string,
 }
 
 // MTU returns the tun endpoint MTU (maximum transmission unit).
+//
+// +checklocksexclude:d.mu
 func (d *Device) MTU() (uint32, error) {
 	d.mu.RLock()
 	endpoint := d.endpoint
@@ -205,10 +226,13 @@ func (d *Device) MTU() (uint32, error) {
 	return endpoint.MTU(), nil
 }
 
-// Write inject one inbound packet to the network interface.
+// Write injects one inbound packet into the network interface.
+//
+// +checklocksexclude:d.mu
 func (d *Device) Write(data *buffer.View) (int64, error) {
 	d.mu.RLock()
 	endpoint := d.endpoint
+	flags := d.flags
 	d.mu.RUnlock()
 	if endpoint == nil {
 		return 0, linuxerr.EBADFD
@@ -221,7 +245,7 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 
 	// Packet information.
 	var pktInfoHdr PacketInfoHeader
-	if !d.flags.NoPacketInfo {
+	if !flags.NoPacketInfo {
 		if dataLen < PacketInfoHeaderSize {
 			// Ignore bad packet.
 			return dataLen, nil
@@ -235,7 +259,7 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 
 	// Ethernet header (TAP only).
 	var ethHdr header.Ethernet
-	if d.flags.TAP {
+	if flags.TAP {
 		if data.Size() < header.EthernetMinimumSize {
 			// Ignore bad packet.
 			return dataLen, nil
@@ -254,7 +278,7 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 		protocol = pktInfoHdr.Protocol()
 	case ethHdr != nil:
 		protocol = ethHdr.Type()
-	case d.flags.TUN:
+	case flags.TUN:
 		// TUN interface with IFF_NO_PI enabled, thus
 		// we need to determine protocol from version field
 		if data.Size() == 0 {
@@ -281,9 +305,12 @@ func (d *Device) Write(data *buffer.View) (int64, error) {
 }
 
 // Read reads one outgoing packet from the network interface.
+//
+// +checklocksexclude:d.mu
 func (d *Device) Read() (*buffer.View, error) {
 	d.mu.RLock()
 	endpoint := d.endpoint
+	noPacketInfo := d.flags.NoPacketInfo
 	d.mu.RUnlock()
 	if endpoint == nil {
 		return nil, linuxerr.EBADFD
@@ -293,17 +320,17 @@ func (d *Device) Read() (*buffer.View, error) {
 	if pkt == nil {
 		return nil, linuxerr.ErrWouldBlock
 	}
-	v := d.encodePkt(pkt)
+	v := encodePkt(pkt, noPacketInfo)
 	pkt.DecRef()
 	return v, nil
 }
 
 // encodePkt encodes packet for fd side.
-func (d *Device) encodePkt(pkt *stack.PacketBuffer) *buffer.View {
+func encodePkt(pkt *stack.PacketBuffer, noPacketInfo bool) *buffer.View {
 	var view *buffer.View
 
 	// Packet information.
-	if !d.flags.NoPacketInfo {
+	if !noPacketInfo {
 		view = buffer.NewView(PacketInfoHeaderSize + pkt.Size())
 		view.Grow(PacketInfoHeaderSize)
 		hdr := PacketInfoHeader(view.AsSlice())
@@ -322,6 +349,8 @@ func (d *Device) encodePkt(pkt *stack.PacketBuffer) *buffer.View {
 
 // Name returns the name of the attached network interface. Empty string if
 // unattached.
+//
+// +checklocksexclude:d.mu
 func (d *Device) Name() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
@@ -332,13 +361,17 @@ func (d *Device) Name() string {
 }
 
 // Flags returns the flags set for d. Zero value if unset.
+//
+// +checklocksexclude:d.mu
 func (d *Device) Flags() Flags {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.flags
 }
 
-// Readiness implements watier.Waitable.Readiness.
+// Readiness implements waiter.Waitable.Readiness.
+//
+// +checklocksexclude:d.mu
 func (d *Device) Readiness(mask waiter.EventMask) waiter.EventMask {
 	if mask&waiter.ReadableEvents != 0 {
 		d.mu.RLock()
@@ -371,12 +404,16 @@ type tunEndpoint struct {
 	name  string
 	isTap bool
 
-	mu            endpointMutex `state:"nosave"`
-	onCloseAction func()        `state:"nosave"`
-	persistent    bool
-	closed        bool
+	mu endpointMutex `state:"nosave"`
+	// +checklocks:mu
+	onCloseAction func() `state:"nosave"`
+	// +checklocks:mu
+	persistent bool
+	// +checklocks:mu
+	closed bool
 }
 
+// +checklocksexclude:e.mu
 func (e *tunEndpoint) setPersistent(v bool) {
 	e.mu.Lock()
 	if e.persistent == v || e.closed {
@@ -393,6 +430,7 @@ func (e *tunEndpoint) setPersistent(v bool) {
 	}
 }
 
+// +checklocksexclude:e.mu
 func (e *tunEndpoint) Close() {
 	e.mu.Lock()
 	if e.closed {
@@ -414,6 +452,8 @@ func (e *tunEndpoint) Close() {
 }
 
 // SetOnCloseAction implements stack.LinkEndpoint.
+//
+// +checklocksexclude:e.mu
 func (e *tunEndpoint) SetOnCloseAction(action func()) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -421,6 +461,10 @@ func (e *tunEndpoint) SetOnCloseAction(action func()) {
 }
 
 // DecRef decrements refcount of e, removing NIC if it reaches 0.
+//
+// The final reference must be dropped without holding e.mu because
+// destruction calls Close. checklocks cannot express a precondition that
+// applies only to the final decrement.
 func (e *tunEndpoint) DecRef(ctx context.Context) {
 	e.tunEndpointRefs.DecRef(func() {
 		e.Close()


### PR DESCRIPTION
Gonet initializes deadline state before publication, and TUN flags are immutable during an attachment. Make those ownership rules checkable with fresh timer construction, locked flag snapshots and concrete locking contracts, preserving endpoint reference lifetimes.

Fix the FIFO test's racing timeout read and ensure failure cleanup joins its dispatcher. Reuse gonet's stack cleanup and keep the existing zero-deadline regression deterministic with synctest.

Part of #14349.

Assisted-by: Codex