### PR TITLE
control: Allow reconfiguring the save/restore exec binary

### DIFF
--- a/pkg/sentry/control/state.go
+++ b/pkg/sentry/control/state.go
@@ -425,20 +425,21 @@ func SaveRestoreExec(k *kernel.Kernel, mode SaveRestoreExecMode) error {
 // ConfigureSaveRestoreExec sets the configuration for the save/restore binary.
 // If containerID is empty, the global init process will be used for the
 // save/restore binary's leader task.
+//
+// A previously stored configuration is replaced: a sandbox may be
+// checkpointed repeatedly, and the configuration also survives in the kernel
+// state across a restore. The leader task is always resolved anew, since a
+// task stored by an earlier call may have exited.
 func ConfigureSaveRestoreExec(k *kernel.Kernel, argv []string, timeout time.Duration, containerID string) error {
-	if k.SaveRestoreExecConfig != nil {
-		return fmt.Errorf("save/restore binary is already set")
-	}
-	k.SaveRestoreExecConfig = &kernel.SaveRestoreExecConfig{
-		Argv:    argv,
-		Timeout: timeout,
-	}
-
 	leader, err := findContainerInitProcess(k, containerID)
 	if err != nil {
 		return err
 	}
-	k.SaveRestoreExecConfig.LeaderTask = leader
+	k.SaveRestoreExecConfig = &kernel.SaveRestoreExecConfig{
+		Argv:       argv,
+		Timeout:    timeout,
+		LeaderTask: leader,
+	}
 	return nil
 }
 


### PR DESCRIPTION
ConfigureSaveRestoreExec() rejected any call made when Kernel.SaveRestoreExecConfig was already set. The field is never cleared and is part of the saved kernel state, so checkpointing a sandbox a second time, or checkpointing a sandbox that was itself restored, always failed with "save/restore binary is already set".

Replace the stored configuration instead, and always resolve the leader task again, since a task stored by an earlier call may have exited, in which case SaveRestoreExec() silently skips the hook. Assign the configuration only after the lookup succeeds, so a failed lookup no longer leaves behind a config with a nil LeaderTask.

Add a test that checkpoints a sandbox twice and once more after a restore, asserting the hook runs every time.