### PR TITLE
lisafs: Use uint64 for the NumBytes bounds check in PReadResp.CheckedUnmarshal.

### DIFF
--- a/pkg/lisafs/message.go
+++ b/pkg/lisafs/message.go
@@ -911,7 +911,7 @@ func (r *PReadResp) MarshalBytes(dst []byte) []byte {
 // CheckedUnmarshal implements marshal.CheckedMarshallable.CheckedUnmarshal.
 func (r *PReadResp) CheckedUnmarshal(src []byte) ([]byte, bool) {
 	srcRemain, ok := r.NumBytes.CheckedUnmarshal(src)
-	if !ok || uint32(r.NumBytes) > uint32(len(srcRemain)) || uint32(r.NumBytes) > uint32(len(r.Buf)) {
+	if !ok || uint64(r.NumBytes) > uint64(len(srcRemain)) || uint64(r.NumBytes) > uint64(len(r.Buf)) {
 		return src, false
 	}
 


### PR DESCRIPTION
This fixes a panic in lisafs when a malformed PReadResp frame contains a NumBytes value with high bits set.

The root cause was a bounds check that compared NumBytes after truncating it to uint32, while the later slice used the full uint64 value. That allowed invalid lengths to pass validation and triggered a slice-bounds panic.

Fixes #14424
