### PR TITLE
mm: reserve contiguous MemoryFile spans for private anonymous mappings

### DIFF
--- a/pkg/sentry/mm/README.md
+++ b/pkg/sentry/mm/README.md
@@ -229,6 +229,15 @@ sentry must retain information about the host VMAs that it has created.
 The sentry implements anonymous mappings consistently with Linux, except that
 there is no shared zero page.
 
+Private anonymous mappings reserve a contiguous uncommitted span of the sandbox
+MemoryFile at mmap time. Faults take extra references on subranges of that span
+instead of allocating from the global free list, so adjacent application pages
+get adjacent host file offsets. Linux merges host VMAs only when virtual
+address, protection, fd, and file offset are all contiguous; without a per-VMA
+span, concurrent anonymous allocations interleave offsets and host VMAs
+fragment. The reservation is not RSS. Forked children do not inherit it:
+already-faulted pages are copy-on-write, and unfaulted pages allocate normally.
+
 # Implementation Constructs
 
 In Linux:

--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -115,6 +115,9 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 	for srcvseg := mm.vmas.FirstSegment(); srcvseg.Ok(); srcvseg = srcvseg.NextSegment() {
 		vma := srcvseg.ValuePtr().copy()
 		vmaAR := srcvseg.Range()
+		// The child must not own the parent's reserved span. Mapping those
+		// pages writable in the child without COW would silently share them.
+		vma.memfileReserved = false
 
 		if vma.dontfork {
 			length := uint64(vmaAR.Length())
@@ -204,7 +207,12 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 			// Since Pin() breaks copy-on-write on the pinned range,
 			// possibly-pinned pages are exactly those in private
 			// non-copy-on-write pmas with more than one reference.
-			if sfr, ok := mm.mf.FirstSharedRange(srcpseg.fileRange()); ok {
+			srcvseg = srcvseg.seekNextLowerBound(srcpseg.Start())
+			baseline := uint64(1)
+			if srcvseg.Ok() {
+				baseline = mm.pmaRefBaseline(srcvseg, srcpseg)
+			}
+			if sfr, ok := mm.mf.FirstRangeWithRefsAbove(srcpseg.fileRange(), baseline); ok {
 				sar := hostarch.AddrRange{
 					Start: srcpseg.Start() + hostarch.Addr(sfr.Start-pma.off),
 					End:   srcpseg.Start() + hostarch.Addr(sfr.End-pma.off),

--- a/pkg/sentry/mm/mm.go
+++ b/pkg/sentry/mm/mm.go
@@ -241,9 +241,16 @@ type vma struct {
 	// nil, the vma represents an anonymous mapping.
 	mappable memmap.Mappable
 
-	// off is the offset into mappable at which this vma begins. If mappable is
-	// nil, off is meaningless.
+	// off is the offset into mappable at which this vma begins. If
+	// memfileReserved is true, off is the offset into mm.mf of this vma's
+	// start. Otherwise, if mappable is nil, off is meaningless.
 	off uint64
+
+	// memfileReserved is true if this anonymous vma holds one MemoryFile
+	// reference on a contiguous uncommitted span in mm.mf starting at off.
+	// Faults IncRef subranges of that span (RSS). removeVMAsLocked DecRefs
+	// the span after pmas for the same addresses have dropped their refs.
+	memfileReserved bool `state:"manual"`
 
 	// To speedup VMA save/restore, we group and save the following booleans
 	// as a single integer.
@@ -311,22 +318,23 @@ type vma struct {
 
 func (v *vma) copy() vma {
 	return vma{
-		mappable:       v.mappable,
-		off:            v.off,
-		realPerms:      v.realPerms,
-		effectivePerms: v.effectivePerms,
-		maxPerms:       v.maxPerms,
-		private:        v.private,
-		growsDown:      v.growsDown,
-		isStack:        v.isStack,
-		dontfork:       v.dontfork,
-		mlockMode:      v.mlockMode,
-		numaPolicy:     v.numaPolicy,
-		numaNodemask:   v.numaNodemask,
-		id:             v.id,
-		name:           v.name,
-		nameMut:        v.nameMut,
-		lastFault:      atomic.LoadUintptr(&v.lastFault),
+		mappable:        v.mappable,
+		off:             v.off,
+		memfileReserved: v.memfileReserved,
+		realPerms:       v.realPerms,
+		effectivePerms:  v.effectivePerms,
+		maxPerms:        v.maxPerms,
+		private:         v.private,
+		growsDown:       v.growsDown,
+		isStack:         v.isStack,
+		dontfork:        v.dontfork,
+		mlockMode:       v.mlockMode,
+		numaPolicy:      v.numaPolicy,
+		numaNodemask:    v.numaNodemask,
+		id:              v.id,
+		name:            v.name,
+		nameMut:         v.nameMut,
+		lastFault:       atomic.LoadUintptr(&v.lastFault),
 	}
 }
 

--- a/pkg/sentry/mm/mm_test.go
+++ b/pkg/sentry/mm/mm_test.go
@@ -16,6 +16,7 @@ package mm
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/context"
@@ -580,5 +581,641 @@ func TestMRemapMappableOffsetOverflow(t *testing.T) {
 	// We remap with oldSize = PageSize, newSize = 3*PageSize.
 	if _, err := mm.MRemap(ctx, addr, hostarch.PageSize, 3*hostarch.PageSize, MRemapOpts{}); !linuxerr.Equals(linuxerr.EINVAL, err) {
 		t.Errorf("MRemap grow got err %v want EINVAL", err)
+	}
+}
+
+func mmapPrivateAnon(ctx context.Context, t *testing.T, mm *MemoryManager, pages int) hostarch.Addr {
+	t.Helper()
+	addr, err := mm.MMap(ctx, memmap.MMapOpts{
+		Length:   uint64(pages) * hostarch.PageSize,
+		Private:  true,
+		Perms:    hostarch.ReadWrite,
+		MaxPerms: hostarch.AnyAccess,
+	})
+	if err != nil {
+		t.Fatalf("MMap got err %v want nil", err)
+	}
+	return addr
+}
+
+func faultPagesErr(ctx context.Context, mm *MemoryManager, addr hostarch.Addr, pages int) error {
+	buf := []byte{1}
+	for i := 0; i < pages; i++ {
+		if _, err := mm.CopyOut(ctx, addr+hostarch.Addr(i)*hostarch.PageSize, buf, usermem.IOOpts{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func faultPages(ctx context.Context, t *testing.T, mm *MemoryManager, addr hostarch.Addr, pages int) {
+	t.Helper()
+	if err := faultPagesErr(ctx, mm, addr, pages); err != nil {
+		t.Fatalf("CopyOut got err %v want nil", err)
+	}
+}
+
+type reservedVMA struct {
+	ar       hostarch.AddrRange
+	off      uint64
+	reserved bool
+}
+
+func lookupReservedVMA(t *testing.T, mm *MemoryManager, addr hostarch.Addr) reservedVMA {
+	t.Helper()
+	mm.mappingMu.RLock()
+	defer mm.mappingMu.RUnlock()
+	vseg := mm.vmas.FindSegment(addr)
+	if !vseg.Ok() {
+		t.Fatalf("no vma at %#x", addr)
+	}
+	v := vseg.ValuePtr()
+	return reservedVMA{ar: vseg.Range(), off: v.off, reserved: v.memfileReserved}
+}
+
+func pmaFileOffAt(t *testing.T, mm *MemoryManager, addr hostarch.Addr) uint64 {
+	t.Helper()
+	mm.activeMu.RLock()
+	defer mm.activeMu.RUnlock()
+	pseg := mm.pmas.FindSegment(addr)
+	if !pseg.Ok() {
+		t.Fatalf("no pma at %#x", addr)
+	}
+	return pseg.ValuePtr().off + uint64(addr-pseg.Start())
+}
+
+func TestAnonymousVMAReservesContiguousSpan(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	const pages = 4
+	addr := mmapPrivateAnon(ctx, t, mm, pages)
+	v := lookupReservedVMA(t, mm, addr)
+	if !v.reserved {
+		t.Fatal("anonymous vma did not reserve a MemoryFile span")
+	}
+	if v.ar.Length() != pages*hostarch.PageSize {
+		t.Fatalf("vma length got %#x want %#x", v.ar.Length(), pages*hostarch.PageSize)
+	}
+
+	faultPages(ctx, t, mm, addr, pages)
+	for i := 0; i < pages; i++ {
+		pageAddr := addr + hostarch.Addr(i)*hostarch.PageSize
+		got := pmaFileOffAt(t, mm, pageAddr)
+		want := v.off + uint64(i)*hostarch.PageSize
+		if got != want {
+			t.Errorf("page %d file offset got %#x want %#x", i, got, want)
+		}
+	}
+}
+
+func TestAnonymousVMAsDoNotInterleaveOffsets(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	const pages = 8
+	addr1 := mmapPrivateAnon(ctx, t, mm, pages)
+	addr2, err := mm.MMap(ctx, memmap.MMapOpts{
+		Length:   uint64(pages) * hostarch.PageSize,
+		Private:  true,
+		Perms:    hostarch.ReadWrite.Union(hostarch.Execute),
+		MaxPerms: hostarch.AnyAccess,
+	})
+	if err != nil {
+		t.Fatalf("MMap 2 got err %v want nil", err)
+	}
+	v1 := lookupReservedVMA(t, mm, addr1)
+	v2 := lookupReservedVMA(t, mm, addr2)
+	if !v1.reserved || !v2.reserved {
+		t.Fatal("anonymous vmas did not reserve MemoryFile spans")
+	}
+	fr1 := memmap.FileRange{Start: v1.off, End: v1.off + uint64(v1.ar.Length())}
+	fr2 := memmap.FileRange{Start: v2.off, End: v2.off + uint64(v2.ar.Length())}
+	if fr1.Start < fr2.End && fr2.Start < fr1.End {
+		t.Fatalf("reserved spans overlap: %v and %v", fr1, fr2)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errCh <- faultPagesErr(ctx, mm, addr1, pages)
+	}()
+	go func() {
+		defer wg.Done()
+		errCh <- faultPagesErr(ctx, mm, addr2, pages)
+	}()
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent fault: %v", err)
+		}
+	}
+
+	for i := 0; i < pages; i++ {
+		off1 := pmaFileOffAt(t, mm, addr1+hostarch.Addr(i)*hostarch.PageSize)
+		off2 := pmaFileOffAt(t, mm, addr2+hostarch.Addr(i)*hostarch.PageSize)
+		if off1 != v1.off+uint64(i)*hostarch.PageSize {
+			t.Errorf("vma1 page %d offset got %#x want %#x", i, off1, v1.off+uint64(i)*hostarch.PageSize)
+		}
+		if off2 != v2.off+uint64(i)*hostarch.PageSize {
+			t.Errorf("vma2 page %d offset got %#x want %#x", i, off2, v2.off+uint64(i)*hostarch.PageSize)
+		}
+		if i > 0 {
+			prev1 := pmaFileOffAt(t, mm, addr1+hostarch.Addr(i-1)*hostarch.PageSize)
+			if off1 != prev1+hostarch.PageSize {
+				t.Errorf("vma1 page %d offset %#x is not adjacent to previous %#x", i, off1, prev1)
+			}
+		}
+	}
+}
+
+func TestMprotectSplitKeepsLinearFileOffsets(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	const pages = 3
+	addr := mmapPrivateAnon(ctx, t, mm, pages)
+	before := lookupReservedVMA(t, mm, addr)
+	if !before.reserved {
+		t.Fatal("anonymous vma did not reserve a MemoryFile span")
+	}
+
+	mid := addr + hostarch.PageSize
+	if err := mm.MProtect(mid, hostarch.PageSize, hostarch.Read, false); err != nil {
+		t.Fatalf("MProtect got err %v want nil", err)
+	}
+
+	left := lookupReservedVMA(t, mm, addr)
+	middle := lookupReservedVMA(t, mm, mid)
+	right := lookupReservedVMA(t, mm, addr+2*hostarch.PageSize)
+	if !left.reserved || !middle.reserved || !right.reserved {
+		t.Fatal("split vmas lost MemoryFile reservation")
+	}
+	if left.off != before.off {
+		t.Errorf("left vma off got %#x want %#x", left.off, before.off)
+	}
+	if middle.off != before.off+hostarch.PageSize {
+		t.Errorf("middle vma off got %#x want %#x", middle.off, before.off+hostarch.PageSize)
+	}
+	if right.off != before.off+2*hostarch.PageSize {
+		t.Errorf("right vma off got %#x want %#x", right.off, before.off+2*hostarch.PageSize)
+	}
+
+	buf := []byte{1}
+	if _, err := mm.CopyOut(ctx, addr, buf, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyOut left got err %v want nil", err)
+	}
+	if _, err := mm.CopyIn(ctx, mid, buf, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyIn middle got err %v want nil", err)
+	}
+	if _, err := mm.CopyOut(ctx, addr+2*hostarch.PageSize, buf, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyOut right got err %v want nil", err)
+	}
+
+	if got, want := pmaFileOffAt(t, mm, addr), before.off; got != want {
+		t.Errorf("left page offset got %#x want %#x", got, want)
+	}
+	if got, want := pmaFileOffAt(t, mm, mid), before.off+hostarch.PageSize; got != want {
+		t.Errorf("middle page offset got %#x want %#x", got, want)
+	}
+	if got, want := pmaFileOffAt(t, mm, addr+2*hostarch.PageSize), before.off+2*hostarch.PageSize; got != want {
+		t.Errorf("right page offset got %#x want %#x", got, want)
+	}
+}
+
+func TestForkDoesNotInheritMemfileReservation(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	addr := mmapPrivateAnon(ctx, t, mm, 2)
+	if v := lookupReservedVMA(t, mm, addr); !v.reserved {
+		t.Fatal("parent anonymous vma did not reserve a MemoryFile span")
+	}
+
+	mm2, err := mm.Fork(ctx)
+	if err != nil {
+		t.Fatalf("Fork got err %v want nil", err)
+	}
+	defer mm2.DecUsers(ctx)
+
+	if v := lookupReservedVMA(t, mm2, addr); v.reserved {
+		t.Fatal("child inherited parent MemoryFile reservation")
+	}
+	if v := lookupReservedVMA(t, mm, addr); !v.reserved {
+		t.Fatal("parent lost MemoryFile reservation after fork")
+	}
+}
+
+func TestReservedAnonymousDoesNotCountUnfaultedRSS(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	// Mappings larger than a huge page are not eagerly populated.
+	length := uint64(hostarch.HugePageSize + hostarch.PageSize)
+	addr, err := mm.MMap(ctx, memmap.MMapOpts{
+		Length:   length,
+		Private:  true,
+		Perms:    hostarch.ReadWrite,
+		MaxPerms: hostarch.AnyAccess,
+	})
+	if err != nil {
+		t.Fatalf("MMap got err %v want nil", err)
+	}
+	if v := lookupReservedVMA(t, mm, addr); !v.reserved {
+		t.Fatal("anonymous vma did not reserve a MemoryFile span")
+	}
+	if got := mm.ResidentSetSize(); got != 0 {
+		t.Fatalf("unfaulted reserved mapping RSS got %#x want 0", got)
+	}
+
+	faultPages(ctx, t, mm, addr, 1)
+	if got := mm.ResidentSetSize(); got == 0 {
+		t.Fatal("RSS still 0 after fault")
+	}
+	if got, want := mm.ResidentSetSize(), length; got > want {
+		t.Fatalf("RSS %#x exceeds mapping length %#x", got, want)
+	}
+}
+
+func TestMunmapDropsReservedRSS(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	const pages = 4
+	addr := mmapPrivateAnon(ctx, t, mm, pages)
+	faultPages(ctx, t, mm, addr, pages)
+	if got, want := mm.ResidentSetSize(), uint64(pages*hostarch.PageSize); got != want {
+		t.Fatalf("RSS after fault got %#x want %#x", got, want)
+	}
+
+	if err := mm.MUnmap(ctx, addr, uint64(pages)*hostarch.PageSize); err != nil {
+		t.Fatalf("MUnmap got err %v want nil", err)
+	}
+	if got := mm.ResidentSetSize(); got != 0 {
+		t.Fatalf("RSS after munmap got %#x want 0", got)
+	}
+
+	addr2 := mmapPrivateAnon(ctx, t, mm, pages)
+	faultPages(ctx, t, mm, addr2, pages)
+	buf := []byte{0xab}
+	if _, err := mm.CopyOut(ctx, addr2, buf, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyOut after remap got err %v want nil", err)
+	}
+}
+
+func TestMremapInPlaceGrowKeepsLinearFileOffsets(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	const oldPages = 2
+	addr := mmapPrivateAnon(ctx, t, mm, oldPages)
+	before := lookupReservedVMA(t, mm, addr)
+
+	newAddr, err := mm.MRemap(ctx, addr, uint64(oldPages)*hostarch.PageSize, uint64(oldPages+1)*hostarch.PageSize, MRemapOpts{
+		Move: MRemapNoMove,
+	})
+	if err != nil {
+		t.Fatalf("MRemap grow got err %v want nil", err)
+	}
+	if newAddr != addr {
+		t.Fatalf("MRemap grow moved mapping to %#x, want in-place %#x", newAddr, addr)
+	}
+
+	after := lookupReservedVMA(t, mm, addr)
+	if !after.reserved {
+		t.Fatal("grown vma lost MemoryFile reservation")
+	}
+	if after.ar.Length() != hostarch.Addr(oldPages+1)*hostarch.PageSize {
+		t.Fatalf("grown vma length got %#x want %#x", after.ar.Length(), uint64(oldPages+1)*hostarch.PageSize)
+	}
+	if after.off != before.off {
+		t.Fatalf("grown vma off got %#x want %#x (merged with original span)", after.off, before.off)
+	}
+
+	faultPages(ctx, t, mm, addr, oldPages+1)
+	for i := 0; i < oldPages+1; i++ {
+		got := pmaFileOffAt(t, mm, addr+hostarch.Addr(i)*hostarch.PageSize)
+		want := after.off + uint64(i)*hostarch.PageSize
+		if got != want {
+			t.Errorf("page %d file offset got %#x want %#x", i, got, want)
+		}
+	}
+}
+
+func TestMremapCopyDoesNotAliasSource(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	const pages = 2
+	addr := mmapPrivateAnon(ctx, t, mm, pages)
+	src := lookupReservedVMA(t, mm, addr)
+
+	dst, err := mm.MRemap(ctx, addr, 0, uint64(pages)*hostarch.PageSize, MRemapOpts{
+		Move: MRemapMayMove,
+	})
+	if err != nil {
+		t.Fatalf("MRemap copy got err %v want nil", err)
+	}
+	if dst == addr {
+		t.Fatal("MRemap copy returned the source address")
+	}
+
+	copyV := lookupReservedVMA(t, mm, dst)
+	if copyV.reserved {
+		t.Fatal("copied vma kept source MemoryFile reservation")
+	}
+	srcAfter := lookupReservedVMA(t, mm, addr)
+	if !srcAfter.reserved {
+		t.Fatal("source vma lost MemoryFile reservation after copy")
+	}
+	if srcAfter.off != src.off {
+		t.Fatalf("source off changed %#x -> %#x", src.off, srcAfter.off)
+	}
+
+	faultPages(ctx, t, mm, addr, pages)
+	faultPages(ctx, t, mm, dst, pages)
+	srcPat := []byte{0x11}
+	dstPat := []byte{0x22}
+	if _, err := mm.CopyOut(ctx, addr, srcPat, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyOut source: %v", err)
+	}
+	if _, err := mm.CopyOut(ctx, dst, dstPat, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyOut copy: %v", err)
+	}
+	got := make([]byte, 1)
+	if _, err := mm.CopyIn(ctx, addr, got, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyIn source: %v", err)
+	}
+	if got[0] != srcPat[0] {
+		t.Errorf("source page got %#x want %#x; copy shared memory with source", got[0], srcPat[0])
+	}
+	if _, err := mm.CopyIn(ctx, dst, got, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyIn copy: %v", err)
+	}
+	if got[0] != dstPat[0] {
+		t.Errorf("copy page got %#x want %#x", got[0], dstPat[0])
+	}
+}
+
+func TestAdjacentAnonymousMmapsKeepLinearFileOffsets(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	addr := mmapPrivateAnon(ctx, t, mm, 1)
+	first := lookupReservedVMA(t, mm, addr)
+	next, err := mm.MMap(ctx, memmap.MMapOpts{
+		Length:   hostarch.PageSize,
+		Private:  true,
+		Perms:    hostarch.ReadWrite,
+		MaxPerms: hostarch.AnyAccess,
+		Addr:     addr + hostarch.PageSize,
+		Fixed:    true,
+	})
+	if err != nil {
+		t.Fatalf("adjacent MMap got err %v want nil", err)
+	}
+	if next != addr+hostarch.PageSize {
+		t.Fatalf("adjacent MMap got %#x want %#x", next, addr+hostarch.PageSize)
+	}
+
+	merged := lookupReservedVMA(t, mm, addr)
+	if !merged.reserved {
+		t.Fatal("merged mapping lost MemoryFile reservation")
+	}
+	if merged.ar.Length() != 2*hostarch.PageSize {
+		t.Fatalf("adjacent reserved vmas did not merge: length %#x", merged.ar.Length())
+	}
+	if merged.off != first.off {
+		t.Fatalf("merged off got %#x want %#x", merged.off, first.off)
+	}
+
+	faultPages(ctx, t, mm, addr, 2)
+	if got, want := pmaFileOffAt(t, mm, addr), merged.off; got != want {
+		t.Errorf("page 0 file offset got %#x want %#x", got, want)
+	}
+	if got, want := pmaFileOffAt(t, mm, next), merged.off+hostarch.PageSize; got != want {
+		t.Errorf("page 1 file offset got %#x want %#x", got, want)
+	}
+}
+
+func TestMremapMoveAndGrowKeepsLinearFileOffsets(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	const oldPages = 2
+	addr := mmapPrivateAnon(ctx, t, mm, oldPages)
+	before := lookupReservedVMA(t, mm, addr)
+	dst := addr + hostarch.Addr(16)*hostarch.PageSize
+
+	newAddr, err := mm.MRemap(ctx, addr, uint64(oldPages)*hostarch.PageSize, uint64(oldPages+1)*hostarch.PageSize, MRemapOpts{
+		Move:    MRemapMustMove,
+		NewAddr: dst,
+	})
+	if err != nil {
+		t.Fatalf("MRemap move+grow got err %v want nil", err)
+	}
+	if newAddr != dst {
+		t.Fatalf("MRemap move+grow got %#x want %#x", newAddr, dst)
+	}
+
+	after := lookupReservedVMA(t, mm, newAddr)
+	if !after.reserved {
+		t.Fatal("moved+grown vma lost MemoryFile reservation")
+	}
+	if after.ar.Length() != hostarch.Addr(oldPages+1)*hostarch.PageSize {
+		t.Fatalf("moved+grown vma length got %#x want %#x", after.ar.Length(), uint64(oldPages+1)*hostarch.PageSize)
+	}
+	if after.off != before.off {
+		t.Fatalf("moved+grown vma off got %#x want %#x", after.off, before.off)
+	}
+
+	faultPages(ctx, t, mm, newAddr, oldPages+1)
+	for i := 0; i < oldPages+1; i++ {
+		got := pmaFileOffAt(t, mm, newAddr+hostarch.Addr(i)*hostarch.PageSize)
+		want := after.off + uint64(i)*hostarch.PageSize
+		if got != want {
+			t.Errorf("page %d file offset got %#x want %#x", i, got, want)
+		}
+	}
+}
+
+func TestReservedAnonymousForkCopyOnWrite(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	addr := mmapPrivateAnon(ctx, t, mm, 1)
+	preFork := []byte{'A'}
+	if _, err := mm.CopyOut(ctx, addr, preFork, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyOut got err %v want nil", err)
+	}
+
+	mm2, err := mm.Fork(ctx)
+	if err != nil {
+		t.Fatalf("Fork got err %v want nil", err)
+	}
+	defer mm2.DecUsers(ctx)
+
+	if v := lookupReservedVMA(t, mm2, addr); v.reserved {
+		t.Fatal("child inherited parent MemoryFile reservation")
+	}
+
+	if _, err := mm.CopyOut(ctx, addr, []byte{'B'}, usermem.IOOpts{}); err != nil {
+		t.Fatalf("parent CopyOut got err %v want nil", err)
+	}
+	childBuf := make([]byte, 1)
+	if _, err := mm2.CopyIn(ctx, addr, childBuf, usermem.IOOpts{}); err != nil {
+		t.Fatalf("child CopyIn got err %v want nil", err)
+	}
+	if childBuf[0] != 'A' {
+		t.Errorf("child saw %#x want 'A'; parent write was visible in child", childBuf[0])
+	}
+
+	if _, err := mm2.CopyOut(ctx, addr, []byte{'C'}, usermem.IOOpts{}); err != nil {
+		t.Fatalf("child CopyOut got err %v want nil", err)
+	}
+	parentBuf := make([]byte, 1)
+	if _, err := mm.CopyIn(ctx, addr, parentBuf, usermem.IOOpts{}); err != nil {
+		t.Fatalf("parent CopyIn got err %v want nil", err)
+	}
+	if parentBuf[0] != 'B' {
+		t.Errorf("parent saw %#x want 'B'; child write was visible in parent", parentBuf[0])
+	}
+}
+
+func TestDontNeedZerosReservedAnonymous(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	addr := mmapPrivateAnon(ctx, t, mm, 1)
+	before := lookupReservedVMA(t, mm, addr)
+	if _, err := mm.CopyOut(ctx, addr, []byte{0xab}, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyOut got err %v want nil", err)
+	}
+	off := pmaFileOffAt(t, mm, addr)
+	if off != before.off {
+		t.Fatalf("file offset after fault got %#x want %#x", off, before.off)
+	}
+	if got, want := mm.ResidentSetSize(), uint64(hostarch.PageSize); got != want {
+		t.Fatalf("RSS after fault got %#x want %#x", got, want)
+	}
+
+	if err := mm.Decommit(addr, hostarch.PageSize); err != nil {
+		t.Fatalf("Decommit got err %v want nil", err)
+	}
+	after := lookupReservedVMA(t, mm, addr)
+	if !after.reserved {
+		t.Fatal("DONTNEED dropped MemoryFile reservation")
+	}
+	if after.off != before.off {
+		t.Fatalf("DONTNEED changed file offset %#x -> %#x", before.off, after.off)
+	}
+	if got := mm.ResidentSetSize(); got != 0 {
+		t.Fatalf("RSS after DONTNEED got %#x want 0", got)
+	}
+
+	got := make([]byte, 1)
+	if _, err := mm.CopyIn(ctx, addr, got, usermem.IOOpts{}); err != nil {
+		t.Fatalf("CopyIn after DONTNEED got err %v want nil", err)
+	}
+	if got[0] != 0 {
+		t.Errorf("after DONTNEED got %#x want 0", got[0])
+	}
+	if pmaFileOffAt(t, mm, addr) != before.off {
+		t.Errorf("refault file offset got %#x want %#x", pmaFileOffAt(t, mm, addr), before.off)
+	}
+	if got, want := mm.ResidentSetSize(), uint64(hostarch.PageSize); got != want {
+		t.Fatalf("RSS after refault got %#x want %#x", got, want)
+	}
+}
+
+func TestOversizedAnonymousMmapDoesNotReserve(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManager(ctx, t)
+	defer mm.DecUsers(ctx)
+
+	length := pgalloc.MaxAnonymousReserve + uint64(hostarch.PageSize)
+	addr, err := mm.MMap(ctx, memmap.MMapOpts{
+		Length:   length,
+		Private:  true,
+		Perms:    hostarch.ReadWrite,
+		MaxPerms: hostarch.AnyAccess,
+	})
+	if err != nil {
+		t.Fatalf("MMap oversized got err %v want nil", err)
+	}
+	if v := lookupReservedVMA(t, mm, addr); v.reserved {
+		t.Fatal("mmap larger than MaxAnonymousReserve reserved a MemoryFile span")
+	}
+
+	small := mmapPrivateAnon(ctx, t, mm, 1)
+	if v := lookupReservedVMA(t, mm, small); !v.reserved {
+		t.Fatal("small anonymous mmap did not reserve")
+	}
+}
+
+func TestMapFixedBelowReservedKeepsLinearFileOffsets(t *testing.T) {
+	ctx := contexttest.Context(t)
+	mm := testMemoryManagerWithMmapDirection(ctx, t, arch.MmapTopDown)
+	defer mm.DecUsers(ctx)
+
+	upper := mmapPrivateAnon(ctx, t, mm, 1)
+	if upper < mm.layout.MinAddr+hostarch.PageSize {
+		t.Fatalf("upper mapping %#x has no room below", upper)
+	}
+	uv := lookupReservedVMA(t, mm, upper)
+	if !uv.reserved {
+		t.Fatal("upper mapping did not reserve")
+	}
+	if uv.off < hostarch.PageSize {
+		t.Fatalf("upper file offset %#x has no room below; top-down Reserve should leave a gap", uv.off)
+	}
+
+	lower, err := mm.MMap(ctx, memmap.MMapOpts{
+		Length:   hostarch.PageSize,
+		Private:  true,
+		Perms:    hostarch.ReadWrite,
+		MaxPerms: hostarch.AnyAccess,
+		Addr:     upper - hostarch.PageSize,
+		Fixed:    true,
+	})
+	if err != nil {
+		t.Fatalf("MAP_FIXED below got err %v want nil", err)
+	}
+	if lower != upper-hostarch.PageSize {
+		t.Fatalf("MAP_FIXED below got %#x want %#x", lower, upper-hostarch.PageSize)
+	}
+
+	merged := lookupReservedVMA(t, mm, lower)
+	if !merged.reserved {
+		t.Fatal("lower mapping did not reserve")
+	}
+	if merged.ar.Length() != 2*hostarch.PageSize {
+		t.Fatalf("adjacent reserved vmas did not merge: length %#x", merged.ar.Length())
+	}
+	if merged.off+uint64(hostarch.PageSize) != uv.off && merged.off != uv.off-hostarch.PageSize {
+		t.Fatalf("file offsets not contiguous: merged off %#x upper off %#x", merged.off, uv.off)
+	}
+
+	faultPages(ctx, t, mm, lower, 2)
+	if got, want := pmaFileOffAt(t, mm, lower), merged.off; got != want {
+		t.Errorf("lower page offset got %#x want %#x", got, want)
+	}
+	if got, want := pmaFileOffAt(t, mm, upper), merged.off+hostarch.PageSize; got != want {
+		t.Errorf("upper page offset got %#x want %#x", got, want)
 	}
 }

--- a/pkg/sentry/mm/pma.go
+++ b/pkg/sentry/mm/pma.go
@@ -278,13 +278,35 @@ func (mm *MemoryManager) getPMAsInternalLocked(ctx context.Context, vseg vmaIter
 					}
 				}
 				if vma.mappable == nil {
-					// Private anonymous mappings get pmas by allocating.
-					// The allocated range is limited to ar, expanded to
-					// hugepage alignment. This is done even if the allocation
-					// will not be hugepage-backed, in an attempt to reduce
-					// application page faults (that trap into the sentry) by
-					// creating AddressSpace mappings in advance.
+					// Private anonymous mappings get pmas from a span reserved
+					// at mmap time when the vma owns one, so adjacent guest
+					// pages get contiguous memfd offsets and the host can
+					// merge VMAs. Otherwise they Allocate from the global
+					// free list (forked children, COW leftovers).
 					allocAR := optAR.Intersect(hugeMaskAR)
+					if vma.memfileReserved {
+						off := vseg.fileOffsetAt(allocAR.Start)
+						fr := memmap.FileRange{Start: off, End: off + uint64(allocAR.Length())}
+						mm.mf.IncRef(fr, memCgID)
+						mm.addRSSLocked(allocAR)
+						// IsHugeChunk is required: a non-hugepage-aligned
+						// mmap still Reserves into small chunks, but off
+						// can be 0 (huge-aligned).
+						huge := mm.mf.HugepagesEnabled() && !vma.growsDown && !vma.isStack &&
+							allocAR.IsHugePageAligned() && hostarch.IsHugePageAligned(off) &&
+							mm.mf.IsHugeChunk(off)
+						pseg, pgap = mm.pmas.Insert(pgap, allocAR, pma{
+							file:           mm.mf,
+							off:            off,
+							translatePerms: hostarch.AnyAccess,
+							effectivePerms: vma.effectivePerms,
+							maxPerms:       vma.maxPerms,
+							private:        true,
+							huge:           huge,
+						}).NextNonEmpty()
+						pstart = pmaIterator{} // iterators invalidated
+						break
+					}
 					// Don't back stacks with huge pages due to low utilization
 					// and because they're often fragmented by copy-on-write.
 					mayHuge := mm.mf.HugepagesEnabled() && !vma.growsDown && !vma.isStack
@@ -644,7 +666,7 @@ func (mm *MemoryManager) isPMACopyOnWriteLocked(vseg vmaIterator, pseg pmaIterat
 	// ownership of it instead of copying. If we do hold the only reference,
 	// additional references can only be taken by mm.Fork(), which is excluded
 	// by mm.activeMu, so this isn't racy.
-	if mm.mf.HasUniqueRef(pseg.fileRange()) {
+	if mm.mf.HasExactRefs(pseg.fileRange(), mm.pmaRefBaseline(vseg, pseg)) {
 		pma.needCOW = false
 		// pma.private => pma.translatePerms == hostarch.AnyAccess
 		vma := vseg.ValuePtr()
@@ -653,6 +675,21 @@ func (mm *MemoryManager) isPMACopyOnWriteLocked(vseg vmaIterator, pseg pmaIterat
 		return false
 	}
 	return true
+}
+
+// pmaRefBaseline is the MemoryFile refcount this mm holds on pseg when no
+// other mm or pin shares the pages. A reservation-backed pma is unique at 2
+// (vma span + pma). A COW-allocated pma whose file offset is no longer the
+// reserved linear offset is unique at 1.
+func (mm *MemoryManager) pmaRefBaseline(vseg vmaIterator, pseg pmaIterator) uint64 {
+	v := vseg.ValuePtr()
+	if !v.memfileReserved {
+		return 1
+	}
+	if pseg.ValuePtr().off == vseg.fileOffsetAt(pseg.Start()) {
+		return 2
+	}
+	return 1
 }
 
 // Invalidate implements memmap.MappingSpace.Invalidate.
@@ -740,7 +777,8 @@ func (mm *MemoryManager) invalidateLocked(ar hostarch.AddrRange, invalidatePriva
 // pin_user_pages(FOLL_LONGTERM) in the Linux kernel. Like Linux, Pin breaks
 // copy-on-write on the pinned range (even if at.Write is false). This also
 // yields the invariant that pinned pages in private mappings live in non-CoW
-// pmas with >1 reference.
+// pmas with more references than the mm's baseline (1, or 2 when the pma is
+// backed by a vma reservation).
 //
 // Preconditions:
 //   - ar.Length() != 0.

--- a/pkg/sentry/mm/save_restore.go
+++ b/pkg/sentry/mm/save_restore.go
@@ -69,6 +69,7 @@ const (
 	vmaPrivate
 	vmaGrowsDown
 	vmaIsStack
+	vmaMemfileReserved
 )
 
 func (v *vma) saveRealPerms() int {
@@ -109,6 +110,9 @@ func (v *vma) saveRealPerms() int {
 	if v.isStack {
 		b |= vmaIsStack
 	}
+	if v.memfileReserved {
+		b |= vmaMemfileReserved
+	}
 	return b
 }
 
@@ -148,6 +152,9 @@ func (v *vma) loadRealPerms(_ goContext.Context, b int) {
 	}
 	if b&vmaIsStack > 0 {
 		v.isStack = true
+	}
+	if b&vmaMemfileReserved > 0 {
+		v.memfileReserved = true
 	}
 }
 

--- a/pkg/sentry/mm/syscalls.go
+++ b/pkg/sentry/mm/syscalls.go
@@ -574,6 +574,13 @@ func (mm *MemoryManager) MRemap(ctx context.Context, oldAddr hostarch.Addr, oldS
 		vma := vseg.ValuePtr().copy()
 		if vma.mappable != nil {
 			vma.off = vseg.mappableOffsetAt(oldAR.Start)
+		} else if vma.memfileReserved {
+			// mremap copy (oldSize==0) is a new mapping. Keeping or extending
+			// the source reservation would alias the copy onto the source if
+			// the destination VA is adjacent and Merge sees contiguous file
+			// offsets. Faults Allocate independently, as for a forked child.
+			vma.memfileReserved = false
+			vma.off = 0
 		}
 		if vma.id != nil {
 			vma.id.IncRef()
@@ -607,29 +614,51 @@ func (mm *MemoryManager) MRemap(ctx context.Context, oldAddr hostarch.Addr, oldS
 	vseg = mm.vmas.Isolate(vseg, oldAR)
 	vma := vseg.ValuePtr().copy()
 	mm.vmas.Remove(vseg)
-	vseg = mm.vmas.Insert(mm.vmas.FindGap(newAR.Start), newAR, vma)
-	mm.usageAS = mm.usageAS - uint64(oldAR.Length()) + uint64(newAR.Length())
-	if vma.isPrivateDataLocked() {
-		mm.dataAS = mm.dataAS - uint64(oldAR.Length()) + uint64(newAR.Length())
-	}
-	if vma.mlockMode != memmap.MLockNone {
-		mm.lockedAS = mm.lockedAS - uint64(oldAR.Length()) + uint64(newAR.Length())
-	}
+	movedAR := hostarch.AddrRange{Start: newAR.Start, End: newAR.Start + hostarch.Addr(oldAR.Length())}
+	vseg = mm.vmas.Insert(mm.vmas.FindGap(newAR.Start), movedAR, vma)
 
 	// Move pmas. This is technically optional for non-private pmas, which
 	// could just go through memmap.Mappable.Translate again, but it's required
 	// for private pmas.
 	mm.activeMu.Lock()
-	mm.movePMAsLocked(oldAR, newAR)
+	mm.movePMAsLocked(oldAR, movedAR)
 	mm.activeMu.Unlock()
 
-	// Now that pmas have been moved to newAR, we can notify vma.mappable that
+	// Now that pmas have been moved to movedAR, we can notify vma.mappable that
 	// oldAR is no longer mapped.
 	if vma.mappable != nil {
 		vma.mappable.RemoveMapping(ctx, mm, oldAR, vma.off, vma.canWriteMappableLocked())
 	}
 
+	if newAR.End > movedAR.End {
+		var extraOff uint64
+		if vma.mappable != nil {
+			extraOff = vma.off + uint64(oldAR.Length())
+		}
+		var extraErr error
+		vseg, _, droppedIDs, extraErr = mm.createVMALocked(ctx, memmap.MMapOpts{
+			Length:          uint64(newAR.End - movedAR.End),
+			MappingIdentity: vma.id,
+			Mappable:        vma.mappable,
+			Offset:          extraOff,
+			Addr:            movedAR.End,
+			Fixed:           true,
+			Perms:           vma.realPerms,
+			MaxPerms:        vma.maxPerms,
+			Private:         vma.private,
+			GrowsDown:       vma.growsDown,
+			Stack:           vma.isStack,
+			MLockMode:       vma.mlockMode,
+			Name:            vma.name,
+			NameMut:         vma.nameMut,
+		}, droppedIDs)
+		if extraErr != nil {
+			return 0, extraErr
+		}
+	}
+
 	if vma.mlockMode == memmap.MLockEager {
+		vseg = mm.vmas.FindSegment(newAR.Start)
 		mm.populateVMA(ctx, vseg, newAR, memmap.PlatformEffectCommit)
 	}
 
@@ -1195,17 +1224,7 @@ func (mm *MemoryManager) Decommit(addr hostarch.Addr, length uint64) error {
 					// normally.
 					if psegAR.Start < lastWholeHugeEnd {
 						pseg = mm.pmas.Isolate(pseg, hostarch.AddrRange{psegAR.Start, lastWholeHugeEnd})
-						pma = pseg.ValuePtr()
-						if !didUnmapAS {
-							// Unmap all of ar, not just pseg.Range(), to minimize host
-							// syscalls. AddressSpace mappings must be removed before
-							// pma.file.DecRef().
-							mm.unmapASLocked(ar)
-							didUnmapAS = true
-						}
-						pma.file.DecRef(pseg.fileRange())
-						mm.removeRSSLocked(pseg.Range())
-						pseg = mm.pmas.Remove(pseg).NextSegment()
+						pseg = mm.dropDecommittedPMALocked(vseg, pseg, ar, &didUnmapAS)
 					}
 					if lastWholeHugeEnd != psegAR.End {
 						// psegAR.End is not hugepage-aligned.
@@ -1216,17 +1235,7 @@ func (mm *MemoryManager) Decommit(addr hostarch.Addr, length uint64) error {
 				}
 			}
 			pseg = mm.pmas.Isolate(pseg, vsegAR)
-			pma = pseg.ValuePtr()
-			if !didUnmapAS {
-				// Unmap all of ar, not just pseg.Range(), to minimize host
-				// syscalls. AddressSpace mappings must be removed before
-				// pma.file.DecRef().
-				mm.unmapASLocked(ar)
-				didUnmapAS = true
-			}
-			pma.file.DecRef(pseg.fileRange())
-			mm.removeRSSLocked(pseg.Range())
-			pseg = mm.pmas.Remove(pseg).NextSegment()
+			pseg = mm.dropDecommittedPMALocked(vseg, pseg, ar, &didUnmapAS)
 		}
 		if ar.End <= vseg.End() {
 			break
@@ -1246,6 +1255,29 @@ func (mm *MemoryManager) Decommit(addr hostarch.Addr, length uint64) error {
 		return linuxerr.ENOMEM
 	}
 	return nil
+}
+
+// dropDecommittedPMALocked drops a PMA during MADV_DONTNEED. If the pages
+// still sit on a reserved linear span, DecRef leaves the reservation ref, so
+// the file range is punched to match Linux zeroing.
+func (mm *MemoryManager) dropDecommittedPMALocked(vseg vmaIterator, pseg pmaIterator, unmapAR hostarch.AddrRange, didUnmapAS *bool) pmaIterator {
+	pma := pseg.ValuePtr()
+	if !*didUnmapAS {
+		// Unmap all of unmapAR, not just pseg.Range(), to minimize host
+		// syscalls. AddressSpace mappings must be removed before
+		// pma.file.DecRef().
+		mm.unmapASLocked(unmapAR)
+		*didUnmapAS = true
+	}
+	fr := pseg.fileRange()
+	reservedLinear := vseg.ValuePtr().memfileReserved && pma.off == vseg.fileOffsetAt(pseg.Start())
+	pma.file.DecRef(fr)
+	mm.removeRSSLocked(pseg.Range())
+	if reservedLinear {
+		mm.mf.Decommit(fr)
+		mm.mf.MarkImplicitZero(fr)
+	}
+	return mm.pmas.Remove(pseg).NextSegment()
 }
 
 // madviseMutateVMAs is similar to mm.vmas.MutateRange(), but:

--- a/pkg/sentry/mm/vma.go
+++ b/pkg/sentry/mm/vma.go
@@ -26,6 +26,8 @@ import (
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/limits"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
+	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
+	"gvisor.dev/gvisor/pkg/sentry/usage"
 )
 
 // Caller provides the droppedIDs slice to collect dropped mapping
@@ -130,6 +132,17 @@ func (mm *MemoryManager) createVMALocked(ctx context.Context, opts memmap.MMapOp
 		name:           opts.Name,
 		nameMut:        opts.NameMut,
 	}
+	if opts.Mappable == nil && opts.Length <= pgalloc.MaxAnonymousReserve {
+		fr, err := mm.reserveAnonymousLocked(ctx, opts.Length, vgap, ar.Start, opts.GrowsDown, opts.Stack)
+		if err != nil {
+			if opts.MappingIdentity != nil {
+				opts.MappingIdentity.DecRef(ctx)
+			}
+			return vmaIterator{}, hostarch.AddrRange{}, droppedIDs, err
+		}
+		v.off = fr.Start
+		v.memfileReserved = true
+	}
 
 	vseg := mm.vmas.Insert(vgap, ar, v)
 	mm.usageAS += opts.Length
@@ -141,6 +154,39 @@ func (mm *MemoryManager) createVMALocked(ctx context.Context, opts memmap.MMapOp
 	}
 
 	return vseg, ar, droppedIDs, nil
+}
+
+// reserveAnonymousLocked takes a contiguous uncommitted MemoryFile span for a
+// new anonymous vma. If an adjacent reserved vma exists, it tries to extend
+// that span so the two vmas can merge (brk, mremap grow, MAP_FIXED filling a
+// hole). Previous (lower-address) wins when both sides exist.
+func (mm *MemoryManager) reserveAnonymousLocked(ctx context.Context, length uint64, vgap vmaGapIterator, addr hostarch.Addr, growsDown, isStack bool) (memmap.FileRange, error) {
+	opts := pgalloc.AllocOpts{
+		Kind:    usage.Anonymous,
+		MemCgID: pgalloc.MemoryCgroupIDFromContext(ctx),
+		Mode:    pgalloc.AllocateUncommitted,
+		Dir:     mm.getDefaultAllocationDirection(),
+	}
+	if mm.mf.HugepagesEnabled() && hostarch.IsHugePageAligned(length) && !growsDown && !isStack {
+		opts.Huge = true
+	}
+	if prev := vgap.PrevSegment(); prev.Ok() && prev.End() == addr {
+		pv := prev.ValuePtr()
+		if pv.memfileReserved {
+			opts.PreferStart = true
+			opts.PreferredStart = pv.off + uint64(prev.Range().Length())
+		}
+	}
+	if !opts.PreferStart {
+		if next := vgap.NextSegment(); next.Ok() && next.Start() == addr+hostarch.Addr(length) {
+			nv := next.ValuePtr()
+			if nv.memfileReserved && nv.off >= length {
+				opts.PreferStart = true
+				opts.PreferredStart = nv.off - length
+			}
+		}
+	}
+	return mm.mf.Reserve(length, opts)
 }
 
 type findAvailableOpts struct {
@@ -424,6 +470,12 @@ func (mm *MemoryManager) removeVMAsLocked(ctx context.Context, ar hostarch.AddrR
 		if vma.mappable != nil {
 			vma.mappable.RemoveMapping(ctx, mm, vmaAR, vma.off, vma.canWriteMappableLocked())
 		}
+		if vma.memfileReserved {
+			// Drop the reservation after Invalidate removed pmas (see
+			// unmapLocked). Faulted pages still have the pma ref until
+			// then; unfaulted pages go from 1 to 0 here.
+			mm.mf.DecRef(memmap.FileRange{Start: vma.off, End: vma.off + uint64(vmaAR.Length())})
+		}
 		if vma.id != nil {
 			droppedIDs = append(droppedIDs, vma.id)
 		}
@@ -478,7 +530,8 @@ func (vmaSetFunctions) ClearValue(vma *vma) {
 
 func (vmaSetFunctions) Merge(ar1 hostarch.AddrRange, vma1 vma, ar2 hostarch.AddrRange, vma2 vma) (vma, bool) {
 	if vma1.mappable != vma2.mappable ||
-		(vma1.mappable != nil && vma1.off+uint64(ar1.Length()) != vma2.off) ||
+		vma1.memfileReserved != vma2.memfileReserved ||
+		((vma1.mappable != nil || vma1.memfileReserved) && vma1.off+uint64(ar1.Length()) != vma2.off) ||
 		vma1.realPerms != vma2.realPerms ||
 		vma1.maxPerms != vma2.maxPerms ||
 		vma1.private != vma2.private ||
@@ -512,13 +565,21 @@ func (vmaSetFunctions) Merge(ar1 hostarch.AddrRange, vma1 vma, ar2 hostarch.Addr
 
 func (vmaSetFunctions) Split(ar hostarch.AddrRange, v vma, split hostarch.Addr) (vma, vma) {
 	v2 := v
-	if v2.mappable != nil {
+	if v2.mappable != nil || v2.memfileReserved {
 		v2.off += uint64(split - ar.Start)
 	}
 	if v2.id != nil {
 		v2.id.IncRef()
 	}
 	return v, v2
+}
+
+// fileOffsetAt returns the memmap.File or Mappable offset for addr in vseg:
+// vma.off plus the distance from the start of the vma.
+//
+// Preconditions: vseg.Range().Contains(addr).
+func (vseg vmaIterator) fileOffsetAt(addr hostarch.Addr) uint64 {
+	return vseg.ValuePtr().off + uint64(addr-vseg.Start())
 }
 
 // Preconditions:
@@ -537,9 +598,7 @@ func (vseg vmaIterator) mappableOffsetAt(addr hostarch.Addr) uint64 {
 		}
 	}
 
-	vma := vseg.ValuePtr()
-	vstart := vseg.Start()
-	return vma.off + uint64(addr-vstart)
+	return vseg.fileOffsetAt(addr)
 }
 
 // Preconditions: vseg.ValuePtr().mappable != nil.

--- a/pkg/sentry/pgalloc/pgalloc.go
+++ b/pkg/sentry/pgalloc/pgalloc.go
@@ -221,6 +221,11 @@ const (
 	chunkSize  = 1 << chunkShift // 1 GB
 	chunkMask  = chunkSize - 1
 	maxChunks  = math.MaxInt64 / chunkSize // because file size is int64
+
+	// MaxAnonymousReserve is the largest span mm should Reserve for a
+	// private anonymous mmap. Larger mappings allocate on fault so one
+	// sparse mmap does not grow the MemoryFile by multiple 1 GiB chunks.
+	MaxAnonymousReserve = chunkSize
 )
 
 // chunkInfo is the value type of MemoryFile.chunks.
@@ -301,6 +306,13 @@ type memAcctInfo struct {
 	// MemoryFile.commitSeq when knownCommitted last transitioned to false.
 	// Otherwise, commitSeq is 0.
 	commitSeq uint64
+
+	// implicitZero is true if represented pages are known to read as zeros
+	// without being committed (a reservation that has not been IncRef'd, or
+	// pages MarkImplicitZero'd after DONTNEED dropped the PMA). SaveTo
+	// skips scanning these ranges so a large unfaulted mmap does not
+	// transiently commit the whole span.
+	implicitZero bool
 }
 
 // An EvictableMemoryUser represents a user of MemoryFile-allocated memory that
@@ -577,6 +589,13 @@ type AllocOpts struct {
 	// Dir indicates the direction in which offsets are allocated.
 	Dir Direction
 
+	// If PreferStart is true, Allocate/Reserve try to return the range
+	// starting at PreferredStart when that exact range is still free.
+	// Otherwise they fall back to Dir. PreferStart is ignored when
+	// Allocate recycles waste pages.
+	PreferStart    bool
+	PreferredStart uint64
+
 	// If ReaderFunc is provided, the allocated memory is filled by calling it
 	// repeatedly until either length bytes are read or a non-nil error is
 	// returned. It returns the allocated memory, truncated down to the nearest
@@ -634,11 +653,12 @@ const (
 
 // allocState holds the state of a call to MemoryFile.Allocate().
 type allocState struct {
-	length     uint64
-	opts       AllocOpts
-	willCommit bool // either us or our caller
-	recycled   bool
-	huge       bool
+	length       uint64
+	opts         AllocOpts
+	willCommit   bool // either us or our caller
+	recycled     bool
+	huge         bool
+	implicitZero bool
 }
 
 // Allocate returns a range of initially-zeroed pages of the given length, with
@@ -773,6 +793,35 @@ func (f *MemoryFile) Allocate(length uint64, opts AllocOpts) (memmap.FileRange, 
 	return fr, nil
 }
 
+// Reserve marks a contiguous range of uncommitted pages as used, with a
+// single reference on each page held by the caller. Unlike Allocate, Reserve
+// never commits, zeros, or populates pages, so the span must not be counted
+// as RSS until the caller takes additional references on faulted subranges.
+// The caller must release the reference with DecRef.
+//
+// Reserve uses the same chunk allocator as Allocate: the backing file and
+// sentry mappings grow in chunkSize steps to cover the reserved span, even
+// though pages stay uncommitted. Callers that mmap large sparse regions
+// therefore grow MemoryFile at mmap time rather than at fault time.
+//
+// Preconditions: same as Allocate.
+func (f *MemoryFile) Reserve(length uint64, opts AllocOpts) (memmap.FileRange, error) {
+	if length == 0 || !hostarch.IsPageAligned(length) || (opts.Huge && !hostarch.IsHugePageAligned(length)) {
+		panic(fmt.Sprintf("invalid reservation length: %#x", length))
+	}
+
+	opts.Mode = AllocateUncommitted
+	opts.ReaderFunc = nil
+	alloc := allocState{
+		length:       length,
+		opts:         opts,
+		willCommit:   false,
+		huge:         opts.Huge && f.opts.ExpectHugepages,
+		implicitZero: true,
+	}
+	return f.findAllocatableAndMarkUsed(&alloc)
+}
+
 func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.FileRange, err error) {
 	unwaste := &f.unwasteSmall
 	unfree := &f.unfreeSmall
@@ -843,6 +892,22 @@ func (f *MemoryFile) findAllocatableAndMarkUsed(alloc *allocState) (fr memmap.Fi
 	}
 
 	// No suitable waste pages or we can't use them.
+	if alloc.opts.PreferStart {
+		if pref, ok := f.tryMarkUsedAtLocked(unfree, alloc, alloc.opts.PreferredStart); ok {
+			fr = pref
+			return
+		}
+		oldFileSize := uint64(len(f.chunksLoad())) * chunkSize
+		if alloc.opts.PreferredStart+alloc.length > oldFileSize {
+			if extErr := f.extendChunksLocked(alloc); extErr == nil {
+				if pref, ok := f.tryMarkUsedAtLocked(unfree, alloc, alloc.opts.PreferredStart); ok {
+					fr = pref
+					return
+				}
+			}
+		}
+	}
+
 retryFree:
 	// Try to allocate free pages from existing chunks.
 	var ufgap unfreeGapIterator
@@ -885,8 +950,35 @@ retryFree:
 		memCgID:        alloc.opts.MemCgID,
 		knownCommitted: false,
 		commitSeq:      f.commitSeq,
+		implicitZero:   alloc.implicitZero,
 	})
 	return
+}
+
+// tryMarkUsedAtLocked attempts to mark [start, start+alloc.length) used if
+// that exact range is currently a free gap. Preconditions: f.mu is locked.
+func (f *MemoryFile) tryMarkUsedAtLocked(unfree *unfreeSet, alloc *allocState, start uint64) (memmap.FileRange, bool) {
+	fr := memmap.FileRange{Start: start, End: start + alloc.length}
+	if fr.Length() != alloc.length {
+		return memmap.FileRange{}, false
+	}
+	ufgap := unfree.FindGap(start)
+	if !ufgap.Ok() {
+		return memmap.FileRange{}, false
+	}
+	gap := ufgap.Range()
+	if gap.Start > start || gap.End < fr.End {
+		return memmap.FileRange{}, false
+	}
+	unfree.Insert(ufgap, fr, unfreeInfo{refs: 1})
+	f.memAcct.InsertRange(fr, memAcctInfo{
+		kind:           alloc.opts.Kind,
+		memCgID:        alloc.opts.MemCgID,
+		knownCommitted: false,
+		commitSeq:      f.commitSeq,
+		implicitZero:   alloc.implicitZero,
+	})
+	return fr, true
 }
 
 // Preconditions: f.mu must be locked.
@@ -1108,6 +1200,28 @@ func (f *MemoryFile) Decommit(fr memmap.FileRange) {
 	})
 }
 
+// MarkImplicitZero records that pages in fr are known to contain zeros
+// without being committed. SaveTo skips scanning these ranges.
+//
+// Call this only when no PMA maps fr (typically after DONTNEED dropped the
+// PMA and only the reservation ref remains). Generic Decommit must not set
+// this: hugepage DONTNEED punches while the PMA stays, and the next write
+// does not IncRef.
+//
+// Preconditions: same as Decommit.
+func (f *MemoryFile) MarkImplicitZero(fr memmap.FileRange) {
+	if !fr.WellFormed() || fr.Length() == 0 || fr.Start%hostarch.PageSize != 0 || fr.End%hostarch.PageSize != 0 {
+		panic(fmt.Sprintf("invalid range: %v", fr))
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.memAcct.MutateFullRange(fr, func(maseg memAcctIterator) bool {
+		maseg.ValuePtr().implicitZero = true
+		return true
+	})
+}
+
 func (f *MemoryFile) commitFile(fr memmap.FileRange) error {
 	// "The default operation (i.e., mode is zero) of fallocate() allocates the
 	// disk space within the range specified by offset and len." - fallocate(2)
@@ -1151,7 +1265,17 @@ func (f *MemoryFile) decommitOrManuallyZero(fr memmap.FileRange) {
 //
 // Preconditions: At least one reference must be held on all pages in fr.
 func (f *MemoryFile) HasUniqueRef(fr memmap.FileRange) bool {
-	hasUniqueRef := true
+	return f.HasExactRefs(fr, 1)
+}
+
+// HasExactRefs returns true if all pages in fr have exactly n references.
+// A return value of false is inherently racy, but if the caller holds a
+// reference on the given range and is preventing other goroutines from
+// copying it, then a return value of true is not racy.
+//
+// Preconditions: At least one reference must be held on all pages in fr.
+func (f *MemoryFile) HasExactRefs(fr memmap.FileRange, n uint64) bool {
+	ok := true
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.forEachChunk(fr, func(chunk *chunkInfo, chunkFR memmap.FileRange) bool {
@@ -1159,16 +1283,16 @@ func (f *MemoryFile) HasUniqueRef(fr memmap.FileRange) bool {
 		if chunk.huge {
 			unfree = &f.unfreeHuge
 		}
-		unfree.VisitFullRange(fr, func(ufseg unfreeIterator) bool {
-			if ufseg.ValuePtr().refs != 1 {
-				hasUniqueRef = false
+		unfree.VisitFullRange(chunkFR, func(ufseg unfreeIterator) bool {
+			if ufseg.ValuePtr().refs != n {
+				ok = false
 				return false
 			}
 			return true
 		})
-		return hasUniqueRef
+		return ok
 	})
-	return hasUniqueRef
+	return ok
 }
 
 // FirstSharedRange returns the first subrange of fr on which more than one
@@ -1179,6 +1303,17 @@ func (f *MemoryFile) HasUniqueRef(fr memmap.FileRange) bool {
 //
 // Preconditions: At least one reference must be held on all pages in fr.
 func (f *MemoryFile) FirstSharedRange(fr memmap.FileRange) (memmap.FileRange, bool) {
+	return f.FirstRangeWithRefsAbove(fr, 1)
+}
+
+// FirstRangeWithRefsAbove returns the first subrange of fr on which more than
+// n references are held, and true if such a subrange exists. As for
+// HasUniqueRef, if the caller holds a reference on the given range and is
+// preventing other goroutines from copying it, then subranges reported as
+// unshared (i.e. not contained in the returned range) are not racy.
+//
+// Preconditions: At least one reference must be held on all pages in fr.
+func (f *MemoryFile) FirstRangeWithRefsAbove(fr memmap.FileRange, n uint64) (memmap.FileRange, bool) {
 	var sr memmap.FileRange
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -1189,7 +1324,7 @@ func (f *MemoryFile) FirstSharedRange(fr memmap.FileRange) (memmap.FileRange, bo
 		}
 		cont := true
 		unfree.VisitFullRange(chunkFR, func(ufseg unfreeIterator) bool {
-			if ufseg.ValuePtr().refs > 1 {
+			if ufseg.ValuePtr().refs > n {
 				r := ufseg.Range().Intersect(chunkFR)
 				if sr.Length() == 0 {
 					sr = r
@@ -1203,8 +1338,6 @@ func (f *MemoryFile) FirstSharedRange(fr memmap.FileRange) (memmap.FileRange, bo
 			}
 			return cont
 		})
-		// Continue to the next chunk only if no shared range has been found,
-		// or if the one found may extend into the next chunk.
 		return cont && (sr.Length() == 0 || sr.End == chunkFR.End)
 	})
 	return sr, sr.Length() != 0
@@ -1236,6 +1369,11 @@ func (f *MemoryFile) incRefLocked(fr memmap.FileRange) {
 			uf.refs++
 			return true
 		})
+		return true
+	})
+	// Faulted pages may be written; SaveTo must scan them.
+	f.memAcct.MutateFullRange(fr, func(maseg memAcctIterator) bool {
+		maseg.ValuePtr().implicitZero = false
 		return true
 	})
 }
@@ -1868,6 +2006,17 @@ func (f *MemoryFile) IsDiskBacked() bool {
 // for which AllocOpts.Huge == true with huge pages.
 func (f *MemoryFile) HugepagesEnabled() bool {
 	return f.opts.ExpectHugepages
+}
+
+// IsHugeChunk reports whether the chunk containing off is huge-page-backed.
+// chunk.huge is immutable after the chunk is created.
+func (f *MemoryFile) IsHugeChunk(off uint64) bool {
+	chunks := f.chunksLoad()
+	i := off / chunkSize
+	if i >= uint64(len(chunks)) {
+		return false
+	}
+	return chunks[i].huge
 }
 
 // String implements fmt.Stringer.String.

--- a/pkg/sentry/pgalloc/pgalloc.proto
+++ b/pkg/sentry/pgalloc/pgalloc.proto
@@ -33,6 +33,7 @@ message MemAcctRangeProto {
   uint32 kind = 3;
   uint32 mem_cg_id = 4;
   bool known_committed = 5;
+  bool implicit_zero = 6;
 }
 
 message ChunkInfoProto {

--- a/pkg/sentry/pgalloc/pgalloc_test.go
+++ b/pkg/sentry/pgalloc/pgalloc_test.go
@@ -17,6 +17,8 @@
 package pgalloc
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
 	"gvisor.dev/gvisor/pkg/hostarch"
@@ -583,5 +585,184 @@ func TestFindAllocatable(t *testing.T) {
 				t.Errorf("findAllocatableAndMarkUsed(%+v): got: end=%#x, want: %#x\n%v", alloc, fr.End, wantEnd, f)
 			}
 		})
+	}
+}
+
+func TestReserve(t *testing.T) {
+	f := &MemoryFile{
+		opts: MemoryFileOpts{
+			DisableMemoryAccounting: true,
+		},
+	}
+	f.initFields()
+
+	fr1, err := f.Reserve(2*page, AllocOpts{Dir: BottomUp})
+	if err != nil {
+		t.Fatalf("Reserve(2 pages): %v", err)
+	}
+	fr2, err := f.Reserve(page, AllocOpts{Dir: BottomUp})
+	if err != nil {
+		t.Fatalf("Reserve(1 page): %v", err)
+	}
+	if fr1.Start < fr2.End && fr2.Start < fr1.End {
+		t.Fatalf("overlapping reservations: %v and %v", fr1, fr2)
+	}
+
+	// PreferStart should extend a span when the next pages are still free.
+	wantNext := fr1.End
+	if fr2.Start == fr1.End {
+		wantNext = fr2.End
+	}
+	fr3, err := f.Reserve(page, AllocOpts{
+		Dir:            BottomUp,
+		PreferStart:    true,
+		PreferredStart: wantNext,
+	})
+	if err != nil {
+		t.Fatalf("Reserve PreferStart: %v", err)
+	}
+	if fr3.Start != wantNext {
+		t.Errorf("PreferStart got %#x want %#x", fr3.Start, wantNext)
+	}
+
+	// PreferStart falls back to Dir when the preferred offset is occupied.
+	frMiss, err := f.Reserve(page, AllocOpts{
+		Dir:            BottomUp,
+		PreferStart:    true,
+		PreferredStart: fr1.Start,
+	})
+	if err != nil {
+		t.Fatalf("Reserve PreferStart occupied: %v", err)
+	}
+	if frMiss.Start == fr1.Start {
+		t.Errorf("PreferStart occupied still returned %#x", frMiss.Start)
+	}
+	f.DecRef(frMiss)
+
+	if !f.HasExactRefs(fr1, 1) {
+		t.Errorf("HasExactRefs(%v, 1) got false want true", fr1)
+	}
+	if !f.HasUniqueRef(fr1) {
+		t.Errorf("HasUniqueRef(%v) got false want true", fr1)
+	}
+	f.IncRef(fr1, 0)
+	if !f.HasExactRefs(fr1, 2) {
+		t.Errorf("after IncRef, HasExactRefs(%v, 2) got false want true", fr1)
+	}
+	if f.HasUniqueRef(fr1) {
+		t.Errorf("after IncRef, HasUniqueRef(%v) got true want false", fr1)
+	}
+	f.DecRef(fr1)
+
+	f.DecRef(fr1)
+	seg := f.unfreeSmall.FindSegment(fr1.Start)
+	if !seg.Ok() {
+		t.Fatalf("no unfree segment covering released range %v", fr1)
+	}
+	if refs := seg.ValuePtr().refs; refs != 0 {
+		t.Errorf("after DecRef, refs=%d want 0 (span leaked as used)", refs)
+	}
+}
+
+func implicitZeroAt(f *MemoryFile, off uint64) bool {
+	seg := f.memAcct.FindSegment(off)
+	return seg.Ok() && seg.ValuePtr().implicitZero
+}
+
+func TestReserveSaveSkipsUnfaultedPages(t *testing.T) {
+	f := &MemoryFile{
+		opts: MemoryFileOpts{
+			DisableMemoryAccounting: true,
+		},
+	}
+	f.initFields()
+
+	const length = 4 << 20
+	fr, err := f.Reserve(length, AllocOpts{Dir: BottomUp})
+	if err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if !implicitZeroAt(f, fr.Start) {
+		t.Fatal("Reserve left implicitZero false")
+	}
+
+	var buf bytes.Buffer
+	if err := f.SaveTo(context.Background(), &buf, &SaveOpts{}); err != nil {
+		t.Fatalf("SaveTo unfaulted reserve: %v", err)
+	}
+	seg := f.memAcct.FindSegment(fr.Start)
+	if !seg.Ok() {
+		t.Fatal("memAcct lost reserved span after SaveTo")
+	}
+	if seg.ValuePtr().knownCommitted {
+		t.Fatal("SaveTo marked unfaulted reserved pages knownCommitted")
+	}
+	if !seg.ValuePtr().implicitZero {
+		t.Fatal("SaveTo cleared implicitZero")
+	}
+
+	touched := memmap.FileRange{Start: fr.Start, End: fr.Start + page}
+	f.IncRef(touched, 0)
+	if implicitZeroAt(f, touched.Start) {
+		t.Fatal("IncRef left implicitZero true")
+	}
+	if !implicitZeroAt(f, touched.End) {
+		t.Fatal("IncRef cleared implicitZero on untouched pages")
+	}
+
+	f.DecRef(touched)
+	f.MarkImplicitZero(touched)
+	if !implicitZeroAt(f, touched.Start) {
+		t.Fatal("MarkImplicitZero left implicitZero false")
+	}
+
+	pb := f.exportMetadataProto()
+	var found bool
+	for _, ma := range pb.MemAcct {
+		if ma.Start <= fr.Start && fr.Start < ma.End {
+			found = true
+			if !ma.ImplicitZero {
+				t.Fatal("exportMetadataProto dropped implicitZero")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("exportMetadataProto omitted reserved span")
+	}
+
+	f2 := &MemoryFile{
+		opts: MemoryFileOpts{DisableMemoryAccounting: true},
+	}
+	f2.initFields()
+	if err := f2.importMetadataProto(pb); err != nil {
+		t.Fatalf("importMetadataProto: %v", err)
+	}
+	if !implicitZeroAt(f2, fr.Start) {
+		t.Fatal("importMetadataProto dropped implicitZero")
+	}
+}
+
+func TestReserveHugeUsesHugeUnfree(t *testing.T) {
+	f := &MemoryFile{
+		opts: MemoryFileOpts{
+			ExpectHugepages:         true,
+			DisableMemoryAccounting: true,
+		},
+	}
+	f.initFields()
+
+	fr, err := f.Reserve(hugepage, AllocOpts{Huge: true, Dir: BottomUp})
+	if err != nil {
+		t.Fatalf("Reserve huge: %v", err)
+	}
+	if !f.IsHugeChunk(fr.Start) {
+		t.Fatalf("Reserve(Huge) chunk at %#x is not huge", fr.Start)
+	}
+	seg := f.unfreeHuge.FindSegment(fr.Start)
+	if !seg.Ok() {
+		t.Fatal("Reserve(Huge) did not insert into unfreeHuge")
+	}
+	if refs := seg.ValuePtr().refs; refs != 1 {
+		t.Errorf("unfreeHuge refs=%d want 1", refs)
 	}
 }

--- a/pkg/sentry/pgalloc/save_restore.go
+++ b/pkg/sentry/pgalloc/save_restore.go
@@ -89,6 +89,7 @@ func (f *MemoryFile) exportMetadataProto() *pgallocpb.MemoryFileMetadataProto {
 			Kind:           uint32(val.kind),
 			MemCgId:        val.memCgID,
 			KnownCommitted: val.knownCommitted,
+			ImplicitZero:   val.implicitZero,
 		})
 	}
 	for s := f.unfreeSmall.FirstSegment(); s.Ok(); s = s.NextSegment() {
@@ -144,6 +145,7 @@ func (f *MemoryFile) importMetadataProto(pb *pgallocpb.MemoryFileMetadataProto) 
 			kind:           usage.MemoryKind(s.Kind),
 			memCgID:        s.MemCgId,
 			knownCommitted: s.KnownCommitted,
+			implicitZero:   s.ImplicitZero,
 		})
 	}
 	f.unfreeSmall.RemoveAll()
@@ -404,6 +406,11 @@ func (f *MemoryFile) SaveTo(ctx context.Context, w io.Writer, opts *SaveOpts) er
 		allocatedBytes += fr.Length()
 		ma.commitSeq = 0
 		wasCommitted := ma.knownCommitted
+		if ma.implicitZero && !wasCommitted {
+			alreadyUncommittedBytes += fr.Length()
+			maseg = maseg.NextSegment()
+			continue
+		}
 		if !opts.ExcludeCommittedZeroPages && wasCommitted {
 			alreadyCommittedBytes += fr.Length()
 			maseg = updateAddRange(maseg, fr, true /* wasCommitted */, true /* nowCommitted */)


### PR DESCRIPTION
Linux merges host VMAs only when virtual address, protection, fd, and file offset are contiguous. Private anonymous faults previously allocated from a sandbox-wide MemoryFile free list, so concurrent anonymous allocations (for example multiple glibc arenas) interleaved memfd offsets. On systrap that produces one host VMA per page until `mmap` hits `ENOMEM` (`vm.max_map_count`) and the sentry delivers SIGSEGV on a valid guest mapping. kvm is unaffected because it programs guest PTEs rather than host VMAs.

Reserve an uncommitted MemoryFile span at private anonymous mmap time. Faults `IncRef` subranges of that span instead of `Allocate`, so adjacent guest pages keep adjacent host file offsets and the host can merge VMAs. The reservation is not RSS. Forked children do not inherit it. `mremap` copy drops it so an adjacent destination cannot Merge into an alias of the source.

Also:

- `MADV_DONTNEED` punches reserved pages after dropping the PMA so the next fault reads zeros. The reservation ref stays.
- `SaveTo` skips implicit-zero reserved spans so a large unfaulted mmap does not transiently commit the whole memfd. The flag is persisted in checkpoint metadata.
- Mappings larger than 1 GiB (`MaxAnonymousReserve`) allocate on fault so one sparse mmap does not grow the MemoryFile by multiple chunks.
- Hugepage-aligned reservations may use huge PMAs when the file chunk is huge-backed.
- `MAP_FIXED` immediately below an existing reserved VMA `PreferStart`s the preceding file offset so the mappings can merge.

## Test plan
- [x] `//pkg/sentry/mm:mm_test` and `//pkg/sentry/pgalloc:pgalloc_test` on this branch
- [x] Concurrent faults into two private anonymous mappings keep per-VMA linear offsets
- [x] `mprotect` split, in-place `mremap` grow, `mremap` move+grow, adjacent `MAP_FIXED`, fork COW, munmap RSS drop
- [x] `mremap` copy (`oldSize==0`) does not keep the source reservation; writes do not alias
- [x] `MADV_DONTNEED` zeros reserved pages; RSS drops; refault stays on the same file offset
- [x] `SaveTo` does not mark unfaulted reserved pages known-committed; `implicitZero` round-trips in metadata
- [x] mmap larger than 1 GiB does not reserve; `MAP_FIXED` below a reserved VMA keeps linear offsets
- [x] systrap workload that previously exhausted host VMAs no longer gets `mmap` `ENOMEM`