### PR TITLE
pgalloc: skip host holes during checkpoint

### DIFF
--- a/pkg/sentry/pgalloc/BUILD
+++ b/pkg/sentry/pgalloc/BUILD
@@ -209,10 +209,12 @@ go_test(
     srcs = [
         "pgalloc_64k_test.go",
         "pgalloc_test.go",
+        "save_restore_test.go",
     ],
     library = ":pgalloc",
     deps = [
         "//pkg/hostarch",
+        "//pkg/memutil",
         "//pkg/sentry/memmap",
     ],
 )

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -185,7 +185,7 @@ type SaveOpts struct {
 }
 
 // SaveTo writes f's state to the given stream.
-func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) error {
+func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) (retErr error) {
 	if err := f.AwaitLoadAll(); err != nil {
 		return fmt.Errorf("previous async page loading failed: %w", err)
 	}
@@ -373,6 +373,33 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 		return maseg
 	}
 
+	var hostData *hostFileDataIterator
+	if !f.opts.DiskBackedFile {
+		fileSize := f.TotalSize()
+		fd := int(f.file.Fd())
+		backingFileUsageBytes, err := f.TotalUsage()
+		if err != nil {
+			log.Debugf("MemoryFile(%p): falling back to page scanning because backing file usage is unavailable: %v", f, err)
+		} else if accountedBytes := uint64(f.memAcct.Span()); hostFileUsageShowsEnoughHoles(backingFileUsageBytes, accountedBytes) {
+			off, err := unix.Seek(fd, 0, unix.SEEK_CUR)
+			if err != nil {
+				log.Debugf("MemoryFile(%p): falling back to page scanning because the backing file offset is unavailable: %v", f, err)
+			} else {
+				hostData = &hostFileDataIterator{
+					size: fileSize,
+					seek: func(offset int64, whence int) (int64, error) {
+						return unix.Seek(fd, offset, whence)
+					},
+				}
+				defer func() {
+					if _, err := unix.Seek(fd, off, unix.SEEK_SET); retErr == nil && err != nil {
+						retErr = fmt.Errorf("failed to restore host file offset: %w", err)
+					}
+				}()
+			}
+		}
+	}
+
 	zeroPage := make([]byte, hostarch.PageSize)
 	// f.mu is unlocked below, allowing concurrent calls to f.UpdateUsage() to
 	// observe pages that we transiently commit (for comparisons to zero) or
@@ -389,30 +416,7 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 	f.commitSeq = 0
 	maseg := f.memAcct.FirstSegment()
 	unscannedStart := uint64(0)
