### PR TITLE
tools: add standalone tpu-checkpoint CLI

### DIFF
--- a/tools/tpucheckpoint/BUILD
+++ b/tools/tpucheckpoint/BUILD
@@ -1,0 +1,15 @@
+load("//tools:defs.bzl", "go_binary")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_binary(
+    name = "tpucheckpoint",
+    srcs = ["tpucheckpoint.go"],
+    visibility = ["//:sandbox"],
+    deps = [
+        "//tools/tpucheckpoint/tpucontrol",
+    ],
+)

--- a/tools/tpucheckpoint/tpucheckpoint.go
+++ b/tools/tpucheckpoint/tpucheckpoint.go
@@ -1,0 +1,168 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// tpucheckpoint drives the libtpu checkpoint/restore control protocol
+// against unsandboxed processes. It discovers the libtpu control threads
+// of each target PID by scanning /proc/<pid>/task/*/comm, opens the
+// encoded pipe FDs via /proc/<pid>/fd/, and sends ControlRequest messages.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"gvisor.dev/gvisor/tools/tpucheckpoint/tpucontrol"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `tpucheckpoint: checkpoint and restore the TPU state of processes.
+
+Discovers libtpu control pipes by scanning thread names in /proc/<pid>/task/,
+then sends control messages using the tpu_control protocol.
+
+Operations:
+  --action checkpoint | restore   --pid <pid>[,<pid>...] [--timeout <seconds>]
+        Checkpoint or restore the TPU runtime state of the given PIDs.
+        Multiple PIDs are processed concurrently.
+
+  --get-state --pid <pid>[,<pid>...]
+        Print the current TPU runtime state of the given PIDs.
+
+Options:
+  --pid|-p <pid>[,<pid>...]   Target process PIDs, comma-separated.
+  --timeout|-t <seconds>      Per-process operation timeout in seconds (default: 180).
+  --help|-h                   Print this help message.
+
+Discovery:
+  Scans /proc/<pid>/task/*/comm for threads named "libtpu{XXXXYYYY}".
+  The 8-character hex suffix encodes the request/response pipe FD numbers.
+  Pipes are accessed via /proc/<pid>/fd/<N>, which requires ptrace-level
+  access to the target (same user or CAP_SYS_PTRACE).
+`)
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "tpucheckpoint: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+// report prints per-PID results and returns false if any operation failed.
+// line renders the success output for one result; for a single PID the
+// "pid N: " prefix is omitted, keeping the original single-PID output.
+func report(results []tpucontrol.Result, line func(r tpucontrol.Result) string) bool {
+	ok := true
+	for _, r := range results {
+		if r.Err != nil {
+			ok = false
+			fmt.Fprintf(os.Stderr, "tpucheckpoint: pid %d: %v\n", r.PID, r.Err)
+			continue
+		}
+		if len(results) == 1 {
+			fmt.Println(line(r))
+		} else {
+			fmt.Printf("pid %d: %s\n", r.PID, line(r))
+		}
+	}
+	return ok
+}
+
+func main() {
+	args := os.Args[1:]
+	if len(args) == 0 {
+		usage()
+		os.Exit(1)
+	}
+
+	var (
+		pids       []int
+		action     string
+		getState   bool
+		timeoutSec = 180
+	)
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--help", "-h":
+			usage()
+			os.Exit(0)
+		case "--pid", "-p":
+			i++
+			if i >= len(args) {
+				fatal("--pid requires a value")
+			}
+			if pids != nil {
+				fatal("--pid may be specified only once; use a comma-separated list")
+			}
+			var err error
+			pids, err = tpucontrol.ParsePIDs(args[i])
+			if err != nil {
+				fatal("%v", err)
+			}
+		case "--action":
+			i++
+			if i >= len(args) {
+				fatal("--action requires a value")
+			}
+			action = strings.ToLower(args[i])
+		case "--get-state":
+			getState = true
+		case "--timeout", "-t":
+			i++
+			if i >= len(args) {
+				fatal("--timeout requires a value")
+			}
+			var err error
+			timeoutSec, err = strconv.Atoi(args[i])
+			if err != nil || timeoutSec <= 0 {
+				fatal("invalid timeout: %s", args[i])
+			}
+		default:
+			fatal("unknown option: %s\nrun 'tpucheckpoint --help' for usage", args[i])
+		}
+	}
+
+	if len(pids) == 0 {
+		fatal("--pid is required")
+	}
+
+	var ok bool
+	switch {
+	case getState:
+		ok = report(tpucontrol.GetState(pids, timeoutSec), func(r tpucontrol.Result) string {
+			return r.State.String()
+		})
+
+	case action == "checkpoint":
+		ok = report(tpucontrol.Checkpoint(pids, timeoutSec), func(r tpucontrol.Result) string {
+			return fmt.Sprintf("checkpoint complete (%.3fs)", r.Duration.Seconds())
+		})
+
+	case action == "restore":
+		ok = report(tpucontrol.Restore(pids, timeoutSec), func(r tpucontrol.Result) string {
+			return fmt.Sprintf("restore complete (%.3fs)", r.Duration.Seconds())
+		})
+
+	case action != "":
+		fatal("unknown action: %s (supported: checkpoint, restore)", action)
+
+	default:
+		fatal("no operation specified (use --action checkpoint|restore or --get-state)\nrun 'tpucheckpoint --help' for usage")
+	}
+
+	if !ok {
+		os.Exit(1)
+	}
+}

--- a/tools/tpucheckpoint/tpucontrol/BUILD
+++ b/tools/tpucheckpoint/tpucontrol/BUILD
@@ -1,0 +1,34 @@
+load("//tools:defs.bzl", "go_library", "go_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+go_library(
+    name = "tpucontrol",
+    srcs = [
+        "control.go",
+        "discovery.go",
+        "errors.go",
+    ],
+    visibility = ["//tools/tpucheckpoint:__pkg__"],
+    deps = [
+        "//pkg/sentry/control:tpu_control_proto_go_proto",
+        "@org_golang_google_protobuf//proto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "tpucontrol_test",
+    size = "small",
+    srcs = [
+        "control_test.go",
+        "discovery_test.go",
+    ],
+    deps = [
+        ":tpucontrol",
+        "//pkg/sentry/control:tpu_control_proto_go_proto",
+        "@org_golang_google_protobuf//proto:go_default_library",
+    ],
+)

--- a/tools/tpucheckpoint/tpucontrol/control.go
+++ b/tools/tpucheckpoint/tpucontrol/control.go
@@ -1,0 +1,257 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpucontrol
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	tpupb "gvisor.dev/gvisor/pkg/sentry/control/tpu_control_proto_go_proto"
+)
+
+const (
+	defaultTimeoutSecs = 180
+
+	// maxResponseBytes bounds the response message size read from the
+	// pipe, as a defense against a corrupted size prefix.
+	maxResponseBytes = 1 << 20
+)
+
+// OpenPipeFile opens a pipe by path. Overridable for tests to supply
+// pre-opened pipes.
+var OpenPipeFile = func(path string, flag int) (*os.File, error) {
+	return os.OpenFile(path, flag, 0)
+}
+
+// Result holds the outcome of an operation on a single PID.
+type Result struct {
+	PID      int
+	Err      error
+	Duration time.Duration
+
+	// State is only set by GetState.
+	State tpupb.RuntimeState
+}
+
+// ParsePIDs parses a comma-separated list of PIDs.
+func ParsePIDs(arg string) ([]int, error) {
+	var pids []int
+	for _, s := range strings.Split(arg, ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		pid, err := strconv.Atoi(s)
+		if err != nil || pid <= 0 {
+			return nil, fmt.Errorf("invalid PID: %q", s)
+		}
+		pids = append(pids, pid)
+	}
+	if len(pids) == 0 {
+		return nil, fmt.Errorf("no PIDs specified")
+	}
+	return pids, nil
+}
+
+// CheckProcessExists verifies that the target process is alive.
+func CheckProcessExists(pid int) error {
+	path := fmt.Sprintf("%s/%d", ProcRoot, pid)
+	if _, err := os.Stat(path); err != nil {
+		return &DiscoveryError{PID: pid, Err: fmt.Errorf("process not found: %w", err)}
+	}
+	return nil
+}
+
+// Checkpoint sends ACTION_CHECKPOINT to all libtpu threads of every PID,
+// concurrently across PIDs. Results are indexed to match pids.
+func Checkpoint(pids []int, timeoutSecs int) []Result {
+	return forEachPID(pids, func(r *Result) {
+		r.Err = controlPid(r.PID, tpupb.ControlAction_ACTION_CHECKPOINT, timeoutSecs)
+	})
+}
+
+// Restore sends ACTION_RESTORE to all libtpu threads of every PID,
+// concurrently across PIDs. Results are indexed to match pids.
+func Restore(pids []int, timeoutSecs int) []Result {
+	return forEachPID(pids, func(r *Result) {
+		r.Err = controlPid(r.PID, tpupb.ControlAction_ACTION_RESTORE, timeoutSecs)
+	})
+}
+
+// GetState sends ACTION_GETSTATE to the first libtpu thread of every PID,
+// concurrently across PIDs. Results are indexed to match pids.
+func GetState(pids []int, timeoutSecs int) []Result {
+	return forEachPID(pids, func(r *Result) {
+		r.State, r.Err = getStatePid(r.PID, timeoutSecs)
+	})
+}
+
+// forEachPID runs op concurrently for every PID and returns the per-PID
+// results, indexed to match pids.
+func forEachPID(pids []int, op func(r *Result)) []Result {
+	results := make([]Result, len(pids))
+
+	var wg sync.WaitGroup
+	for i, pid := range pids {
+		results[i].PID = pid
+		wg.Add(1)
+		go func(r *Result) {
+			defer wg.Done()
+			start := time.Now()
+			op(r)
+			r.Duration = time.Since(start)
+		}(&results[i])
+	}
+	wg.Wait()
+
+	return results
+}
+
+func getStatePid(pid int, timeoutSecs int) (tpupb.RuntimeState, error) {
+	if err := CheckProcessExists(pid); err != nil {
+		return tpupb.RuntimeState_STATE_UNSPECIFIED, err
+	}
+	pipes, err := DiscoverPipes(pid)
+	if err != nil {
+		return tpupb.RuntimeState_STATE_UNSPECIFIED, &DiscoveryError{PID: pid, Err: err}
+	}
+	resp, err := controlOne(pid, pipes[0], tpupb.ControlAction_ACTION_GETSTATE, timeoutSecs)
+	if err != nil {
+		return tpupb.RuntimeState_STATE_UNSPECIFIED, err
+	}
+	return resp.GetCurrentState(), nil
+}
+
+func controlPid(pid int, action tpupb.ControlAction, timeoutSecs int) error {
+	if err := CheckProcessExists(pid); err != nil {
+		return err
+	}
+
+	pipes, err := DiscoverPipes(pid)
+	if err != nil {
+		return &DiscoveryError{PID: pid, Err: err}
+	}
+
+	if timeoutSecs <= 0 {
+		timeoutSecs = defaultTimeoutSecs
+	}
+
+	for _, p := range pipes {
+		if _, err := controlOne(pid, p, action, timeoutSecs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func controlOne(pid int, pipe PipeInfo, action tpupb.ControlAction, timeoutSecs int) (*tpupb.ControlResponse, error) {
+	reqPath := PipePath(pid, pipe.ReqWriteFD)
+	rspPath := PipePath(pid, pipe.RspReadFD)
+
+	reqFile, err := OpenPipeFile(reqPath, os.O_WRONLY)
+	if err != nil {
+		return nil, &ProtocolError{Action: action, TID: pipe.TID, Err: fmt.Errorf("open request pipe %s: %w", reqPath, err)}
+	}
+	defer reqFile.Close()
+
+	rspFile, err := OpenPipeFile(rspPath, os.O_RDONLY)
+	if err != nil {
+		return nil, &ProtocolError{Action: action, TID: pipe.TID, Err: fmt.Errorf("open response pipe %s: %w", rspPath, err)}
+	}
+	defer rspFile.Close()
+
+	if timeoutSecs > 0 {
+		// SetReadDeadline may be unsupported for this FD type; in that
+		// case proceed without a deadline.
+		_ = rspFile.SetReadDeadline(time.Now().Add(time.Duration(timeoutSecs) * time.Second))
+	}
+
+	req := tpupb.ControlRequest_builder{
+		Action:      action.Enum(),
+		TimeoutSecs: proto.Int32(int32(timeoutSecs)),
+	}.Build()
+	reqBytes, err := proto.Marshal(req)
+	if err != nil {
+		return nil, &ProtocolError{Action: action, TID: pipe.TID, Err: fmt.Errorf("marshal request: %w", err)}
+	}
+
+	if err := writeDelimited(reqFile, reqBytes); err != nil {
+		return nil, &ProtocolError{Action: action, TID: pipe.TID, Err: fmt.Errorf("write request: %w", err)}
+	}
+
+	respData, err := readDelimited(rspFile)
+	if err != nil {
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			return nil, &TimeoutError{Action: action, TID: pipe.TID, Err: err}
+		}
+		return nil, &ProtocolError{Action: action, TID: pipe.TID, Err: fmt.Errorf("read response: %w", err)}
+	}
+
+	resp := &tpupb.ControlResponse{}
+	if err := proto.Unmarshal(respData, resp); err != nil {
+		return nil, &ProtocolError{Action: action, TID: pipe.TID, Err: fmt.Errorf("unmarshal response: %w", err)}
+	}
+
+	if !resp.GetSuccess() {
+		return nil, &ControlFailedError{
+			Action:       action,
+			TID:          pipe.TID,
+			CurrentState: resp.GetCurrentState(),
+			ErrorMessage: resp.GetErrorMessage(),
+		}
+	}
+
+	return resp, nil
+}
+
+// writeDelimited writes a protobuf message framed with a 4-byte big-endian
+// size prefix.
+func writeDelimited(w io.Writer, msg []byte) error {
+	var sizeBuf [4]byte
+	binary.BigEndian.PutUint32(sizeBuf[:], uint32(len(msg)))
+	if _, err := w.Write(sizeBuf[:]); err != nil {
+		return fmt.Errorf("write size prefix: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("write message: %w", err)
+	}
+	return nil
+}
+
+// readDelimited reads a protobuf message framed with a 4-byte big-endian
+// size prefix.
+func readDelimited(r io.Reader) ([]byte, error) {
+	var sizeBuf [4]byte
+	if _, err := io.ReadFull(r, sizeBuf[:]); err != nil {
+		return nil, fmt.Errorf("read size prefix: %w", err)
+	}
+	size := binary.BigEndian.Uint32(sizeBuf[:])
+	if size > maxResponseBytes {
+		return nil, fmt.Errorf("message too large: %d bytes", size)
+	}
+	msg := make([]byte, size)
+	if _, err := io.ReadFull(r, msg); err != nil {
+		return nil, fmt.Errorf("read message body (%d bytes): %w", size, err)
+	}
+	return msg, nil
+}

--- a/tools/tpucheckpoint/tpucontrol/control_test.go
+++ b/tools/tpucheckpoint/tpucontrol/control_test.go
@@ -1,0 +1,519 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpucontrol_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	tpupb "gvisor.dev/gvisor/pkg/sentry/control/tpu_control_proto_go_proto"
+	"gvisor.dev/gvisor/tools/tpucheckpoint/tpucontrol"
+)
+
+type pipePair struct {
+	threadName   string
+	reqWriteFD   int
+	rspReadFD    int
+	reqWriteFile *os.File
+	rspReadFile  *os.File
+}
+
+func setupPipeTest(t *testing.T, pid int, pipes []pipePair) {
+	t.Helper()
+	setupMultiPidPipeTest(t, map[int][]pipePair{pid: pipes})
+}
+
+func setupMultiPidPipeTest(t *testing.T, pidPipes map[int][]pipePair) {
+	t.Helper()
+	root := t.TempDir()
+	old := tpucontrol.ProcRoot
+	tpucontrol.ProcRoot = root
+	t.Cleanup(func() { tpucontrol.ProcRoot = old })
+
+	oldOpen := tpucontrol.OpenPipeFile
+	t.Cleanup(func() { tpucontrol.OpenPipeFile = oldOpen })
+
+	fdMap := make(map[string]*os.File)
+	for pid, pipes := range pidPipes {
+		pidDir := filepath.Join(root, strconv.Itoa(pid))
+		if err := os.MkdirAll(pidDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", pidDir, err)
+		}
+
+		for i, pp := range pipes {
+			tid := 1000 + i
+			tidDir := filepath.Join(pidDir, "task", strconv.Itoa(tid))
+			if err := os.MkdirAll(tidDir, 0o755); err != nil {
+				t.Fatalf("MkdirAll(%s): %v", tidDir, err)
+			}
+			if err := os.WriteFile(filepath.Join(tidDir, "comm"), []byte(pp.threadName+"\n"), 0o644); err != nil {
+				t.Fatalf("WriteFile comm: %v", err)
+			}
+
+			fdMap[tpucontrol.PipePath(pid, pp.reqWriteFD)] = pp.reqWriteFile
+			fdMap[tpucontrol.PipePath(pid, pp.rspReadFD)] = pp.rspReadFile
+		}
+	}
+
+	tpucontrol.OpenPipeFile = func(path string, flag int) (*os.File, error) {
+		if f, ok := fdMap[path]; ok {
+			return f, nil
+		}
+		return nil, os.ErrNotExist
+	}
+}
+
+func marshalResponse(t *testing.T, success bool, state tpupb.RuntimeState, errMsg string) []byte {
+	t.Helper()
+	resp := tpupb.ControlResponse_builder{
+		Success:      proto.Bool(success),
+		CurrentState: state.Enum(),
+		ErrorMessage: proto.String(errMsg),
+	}.Build()
+	data, err := proto.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	return data
+}
+
+func writeDelimited(f *os.File, msg []byte) {
+	var sizeBuf [4]byte
+	binary.BigEndian.PutUint32(sizeBuf[:], uint32(len(msg)))
+	f.Write(sizeBuf[:])
+	f.Write(msg)
+}
+
+// readRequest consumes one framed request message from the pipe.
+func readRequest(reqRead *os.File) {
+	var sizeBuf [4]byte
+	if _, err := reqRead.Read(sizeBuf[:]); err != nil {
+		return
+	}
+	size := binary.BigEndian.Uint32(sizeBuf[:])
+	discard := make([]byte, size)
+	reqRead.Read(discard)
+}
+
+func mockResponder(t *testing.T, reqRead, rspWrite *os.File, success bool, state tpupb.RuntimeState, errMsg string) {
+	t.Helper()
+	resp := marshalResponse(t, success, state, errMsg)
+	go func() {
+		defer rspWrite.Close()
+		readRequest(reqRead)
+		writeDelimited(rspWrite, resp)
+	}()
+}
+
+func TestParsePIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		want    []int
+		wantErr bool
+	}{
+		{"single", "123", []int{123}, false},
+		{"multiple", "123,456,789", []int{123, 456, 789}, false},
+		{"whitespace", " 123 , 456 ", []int{123, 456}, false},
+		{"trailing_comma", "123,456,", []int{123, 456}, false},
+		{"empty", "", nil, true},
+		{"only_commas", ",,", nil, true},
+		{"non_numeric", "abc", nil, true},
+		{"mixed_invalid", "123,abc", nil, true},
+		{"negative", "-1", nil, true},
+		{"zero", "0", nil, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tpucontrol.ParsePIDs(tc.arg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParsePIDs(%q) = %v, want error", tc.arg, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePIDs(%q) error = %v", tc.arg, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParsePIDs(%q) = %v, want %v", tc.arg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckpointSuccess(t *testing.T) {
+	reqRead, reqWrite, _ := os.Pipe()
+	rspRead, rspWrite, _ := os.Pipe()
+	defer reqRead.Close()
+
+	setupPipeTest(t, 42, []pipePair{{
+		threadName:   "libtpu00010002",
+		reqWriteFD:   1,
+		rspReadFD:    2,
+		reqWriteFile: reqWrite,
+		rspReadFile:  rspRead,
+	}})
+
+	mockResponder(t, reqRead, rspWrite, true, tpupb.RuntimeState_STATE_DETACHED, "")
+
+	results := tpucontrol.Checkpoint([]int{42}, 10)
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Err != nil {
+		t.Fatalf("Checkpoint() error = %v", results[0].Err)
+	}
+	if results[0].PID != 42 {
+		t.Errorf("results[0].PID = %d, want 42", results[0].PID)
+	}
+}
+
+func TestRestoreSuccess(t *testing.T) {
+	reqRead, reqWrite, _ := os.Pipe()
+	rspRead, rspWrite, _ := os.Pipe()
+	defer reqRead.Close()
+
+	setupPipeTest(t, 42, []pipePair{{
+		threadName:   "libtpu00010002",
+		reqWriteFD:   1,
+		rspReadFD:    2,
+		reqWriteFile: reqWrite,
+		rspReadFile:  rspRead,
+	}})
+
+	mockResponder(t, reqRead, rspWrite, true, tpupb.RuntimeState_STATE_RUNNING, "")
+
+	results := tpucontrol.Restore([]int{42}, 10)
+	if results[0].Err != nil {
+		t.Fatalf("Restore() error = %v", results[0].Err)
+	}
+}
+
+func TestGetStateSuccess(t *testing.T) {
+	reqRead, reqWrite, _ := os.Pipe()
+	rspRead, rspWrite, _ := os.Pipe()
+	defer reqRead.Close()
+
+	setupPipeTest(t, 42, []pipePair{{
+		threadName:   "libtpu00010002",
+		reqWriteFD:   1,
+		rspReadFD:    2,
+		reqWriteFile: reqWrite,
+		rspReadFile:  rspRead,
+	}})
+
+	mockResponder(t, reqRead, rspWrite, true, tpupb.RuntimeState_STATE_DETACHED, "")
+
+	results := tpucontrol.GetState([]int{42}, 10)
+	if results[0].Err != nil {
+		t.Fatalf("GetState() error = %v", results[0].Err)
+	}
+	if results[0].State != tpupb.RuntimeState_STATE_DETACHED {
+		t.Errorf("GetState() = %v, want %v", results[0].State, tpupb.RuntimeState_STATE_DETACHED)
+	}
+}
+
+func TestControlFailureResponse(t *testing.T) {
+	reqRead, reqWrite, _ := os.Pipe()
+	rspRead, rspWrite, _ := os.Pipe()
+	defer reqRead.Close()
+
+	setupPipeTest(t, 42, []pipePair{{
+		threadName:   "libtpu00010002",
+		reqWriteFD:   1,
+		rspReadFD:    2,
+		reqWriteFile: reqWrite,
+		rspReadFile:  rspRead,
+	}})
+
+	mockResponder(t, reqRead, rspWrite, false, tpupb.RuntimeState_STATE_FAULTED, "device busy")
+
+	results := tpucontrol.Checkpoint([]int{42}, 10)
+	if results[0].Err == nil {
+		t.Fatal("expected error for failure response")
+	}
+
+	var cfe *tpucontrol.ControlFailedError
+	if !errors.As(results[0].Err, &cfe) {
+		t.Fatalf("expected ControlFailedError, got %T: %v", results[0].Err, results[0].Err)
+	}
+	if cfe.ErrorMessage != "device busy" {
+		t.Errorf("ErrorMessage = %q, want %q", cfe.ErrorMessage, "device busy")
+	}
+	if cfe.CurrentState != tpupb.RuntimeState_STATE_FAULTED {
+		t.Errorf("CurrentState = %v, want %v", cfe.CurrentState, tpupb.RuntimeState_STATE_FAULTED)
+	}
+}
+
+func TestControlTimeout(t *testing.T) {
+	reqRead, reqWrite, _ := os.Pipe()
+	rspRead, rspWrite, _ := os.Pipe()
+	defer reqRead.Close()
+	defer rspWrite.Close()
+
+	setupPipeTest(t, 42, []pipePair{{
+		threadName:   "libtpu00010002",
+		reqWriteFD:   1,
+		rspReadFD:    2,
+		reqWriteFile: reqWrite,
+		rspReadFile:  rspRead,
+	}})
+
+	// Read the request but never write a response.
+	go func() {
+		readRequest(reqRead)
+		time.Sleep(5 * time.Second)
+	}()
+
+	results := tpucontrol.Checkpoint([]int{42}, 1)
+	if results[0].Err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	var te *tpucontrol.TimeoutError
+	if !errors.As(results[0].Err, &te) {
+		// Pipe deadlines may surface as a ProtocolError on some kernels.
+		var pe *tpucontrol.ProtocolError
+		if !errors.As(results[0].Err, &pe) {
+			t.Fatalf("expected TimeoutError or ProtocolError, got %T: %v", results[0].Err, results[0].Err)
+		}
+	}
+}
+
+func TestControlPipeClosed(t *testing.T) {
+	reqRead, reqWrite, _ := os.Pipe()
+	rspRead, rspWrite, _ := os.Pipe()
+	defer reqRead.Close()
+
+	setupPipeTest(t, 42, []pipePair{{
+		threadName:   "libtpu00010002",
+		reqWriteFD:   1,
+		rspReadFD:    2,
+		reqWriteFile: reqWrite,
+		rspReadFile:  rspRead,
+	}})
+
+	// Read the request, then close the response pipe without writing.
+	go func() {
+		readRequest(reqRead)
+		rspWrite.Close()
+	}()
+
+	results := tpucontrol.Checkpoint([]int{42}, 10)
+	if results[0].Err == nil {
+		t.Fatal("expected error for closed pipe")
+	}
+
+	var pe *tpucontrol.ProtocolError
+	if !errors.As(results[0].Err, &pe) {
+		t.Fatalf("expected ProtocolError, got %T: %v", results[0].Err, results[0].Err)
+	}
+}
+
+func TestControlCorruptedResponse(t *testing.T) {
+	reqRead, reqWrite, _ := os.Pipe()
+	rspRead, rspWrite, _ := os.Pipe()
+	defer reqRead.Close()
+
+	setupPipeTest(t, 42, []pipePair{{
+		threadName:   "libtpu00010002",
+		reqWriteFD:   1,
+		rspReadFD:    2,
+		reqWriteFile: reqWrite,
+		rspReadFile:  rspRead,
+	}})
+
+	go func() {
+		defer rspWrite.Close()
+		readRequest(reqRead)
+
+		// Valid size prefix but a truncated varint payload.
+		writeDelimited(rspWrite, []byte{0x08})
+	}()
+
+	results := tpucontrol.Checkpoint([]int{42}, 10)
+	if results[0].Err == nil {
+		t.Fatal("expected error for corrupted response")
+	}
+
+	var pe *tpucontrol.ProtocolError
+	if !errors.As(results[0].Err, &pe) {
+		t.Fatalf("expected ProtocolError, got %T: %v", results[0].Err, results[0].Err)
+	}
+}
+
+func TestControlAllMultipleThreads(t *testing.T) {
+	reqRead1, reqWrite1, _ := os.Pipe()
+	rspRead1, rspWrite1, _ := os.Pipe()
+	reqRead2, reqWrite2, _ := os.Pipe()
+	rspRead2, rspWrite2, _ := os.Pipe()
+	defer reqRead1.Close()
+	defer reqRead2.Close()
+
+	setupPipeTest(t, 42, []pipePair{
+		{threadName: "libtpu00010002", reqWriteFD: 1, rspReadFD: 2, reqWriteFile: reqWrite1, rspReadFile: rspRead1},
+		{threadName: "libtpu00030004", reqWriteFD: 3, rspReadFD: 4, reqWriteFile: reqWrite2, rspReadFile: rspRead2},
+	})
+
+	mockResponder(t, reqRead1, rspWrite1, true, tpupb.RuntimeState_STATE_DETACHED, "")
+	mockResponder(t, reqRead2, rspWrite2, true, tpupb.RuntimeState_STATE_DETACHED, "")
+
+	results := tpucontrol.Checkpoint([]int{42}, 10)
+	if results[0].Err != nil {
+		t.Fatalf("Checkpoint() error = %v", results[0].Err)
+	}
+}
+
+func TestControlAllFirstFails(t *testing.T) {
+	reqRead1, reqWrite1, _ := os.Pipe()
+	rspRead1, rspWrite1, _ := os.Pipe()
+	reqRead2, reqWrite2, _ := os.Pipe()
+	rspRead2, rspWrite2, _ := os.Pipe()
+	defer reqRead1.Close()
+	defer reqRead2.Close()
+	defer rspWrite2.Close()
+
+	setupPipeTest(t, 42, []pipePair{
+		{threadName: "libtpu00010002", reqWriteFD: 1, rspReadFD: 2, reqWriteFile: reqWrite1, rspReadFile: rspRead1},
+		{threadName: "libtpu00030004", reqWriteFD: 3, rspReadFD: 4, reqWriteFile: reqWrite2, rspReadFile: rspRead2},
+	})
+
+	// The first thread fails; the operation should report the failure.
+	mockResponder(t, reqRead1, rspWrite1, false, tpupb.RuntimeState_STATE_FAULTED, "device error")
+
+	results := tpucontrol.Checkpoint([]int{42}, 10)
+	if results[0].Err == nil {
+		t.Fatal("expected error when first thread fails")
+	}
+
+	var cfe *tpucontrol.ControlFailedError
+	if !errors.As(results[0].Err, &cfe) {
+		t.Fatalf("expected ControlFailedError, got %T: %v", results[0].Err, results[0].Err)
+	}
+}
+
+// TestCheckpointMultiplePIDs checkpoints two processes at once and proves
+// the PIDs are handled concurrently: each mock responder waits for BOTH
+// requests to arrive before responding, which deadlocks (and times out the
+// test) if PIDs are processed sequentially.
+func TestCheckpointMultiplePIDs(t *testing.T) {
+	reqRead1, reqWrite1, _ := os.Pipe()
+	rspRead1, rspWrite1, _ := os.Pipe()
+	reqRead2, reqWrite2, _ := os.Pipe()
+	rspRead2, rspWrite2, _ := os.Pipe()
+	defer reqRead1.Close()
+	defer reqRead2.Close()
+
+	setupMultiPidPipeTest(t, map[int][]pipePair{
+		41: {{threadName: "libtpu00010002", reqWriteFD: 1, rspReadFD: 2, reqWriteFile: reqWrite1, rspReadFile: rspRead1}},
+		42: {{threadName: "libtpu00030004", reqWriteFD: 3, rspReadFD: 4, reqWriteFile: reqWrite2, rspReadFile: rspRead2}},
+	})
+
+	var barrier sync.WaitGroup
+	barrier.Add(2)
+	resp := marshalResponse(t, true, tpupb.RuntimeState_STATE_DETACHED, "")
+	for _, p := range []struct{ reqRead, rspWrite *os.File }{
+		{reqRead1, rspWrite1},
+		{reqRead2, rspWrite2},
+	} {
+		go func(reqRead, rspWrite *os.File) {
+			defer rspWrite.Close()
+			readRequest(reqRead)
+			barrier.Done()
+			barrier.Wait()
+			writeDelimited(rspWrite, resp)
+		}(p.reqRead, p.rspWrite)
+	}
+
+	results := tpucontrol.Checkpoint([]int{41, 42}, 10)
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	for _, r := range results {
+		if r.Err != nil {
+			t.Errorf("pid %d: Checkpoint() error = %v", r.PID, r.Err)
+		}
+	}
+}
+
+// TestCheckpointMultiplePIDsPartialFailure verifies that per-PID results
+// are indexed to match the input and that one PID's failure doesn't affect
+// the others.
+func TestCheckpointMultiplePIDsPartialFailure(t *testing.T) {
+	reqRead1, reqWrite1, _ := os.Pipe()
+	rspRead1, rspWrite1, _ := os.Pipe()
+	reqRead2, reqWrite2, _ := os.Pipe()
+	rspRead2, rspWrite2, _ := os.Pipe()
+	defer reqRead1.Close()
+	defer reqRead2.Close()
+
+	setupMultiPidPipeTest(t, map[int][]pipePair{
+		41: {{threadName: "libtpu00010002", reqWriteFD: 1, rspReadFD: 2, reqWriteFile: reqWrite1, rspReadFile: rspRead1}},
+		42: {{threadName: "libtpu00030004", reqWriteFD: 3, rspReadFD: 4, reqWriteFile: reqWrite2, rspReadFile: rspRead2}},
+	})
+
+	mockResponder(t, reqRead1, rspWrite1, true, tpupb.RuntimeState_STATE_DETACHED, "")
+	mockResponder(t, reqRead2, rspWrite2, false, tpupb.RuntimeState_STATE_FAULTED, "device busy")
+
+	results := tpucontrol.Checkpoint([]int{41, 42}, 10)
+	if results[0].PID != 41 || results[1].PID != 42 {
+		t.Fatalf("results out of order: %d, %d", results[0].PID, results[1].PID)
+	}
+	if results[0].Err != nil {
+		t.Errorf("pid 41: unexpected error %v", results[0].Err)
+	}
+	if results[1].Err == nil {
+		t.Error("pid 42: expected error")
+	}
+	var cfe *tpucontrol.ControlFailedError
+	if !errors.As(results[1].Err, &cfe) {
+		t.Fatalf("expected ControlFailedError, got %T: %v", results[1].Err, results[1].Err)
+	}
+}
+
+func TestCheckProcessExists(t *testing.T) {
+	root := t.TempDir()
+	old := tpucontrol.ProcRoot
+	tpucontrol.ProcRoot = root
+	defer func() { tpucontrol.ProcRoot = old }()
+
+	// PID doesn't exist.
+	err := tpucontrol.CheckProcessExists(12345)
+	if err == nil {
+		t.Error("expected error for non-existent PID")
+	}
+	var de *tpucontrol.DiscoveryError
+	if !errors.As(err, &de) {
+		t.Fatalf("expected DiscoveryError, got %T", err)
+	}
+
+	// Create the PID dir.
+	if err := os.MkdirAll(filepath.Join(root, "12345"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := tpucontrol.CheckProcessExists(12345); err != nil {
+		t.Errorf("unexpected error for existing PID: %v", err)
+	}
+}

--- a/tools/tpucheckpoint/tpucontrol/discovery.go
+++ b/tools/tpucheckpoint/tpucontrol/discovery.go
@@ -1,0 +1,109 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tpucontrol implements a host-side client for the libtpu
+// checkpoint/restore control protocol.
+//
+// libtpu advertises its control channel by naming a thread
+// "libtpu{XXXXYYYY}", where XXXX and YYYY are the hex-encoded file
+// descriptor numbers of the request-write and response-read pipes. This
+// package discovers those threads via /proc and exchanges length-delimited
+// protobuf messages over the pipes.
+package tpucontrol
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const threadNamePrefix = "libtpu"
+
+// ProcRoot is the base path for /proc. Overridable for tests.
+var ProcRoot = "/proc"
+
+// PipeInfo holds the pipe file descriptor numbers extracted from a libtpu
+// thread name.
+type PipeInfo struct {
+	TID        int
+	ThreadName string
+	ReqWriteFD int
+	RspReadFD  int
+}
+
+// DiscoverPipes scans /proc/<pid>/task/*/comm for threads named
+// "libtpu{XXXXYYYY}" and extracts the pipe FD numbers encoded in the hex
+// suffix.
+func DiscoverPipes(pid int) ([]PipeInfo, error) {
+	taskDir := fmt.Sprintf("%s/%d/task", ProcRoot, pid)
+	entries, err := os.ReadDir(taskDir)
+	if err != nil {
+		return nil, fmt.Errorf("read task dir %s: %w", taskDir, err)
+	}
+
+	var pipes []PipeInfo
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		tid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+
+		commPath := filepath.Join(taskDir, e.Name(), "comm")
+		data, err := os.ReadFile(commPath)
+		if err != nil {
+			continue
+		}
+		name := strings.TrimSpace(string(data))
+
+		if !strings.HasPrefix(name, threadNamePrefix) {
+			continue
+		}
+		hexSuffix := strings.TrimPrefix(name, threadNamePrefix)
+		if len(hexSuffix) != 8 {
+			continue
+		}
+
+		reqFD, err := strconv.ParseInt(hexSuffix[:4], 16, 32)
+		if err != nil {
+			continue
+		}
+		rspFD, err := strconv.ParseInt(hexSuffix[4:], 16, 32)
+		if err != nil {
+			continue
+		}
+
+		pipes = append(pipes, PipeInfo{
+			TID:        tid,
+			ThreadName: name,
+			ReqWriteFD: int(reqFD),
+			RspReadFD:  int(rspFD),
+		})
+	}
+
+	if len(pipes) == 0 {
+		return nil, fmt.Errorf("no libtpu threads found for PID %d", pid)
+	}
+	return pipes, nil
+}
+
+// PipePath returns the /proc path used to access a file descriptor of
+// another process.
+func PipePath(pid, fd int) string {
+	return fmt.Sprintf("%s/%d/fd/%d", ProcRoot, pid, fd)
+}

