### PR TITLE
Probe the minimum mappable address when vm.mmap_min_addr is unreadable

### DIFF
--- a/pkg/sentry/platform/BUILD
+++ b/pkg/sentry/platform/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -21,14 +21,24 @@ go_library(
         "//pkg/cpuid",
         "//pkg/fd",
         "//pkg/hostarch",
+        "//pkg/log",
         "//pkg/pinring",
         "//pkg/seccomp",
         "//pkg/seccomp/precompiledseccomp",
         "//pkg/sentry/arch",
         "//pkg/sentry/hostmm",
         "//pkg/sentry/memmap",
+        "//pkg/sync",
         "//pkg/timing",
         "//pkg/usermem",
         "@org_golang_x_sys//unix:go_default_library",
     ],
+)
+
+go_test(
+    name = "platform_test",
+    size = "small",
+    srcs = ["mmap_min_addr_test.go"],
+    library = ":platform",
+    deps = ["//pkg/hostarch"],
 )

--- a/pkg/sentry/platform/mmap_min_addr.go
+++ b/pkg/sentry/platform/mmap_min_addr.go
@@ -20,18 +20,18 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sync"
 )
 
 // systemMMapMinAddrSource is the source file.
 const systemMMapMinAddrSource = "/proc/sys/vm/mmap_min_addr"
 
-// systemMMapMinAddr is the system's minimum map address.
-var systemMMapMinAddr uint64
-
 // SystemMMapMinAddr returns the minimum system address.
 func SystemMMapMinAddr() hostarch.Addr {
-	return hostarch.Addr(systemMMapMinAddr)
+	return hostarch.Addr(systemMMapMinAddr())
 }
 
 // MMapMinAddr is a size zero struct that implements MinUserAddress based on
@@ -45,16 +45,108 @@ func (*MMapMinAddr) MinUserAddress() hostarch.Addr {
 	return SystemMMapMinAddr()
 }
 
-func init() {
-	// Open the source file.
+// probeMaxAddr bounds the empirical search for the minimum mappable address.
+// No known configuration protects more than a small fraction of this.
+const probeMaxAddr = 1 << 30 // 1 GiB
+
+// mmapProbe returns whether the host kernel permits a fixed anonymous mapping
+// at addr. It never replaces or disturbs existing mappings.
+func mmapProbe(addr uintptr) (bool, error) {
+	length := uintptr(hostarch.PageSize)
+	ret, _, errno := unix.RawSyscall6(unix.SYS_MMAP, addr, length,
+		uintptr(unix.PROT_NONE),
+		uintptr(unix.MAP_PRIVATE|unix.MAP_ANONYMOUS|unix.MAP_FIXED_NOREPLACE),
+		^uintptr(0) /* fd */, 0 /* offset */)
+	switch errno {
+	case 0:
+		unix.RawSyscall(unix.SYS_MUNMAP, ret, length, 0)
+		if ret != addr {
+			// The kernel treated addr as a hint, i.e. it predates
+			// MAP_FIXED_NOREPLACE (Linux 4.17); gVisor requires Linux 5.6+.
+			return false, fmt.Errorf("mmap(%#x) probe was remapped to %#x: MAP_FIXED_NOREPLACE unsupported", addr, ret)
+		}
+		return true, nil
+	case unix.EEXIST:
+		// Something is already mapped at addr. The kernel checks
+		// security_mmap_addr() before checking for overlap, so this still
+		// implies that addr is at or above the enforced minimum.
+		return true, nil
+	case unix.EPERM:
+		// addr is below the enforced minimum mappable address.
+		return false, nil
+	default:
+		return false, fmt.Errorf("mmap(%#x) probe failed: %v", addr, errno)
+	}
+}
+
+// probeMMapMinAddr empirically determines the minimum mappable address by
+// binary-searching the boundary at which fixed mappings stop failing with
+// EPERM.
+func probeMMapMinAddr() (uint64, error) {
+	pageSize := uint64(hostarch.PageSize)
+	// Find the lowest mappable power-of-two multiple of the page size,
+	// starting with address 0 itself.
+	ok, err := mmapProbe(0)
+	if err != nil {
+		return 0, err
+	}
+	if ok {
+		return 0, nil
+	}
+	hi := uint64(0)
+	for addr := pageSize; addr <= probeMaxAddr; addr *= 2 {
+		ok, err := mmapProbe(uintptr(addr))
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			hi = addr
+			break
+		}
+	}
+	if hi == 0 {
+		return 0, fmt.Errorf("no mappable address found at or below %#x", uint64(probeMaxAddr))
+	}
+	// Invariant: hi/pageSize pages is mappable, hi/(2*pageSize) pages (the
+	// previous probe, or address 0 for hi == pageSize) is not. Binary-search
+	// the smallest mappable page.
+	hiPage := hi / pageSize
+	loPage := hiPage / 2
+	for hiPage-loPage > 1 {
+		midPage := loPage + (hiPage-loPage)/2
+		ok, err := mmapProbe(uintptr(midPage * pageSize))
+		if err != nil {
+			return 0, err
+		}
+		if ok {
+			hiPage = midPage
+		} else {
+			loPage = midPage
+		}
+	}
+	return hiPage * pageSize, nil
+}
+
+// systemMMapMinAddr lazily determines the system's minimum map address on
+// first use, so that probing never adds to sentry initialization time.
+var systemMMapMinAddr = sync.OnceValue(func() uint64 {
 	b, err := os.ReadFile(systemMMapMinAddrSource)
 	if err != nil {
-		panic(fmt.Sprintf("couldn't open %s: %v", systemMMapMinAddrSource, err))
+		// In some environments the file is unreadable: for example, Android's
+		// SELinux policy denies app domains read access to it. Fall back to
+		// measuring the limit empirically.
+		probed, probeErr := probeMMapMinAddr()
+		if probeErr != nil {
+			panic(fmt.Sprintf("couldn't read %s (%v), and probing the minimum mappable address failed: %v", systemMMapMinAddrSource, err, probeErr))
+		}
+		log.Infof("Couldn't read %s (%v); using empirically probed minimum mappable address %#x.", systemMMapMinAddrSource, err, probed)
+		return probed
 	}
 
 	// Parse the result.
-	systemMMapMinAddr, err = strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	val, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
 	if err != nil {
 		panic(fmt.Sprintf("couldn't parse %s from %s: %v", string(b), systemMMapMinAddrSource, err))
 	}
-}
+	return val
+})

