### PR TITLE
Move `pinring` to its own sidecar binary rather than the gofer.

### DIFF
--- a/pkg/pinring/pinring.go
+++ b/pkg/pinring/pinring.go
@@ -34,10 +34,7 @@
 package pinring
 
 import (
-	"fmt"
-	"os"
 	"sync"
-	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -105,53 +102,4 @@ func (r *PinRing) Finalize() error {
 		unix.Close(int(fd))
 	}
 	return err
-}
-
-// SendPidfd sends a `pidfd` of process `pid` over `sock`.
-// See `WaitExit` below.
-func SendPidfd(sock *os.File, pid int) error {
-	pidfd, err := unix.PidfdOpen(pid, 0)
-	if err != nil {
-		return fmt.Errorf("pidfd_open(%d): %w", pid, err)
-	}
-	defer unix.Close(pidfd)
-	return unix.Sendmsg(int(sock.Fd()), []byte{0}, unix.UnixRights(pidfd), nil, 0)
-}
-
-// WaitExit blocks until the process whose `pidfd` arrives over socket `sockFD`
-// (sent by `SendPidfd`) has fully exited, and reports false only if it is
-// confirmed still running after `timeout`.
-func WaitExit(sockFD int, timeout time.Duration) bool {
-	pollIn := func(fd int32, timeout time.Duration) bool {
-		ts := unix.NsecToTimespec(timeout.Nanoseconds())
-		for {
-			n, err := unix.Ppoll([]unix.PollFd{{Fd: fd, Events: unix.POLLIN}}, &ts, nil)
-			if err == unix.EINTR {
-				continue
-			}
-			return err == nil && n > 0
-		}
-	}
-	// Wait for the pidfd to come in.
-	if !pollIn(int32(sockFD), timeout) {
-		return true
-	}
-	// The flags must be exactly what the gofer's seccomp filter allows for `recvmsg`.
-	buf := make([]byte, 1)
-	oob := make([]byte, unix.CmsgSpace(4))
-	_, oobn, _, _, err := unix.Recvmsg(sockFD, buf, oob, unix.MSG_DONTWAIT|unix.MSG_TRUNC)
-	if err != nil {
-		return true
-	}
-	msgs, err := unix.ParseSocketControlMessage(oob[:oobn])
-	if err != nil || len(msgs) == 0 {
-		return true
-	}
-	fds, err := unix.ParseUnixRights(&msgs[0])
-	if err != nil || len(fds) == 0 {
-		return true
-	}
-	defer unix.Close(fds[0])
-	// Wait for the process to die.
-	return pollIn(int32(fds[0]), timeout)
 }

