### PR TITLE
Apply CRI sandbox pod resources in runsc shim

### DIFF
--- a/pkg/shim/v1/runsc/service.go
+++ b/pkg/shim/v1/runsc/service.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -711,6 +712,7 @@ func newInit(workDir, namespace string, platform stdio.Platform, r *proc.CreateC
 		return nil, fmt.Errorf("update volume annotations: %w", err)
 	}
 	updated = setPodCgroup(spec) || updated
+	updated = applyPodResourcesFromAnnotations(spec) || updated
 
 	if updated {
 		if err := utils.WriteSpec(r.Bundle, spec); err != nil {
@@ -774,6 +776,152 @@ func setPodCgroup(spec *specs.Spec) bool {
 		}
 	}
 	return false
+}
+
+// applyPodResourcesFromAnnotations copies pod-level CPU settings and memory
+// limits from the CRI sandbox annotations into spec.Linux.Resources so that
+// runsc writes them to the sandbox host cgroup (e.g. cpu.max on the sandbox
+// scope).
+//
+// Background: containerd's CRI plugin puts pod-level limits on the sandbox
+// (pause) container's OCI spec as annotations only. Its Linux.Resources block
+// carries just cpu.shares=2 (the pause container's own resources). Because
+// gVisor collapses all containers of a pod into a single sandbox process, the
+// per-container cgroup limits never apply to the actual workload; the only
+// cgroup where a pod-wide limit can meaningfully bite is the sandbox scope.
+// Without this translation the sandbox scope ends up with cpu.max=max /
+// memory.max=max and pod-level limits are silently unenforced.
+// See google/gvisor#13777.
+//
+// This runs only for sandbox containers. Existing explicit values in
+// spec.Linux.Resources take precedence for quota/period/memory. For CPU shares,
+// the pause-container default (2) is treated as non-pod-level metadata and may
+// be replaced by the pod-level sandbox-cpu-shares annotation.
+//
+// Non-positive annotation values are ignored. containerd may emit zero-valued
+// annotations when the CRI resource object exists but fields are unset; copying
+// memory=0 into the OCI spec would become systemd MemoryMax=0 on cgroup v2.
+func applyPodResourcesFromAnnotations(spec *specs.Spec) bool {
+	if spec == nil || spec.Annotations == nil {
+		return false
+	}
+	if !utils.IsSandbox(spec) {
+		return false
+	}
+
+	ensureResources := func() *specs.LinuxResources {
+		if spec.Linux == nil {
+			spec.Linux = &specs.Linux{}
+		}
+		if spec.Linux.Resources == nil {
+			spec.Linux.Resources = &specs.LinuxResources{}
+		}
+		return spec.Linux.Resources
+	}
+
+	updated := false
+
+	// CPU quota / period / shares.
+	cpuQuotaStr := spec.Annotations[utils.SandboxCPUQuotaAnnotation]
+	cpuPeriodStr := spec.Annotations[utils.SandboxCPUPeriodAnnotation]
+	cpuSharesStr := spec.Annotations[utils.SandboxCPUSharesAnnotation]
+
+	if cpuQuotaStr != "" || cpuPeriodStr != "" || cpuSharesStr != "" {
+		var cpu *specs.LinuxCPU
+		ensureCPU := func() *specs.LinuxCPU {
+			if cpu != nil {
+				return cpu
+			}
+			res := ensureResources()
+			if res.CPU == nil {
+				res.CPU = &specs.LinuxCPU{}
+			}
+			cpu = res.CPU
+			return cpu
+		}
+		getCPU := func() *specs.LinuxCPU {
+			if cpu != nil {
+				return cpu
+			}
+			if spec.Linux != nil && spec.Linux.Resources != nil {
+				cpu = spec.Linux.Resources.CPU
+			}
+			return cpu
+		}
+
+		if cpuQuotaStr != "" {
+			if existing := getCPU(); existing == nil || existing.Quota == nil {
+				if v, ok := parsePositiveInt64Annotation(utils.SandboxCPUQuotaAnnotation, cpuQuotaStr); ok {
+					ensureCPU().Quota = &v
+					updated = true
+				}
+			}
+		}
+		if cpuPeriodStr != "" {
+			if existing := getCPU(); existing == nil || existing.Period == nil {
+				if v, ok := parsePositiveUint64Annotation(utils.SandboxCPUPeriodAnnotation, cpuPeriodStr); ok {
+					ensureCPU().Period = &v
+					updated = true
+				}
+			}
+		}
+		if cpuSharesStr != "" {
+			if existing := getCPU(); existing == nil || existing.Shares == nil || *existing.Shares == pauseContainerDefaultCPUShares {
+				if v, ok := parsePositiveUint64Annotation(utils.SandboxCPUSharesAnnotation, cpuSharesStr); ok {
+					ensureCPU().Shares = &v
+					updated = true
+				}
+			}
+		}
+	}
+
+	// Memory limit.
+	if memStr := spec.Annotations[utils.SandboxMemoryAnnotation]; memStr != "" {
+		var mem *specs.LinuxMemory
+		if spec.Linux != nil && spec.Linux.Resources != nil {
+			mem = spec.Linux.Resources.Memory
+		}
+		if mem == nil || mem.Limit == nil {
+			if v, ok := parsePositiveInt64Annotation(utils.SandboxMemoryAnnotation, memStr); ok {
+				res := ensureResources()
+				if res.Memory == nil {
+					res.Memory = &specs.LinuxMemory{}
+				}
+				res.Memory.Limit = &v
+				updated = true
+			}
+		}
+	}
+
+	return updated
+}
+
+const pauseContainerDefaultCPUShares uint64 = 2
+
+func parsePositiveInt64Annotation(name, value string) (int64, bool) {
+	v, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		log.L.Warnf("gvisor: ignoring unparsable %s=%q: %v", name, value, err)
+		return 0, false
+	}
+	if v <= 0 {
+		log.L.Debugf("gvisor: ignoring non-positive %s=%q", name, value)
+		return 0, false
+	}
+	return v, true
+}
+
+func parsePositiveUint64Annotation(name, value string) (uint64, bool) {
+	v, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		log.L.Warnf("gvisor: ignoring unparsable %s=%q: %v", name, value, err)
+		return 0, false
+	}
+	if v == 0 {
+		log.L.Debugf("gvisor: ignoring non-positive %s=%q", name, value)
+		return 0, false
+	}
+	return v, true
 }
 
 // GvisorTaskServer adapters runscService to taskServer.GvisorTaskServiceExt.

