### PR TITLE
fix(tcpip): keep readv dispatcher alive after filtered frame

### DIFF
--- a/pkg/tcpip/link/fdbased/packet_dispatchers.go
+++ b/pkg/tcpip/link/fdbased/packet_dispatchers.go
@@ -202,7 +202,7 @@ func (d *readVDispatcher) dispatch() (bool, tcpip.Error) {
 	addr := d.e.addr
 	d.e.mu.RUnlock()
 	if !d.e.parseInboundHeader(pkt, addr) {
-		return false, nil
+		return true, nil
 	}
 	d.mgr.queuePacket(pkt, d.e.hdrSize > 0)
 	d.mgr.wakeReady()


### PR DESCRIPTION
Treat an Ethernet frame rejected by the endpoint address filter as a consumed packet rather than a request to stop the ReadV dispatch loop.

A direct TAP endpoint can receive foreign unicast traffic after a sandbox is restored and reattached to a bridge with stale FDB or neighbor state. Returning false for that frame tears down the receive dispatcher, leaving the restored sandbox running but unable to receive subsequent traffic.

Keep the dispatcher alive after dropping the frame, matching the RecvMMsg and PacketMMap paths.