### PR TITLE
Remove the first veth end when the peer netns is refused

### DIFF
--- a/pkg/sentry/socket/netstack/stack.go
+++ b/pkg/sentry/socket/netstack/stack.go
@@ -497,6 +497,7 @@ func (s *Stack) newVeth(ctx context.Context, linkAttrs map[uint16]nlmsg.BytesVie
 	}
 	peerDstNs, sysErr := peerStack.lockSrcAndDst(ctx, peerLinkAttrs)
 	if sysErr != nil {
+		peerEP.Close()
 		return sysErr
 	}
 	defer peerStack.unlockSrcAndDst(ctx, peerDstNs)

--- a/test/syscalls/linux/socket_netlink_route.cc
+++ b/test/syscalls/linux/socket_netlink_route.cc
@@ -2073,7 +2073,8 @@ struct VethRequest {
 };
 
 struct VethRequest GetVethRequest(uint32_t seq, const char* ifname_first,
-                                  const char* ifname_second) {
+                                  const char* ifname_second,
+                                  int peer_netns_fd = -1) {
   struct VethRequest req = {};
   req.hdr.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
   req.hdr.nlmsg_type = RTM_NEWLINK;
@@ -2098,6 +2099,10 @@ struct VethRequest GetVethRequest(uint32_t seq, const char* ifname_first,
         addattr(&req.hdr, sizeof(req), VETH_INFO_PEER, &ifm, sizeof(ifm));
         addattr(&req.hdr, sizeof(req), IFLA_IFNAME, ifname_second,
                 strlen(ifname_second));
+        if (peer_netns_fd >= 0) {
+          addattr(&req.hdr, sizeof(req), IFLA_NET_NS_FD, &peer_netns_fd,
+                  sizeof(peer_netns_fd));
+        }
       }
       peer_data->rta_len = (uint64_t)NLMSG_TAIL(&req.hdr) - (uint64_t)peer_data;
     }
@@ -2263,6 +2268,40 @@ TEST(NetlinkRouteTest, VethAddShortPeerIfInfoMsg) {
   for (const Link& link : links) {
     EXPECT_NE(link.name, "veth1");
   }
+}
+
+TEST(NetlinkRouteTest, VethAddRefusedPeerNetnsLeavesNothing) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_NET_ADMIN)));
+  SKIP_IF(IsRunningWithHostinet());
+  if (!IsRunningOnGvisor()) {
+    auto version = ASSERT_NO_ERRNO_AND_VALUE(GetKernelVersion());
+    // Linux refuses a peer netns the caller does not own since 7.0 -
+    // https://github.com/torvalds/linux/commit/7b735ef81286
+    SKIP_IF(version.major < 7);
+  }
+
+  const FileDescriptor outer_nsfd =
+      ASSERT_NO_ERRNO_AND_VALUE(Open("/proc/thread-self/ns/net", O_RDONLY));
+
+  ASSERT_THAT(InForkedProcess([&] {
+                // The new user namespace does not own the netns
+                // outer_nsfd points at, so the peer is refused.
+                TEST_PCHECK(syscall(SYS_unshare,
+                                    CLONE_NEWUSER | CLONE_NEWNET) == 0);
+
+                FileDescriptor fd = TEST_CHECK_NO_ERRNO_AND_VALUE(
+                    NetlinkBoundSocket(NETLINK_ROUTE));
+                VethRequest req =
+                    GetVethRequest(kSeq, "veth1", "veth2", outer_nsfd.get());
+                TEST_CHECK(
+                    NetlinkRequestAckOrError(fd, kSeq, &req, req.hdr.nlmsg_len)
+                        .errno_value() == EPERM);
+
+                TEST_CHECK(if_nametoindex("veth1") == 0);
+                TEST_CHECK(if_nametoindex("veth2") == 0);
+                _exit(0);
+              }),
+              IsPosixErrorOkAndHolds(0));
 }
 
 TEST(NetlinkRouteTest, LinkInfoKind) {


### PR DESCRIPTION
lockSrcAndDst on the peer stack runs after the first NIC is up, and its error return skips the cleanup. Every refused create leaves a device the caller never asked to keep.

Close the pair there too.

Linux refuses an unowned peer netns since 7b735ef81286 (7.0), so the test skips older kernels.

Fixes #14511