--- a/pkg/shim/v1/runsc/service_test.go
+++ b/pkg/shim/v1/runsc/service_test.go
@@ -201,3 +201,243 @@ func TestCgroupNoUpdate(t *testing.T) {
 		})
 	}
 }
+
+// TestApplyPodResourcesFromAnnotations exercises the translation of the CRI
+// io.kubernetes.cri.sandbox-* annotations into spec.Linux.Resources.
+// See google/gvisor#13777.
+func TestApplyPodResourcesFromAnnotations(t *testing.T) {
+	i64 := func(v int64) *int64 { return &v }
+	u64 := func(v uint64) *uint64 { return &v }
+
+	for _, tc := range []struct {
+		name        string
+		spec        *specs.Spec
+		wantUpdated bool
+		wantQuota   *int64
+		wantPeriod  *uint64
+		wantShares  *uint64
+		wantMemLim  *int64
+		// wantNoLinux asserts spec.Linux stays nil (used for the non-sandbox case).
+		wantNoLinux bool
+		// wantNoResources asserts spec.Linux.Resources stays nil.
+		wantNoResources bool
+	}{
+		{
+			name: "nil-spec",
+			spec: nil,
+		},
+		{
+			name: "no-annotations",
+			spec: &specs.Spec{},
+		},
+		{
+			name: "container-untouched",
+			spec: &specs.Spec{
+				Annotations: map[string]string{
+					utils.ContainerTypeAnnotation:    utils.ContainerTypeContainer,
+					utils.SandboxCPUQuotaAnnotation:  "85800",
+					utils.SandboxCPUPeriodAnnotation: "100000",
+					utils.SandboxMemoryAnnotation:    "2304770048",
+				},
+			},
+			wantNoLinux: true,
+		},
+		{
+			name: "sandbox-no-relevant-annotations",
+			spec: &specs.Spec{
+				Annotations: map[string]string{"foo": "bar"},
+			},
+		},
+		{
+			name: "sandbox-full-limits-overwrite-pause-shares",
+			spec: &specs.Spec{
+				Linux: &specs.Linux{
+					Resources: &specs.LinuxResources{
+						CPU: &specs.LinuxCPU{Shares: u64(2)}, // pause container's default shares
+					},
+				},
+				Annotations: map[string]string{
+					utils.SandboxCPUQuotaAnnotation:  "85800",
+					utils.SandboxCPUPeriodAnnotation: "100000",
+					utils.SandboxCPUSharesAnnotation: "684",
+					utils.SandboxMemoryAnnotation:    "2304770048",
+				},
+			},
+			wantUpdated: true,
+			wantQuota:   i64(85800),
+			wantPeriod:  u64(100000),
+			// Shares=2 is containerd's pause-container default, not pod-level shares.
+			wantShares: u64(684),
+			wantMemLim: i64(2304770048),
+		},
+		{
+			name: "sandbox-memory-only",
+			spec: &specs.Spec{
+				Annotations: map[string]string{
+					utils.SandboxMemoryAnnotation: "1073741824",
+				},
+			},
+			wantUpdated: true,
+			wantMemLim:  i64(1073741824),
+		},
+		{
+			name: "sandbox-unparsable-cpu-quota-skipped",
+			spec: &specs.Spec{
+				Annotations: map[string]string{
+					utils.SandboxCPUQuotaAnnotation: "not-an-int",
+					utils.SandboxMemoryAnnotation:   "1073741824",
+				},
+			},
+			// mem still applied, so still updated
+			wantUpdated: true,
+			wantQuota:   nil,
+			wantMemLim:  i64(1073741824),
+		},
+		{
+			name: "sandbox-zero-annotations-skipped",
+			spec: &specs.Spec{
+				Annotations: map[string]string{
+					utils.SandboxCPUQuotaAnnotation:  "0",
+					utils.SandboxCPUPeriodAnnotation: "0",
+					utils.SandboxCPUSharesAnnotation: "0",
+					utils.SandboxMemoryAnnotation:    "0",
+				},
+			},
+			wantNoResources: true,
+		},
+		{
+			name: "sandbox-negative-quota-and-memory-skipped",
+			spec: &specs.Spec{
+				Annotations: map[string]string{
+					utils.SandboxCPUQuotaAnnotation:  "-1",
+					utils.SandboxCPUPeriodAnnotation: "100000",
+					utils.SandboxMemoryAnnotation:    "-1",
+				},
+			},
+			wantUpdated: true,
+			wantPeriod:  u64(100000),
+		},
+		{
+			name: "sandbox-preexisting-non-default-shares-preserved",
+			spec: &specs.Spec{
+				Linux: &specs.Linux{
+					Resources: &specs.LinuxResources{
+						CPU: &specs.LinuxCPU{Shares: u64(1024)},
+					},
+				},
+				Annotations: map[string]string{
+					utils.SandboxCPUSharesAnnotation: "684",
+				},
+			},
+			wantUpdated: false,
+			wantShares:  u64(1024),
+		},
+		{
+			name: "containerd-sandbox-spec-fixture",
+			// Mirrors a real fixture captured from eks-verdent-ag: a gVisor
+			// sandbox pod with requests/limits cpu=2,memory=4Gi had pod-level
+			// annotations shares=2048/quota=200000/period=100000/memory=4294967296,
+			// while linux.resources.cpu.shares still carried the pause default 2.
+			spec: &specs.Spec{
+				Linux: &specs.Linux{
+					CgroupsPath: "kubepods-podfixture.slice:cri-containerd:sandbox",
+					Resources: &specs.LinuxResources{
+						Memory: &specs.LinuxMemory{Limit: i64(4294967296)},
+						CPU: &specs.LinuxCPU{
+							Shares: u64(2),
+							Quota:  i64(200000),
+							Period: u64(100000),
+						},
+					},
+				},
+				Annotations: map[string]string{
+					utils.ContainerTypeAnnotation:    "sandbox",
+					utils.SandboxCPUPeriodAnnotation: "100000",
+					utils.SandboxCPUQuotaAnnotation:  "200000",
+					utils.SandboxCPUSharesAnnotation: "2048",
+					utils.SandboxMemoryAnnotation:    "4294967296",
+				},
+			},
+			wantUpdated: true,
+			wantQuota:   i64(200000),
+			wantPeriod:  u64(100000),
+			wantShares:  u64(2048),
+			wantMemLim:  i64(4294967296),
+		},
+		{
+			name: "sandbox-preexisting-quota-preserved",
+			spec: &specs.Spec{
+				Linux: &specs.Linux{
+					Resources: &specs.LinuxResources{
+						CPU: &specs.LinuxCPU{Quota: i64(50000)},
+					},
+				},
+				Annotations: map[string]string{
+					utils.SandboxCPUQuotaAnnotation: "85800",
+				},
+			},
+			wantUpdated: false,
+			// Preexisting quota must be preserved.
+			wantQuota: i64(50000),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			updated := applyPodResourcesFromAnnotations(tc.spec)
+			if updated != tc.wantUpdated {
+				t.Errorf("applyPodResourcesFromAnnotations updated = %v, want %v",
+					updated, tc.wantUpdated)
+			}
+			if tc.spec == nil {
+				return
+			}
+			if tc.wantNoLinux {
+				if tc.spec.Linux != nil {
+					t.Errorf("expected Linux to remain nil for non-sandbox container")
+				}
+				return
+			}
+			if tc.wantNoResources {
+				if tc.spec.Linux != nil && tc.spec.Linux.Resources != nil {
+					t.Errorf("expected Linux.Resources to remain nil, got %+v", tc.spec.Linux.Resources)
+				}
+				return
+			}
+			// Extract actual values, tolerating nil chains.
+			var gotQuota *int64
+			var gotPeriod, gotShares *uint64
+			var gotMemLim *int64
+			if tc.spec.Linux != nil && tc.spec.Linux.Resources != nil {
+				if c := tc.spec.Linux.Resources.CPU; c != nil {
+					gotQuota, gotPeriod, gotShares = c.Quota, c.Period, c.Shares
+				}
+				if m := tc.spec.Linux.Resources.Memory; m != nil {
+					gotMemLim = m.Limit
+				}
+			}
+			eqI := func(t *testing.T, name string, got, want *int64) {
+				t.Helper()
+				switch {
+				case got == nil && want == nil:
+				case got == nil || want == nil:
+					t.Errorf("%s got=%v want=%v", name, got, want)
+				case *got != *want:
+					t.Errorf("%s got=%d want=%d", name, *got, *want)
+				}
+			}
+			eqU := func(t *testing.T, name string, got, want *uint64) {
+				t.Helper()
+				switch {
+				case got == nil && want == nil:
+				case got == nil || want == nil:
+					t.Errorf("%s got=%v want=%v", name, got, want)
+				case *got != *want:
+					t.Errorf("%s got=%d want=%d", name, *got, *want)
+				}
+			}
+			eqI(t, "cpu.quota", gotQuota, tc.wantQuota)
+			eqU(t, "cpu.period", gotPeriod, tc.wantPeriod)
+			eqU(t, "cpu.shares", gotShares, tc.wantShares)
+			eqI(t, "mem.limit", gotMemLim, tc.wantMemLim)
+		})
+	}
+}

