### PR TITLE
Return ETXTBSY when writing to a binary that is being executed

### DIFF
--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -1091,6 +1091,14 @@ func (d *dentry) open(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.Open
 	if err := d.checkPermissions(rp.Credentials(), ats); err != nil {
 		return nil, err
 	}
+	if ats.MayWrite() {
+		// Reject writes to a file that is currently being executed, as Linux
+		// does in fs/namei.c:may_open() and fs/open.c:handle_truncate(). This
+		// covers O_TRUNC, which AccessTypesForOpenFlags folds into MayWrite.
+		if err := d.inode.writeCount.CheckWrite(); err != nil {
+			return nil, err
+		}
+	}
 	if !d.inode.isSynthetic() {
 		// renameMu is locked here because it is required by d.openHandle(), which
 		// is called by d.ensureSharedHandle() and d.openSpecialFile() below. It is

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -1036,6 +1036,11 @@ type inode struct {
 
 	locks vfs.FileLocks
 
+	// writeCount tracks write access to this inode's contents, and is used to
+	// prevent a file from being written while it is being executed. See
+	// vfs.WriteCount.
+	writeCount vfs.WriteCount
+
 	// Inotify watches for this inode.
 	//
 	// Note that inotify may behave unexpectedly in the presence of hard links,
@@ -1268,6 +1273,11 @@ func (d *dentry) init() {
 	refs.Register(d)
 }
 
+// WriteCount implements vfs.WriteCounter.WriteCount.
+func (d *dentry) WriteCount() *vfs.WriteCount {
+	return &d.inode.writeCount
+}
+
 // Preconditions: !d.inode.isSynthetic().
 // Preconditions: d.inode.metadataMu is locked.
 // +checklocks:d.inode.metadataMu
@@ -1351,6 +1361,14 @@ func (d *dentry) setStat(ctx context.Context, creds *auth.Credentials, opts *vfs
 	mode := linux.FileMode(d.inode.mode.Load())
 	if err := vfs.CheckSetStat(ctx, creds, opts, mode, nil, auth.KUID(d.inode.uid.Load()), auth.KGID(d.inode.gid.Load())); err != nil {
 		return err
+	}
+	if opts.NeedWritePerm {
+		// truncate(2), unlike ftruncate(2), acquires write access to the file
+		// and so fails with ETXTBSY if it is being executed. See
+		// fs/open.c:do_sys_truncate().
+		if err := d.inode.writeCount.CheckWrite(); err != nil {
+			return err
+		}
 	}
 	if err := mnt.CheckBeginWrite(); err != nil {
 		return err

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -915,6 +915,13 @@ func (d *dentry) ensureOpenableLocked(ctx context.Context, rp *vfs.ResolvingPath
 	if !ats.MayWrite() {
 		return nil
 	}
+	// Reject writes to a file that is currently being executed, as Linux does
+	// in fs/namei.c:may_open() and fs/open.c:handle_truncate(). This must
+	// happen before copy-up, since copying up would otherwise create a fresh
+	// upper file with a zero write count and silently bypass the check.
+	if err := d.writeCount.CheckWrite(); err != nil {
+		return err
+	}
 	if !d.upperVD.Ok() && !d.canBeCopiedUp() {
 		return linuxerr.EPERM
 	}
@@ -1524,6 +1531,14 @@ func (d *dentry) setStatLocked(ctx context.Context, rp *vfs.ResolvingPath, opts 
 	mode := linux.FileMode(d.mode.Load())
 	if err := vfs.CheckSetStat(ctx, rp.Credentials(), &opts, mode, d.accessACL.Load(), auth.KUID(d.uid.Load()), auth.KGID(d.gid.Load())); err != nil {
 		return err
+	}
+	if opts.NeedWritePerm {
+		// truncate(2), unlike ftruncate(2), acquires write access to the file
+		// and so fails with ETXTBSY if it is being executed. See
+		// fs/open.c:do_sys_truncate().
+		if err := d.writeCount.CheckWrite(); err != nil {
+			return err
+		}
 	}
 	mnt := rp.Mount()
 	if err := mnt.CheckBeginWrite(); err != nil {

--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -656,6 +656,15 @@ type dentry struct {
 
 	locks vfs.FileLocks
 
+	// writeCount tracks write access to the file represented by this dentry,
+	// and is used to prevent a file from being written while it is being
+	// executed. See vfs.WriteCount.
+	//
+	// Note that, as with watches below, hard links to the same file do not
+	// share a writeCount, because this overlay implementation has no inode
+	// structures.
+	writeCount vfs.WriteCount
+
 	// watches is the set of inotify watches on the file represented by this dentry.
 	//
 	// Note that hard links to the same file will not share the same set of
@@ -884,6 +893,11 @@ func (d *dentry) topLookupLayer() lookupLayer {
 		return lookupLayerUpper
 	}
 	return lookupLayerLower
+}
+
+// WriteCount implements vfs.WriteCounter.WriteCount.
+func (d *dentry) WriteCount() *vfs.WriteCount {
+	return &d.writeCount
 }
 
 func (d *dentry) checkPermissions(creds *auth.Credentials, ats vfs.AccessTypes) error {

--- a/pkg/sentry/fsimpl/tmpfs/filesystem.go
+++ b/pkg/sentry/fsimpl/tmpfs/filesystem.go
@@ -467,6 +467,15 @@ func (d *dentry) open(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.Open
 		if err := d.inode.checkPermissions(rp.Credentials(), ats); err != nil {
 			return nil, err
 		}
+		if ats.MayWrite() {
+			// Reject writes to a file that is currently being executed, as
+			// Linux does in fs/namei.c:may_open() and
+			// fs/open.c:handle_truncate(). This covers O_TRUNC, which
+			// AccessTypesForOpenFlags folds into MayWrite.
+			if err := d.inode.writeCount.CheckWrite(); err != nil {
+				return nil, err
+			}
+		}
 	}
 	switch impl := d.inode.impl.(type) {
 	case *regularFile:

--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -558,6 +558,11 @@ type dentry struct {
 	inode *inode
 }
 
+// WriteCount implements vfs.WriteCounter.WriteCount.
+func (d *dentry) WriteCount() *vfs.WriteCount {
+	return &d.inode.writeCount
+}
+
 func (fs *filesystem) newDentry(inode *inode) *dentry {
 	d := &dentry{
 		inode: inode,
@@ -648,6 +653,11 @@ type inode struct {
 	mtime atomicbitops.Int64 // nanoseconds
 
 	locks vfs.FileLocks
+
+	// writeCount tracks write access to this inode's contents, and is used to
+	// prevent a file from being written while it is being executed. See
+	// vfs.WriteCount.
+	writeCount vfs.WriteCount
 
 	// Inotify watches for this inode.
 	watches vfs.Watches
@@ -853,6 +863,14 @@ func (i *inode) setStat(ctx context.Context, creds *auth.Credentials, opts *vfs.
 	mode := linux.FileMode(i.mode.Load())
 	if err := vfs.CheckSetStat(ctx, creds, opts, mode, i.accessACL.Load(), auth.KUID(i.uid.Load()), auth.KGID(i.gid.Load())); err != nil {
 		return err
+	}
+	if opts.NeedWritePerm {
+		// truncate(2), unlike ftruncate(2), acquires write access to the file
+		// and so fails with ETXTBSY if it is being executed. See
+		// fs/open.c:do_sys_truncate().
+		if err := i.writeCount.CheckWrite(); err != nil {
+			return err
+		}
 	}
 
 	i.mu.Lock()

--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -299,6 +299,7 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 
 	if mm2.executable != nil {
 		mm2.executable.IncRef()
+		mm2.executable.DenyWriteAccess()
 	}
 	return mm2, nil
 }
@@ -377,6 +378,7 @@ func (mm *MemoryManager) DecUsers(ctx context.Context) {
 	mm.executable = nil
 	mm.metadataMu.Unlock()
 	if exe != nil {
+		exe.AllowWriteAccess()
 		exe.DecRef(ctx)
 	}
 

--- a/pkg/sentry/mm/metadata.go
+++ b/pkg/sentry/mm/metadata.go
@@ -145,6 +145,10 @@ func (mm *MemoryManager) Executable() *vfs.FileDescription {
 //
 // This takes a reference on d.
 func (mm *MemoryManager) SetExecutable(ctx context.Context, fd *vfs.FileDescription) {
+	// Deny writes to the executable for as long as mm holds it, as Linux does
+	// in fs/exec.c:set_mm_exe_file().
+	fd.DenyWriteAccess()
+
 	mm.metadataMu.Lock()
 
 	// Grab a new reference.
@@ -161,6 +165,7 @@ func (mm *MemoryManager) SetExecutable(ctx context.Context, fd *vfs.FileDescript
 	// Do this without holding the lock, since it may wind up doing some
 	// I/O to sync the dirent, etc.
 	if orig != nil {
+		orig.AllowWriteAccess()
 		orig.DecRef(ctx)
 	}
 }

--- a/pkg/sentry/vfs/BUILD
+++ b/pkg/sentry/vfs/BUILD
@@ -169,6 +169,7 @@ go_library(
         "save_restore.go",
         "vfs.go",
         "virtual_filesystem_mutex.go",
+        "write_count.go",
     ],
     visibility = ["//pkg/sentry:internal"],
     deps = [

--- a/pkg/sentry/vfs/write_count.go
+++ b/pkg/sentry/vfs/write_count.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vfs
+
+import (
+	"gvisor.dev/gvisor/pkg/atomicbitops"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+)
+
+// WriteCount counts the MemoryManagers currently executing a file, which must
+// not be written while they do. It is a partial analogue of Linux's
+// inode::i_writecount: only write denials are counted, not writers, so
+// execve(2) on a file that is already open for writing does not fail with
+// ETXTBSY as it does in Linux.
+//
+// Filesystems that can host executables should embed WriteCount in whatever
+// type represents an inode, so that hard links to the same file share it, and
+// call CheckWrite from paths that mutate file contents. VFS does not associate
+// Dentries with inodes (see Dentry), so this state cannot live in VFS itself.
+//
+// +stateify savable
+type WriteCount struct {
+	execs atomicbitops.Int32
+}
+
+// denyWrite records that the file is being executed, causing CheckWrite to
+// fail until a matching call to allowWrite.
+func (wc *WriteCount) denyWrite() {
+	wc.execs.Add(1)
+}
+
+// allowWrite reverses a previous call to denyWrite.
+func (wc *WriteCount) allowWrite() {
+	wc.execs.Add(-1)
+}
+
+// CheckWrite returns ETXTBSY if the file is being executed.
+func (wc *WriteCount) CheckWrite() error {
+	if wc.execs.Load() > 0 {
+		return linuxerr.ETXTBSY
+	}
+	return nil
+}
+
+// WriteCounter is an optional extension to DentryImpl implemented by
+// filesystems that can host executables. Filesystems that do not implement it
+// never deny writes.
+type WriteCounter interface {
+	// WriteCount returns the WriteCount shared by all Dentries representing
+	// the same file.
+	WriteCount() *WriteCount
+}
+
+// DenyWriteAccess prevents the file represented by fd from being written until
+// a matching call to AllowWriteAccess. It is a no-op if fd's filesystem does
+// not implement WriteCounter.
+func (fd *FileDescription) DenyWriteAccess() {
+	if impl, ok := fd.Dentry().Impl().(WriteCounter); ok {
+		impl.WriteCount().denyWrite()
+	}
+}
+
+// AllowWriteAccess reverses a previous call to DenyWriteAccess.
+func (fd *FileDescription) AllowWriteAccess() {
+	if impl, ok := fd.Dentry().Impl().(WriteCounter); ok {
+		impl.WriteCount().allowWrite()
+	}
+}

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -89,6 +89,12 @@ cc_binary(
 )
 
 cc_binary(
+    name = "exec_etxtbsy_workload",
+    testonly = 1,
+    srcs = ["exec_etxtbsy_workload.cc"],
+)
+
+cc_binary(
     name = "exec_state_workload",
     testonly = 1,
     srcs = ["exec_state_workload.cc"],
@@ -854,6 +860,7 @@ cc_binary(
         ":exec_assert_closed_workload",
         ":exec_basic_workload",
         ":exec_check_creds",
+        ":exec_etxtbsy_workload",
         ":exec_proc_exe_workload",
         ":exec_state_workload",
         ":exit_script",

--- a/test/syscalls/linux/exec.cc
+++ b/test/syscalls/linux/exec.cc
@@ -75,6 +75,8 @@ constexpr char kBasicWorkload[] = "test/syscalls/linux/exec_basic_workload";
 constexpr char kCheckEuidProgram[] = "test/syscalls/linux/exec_check_creds";
 constexpr char kExitScript[] = "test/syscalls/linux/exit_script";
 constexpr char kStateWorkload[] = "test/syscalls/linux/exec_state_workload";
+constexpr char kEtxtbsyWorkload[] =
+    "test/syscalls/linux/exec_etxtbsy_workload";
 constexpr char kProcExeWorkload[] =
     "test/syscalls/linux/exec_proc_exe_workload";
 constexpr char kAssertClosedWorkload[] =
@@ -1312,6 +1314,52 @@ bool ValidateProcCmdlineVsArgv(const int argc, const char* const* argv) {
     }
   }
   return true;
+}
+
+
+// A binary that is being executed cannot be written, and becomes writable
+// again once it is not. See fs/exec.c:set_mm_exe_file().
+TEST(ExecTest, RunningBinaryIsNotWritable) {
+  // Copy the workload somewhere we own, so that we may attempt to write it.
+  const std::string blob =
+      ASSERT_NO_ERRNO_AND_VALUE(GetContents(RunfilePath(kEtxtbsyWorkload)));
+  const TempPath binary = ASSERT_NO_ERRNO_AND_VALUE(
+      TempPath::CreateFileWith(GetAbsoluteTestTmpdir(), blob, 0755));
+  const std::string path = binary.path();
+  EXPECT_NO_ERRNO(Open(path, O_WRONLY));
+
+  // The workload writes a byte to stdout once execve(2) has completed, so that
+  // we do not race against it.
+  int fds[2];
+  ASSERT_THAT(pipe(fds), SyscallSucceeds());
+  FileDescriptor rd(fds[0]);
+  FileDescriptor wr(fds[1]);
+
+  pid_t child;
+  int execve_errno;
+  const int wfd = wr.get();
+  Cleanup kill_child = ASSERT_NO_ERRNO_AND_VALUE(ForkAndExec(
+      path, {path}, {}, [wfd] { dup2(wfd, STDOUT_FILENO); }, &child,
+      &execve_errno));
+  ASSERT_EQ(execve_errno, 0);
+  wr.reset();
+  char c;
+  ASSERT_THAT(RetryEINTR(read)(rd.get(), &c, 1), SyscallSucceedsWithValue(1));
+
+  // Writing the contents must fail, whether by open(2) or truncate(2).
+  EXPECT_THAT(open(path.c_str(), O_WRONLY), SyscallFailsWithErrno(ETXTBSY));
+  EXPECT_THAT(open(path.c_str(), O_RDONLY | O_TRUNC),
+              SyscallFailsWithErrno(ETXTBSY));
+  EXPECT_THAT(truncate(path.c_str(), 0), SyscallFailsWithErrno(ETXTBSY));
+
+  // Reads and metadata changes are unaffected.
+  EXPECT_NO_ERRNO(Open(path, O_RDONLY));
+  EXPECT_THAT(chmod(path.c_str(), 0755), SyscallSucceeds());
+
+  // Killing the child reaps it, so the executable is released by the time this
+  // returns. A leaked denial would leave the file permanently unwritable.
+  kill_child.Release()();
+  EXPECT_NO_ERRNO(Open(path, O_WRONLY));
 }
 
 }  // namespace

--- a/test/syscalls/linux/exec_etxtbsy_workload.cc
+++ b/test/syscalls/linux/exec_etxtbsy_workload.cc
@@ -1,0 +1,29 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <unistd.h>
+
+// Writes a single byte to stdout to signal that execve(2) has completed, then
+// blocks forever. This lets a parent wait until this binary is definitely
+// being executed before asserting that it cannot be written to.
+int main(int argc, char** argv, char** envp) {
+  const char c = 'x';
+  if (write(STDOUT_FILENO, &c, 1) != 1) {
+    return 1;
+  }
+  for (;;) {
+    pause();
+  }
+  return 0;
+}


### PR DESCRIPTION
Overwriting a binary while a task is executing it silently succeeds today, corrupting the running image and usually killing the task with `SIGBUS`:

```
$ stress -c 1 &
$ cp /bin/ls /usr/bin/stress
[1]+  Bus error               stress -c 1
```

Linux returns `ETXTBSY`. `linuxerr.ETXTBSY` already exists in the tree but was never returned from anywhere, and there was no write tracking of any kind.

## Approach

`vfs.WriteCount` counts the `MemoryManager`s currently executing a file. Writes to the file's contents are rejected while that count is non-zero.

**The count is held for as long as `mm.executable` refers to the file, not for the duration of the exec.** This mirrors `fs/exec.c:set_mm_exe_file()` and is the part that makes it work — a count released when `Load()` returns would leave the running binary writable again. It is taken in `SetExecutable()` and `MemoryManager.Fork()`, dropped in `SetExecutable()` and `DecUsers()`.

Anchoring here also gives interpreter scripts Linux's behavior for free: the loader leaves `mm.executable` as the interpreter, so `/bin/bash` is protected while the script it runs is not — matching Linux, where a running shell script can be rewritten.

## Where the state lives

VFS deliberately does not associate Dentries with inodes (see the `Dentry` documentation), so the count cannot live in VFS itself. Filesystems embed it the way `vfs.FileLocks` is embedded and expose it through a new optional `vfs.WriteCounter` extension to `DentryImpl`; filesystems that cannot host executables simply do not implement it and never deny writes.

- **tmpfs** and **gofer** store it on their `inode`, so hard links share it.
- **overlayfs** stores it on the dentry, which has no inode structure, and therefore carries the same hard-link limitation its inotify watches already document.

overlayfs is required rather than optional scope: `defaultOverlay2()` enables a rootfs overlay by default, so the issue's own reproducer goes through overlay rather than raw gofer. erofs is read-only and needs nothing.

## Where the checks run

Both checks run **before** the file is mutated:

- Each filesystem's open path, ahead of `O_TRUNC` truncation and ahead of overlayfs copy-up. Copy-up ordering matters: copying up first would create an upper file with a zero count and silently bypass the check. `AccessTypesForOpenFlags` already folds `O_TRUNC` into `MayWrite`, so one check covers `O_WRONLY`, `O_RDWR` and `O_TRUNC`.
- `setStat` under `NeedWritePerm`, which is set by `truncate(2)` and not by `ftruncate(2)` — matching `do_sys_truncate()` vs `handle_truncate()`.

Shared libraries are deliberately not protected: `VM_DENYWRITE` was removed in Linux 5.15 and `MAP_DENYWRITE` is a no-op, so modern Linux gives no `ETXTBSY` for `.so` files either.

## Testing

One test in `test/syscalls/linux/exec.cc`, plus a small workload that signals once `execve` has completed so the test never races the child. It asserts the file is writable before exec; that `O_WRONLY`, `O_RDONLY|O_TRUNC` and `truncate()` all fail with `ETXTBSY` while it runs; that `O_RDONLY` and `chmod()` still succeed (the change must not over-block); and that the file is writable again once the process is reaped, which is where a leaked count would surface.

| Configuration | Result |
| --- | --- |
| native Linux | pass |
| runsc, systrap + **tmpfs** (`--use-tmpfs`, no overlay) | pass |
| runsc, systrap + **gofer** (shared) | pass |
| runsc, systrap + **gofer** (directfs) | pass |
| runsc, systrap + **overlay** | pass |
| runsc, systrap + overlay, **save** (checkpoint/restore) | pass |
| runsc, systrap + overlay, **save_resume** | pass |
| Full `exec_test` suite (63 tests), overlay | 63/63 pass |
| Unit tests + `nogo` for vfs, mm, tmpfs, gofer, overlay | pass |

All three filesystems that carry the counter are covered, as is checkpoint/restore. The native run is load-bearing: it confirms these are genuinely Linux's semantics rather than a reading of them.

## Notes for reviewers

- **Scope.** Only executors are counted, not writers, so `execve(2)` on a file already open for writing does not yet fail with `ETXTBSY`. That needs a count taken on every writable open and released when the file description is destroyed, which is a considerably larger surface. This is stated in the type's doc comment rather than claiming full `i_writecount` semantics, and is why this says `Updates #1014` rather than fixing it.
- **Architecture.** Developed and tested on arm64. CI will be the first amd64 run.
- **Possible simplification.** The three `NeedWritePerm` blocks in `setStat` are identical across tmpfs/gofer/overlay. They could instead be folded into `vfs.CheckSetStat()` by giving it a `*WriteCount` parameter, making the check compiler-enforced for every filesystem at the cost of touching all nine call sites (six passing nil). Happy to switch if preferred.

Fixes #1005.
Updates #1014.

---

*Disclosure: I used AI tooling for the grunt and mechanical work here — boilerplate, test scaffolding, and running the test matrix. The approach and direction were mine, and I reviewed the result before submitting.*
