### PR TITLE
nvproxy: include ngx in "all" container driver capabilities

### DIFF
--- a/pkg/sentry/devices/nvproxy/nvconf/caps.go
+++ b/pkg/sentry/devices/nvproxy/nvconf/caps.go
@@ -62,7 +62,7 @@ const (
 	// enabled when enabling "all" capabilities is requested, which excludes
 	// "privileged" capabilities that are usually not intended. Similar to
 	// nvidia-container-toolkit/internal/config/image/capabilities.go:SupportedDriverCapabilities.
-	AllContainerDriverCaps = CapCompute | CapUtility | CapGraphics | CapVideo
+	AllContainerDriverCaps = CapCompute | CapUtility | CapGraphics | CapVideo | CapNGX
 
 	// DefaultDriverCaps is the set of driver capabilities that are enabled by
 	// default in the absence of any other configuration. See

--- a/pkg/sentry/devices/nvproxy/nvconf/caps_test.go
+++ b/pkg/sentry/devices/nvproxy/nvconf/caps_test.go
@@ -38,7 +38,7 @@ func TestNVIDIAFlagsSkipsPrivilegedCaps(t *testing.T) {
 		{
 			name: "all_plus_profiling",
 			caps: AllContainerDriverCaps | CapProfiling,
-			want: []string{"--compute", "--graphics", "--utility", "--video"},
+			want: []string{"--compute", "--graphics", "--ngx", "--utility", "--video"},
 		},
 		{
 			name: "profiling_only",


### PR DESCRIPTION
Omniverse / Isaac Sim RTX camera workloads initialize NGX (DLSS / Super Resolution) through `libnvidia-ngx`. If that library is not injected, Kit logs `NGX isn't enabled` / `Failed to create NGX context`, and the Vulkan device is often lost (`VkResult: ERROR_DEVICE_LOST`) while loading a scene with RTX cameras.

nvproxy already has `CapNGX` as the nvidia-container-toolkit `ngx` flag (`--ngx` injects `libnvidia-ngx`). It is not a Resource Manager class and does not need a new ioctl. No handler in `version.go` is keyed on `CapNGX`.

The gap is `AllContainerDriverCaps`: it did not include `CapNGX`, so `NVIDIA_DRIVER_CAPABILITIES=all` never passed `--ngx` to `nvidia-container-cli`. Toolkit's `SupportedDriverCapabilities` does include `ngx` (`compute,compat32,graphics,utility,video,display,ngx`).

This change adds `CapNGX` to `AllContainerDriverCaps` only. `DefaultDriverCaps` stays `compute,utility`, so ngx remains off unless the container requests `all` or `ngx` and the runtime allows it.

Split from the AMPERE_B ioctl work in #14449.

Assisted-by: Cursor

## Test plan
- [x] With `NVIDIA_DRIVER_CAPABILITIES=all`, `libnvidia-ngx` is injected
- [x] Isaac Sim 5.1 headless RTX camera init no longer fails with `Failed to create NGX context` / `ERROR_DEVICE_LOST` once ngx is included in `all`
- [ ] Default capabilities (`compute,utility`) still do not pass `--ngx`
- [ ] No RM allocation/class changes; independent of #14449