### PR TITLE
Resolve runsc binary path early to fix rootless Docker

### DIFF
--- a/runsc/cli/maincli/maincli.go
+++ b/runsc/cli/maincli/maincli.go
@@ -25,6 +25,7 @@ import (
 	"gvisor.dev/gvisor/runsc/cmd/sentry/sentrycmd"
 	"gvisor.dev/gvisor/runsc/cmd/trace"
 	"gvisor.dev/gvisor/runsc/cmd/util"
+	"gvisor.dev/gvisor/runsc/specutils"
 
 	// TODO(gvisor.dev/issue/13718): Temporary.
 	// Remove this import once sidecar binaries are replaced by on-disk binaries.
@@ -41,6 +42,8 @@ const (
 
 // Main is the main entrypoint.
 func Main() {
+	// Resolve binary path early, before entering any namespaces.
+	specutils.InitExePath()
 	alias.HandleAlias()
 	cmds, helpCmds := commands()
 	cli.Run(nil, cmds, helpCmds)

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -96,6 +96,17 @@ const (
 // changed in tests that aren't linked in the same binary.
 var ExePath = "/proc/self/exe"
 
+func init() {
+	// Resolve the actual binary path early to work around issues in rootless
+	// Docker, where the binary is copied to a temporary location before execution.
+	// This makes /proc/self/exe invalid once we enter a different mount namespace.
+	// See https://github.com/google/gvisor/issues/12575
+	if exePath, err := os.Executable(); err == nil {
+		ExePath = exePath
+	}
+	// If os.Executable() fails, fall back to /proc/self/exe
+}
+
 // Version is the supported spec version.
 var Version = specs.Version
 

--- a/runsc/specutils/specutils.go
+++ b/runsc/specutils/specutils.go
@@ -96,11 +96,12 @@ const (
 // changed in tests that aren't linked in the same binary.
 var ExePath = "/proc/self/exe"
 
-func init() {
-	// Resolve the actual binary path early to work around issues in rootless
-	// Docker, where the binary is copied to a temporary location before execution.
-	// This makes /proc/self/exe invalid once we enter a different mount namespace.
-	// See https://github.com/google/gvisor/issues/12575
+// InitExePath resolves the actual binary path early to work around issues in rootless
+// Docker, where the binary is copied to a temporary location before execution.
+// This makes /proc/self/exe invalid once we enter a different mount namespace.
+// See https://github.com/google/gvisor/issues/12575
+// This must be called early in the program, before entering any mount namespaces.
+func InitExePath() {
 	if exePath, err := os.Executable(); err == nil {
 		ExePath = exePath
 	}


### PR DESCRIPTION
In rootless Docker, the runsc binary is copied to a temporary location before execution, which breaks `/proc/self/exe` lookups after entering a different mount namespace. This causes the umounter subprocess to fail with "fork/exec /proc/self/exe: no such file or directory" when spawning.

The fix resolves the actual binary path using `os.Executable()` early in program startup via `specutils.InitExePath()`, which is called from `maincli.Main()` before any namespace changes occur. The resolved path is stored in `specutils.ExePath`, which is used throughout runsc for spawning subprocesses including the umounter, making it work correctly in rootless environments.

Users no longer need the `--TESTONLY-unsafe-nonroot` flag workaround when running runsc with rootless Docker.

Fixes #12575