### PR TITLE
Return EACCES for exec from noexec mounts and propagate host noexec

### DIFF
--- a/runsc/cmd/sandboxsetup/fs.go
+++ b/runsc/cmd/sandboxsetup/fs.go
@@ -124,15 +124,36 @@ func resolveSymlinksImpl(root, base, rel string, followCount uint) (string, erro
 	return base, nil
 }
 
+// optionsWithHostNoExec adds "noexec" when the host mount has ST_NOEXEC
+// and drops an explicit "exec". SetupMounts only applies MS_NOEXEC in
+// the gofer namespace. The Sentry reads specs.Mount.Options.
+func optionsWithHostNoExec(opts []string, noexec bool) []string {
+	rv := make([]string, 0, len(opts)+1)
+	hasNoExec := false
+	for _, o := range opts {
+		if noexec && o == "exec" {
+			continue
+		}
+		if o == "noexec" {
+			hasNoExec = true
+		}
+		rv = append(rv, o)
+	}
+	if noexec && !hasNoExec {
+		rv = append(rv, "noexec")
+	}
+	return rv
+}
+
 // AdjustMountOptions adds filesystem-specific gofer mount options.
 func AdjustMountOptions(conf *config.Config, path string, opts []string) ([]string, error) {
-	rv := make([]string, len(opts))
-	copy(rv, opts)
-
 	statfs := unix.Statfs_t{}
 	if err := unix.Statfs(path, &statfs); err != nil {
 		return nil, err
 	}
+
+	rv := optionsWithHostNoExec(opts, statfs.Flags&unix.ST_NOEXEC == unix.ST_NOEXEC)
+
 	switch statfs.Type {
 	case unix.OVERLAYFS_SUPER_MAGIC:
 		rv = append(rv, "overlayfs_stale_read")

--- a/runsc/cmd/sandboxsetup/gofer_mount.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount.go
@@ -373,6 +373,13 @@ func SetupMounts(conf *config.Config, mounts []specs.Mount, root, procPath strin
 			// Force mount read-only if writes are not going to be sent to it.
 			flags |= unix.MS_RDONLY
 		}
+		// Bind mounts do not inherit MS_NOEXEC from the source.
+		var srcStat unix.Statfs_t
+		if err := unix.Statfs(m.Source, &srcStat); err == nil {
+			if srcStat.Flags&unix.ST_NOEXEC == unix.ST_NOEXEC {
+				flags |= unix.MS_NOEXEC
+			}
+		}
 
 		log.Infof("Mounting src: %q, dst: %q, flags: %#x, idMapped: %t", m.Source, dst, flags, specutils.IsIDMappedMount(m))
 		src := m.Source

--- a/runsc/cmd/sandboxsetup/gofer_mount_test.go
+++ b/runsc/cmd/sandboxsetup/gofer_mount_test.go
@@ -15,6 +15,7 @@
 package sandboxsetup
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -84,6 +85,42 @@ func TestShouldExposeTpuDevice(t *testing.T) {
 			got := ShouldExposeTpuDevice(tst.path)
 			if got != tst.want {
 				t.Errorf("ShouldExposeTpuDevice(%q) = %v, want %v", tst.path, got, tst.want)
+			}
+		})
+	}
+}
+
+func TestOptionsWithHostNoExec(t *testing.T) {
+	tests := []struct {
+		name   string
+		opts   []string
+		noexec bool
+		want   []string
+	}{
+		{
+			name:   "adds noexec and drops exec",
+			opts:   []string{"bind", "exec"},
+			noexec: true,
+			want:   []string{"bind", "noexec"},
+		},
+		{
+			name:   "keeps existing noexec",
+			opts:   []string{"bind", "noexec"},
+			noexec: true,
+			want:   []string{"bind", "noexec"},
+		},
+		{
+			name:   "leaves exec when host allows it",
+			opts:   []string{"bind", "exec"},
+			noexec: false,
+			want:   []string{"bind", "exec"},
+		},
+	}
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			got := optionsWithHostNoExec(tst.opts, tst.noexec)
+			if fmt.Sprintf("%q", got) != fmt.Sprintf("%q", tst.want) {
+				t.Errorf("optionsWithHostNoExec(%q, %v) = %q, want %q", tst.opts, tst.noexec, got, tst.want)
 			}
 		})
 	}

