### PR TITLE
devpts: return ESPIPE on positional read and write

### DIFF
--- a/pkg/sentry/fsimpl/devpts/master.go
+++ b/pkg/sentry/fsimpl/devpts/master.go
@@ -66,6 +66,8 @@ func (mi *masterInode) Open(ctx context.Context, rp *vfs.ResolvingPath, d *kernf
 	}
 	fd.LockFD.Init(&mi.locks)
 	if err := fd.vfsfd.Init(fd, opts.Flags, rp.Credentials(), rp.Mount(), d.VFSDentry(), &vfs.FileDescriptionOptions{
+		DenyPRead:   true,
+		DenyPWrite:  true,
 		SpecialFile: true,
 	}); err != nil {
 		return nil, err

--- a/pkg/sentry/fsimpl/devpts/terminal.go
+++ b/pkg/sentry/fsimpl/devpts/terminal.go
@@ -74,6 +74,8 @@ func (t *Terminal) OpenTTY(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry
 	}
 	fd.LockFD.Init(&ri.locks)
 	if err := fd.vfsfd.Init(fd, opts.Flags, tsk.Credentials(), mnt, vfsd, &vfs.FileDescriptionOptions{
+		DenyPRead:   true,
+		DenyPWrite:  true,
 		SpecialFile: true,
 	}); err != nil {
 		return nil, err

--- a/test/syscalls/linux/pty.cc
+++ b/test/syscalls/linux/pty.cc
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 #include <sys/wait.h>
 #include <termios.h>
 #include <unistd.h>
@@ -2719,6 +2720,34 @@ TEST_F(JobControlTest, SigwinchOnWindowSizeChange) {
   ASSERT_THAT(waitpid(child, &wstatus, 0), SyscallSucceedsWithValue(child));
   ASSERT_TRUE(WIFEXITED(wstatus));
   EXPECT_EQ(WEXITSTATUS(wstatus), 42);
+}
+
+TEST_F(PtyTest, PositionalIO) {
+  char buf[32] = {};
+  struct iovec iov = {
+      .iov_base = buf,
+      .iov_len = sizeof(buf),
+  };
+
+  // Positional I/O on master should return ESPIPE.
+  EXPECT_THAT(pread(master_.get(), buf, sizeof(buf), 0),
+              SyscallFailsWithErrno(ESPIPE));
+  EXPECT_THAT(pwrite(master_.get(), buf, sizeof(buf), 0),
+              SyscallFailsWithErrno(ESPIPE));
+  EXPECT_THAT(preadv(master_.get(), &iov, 1, 0),
+              SyscallFailsWithErrno(ESPIPE));
+  EXPECT_THAT(pwritev(master_.get(), &iov, 1, 0),
+              SyscallFailsWithErrno(ESPIPE));
+
+  // Positional I/O on replica should return ESPIPE.
+  EXPECT_THAT(pread(replica_.get(), buf, sizeof(buf), 0),
+              SyscallFailsWithErrno(ESPIPE));
+  EXPECT_THAT(pwrite(replica_.get(), buf, sizeof(buf), 0),
+              SyscallFailsWithErrno(ESPIPE));
+  EXPECT_THAT(preadv(replica_.get(), &iov, 1, 0),
+              SyscallFailsWithErrno(ESPIPE));
+  EXPECT_THAT(pwritev(replica_.get(), &iov, 1, 0),
+              SyscallFailsWithErrno(ESPIPE));
 }
 
 }  // namespace


### PR DESCRIPTION
Positional I/O (`pread`, `pwrite`, `preadv`, `pwritev`, `preadv2`, `pwritev2` with an offset) on Linux pseudo-terminals fails with `ESPIPE`.

In gVisor, `masterFileDescription` and `replicaFileDescription` inherited `FileDescriptionDefaultImpl`, which returns `EINVAL` when `opts.DenyPRead` and `opts.DenyPWrite` are false.

Set `DenyPRead` and `DenyPWrite` in `FileDescriptionOptions` when initializing both master and replica file descriptions so positional reads and writes return `ESPIPE`.

Fixes #13738.