--- a/runsc/cmd/BUILD
+++ b/runsc/cmd/BUILD
@@ -62,7 +62,6 @@ go_library(
         "//pkg/lisafs",
         "//pkg/log",
         "//pkg/metric",
-        "//pkg/pinring",
         "//pkg/prometheus",
         "//pkg/sentry/checkpoint",
         "//pkg/sentry/control",

--- a/runsc/cmd/gofer.go
+++ b/runsc/cmd/gofer.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
-	"time"
 
 	"github.com/google/subcommands"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -28,7 +27,6 @@ import (
 
 	"gvisor.dev/gvisor/pkg/lisafs"
 	"gvisor.dev/gvisor/pkg/log"
-	"gvisor.dev/gvisor/pkg/pinring"
 	"gvisor.dev/gvisor/pkg/unet"
 	"gvisor.dev/gvisor/pkg/urpc"
 	"gvisor.dev/gvisor/runsc/boot"
@@ -120,16 +118,6 @@ type Gofer struct {
 	profileFDs       profile.FDArgs
 	syncFDs          goferSyncFDs
 	stopProfiling    func()
-
-	// pinRingFD is the donated pin ring (see `//pkg/pinring`).
-	// Never used (on purpose), and never closed.
-	// It must stay open until this process exits to reap the benefits.
-	// See `--pin-ring-fd`.
-	pinRingFD int
-
-	// sentryExitSyncFD receives a pidfd of the sandbox process.
-	// The gofer waits on it before exiting. See `--sync-sentry-exit-fd`.
-	sentryExitSyncFD int
 }
 
 // Name implements subcommands.Command.
@@ -160,8 +148,6 @@ func (g *Gofer) SetFlags(f *flag.FlagSet) {
 	f.IntVar(&g.specFD, "spec-fd", -1, "required fd with the container spec")
 	f.IntVar(&g.mountsFD, "mounts-fd", -1, "mountsFD is the file descriptor to write list of mounts after they have been resolved (direct paths, no symlinks).")
 	f.IntVar(&g.goferToHostRPCFD, "rpc-fd", -1, "gofer-to-host RPC file descriptor.")
-	f.IntVar(&g.pinRingFD, "pin-ring-fd", -1, "FD of a disabled io_uring with slow-to-release sandbox FDs pinned to it. Deliberately held open and unused by the gofer such that the sandbox process is not the last ref holder to them, making their release asynchronous.")
-	f.IntVar(&g.sentryExitSyncFD, "sync-sentry-exit-fd", -1, "socket FD over which a pidfd of the sandbox process is received. Used by the gofer to wait for the sandbox to fully exit before exiting itself.")
 
 	// IDs to run gofer as.
 	f.IntVar(&g.uid, "uid", 0, "User ID")
@@ -511,11 +497,6 @@ func (g *Gofer) serve(spec *specs.Spec, conf *config.Config, root string, ruid i
 	server.Wait()
 	server.Destroy()
 	log.Infof("All lisafs servers exited.")
-	if g.sentryExitSyncFD >= 0 {
-		if !pinring.WaitExit(g.sentryExitSyncFD, 500*time.Millisecond) {
-			log.Warningf("Sandbox still running 500ms after its gofer connections closed; something is slowing down sandbox teardown more than necessary. Exiting anyway.")
-		}
-	}
 	if g.stopProfiling != nil {
 		g.stopProfiling()
 	}

--- a/runsc/container/BUILD
+++ b/runsc/container/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//pkg/abi/linux",
         "//pkg/cleanup",
         "//pkg/log",
-        "//pkg/pinring",
         "//pkg/sentry/control",
         "//pkg/sentry/fsimpl/erofs",
         "//pkg/sentry/fsimpl/tmpfs",

--- a/runsc/container/container.go
+++ b/runsc/container/container.go
@@ -35,7 +35,6 @@ import (
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/cleanup"
 	"gvisor.dev/gvisor/pkg/log"
-	"gvisor.dev/gvisor/pkg/pinring"
 	"gvisor.dev/gvisor/pkg/sentry/control"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/erofs"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/tmpfs"
@@ -154,16 +153,6 @@ type Container struct {
 	// This field isn't saved to json, because only a creator of a gofer
 	// process will have it as a child process.
 	goferIsChild bool `nojson:"true"`
-
-	// sentryExitSock is the creator's end of the root gofer's
-	// `--sync-sentry-exit-fd` socket,
-	// A pidfd of the sandbox process is sent over it once the sandbox has been
-	// spawned, and then it is closed.
-	sentryExitSock *os.File `nojson:"true"`
-
-	// pinRingFile is the pin ring (see `//pkg/pinring`)
-	// It is held between the gofer and the boot process's spawn.
-	pinRingFile *os.File `nojson:"true"`
 }
 
 // Args is used to configure a new container.
@@ -404,23 +393,12 @@ func (c *Container) createRoot(conf *config.Config, args Args, sandboxID string)
 			ExecFile:            args.ExecFile,
 			FSRestoreImagePath:  args.FSRestoreImagePath,
 			FSRestoreDirect:     args.FSRestoreDirect,
-			PinRingFile:         c.pinRingFile,
 		}
 		sand, err := sandbox.New(conf, sandArgs)
 		if err != nil {
 			return fmt.Errorf("cannot create sandbox: %w", err)
 		}
 		c.Sandbox = sand
-		c.pinRingFile = nil // Now owned by the sandbox's donation agency.
-		if c.sentryExitSock != nil {
-			// The gofer waits on this pidfd before exiting, so it is
-			// always the last holder of the pin ring.
-			if err := pinring.SendPidfd(c.sentryExitSock, sand.Pid.Load()); err != nil {
-				log.Warningf("Cannot send the sandbox's pidfd to the gofer (gofer exit may race the sandbox's): %v", err)
-			}
-			c.sentryExitSock.Close()
-			c.sentryExitSock = nil
-		}
 		return nil
 
 	}); err != nil {
@@ -1605,19 +1583,6 @@ func (c *Container) createGoferProcess(conf *config.Config, mountHints *boot.Pod
 		s.Register(&goferToHostRPC{goferPID: pid})
 		s.StartHandling(rpcServ)
 	}()
-
-	if ring, err := pinring.NewDisabledIOURing(); err != nil {
-		log.Warningf("Cannot create disabled io_uring ring: %v. This slows down gVisor sandbox teardown.", err)
-	} else {
-		donations.Donate("pin-ring-fd", ring)
-		c.pinRingFile = ring
-		fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
-		if err != nil {
-			return nil, nil, nil, nil, err
-		}
-		donations.DonateAndClose("sync-sentry-exit-fd", os.NewFile(uintptr(fds[1]), "sentry exit sync gofer FD"))
-		c.sentryExitSock = os.NewFile(uintptr(fds[0]), "sentry exit sync runsc FD")
-	}
 
 	// Count the number of mounts that needs an IO file.
 	ioFileCount := 0

--- a/runsc/donation/donation.go
+++ b/runsc/donation/donation.go
@@ -32,16 +32,10 @@ func LogDonations(cmd *exec.Cmd) {
 	}
 }
 
-const multipleFDTransferred = -42
-
 // Agency keeps track of files that need to be donated to a child process.
 type Agency struct {
 	donations    []donation
 	closePending []*os.File
-	// transferred maps flag names to FD numbers.
-	// The special value `multipleFDTransferred` means this flag was used
-	// multiple times, so it cannot be mapped to a single FD.
-	transferred map[string]int
 }
 
 type donation struct {
@@ -106,28 +100,11 @@ func (f *Agency) Transfer(cmd *exec.Cmd, nextFD int) int {
 				nextFD++
 			}
 			cmd.Args = append(cmd.Args, fmt.Sprintf("--%s=%d", d.flag, fd))
-			if f.transferred == nil {
-				f.transferred = make(map[string]int)
-			}
-			if _, alreadyExist := f.transferred[d.flag]; alreadyExist {
-				f.transferred[d.flag] = multipleFDTransferred
-			} else {
-				f.transferred[d.flag] = fd
-			}
 		}
 	}
 	// Reset donations made so far in case more transfers are needed.
 	f.donations = nil
 	return nextFD
-}
-
-// TransferredFD returns the FD number that the file donated under flag was
-// given in the child, or -1 if nothing or multiple FDs were donated with it.
-func (f *Agency) TransferredFD(flag string) int {
-	if fd, ok := f.transferred[flag]; ok && fd != multipleFDTransferred {
-		return fd
-	}
-	return -1
 }
 
 // DonateAndTransferCustomFiles sets up the flags for passing file descriptors from the

