### PR TITLE
Support SECCOMP_RET_KILL_PROCESS in seccomp filter evaluation

### DIFF
--- a/pkg/sentry/kernel/seccomp.go
+++ b/pkg/sentry/kernel/seccomp.go
@@ -95,7 +95,7 @@ func seccompSiginfo(t *Task, errno, sysno int32, ip hostarch.Addr) *linux.Signal
 // Preconditions: The caller must be running on the task goroutine.
 func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip hostarch.Addr) linux.BPFAction {
 	result := linux.BPFAction(t.evaluateSyscallFilters(sysno, args, ip))
-	action := result & linux.SECCOMP_RET_ACTION
+	action := result & linux.SECCOMP_RET_ACTION_FULL
 	switch action {
 	case linux.SECCOMP_RET_TRAP:
 		// "Results in the kernel sending a SIGSYS signal to the triggering
@@ -131,6 +131,11 @@ func (t *Task) checkSeccompSyscall(sysno int32, args arch.SyscallArguments, ip h
 		// "Results in the task exiting immediately without executing the
 		// system call. The exit status of the task will be SIGSYS, not
 		// SIGKILL."
+
+	case linux.SECCOMP_RET_KILL_PROCESS:
+		// "Results in the entire thread group exiting immediately without
+		// executing the system call. The exit status of the thread group
+		// will be SIGSYS, not SIGKILL."
 
 	default:
 		// consistent with Linux
@@ -186,7 +191,12 @@ func (t *Task) evaluateSyscallFilters(sysno int32, args arch.SyscallArguments, i
 		// "The ordering ensures that a min_t() over composed return values
 		// always selects the least permissive choice." -
 		// include/uapi/linux/seccomp.h
-		if (thisRet & linux.SECCOMP_RET_ACTION) < (ret & linux.SECCOMP_RET_ACTION) {
+		//
+		// In Linux (kernel/seccomp.c), ACTION_ONLY is defined as:
+		// ((s32)((ret) & SECCOMP_RET_ACTION_FULL))
+		// Signed comparison ensures that SECCOMP_RET_KILL_PROCESS (0x80000000,
+		// i.e. -2147483648) has the highest precedence.
+		if int32(thisRet&linux.SECCOMP_RET_ACTION_FULL) < int32(ret&linux.SECCOMP_RET_ACTION_FULL) {
 			ret = thisRet
 		}
 	}
@@ -252,7 +262,7 @@ func (ts *taskSeccomp) populateCache(t *Task) {
 				sysnoIsCacheable = false
 				break
 			}
-			if (linux.BPFAction(result) & linux.SECCOMP_RET_ACTION) < (ret & linux.SECCOMP_RET_ACTION) {
+			if int32(linux.BPFAction(result)&linux.SECCOMP_RET_ACTION_FULL) < int32(ret&linux.SECCOMP_RET_ACTION_FULL) {
 				ret = linux.BPFAction(result)
 			}
 		}

--- a/pkg/sentry/kernel/task_syscall.go
+++ b/pkg/sentry/kernel/task_syscall.go
@@ -243,8 +243,12 @@ func (t *Task) doSyscall() taskRunState {
 		case linux.SECCOMP_RET_ALLOW:
 			// ok
 		case linux.SECCOMP_RET_KILL_THREAD:
-			t.Debugf("Syscall %d: killed by seccomp", sysno)
+			t.Debugf("Syscall %d: thread killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("Syscall %d: process killed by seccomp", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
 			return (*runExit)(nil)
 		case linux.SECCOMP_RET_TRACE:
 			t.Debugf("Syscall %d: stopping for PTRACE_EVENT_SECCOMP", sysno)
@@ -400,8 +404,12 @@ func (t *Task) doVsyscall(addr hostarch.Addr, sysno uintptr) taskRunState {
 			t.Debugf("vsyscall %d, caller %x: stopping for PTRACE_EVENT_SECCOMP", sysno, t.Arch().Value(caller))
 			return &runVsyscallAfterPtraceEventSeccomp{addr, sysno, caller}
 		case linux.SECCOMP_RET_KILL_THREAD:
-			t.Debugf("vsyscall %d: killed by seccomp", sysno)
+			t.Debugf("vsyscall %d: thread killed by seccomp", sysno)
 			t.PrepareExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
+			return (*runExit)(nil)
+		case linux.SECCOMP_RET_KILL_PROCESS:
+			t.Debugf("vsyscall %d: process killed by seccomp", sysno)
+			t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))
 			return (*runExit)(nil)
 		default:
 			panic(fmt.Sprintf("Unknown seccomp result %d", r))

--- a/test/syscalls/linux/seccomp.cc
+++ b/test/syscalls/linux/seccomp.cc
@@ -218,6 +218,35 @@ TEST(SeccompTest, RetKillOnlyKillsOneThread) {
       << "status " << status;
 }
 
+TEST(SeccompTest, RetKillProcessKillsAllThreads) {
+  Mapping stack = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_READ | PROT_WRITE, MAP_PRIVATE));
+
+  pid_t const pid = fork();
+  if (pid == 0) {
+    RegisterSignalHandler(SIGSYS, +[](int, siginfo_t*, void*) { _exit(1); });
+    ApplySeccompFilter(kFilteredSyscall, SECCOMP_RET_KILL_PROCESS);
+    clone(
+        +[](void* arg) {
+          syscall(kFilteredSyscall);  // should kill the entire process
+          _exit(1);                   // unreachable
+          return 2;
+        },
+        stack.endptr(),
+        CLONE_FILES | CLONE_FS | CLONE_SIGHAND | CLONE_THREAD | CLONE_VM |
+            CLONE_VFORK,
+        nullptr);
+    // If only the thread was killed instead of the process, this thread
+    // would wake up from CLONE_VFORK and exit with 0.
+    _exit(0);
+  }
+  ASSERT_THAT(pid, SyscallSucceeds());
+  int status;
+  ASSERT_THAT(waitpid(pid, &status, 0), SyscallSucceedsWithValue(pid));
+  EXPECT_TRUE(WIFSIGNALED(status) && WTERMSIG(status) == SIGSYS)
+      << "status " << status;
+}
+
 TEST(SeccompTest, RetTrapCausesSIGSYS) {
   pid_t const pid = fork();
   if (pid == 0) {


### PR DESCRIPTION
In Linux seccomp BPF filters, `SECCOMP_RET_KILL_PROCESS` (0x80000000) terminates the entire thread group and carries the highest priority among filter actions.

gVisor previously masked filter results using `linux.SECCOMP_RET_ACTION` (0x7fff0000), which stripped bit 31 and evaluated `SECCOMP_RET_KILL_PROCESS` as `SECCOMP_RET_KILL_THREAD` (0x0). Furthermore, filter precedence comparisons were unsigned, preventing `0x80000000` from winning over more permissive actions, and `doSyscall`/`doVsyscall` only handled individual thread termination.

This patch:
- Changes the filter action mask in `checkSeccompSyscall` to `linux.SECCOMP_RET_ACTION_FULL`.
- Casts action comparisons in `evaluateSyscallFilters` and `populateCache` to signed 32-bit integers, mirroring Linux `ACTION_ONLY`.
- Triggers `t.PrepareGroupExit(linux.WaitStatusTerminationSignal(linux.SIGSYS))` on `linux.SECCOMP_RET_KILL_PROCESS` in `doSyscall` and `doVsyscall`.
- Adds `RetKillProcessKillsAllThreads` to `test/syscalls/linux/seccomp.cc`.