-	for maseg.Ok() {
-		ma := maseg.ValuePtr()
-		if ma.wasteOrReleasing {
-			// This shouldn't be possible since we waited for memory release
-			// above, and f shouldn't be mutated during saving.
-			panic(fmt.Sprintf("found waste or releasing pages %v during pgalloc.MemoryFile.SaveTo()", maseg.Range()))
-		}
-		fr := maseg.Range()
-		if fr.Start < unscannedStart {
-			fr.Start = unscannedStart
-		}
-		unscannedStart = fr.End
-		allocatedBytes += fr.Length()
-		ma.commitSeq = 0
-		wasCommitted := ma.knownCommitted
-		if !opts.ExcludeCommittedZeroPages && wasCommitted {
-			alreadyCommittedBytes += fr.Length()
-			maseg = updateAddRange(maseg, fr, true /* wasCommitted */, true /* nowCommitted */)
-			maseg = updateFlush(maseg)
-			if maseg.End() == unscannedStart {
-				maseg = maseg.NextSegment()
-			}
-			continue
-		}
+	scanRange := func(fr memmap.FileRange, wasCommitted bool) {
 		f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
 			bs := chunk.sliceAt(chunkFR)
 			for pgoff := 0; pgoff < len(bs); pgoff += hostarch.PageSize {
@@ -444,6 +448,61 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 			f.mu.Lock()
 			return true
 		})
+	}
+	markHostHoleUncommitted := func(fr memmap.FileRange, wasCommitted bool) {
+		if wasCommitted {
+			newUncommittedBytes += fr.Length()
+		} else {
+			alreadyUncommittedBytes += fr.Length()
+		}
+		maseg = updateAddRange(maseg, fr, wasCommitted, false /* nowCommitted */)
+	}
+	for maseg.Ok() {
+		ma := maseg.ValuePtr()
+		if ma.wasteOrReleasing {
+			// This shouldn't be possible since we waited for memory release
+			// above, and f shouldn't be mutated during saving.
+			panic(fmt.Sprintf("found waste or releasing pages %v during pgalloc.MemoryFile.SaveTo()", maseg.Range()))
+		}
+		fr := maseg.Range()
+		if fr.Start < unscannedStart {
+			fr.Start = unscannedStart
+		}
+		unscannedStart = fr.End
+		allocatedBytes += fr.Length()
+		ma.commitSeq = 0
+		wasCommitted := ma.knownCommitted
+		if !opts.ExcludeCommittedZeroPages && wasCommitted {
+			alreadyCommittedBytes += fr.Length()
+			maseg = updateAddRange(maseg, fr, true /* wasCommitted */, true /* nowCommitted */)
+		} else if hostData != nil {
+			off := fr.Start
+			for off < fr.End {
+				dataFR, ok, err := hostData.rangeAtOrAfter(off)
+				if err != nil {
+					log.Debugf("MemoryFile(%p): scanning remaining pages because backing file extents are unavailable: %v", f, err)
+					hostData = nil
+					scanRange(memmap.FileRange{Start: off, End: fr.End}, wasCommitted)
+					off = fr.End
+					break
+				}
+				if !ok || dataFR.Start >= fr.End {
+					break
+				}
+				dataStart := max(off, dataFR.Start)
+				if off < dataStart {
+					markHostHoleUncommitted(memmap.FileRange{Start: off, End: dataStart}, wasCommitted)
+				}
+				dataEnd := min(fr.End, dataFR.End)
+				scanRange(memmap.FileRange{Start: dataStart, End: dataEnd}, wasCommitted)
+				off = dataEnd
+			}
+			if off < fr.End {
+				markHostHoleUncommitted(memmap.FileRange{Start: off, End: fr.End}, wasCommitted)
+			}
+		} else {
+			scanRange(fr, wasCommitted)
+		}
 		// We need to flush batched updates to f.memAcct whenever potentially
 		// reaching the end of a segment, in order to maintain the invariant
 		// that updatePendingFR corresponds to a single segment.
@@ -521,6 +580,61 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 	}
 
 	return nil
+}
+
+const extentScanMinHoleFractionDivisor = 8
+
+// hostFileUsageShowsEnoughHoles reports whether the host file allocation proves
+// that more than one eighth of the accounted MemoryFile ranges are holes.
+// Finding holes in a dense tmpfs file may scan the same pages as SaveTo. File
+// allocation outside the accounted ranges can only prevent this optimization.
+func hostFileUsageShowsEnoughHoles(backingFileUsageBytes, accountedBytes uint64) bool {
+	if accountedBytes == 0 {
+		return false
+	}
+	return backingFileUsageBytes < accountedBytes-accountedBytes/extentScanMinHoleFractionDivisor
+}
+
+// hostFileDataIterator iterates over page-aligned ranges reported by SEEK_DATA.
+// SaveTo still scans these ranges because they may contain zero pages. The
+// iterator holds at most one range regardless of file fragmentation.
+type hostFileDataIterator struct {
+	size    uint64
+	current memmap.FileRange
+	done    bool
+	seek    func(offset int64, whence int) (int64, error)
+}
+
+func (it *hostFileDataIterator) rangeAtOrAfter(off uint64) (memmap.FileRange, bool, error) {
+	for it.current.End <= off {
+		it.current = memmap.FileRange{}
+		if it.done || off >= it.size {
+			return memmap.FileRange{}, false, nil
+		}
+		data, err := it.seek(int64(off), unix.SEEK_DATA)
+		if err == unix.ENXIO {
+			it.done = true
+			return memmap.FileRange{}, false, nil
+		}
+		if err != nil {
+			return memmap.FileRange{}, false, fmt.Errorf("SEEK_DATA from %#x: %w", off, err)
+		}
+		if data < int64(off) || uint64(data) >= it.size {
+			return memmap.FileRange{}, false, fmt.Errorf("SEEK_DATA from %#x returned %#x for file size %#x", off, data, it.size)
+		}
+		hole, err := it.seek(data, unix.SEEK_HOLE)
+		if err != nil {
+			return memmap.FileRange{}, false, fmt.Errorf("SEEK_HOLE from %#x: %w", data, err)
+		}
+		if hole <= data || uint64(hole) > it.size {
+			return memmap.FileRange{}, false, fmt.Errorf("SEEK_HOLE from %#x returned %#x for file size %#x", data, hole, it.size)
+		}
+		it.current = memmap.FileRange{
+			Start: hostarch.PageRoundDown(uint64(data)),
+			End:   hostarch.MustPageRoundUp(uint64(hole)),
+		}.Intersect(memmap.FileRange{End: it.size})
+	}
+	return it.current, true, nil
 }
 
 // AsyncPagesFileSave holds async page saving state for a single pages file.