--- a/pkg/sentry/platform/mmap_min_addr_test.go
+++ b/pkg/sentry/platform/mmap_min_addr_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package platform
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/hostarch"
+)
+
+// dacMMapMinAddr returns the DAC component of the mmap address limit from
+// procfs. The limit the kernel enforces is at least this (an LSM may raise
+// it further).
+func dacMMapMinAddr(t *testing.T) uint64 {
+	t.Helper()
+	b, err := os.ReadFile(systemMMapMinAddrSource)
+	if err != nil {
+		t.Skipf("cannot read %s: %v", systemMMapMinAddrSource, err)
+	}
+	val, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		t.Fatalf("cannot parse %s: %v", systemMMapMinAddrSource, err)
+	}
+	return val
+}
+
+func TestProbeMMapMinAddr(t *testing.T) {
+	probed, err := probeMMapMinAddr()
+	if err != nil {
+		t.Fatalf("probeMMapMinAddr() failed: %v", err)
+	}
+	t.Logf("probed minimum mappable address: %#x", probed)
+	if probed%hostarch.PageSize != 0 {
+		t.Errorf("probed value %#x is not page-aligned", probed)
+	}
+	// The probed address must itself be mappable...
+	if ok, err := mmapProbe(uintptr(probed)); err != nil {
+		t.Fatalf("mmapProbe(%#x) failed: %v", probed, err)
+	} else if !ok {
+		t.Errorf("probed value %#x is not mappable", probed)
+	}
+	// ... and the page below it must not be, i.e. probed is the boundary.
+	if probed > 0 {
+		below := probed - hostarch.PageSize
+		if ok, err := mmapProbe(uintptr(below)); err != nil {
+			t.Fatalf("mmapProbe(%#x) failed: %v", below, err)
+		} else if ok {
+			t.Errorf("%#x is mappable, but probe returned %#x as the minimum", below, probed)
+		}
+	}
+	// The enforced limit is never below the DAC component from procfs.
+	if dac := dacMMapMinAddr(t); probed < dac {
+		t.Errorf("probed value %#x is below vm.mmap_min_addr %#x", probed, dac)
+	} else if probed != dac {
+		t.Logf("probed value %#x exceeds vm.mmap_min_addr %#x (LSM restriction, or non-page-aligned sysctl value)", probed, dac)
+	}
+}
+
+func TestSystemMMapMinAddrMatchesProcfs(t *testing.T) {
+	// On hosts where the file is readable, the lazy initializer must use it
+	// verbatim.
+	if dac, got := dacMMapMinAddr(t), uint64(SystemMMapMinAddr()); got != dac {
+		t.Errorf("SystemMMapMinAddr() = %#x, want vm.mmap_min_addr value %#x", got, dac)
+	}
+}

--- a/runsc/cmd/sentry/sentrycmd/chroot.go
+++ b/runsc/cmd/sentry/sentrycmd/chroot.go
@@ -111,12 +111,20 @@ func setupMinimalProcfs(chroot string, timer *timing.Timer) error {
 		}
 	}
 	// Copy needed files.
-	for _, f := range []string{
-		"/proc/sys/vm/mmap_min_addr",
-		"/proc/sys/kernel/cap_last_cap",
+	for _, f := range []struct {
+		path     string
+		optional bool
+	}{
+		// If mmap_min_addr is unreadable the sentry will probe for the value.
+		{path: "/proc/sys/vm/mmap_min_addr", optional: true},
+		{path: "/proc/sys/kernel/cap_last_cap"},
 	} {
-		if err := sandboxsetup.CopyFile(filepath.Join(chroot, f), f); err != nil {
-			return fmt.Errorf("failed to copy %q -> %q: %w", f, filepath.Join(chroot, f), err)
+		if err := sandboxsetup.CopyFile(filepath.Join(chroot, f.path), f.path); err != nil {
+			if f.optional {
+				log.Infof("Failed to copy %q -> %q: %v; continuing anyway.", f.path, filepath.Join(chroot, f.path), err)
+				continue
+			}
+			return fmt.Errorf("failed to copy %q -> %q: %w", f.path, filepath.Join(chroot, f.path), err)
 		}
 	}
 	// Create symlink for /proc/self.


### PR DESCRIPTION
When /proc/sys/vm/mmap_min_addr cannot be read, determine the limit empirically instead of panicking: binary-search the lowest address at which an anonymous MAP_FIXED_NOREPLACE mapping stops failing with EPERM (~20 probes, each unmapped immediately, never disturbing existing mappings). Probing measures the restriction the kernel actually enforces on the sentry (and thus on stub processes, which share its security context), including any LSM contribution that the sysctl - which only reflects dac_mmap_min_addr - does not report, so it cannot underestimate the enforced minimum. Also make the mmap_min_addr copy into the sandbox chroot best-effort, since otherwise sandbox creation fails while copying the unreadable file before the sentry ever runs.

Android's SELinux policy denies app domains read access to this file, so runsc previously panicked at startup under Termux.

Fully LLM generated, reviewed by me and tested with various host values of vm.mmap_min_addr.

Updates #12544.