### PR TITLE
Allow GSO packet forwarding when per-segment size fits MTU

### DIFF
--- a/pkg/tcpip/network/ipv4/ipv4.go
+++ b/pkg/tcpip/network/ipv4/ipv4.go
@@ -688,6 +688,14 @@ func (e *endpoint) writePacketPostRouting(r *stack.Route, pkt *stack.PacketBuffe
 	if packetMustBeFragmented(pkt, networkMTU) {
 		h := header.IPv4(pkt.NetworkHeader().Slice())
 		if h.Flags()&header.IPv4FlagDontFragment != 0 && pkt.NetworkPacketInfo.IsForwardedPacket {
+			// For forwarded packets with DF set, check if this is a GSO packet whose
+			// per-segment size fits the MTU. If so, allow it to proceed for re-segmentation
+			// at transmit time instead of dropping it.
+			if gsoSegmentFitsNetworkMTU(pkt, networkMTU) {
+				// GSO packet with segments that fit MTU - skip fragmentation.
+				// The NIC will handle segmentation at transmit time.
+				goto skipFragmentation
+			}
 			// TODO(gvisor.dev/issue/5919): Handle error condition in which DontFragment
 			// is set but the packet must be fragmented for the non-forwarding case.
 			return &tcpip.ErrMessageTooLong{}
@@ -704,6 +712,7 @@ func (e *endpoint) writePacketPostRouting(r *stack.Route, pkt *stack.PacketBuffe
 		return err
 	}
 
+skipFragmentation:
 	if err := e.nic.WritePacket(r, pkt); err != nil {
 		stats.OutgoingPacketErrors.Increment()
 		return err
@@ -2023,6 +2032,19 @@ func calculateNetworkMTU(linkMTU, networkHeaderSize uint32) (uint32, tcpip.Error
 func packetMustBeFragmented(pkt *stack.PacketBuffer, networkMTU uint32) bool {
 	payload := len(pkt.TransportHeader().Slice()) + pkt.Data().Size()
 	return pkt.GSOOptions.Type == stack.GSONone && uint32(payload) > networkMTU
+}
+
+// gsoSegmentFitsNetworkMTU checks if a GSO packet's per-segment size would fit
+// within the network MTU. This is equivalent to Linux's skb_gso_validate_network_len.
+func gsoSegmentFitsNetworkMTU(pkt *stack.PacketBuffer, networkMTU uint32) bool {
+	if pkt.GSOOptions.Type == stack.GSONone {
+		return false
+	}
+	// For GSO packets, check if the per-segment size (MSS + headers) fits MTU.
+	// The MSS is the data portion per segment; we need to add transport and network headers.
+	transportHdrLen := uint32(len(pkt.TransportHeader().Slice()))
+	perSegmentSize := uint32(pkt.GSOOptions.MSS) + transportHdrLen
+	return perSegmentSize <= networkMTU
 }
 
 // addressToUint32 translates an IPv4 address into its little endian uint32

--- a/pkg/tcpip/network/ipv6/ipv6.go
+++ b/pkg/tcpip/network/ipv6/ipv6.go
@@ -782,6 +782,19 @@ func packetMustBeFragmented(pkt *stack.PacketBuffer, networkMTU uint32) bool {
 	return pkt.GSOOptions.Type == stack.GSONone && uint32(payload) > networkMTU
 }
 
+// gsoSegmentFitsNetworkMTU checks if a GSO packet's per-segment size would fit
+// within the network MTU. This is equivalent to Linux's skb_gso_validate_network_len.
+func gsoSegmentFitsNetworkMTU(pkt *stack.PacketBuffer, networkMTU uint32) bool {
+	if pkt.GSOOptions.Type == stack.GSONone {
+		return false
+	}
+	// For GSO packets, check if the per-segment size (MSS + headers) fits MTU.
+	// The MSS is the data portion per segment; we need to add transport and network headers.
+	transportHdrLen := uint32(len(pkt.TransportHeader().Slice()))
+	perSegmentSize := uint32(pkt.GSOOptions.MSS) + transportHdrLen
+	return perSegmentSize <= networkMTU
+}
+
 // handleFragments fragments pkt and calls the handler function on each
 // fragment. It returns the number of fragments handled and the number of
 // fragments left to be processed. The IP header must already be present in the
@@ -1002,6 +1015,13 @@ func (e *endpoint) writePacket(r *stack.Route, pkt *stack.PacketBuffer, protocol
 			// As per RFC 2460, section 4.5:
 			//   Unlike IPv4, fragmentation in IPv6 is performed only by source nodes,
 			//   not by routers along a packet's delivery path.
+			// However, for GSO packets whose per-segment size fits the MTU, allow
+			// re-segmentation at transmit time instead of dropping.
+			if gsoSegmentFitsNetworkMTU(pkt, networkMTU) {
+				// GSO packet with segments that fit MTU - skip fragmentation.
+				// The NIC will handle segmentation at transmit time.
+				goto skipFragmentation
+			}
 			return &tcpip.ErrMessageTooLong{}
 		}
 		sent, remain, err := e.handleFragments(r, networkMTU, pkt, protocol, func(fragPkt *stack.PacketBuffer) tcpip.Error {
@@ -1016,6 +1036,7 @@ func (e *endpoint) writePacket(r *stack.Route, pkt *stack.PacketBuffer, protocol
 		return err
 	}
 
+skipFragmentation:
 	if err := e.nic.WritePacket(r, pkt); err != nil {
 		stats.OutgoingPacketErrors.Increment()
 		return err


### PR DESCRIPTION
The forwarding path in both IPv4 and IPv6 was dropping oversized TCP packets with DF set, even when those packets were GSO (Generic Segmentation Offload) packets whose per-segment size would fit within the outgoing MTU. This caused severe throughput degradation in Docker-in-gVisor scenarios where the host coalesces received packets (GRO/TSO) into large buffers (2KB-20KB) before forwarding them through a smaller MTU interface.

The root cause is in `writePacketPostRouting` (IPv4) and `writePacket` (IPv6), where the code checks if the total packet size exceeds the MTU and drops it when DF is set on forwarded packets. This check ignored the GSO metadata that indicates the packet will be re-segmented at transmit time.

The fix adds a `gsoSegmentFitsNetworkMTU` function that validates whether a GSO packet's per-segment size (MSS + transport header) fits within the MTU, mirroring Linux's `skb_gso_validate_network_len` logic. When forwarding oversized packets with DF set, the code now checks if the packet is a valid GSO packet before dropping it, allowing re-segmentation at transmit time instead of incorrectly rejecting the entire coalesced packet.

This resolves the ~35 KB/s throughput observed in the issue by allowing normal TCP GSO processing in the forwarding path.

Fixes #14011