--- a/pkg/sentry/pgalloc/save_restore_test.go
+++ b/pkg/sentry/pgalloc/save_restore_test.go
@@ -1,0 +1,374 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !pagesize_64k
+
+package pgalloc
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/memutil"
+	"gvisor.dev/gvisor/pkg/sentry/memmap"
+)
+
+type seekStep struct {
+	offset int64
+	whence int
+	result int64
+	err    error
+}
+
+func scriptedSeek(t *testing.T, steps []seekStep) func(int64, int) (int64, error) {
+	t.Helper()
+	next := 0
+	t.Cleanup(func() {
+		if next != len(steps) {
+			t.Errorf("seek called %d times, want %d", next, len(steps))
+		}
+	})
+	return func(offset int64, whence int) (int64, error) {
+		if next == len(steps) {
+			t.Fatalf("unexpected seek(%#x, %d)", offset, whence)
+		}
+		step := steps[next]
+		next++
+		if offset != step.offset || whence != step.whence {
+			t.Errorf("seek %d: got (%#x, %d), want (%#x, %d)", next, offset, whence, step.offset, step.whence)
+		}
+		return step.result, step.err
+	}
+}
+
+func newSaveTestMemoryFile(t testing.TB, diskBacked bool) *MemoryFile {
+	t.Helper()
+	fd, err := memutil.CreateMemFD("pgalloc-save-test", 0)
+	if err != nil {
+		t.Fatalf("CreateMemFD: %v", err)
+	}
+	f, err := NewMemoryFile(os.NewFile(uintptr(fd), "pgalloc-save-test"), MemoryFileOpts{
+		DelayedEviction:         DelayedEvictionDisabled,
+		DisableMemoryAccounting: true,
+		DiskBackedFile:          diskBacked,
+	})
+	if err != nil {
+		unix.Close(fd)
+		t.Fatalf("NewMemoryFile: %v", err)
+	}
+	return f
+}
+
+func destroySaveTestMemoryFile(f *MemoryFile, fr memmap.FileRange) {
+	f.DecRef(fr)
+	f.Destroy()
+}
+
+func restoreAndCheckSaveTestContents(t *testing.T, diskBacked bool, fr memmap.FileRange, checkpoint io.Reader, want []byte) {
+	t.Helper()
+	restored := newSaveTestMemoryFile(t, diskBacked)
+	if err := restored.LoadFrom(context.Background(), checkpoint, &LoadOpts{}); err != nil {
+		restored.Destroy()
+		t.Fatalf("LoadFrom: %v", err)
+	}
+	defer destroySaveTestMemoryFile(restored, fr)
+	restored.forEachMappingSlice(fr, func(bs []byte) {
+		if !bytes.Equal(bs, want) {
+			t.Error("restored contents differ from saved contents")
+		}
+	})
+}
+
+func TestHostFileUsageShowsEnoughHoles(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		backingFileUsageBytes uint64
+		accountedBytes        uint64
+		want                  bool
+	}{
+		{name: "no accounted memory", backingFileUsageBytes: 0, accountedBytes: 0, want: false},
+		{name: "sparse", backingFileUsageBytes: 1, accountedBytes: 8, want: true},
+		{name: "below dense boundary", backingFileUsageBytes: 6, accountedBytes: 8, want: true},
+		{name: "at dense boundary", backingFileUsageBytes: 7, accountedBytes: 8, want: false},
+		{name: "data exceeds accounted memory", backingFileUsageBytes: 9, accountedBytes: 8, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hostFileUsageShowsEnoughHoles(tc.backingFileUsageBytes, tc.accountedBytes); got != tc.want {
+				t.Errorf("hostFileUsageShowsEnoughHoles(%d, %d): got %t, want %t", tc.backingFileUsageBytes, tc.accountedBytes, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHostFileDataIterator(t *testing.T) {
+	const page = hostarch.PageSize
+	testErr := errors.New("seek failed")
+	type call struct {
+		off         uint64
+		want        memmap.FileRange
+		wantOK      bool
+		wantFailure bool
+		wantErr     error
+	}
+	for _, tc := range []struct {
+		name  string
+		size  uint64
+		steps []seekStep
+		calls []call
+	}{
+		{
+			name: "unaligned data with leading, middle, and trailing holes",
+			size: 8 * page,
+			steps: []seekStep{
+				{offset: 0, whence: unix.SEEK_DATA, result: page + 1},
+				{offset: page + 1, whence: unix.SEEK_HOLE, result: 3*page - 1},
+				{offset: 3 * page, whence: unix.SEEK_DATA, result: 5*page + 1},
+				{offset: 5*page + 1, whence: unix.SEEK_HOLE, result: 7*page - 1},
+				{offset: 7 * page, whence: unix.SEEK_DATA, err: unix.ENXIO},
+			},
+			calls: []call{
+				{off: 0, want: memmap.FileRange{Start: page, End: 3 * page}, wantOK: true},
+				{off: 3 * page, want: memmap.FileRange{Start: 5 * page, End: 7 * page}, wantOK: true},
+				{off: 7 * page},
+			},
+		},
+		{
+			name: "retains current range before propagating error",
+			size: 4 * page,
+			steps: []seekStep{
+				{offset: 0, whence: unix.SEEK_DATA, result: page},
+				{offset: page, whence: unix.SEEK_HOLE, result: 3 * page},
+				{offset: 3 * page, whence: unix.SEEK_DATA, err: testErr},
+			},
+			calls: []call{
+				{off: 0, want: memmap.FileRange{Start: page, End: 3 * page}, wantOK: true},
+				{off: 2 * page, want: memmap.FileRange{Start: page, End: 3 * page}, wantOK: true},
+				{off: 3 * page, wantFailure: true, wantErr: testErr},
+			},
+		},
+		{
+			name: "starts at requested offset and rejects backward data",
+			size: 4 * page,
+			steps: []seekStep{
+				{offset: 2 * page, whence: unix.SEEK_DATA, result: 2 * page},
+				{offset: 2 * page, whence: unix.SEEK_HOLE, result: 3 * page},
+				{offset: 3 * page, whence: unix.SEEK_DATA, result: 2 * page},
+			},
+			calls: []call{
+				{off: 2 * page, want: memmap.FileRange{Start: 2 * page, End: 3 * page}, wantOK: true},
+				{off: 3 * page, wantFailure: true},
+			},
+		},
+		{
+			name: "seek hole does not advance",
+			size: 4 * page,
+			steps: []seekStep{
+				{offset: 0, whence: unix.SEEK_DATA, result: page},
+				{offset: page, whence: unix.SEEK_HOLE, result: page},
+			},
+			calls: []call{{wantFailure: true}},
+		},
+		{
+			name: "seek hole exceeds file",
+			size: 4 * page,
+			steps: []seekStep{
+				{offset: 0, whence: unix.SEEK_DATA, result: page},
+				{offset: page, whence: unix.SEEK_HOLE, result: 4*page + 1},
+			},
+			calls: []call{{wantFailure: true}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			it := hostFileDataIterator{size: tc.size, seek: scriptedSeek(t, tc.steps)}
+			for i, call := range tc.calls {
+				got, ok, err := it.rangeAtOrAfter(call.off)
+				if call.wantFailure {
+					if err == nil {
+						t.Errorf("call %d rangeAtOrAfter(%#x) succeeded, want error", i, call.off)
+					} else if call.wantErr != nil && !errors.Is(err, call.wantErr) {
+						t.Errorf("call %d rangeAtOrAfter(%#x) error: got %v, want %v", i, call.off, err, call.wantErr)
+					}
+					continue
+				}
+				if err != nil || ok != call.wantOK || got != call.want {
+					t.Errorf("call %d rangeAtOrAfter(%#x): got (%v, %t, %v), want (%v, %t, nil)", i, call.off, got, ok, err, call.want, call.wantOK)
+				}
+			}
+		})
+	}
+}
+
+func TestHostFileDataIteratorOnMemFD(t *testing.T) {
+	fd, err := memutil.CreateMemFD("pgalloc-data-pages-test", 0)
+	if err != nil {
+		t.Fatalf("CreateMemFD: %v", err)
+	}
+	defer unix.Close(fd)
+
+	const size = 16 * hostarch.PageSize
+	if err := unix.Ftruncate(fd, size); err != nil {
+		t.Fatalf("Ftruncate: %v", err)
+	}
+	for _, offset := range []int64{2 * hostarch.PageSize, 9 * hostarch.PageSize} {
+		if _, err := unix.Pwrite(fd, []byte{1}, offset); err != nil {
+			t.Fatalf("Pwrite(%#x): %v", offset, err)
+		}
+	}
+	it := hostFileDataIterator{
+		size: size,
+		seek: func(offset int64, whence int) (int64, error) {
+			return unix.Seek(fd, offset, whence)
+		},
+	}
+	got := make(map[uint64]struct{})
+	for off := uint64(0); off < it.size; {
+		fr, ok, err := it.rangeAtOrAfter(off)
+		if err != nil {
+			t.Fatalf("rangeAtOrAfter(%#x): %v", off, err)
+		}
+		if !ok {
+			break
+		}
+		for page := max(off, fr.Start) / hostarch.PageSize; page < fr.End/hostarch.PageSize; page++ {
+			got[page] = struct{}{}
+		}
+		off = fr.End
+	}
+	for _, page := range []uint64{2, 9} {
+		if _, ok := got[page]; !ok {
+			t.Errorf("written page %d was not reported as data", page)
+		}
+	}
+}
+
+func TestSaveToPreservesSparseContents(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		diskBacked bool
+	}{
+		{name: "host data pages"},
+		{name: "disk-backed scan", diskBacked: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newSaveTestMemoryFile(t, tc.diskBacked)
+			fr, err := f.Allocate(16*hostarch.PageSize, AllocOpts{Mode: AllocateUncommitted})
+			if err != nil {
+				t.Fatalf("Allocate: %v", err)
+			}
+			defer destroySaveTestMemoryFile(f, fr)
+			want := make([]byte, int(fr.Length()))
+			want[2*hostarch.PageSize] = 1
+			want[13*hostarch.PageSize+17] = 2
+			f.forEachMappingSlice(fr, func(bs []byte) {
+				bs[2*hostarch.PageSize] = want[2*hostarch.PageSize]
+				bs[13*hostarch.PageSize+17] = want[13*hostarch.PageSize+17]
+			})
+			if _, err := unix.Pwrite(f.FD(), []byte{0}, int64(9*hostarch.PageSize)); err != nil {
+				t.Fatalf("Pwrite explicit zero: %v", err)
+			}
+			if !tc.diskBacked {
+				backingFileUsageBytes, err := f.TotalUsage()
+				if err != nil {
+					t.Fatalf("TotalUsage: %v", err)
+				}
+				if wantMin := uint64(3 * hostarch.PageSize); backingFileUsageBytes < wantMin {
+					t.Fatalf("backing file usage %d, want at least %d for nonzero and explicitly zero pages", backingFileUsageBytes, wantMin)
+				}
+				accountedBytes := uint64(f.memAcct.Span())
+				if !hostFileUsageShowsEnoughHoles(backingFileUsageBytes, accountedBytes) {
+					t.Fatalf("sparse MemoryFile did not pass extent scan gate: backing file usage %d, accounted bytes %d", backingFileUsageBytes, accountedBytes)
+				}
+			}
+			const originalOffset = 7 * hostarch.PageSize
+			if _, err := unix.Seek(int(f.file.Fd()), originalOffset, unix.SEEK_SET); err != nil {
+				t.Fatalf("Seek: %v", err)
+			}
+
+			var checkpoint bytes.Buffer
+			if err := f.SaveTo(context.Background(), &checkpoint, &SaveOpts{}); err != nil {
+				t.Fatalf("SaveTo: %v", err)
+			}
+			if got, want := f.knownCommittedBytes, uint64(2*hostarch.PageSize); got != want {
+				t.Errorf("knownCommittedBytes: got %d, want %d", got, want)
+			}
+			if off, err := unix.Seek(int(f.file.Fd()), 0, unix.SEEK_CUR); err != nil {
+				t.Fatalf("Seek(SEEK_CUR): %v", err)
+			} else if off != originalOffset {
+				t.Errorf("file offset: got %#x, want %#x", off, originalOffset)
+			}
+
+			restoreAndCheckSaveTestContents(t, tc.diskBacked, fr, &checkpoint, want)
+		})
+	}
+}
+
+func TestSaveToExcludeCommittedZeroPages(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		exclude       bool
+		wantCommitted uint64
+	}{
+		{name: "disabled", wantCommitted: 16 * hostarch.PageSize},
+		{name: "enabled", exclude: true, wantCommitted: 3 * hostarch.PageSize},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newSaveTestMemoryFile(t, false)
+			fr, err := f.Allocate(16*hostarch.PageSize, AllocOpts{Mode: AllocateUncommitted})
+			if err != nil {
+				t.Fatalf("Allocate: %v", err)
+			}
+			defer destroySaveTestMemoryFile(f, fr)
+			initial := make([]byte, int(fr.Length()))
+			for page := 0; page < 16; page++ {
+				initial[page*hostarch.PageSize] = byte(page + 1)
+			}
+			if _, err := unix.Pwrite(f.FD(), initial, int64(fr.Start)); err != nil {
+				t.Fatalf("Pwrite initial contents: %v", err)
+			}
+			if err := f.SaveTo(context.Background(), io.Discard, &SaveOpts{}); err != nil {
+				t.Fatalf("initial SaveTo: %v", err)
+			}
+			decommitted := memmap.FileRange{
+				Start: fr.Start + 2*hostarch.PageSize,
+				End:   fr.End - hostarch.PageSize,
+			}
+			if err := f.decommitFile(decommitted); err != nil {
+				t.Fatalf("decommitFile: %v", err)
+			}
+			if _, err := unix.Pwrite(f.FD(), make([]byte, hostarch.PageSize), int64(fr.Start+9*hostarch.PageSize)); err != nil {
+				t.Fatalf("Pwrite explicit zero: %v", err)
+			}
+			wantContents := make([]byte, int(fr.Length()))
+			wantContents[0] = 1
+			wantContents[hostarch.PageSize] = 2
+			wantContents[15*hostarch.PageSize] = 16
+
+			var checkpoint bytes.Buffer
+			if err := f.SaveTo(context.Background(), &checkpoint, &SaveOpts{ExcludeCommittedZeroPages: tc.exclude}); err != nil {
+				t.Fatalf("SaveTo: %v", err)
+			}
+			if got := f.knownCommittedBytes; got != tc.wantCommitted {
+				t.Errorf("knownCommittedBytes: got %d, want %d", got, tc.wantCommitted)
+			}
+
+			restoreAndCheckSaveTestContents(t, false, fr, &checkpoint, wantContents)
+		})
+	}
+}


