### PR TITLE
Enforce ownership check on shmctl(IPC_RMID)

### DIFF
--- a/pkg/sentry/kernel/shm/shm.go
+++ b/pkg/sentry/kernel/shm/shm.go
@@ -647,20 +647,26 @@ func (s *Shm) Set(ctx context.Context, ds *linux.ShmidDS) error {
 	return nil
 }
 
-// MarkDestroyed marks a segment for destruction. The segment is actually
-// destroyed once it has no references. MarkDestroyed may be called multiple
-// times, and is safe to call after a segment has already been destroyed. See
-// shmctl(IPC_RMID).
-func (s *Shm) MarkDestroyed(ctx context.Context) {
-	s.registry.dissociateKey(s)
+// MarkDestroyed marks a segment for destruction. The segment is
+// actually destroyed once it has no references. MarkDestroyed may be called
+// multiple times, and is safe to call after a segment has already been
+// destroyed. See shmctl(IPC_RMID).
+func (s *Shm) MarkDestroyed(ctx context.Context) error {
+	creds := auth.CredentialsFromContext(ctx)
 
 	s.mu.Lock()
+	if !s.obj.CheckOwnership(creds) {
+		s.mu.Unlock()
+		return linuxerr.EPERM
+	}
 	if s.pendingDestruction {
 		s.mu.Unlock()
-		return
+		return nil
 	}
 	s.pendingDestruction = true
 	s.mu.Unlock()
+
+	s.registry.dissociateKey(s)
 
 	// Drop the self-reference so destruction occurs when all
 	// external references are gone.
@@ -668,4 +674,5 @@ func (s *Shm) MarkDestroyed(ctx context.Context) {
 	// N.B. This cannot be the final DecRef, as the caller also
 	// holds a reference.
 	s.DecRef(ctx)
+	return nil
 }

--- a/pkg/sentry/syscalls/linux/sys_shm.go
+++ b/pkg/sentry/syscalls/linux/sys_shm.go
@@ -145,8 +145,7 @@ func Shmctl(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr,
 		return 0, nil, err
 
 	case linux.IPC_RMID:
-		segment.MarkDestroyed(t)
-		return 0, nil, nil
+		return 0, nil, segment.MarkDestroyed(t)
 
 	case linux.SHM_LOCK, linux.SHM_UNLOCK:
 		// We currently do not support memory locking anywhere.

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4928,11 +4928,14 @@ cc_binary(
     linkstatic = 1,
     malloc = "//test/util:errno_safe_allocator",
     deps = select_gtest() + [
+        "//test/util:capability_util",
         "//test/util:multiprocess_util",
         "//test/util:posix_error",
         "//test/util:temp_path",
         "//test/util:test_main",
         "//test/util:test_util",
+        "//test/util:thread_util",
+        "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/time",
     ],
 )

--- a/test/syscalls/linux/shm.cc
+++ b/test/syscalls/linux/shm.cc
@@ -17,14 +17,22 @@
 #include <sys/ipc.h>
 #include <sys/mman.h>
 #include <sys/shm.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
+#include <unistd.h>
 
 #include "gmock/gmock.h"
+#include "absl/flags/flag.h"
 #include "absl/time/clock.h"
+#include "test/util/capability_util.h"
 #include "test/util/multiprocess_util.h"
 #include "test/util/posix_error.h"
 #include "test/util/temp_path.h"
 #include "test/util/test_util.h"
+#include "test/util/thread_util.h"
+
+ABSL_FLAG(int32_t, scratch_uid, 65534, "scratch UID");
+ABSL_FLAG(int32_t, scratch_gid, 65534, "scratch GID");
 
 namespace gvisor {
 namespace testing {
@@ -537,6 +545,49 @@ TEST(ShmTest, MprotectWriteOnWritableSegmentSucceeds) {
   EXPECT_EQ(addr[0], 'y');
 
   ASSERT_NO_ERRNO(Shmdt(addr));
+}
+
+TEST(ShmTest, RmidOwnershipPermissionDenied) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  const uid_t scratch_uid = absl::GetFlag(FLAGS_scratch_uid);
+  const gid_t scratch_gid = absl::GetFlag(FLAGS_scratch_gid);
+
+  ShmSegment shm = ASSERT_NO_ERRNO_AND_VALUE(
+      Shmget(IPC_PRIVATE, kAllocSize, IPC_CREAT | 0600));
+
+  // Drop privileges and change IDs in a separate thread so the test runner's
+  // main thread credentials remain unaffected. AutoCapability must stay in
+  // scope for the shmctl body.
+  auto drop_privs = [&](auto&& body) {
+    AutoCapability cap(CAP_SYS_ADMIN, false);
+    EXPECT_THAT(syscall(SYS_setresgid, -1, scratch_gid, -1), SyscallSucceeds());
+    EXPECT_THAT(syscall(SYS_setresuid, -1, scratch_uid, -1), SyscallSucceeds());
+    body();
+  };
+
+  ScopedThread([&] {
+    drop_privs([&] {
+      EXPECT_THAT(Shmctl<void>(shm.id(), IPC_RMID, nullptr),
+                  PosixErrorIs(EPERM, _));
+    });
+  });
+
+  // Verify that the segment was not destroyed and remains valid.
+  struct shmid_ds attr;
+  ASSERT_NO_ERRNO(Shmctl(shm.id(), IPC_STAT, &attr));
+  EXPECT_EQ(attr.shm_perm.mode & 0777, 0600);
+  EXPECT_FALSE(attr.shm_perm.mode & SHM_DEST);
+
+  // Transfer ownership to the scratch user via IPC_SET.
+  attr.shm_perm.uid = scratch_uid;
+  ASSERT_NO_ERRNO(Shmctl(shm.id(), IPC_SET, &attr));
+
+  // In the same dropped-privilege thread (now the owner), IPC_RMID
+  // should succeed.
+  ScopedThread([&] {
+    drop_privs([&] { EXPECT_NO_ERRNO(shm.Rmid()); });
+  });
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes #14191

### What was wrong

Any uid could destroy any SysV shared memory segment via `shmctl(IPC_RMID)`. `Shmctl` in `pkg/sentry/syscalls/linux/sys_shm.go` directly invoked `segment.MarkDestroyed(t)` without checking that the caller is the creator, the current owner, or holds `CAP_SYS_ADMIN` in the owning user namespace. In Linux (`ipc/shm.c:shmctl_down`), `IPC_RMID` and `IPC_SET` both require `ipcctl_obtain_check`. In gVisor, `IPC_SET` already enforces this via `s.obj.Set`, and other SysV mechanisms (`semaphore`, `msgqueue`) enforce it via `Registry.Remove`, but `shmctl(IPC_RMID)` was unauthenticated.

### What changed

1. **Authorization in `Shm.MarkDestroyed` (`pkg/sentry/kernel/shm/shm.go`)**:
   - `Shm.MarkDestroyed(ctx context.Context) error` now extracts credentials via `auth.CredentialsFromContext(ctx)` and executes `s.obj.CheckOwnership(creds)` under `s.mu.Lock()` within the same critical section that sets `pendingDestruction = true`.
   - Returns `linuxerr.EPERM` if unauthorized.
   - Prevents data races and TOCTOU with concurrent `shmctl(IPC_SET)` calls while keeping the ownership policy centralized in the `shm` package.
   - Calls `s.registry.dissociateKey(s)` and `s.DecRef(ctx)` outside `s.mu` to preserve the `Registry.mu -> Shm.mu` lock hierarchy.

2. **Syscall Handler (`pkg/sentry/syscalls/linux/sys_shm.go`)**:
   - In `Shmctl`, `linux.IPC_RMID` directly delegates to `return 0, nil, segment.MarkDestroyed(t)`.

3. **Syscall Regression Test (`test/syscalls/linux/shm.cc`)**:
   - Added `ShmTest.RmidOwnershipPermissionDenied`.
   - Verifies that a non-owner/non-creator process with dropped privileges (`CAP_SYS_ADMIN` dropped, scratch UID/GID) receives `EPERM` when calling `shmctl(IPC_RMID)`.
   - Confirms the segment survives and `SHM_DEST` is not set on `IPC_STAT`.
   - Verifies the positive path: after transferring ownership to the scratch user via `IPC_SET`, `shmctl(IPC_RMID)` succeeds.

### Verification

- `make test TARGETS="//test/syscalls:shm_test_runsc_ptrace"`: PASS
- `make test TARGETS="//test/syscalls:shm_test_native"`: PASS