### PR TITLE
state: reduce statistics clock overhead

### DIFF
--- a/pkg/state/BUILD
+++ b/pkg/state/BUILD
@@ -84,6 +84,7 @@ go_library(
         "//visibility:public",
     ],
     deps = [
+        "//pkg/gohacks",
         "//pkg/state/wire",
     ],
 )

--- a/pkg/state/stats.go
+++ b/pkg/state/stats.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sort"
 	"time"
+
+	"gvisor.dev/gvisor/pkg/gohacks"
 )
 
 type statEntry struct {
@@ -48,13 +50,13 @@ type Stats struct {
 	// on the stats object.
 	names []string
 
-	// last is the last start time.
-	last time.Time
+	// last is the monotonic time of the last sample.
+	last int64
 }
 
 // init initializes statistics.
 func (s *Stats) init() {
-	s.last = time.Now()
+	s.last = gohacks.Nanotime()
 	s.stack = append(s.stack, 0)
 }
 
@@ -72,12 +74,12 @@ func (s *Stats) fini(resolve func(id typeID) string) {
 
 // sample adds the samples to the given object.
 func (s *Stats) sample(id typeID) {
-	now := time.Now()
+	now := gohacks.Nanotime()
 	if len(s.byType) <= int(id) {
 		// Allocate all the missing entries in one fell swoop.
 		s.byType = append(s.byType, make([]statEntry, 1+int(id)-len(s.byType))...)
 	}
-	s.byType[id].total += now.Sub(s.last)
+	s.byType[id].total += time.Duration(now - s.last)
 	s.last = now
 }
 


### PR DESCRIPTION
I was profiling checkpoint and restore for object-heavy sandboxes and found that `state.(*Stats).sample` consumed 210 ms of cumulative CPU during a restore with 20,000 open regular files, including 190 ms in `time.runtimeNow`. State statistics call `time.Now` for every nested encode and decode interval even though they retain only elapsed durations.

This change uses gVisor’s existing `gohacks.Nanotime` wrapper for those samples. The current calculation already uses the monotonic component of `time.Time`, so the behavioral change is limited to avoiding wall-clock acquisition and `time.Time` construction. The public `Stats` API, per-type counts, timing table, and checkpoint format remain unchanged. This adds no option, alternate state path, or application hot-path work.

The object-heavy test used a checkpointable Go service with a 64 MiB heap. It created 5,000 small regular files and kept every file descriptor open across checkpoint and restore, so the file count represents live file-description state processed by the encoder and decoder rather than files merely present in the filesystem. Across six alternating pairs, checkpoint time dropped by 7.73%, checkpoint CPU dropped by 10.27%, restore start time dropped by 10.13%, and restore CPU dropped by 8.99%. The 20,000-open-file restore profile reduced cumulative `Stats.sample` CPU from 210 ms to 110 ms. An empty-state control remained within run variation, so the expected benefit is small for simple state graphs. The 20,000-open-file checkpoint CPU result was noisy and is not included in the improvement claim.