--- a/tools/tpucheckpoint/tpucontrol/discovery_test.go
+++ b/tools/tpucheckpoint/tpucontrol/discovery_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpucontrol_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"gvisor.dev/gvisor/tools/tpucheckpoint/tpucontrol"
+)
+
+func setupFakeProc(t *testing.T, pid int, threads map[int]string) string {
+	t.Helper()
+	root := t.TempDir()
+	old := tpucontrol.ProcRoot
+	tpucontrol.ProcRoot = root
+	t.Cleanup(func() { tpucontrol.ProcRoot = old })
+
+	pidDir := filepath.Join(root, strconv.Itoa(pid))
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", pidDir, err)
+	}
+
+	for tid, name := range threads {
+		tidDir := filepath.Join(pidDir, "task", strconv.Itoa(tid))
+		if err := os.MkdirAll(tidDir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", tidDir, err)
+		}
+		if err := os.WriteFile(filepath.Join(tidDir, "comm"), []byte(name+"\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile comm: %v", err)
+		}
+	}
+	return root
+}
+
+func TestDiscoverPipesSingleThread(t *testing.T) {
+	setupFakeProc(t, 1234, map[int]string{
+		100: "libtpu00010002",
+	})
+
+	pipes, err := tpucontrol.DiscoverPipes(1234)
+	if err != nil {
+		t.Fatalf("DiscoverPipes() error = %v", err)
+	}
+	if len(pipes) != 1 {
+		t.Fatalf("got %d pipes, want 1", len(pipes))
+	}
+	if pipes[0].ReqWriteFD != 1 {
+		t.Errorf("ReqWriteFD = %d, want 1", pipes[0].ReqWriteFD)
+	}
+	if pipes[0].RspReadFD != 2 {
+		t.Errorf("RspReadFD = %d, want 2", pipes[0].RspReadFD)
+	}
+	if pipes[0].TID != 100 {
+		t.Errorf("TID = %d, want 100", pipes[0].TID)
+	}
+	if pipes[0].ThreadName != "libtpu00010002" {
+		t.Errorf("ThreadName = %q, want %q", pipes[0].ThreadName, "libtpu00010002")
+	}
+}
+
+func TestDiscoverPipesMultipleThreads(t *testing.T) {
+	setupFakeProc(t, 5678, map[int]string{
+		200: "libtpu00030004",
+		201: "libtpu00050006",
+		202: "libtpu00070008",
+	})
+
+	pipes, err := tpucontrol.DiscoverPipes(5678)
+	if err != nil {
+		t.Fatalf("DiscoverPipes() error = %v", err)
+	}
+	if len(pipes) != 3 {
+		t.Fatalf("got %d pipes, want 3", len(pipes))
+	}
+}
+
+func TestDiscoverPipesLargeHexFDs(t *testing.T) {
+	setupFakeProc(t, 1000, map[int]string{
+		300: "libtpu035f0360",
+	})
+
+	pipes, err := tpucontrol.DiscoverPipes(1000)
+	if err != nil {
+		t.Fatalf("DiscoverPipes() error = %v", err)
+	}
+	if len(pipes) != 1 {
+		t.Fatalf("got %d pipes, want 1", len(pipes))
+	}
+	if pipes[0].ReqWriteFD != 0x035f {
+		t.Errorf("ReqWriteFD = %d, want %d", pipes[0].ReqWriteFD, 0x035f)
+	}
+	if pipes[0].RspReadFD != 0x0360 {
+		t.Errorf("RspReadFD = %d, want %d", pipes[0].RspReadFD, 0x0360)
+	}
+}
+
+func TestDiscoverPipesInvalidHex(t *testing.T) {
+	setupFakeProc(t, 1234, map[int]string{
+		100: "libtpuZZZZYYYY",
+	})
+
+	if _, err := tpucontrol.DiscoverPipes(1234); err == nil {
+		t.Error("expected error for invalid hex suffix")
+	}
+}
+
+func TestDiscoverPipesWrongSuffixLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		threadName string
+	}{
+		{"too_short", "libtpu123"},
+		{"too_long", "libtpu1234567890"},
+		{"just_prefix", "libtpu"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setupFakeProc(t, 1234, map[int]string{
+				100: tc.threadName,
+			})
+			if _, err := tpucontrol.DiscoverPipes(1234); err == nil {
+				t.Errorf("expected error for thread name %q", tc.threadName)
+			}
+		})
+	}
+}
+
+func TestDiscoverPipesNoLibtpuThreads(t *testing.T) {
+	setupFakeProc(t, 1234, map[int]string{
+		100: "main",
+		101: "worker-1",
+		102: "python3",
+	})
+
+	if _, err := tpucontrol.DiscoverPipes(1234); err == nil {
+		t.Error("expected error when no libtpu threads present")
+	}
+}
+
+func TestDiscoverPipesMixedThreads(t *testing.T) {
+	setupFakeProc(t, 1234, map[int]string{
+		100: "main",
+		101: "libtpu00010002",
+		102: "worker-1",
+		103: "libtpu00030004",
+		104: "python3",
+		105: "libtpuZZZZ0001", // Invalid hex, should be skipped.
+		106: "libtpu123",      // Wrong length, should be skipped.
+	})
+
+	pipes, err := tpucontrol.DiscoverPipes(1234)
+	if err != nil {
+		t.Fatalf("DiscoverPipes() error = %v", err)
+	}
+	if len(pipes) != 2 {
+		t.Fatalf("got %d pipes, want 2 (valid libtpu threads only)", len(pipes))
+	}
+}
+
+func TestDiscoverPipesNonExistentPID(t *testing.T) {
+	root := t.TempDir()
+	old := tpucontrol.ProcRoot
+	tpucontrol.ProcRoot = root
+	t.Cleanup(func() { tpucontrol.ProcRoot = old })
+
+	if _, err := tpucontrol.DiscoverPipes(99999); err == nil {
+		t.Error("expected error for non-existent PID")
+	}
+}
+
+func TestDiscoverPipesEmptyCommFile(t *testing.T) {
+	setupFakeProc(t, 1234, map[int]string{
+		100: "",
+	})
+
+	if _, err := tpucontrol.DiscoverPipes(1234); err == nil {
+		t.Error("expected error for empty comm file")
+	}
+}
+
+func TestPipePath(t *testing.T) {
+	old := tpucontrol.ProcRoot
+	tpucontrol.ProcRoot = "/proc"
+	defer func() { tpucontrol.ProcRoot = old }()
+
+	got := tpucontrol.PipePath(1234, 5)
+	want := "/proc/1234/fd/5"
+	if got != want {
+		t.Errorf("PipePath(1234, 5) = %q, want %q", got, want)
+	}
+}

