### PR TITLE
`CODEOWNERS`: Limit to a few security-sensitive areas.

### DIFF
--- a/.agents/skills/update-gvisor-maintainers/SKILL.md
+++ b/.agents/skills/update-gvisor-maintainers/SKILL.md
@@ -32,9 +32,22 @@ Each entry under `maintainers:`:
         until: 2025-03-01
     started: 2018-05-08         # First contribution. The list is sorted by this.
     status: HIATUS_SINCE:2026-07-17
-    codeowner: true             # Required. Owns / in CODEOWNERS. false for emeritus.
     areas: [gpu, networking]    # Optional. Sorted area names from areas.yaml;
-                                # grants CODEOWNERS ownership of the areas' paths.
+                                # grants CODEOWNERS ownership of the paths of
+                                # areas with enforced_review. Not for emeritus.
+```
+
+Each entry under `areas:` in `areas.yaml`:
+
+```yaml
+  - name: gpu                   # Sorted by name.
+    enforced_review: false      # Required. `true` generates a CODEOWNERS
+                                # section for the area, making
+                                # specialized-maintainer review mandatory.
+                                # Needs at least one non-emeritus maintainer
+                                # with the area.
+    paths:                      # Repo-root-relative dirs (/like/this), no
+      - /images/gpu             # trailing slash. Each path in one area only.
 ```
 
 `status` is one of three, and it drives everything downstream:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,122 +1,12 @@
 # Generated from governance/maintainers.yaml and governance/areas.yaml by
 # //governance/tools/maintainers:maintainers_gen; do not edit directly.
 
-# Area: benchmarks
-/images/benchmarks/ @etienneperot @zkoopmans
-/runsc/profile/ @etienneperot @zkoopmans
-/test/benchmarks/ @etienneperot @zkoopmans
-/test/perf/ @etienneperot @zkoopmans
-/tools/bigquery/ @etienneperot @zkoopmans
-/tools/parsers/ @etienneperot @zkoopmans
-/tools/profiletool/ @etienneperot @zkoopmans
-
-# Area: checkpointing
-/pkg/aio/ @nixprime
-/pkg/compressio/ @nixprime
-/pkg/sentry/checkpoint/ @nixprime
-/pkg/sentry/fscheckpoint/ @nixprime
-/pkg/sentry/state/ @nixprime
-/pkg/state/ @nixprime
-/runsc/checkpointgofer/ @nixprime
-/tools/go_stateify/ @nixprime
-
-# Area: fuse
-/images/fuse/ @manninglucas
-/pkg/sentry/fsimpl/fuse/ @manninglucas
-/test/fuse_host/ @manninglucas
-
-# Area: gpu
-/images/gpu/ @parth-opensrc
-/pkg/sentry/devices/nvproxy/ @parth-opensrc
-/test/gpu/ @parth-opensrc
-/tools/gpu/ @parth-opensrc
-/tools/ioctl_sniffer/ @parth-opensrc
-/tools/nvidia_driver_differ/ @parth-opensrc
-
-# Area: kubernetes
-/test/kubernetes/ @etienneperot @zkoopmans
-/tools/gvisor_k8s_tool/ @etienneperot @zkoopmans
-/webhook/ @etienneperot @zkoopmans
-
-# Area: metrics
-/pkg/metric/ @etienneperot
-/pkg/prometheus/ @etienneperot
-/runsc/cmd/metricserver/ @etienneperot
-/runsc/metricserver/ @etienneperot
-/test/metricclient/ @etienneperot
-/test/metricsviz/ @etienneperot
-
-# Area: mm
-/pkg/memutil/ @nixprime
-/pkg/safecopy/ @nixprime
-/pkg/safemem/ @nixprime
-/pkg/sentry/hostmm/ @nixprime
-/pkg/sentry/memmap/ @nixprime
-/pkg/sentry/mm/ @nixprime
-/pkg/sentry/pgalloc/ @nixprime
-/pkg/sentry/usage/ @nixprime
-/pkg/usermem/ @nixprime
-
-# Area: networking
-/images/iptables/ @manninglucas @nybidari
-/images/nftables/ @manninglucas @nybidari
-/images/packetdrill/ @manninglucas @nybidari
-/pkg/ebpf/ @manninglucas @nybidari
-/pkg/rawfile/ @manninglucas @nybidari
-/pkg/sentry/inet/ @manninglucas @nybidari
-/pkg/sentry/socket/ @manninglucas @nybidari
-/pkg/tcpip/ @manninglucas @nybidari
-/pkg/xdp/ @manninglucas @nybidari
-/test/iptables/ @manninglucas @nybidari
-/test/netutils/ @manninglucas @nybidari
-/test/nftables/ @manninglucas @nybidari
-/test/packetdrill/ @manninglucas @nybidari
-/test/packetimpact/ @manninglucas @nybidari
-/test/rtnetlink/ @manninglucas @nybidari
-/tools/gvisor2pcap/ @manninglucas @nybidari
-/tools/xdp/ @manninglucas @nybidari
-
-# Area: oci
-/pkg/shim/ @etienneperot @fvoznika
-/runsc/container/ @etienneperot @fvoznika
-/runsc/specutils/ @etienneperot @fvoznika
-/shim/ @etienneperot @fvoznika
-
-# Area: platform_kvm
-/pkg/sentry/platform/kvm/ @konstantin-s-bogom @nixprime
-
-# Area: platform_ptrace
-/pkg/sentry/platform/ptrace/ @konstantin-s-bogom @nixprime
-
-# Area: platform_systrap
-/pkg/sentry/platform/systrap/ @konstantin-s-bogom @nixprime
-
-# Area: platforms
-/pkg/ring0/ @konstantin-s-bogom @nixprime
-/pkg/sentry/platform/ @konstantin-s-bogom @nixprime
-/pkg/sigframe/ @konstantin-s-bogom @nixprime
-
 # Area: release_pipeline
 /.buildkite/ @etienneperot @relkochta
 /.github/ @etienneperot @relkochta
 /debian/ @etienneperot @relkochta
 /images/agent/ @etienneperot @relkochta
 /tools/github/ @etienneperot @relkochta
-
-# Area: runsc
-/runsc/ @etienneperot @fvoznika
-
-# Area: runtime_monitoring
-/examples/seccheck/ @fvoznika @xinzhong
-/pkg/eventchannel/ @fvoznika @xinzhong
-/pkg/seccheck/ @fvoznika @xinzhong
-/pkg/sentry/seccheck/ @fvoznika @xinzhong
-/test/trace/ @fvoznika @xinzhong
-/tools/tracereplay/ @fvoznika @xinzhong
-
-# Area: sandboxexec
-/examples/sandboxexec/ @carzh @manninglucas @milantracy
-/sandboxexec/ @carzh @manninglucas @milantracy
 
 # Area: seccomp
 /pkg/bpf/ @etienneperot @fvoznika
@@ -125,28 +15,3 @@
 /runsc/fsgofer/filter/ @etienneperot @fvoznika
 /test/secbench/ @etienneperot @fvoznika
 /test/secfuzz/ @etienneperot @fvoznika
-
-# Area: sentry
-/pkg/sentry/ @nixprime
-/vdso/ @nixprime
-
-# Area: tpu
-/images/tpu/ @manninglucas @milantracy
-/pkg/sentry/devices/tpuproxy/ @manninglucas @milantracy
-/test/tpu/ @manninglucas @milantracy
-/tools/tpu/ @manninglucas @milantracy
-
-# Area: vfs
-/pkg/fspath/ @manninglucas @nixprime
-/pkg/lisafs/ @manninglucas @nixprime
-/pkg/p9/ @manninglucas @nixprime
-/pkg/sentry/fsimpl/ @manninglucas @nixprime
-/pkg/sentry/fsutil/ @manninglucas @nixprime
-/pkg/sentry/vfs/ @manninglucas @nixprime
-/runsc/fsgofer/ @manninglucas @nixprime
-/test/fsstress/ @manninglucas @nixprime
-
-# Area: website
-/g3doc/ @etienneperot
-/images/jekyll/ @etienneperot
-/website/ @etienneperot

--- a/governance/areas.yaml
+++ b/governance/areas.yaml
@@ -3,11 +3,14 @@
 # Each area maps a name to the set of repository paths that it covers.
 #
 # Area fields:
-#   name:   Area name. Areas must be sorted by name.
-#   paths:  Repo-root-relative directories (each starting with a slash, no
-#           trailing slash) covered by the area.
+#   name:             Area name. Areas must be sorted by name.
+#   enforced_review:  Whether the area gets a CODEOWNERS section, making review
+#                     by one of its specialized maintainers mandatory.
+#   paths:            Repo-root-relative directories (each starting with a
+#                     slash, no trailing slash) covered by the area.
 areas:
   - name: benchmarks
+    enforced_review: false
     paths:
       - /images/benchmarks
       - /runsc/profile
@@ -17,9 +20,11 @@ areas:
       - /tools/parsers
       - /tools/profiletool
   - name: checklocks
+    enforced_review: false
     paths:
       - /tools/checklocks
   - name: checkpointing
+    enforced_review: false
     paths:
       - /pkg/aio
       - /pkg/compressio
@@ -30,15 +35,18 @@ areas:
       - /runsc/checkpointgofer
       - /tools/go_stateify
   - name: erofs
+    enforced_review: false
     paths:
       - /pkg/erofs
       - /pkg/sentry/fsimpl/erofs
   - name: fuse
+    enforced_review: false
     paths:
       - /images/fuse
       - /pkg/sentry/fsimpl/fuse
       - /test/fuse_host
   - name: gpu
+    enforced_review: false
     paths:
       - /images/gpu
       - /pkg/sentry/devices/nvproxy
@@ -47,11 +55,13 @@ areas:
       - /tools/ioctl_sniffer
       - /tools/nvidia_driver_differ
   - name: kubernetes
+    enforced_review: false
     paths:
       - /test/kubernetes
       - /tools/gvisor_k8s_tool
       - /webhook
   - name: metrics
+    enforced_review: false
     paths:
       - /pkg/metric
       - /pkg/prometheus
@@ -60,6 +70,7 @@ areas:
       - /test/metricclient
       - /test/metricsviz
   - name: mm
+    enforced_review: false
     paths:
       - /pkg/memutil
       - /pkg/safecopy
@@ -71,6 +82,7 @@ areas:
       - /pkg/sentry/usage
       - /pkg/usermem
   - name: networking
+    enforced_review: false
     paths:
       - /images/iptables
       - /images/nftables
@@ -90,33 +102,41 @@ areas:
       - /tools/gvisor2pcap
       - /tools/xdp
   - name: oci
+    enforced_review: false
     paths:
       - /pkg/shim
       - /runsc/container
       - /runsc/specutils
       - /shim
   - name: platform_kvm
+    enforced_review: false
     paths:
       - /pkg/sentry/platform/kvm
   - name: platform_ptrace
+    enforced_review: false
     paths:
       - /pkg/sentry/platform/ptrace
   - name: platform_slimvm
+    enforced_review: false
     paths:
       - /pkg/sentry/platform/slimvm
   - name: platform_systrap
+    enforced_review: false
     paths:
       - /pkg/sentry/platform/systrap
   - name: platforms
+    enforced_review: false
     paths:
       - /pkg/ring0
       - /pkg/sentry/platform
       - /pkg/sigframe
   - name: rdma
+    enforced_review: false
     paths:
       - /pkg/rdma
       - /pkg/sentry/devices/rdmaproxy
   - name: release_pipeline
+    enforced_review: true
     paths:
       - /.buildkite
       - /.github
@@ -124,9 +144,11 @@ areas:
       - /images/agent
       - /tools/github
   - name: runsc
+    enforced_review: false
     paths:
       - /runsc
   - name: runtime_monitoring
+    enforced_review: false
     paths:
       - /examples/seccheck
       - /pkg/eventchannel
@@ -135,10 +157,12 @@ areas:
       - /test/trace
       - /tools/tracereplay
   - name: sandboxexec
+    enforced_review: false
     paths:
       - /examples/sandboxexec
       - /sandboxexec
   - name: seccomp
+    enforced_review: true
     paths:
       - /pkg/bpf
       - /pkg/seccomp
@@ -147,16 +171,19 @@ areas:
       - /test/secbench
       - /test/secfuzz
   - name: sentry
+    enforced_review: false
     paths:
       - /pkg/sentry
       - /vdso
   - name: tpu
+    enforced_review: false
     paths:
       - /images/tpu
       - /pkg/sentry/devices/tpuproxy
       - /test/tpu
       - /tools/tpu
   - name: vfs
+    enforced_review: false
     paths:
       - /pkg/fspath
       - /pkg/lisafs
@@ -167,6 +194,7 @@ areas:
       - /runsc/fsgofer
       - /test/fsstress
   - name: website
+    enforced_review: false
     paths:
       - /g3doc
       - /images/jekyll

--- a/governance/maintainers.yaml
+++ b/governance/maintainers.yaml
@@ -10,93 +10,77 @@
 #                       - "ACTIVE" (does reviews, has merge permissions)
 #                       - "HIATUS_SINCE:YYYY-MM-DD" (doesn't do reviews, has permissions)
 #                       - "EMERITUS_SINCE:YYYY-MM-DD" (doesn't do reviews, no permissions)
-#   codeowner:        Whether the maintainer appears in CODEOWNERS.
-#                     Required; must be false for emeritus maintainers.
 #   areas:            Optional sorted list of area names from areas.yaml that
-#                     the maintainer has specialization in; grants CODEOWNERS
-#                     ownership of each area's paths. Emeritus maintainers may
-#                     not have areas.
+#                     the maintainer has specialization in.
+#                     Emeritus maintainers may not have areas.
 maintainers:
   - name: Adin Scannell
     github: amscanne
     affiliation: Google
     started: 2018-04-28
     status: EMERITUS_SINCE:2023-03-03
-    codeowner: false
   - name: Fabricio Voznika
     github: fvoznika
     affiliation: Google
     started: 2018-04-28
     status: ACTIVE
-    codeowner: true
     areas: [oci, runsc, runtime_monitoring, seccomp]
   - name: Nicolas Lacasse
     github: nlacasse
     affiliation: Google
     started: 2018-04-28
     status: EMERITUS_SINCE:2025-06-27
-    codeowner: false
   - name: Bhasker Hariharan
     github: hbhasker
     affiliation: Google
     started: 2018-05-01
     status: EMERITUS_SINCE:2022-09-16
-    codeowner: false
   - name: Ian Gudger
     github: iangudger
     affiliation: Google
     started: 2018-05-01
     status: EMERITUS_SINCE:2020-06-26
-    codeowner: false
   - name: Michael Pratt
     github: prattmic
     affiliation: Google
     started: 2018-05-01
     status: EMERITUS_SINCE:2020-04-02
-    codeowner: false
   - name: Kevin Krakauer
     github: kevinGC
     affiliation: Google
     started: 2018-05-04
     status: EMERITUS_SINCE:2025-01-28
-    codeowner: false
   - name: Jamie Liu
     github: nixprime
     affiliation: Google
     started: 2018-05-08
     status: HIATUS_SINCE:2026-07-17
-    codeowner: true
     areas: [checkpointing, mm, platform_kvm, platform_ptrace, platform_systrap, platforms, sentry, vfs]
   - name: Rahat Mahmood
     github: mrahatm
     affiliation: Google
     started: 2018-05-17
     status: EMERITUS_SINCE:2023-01-19
-    codeowner: false
   - name: Andrei Vagin
     github: avagin
     affiliation: Google
     started: 2018-07-31
     status: EMERITUS_SINCE:2026-02-12
-    codeowner: false
   - name: Tamir Duberstein
     github: tamird
     affiliation: Google
     started: 2018-08-25
     status: EMERITUS_SINCE:2022-07-12
-    codeowner: false
   - name: Ian Lewis
     github: ianlewis
     affiliation: Google
     started: 2018-10-12
     status: EMERITUS_SINCE:2023-07-17
-    codeowner: false
   - name: Zach Koopmans
     github: zkoopmans
     affiliation: Google
     started: 2018-11-26
     status: ACTIVE
-    codeowner: true
     areas: [benchmarks, kubernetes]
   - name: Ayush Ranjan
     github: ayushr2
@@ -106,110 +90,93 @@ maintainers:
         until: 2026-07-04
     started: 2019-05-23
     status: EMERITUS_SINCE:2026-06-24
-    codeowner: false
     # areas: [checkpointing, erofs, gpu, mm, rdma, runsc, sentry, vfs]
   - name: Ghanan Gowripalan
     github: ghananigans
     affiliation: Google
     started: 2019-09-03
     status: EMERITUS_SINCE:2023-10-16
-    codeowner: false
   - name: Nayana Bidari
     github: nybidari
     affiliation: Google
     started: 2020-01-09
     status: ACTIVE
-    codeowner: true
     areas: [networking]
   - name: Etienne Perot
     github: etienneperot
     affiliation: Google
     started: 2020-11-18
     status: ACTIVE
-    codeowner: true
     areas: [benchmarks, kubernetes, metrics, oci, release_pipeline, runsc, seccomp, website]
   - name: Lucas Manning
     github: manninglucas
     affiliation: Google
     started: 2021-06-29
     status: HIATUS_SINCE:2026-07-17
-    codeowner: true
     areas: [fuse, networking, sandboxexec, tpu, vfs]
   - name: Jing Chen
     github: milantracy
     affiliation: Google
     started: 2021-10-20
     status: ACTIVE
-    codeowner: true
     areas: [sandboxexec, tpu]
   - name: Konstantin Bogomolov
     github: konstantin-s-bogom
     affiliation: Google
     started: 2022-02-28
     status: ACTIVE
-    codeowner: true
     areas: [platform_kvm, platform_ptrace, platform_systrap, platforms]
   - name: Shambhavi Srivastava
     github: sshambhavi-252
     affiliation: Google
     started: 2022-04-01
     status: EMERITUS_SINCE:2023-10-10
-    codeowner: false
   - name: Jimmy Tran
     github: trantoji
     affiliation: Google
     started: 2025-02-07
     status: ACTIVE
-    codeowner: true
   - name: Anil Altinay
     github: aaltinaydev
     affiliation: Google
     started: 2025-08-05
     status: ACTIVE
-    codeowner: true
   - name: Shailend Chand
     github: shailend-g
     affiliation: Google
     started: 2025-08-12
     status: ACTIVE
-    codeowner: true
   - name: Parth Sarthi
     github: parth-opensrc
     affiliation: Google
     started: 2025-11-06
     status: ACTIVE
-    codeowner: true
     areas: [gpu]
   - name: Ryan El Kochta
     github: relkochta
     affiliation: Google
     started: 2026-05-04
     status: ACTIVE
-    codeowner: true
     areas: [release_pipeline]
   - name: Rex Ren
     github: rexren-gif
     affiliation: Google
     started: 2026-05-07
     status: ACTIVE
-    codeowner: true
   - name: Xin Zhong
     github: xinzhong
     affiliation: Google
     started: 2026-05-22
     status: ACTIVE
-    codeowner: true
     areas: [runtime_monitoring]
   - name: Caroline Zhu
     github: carzh
     affiliation: Google
     started: 2026-06-29
     status: ACTIVE
-    codeowner: true
     areas: [sandboxexec]
   - name: Alexander Cueva
     github: kerumeto
     affiliation: Google
     started: 2026-08-17
     status: ACTIVE
-    codeowner: true

--- a/governance/tools/maintainers/maintainers_gen.go
+++ b/governance/tools/maintainers/maintainers_gen.go
@@ -52,7 +52,6 @@ type maintainer struct {
 	PastAffiliations []pastAffiliation `yaml:"past_affiliation"`
 	Started          string            `yaml:"started"`
 	Status           string            `yaml:"status"`
-	Codeowner        *bool             `yaml:"codeowner"`
 	Areas            []string          `yaml:"areas"`
 }
 
@@ -63,8 +62,9 @@ type roster struct {
 
 // area is a single entry of areas.yaml.
 type area struct {
-	Name  string   `yaml:"name"`
-	Paths []string `yaml:"paths"`
+	Name           string   `yaml:"name"`
+	EnforcedReview *bool    `yaml:"enforced_review"`
+	Paths          []string `yaml:"paths"`
 }
 
 // areaList is the schema of areas.yaml.
@@ -73,20 +73,20 @@ type areaList struct {
 }
 
 // parseAreas parses and validates areas.yaml contents, returning a map of
-// area name to the paths it covers.
-func parseAreas(yamlData []byte) (map[string][]string, error) {
+// area name to the area.
+func parseAreas(yamlData []byte) (map[string]area, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(yamlData))
 	dec.KnownFields(true)
 	var al areaList
 	if err := dec.Decode(&al); err != nil {
 		return nil, fmt.Errorf("cannot parse areas: %w", err)
 	}
-	byName := make(map[string][]string, len(al.Areas))
+	byName := make(map[string]area, len(al.Areas))
 	pathArea := make(map[string]string)
 	var prev area
 	for _, a := range al.Areas {
-		if a.Name == "" || len(a.Paths) == 0 {
-			return nil, fmt.Errorf("area %+v: name and paths are required", a)
+		if a.Name == "" || a.EnforcedReview == nil || len(a.Paths) == 0 {
+			return nil, fmt.Errorf("area %+v: name, enforced_review and paths are required", a)
 		}
 		if a.Name <= prev.Name {
 			return nil, fmt.Errorf("areas must be sorted by name and unique: %q comes after %q", a.Name, prev.Name)
@@ -101,7 +101,7 @@ func parseAreas(yamlData []byte) (map[string][]string, error) {
 			}
 			pathArea[p] = a.Name
 		}
-		byName[a.Name] = a.Paths
+		byName[a.Name] = a
 	}
 	return byName, nil
 }
@@ -126,7 +126,7 @@ func parseStatus(status string) (string, string, error) {
 }
 
 // parseRoster parses and validates maintainers.yaml contents.
-func parseRoster(yamlData []byte, areasByName map[string][]string) (*roster, error) {
+func parseRoster(yamlData []byte, areasByName map[string]area) (*roster, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(yamlData))
 	dec.KnownFields(true)
 	var r roster
@@ -136,8 +136,8 @@ func parseRoster(yamlData []byte, areasByName map[string][]string) (*roster, err
 	seen := make(map[string]bool, len(r.Maintainers))
 	var prev maintainer
 	for _, m := range r.Maintainers {
-		if m.Name == "" || m.GitHub == "" || m.Affiliation == "" || m.Started == "" || m.Status == "" || m.Codeowner == nil {
-			return nil, fmt.Errorf("maintainer %+v: name, github, affiliation, started, status and codeowner are required", m)
+		if m.Name == "" || m.GitHub == "" || m.Affiliation == "" || m.Started == "" || m.Status == "" {
+			return nil, fmt.Errorf("maintainer %+v: name, github, affiliation, started and status are required", m)
 		}
 		if _, err := time.Parse("2006-01-02", m.Started); err != nil {
 			return nil, fmt.Errorf("maintainer %q: invalid started date %q", m.GitHub, m.Started)
@@ -162,7 +162,7 @@ func parseRoster(yamlData []byte, areasByName map[string][]string) (*roster, err
 				return nil, fmt.Errorf("maintainer %q: areas must be sorted and unique: %q comes after %q", m.GitHub, a, m.Areas[i-1])
 			}
 		}
-		if kind == "EMERITUS_SINCE" && (*m.Codeowner || len(m.Areas) > 0) {
+		if kind == "EMERITUS_SINCE" && len(m.Areas) > 0 {
 			return nil, fmt.Errorf("maintainer %q: emeritus maintainers may not own any path", m.GitHub)
 		}
 		if m.Started < prev.Started {
@@ -195,38 +195,39 @@ func generateReviewerJSON(r *roster) ([]byte, error) {
 }
 
 // generateCODEOWNERS renders `CODEOWNERS` contents. All area paths must
-// exist as directories under the repository root.
-func generateCODEOWNERS(r *roster, areasByName map[string][]string, root string) ([]byte, error) {
+// exist as directories under the repository root. Only areas with
+// enforced_review get a CODEOWNERS section.
+func generateCODEOWNERS(r *roster, areasByName map[string]area, root string) ([]byte, error) {
 	for _, name := range slices.Sorted(maps.Keys(areasByName)) {
-		for _, p := range areasByName[name] {
+		for _, p := range areasByName[name].Paths {
 			if st, err := os.Stat(filepath.Join(root, p)); err != nil || !st.IsDir() {
 				return nil, fmt.Errorf("area %q: path %q is not a directory under %q", name, p, root)
 			}
 		}
 	}
-	// gvisor-bot is not a maintainer but always owns the repository root.
 	ownersByArea := make(map[string][]string)
 	for _, m := range r.Maintainers {
-		if !*m.Codeowner {
-			continue
-		}
 		for _, a := range m.Areas {
 			ownersByArea[a] = append(ownersByArea[a], "@"+m.GitHub)
 		}
 	}
-	sortOwners := func(owners []string) {
-		slices.SortFunc(owners, func(a, b string) int {
-			return strings.Compare(strings.ToLower(a), strings.ToLower(b))
-		})
-	}
 	var b bytes.Buffer
 	b.WriteString("# Generated from governance/maintainers.yaml and governance/areas.yaml by\n")
 	b.WriteString("# //governance/tools/maintainers:maintainers_gen; do not edit directly.\n")
-	for _, a := range slices.Sorted(maps.Keys(ownersByArea)) {
-		owners := ownersByArea[a]
-		sortOwners(owners)
-		fmt.Fprintf(&b, "\n# Area: %s\n", a)
-		for _, p := range slices.Sorted(slices.Values(areasByName[a])) {
+	for _, name := range slices.Sorted(maps.Keys(areasByName)) {
+		a := areasByName[name]
+		if !*a.EnforcedReview {
+			continue
+		}
+		owners := ownersByArea[name]
+		if len(owners) == 0 {
+			return nil, fmt.Errorf("area %q: enforced_review requires at least one maintainer specialized in the area", name)
+		}
+		slices.SortFunc(owners, func(a, b string) int {
+			return strings.Compare(strings.ToLower(a), strings.ToLower(b))
+		})
+		fmt.Fprintf(&b, "\n# Area: %s\n", name)
+		for _, p := range slices.Sorted(slices.Values(a.Paths)) {
 			fmt.Fprintf(&b, "%s/ %s\n", p, strings.Join(owners, " "))
 		}
 	}


### PR DESCRIPTION
This removes most `CODEOWNERS` entry other than to a few parts of the codebase that are security-sensitive.

The rest of the metadata in `areas.yaml` is still useful for the purpose of PR auto-assignment, but it needs not be as strongly gated as `CODEOWNERS` implies...