--- a/runsc/fdparking/BUILD
+++ b/runsc/fdparking/BUILD
@@ -1,0 +1,63 @@
+load("//tools:defs.bzl", "cc_flags_supplier", "cc_toolchain", "go_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    licenses = ["notice"],
+)
+
+# Tell build_cleaner not to create an unnecessary cc_library for
+# fdparking.c.
+filegroup(
+    name = "ignore_srcs",
+    srcs = ["fdparking.c"],
+    tags = ["ignore_srcs"],
+)
+
+# runsc-fd-parking must remain a statically-linked, freestanding
+# (no libc) C binary. It exists for the lifetime of each sandbox just to hold
+# some FDs, so its runtime memory footprint *must* stay absolutely minimal.
+genrule(
+    name = "runsc-fd-parking",
+    srcs = ["fdparking.c"],
+    outs = ["runsc-fd-parking"],
+    cmd = "$(CC) $(CC_FLAGS) " +
+          "-Os " +
+          "-ffreestanding " +
+          "-fno-sanitize=all " +
+          "-fno-stack-protector " +
+          "-fno-asynchronous-unwind-tables " +
+          "-fno-unwind-tables " +
+          "-static " +
+          "-nostdlib " +
+          "-nostartfiles " +
+          "-Wl,--build-id=none " +
+          "-Wl,--gc-sections " +
+          "-Wl,-s " +
+          "-Wl,-z,max-page-size=65536 " +
+          "-Wl,-z,noseparate-code " +
+          "-o $(location runsc-fd-parking) " +
+          "$(location fdparking.c)",
+    executable = True,
+    features = ["-pie"],
+    toolchains = [
+        cc_toolchain,
+        ":no_pie_cc_flags",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_flags_supplier(
+    name = "no_pie_cc_flags",
+    features = ["-pie"],
+)
+
+go_test(
+    name = "fdparking_test",
+    size = "small",
+    srcs = ["fdparking_test.go"],
+    data = [":runsc-fd-parking"],
+    deps = [
+        "//pkg/test/testutil",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
+)

--- a/runsc/fdparking/fdparking.c
+++ b/runsc/fdparking/fdparking.c
@@ -1,0 +1,220 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// runsc-fd-parking holds FD 4 open until the process whose pidfd it
+// inherits as FD 3 has exited, then exits. Inherited FDs above 4 are closed
+// at startup.
+//
+// runsc spawns it alongside the sandbox (Sentry) process to hold the "pin
+// ring" (inherited as FD 4, see `//pkg/pinring`): a permanently-disabled
+// `io_uring` into which the Sentry pins host FDs that should remain open
+// during and past the lifetime of the sandbox.
+// This includes slow-to-release `AF_PACKET` sockets and KVM VM FDs.
+// This makes sandbox teardown faster, because the Sentry process isn't the
+// last ref holder of these FDs, so its memory can be released earlier.
+// This `fdparking` process's purpose is to be the ring's last ref holder.
+//
+// Because this process must outlive the sentry, it tries its hardest to
+// minimize its runtime CPU and memory usage.
+// Therefore, it is a minimal C binary (A Go binary would incur megabytes of
+// runtime overhead, and periodic wakeups for Go garbage collection).
+//
+// Additionally, because it starts during the sandbox startup hot path but its
+// work is entirely low-priority work that only matters by the time the sandbox
+// *exits*, it makes itself SCHED_IDLE as its very first act so that it never
+// competes with the sandbox for CPU, and parks on the pidfd right away,
+// deferring all remaining self-memory-minimization work after a 1-second grace
+// period (or skipping it entirely for sandboxes that exit sooner).
+//
+// To minimize its own kernel-object footprint, it pivots onto a single .bss
+// stack page (which shares the text's page table entry), then unmaps the
+// original stack and the vdso/vvar, which frees their anonymous pages and
+// page-table pages. This roughly halves the page-table cost and the anonymous
+// memory of the process.
+
+#include <asm/poll.h>      // POLLIN, POLLNVAL, struct pollfd.
+#include <asm/unistd.h>    // __NR_* syscall numbers for the target arch.
+#include <linux/auxvec.h>  // AT_SYSINFO_EHDR, AT_PAGESZ.
+#include <linux/errno.h>   // EINTR.
+#include <linux/prctl.h>   // PR_SET_TIMERSLACK.
+#include <linux/sched.h>   // SCHED_IDLE.
+
+// The pidfd (see pidfd_open(2)) of the sandbox process.
+// Polls readable once the sandbox has exited.
+#define SANDBOX_PIDFD 3
+
+// The pin ring FD.
+// Never touched, but must remain open until this process exits.
+#define PIN_RING_FD 4
+
+// The close_range(2) syscall number is the same across all architectures.
+#ifndef __NR_close_range
+#define __NR_close_range 436
+#endif
+
+#define PAGE 4096UL
+
+// The one page this process runs on after _start pivots off the original
+// stack. Non-static so that the asm in _start can name it.
+char park_stack[PAGE] __attribute__((aligned(PAGE), used));
+
+// Raw 5-argument syscall function.
+#if defined(__x86_64__)
+static long sys5(long nr, long a0, long a1, long a2, long a3, long a4) {
+  register long r10 __asm__("r10") = a3;
+  register long r8 __asm__("r8") = a4;
+  long ret;
+  __asm__ volatile("syscall"
+                   : "=a"(ret)
+                   : "a"(nr), "D"(a0), "S"(a1), "d"(a2), "r"(r10), "r"(r8)
+                   : "rcx", "r11", "memory");
+  return ret;
+}
+#elif defined(__aarch64__)
+static long sys5(long nr, long a0, long a1, long a2, long a3, long a4) {
+  register long x8 __asm__("x8") = nr;
+  register long x0 __asm__("x0") = a0;
+  register long x1 __asm__("x1") = a1;
+  register long x2 __asm__("x2") = a2;
+  register long x3 __asm__("x3") = a3;
+  register long x4 __asm__("x4") = a4;
+  __asm__ volatile("svc #0"
+                   : "+r"(x0)
+                   : "r"(x8), "r"(x1), "r"(x2), "r"(x3), "r"(x4)
+                   : "memory", "cc");
+  return x0;
+}
+#else
+#error "unsupported architecture"
+#endif
+
+static __attribute__((noreturn)) void sys_exit(long code) {
+  for (;;) {
+    sys5(__NR_exit_group, code, 0, 0, 0, 0);
+  }
+}
+
+// Basic stderr logging function. Look ma, no libc.
+static void write_stderr(const char* s) {
+  long len = 0;
+  while (s[len] != '\0') {
+    len++;
+  }
+  sys5(__NR_write, 2, (long)s, len, 0, 0);
+}
+
+// slim unmaps the original stack (whose bottom `old_stack` points into) and
+// the vdso/vvar, none of which are needed by the ppoll loop.
+// If we find the wrong page size or a surprising layout, do nothing.
+static void slim(long* old_stack) {
+  // The initial stack holds: argc, argv[], NULL, envp[], NULL, auxv.
+  long argc = old_stack[0];
+  char** p = (char**)(old_stack + 1) + argc + 1;
+  while (*p) {
+    p++;
+  }
+  unsigned long vdso = 0, pagesz = 0;
+  for (unsigned long* a = (unsigned long*)(p + 1); a[0]; a += 2) {
+    if (a[0] == AT_SYSINFO_EHDR) {
+      vdso = a[1];
+    } else if (a[0] == AT_PAGESZ) {
+      pagesz = a[1];
+    }
+  }
+  if (pagesz != PAGE) {
+    return;
+  }
+  // Nothing we unmap may sit at or below our own image (text + park_stack).
+  unsigned long floor = (unsigned long)park_stack + PAGE;
+  unsigned long sp = (unsigned long)old_stack & ~(PAGE - 1);
+  unsigned long base = sp - (1UL << 20);  // Covers the whole stack VMA.
+  if (vdso > floor && vdso + 4 * PAGE < base) {
+    // The vvar pages (up to 6 of them) sit just below the vdso.
+    sys5(__NR_munmap, (long)(vdso - 16 * PAGE), 20 * PAGE, 0, 0, 0);
+  }
+  if (base > floor) {
+    // + 4 pages: past the argv/envp/auxv strings above the entry sp.
+    sys5(__NR_munmap, (long)base, (sp + 4 * PAGE) - base, 0, 0, 0);
+  }
+}
+
+// The kernel's native 64-bit timespec.
+struct kernel_timespec {
+  long tv_sec;
+  long tv_nsec;
+};
+
+// park ppolls the sandbox pidfd (readable once the sandbox has exited).
+static long park(struct pollfd* pfd, struct kernel_timespec* timeout) {
+  for (;;) {
+    long n = sys5(__NR_ppoll, (long)pfd, 1, (long)timeout, 0, 0);
+    if (n != -EINTR) {
+      return n;
+    }
+  }
+}
+
+__attribute__((noreturn, used)) void fdparking_main(long* old_stack) {
+  // Make ourselves as low-priority as possible.
+  int idle_prio = 0;
+  sys5(__NR_sched_setscheduler, 0, SCHED_IDLE, (long)&idle_prio, 0, 0);
+  sys5(__NR_prctl, PR_SET_TIMERSLACK, 1000000000L, 0, 0, 0);
+
+  // Wait for a second.
+  // The rest of the startup work is deferrable, and we don't want to starve
+  // the sandbox from CPU while it starts.
+  struct pollfd pfd = {.fd = SANDBOX_PIDFD, .events = POLLIN};
+  struct kernel_timespec grace = {.tv_sec = 1};
+  long n = park(&pfd, &grace);
+  if (n == 0) {
+    // Grace period elapsed and sandbox still running. Slim down.
+    slim(old_stack);
+    // Close out any unexpected FD beyond the ones we understand.
+    sys5(__NR_close_range, PIN_RING_FD + 1, 0xffffffffL, 0, 0, 0);
+    // Long-term parking.
+    n = park(&pfd, 0);
+  }
+  if (n < 0 || (pfd.revents & POLLNVAL)) {
+    write_stderr(
+        "runsc-fd-parking: cannot poll the sandbox pidfd (FD 3).\n");
+    sys_exit(1);
+  }
+  // Done, and sandbox exited. We're done too.
+  sys_exit(0);
+}
+
+// Process entry point: hand the initial stack pointer to `fdparking_main`
+// and pivot onto `park_stack`.
+#if defined(__x86_64__)
+__asm__(
+    ".globl _start\n"
+    ".type _start, @function\n"
+    "_start:\n"
+    "  movq %rsp, %rdi\n"
+    "  leaq park_stack+4096(%rip), %rsp\n"
+    "  call fdparking_main\n"
+    "  ud2\n");
+#elif defined(__aarch64__)
+__asm__(
+    ".globl _start\n"
+    ".type _start, @function\n"
+    "_start:\n"
+    "  mov x0, sp\n"
+    "  adrp x1, park_stack\n"
+    "  add x1, x1, :lo12:park_stack\n"
+    "  add x1, x1, 4096\n"
+    "  mov sp, x1\n"
+    "  bl fdparking_main\n"
+    "  brk #0\n");
+#endif

--- a/runsc/fdparking/fdparking_test.go
+++ b/runsc/fdparking/fdparking_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fdparking_test
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"gvisor.dev/gvisor/pkg/test/testutil"
+)
+
+// childEnv is used to signal that this test binary is running as a child that
+// does nothing. Used in the tests below.
+const childEnv = "FDPARKING_TEST_CHILD"
+
+func TestMain(m *testing.M) {
+	if os.Getenv(childEnv) != "" {
+		// Block until the parent closes our stdin, or kills.
+		io.Copy(io.Discard, os.Stdin)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func parkingPath(t *testing.T) string {
+	t.Helper()
+	path, err := testutil.FindFile("runsc/fdparking/runsc-fd-parking")
+	if err != nil {
+		t.Fatalf("cannot find runsc-fd-parking binary: %v", err)
+	}
+	return path
+}
+
+// parking is a running sidecar under test.
+type parking struct {
+	cmd     *exec.Cmd // The sidecar itself.
+	sandbox *exec.Cmd // The stand-in watched "sandbox" process.
+	ringR   *os.File  // Ring stand-in read end; sees EOF once the sidecar exits.
+}
+
+// startParking starts the sidecar watching a stand-in sandbox process
+// and blocks until the sidecar's deferred work is finished, using the closing
+// of a stray inherited FD as the signal (as `close_range` runs last).
+func startParking(t *testing.T) *parking {
+	t.Helper()
+	sbx := exec.Command(os.Args[0])
+	sbx.Env = append(os.Environ(), childEnv+"=1")
+	stdin, err := sbx.StdinPipe()
+	if err != nil {
+		t.Fatalf("cannot create sandbox stand-in stdin pipe: %v", err)
+	}
+	if err := sbx.Start(); err != nil {
+		t.Fatalf("cannot start sandbox stand-in: %v", err)
+	}
+	t.Cleanup(func() {
+		sbx.Process.Kill()
+		sbx.Wait()
+		stdin.Close()
+	})
+
+	pidfd, err := unix.PidfdOpen(sbx.Process.Pid, 0)
+	if err != nil {
+		t.Fatalf("pidfd_open(%d): %v", sbx.Process.Pid, err)
+	}
+	pidfdFile := os.NewFile(uintptr(pidfd), "sandbox pidfd")
+	defer pidfdFile.Close()
+
+	// A pipe write end stands in for the pin ring: its read end sees EOF
+	// exactly when the last write-end reference is dropped.
+	ringR, ringW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create ring stand-in pipe: %v", err)
+	}
+	t.Cleanup(func() { ringR.Close() })
+	// A second pipe stands in for a stray FD leaked into the sidecar; it must
+	// be closed at sidecar startup, not held until the watched process exits.
+	strayR, strayW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("cannot create stray pipe: %v", err)
+	}
+	t.Cleanup(func() { strayR.Close() })
+
+	cmd := exec.Command(parkingPath(t))
+	// ExtraFiles land at FD 3 (pidfd) and FD 4 (ring), per the contract; the
+	// stray lands at FD 5.
+	cmd.ExtraFiles = []*os.File{pidfdFile, ringW, strayW}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("cannot start sidecar: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+	ringW.Close()
+	strayW.Close()
+
+	strayR.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := strayR.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("sidecar did not finish startup (stray FD still open): read error is %v, expected EOF", err)
+	}
+	return &parking{cmd: cmd, sandbox: sbx, ringR: ringR}
+}
+
+// TestParking checks the fdparking sidecar's whole behavior: it
+// keeps its inherited FDs open while the watched process runs, and exits
+// (releasing them) once that process is gone.
+func TestParking(t *testing.T) {
+	p := startParking(t)
+	pid := p.cmd.Process.Pid
+
+	// Deferred startup is done (startParking waited for it), so the sidecar
+	// must have unmapped its original stack and the vdso by now. Only applies
+	// on 4KiB page kernels; the sidecar skips the unmapping elsewhere.
+	if os.Getpagesize() == 4096 {
+		maps, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
+		if err != nil {
+			t.Fatalf("cannot read sidecar maps: %v", err)
+		}
+		for _, mapping := range []string{"[stack]", "[vdso]", "[vvar]"} {
+			if strings.Contains(string(maps), mapping) {
+				t.Errorf("sidecar did not unmap %s:\n%s", mapping, maps)
+			}
+		}
+	}
+
+	// The sidecar must run as SCHED_IDLE, so that it never competes with
+	// sandbox startup for CPU.
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		t.Fatalf("cannot read sidecar stat: %v", err)
+	}
+	// Fields after the parenthesized comm; fields[0] is stat field 3.
+	fields := strings.Fields(string(stat[strings.LastIndexByte(string(stat), ')')+1:]))
+	const policyField = 41
+	if got, want := fields[policyField-3], "5"; /* SCHED_IDLE */ got != want {
+		t.Errorf("sidecar scheduling policy is %s, expected %s (SCHED_IDLE)", got, want)
+	}
+
+	// While the watched process is alive, the sidecar must keep the ring open:
+	// no EOF on the read end.
+	p.ringR.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, err := p.ringR.Read(make([]byte, 1)); !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("ring was released while the watched process was still alive: read error is %v, expected deadline exceeded", err)
+	}
+
+	if err := p.sandbox.Process.Kill(); err != nil {
+		t.Fatalf("cannot kill sandbox stand-in: %v", err)
+	}
+	p.sandbox.Wait()
+
+	// The sidecar must now exit, dropping the last ring reference.
+	p.ringR.SetReadDeadline(time.Now().Add(30 * time.Second))
+	if _, err := p.ringR.Read(make([]byte, 1)); err != io.EOF {
+		t.Fatalf("ring was not released after the watched process exited: read error is %v, expected EOF", err)
+	}
+	if err := p.cmd.Wait(); err != nil {
+		t.Errorf("sidecar did not exit cleanly: %v", err)
+	}
+}
+
+// procStatus returns the integer fields of /proc/<pid>/status (kB for Vm*).
+func procStatus(t *testing.T, pid int) map[string]int {
+	t.Helper()
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		t.Fatalf("cannot read sidecar status: %v", err)
+	}
+	fields := make(map[string]int)
+	for _, line := range strings.Split(string(data), "\n") {
+		key, rest, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		val := strings.Fields(rest)
+		if len(val) == 0 {
+			continue
+		}
+		if n, err := strconv.Atoi(val[0]); err == nil {
+			fields[key] = n
+		}
+	}
+	return fields
+}
+
+// TestParkingMemoryFootprint verifies the sidecar's exact post-startup
+// memory numbers. Every chunk of process memory is precisely accounted for,
+// thank you very much.
+func TestParkingMemoryFootprint(t *testing.T) {
+	if os.Getpagesize() != 4096 {
+		t.Skipf("the sidecar only self-minimizes on 4KiB-page kernels but current page size is %d", os.Getpagesize())
+	}
+	pid := startParking(t).cmd.Process.Pid
+
+	status := procStatus(t, pid)
+	for _, want := range []struct {
+		field string
+		kb    []int // Acceptable values in KiB
+	}{
+		{"VmSize", []int{8}},  // Two pages: Text page, and .bss stack page.
+		{"VmRSS", []int{8}},   // Both pages necessarily resident.
+		{"RssFile", []int{4}}, // Text page.
+		{"RssAnon", []int{4}}, // .bss stack page.
+		{"RssShmem", []int{0}},
+		{"VmExe", []int{4}},
+		{"VmData", []int{4}},
+		{"VmStk", []int{0}}, // Original stack is unmapped.
+		{"VmLib", []int{0}},
+		{"Threads", []int{1}}, // Single-threaded of course.
+	} {
+		got, ok := status[want.field]
+		if !ok {
+			t.Errorf("%s missing from /proc/%d/status", want.field, pid)
+			continue
+		}
+		if !slices.Contains(want.kb, got) {
+			t.Errorf("%s is %d, expected one of %v", want.field, got, want.kb)
+		}
+	}
+
+	maps, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
+	if err != nil {
+		t.Fatalf("cannot read sidecar maps: %v", err)
+	}
+	if got := strings.Count(string(maps), "\n"); got != 2 {
+		t.Errorf("sidecar has %d mappings, expected exactly 2 (text and stack):\n%s", got, maps)
+	}
+}