--- a/test/root/BUILD
+++ b/test/root/BUILD
@@ -46,6 +46,7 @@ go_test(
         "//runsc/specutils",
         "@com_github_cenkalti_backoff//:go_default_library",
         "@com_github_docker_docker//api/types/container:go_default_library",
+        "@com_github_docker_docker//api/types/mount:go_default_library",
         "@com_github_moby_sys_capability//:go_default_library",
         "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",

--- a/test/root/runsc_test.go
+++ b/test/root/runsc_test.go
@@ -17,6 +17,7 @@ package root
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,6 +29,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
+	"github.com/docker/docker/api/types/mount"
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/test/dockerutil"
 	"gvisor.dev/gvisor/pkg/test/testutil"
@@ -176,5 +178,52 @@ func TestSandboxProcessEnv(t *testing.T) {
 	got = regexp.MustCompile("(^|\x00)GVISOR_ENFORCE_RELEASE=[^\x00]*\x00").ReplaceAll(got, []byte("$1"))
 	if len(got) != 0 && string(got) != "GLIBC_TUNABLES=glibc.pthread.rseq=0\x00" {
 		t.Errorf("sandbox process's environment is not empty: got %s (%v)", string(got), got)
+	}
+}
+
+// TestHostNoExecBindMountExecReturnsEACCES bind-mounts a host noexec
+// tmpfs into a container without noexec in the OCI spec. Exec from that
+// volume must return EACCES, not SIGSEGV. See #14375.
+func TestHostNoExecBindMountExecReturnsEACCES(t *testing.T) {
+	dir := t.TempDir()
+	if err := unix.Mount("tmpfs", dir, "tmpfs", unix.MS_NOEXEC, ""); err != nil {
+		t.Fatalf("mount tmpfs noexec on %q: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := unix.Unmount(dir, unix.MNT_DETACH); err != nil {
+			t.Errorf("unmount %q: %v", dir, err)
+		}
+	})
+
+	script := filepath.Join(dir, "ok.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write %q: %v", script, err)
+	}
+
+	ctx := context.Background()
+	d := dockerutil.MakeContainer(ctx, t)
+	defer d.CleanUp(ctx)
+
+	opts := dockerutil.RunOpts{
+		Image: "basic/alpine",
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: dir,
+				Target: "/noexecvol",
+			},
+		},
+	}
+	if err := d.Spawn(ctx, opts, "sleep", "infinity"); err != nil {
+		t.Fatalf("docker run failed: %v", err)
+	}
+
+	_, err := d.Exec(ctx, dockerutil.ExecOpts{}, "/noexecvol/ok.sh")
+	if err == nil {
+		t.Fatal("exec of /noexecvol/ok.sh succeeded, want EACCES")
+	}
+	var ee *dockerutil.ExecError
+	if errors.As(err, &ee) && (ee.ExitStatus == 139 || ee.ExitStatus == int(unix.SIGSEGV)+128) {
+		t.Fatalf("exec segfaulted, want EACCES: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #14375

Host bind mounts of noexec filesystems did not get MS_NOEXEC. Bind mounts do not inherit that flag from the source, and the Sentry VFS only reads specs.Mount.Options, so exec of a binary from that volume could SIGSEGV instead of returning EACCES.

SetupMounts now sets MS_NOEXEC on the gofer bind when the source has ST_NOEXEC. AdjustMountOptions adds noexec to the options sent to the Sentry.

TestHostNoExecBindMountExecReturnsEACCES covers the host bind without noexec in the OCI spec.

`make test TARGETS="//runsc/cmd/sandboxsetup:sandboxsetup_test"`: PASS