### PR TITLE
stateio: limit concurrent page restore copies

### DIFF
--- a/pkg/sentry/state/stateio/pagesfile.go
+++ b/pkg/sentry/state/stateio/pagesfile.go
@@ -19,8 +19,10 @@ import (
 )
 
 const (
-	pagesFileFDDefaultMaxIOBytes  = 256 << 10
-	pagesFileFDDefaultMaxParallel = 128
+	pagesFileFDDefaultMaxReadBytes  = 4 << 20
+	pagesFileFDDefaultMaxReads      = 12
+	pagesFileFDDefaultMaxWriteBytes = 256 << 10
+	pagesFileFDDefaultMaxWrites     = 128
 )
 
 // NewPagesFileFDReader returns a FDReader that reads a pages file from the
@@ -39,7 +41,7 @@ func NewPagesFileFDReader(fd int32, maxReadBytes uint64, maxParallel int) *FDRea
 // the given host file descriptor, using defaults for MaxReadBytes and
 // MaxParallel. It takes ownership of the file descriptor.
 func NewPagesFileFDReaderDefault(fd int32) *FDReader {
-	return NewPagesFileFDReader(fd, pagesFileFDDefaultMaxIOBytes, pagesFileFDDefaultMaxParallel)
+	return NewPagesFileFDReader(fd, pagesFileFDDefaultMaxReadBytes, pagesFileFDDefaultMaxReads)
 }
 
 // NewPagesFileFDWriter returns a FDWriter that writes a pages file to the
@@ -58,5 +60,5 @@ func NewPagesFileFDWriter(fd int32, maxWriteBytes uint64, maxParallel int) *FDWr
 // file descriptor, using defaults for MaxWriteBytes and MaxParallel. It takes
 // ownership of the file descriptor.
 func NewPagesFileFDWriterDefault(fd int32) *FDWriter {
-	return NewPagesFileFDWriter(fd, pagesFileFDDefaultMaxIOBytes, pagesFileFDDefaultMaxParallel)
+	return NewPagesFileFDWriter(fd, pagesFileFDDefaultMaxWriteBytes, pagesFileFDDefaultMaxWrites)
 }


### PR DESCRIPTION
The pages-file reader copies into the sentry `MemoryFile`, where first-touch faults insert pages into one host shmem inode. With 128 readers on 64 CPUs, a restore profile attributed 77% of sampled sentry CPU to lock spinning in `shmem_add_to_page_cache`. Reducing the reader pool removed most of that cost, and pinning unchanged upstream to 8 CPUs reproduced the result.

Use 12 readers with 4 MiB requests. Eight readers were faster on hot images but regressed cold restores from local NVMe by 7%. Twelve recovered that loss without a residency policy. Keep the writer at 256 KiB requests and 128 operations because larger write batches delayed submission behind the page scan and previously regressed checkpoint time. The existing `aio.GoQueue` `GOMAXPROCS` behavior remains unchanged.

The exact change was compared with current upstream in alternating pairs. The table reports time from starting a restore until the restored workload completes its validation and reports ready, rather than fresh process startup or request latency. Bun and Spring were warmed with 2,000 requests before checkpoint and report ready after one verified framework request following restore, while Go and Python report ready after validating every retained heap page. `Hot` leaves the checkpoint files in the host page cache, while `cold` evicts them and verifies that less than 1% of the page image remains resident before restore.

| Host and storage | Workload | Restore to ready | Restore CPU |
| --- | --- | --- | --- |
| 64 vCPUs with network-backed storage | Go with 2 GiB, hot | 46% faster | 91% less |
| 64 vCPUs with network-backed storage | Go with 4 GiB, hot | 49% faster | 91% less |
| 64 vCPUs with network-backed storage | Python with 2 GiB, hot | 45% faster | 90% less |
| 64 vCPUs with network-backed storage | Spring, hot | 31% faster | 82% less |
| 64 vCPUs with network-backed storage | Bun, hot | 16% faster | 56% less |
| 64 vCPUs with network-backed storage | Go with 2 GiB, cold | Unchanged | 86% less |
| 64 vCPUs with local NVMe | Go with 2 GiB, hot | 34% faster | 87% less |
| 64 vCPUs with local NVMe | Go with 2 GiB, cold | Unchanged | 40% less |
| 8 vCPUs with network-backed storage | Go with 1 GiB, hot | 9% faster | Within measurement noise |
| 8 vCPUs with network-backed storage | Python with 512 MiB, hot | 10% faster | Within measurement noise |
| 8 vCPUs with network-backed storage | Spring, hot | 7% faster | 6% less |
| 8 vCPUs with network-backed storage | Bun, hot | 4% faster | 6% less |
| 8 vCPUs with network-backed storage | Python with 512 MiB, cold | Unchanged | 32% less |

Checkpoint time remained within measurement noise in every case.

Updated per the discussion [here](https://github.com/google/gvisor/pull/14568#issuecomment-5622010724) to use 12 readers and leave the writer and `aio.GoQueue` behavior unchanged.