--- a/runsc/gvisorbinaries/gvisorbinaries.go
+++ b/runsc/gvisorbinaries/gvisorbinaries.go
@@ -74,6 +74,7 @@ const (
 	gvisorSentryName            = "gvisor_sentry"
 	gvisorSentryPluginStackName = "gvisor_sentry_plugin_stack"
 	prewarmerName               = "gvisor-sentry-prewarmer"
+	fdParkingName               = "runsc-fd-parking"
 )
 
 // binDirName is the name of the directory holding sidecar binaries.
@@ -225,10 +226,13 @@ var (
 	GvisorSentryPluginStack = Binary{Name: gvisorSentryPluginStackName}
 	// GvisorSentryPrewarmer is the C binary that runs ahead of `GvisorSentry`.
 	GvisorSentryPrewarmer = Binary{Name: prewarmerName}
+	// FDParking is the C binary that holds ("parks") the pin ring (see
+	// `//pkg/pinring`) until the sandbox process has exited.
+	FDParking = Binary{Name: fdParkingName}
 )
 
 // All lists every sidecar present in a standard installation.
-var All = []*Binary{&MetricServer, &CheckpointGofer, &GvisorSentry, &GvisorSentryPrewarmer}
+var All = []*Binary{&MetricServer, &CheckpointGofer, &GvisorSentry, &GvisorSentryPrewarmer, &FDParking}
 
 // Options is the set of options used to execute a sidecar binary.
 type Options struct {

--- a/runsc/sandbox/BUILD
+++ b/runsc/sandbox/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/hostos",
         "//pkg/log",
         "//pkg/metric:metric_go_proto",
+        "//pkg/pinring",
         "//pkg/prometheus",
         "//pkg/sentry/checkpoint",
         "//pkg/sentry/control",

--- a/runsc/sandbox/sandbox.go
+++ b/runsc/sandbox/sandbox.go
@@ -45,6 +45,7 @@ import (
 	"gvisor.dev/gvisor/pkg/fd"
 	"gvisor.dev/gvisor/pkg/hostos"
 	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/pinring"
 	"gvisor.dev/gvisor/pkg/prometheus"
 	"gvisor.dev/gvisor/pkg/sentry/checkpoint"
 	"gvisor.dev/gvisor/pkg/sentry/control"
@@ -321,10 +322,6 @@ type Args struct {
 	// open filesystem checkpoint files using O_DIRECT.
 	FSRestoreImagePath string
 	FSRestoreDirect    bool
-
-	// PinRingFile, if non-nil, is the pin ring to donate to the boot
-	// process (see `//pkg/pinring`).
-	PinRingFile *os.File
 }
 
 // New creates the sandbox process. The caller must call Destroy() on the
@@ -1030,7 +1027,16 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	donations.DonateAndClose("gofer-filestore-fds", args.GoferFilestoreFiles...)
 	donations.DonateAndClose("mounts-fd", args.MountsFile)
 	donations.Donate("start-sync-fd", startSyncFile)
-	donations.DonateAndClose("pin-ring-fd", args.PinRingFile)
+	var pinRing *os.File
+	if _, err := gvisorbinaries.FDParking.Path(); err != nil {
+		log.Warningf("Sidecar %q not found or usable (%v). This slows down gVisor sandbox teardown.", gvisorbinaries.FDParking.Name, err)
+	} else if ring, err := pinring.NewDisabledIOURing(); err != nil {
+		log.Warningf("Cannot create disabled io_uring ring: %v. This slows down gVisor sandbox teardown.", err)
+	} else {
+		pinRing = ring
+		defer pinRing.Close()
+		donations.Donate("pin-ring-fd", pinRing)
+	}
 	if err := donations.DonateLogFile("user-log-fd", args.UserLog, os.O_CREATE|os.O_WRONLY|os.O_APPEND, lfOpts); err != nil {
 		return err
 	}
@@ -1440,6 +1446,48 @@ func (s *Sandbox) createSandboxProcess(conf *config.Config, args *Args, startSyn
 	s.Pid.Store(cmd.Process.Pid)
 	log.Infof("Sandbox started, PID: %d", cmd.Process.Pid)
 
+	if pinRing != nil {
+		if err := spawnFDParking(pinRing, cmd.Process.Pid); err != nil {
+			log.Warningf("Cannot spawn sidecar %q: %v. This slows down gVisor sandbox teardown.", gvisorbinaries.FDParking.Name, err)
+		}
+	}
+	return nil
+}
+
+// spawnFDParking starts the runsc-fd-parking sidecar, which holds
+// `ring` until the sandbox process `pid` has exited and thus keeps the
+// sandbox from being the last ref holder of the FDs pinned into the ring.
+// See `//pkg/pinring` and `//runsc/fdparking`.
+func spawnFDParking(ring *os.File, pid int) error {
+	pidfd, err := unix.PidfdOpen(pid, 0)
+	if err != nil {
+		return fmt.Errorf("pidfd_open(%d): %w", pid, err)
+	}
+	defer unix.Close(pidfd)
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		return fmt.Errorf("cannot open %s: %w", os.DevNull, err)
+	}
+	defer devNull.Close()
+	parkingPid, err := gvisorbinaries.FDParking.ForkExec(gvisorbinaries.Options{
+		// FDs 3 (sandbox pidfd) and 4 (pin ring) are what the
+		// `//runsc/fdparking` binary expects.
+		Files: []uintptr{devNull.Fd(), devNull.Fd(), devNull.Fd(), uintptr(pidfd), ring.Fd()},
+		// The sidecar must outlive this process and not die with its session.
+		SysProcAttr: &unix.SysProcAttr{Setsid: true},
+	})
+	if err != nil {
+		return fmt.Errorf("cannot fork/exec: %w", err)
+	}
+	log.Infof("FD parking sidecar started, PID: %d", parkingPid)
+	go func() {
+		// Reap in case it does for some reason.
+		for {
+			if _, err := unix.Wait4(parkingPid, nil, 0, nil); err != unix.EINTR {
+				return
+			}
+		}
+	}()
 	return nil
 }
 

--- a/tools/release.bzl
+++ b/tools/release.bzl
@@ -6,6 +6,7 @@ SIDECARS = {
     "//runsc/checkpointgofer:checkpointgofer_binary": "checkpointgofer",
     "//runsc/cmd/metricserver:runsc-metric-server": "runsc-metric-server",
     "//runsc/cmd/sentry:gvisor_sentry": "gvisor_sentry",
+    "//runsc/fdparking:runsc-fd-parking": "runsc-fd-parking",
     "//runsc/prewarmer:gvisor-sentry-prewarmer": "gvisor-sentry-prewarmer",
 }
 


### PR DESCRIPTION
Previously, the ring was held by the gofer, which works well for the case where the gofer is 1-to-1 with the Sentry. This isn't true for multi-container sandboxes (where the current approach means we wait 500ms for each container doing nothing on exit), and it's also not going to work well with the no-root-container mode introduced in PR #13981.

This instead moves the job of holding the ring to a separate tiny C sidecar binary (`runsc-fd-parking`, named such to make its purpose obvious in the process table). Because this sidecar binary's job is very unimportant during startup, it defers as much of its work as possible, and because it must run for the whole lifetime of the sandbox, it minimizes its own memory footprint as aggressively as possible.

Benchmarks show no measurable startup or teardown latency regression, and a +52KiB memory cost per sandbox (i.e. ~5.2 MiB per 100 sandboxes).