### PR TITLE
boot: guard against nil thread group when resolving PID namespace path

### DIFF
--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -1401,8 +1401,10 @@ func (l *Loader) startSubcontainer(spec *specs.Spec, conf *config.Config, cid st
 			for _, p := range l.processes {
 				if ns.Path == p.pidnsPath {
 					log.Debugf("Joining PID namespace named %q", ns.Path)
-					pidns = p.tg.PIDNamespace()
-					break
+					if p.tg != nil {
+						pidns = p.tg.PIDNamespace()
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When a subcontainer configuration specifies a PID namespace path (`ns.Path != ""`), `startSubcontainer` iterates through `l.processes` to match the path.

If the matching process container has not started yet, `p.tg` is nil. Calling `p.tg.PIDNamespace()` causes a nil pointer panic in the Sentry.

Guard the PID namespace lookup with a nil check on `p.tg`. If `p.tg` is nil, the lookup falls through to creating a new child PID namespace as intended when the target namespace is unresolvable.

Fixes #14074.