--- a/tools/tpucheckpoint/tpucontrol/errors.go
+++ b/tools/tpucheckpoint/tpucontrol/errors.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tpucontrol
+
+import (
+	"fmt"
+	"strings"
+
+	tpupb "gvisor.dev/gvisor/pkg/sentry/control/tpu_control_proto_go_proto"
+)
+
+// actionName returns a short lower-case name for a control action, e.g.
+// "checkpoint" for ACTION_CHECKPOINT.
+func actionName(a tpupb.ControlAction) string {
+	return strings.ToLower(strings.TrimPrefix(a.String(), "ACTION_"))
+}
+
+// DiscoveryError indicates failure to find libtpu control threads.
+type DiscoveryError struct {
+	PID int
+	Err error
+}
+
+// Error implements error.Error.
+func (e *DiscoveryError) Error() string {
+	return fmt.Sprintf("discovery for PID %d: %v", e.PID, e.Err)
+}
+
+// Unwrap supports errors.Is/As.
+func (e *DiscoveryError) Unwrap() error { return e.Err }
+
+// TimeoutError indicates the operation timed out waiting for a response.
+type TimeoutError struct {
+	Action tpupb.ControlAction
+	TID    int
+	Err    error
+}
+
+// Error implements error.Error.
+func (e *TimeoutError) Error() string {
+	return fmt.Sprintf("%s timed out on thread %d: %v", actionName(e.Action), e.TID, e.Err)
+}
+
+// Unwrap supports errors.Is/As.
+func (e *TimeoutError) Unwrap() error { return e.Err }
+
+// ProtocolError indicates a wire-format or response parsing failure.
+type ProtocolError struct {
+	Action tpupb.ControlAction
+	TID    int
+	Err    error
+}
+
+// Error implements error.Error.
+func (e *ProtocolError) Error() string {
+	return fmt.Sprintf("%s protocol error on thread %d: %v", actionName(e.Action), e.TID, e.Err)
+}
+
+// Unwrap supports errors.Is/As.
+func (e *ProtocolError) Unwrap() error { return e.Err }
+
+// ControlFailedError indicates libtpu returned success=false.
+type ControlFailedError struct {
+	Action       tpupb.ControlAction
+	TID          int
+	CurrentState tpupb.RuntimeState
+	ErrorMessage string
+}
+
+// Error implements error.Error.
+func (e *ControlFailedError) Error() string {
+	if e.ErrorMessage != "" {
+		return fmt.Sprintf("%s failed on thread %d: %s", actionName(e.Action), e.TID, e.ErrorMessage)
+	}
+	return fmt.Sprintf("%s failed on thread %d: state=%s", actionName(e.Action), e.TID, e.CurrentState)
+}


### PR DESCRIPTION
Host-side CLI for driving the libtpu checkpoint/restore pipe protocol against unsandboxed processes.

Useful for testing libtpu C/R builds and debugging the control path without a full runsc save cycle. Discovers libtpu control threads via /proc, speaks the same tpu_control.proto framing.

Tested against libtpu on v5e-8 hardware.