### PR TITLE
tcp: account for clock resolution in RACK loss detection

### DIFF
--- a/pkg/tcpip/stack/stack.go
+++ b/pkg/tcpip/stack/stack.go
@@ -114,6 +114,10 @@ type Stack struct {
 	// clock is used to generate user-visible times.
 	clock tcpip.Clock
 
+	// clockResolution is an upper bound on the quantization interval of
+	// monotonic timestamps returned by clock.
+	clockResolution time.Duration
+
 	// handleLocal allows non-loopback interfaces to loop packets.
 	handleLocal bool
 
@@ -231,6 +235,17 @@ type Options struct {
 	//
 	// If Clock is nil, tcpip.NewStdClock() will be used.
 	Clock tcpip.Clock
+
+	// ClockResolution is an upper bound on the quantization interval of
+	// timestamps returned by Clock.NowMonotonic. It should be set when the
+	// clock advances in discrete steps large enough to affect TCP loss detection;
+	// for example, some Windows monotonic clocks commonly update every 500 us.
+	// TCP RACK uses this value to avoid declaring loss based on timestamp
+	// quantization alone. It does not describe timer wake-up precision.
+	//
+	// A value of zero means that no quantization allowance is needed or known.
+	// Values less than zero are clamped to zero.
+	ClockResolution time.Duration
 
 	// Stats are optional statistic counters.
 	Stats tcpip.Stats
@@ -415,6 +430,11 @@ func New(opts Options) *Stack {
 
 	opts.NUDConfigs.resetInvalidFields()
 
+	clockResolution := opts.ClockResolution
+	if clockResolution < 0 {
+		clockResolution = 0
+	}
+
 	s := &Stack{
 		transportProtocols:           make(map[tcpip.TransportProtocolNumber]*transportProtocolState),
 		networkProtocols:             make(map[tcpip.NetworkProtocolNumber]NetworkProtocol),
@@ -424,6 +444,7 @@ func New(opts Options) *Stack {
 		cleanupEndpoints:             make(map[TransportEndpoint]struct{}),
 		PortManager:                  ports.NewPortManager(),
 		clock:                        clock,
+		clockResolution:              clockResolution,
 		stats:                        opts.Stats.FillIn(),
 		handleLocal:                  opts.HandleLocal,
 		tables:                       opts.IPTables,
@@ -564,6 +585,16 @@ func (s *Stack) SetTransportProtocolHandler(p tcpip.TransportProtocolNumber, h f
 // scheduling work.
 func (s *Stack) Clock() tcpip.Clock {
 	return s.clock
+}
+
+// ClockResolution returns an upper bound on the quantization interval of
+// monotonic timestamps returned by the Stack's clock.
+//
+// A zero value means to trust the clock advances between reads at a precision
+// close to the precision of the value it returns; consuming code should need no
+// corrections for clock resolution.
+func (s *Stack) ClockResolution() time.Duration {
+	return s.clockResolution
 }
 
 // Stats returns a mutable copy of the current stats.

--- a/pkg/tcpip/stack/stack_test.go
+++ b/pkg/tcpip/stack/stack_test.go
@@ -44,6 +44,25 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip/transport/udp"
 )
 
+func TestClockResolution(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{name: "default"},
+		{name: "positive", got: 500 * time.Microsecond, want: 500 * time.Microsecond},
+		{name: "negative", got: -time.Nanosecond},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s := stack.New(stack.Options{ClockResolution: test.got})
+			if got := s.ClockResolution(); got != test.want {
+				t.Errorf("ClockResolution() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 const (
 	fakeNetNumber        tcpip.NetworkProtocolNumber = math.MaxUint32
 	fakeNetHeaderLen                                 = 12

--- a/pkg/tcpip/transport/tcp/BUILD
+++ b/pkg/tcpip/transport/tcp/BUILD
@@ -219,6 +219,7 @@ go_test(
         "cubic_test.go",
         "endpoint_test.go",
         "main_test.go",
+        "rack_test.go",
         "sack_scoreboard_test.go",
         "segment_test.go",
         "timer_test.go",

--- a/pkg/tcpip/transport/tcp/rack.go
+++ b/pkg/tcpip/transport/tcp/rack.go
@@ -378,6 +378,7 @@ func (rc *rackControl) exitRecovery() {
 func (rc *rackControl) detectLoss(rcvTime tcpip.MonotonicTime) int {
 	var timeout time.Duration
 	numLost := 0
+	clockResolution := rc.snd.ep.stack.ClockResolution()
 	for seg := rc.snd.writeList.Front(); seg != nil && seg.xmitCount != 0; seg = seg.Next() {
 		if rc.snd.ep.scoreboard.IsSACKED(seg.sackBlock()) {
 			continue
@@ -389,13 +390,27 @@ func (rc *rackControl) detectLoss(rcvTime tcpip.MonotonicTime) int {
 		}
 
 		endSeq := seg.sequenceNumber.Add(seqnum.Size(seg.payloadSize()))
-		if seg.xmitTime.Before(rc.XmitTime) || (seg.xmitTime == rc.XmitTime && rc.EndSequence.LessThan(endSeq)) {
-			timeRemaining := seg.xmitTime.Sub(rcvTime) + rc.RTT + rc.ReoWnd
-			if timeRemaining <= 0 {
+		if seg.xmitTime.Before(rc.XmitTime) || (seg.xmitTime == rc.XmitTime && endSeq.LessThan(rc.EndSequence)) {
+			// Timestamp quantization can make two events less than one clock tick
+			// apart appear a full tick apart. Keep that uncertainty separate from
+			// the network reordering window, which RACK may intentionally reduce to
+			// zero during recovery.
+			timeRemaining := seg.xmitTime.Sub(rcvTime) + rc.RTT + rc.ReoWnd + clockResolution
+			if timeRemaining < 0 || (timeRemaining == 0 && clockResolution == 0) {
 				seg.lost = true
 				numLost++
-			} else if timeRemaining > timeout {
-				timeout = timeRemaining
+			} else {
+				// Arm the timer through the uncertainty boundary, so that a timer
+				// target re-evaluation is strictly negative and loss is declared on
+				// the first expiry. Arming only to timeRemaining would make the
+				// expiry a no-op at equality that re-arms a second timer.
+				timeWait := timeRemaining
+				if clockResolution > 0 {
+					timeWait += clockResolution
+				}
+				if timeWait > timeout {
+					timeout = timeWait
+				}
 			}
 		}
 	}

--- a/pkg/tcpip/transport/tcp/rack_test.go
+++ b/pkg/tcpip/transport/tcp/rack_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tcp
+
+import (
+	"testing"
+	"time"
+
+	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/faketime"
+	"gvisor.dev/gvisor/pkg/tcpip/seqnum"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+const testClockResolution = 500 * time.Microsecond
+
+type quantizedClock struct {
+	*faketime.ManualClock
+	resolution time.Duration
+}
+
+func (c *quantizedClock) NowMonotonic() tcpip.MonotonicTime {
+	now := c.ManualClock.NowMonotonic().Sub(tcpip.MonotonicTime{})
+	return tcpip.MonotonicTime{}.Add(now.Truncate(c.resolution))
+}
+
+type rackTestContext struct {
+	clock tcpip.Clock
+	snd   sender
+	segs  []*segment
+}
+
+func newRACKTestContext(clock tcpip.Clock, resolution time.Duration) *rackTestContext {
+	ctx := &rackTestContext{clock: clock}
+	st := stack.New(stack.Options{Clock: clock, ClockResolution: resolution})
+	ctx.snd.ep = &Endpoint{
+		stack:      st,
+		scoreboard: NewSACKScoreboard(1, 0),
+	}
+	ctx.snd.writeList.set = make(map[*segment]struct{})
+	ctx.snd.reorderTimer.init(clock, func() {})
+	ctx.snd.rc.init(&ctx.snd, 0)
+	return ctx
+}
+
+func (ctx *rackTestContext) addSegment(seq seqnum.Value, xmitTime tcpip.MonotonicTime) *segment {
+	seg := newOutgoingSegment(
+		stack.TransportEndpointID{},
+		ctx.clock,
+		buffer.MakeWithView(buffer.NewViewSize(1)),
+		0,
+	)
+	seg.sequenceNumber = seq
+	seg.xmitCount = 1
+	seg.xmitTime = xmitTime
+	ctx.snd.writeList.PushBack(seg)
+	ctx.segs = append(ctx.segs, seg)
+	return seg
+}
+
+func (ctx *rackTestContext) cleanup() {
+	ctx.snd.reorderTimer.cleanup()
+	for _, seg := range ctx.segs {
+		seg.DecRef()
+	}
+}
+
+func TestRACKQuantizedClockPreventsPrematureLossAndSchedulesRecheck(t *testing.T) {
+	clock := &quantizedClock{
+		ManualClock: faketime.NewManualClock(),
+		resolution:  testClockResolution,
+	}
+	ctx := newRACKTestContext(clock, testClockResolution)
+	defer ctx.cleanup()
+
+	// Send the older packet just before a quantization boundary.
+	clock.Advance(testClockResolution - time.Microsecond)
+	older := ctx.addSegment(0, clock.NowMonotonic())
+
+	// Send the newer packet just after the boundary, then receive its ACK
+	// within the same clock bucket.
+	clock.Advance(2 * time.Microsecond)
+	newer := ctx.addSegment(1, clock.NowMonotonic())
+	clock.Advance(49 * time.Microsecond)
+	ack := newOutgoingSegment(stack.TransportEndpointID{}, clock, buffer.Buffer{}, 0)
+	defer ack.DecRef()
+
+	ctx.snd.rc.update(newer, ack)
+	if got := ctx.snd.rc.RTT; got != 0 {
+		t.Fatalf("RACK RTT = %v, want 0", got)
+	}
+	wantXmitTime := (tcpip.MonotonicTime{}).Add(testClockResolution)
+	if got := ctx.snd.rc.XmitTime; got != wantXmitTime {
+		t.Fatalf("RACK transmit time = %v, want %v", got, wantXmitTime)
+	}
+	if got := ctx.snd.rc.EndSequence; got != 2 {
+		t.Fatalf("RACK end sequence = %d, want 2", got)
+	}
+
+	var timerFired bool
+	ctx.snd.reorderTimer.cleanup()
+	ctx.snd.reorderTimer.init(clock, func() { timerFired = true })
+	if got := ctx.snd.rc.detectLoss(ack.rcvdTime); got != 0 {
+		t.Fatalf("detectLoss at ACK got %d losses, want 0", got)
+	}
+	if older.lost {
+		t.Fatal("older packet marked lost from quantization alone")
+	}
+	wantTimerTarget := (tcpip.MonotonicTime{}).Add(2 * testClockResolution)
+	if got := ctx.snd.reorderTimer.target; got != wantTimerTarget {
+		t.Fatalf("reorder timer target = %v, want %v", got, wantTimerTarget)
+	}
+
+	clock.Advance(testClockResolution - time.Nanosecond)
+	if timerFired {
+		t.Fatal("reorder timer fired before its target")
+	}
+	clock.Advance(time.Nanosecond)
+	if !timerFired {
+		t.Fatal("reorder timer did not fire at its target")
+	}
+	if older.lost {
+		t.Fatal("timer callback marked packet lost before endpoint processing")
+	}
+
+	// Delay endpoint processing by another tick. The production expiry path
+	// evaluates loss at the timer target, where the packet is now beyond the
+	// uncertainty boundary, rather than adding callback delay to its age.
+	clock.Advance(testClockResolution)
+	ctx.snd.FastRecovery.Active = true
+	ctx.snd.SndNxt = 1
+	ctx.snd.SndCwnd = 0
+	if err := ctx.snd.rc.reorderTimerExpired(); err != nil {
+		t.Fatalf("reorderTimerExpired failed: %v", err)
+	}
+	if !older.lost {
+		t.Fatal("reorderTimerExpired did not mark older packet lost at timer target")
+	}
+}
+
+func TestRACKClockResolutionPreventsPrematureLoss(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		resolution time.Duration
+		wantLost   bool
+	}{
+		{name: "unspecified resolution", wantLost: true},
+		{name: "quantization allowance", resolution: testClockResolution},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			clock := faketime.NewManualClock()
+			ctx := newRACKTestContext(clock, test.resolution)
+			defer ctx.cleanup()
+			ctx.snd.rc.XmitTime = tcpip.MonotonicTime{}.Add(testClockResolution)
+			ctx.snd.rc.EndSequence = 2
+			seg := ctx.addSegment(0, tcpip.MonotonicTime{})
+
+			gotLost := ctx.snd.rc.detectLoss(tcpip.MonotonicTime{}.Add(testClockResolution)) != 0
+			if gotLost != test.wantLost || seg.lost != test.wantLost {
+				t.Errorf("detectLoss=%t, segment lost=%t; want %t", gotLost, seg.lost, test.wantLost)
+			}
+		})
+	}
+}
+
+func TestRACKClockResolutionLossBoundaryIsExclusive(t *testing.T) {
+	clock := faketime.NewManualClock()
+	ctx := newRACKTestContext(clock, testClockResolution)
+	defer ctx.cleanup()
+	ctx.snd.rc.XmitTime = tcpip.MonotonicTime{}.Add(time.Nanosecond)
+	ctx.snd.rc.EndSequence = 2
+	seg := ctx.addSegment(0, tcpip.MonotonicTime{})
+
+	if got := ctx.snd.rc.detectLoss(tcpip.MonotonicTime{}.Add(testClockResolution)); got != 0 {
+		t.Fatalf("detectLoss at uncertainty boundary got %d losses, want 0", got)
+	}
+	if seg.lost {
+		t.Fatal("segment marked lost at uncertainty boundary")
+	}
+	if !ctx.snd.reorderTimer.enabled() {
+		t.Fatal("reorder timer not enabled at uncertainty boundary")
+	}
+	if got := ctx.snd.rc.detectLoss(tcpip.MonotonicTime{}.Add(2 * testClockResolution)); got != 1 {
+		t.Fatalf("detectLoss after uncertainty boundary got %d losses, want 1", got)
+	}
+}
+
+// TestRACKReorderTimerDeclaresLossOnFirstExpiry verifies that a reorder timer
+// armed on a quantized clock expires exactly once, at the loss deadline
+// including timestamp uncertainty, and that its first expiry declares loss.
+// Arming only to the pre-uncertainty deadline makes every expiry a no-op that
+// re-arms a second timer before any loss is declared.
+func TestRACKReorderTimerDeclaresLossOnFirstExpiry(t *testing.T) {
+	clock := faketime.NewManualClock()
+	ctx := newRACKTestContext(clock, testClockResolution)
+	defer ctx.cleanup()
+
+	// A newer packet was transmitted one tick after the older packet below,
+	// and its ACK was received in the same clock bucket, so RACK.RTT and
+	// RACK.ReoWnd are zero. The older packet's loss deadline is therefore
+	// exactly one clock resolution past the ACK processing time.
+	ctx.snd.rc.XmitTime = tcpip.MonotonicTime{}.Add(testClockResolution)
+	ctx.snd.rc.EndSequence = 2
+	older := ctx.addSegment(0, tcpip.MonotonicTime{})
+
+	var timerFired bool
+	ctx.snd.reorderTimer.cleanup()
+	ctx.snd.reorderTimer.init(clock, func() { timerFired = true })
+
+	// detectLoss must not declare loss while the uncertainty boundary has
+	// not elapsed, and must arm the timer through that boundary so that the
+	// first expiry observes a negative timeRemaining.
+	if got := ctx.snd.rc.detectLoss(tcpip.MonotonicTime{}); got != 0 {
+		t.Fatalf("detectLoss got %d losses, want 0", got)
+	}
+	if older.lost {
+		t.Fatal("segment marked lost before the uncertainty boundary elapsed")
+	}
+	if !ctx.snd.reorderTimer.enabled() {
+		t.Fatal("reorder timer not armed")
+	}
+	if got, want := ctx.snd.reorderTimer.target, (tcpip.MonotonicTime{}).Add(2*testClockResolution); got != want {
+		t.Fatalf("reorder timer target = %v, want %v", got, want)
+	}
+
+	// A single expiry at the target must be sufficient to declare loss.
+	clock.Advance(2 * testClockResolution)
+	if !timerFired {
+		t.Fatal("reorder timer did not fire at its target")
+	}
+	ctx.snd.FastRecovery.Active = true
+	ctx.snd.SndNxt = 1
+	ctx.snd.SndCwnd = 0
+	if err := ctx.snd.rc.reorderTimerExpired(); err != nil {
+		t.Fatalf("reorderTimerExpired failed: %v", err)
+	}
+	if !older.lost {
+		t.Fatal("reorderTimerExpired did not declare loss on the first timer expiry")
+	}
+}
+
+func TestRACKEqualTransmitTimeOrdersByEndSequence(t *testing.T) {
+	clock := faketime.NewManualClock()
+	ctx := newRACKTestContext(clock, 0)
+	defer ctx.cleanup()
+	ctx.snd.rc.EndSequence = 2
+	for seq := seqnum.Value(0); seq < 3; seq++ {
+		ctx.addSegment(seq, tcpip.MonotonicTime{})
+	}
+
+	if got := ctx.snd.rc.detectLoss(tcpip.MonotonicTime{}); got != 1 {
+		t.Fatalf("detectLoss got %d losses, want 1", got)
+	}
+	for seg := ctx.snd.writeList.Front(); seg != nil; seg = seg.Next() {
+		wantLost := seg.sequenceNumber == 0
+		if seg.lost != wantLost {
+			t.Errorf("segment ending at %d lost=%t, want %t", seg.sequenceNumber.Add(1), seg.lost, wantLost)
+		}
+	}
+}
+
+func TestRACKDetectLossSteadyStateDoesNotAllocate(t *testing.T) {
+	clock := faketime.NewManualClock()
+	ctx := newRACKTestContext(clock, testClockResolution)
+	defer ctx.cleanup()
+	ctx.snd.rc.XmitTime = tcpip.MonotonicTime{}.Add(testClockResolution)
+	ctx.snd.rc.EndSequence = 2
+	ctx.addSegment(0, tcpip.MonotonicTime{})
+
+	// Exclude the existing timer facility's one-time initialization.
+	ctx.snd.reorderTimer.enable(testClockResolution)
+	allocs := testing.AllocsPerRun(1000, func() {
+		if got := ctx.snd.rc.detectLoss(tcpip.MonotonicTime{}.Add(testClockResolution)); got != 0 {
+			panic("detectLoss unexpectedly reported loss")
+		}
+	})
+	if allocs != 0 {
+		t.Errorf("detectLoss allocated %v objects per call, want 0", allocs)
+	}
+}
+
+func TestRACKZeroClockResolutionPreservesLossBoundary(t *testing.T) {
+	clock := faketime.NewManualClock()
+	ctx := newRACKTestContext(clock, 0)
+	defer ctx.cleanup()
+	ctx.snd.rc.XmitTime = tcpip.MonotonicTime{}.Add(time.Nanosecond)
+	ctx.snd.rc.EndSequence = 2
+	ctx.addSegment(0, tcpip.MonotonicTime{})
+
+	if got := ctx.snd.rc.detectLoss(tcpip.MonotonicTime{}); got != 1 {
+		t.Fatalf("detectLoss at zero-resolution boundary got %d losses, want 1", got)
+	}
+}


### PR DESCRIPTION
A coarse monotonic clock can make events separated by only a few microseconds appear one full clock tick apart. It can also give RACK a zero RTT sample when a packet and its ACK fall in the same tick. Together, these effects can cause RACK to declare an older packet lost before its loss window has actually elapsed.

Add ClockResolution to stack.Options and include it as timestamp uncertainty in RACK's loss threshold. At the uncertainty boundary, wait for the clock to advance before declaring loss. Keep this allowance separate from the reordering window, which RACK may reduce to zero during recovery.

Windows monotonic clocks commonly have a 500 microsecond resolution. Callers using such a clock should configure ClockResolution accordingly.

Order packets with equal transmit timestamps by ending sequence number. Continue to evaluate delayed reorder-timer processing at the scheduled timer target so callback delay does not add to packet age.

Add regression tests using a clock with 500 microsecond timestamp resolution, including timer expiry, equal-timestamp ordering, option handling, and steady-state allocation behavior.

Fixes #9778