### PR DESCRIPTION
I was looking into optimizing checkpoint and restore performance. In doing so, I found that a fair amount of checkpoint CPU was spent in `MemoryFile.SaveTo`, where it reads every possibly committed page to find zeroes even when the sparse host backing file already proves that a range reads as zero. Runtime heaps can leave large holes after startup or garbage collection, so this scan can become a material part of checkpoint time.

I tried using `SEEK_DATA` and `SEEK_HOLE` to skip those known host holes. The extent path runs only when `fstat` proves that more than one eighth of the accounted memory is unbacked, and it still byte-scans every reported data extent. This adds extent queries to qualifying sparse checkpoints, while dense files, disk-backed memory, and hosts where extent discovery fails keep the existing page scan. I left the image format and restore path unchanged, and the change adds no option or application hot-path work.

In the end-to-end test I did with a Hono application on Bun 1.4 and a Spring Boot application on OpenJDK 21, each application warmed its router, JSON serialization, and small state map with 2,000 validated requests before checkpoint. The applications used no synthetic heap allocation and validated another request after restore. Hono used HTTP over a Unix socket, while Spring used `MockMvc` because the direct-containerd harness has no network device. I ran 20 alternating pairs per application.

| Application | Checkpoint time | Checkpoint cgroup CPU |
| --- | ---: | ---: |
| Bun and Hono | 78 ms to 41 ms, dropped by 47% | 118 ms to 73 ms, dropped by 35% |
| Java and Spring Boot | 101 ms to 75 ms, dropped by 25% | 203 ms to 163 ms, dropped by 22% |

Restore timing, image size, memory use, and faults varied between launches without a consistent candidate effect. Dense or retained heaps continue to use the existing scan.
