### PR TITLE
systrap: preserve latency medians across histogram reset

### DIFF
--- a/pkg/sentry/platform/systrap/metrics.go
+++ b/pkg/sentry/platform/systrap/metrics.go
@@ -656,7 +656,7 @@ func sentryOnStubOn(s *fastPathState) {
 		if s.disableStubFP() {
 			s.curState = sentryOnStubOff
 		}
-	} else if s.shouldDisableSentryFP(latencies.stubBound.getMedian(), latencies.sentryBound.getMedian()) {
+	} else if s.shouldDisableSentryFP(periodStubBoundMedian, periodSentryBoundMedian) {
 		if s.disableSentryFP() {
 			s.curState = sentryOffStubOn
 		}


### PR DESCRIPTION
sentryOnStubOn records the current stub- and sentry-bound latency medians,
then resets both histograms before evaluating the two fast paths. The stub
check correctly uses the saved values. The sentry check samples the now-empty
histograms again, so it always receives zero and cannot account for the
period that just ended.

Use the saved period medians for the sentry check too. This matches the
other state transitions and ensures both decisions are based on the same
completed measurement period.

Fixes: cffce1a94a08 ("systrap: Revise slow-path enablement.")

Tested with:

    make test TARGETS='//pkg/sentry/platform/systrap:systrap_test'