### PR TITLE
Reproduce host errno for unreadable RDMA netdev sysfs attributes.

### DIFF
--- a/pkg/rdma/BUILD
+++ b/pkg/rdma/BUILD
@@ -11,7 +11,10 @@ go_library(
         "snapshot.go",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//pkg/abi/linux"],
+    deps = [
+        "//pkg/abi/linux",
+        "@org_golang_x_sys//unix:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/rdma/collect.go
+++ b/pkg/rdma/collect.go
@@ -24,6 +24,8 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 )
 
@@ -318,11 +320,24 @@ func (d *Device) collectNetDevs(sysRoot, netDir string) error {
 		if !SafeName(name) {
 			continue
 		}
-		attrs, err := readAttrs(path.Join(sysRoot, "class/net", name), netAttrNames)
-		if err != nil {
-			return err
+		nd := NetDev{Name: name, Attrs: map[string]string{}, ErrAttrs: map[string]int32{}}
+		for _, attr := range netAttrNames {
+			p := path.Join(sysRoot, "class/net", name, attr)
+			content, present, err := readAttr(p)
+			if err != nil {
+				// The kernel fails reads of some attributes with EINVAL while
+				// the link is down. Record the errno so the sandbox reproduces it.
+				if errors.Is(err, unix.EINVAL) {
+					nd.ErrAttrs[attr] = int32(unix.EINVAL)
+					continue
+				}
+				return fmt.Errorf("reading %q: %w", p, err)
+			}
+			if present {
+				nd.Attrs[attr] = content
+			}
 		}
-		d.NetDevs = append(d.NetDevs, NetDev{Name: name, Attrs: attrs})
+		d.NetDevs = append(d.NetDevs, nd)
 	}
 	sort.Slice(d.NetDevs, func(i, j int) bool { return d.NetDevs[i].Name < d.NetDevs[j].Name })
 	return nil

--- a/pkg/rdma/snapshot.go
+++ b/pkg/rdma/snapshot.go
@@ -65,8 +65,9 @@ type Port struct {
 // NetDev is a network device associated with an RDMA device, with its
 // curated static attribute set.
 type NetDev struct {
-	Name  string            `json:"name"`
-	Attrs map[string]string `json:"attrs"`
+	Name     string            `json:"name"`
+	Attrs    map[string]string `json:"attrs"`
+	ErrAttrs map[string]int32  `json:"err_attrs,omitempty"`
 }
 
 // Device is one uverbs device and everything hanging off it.

--- a/pkg/sentry/fsimpl/sys/BUILD
+++ b/pkg/sentry/fsimpl/sys/BUILD
@@ -69,5 +69,6 @@ go_test(
         "//pkg/sentry/kernel/auth",
         "//pkg/sentry/vfs",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/sentry/fsimpl/sys/rdma.go
+++ b/pkg/sentry/fsimpl/sys/rdma.go
@@ -70,6 +70,7 @@ type rdmaDirTree struct {
 	children  map[string]*rdmaDirTree
 	files     map[string]string // static file contents
 	hostFiles map[string]string // file name -> host path read at access time
+	errFiles  map[string]int32  // file name -> errno every read fails with
 	symlinks  map[string]string // link name -> relative target
 }
 
@@ -78,6 +79,7 @@ func newRDMADirTree() *rdmaDirTree {
 		children:  map[string]*rdmaDirTree{},
 		files:     map[string]string{},
 		hostFiles: map[string]string{},
+		errFiles:  map[string]int32{},
 		symlinks:  map[string]string{},
 	}
 }
@@ -228,6 +230,11 @@ func (fs *filesystem) newRDMASysfs(ctx context.Context, creds *auth.Credentials,
 			for name, val := range nd.Attrs {
 				if rdma.SafeName(name) {
 					nt.files[name] = val
+				}
+			}
+			for name, errno := range nd.ErrAttrs {
+				if rdma.SafeName(name) && errno > 0 {
+					nt.errFiles[name] = errno
 				}
 			}
 			nt.symlinks["device"] = deviceLink
@@ -392,6 +399,9 @@ func (fs *filesystem) buildRDMADir(ctx context.Context, creds *auth.Credentials,
 		// O_RDONLY|O_NOFOLLOW) (sys.hostFile.Generate); the rdmaproxy seccomp
 		// filter allows that openat.
 		entries[name] = fs.newHostFile(ctx, creds, defaultSysMode, hostPath)
+	}
+	for name, errno := range t.errFiles {
+		entries[name] = fs.newErrorFile(ctx, creds, defaultSysMode, errno)
 	}
 	for name, target := range t.symlinks {
 		entries[name] = kernfs.NewStaticSymlink(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), target)

--- a/pkg/sentry/fsimpl/sys/sys.go
+++ b/pkg/sentry/fsimpl/sys/sys.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/coverage"
@@ -540,4 +541,22 @@ func (fs *filesystem) newHostFile(ctx context.Context, creds *auth.Credentials, 
 	hf := &hostFile{hostPath: hostPath}
 	hf.Init(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), hf, mode)
 	return hf
+}
+
+// errorFile is an inode whose reads fail with a fixed errno.
+//
+// +stateify savable
+type errorFile struct {
+	kernfs.DynamicBytesFile
+	errno int32
+}
+
+func (ef *errorFile) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	return unix.Errno(ef.errno)
+}
+
+func (fs *filesystem) newErrorFile(ctx context.Context, creds *auth.Credentials, mode linux.FileMode, errno int32) kernfs.Inode {
+	ef := &errorFile{errno: errno}
+	ef.Init(ctx, creds, linux.UNNAMED_MAJOR, fs.devMinor, fs.NextIno(), ef, mode)
+	return ef
 }

--- a/pkg/sentry/fsimpl/sys/sys_integration_test.go
+++ b/pkg/sentry/fsimpl/sys/sys_integration_test.go
@@ -15,12 +15,15 @@
 package sys_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/sys/unix"
+
 	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/rdma"
 	"gvisor.dev/gvisor/pkg/sentry/fsimpl/sys"
@@ -368,7 +371,11 @@ func newRDMATestSnapshot() *rdma.Snapshot {
 					CounterNames: []string{"port_rcv_data"},
 				},
 			},
-			NetDevs: []rdma.NetDev{{Name: "eth1", Attrs: map[string]string{"mtu": "9000\n"}}},
+			NetDevs: []rdma.NetDev{{
+				Name:     "eth1",
+				Attrs:    map[string]string{"mtu": "9000\n"},
+				ErrAttrs: map[string]int32{"speed": int32(unix.EINVAL)},
+			}},
 		}},
 		NUMA: &rdma.NUMA{
 			// Two-node host (aggregate ranges "0-1"): the sandbox must
@@ -441,6 +448,7 @@ func TestRDMASysfs(t *testing.T) {
 		},
 		nicLeaf + "/net/eth1": {
 			"mtu":    linux.DT_REG,
+			"speed":  linux.DT_REG,
 			"device": linux.DT_LNK,
 		},
 		// Extended-domain (VMD-style) GPU root.
@@ -509,5 +517,11 @@ func TestRDMASysfs(t *testing.T) {
 		if got != want {
 			t.Errorf("%q contains %q, want %q", p, got, want)
 		}
+	}
+
+	// An attribute whose host read failed exists but fails reads with the
+	// host's errno.
+	if _, err := readTestFile(s, nicLeaf+"/net/eth1/speed"); !errors.Is(err, unix.EINVAL) {
+		t.Errorf("reading speed of a down link returned %v, want EINVAL", err)
 	}
 }


### PR DESCRIPTION
The RDMA sysfs snapshot aborted sandbox creation when reading any curated
netdev attribute failed. But the kernel fails reads of speed, duplex and
carrier with EINVAL whenever the link is down or the driver reports no
ethtool link settings (net/core/net-sysfs.c). This is the normal state of
an unconfigured IPoIB netdev on InfiniBand-link-layer fabrics:

```
FATAL ERROR: error setting up chroot: error configuring chroot for RDMA
sysfs: collecting RDMA sysfs snapshot: ibdev ibp116s0f0: reading
"/sys/class/net/ibp116s0f0/speed": invalid argument
```

Record such attributes in the snapshot along with the errno the host
returned, and have the sentry serve a file that exists but fails reads
with that errno, matching host behavior exactly (omitting the file would
turn the host's EINVAL into ENOENT).

Validated on 2-node B200 hardware (8x EFA + 2x mlx5 IB HCAs whose IPoIB
netdevs are down): without this change sandbox creation fails as above;
with it the sandbox boots, exposes all devices, and in-sandbox reads of
ibp*/speed return EINVAL exactly like the host. A 2-node RDMA training
workload (Megatron + SGLang weight sync over NCCL/EFA) runs to completion.