### PR TITLE
runsc: update sentry total memory on live cgroup memory limit changes

### DIFF
--- a/pkg/sentry/usage/BUILD
+++ b/pkg/sentry/usage/BUILD
@@ -1,5 +1,5 @@
 load("//pkg/sync/locking:locking.bzl", "declare_mutex")
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -29,9 +29,17 @@ go_library(
     deps = [
         "//pkg/atomicbitops",
         "//pkg/bits",
+        "//pkg/log",
         "//pkg/memutil",
         "//pkg/sync",
         "//pkg/sync/locking",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_test(
+    name = "usage_test",
+    size = "small",
+    srcs = ["memory_test.go"],
+    library = ":usage",
 )

--- a/pkg/sentry/usage/memory.go
+++ b/pkg/sentry/usage/memory.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/atomicbitops"
 	"gvisor.dev/gvisor/pkg/bits"
+	"gvisor.dev/gvisor/pkg/log"
 	"gvisor.dev/gvisor/pkg/memutil"
 	"gvisor.dev/gvisor/pkg/sync"
 )
@@ -417,16 +418,52 @@ func (m *MemoryLocked) CopyPerCg(memCgID uint32) (MemoryStats, uint64) {
 }
 
 // These options control how much total memory the is reported to the
-// application. They may only be set before the application starts executing,
-// and must not be modified.
+// application. They are set at boot and may afterwards only be raised, through
+// SetTotalMemoryBytes; they are atomic because the application reads them
+// concurrently via /proc/meminfo and sysinfo(2).
 var (
 	// MinimumTotalMemoryBytes is the minimum reported total system memory.
-	MinimumTotalMemoryBytes uint64 = 2 << 30 // 2 GB
+	MinimumTotalMemoryBytes = atomicbitops.FromUint64(2 << 30) // 2 GB
 
 	// MaximumTotalMemoryBytes is the maximum reported total system memory.
 	// The 0 value indicates no maximum.
-	MaximumTotalMemoryBytes uint64
+	MaximumTotalMemoryBytes atomicbitops.Uint64
 )
+
+// totalMemoryMu serializes SetTotalMemoryBytes so that the two bounds are
+// always raised as a pair. Readers stay lock-free on the atomics.
+var totalMemoryMu sync.Mutex
+
+// SetTotalMemoryBytes raises the total system memory reported to the
+// application to n, without a restart. Grow-only: shrinking would make MemFree
+// meaningless against memory already allocated. Requires a boot-time maximum,
+// without which the reported total tracks host memory and has nothing to raise.
+func SetTotalMemoryBytes(n uint64) error {
+	if n == 0 {
+		return fmt.Errorf("SetTotalMemoryBytes called with invalid n == 0")
+	}
+	totalMemoryMu.Lock()
+	defer totalMemoryMu.Unlock()
+
+	old := MaximumTotalMemoryBytes.Load()
+	if old == 0 {
+		return fmt.Errorf("SetTotalMemoryBytes(%d): no boot-time total memory was set, nothing to raise", n)
+	}
+	if n == old {
+		return nil
+	}
+	if n < old {
+		return fmt.Errorf("SetTotalMemoryBytes(%d) would shrink the reported total memory from %d: not yet supported", n, old)
+	}
+	// Raise the ceiling before the floor so a concurrent reader never sees a
+	// minimum above the maximum. The minimum has to move too: it is what pins
+	// the reported total to the limit, and left at the boot value MemTotal
+	// would instead creep up with the MemoryFile as the application allocates.
+	MaximumTotalMemoryBytes.Store(n)
+	MinimumTotalMemoryBytes.Store(n)
+	log.Infof("Total memory changed from %d to %d bytes", old, n)
+	return nil
+}
 
 // TotalMemory returns the "total usable memory" available.
 //
@@ -437,8 +474,8 @@ var (
 // memSize should be the platform.Memory size reported by platform.Memory.TotalSize()
 // used is the total memory reported by MemoryLocked.Total()
 func TotalMemory(memSize, used uint64) uint64 {
-	if memSize < MinimumTotalMemoryBytes {
-		memSize = MinimumTotalMemoryBytes
+	if minTotal := MinimumTotalMemoryBytes.Load(); memSize < minTotal {
+		memSize = minTotal
 	}
 	if memSize < used {
 		memSize = used
@@ -448,8 +485,8 @@ func TotalMemory(memSize, used uint64) uint64 {
 			memSize = uint64(1) << (uint(msb) + 1)
 		}
 	}
-	if MaximumTotalMemoryBytes > 0 && memSize > MaximumTotalMemoryBytes {
-		memSize = MaximumTotalMemoryBytes
+	if maxTotal := MaximumTotalMemoryBytes.Load(); maxTotal > 0 && memSize > maxTotal {
+		memSize = maxTotal
 	}
 	return memSize
 }

--- a/pkg/sentry/usage/memory_test.go
+++ b/pkg/sentry/usage/memory_test.go
@@ -1,0 +1,152 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package usage
+
+import (
+	"sync"
+	"testing"
+)
+
+const (
+	oneGB = uint64(1) << 30
+	twoGB = uint64(2) << 30
+)
+
+// setBoundsForTest sets the two bounds and restores them when the test ends,
+// since they are package-level state.
+func setBoundsForTest(t *testing.T, minTotal, maxTotal uint64) {
+	t.Helper()
+	oldMin, oldMax := MinimumTotalMemoryBytes.Load(), MaximumTotalMemoryBytes.Load()
+	t.Cleanup(func() {
+		MinimumTotalMemoryBytes.Store(oldMin)
+		MaximumTotalMemoryBytes.Store(oldMax)
+	})
+	MinimumTotalMemoryBytes.Store(minTotal)
+	MaximumTotalMemoryBytes.Store(maxTotal)
+}
+
+// setTotalMemoryForTest pins both bounds together, the way boot does.
+func setTotalMemoryForTest(t *testing.T, total uint64) {
+	t.Helper()
+	setBoundsForTest(t, total, total)
+}
+
+func TestSetTotalMemoryBytesGrows(t *testing.T) {
+	setTotalMemoryForTest(t, oneGB)
+
+	if err := SetTotalMemoryBytes(twoGB); err != nil {
+		t.Fatalf("SetTotalMemoryBytes(%d) failed: %v", twoGB, err)
+	}
+	// The reported total must follow immediately, before the application has
+	// allocated anything, so both bounds have to move.
+	if got := TotalMemory(0, 0); got != twoGB {
+		t.Errorf("TotalMemory(0, 0) = %d, want %d", got, twoGB)
+	}
+	if got := MinimumTotalMemoryBytes.Load(); got != twoGB {
+		t.Errorf("MinimumTotalMemoryBytes = %d, want %d", got, twoGB)
+	}
+	if got := MaximumTotalMemoryBytes.Load(); got != twoGB {
+		t.Errorf("MaximumTotalMemoryBytes = %d, want %d", got, twoGB)
+	}
+}
+
+func TestSetTotalMemoryBytesNoOp(t *testing.T) {
+	setTotalMemoryForTest(t, oneGB)
+
+	if err := SetTotalMemoryBytes(oneGB); err != nil {
+		t.Errorf("SetTotalMemoryBytes(%d) (no-op) failed: %v", oneGB, err)
+	}
+	if got := TotalMemory(0, 0); got != oneGB {
+		t.Errorf("TotalMemory(0, 0) = %d after no-op, want unchanged %d", got, oneGB)
+	}
+}
+
+func TestSetTotalMemoryBytesRejects(t *testing.T) {
+	for _, test := range []struct {
+		name               string
+		minTotal, maxTotal uint64
+		n                  uint64
+	}{
+		{name: "shrink", minTotal: twoGB, maxTotal: twoGB, n: oneGB},
+		{name: "zero", minTotal: oneGB, maxTotal: oneGB, n: 0},
+		// Without --total-memory the maximum stays 0 and the minimum keeps its
+		// package default, so there is no limit to raise.
+		{name: "no boot-time maximum", minTotal: twoGB, maxTotal: 0, n: twoGB * 2},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			setBoundsForTest(t, test.minTotal, test.maxTotal)
+			if err := SetTotalMemoryBytes(test.n); err == nil {
+				t.Errorf("SetTotalMemoryBytes(%d) succeeded, want error", test.n)
+			}
+			// A rejected call must leave both bounds untouched.
+			if got := MinimumTotalMemoryBytes.Load(); got != test.minTotal {
+				t.Errorf("MinimumTotalMemoryBytes = %d, want unchanged %d", got, test.minTotal)
+			}
+			if got := MaximumTotalMemoryBytes.Load(); got != test.maxTotal {
+				t.Errorf("MaximumTotalMemoryBytes = %d, want unchanged %d", got, test.maxTotal)
+			}
+		})
+	}
+}
+
+// TestSetTotalMemoryBytesConcurrent checks that racing raises settle on the
+// largest requested value with both bounds in step: a slower caller raising to
+// a smaller value must not undo a larger one that already landed.
+func TestSetTotalMemoryBytesConcurrent(t *testing.T) {
+	const goroutines = 16
+	setTotalMemoryForTest(t, oneGB)
+
+	var wg sync.WaitGroup
+	for i := 1; i <= goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Shrinks are expected to be rejected here; only the bounds matter.
+			SetTotalMemoryBytes(oneGB * uint64(i))
+		}(i)
+	}
+	wg.Wait()
+
+	want := oneGB * goroutines
+	if got := MaximumTotalMemoryBytes.Load(); got != want {
+		t.Errorf("MaximumTotalMemoryBytes = %d, want %d", got, want)
+	}
+	if got := MinimumTotalMemoryBytes.Load(); got != want {
+		t.Errorf("MinimumTotalMemoryBytes = %d, want %d", got, want)
+	}
+	if got := TotalMemory(0, 0); got != want {
+		t.Errorf("TotalMemory(0, 0) = %d, want %d", got, want)
+	}
+}
+
+func TestTotalMemoryFollowsBounds(t *testing.T) {
+	setTotalMemoryForTest(t, oneGB)
+
+	// While the bounds are pinned together, the reported total is exactly the
+	// limit regardless of how much the MemoryFile has grown.
+	for _, memSize := range []uint64{0, oneGB / 2, twoGB} {
+		if got := TotalMemory(memSize, 0); got != oneGB {
+			t.Errorf("TotalMemory(%d, 0) = %d, want %d", memSize, got, oneGB)
+		}
+	}
+	if err := SetTotalMemoryBytes(twoGB); err != nil {
+		t.Fatalf("SetTotalMemoryBytes(%d) failed: %v", twoGB, err)
+	}
+	for _, memSize := range []uint64{0, oneGB / 2, twoGB} {
+		if got := TotalMemory(memSize, 0); got != twoGB {
+			t.Errorf("TotalMemory(%d, 0) = %d after grow, want %d", memSize, got, twoGB)
+		}
+	}
+}

