### PR TITLE
Fix setsid deadlock when orphaning a shared-sighand process group

### DIFF
--- a/pkg/sentry/kernel/sessions.go
+++ b/pkg/sentry/kernel/sessions.go
@@ -258,9 +258,17 @@ func (pg *ProcessGroup) SendSignal(info *linux.SignalInfo) error {
 // leader, or a ProcessGroup already exists for the ThreadGroup's ID.
 func (tg *ThreadGroup) CreateSession(ctx context.Context) (SessionID, error) {
 	tg.pidns.owner.mu.Lock()
-	tg.signalHandlers.mu.Lock()
-	sid, oldTTY, err := tg.createSession()
-	tg.signalHandlers.mu.Unlock()
+	sid, err := tg.createSession()
+	var oldTTY *TTY
+	if err == nil {
+		// tg.tty is protected by the signal mutex, which must not be held
+		// across createSession: it may orphan the old process group, and
+		// handleOrphan locks the signal mutex of each remaining member.
+		tg.signalHandlers.mu.Lock()
+		oldTTY = tg.tty
+		tg.tty = nil
+		tg.signalHandlers.mu.Unlock()
+	}
 	tg.pidns.owner.mu.Unlock()
 	if oldTTY != nil {
 		oldTTY.DecRef(ctx)
@@ -268,12 +276,10 @@ func (tg *ThreadGroup) CreateSession(ctx context.Context) (SessionID, error) {
 	return sid, err
 }
 
-// createSession creates a new session for a threadgroup. If the thread group
-// had a controlling terminal, it is returned so that the caller can drop the
-// bond reference outside of the locks.
+// createSession creates a new session for a threadgroup.
 //
-// Precondition: callers must hold TaskSet.mu and the signal mutex for writing.
-func (tg *ThreadGroup) createSession() (SessionID, *TTY, error) {
+// +checklocks:tg.pidns.owner.mu
+func (tg *ThreadGroup) createSession() (SessionID, error) {
 	// Get the ID for this thread in the current namespace.
 	id := tg.pidns.tgids[tg]
 
@@ -284,14 +290,14 @@ func (tg *ThreadGroup) createSession() (SessionID, *TTY, error) {
 			continue
 		}
 		if s.leader == tg {
-			return -1, nil, linuxerr.EPERM
+			return -1, linuxerr.EPERM
 		}
 		if s.id == SessionID(id) {
-			return -1, nil, linuxerr.EPERM
+			return -1, linuxerr.EPERM
 		}
 		for pg := s.processGroups.Front(); pg != nil; pg = pg.Next() {
 			if pg.id == ProcessGroupID(id) {
-				return -1, nil, linuxerr.EPERM
+				return -1, linuxerr.EPERM
 			}
 		}
 	}
@@ -329,11 +335,8 @@ func (tg *ThreadGroup) createSession() (SessionID, *TTY, error) {
 			childTG.processGroup.incRefWithParent(pg)
 			childTG.processGroup.decRefWithParent(oldParentPG)
 		})
-		// If tg.processGroup is an orphan, decRefWithParent will lock
-		// the signal mutex of each thread group in tg.processGroup.
-		// However, tg's signal mutex may already be locked at this
-		// point. We change tg's process group before calling
-		// decRefWithParent to avoid locking tg's signal mutex twice.
+		// Reassign before decRef so tg isn't signaled as a member of the
+		// old group if it becomes orphaned.
 		oldPG := tg.processGroup
 		tg.processGroup = pg
 		oldPG.decRefWithParent(oldParentPG)
@@ -360,12 +363,9 @@ func (tg *ThreadGroup) createSession() (SessionID, *TTY, error) {
 		ns.processGroups[ProcessGroupID(local)] = pg
 	}
 
-	// Disconnect from the controlling terminal, handing the bond reference to
-	// the caller to drop outside of the locks.
-	oldTTY := tg.tty
-	tg.tty = nil
-
-	return sid, oldTTY, nil
+	// The caller disconnects the controlling terminal (tg.tty), which is
+	// protected by the signal mutex.
+	return sid, nil
 }
 
 // CreateProcessGroup creates a new process group.

--- a/pkg/sentry/kernel/task_start.go
+++ b/pkg/sentry/kernel/task_start.go
@@ -411,7 +411,7 @@ func (ts *TaskSet) newTask(ctx context.Context, cfg *TaskConfig) (*Task, error) 
 		// New thread group.
 		tg.leader = t
 		if parentPG := tg.parentPG(); parentPG == nil {
-			tg.createSession()
+			tg.createSession() // +checklocksforce: ts.mu is tg.pidns.owner.mu.
 		} else {
 			// Inherit the process group and terminal.
 			parentPG.incRefWithParent(parentPG)

--- a/test/syscalls/linux/processes.cc
+++ b/test/syscalls/linux/processes.cc
@@ -12,9 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
 #include <stdint.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -117,6 +121,65 @@ TEST(Processes, SetPGIDOfZombie) {
   ASSERT_THAT(RetryEINTR(waitpid)(pid, &status, 0),
               SyscallSucceedsWithValue(pid));
   EXPECT_EQ(status, 0);
+}
+
+// Sibling thread group C for SetsidOrphansSharedSignalHandlers below: it shares
+// its creator's signal handlers and idles in the process group until killed.
+int idleUntilKilled(void* arg) {
+  while (true) {
+    pause();
+  }
+  return 0;
+}
+
+// Runs as process B: create sibling C, a distinct thread group that shares B's
+// signal handlers (clone(CLONE_VM|CLONE_SIGHAND) without CLONE_THREAD) and stays
+// in B's process group, then call setsid(2).
+void setsidWithSharedSignalHandlersSibling() {
+  char stack[4096] __attribute__((aligned(16)));
+  pid_t c = clone(idleUntilKilled, stack + sizeof(stack),
+                  CLONE_VM | CLONE_SIGHAND | SIGCHLD, nullptr);
+  TEST_PCHECK(c > 0);
+
+  // setsid(2) moves B into a new session, orphaning its old process group while
+  // C, which shares B's signal handlers (and thus the signal mutex), remains in
+  // it. This previously self-deadlocked the sentry in ProcessGroup.handleOrphan.
+  int r = setsid();
+
+  // Reap C regardless of the outcome.
+  TEST_PCHECK(kill(c, SIGKILL) == 0);
+  int status;
+  TEST_PCHECK(RetryEINTR(waitpid)(c, &status, 0) == c);
+
+  TEST_PCHECK(r != -1);
+  _exit(0);
+}
+
+// Regression test: setsid(2) must not deadlock when it orphans a process group
+// that still contains a thread group sharing the caller's signal handlers.
+TEST(Processes, SetsidOrphansSharedSignalHandlers) {
+  pid_t a = fork();
+  if (a == 0) {
+    // Process A: create a fresh session so its process group has no ancestors
+    // (i.e. is an orphan), then fork B into it.
+    TEST_PCHECK(setsid() != -1);
+    pid_t b = fork();
+    if (b == 0) {
+      setsidWithSharedSignalHandlersSibling();
+      _exit(1);  // Unreachable.
+    }
+    TEST_PCHECK(b > 0);
+    int status;
+    TEST_PCHECK(RetryEINTR(waitpid)(b, &status, 0) == b);
+    TEST_PCHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+    _exit(0);
+  }
+  ASSERT_THAT(a, SyscallSucceeds());
+
+  int status;
+  ASSERT_THAT(RetryEINTR(waitpid)(a, &status, 0), SyscallSucceedsWithValue(a));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "process A exited with status " << status;
 }
 
 void WritePIDToPipe(int* pipe_fds) {


### PR DESCRIPTION
Scope the signal mutex to just the tg.tty clear in CreateSession, matching how CreateProcessGroup, JoinProcessGroup, and the exit path already call handleOrphan without holding a signal mutex.

CreateSession held tg.signalHandlers.mu across the entire process group manipulation, but it only needs that mutex to clear tg.tty. When setsid(2) orphans the caller's old process group, decRefWithParent calls handleOrphan, which locks the signal mutex of every thread group remaining in the group. If the caller itself, or a sibling thread group that shares the caller's SignalHandlers (created via clone(CLONE_VM|CLONE_SIGHAND) without CLONE_THREAD), is still a member, handleOrphan re-locks the already-held, non-reentrant mutex and the sentry deadlocks while holding TaskSet.mu, freezing the whole sandbox.

Regression test hangs prior to the fix.