--- a/pkg/shim/v1/utils/annotations.go
+++ b/pkg/shim/v1/utils/annotations.go
@@ -24,4 +24,19 @@ const (
 	containerTypeSandbox    = "sandbox"
 	// ContainerTypeContainer is the value for container.
 	ContainerTypeContainer = "container"
+
+	// Pod-level resource annotations set by the containerd CRI plugin on the
+	// sandbox (pause) container's OCI config. Because gVisor collapses all
+	// containers in a pod into a single sandbox process, the pod-level limits
+	// carried in these annotations are the only ones that can meaningfully
+	// bound the sandbox's host cgroup. See google/gvisor#13777.
+	//
+	// These match the constants in containerd's pkg/cri/annotations package
+	// (SandboxCPUQuota / SandboxCPUPeriod / SandboxCPUShares / SandboxMem).
+	// They are duplicated here (rather than imported) to avoid a heavy
+	// dependency on containerd internals.
+	SandboxCPUQuotaAnnotation  = "io.kubernetes.cri.sandbox-cpu-quota"
+	SandboxCPUPeriodAnnotation = "io.kubernetes.cri.sandbox-cpu-period"
+	SandboxCPUSharesAnnotation = "io.kubernetes.cri.sandbox-cpu-shares"
+	SandboxMemoryAnnotation    = "io.kubernetes.cri.sandbox-memory"
 )


### PR DESCRIPTION
Containerd CRI stores pod-level CPU and memory settings on the sandbox OCI spec as annotations. Copy those values into Linux.Resources for sandbox specs so runsc applies them to the sandbox host cgroup. Preserve explicit resource values, ignore non-positive annotations, and replace pause-container default CPU shares with the pod-level sandbox shares annotation.\n\nFixes #13777.