--- a/runsc/boot/controller.go
+++ b/runsc/boot/controller.go
@@ -43,6 +43,7 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/state/checkpointfiles"
 	"gvisor.dev/gvisor/pkg/sentry/state/stateio"
 	"gvisor.dev/gvisor/pkg/sentry/state/stateipc"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 	"gvisor.dev/gvisor/pkg/tcpip/link/fdbased"
 	"gvisor.dev/gvisor/pkg/unet"
@@ -150,6 +151,10 @@ const (
 	// ContMgrGetNetworkConfig returns the network interfaces and routes applied
 	// during the creation of root container.
 	ContMgrGetNetworkConfig = "containerManager.GetNetworkConfig"
+
+	// ContMgrSetTotalMemory updates the total memory reported inside the
+	// sandbox, without a restart.
+	ContMgrSetTotalMemory = "containerManager.SetTotalMemory"
 )
 
 const (
@@ -908,6 +913,19 @@ func (cm *containerManager) Pause(_, _ *struct{}) error {
 func (cm *containerManager) Resume(_, _ *struct{}) error {
 	cm.l.k.Unpause()
 	return control.PostResume(cm.l.k, nil)
+}
+
+// SetTotalMemoryArgs are arguments to the SetTotalMemory method.
+type SetTotalMemoryArgs struct {
+	// TotalMem is the new total memory, in bytes, to report to applications.
+	TotalMem uint64
+}
+
+// SetTotalMemory pushes a live cgroup memory limit change into the running
+// sentry, without restarting the sandbox.
+func (cm *containerManager) SetTotalMemory(args *SetTotalMemoryArgs, _ *struct{}) error {
+	log.Debugf("containerManager.SetTotalMemory: %d", args.TotalMem)
+	return usage.SetTotalMemoryBytes(args.TotalMem)
 }
 
 // Wait waits for the init process in the given container.

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -790,8 +790,10 @@ func New(args Args) (*Loader, error) {
 	if args.TotalMem > 0 {
 		// Adjust the total memory returned by the Sentry so that applications that
 		// use /proc/meminfo can make allocations based on this limit.
-		usage.MinimumTotalMemoryBytes = args.TotalMem
-		usage.MaximumTotalMemoryBytes = args.TotalMem
+		// Ceiling before floor, the same order SetTotalMemoryBytes uses, so the
+		// minimum is never momentarily above the maximum.
+		usage.MaximumTotalMemoryBytes.Store(args.TotalMem)
+		usage.MinimumTotalMemoryBytes.Store(args.TotalMem)
 		log.Infof("Setting total memory to %.2f GB", float64(args.TotalMem)/(1<<30))
 	}
 

--- a/runsc/boot/vfs.go
+++ b/runsc/boot/vfs.go
@@ -1552,9 +1552,9 @@ func (l *Loader) mountCgroupMounts(conf *config.Config, creds *auth.Credentials)
 		case "memory":
 			// Set memory limit from --total-memory if specified.
 			// This allows applications to see the correct memory limit in cgroup.
-			if defaults := cgroupfsMemoryDefaults(usage.MaximumTotalMemoryBytes); defaults != nil {
+			if defaults := cgroupfsMemoryDefaults(usage.MaximumTotalMemoryBytes.Load()); defaults != nil {
 				internalData = &cgroupfs.InternalData{DefaultControlValues: defaults}
-				log.Infof("Setting cgroupfs memory defaults: limit=%d bytes (%.2f GB)", usage.MaximumTotalMemoryBytes, float64(usage.MaximumTotalMemoryBytes)/(1<<30))
+				log.Infof("Setting cgroupfs memory defaults: limit=%d bytes (%.2f GB)", usage.MaximumTotalMemoryBytes.Load(), float64(usage.MaximumTotalMemoryBytes.Load())/(1<<30))
 			}
 		}
 

--- a/runsc/container/BUILD
+++ b/runsc/container/BUILD
@@ -116,6 +116,16 @@ go_test(
 )
 
 go_test(
+    name = "update_test",
+    size = "small",
+    srcs = ["update_test.go"],
+    library = ":container",
+    deps = [
+        "@com_github_opencontainers_runtime_spec//specs-go:go_default_library",
+    ],
+)
+
+go_test(
     name = "serialization_test",
     srcs = ["serialization_test.go"],
     deps = [

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -598,6 +598,15 @@ func Run(conf *config.Config, args Args) (unix.WaitStatus, error) {
 	return 0, nil
 }
 
+// memoryLimit returns the memory limit res sets, if any. A missing or
+// non-positive limit means unspecified or unlimited: no size to report.
+func memoryLimit(res *specs.LinuxResources) (uint64, bool) {
+	if res == nil || res.Memory == nil || res.Memory.Limit == nil || *res.Memory.Limit <= 0 {
+		return 0, false
+	}
+	return uint64(*res.Memory.Limit), true
+}
+
 // Update sets the resources of a running container as configured.
 func (c *Container) Update(res *specs.LinuxResources) error {
 	log.Debugf("Set resources for container, cid: %s", c.ID)
@@ -620,6 +629,18 @@ func (c *Container) Update(res *specs.LinuxResources) error {
 				return fmt.Errorf("setting back cgroup configs failed due to error: %v, your state file and actual configs might be inconsistent", err2)
 			}
 			return err
+		}
+	}
+
+	// Push the new limit into the sentry too, subcontainers included: under
+	// Kubernetes only the subcontainer gets this call. Skipped when unchanged,
+	// since update back-fills the current limit into every request, including
+	// CPU-only ones. Best-effort; the cgroup is already set.
+	if newLimit, ok := memoryLimit(res); ok {
+		if oldLimit, hadLimit := memoryLimit(c.Spec.Linux.Resources); !hadLimit || oldLimit != newLimit {
+			if err := c.Sandbox.SetTotalMemory(newLimit); err != nil {
+				log.Warningf("Setting sandbox total memory for container %q: %v", c.ID, err)
+			}
 		}
 	}
 

--- a/runsc/container/update_test.go
+++ b/runsc/container/update_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package container
+
+import (
+	"testing"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestMemoryLimit(t *testing.T) {
+	limit := func(v int64) *specs.LinuxResources {
+		return &specs.LinuxResources{Memory: &specs.LinuxMemory{Limit: &v}}
+	}
+	for _, test := range []struct {
+		name    string
+		res     *specs.LinuxResources
+		want    uint64
+		wantSet bool
+	}{
+		{name: "positive limit", res: limit(2 << 30), want: 2 << 30, wantSet: true},
+		{name: "unlimited", res: limit(-1)},
+		{name: "unset limit", res: limit(0)},
+		{name: "no limit field", res: &specs.LinuxResources{Memory: &specs.LinuxMemory{}}},
+		{name: "no memory", res: &specs.LinuxResources{}},
+		{name: "no resources", res: nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, gotSet := memoryLimit(test.res)
+			if got != test.want || gotSet != test.wantSet {
+				t.Errorf("memoryLimit() = (%d, %t), want (%d, %t)", got, gotSet, test.want, test.wantSet)
+			}
+		})
+	}
+}

--- a/runsc/sandbox/BUILD
+++ b/runsc/sandbox/BUILD
@@ -71,6 +71,7 @@ go_test(
     name = "sandbox_test",
     size = "small",
     srcs = [
+        "memory_test.go",
         "network_test.go",
     ],
     library = ":sandbox",

--- a/runsc/sandbox/memory_test.go
+++ b/runsc/sandbox/memory_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sandbox
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTotalMemForLimit(t *testing.T) {
+	const totalSysMem = uint64(16) << 30
+	for _, test := range []struct {
+		name     string
+		memLimit uint64
+		want     uint64
+	}{
+		{name: "limit below host memory", memLimit: 2 << 30, want: 2 << 30},
+		{name: "limit above host memory caps", memLimit: 32 << 30, want: totalSysMem},
+		{name: "cgroup v2 unlimited caps", memLimit: math.MaxUint64, want: totalSysMem},
+		{name: "limit equal to host memory", memLimit: totalSysMem, want: totalSysMem},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := totalMemForLimit(test.memLimit, totalSysMem); got != test.want {
+				t.Errorf("totalMemForLimit(%d, %d) = %d, want %d", test.memLimit, totalSysMem, got, test.want)
+			}
+		})
+	}
+}

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -881,6 +881,17 @@ func (s *Sandbox) connError(err error) error {
 	return fmt.Errorf("connecting to control server at PID %d: %v", s.Pid.Load(), err)
 }
 
+// totalMemForLimit returns the total memory to report inside the sandbox for a
+// cgroup memory limit of memLimit bytes. An unlimited cgroup reports a value
+// far above host memory, so cap at totalSysMem. Used at boot and again on a
+// live cgroup memory update.
+func totalMemForLimit(memLimit, totalSysMem uint64) uint64 {
+	if memLimit < totalSysMem {
+		return memLimit
+	}
+	return totalSysMem
+}
+
 // createSandboxProcess starts the sandbox as a subprocess by running the "boot"
 // command, passing in the bundle dir.
 func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyncFile *os.File) error {
@@ -1379,9 +1390,7 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 		if err != nil {
 			return fmt.Errorf("getting memory limit from cgroups: %v", err)
 		}
-		if memLimit < mem {
-			mem = memLimit
-		}
+		mem = totalMemForLimit(memLimit, totalSysMem)
 	}
 	cmd.Args = append(cmd.Args, "--total-memory", strconv.FormatUint(mem, 10))
 
@@ -2074,6 +2083,24 @@ func (s *Sandbox) Resume(cid string) error {
 	log.Debugf("Resume sandbox %q", s.ID)
 	if err := s.call(boot.ContMgrResume, nil, nil); err != nil {
 		return fmt.Errorf("resuming container %q: %w", cid, err)
+	}
+	return nil
+}
+
+// SetTotalMemory pushes memLimit, a container's new memory limit in bytes,
+// into the running sentry so /proc/meminfo tracks it without a sandbox
+// restart. memLimit is the requested limit rather than a re-read of the
+// sandbox cgroup, which runsc updates only for the root container.
+func (s *Sandbox) SetTotalMemory(memLimit uint64) error {
+	totalSysMem, err := hostos.TotalSystemMemory()
+	if err != nil {
+		return fmt.Errorf("getting total system memory: %w", err)
+	}
+	mem := totalMemForLimit(memLimit, totalSysMem)
+	log.Debugf("Sandbox %q: setting total memory to %d", s.ID, mem)
+	args := &boot.SetTotalMemoryArgs{TotalMem: mem}
+	if err := s.call(boot.ContMgrSetTotalMemory, args, nil); err != nil {
+		return fmt.Errorf("setting total memory: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
When a sandbox's memory cgroup limit changes without a restart (a Kubernetes in-place pod
resize, say), the total memory the sentry reports stays at its boot-time value, so
`/proc/meminfo` `MemTotal` and `sysinfo(2)` keep showing the old limit and anything sizing
itself from them cannot use the added memory without recreating the sandbox. `runsc update`
already accepts `--memory` and writes the host cgroup; nothing told the sentry. Fixes #14409.

Adds `usage.SetTotalMemoryBytes`, wired through the existing `runsc update` path, so the
reported total tracks the live cgroup limit. Grow-only: shrinking below what is already
allocated would make `MemFree` meaningless, and `TotalMemory()` already special-cases
`memSize < used`.

Both bounds are raised together. `TotalMemory()` computes `max(mf.TotalSize(), Minimum,
rounded-used)` and only then clamps to `Maximum`, and `mf.TotalSize()` is what the
MemoryFile has grown to rather than the limit — so raising only the maximum would leave
`MemTotal` at roughly the old value and creep upward as the application allocates, which is
backwards for a runtime that sizes itself before allocating. Keeping `Minimum == Maximum`
preserves the invariant boot already establishes. Shrinking is rejected, so the usual
objection to a high floor cannot arise.

The value comes from the update request rather than a re-read of the cgroup, since runsc
writes that cgroup only for the root container. The push is skipped when the limit is
unchanged, because `runsc update` back-fills the current limit into every request, including
CPU-only ones.

The two bounds become `atomicbitops.Uint64` so the `/proc/meminfo` and `sysinfo` readers stay
lock-free, and the setter serialises under a mutex. That mutex is load-bearing rather than
defensive: urpc serves each connection on its own goroutine and `Sandbox.call` opens a fresh
connection per call, so two concurrent `runsc update` invocations really can race here. An
earlier CAS-on-max/store-on-min version had a durable bug where a slower caller raising to a
smaller value could clobber a larger minimum, leaving `Minimum < Maximum` permanently and
`MemTotal` stuck low, unrepairable because a later identical call returns early.

Neither bound was in the statefile, so save/restore is unaffected: a restore re-derives both
from the new boot's `--total-memory`.

### Verification

Unit tests cover grow, no-op, shrink/zero/no-maximum rejection, that `TotalMemory()` follows
the bounds, and a 16-goroutine concurrency test asserting both bounds settle on the largest
requested value.

    //pkg/sentry/usage:usage_test      PASSED in 0.0s
    //runsc/container:update_test      PASSED in 0.0s
    //runsc/sandbox:sandbox_test       PASSED in 0.0s

End to end on kind (Kubernetes v1.35.0, containerd 2.2.0, systrap, aarch64), booting a pod at
128Mi and resizing it to 2Gi in place, against this build and against stock
release-20260817.0 on the same cluster for comparison:

    patched   MemTotal 131072 kB -> 2097152 kB   restartCount=0
    stock     MemTotal 131072 kB ->  131072 kB   restartCount=0

Grow-only also holds in-cluster: booting at 2Gi and resizing down to 512Mi leaves `MemTotal`
at 2097152 kB.

### Known limitation

The sandbox's own cgroupfs `memory.limit_in_bytes` is seeded once when the sandboxed cgroupfs
is mounted and is not updated here, so a guest reading its cgroup limit still sees the boot
value. This mirrors #14277, which likewise leaves the guest's `cpu.cfs_quota_us` stale, but
the consequence differs: after this change `/proc/meminfo` and the guest cgroup disagree,
where before they were consistently stale. Container-aware runtimes prefer the cgroup limit —
the JVM's `UseContainerSupport` and .NET's GC heap limit read it — so those are not addressed
by this change alone.

I left it out deliberately: updating it means writing the mounted cgroupfs memory controller
from the RPC, overwriting a file the guest can itself write, which seemed like a design call
for maintainers rather than mine to make. Happy to extend this PR if you would like that
behaviour, or to follow up separately.
