### PR TITLE
Fix key permission selection and lookup

### DIFF
--- a/pkg/sentry/kernel/auth/key.go
+++ b/pkg/sentry/kernel/auth/key.go
@@ -247,15 +247,20 @@ func (c *Credentials) PossessedKeys(sessionKeyring, processKeyring, threadKeyrin
 //
 //go:nosplit
 func (c *Credentials) HasKeyPermission(k *Key, possessed *PossessedKeys, permission KeyPermission) bool {
-	perms := k.perms & keyOtherPermissionsMask
+	keyPerms := k.Permissions()
+	// Select one permission class before adding possessor permissions. Linux
+	// falls back to other permissions when the group permission mask is empty.
+	var perms KeyPermissions
+	switch {
+	case c.EffectiveKUID == k.kuid:
+		perms = (keyPerms & keyOwnerPermissionsMask) >> keyOwnerPermissionsShift
+	case k.kgid.Ok() && keyPerms&keyGroupPermissionsMask != 0 && c.InGroup(k.kgid):
+		perms = (keyPerms & keyGroupPermissionsMask) >> keyGroupPermissionsShift
+	default:
+		perms = keyPerms & keyOtherPermissionsMask
+	}
 	if _, ok := possessed.possessed[k.ID]; ok {
-		perms |= (k.perms & keyPossessorPermissionsMask) >> keyPossessorPermissionsShift
-	}
-	if c.EffectiveKUID == k.kuid {
-		perms |= (k.perms & keyOwnerPermissionsMask) >> keyOwnerPermissionsShift
-	}
-	if c.EffectiveKGID == k.kgid {
-		perms |= (k.perms & keyGroupPermissionsMask) >> keyGroupPermissionsShift
+		perms |= (keyPerms & keyPossessorPermissionsMask) >> keyPossessorPermissionsShift
 	}
 	switch permission {
 	case KeyView:

--- a/pkg/sentry/kernel/task_key.go
+++ b/pkg/sentry/kernel/task_key.go
@@ -15,28 +15,10 @@
 package kernel
 
 import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 )
-
-// SessionKeyring returns this Task's session keyring.
-// Session keyrings are inherited from the parent when a task is started.
-// If the session keyring is unset, it is implicitly initialized.
-// As such, this function should never return ENOKEY.
-func (t *Task) SessionKeyring() (*auth.Key, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.sessionKeyring != nil {
-		// Verify that we still have access to this keyring.
-		creds := t.Credentials()
-		if !creds.HasKeyPermission(t.sessionKeyring, creds.PossessedKeys(t.sessionKeyring, nil, nil), auth.KeySearch) {
-			return nil, linuxerr.EACCES
-		}
-		return t.sessionKeyring, nil
-	}
-	// If we don't have a session keyring, implicitly create one.
-	return t.joinNewSessionKeyringLocked(auth.DefaultSessionKeyringName, auth.DefaultUnnamedSessionKeyringPermissions)
-}
 
 // joinNewSessionKeyringLocked creates a new session keyring with the given
 // description, and joins it immediately.
@@ -90,15 +72,37 @@ func (t *Task) JoinSessionKeyring(keyDesc *string) (*auth.Key, error) {
 	return t.joinNewSessionKeyringLocked(newKeyDesc, newKeyPerms)
 }
 
-// LookupKey looks up a key by ID using this task's credentials.
+// lookupKeyLocked resolves a key ID without checking permissions. The caller
+// must check the permissions required by its operation. If the session keyring
+// is requested but unset, it is implicitly initialized.
+//
+// Preconditions: t.mu is held.
+//
+// +checklocks:t.mu
+func (t *Task) lookupKeyLocked(keyID auth.KeySerial) (*auth.Key, error) {
+	if keyID == linux.KEY_SPEC_SESSION_KEYRING {
+		if t.sessionKeyring == nil {
+			return t.joinNewSessionKeyringLocked(auth.DefaultSessionKeyringName, auth.DefaultUnnamedSessionKeyringPermissions)
+		}
+		return t.sessionKeyring, nil
+	}
+	// The session keyring may belong to a previous user namespace.
+	if key := t.sessionKeyring; key != nil && key.ID == keyID {
+		return key, nil
+	}
+	return t.UserNamespace().Keys.Lookup(keyID)
+}
+
+// LookupKey looks up a key by ID and checks search permission using this task's
+// credentials. keyID may be KEY_SPEC_SESSION_KEYRING.
 func (t *Task) LookupKey(keyID auth.KeySerial) (*auth.Key, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	creds := t.Credentials()
-	key, err := creds.UserNamespace.Keys.Lookup(keyID)
+	key, err := t.lookupKeyLocked(keyID)
 	if err != nil {
 		return nil, err
 	}
+	creds := t.Credentials()
 	if !creds.HasKeyPermission(key, creds.PossessedKeys(t.sessionKeyring, nil, nil), auth.KeySearch) {
 		return nil, linuxerr.EACCES
 	}
@@ -106,10 +110,14 @@ func (t *Task) LookupKey(keyID auth.KeySerial) (*auth.Key, error) {
 }
 
 // SetPermsOnKey sets the permission bits on the given key using the task's
-// credentials.
-func (t *Task) SetPermsOnKey(key *auth.Key, perms auth.KeyPermissions) error {
+// credentials. keyID may be KEY_SPEC_SESSION_KEYRING.
+func (t *Task) SetPermsOnKey(keyID auth.KeySerial, perms auth.KeyPermissions) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	key, err := t.lookupKeyLocked(keyID)
+	if err != nil {
+		return err
+	}
 	creds := t.Credentials()
 	possessed := creds.PossessedKeys(t.sessionKeyring, nil, nil)
 	return creds.UserNamespace.Keys.Do(func(keySet *auth.LockedKeySet) error {

--- a/pkg/sentry/syscalls/linux/sys_key.go
+++ b/pkg/sentry/syscalls/linux/sys_key.go
@@ -47,24 +47,11 @@ func Keyctl(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr,
 // KEYCTL_GET_KEYRING_ID.
 func keyCtlGetKeyringID(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
 	keyID := auth.KeySerial(args[1].Int())
-	var key *auth.Key
-	var err error
-	if keyID > 0 {
-		// Not a special key ID, so return as-is.
-		return uintptr(keyID), nil, nil
+	if keyID <= 0 && keyID != linux.KEY_SPEC_SESSION_KEYRING {
+		// Other special key IDs are not implemented.
+		return 0, nil, linuxerr.ENOSYS
 	}
-	switch keyID {
-	case linux.KEY_SPEC_SESSION_KEYRING:
-		key, err = t.SessionKeyring()
-	default:
-		if keyID <= 0 {
-			// Other special key IDs are not implemented.
-			return 0, nil, linuxerr.ENOSYS
-		}
-		// For positive key IDs, KEYCTL_GET_KEYRING_ID can be used as an existence
-		// and permissions check.
-		key, err = t.LookupKey(keyID)
-	}
+	key, err := t.LookupKey(keyID)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -82,14 +69,7 @@ func keyctlDescribe(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kerne
 		bufSize = math.MaxInt32
 	}
 
-	var key *auth.Key
-	var err error
-	switch keyID {
-	case linux.KEY_SPEC_SESSION_KEYRING:
-		key, err = t.SessionKeyring()
-	default:
-		key, err = t.LookupKey(keyID)
-	}
+	key, err := t.LookupKey(keyID)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -137,16 +117,5 @@ func keyctlJoinSessionKeyring(t *kernel.Task, args arch.SyscallArguments) (uintp
 func keyctlSetPerm(t *kernel.Task, args arch.SyscallArguments) (uintptr, *kernel.SyscallControl, error) {
 	keyID := auth.KeySerial(args[1].Int())
 	newPerms := auth.KeyPermissions(args[2].Uint64())
-	var key *auth.Key
-	var err error
-	switch keyID {
-	case linux.KEY_SPEC_SESSION_KEYRING:
-		key, err = t.SessionKeyring()
-	default:
-		key, err = t.UserNamespace().Keys.Lookup(keyID)
-	}
-	if err != nil {
-		return 0, nil, err
-	}
-	return 0, nil, t.SetPermsOnKey(key, newPerms)
+	return 0, nil, t.SetPermsOnKey(keyID, newPerms)
 }

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -1339,8 +1339,12 @@ cc_binary(
     linkstatic = 1,
     malloc = "//test/util:errno_safe_allocator",
     deps = select_gtest() + [
+        "//test/util:capability_util",
+        "//test/util:logging",
+        "//test/util:multiprocess_util",
         "//test/util:posix_error",
         "//test/util:test_main",
+        "//test/util:test_util",
         "//test/util:thread_util",
         "@com_google_absl//absl/random",
         "@com_google_absl//absl/strings",

--- a/test/syscalls/linux/keys.cc
+++ b/test/syscalls/linux/keys.cc
@@ -14,6 +14,7 @@
 
 #include <asm-generic/errno.h>
 #include <linux/keyctl.h>
+#include <sched.h>
 #include <signal.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -35,7 +36,11 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "test/util/capability_util.h"
+#include "test/util/logging.h"
+#include "test/util/multiprocess_util.h"
 #include "test/util/posix_error.h"
+#include "test/util/test_util.h"
 #include "test/util/thread_util.h"
 
 #define KEY_POS_VIEW 0x01000000
@@ -607,6 +612,125 @@ TEST(KeysTest, EnforceKeyPermissions) {
     }).Join();
   }).Join();
 }
+
+TEST(KeysTest, SessionKeyringAfterUnshareUserNamespace) {
+  EXPECT_THAT(InForkedProcess([] {
+                const int64_t id = syscall(SYS_keyctl, KEYCTL_JOIN_SESSION_KEYRING,
+                                           0, 0, 0, 0);
+                TEST_PCHECK(id > 0);
+                TEST_CHECK_SUCCESS(unshare(CLONE_NEWUSER));
+                TEST_CHECK(syscall(SYS_keyctl, KEYCTL_GET_KEYRING_ID,
+                                   KEY_SPEC_SESSION_KEYRING, 0, 0, 0) == id);
+                TEST_CHECK(syscall(SYS_keyctl, KEYCTL_GET_KEYRING_ID, id, 0, 0,
+                                   0) == id);
+                TEST_CHECK_SUCCESS(syscall(SYS_keyctl, KEYCTL_SETPERM, id,
+                                           KEY_USR_SETATTR, 0, 0));
+                // Changing permissions requires SETATTR, even without SEARCH.
+                TEST_CHECK_SUCCESS(syscall(SYS_keyctl, KEYCTL_SETPERM,
+                                           KEY_SPEC_SESSION_KEYRING,
+                                           KEY_USR_SETATTR, 0, 0));
+                TEST_CHECK_SUCCESS(syscall(SYS_keyctl, KEYCTL_SETPERM, id,
+                                           KEY_USR_SEARCH, 0, 0));
+                TEST_CHECK_ERRNO(syscall(SYS_keyctl, KEYCTL_SETPERM, id,
+                                         KEY_USR_SEARCH, 0, 0),
+                                 EACCES);
+                TEST_CHECK_ERRNO(syscall(SYS_keyctl, KEYCTL_SETPERM,
+                                         KEY_SPEC_SESSION_KEYRING,
+                                         KEY_USR_SEARCH, 0, 0),
+                                 EACCES);
+                _exit(0);
+              }),
+              IsPosixErrorOkAndHolds(0));
+}
+
+enum class KeyAccessor { kOwner, kGroup, kSupplementaryGroup, kOther };
+
+struct KeyPermissionTestCase {
+  const char* name;
+  KeyAccessor accessor;
+  uint64_t permissions;
+  bool searchable;
+};
+
+class KeyPermissionTest
+    : public ::testing::TestWithParam<KeyPermissionTestCase> {};
+
+TEST_P(KeyPermissionTest, SearchPermission) {
+  const auto& test = GetParam();
+  ASSERT_EQ(getuid(), geteuid());
+  ASSERT_EQ(getgid(), getegid());
+  if (test.accessor != KeyAccessor::kOwner) {
+    SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+    SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETGID)));
+  }
+  ScopedThread([&] {
+    const int64_t id =
+        ASSERT_NO_ERRNO_AND_VALUE(keyctl(KEYCTL_JOIN_SESSION_KEYRING));
+    ASSERT_NO_ERRNO(keyctl(KEYCTL_SETPERM, id, test.permissions));
+
+    if (test.accessor != KeyAccessor::kOwner) {
+      const gid_t key_gid = getegid();
+      const gid_t other_gid = key_gid == 65534 ? 65533 : 65534;
+      const uid_t other_uid = geteuid() == 65534 ? 65533 : 65534;
+      // Use raw syscalls to change only this thread's credentials. Set groups
+      // before changing the UID, which may drop capabilities.
+      ASSERT_THAT(syscall(SYS_setgroups,
+                          test.accessor == KeyAccessor::kSupplementaryGroup,
+                          &key_gid),
+                  SyscallSucceeds());
+      if (test.accessor != KeyAccessor::kGroup) {
+        ASSERT_THAT(syscall(SYS_setresgid, -1, other_gid, -1),
+                    SyscallSucceeds());
+      }
+      ASSERT_THAT(syscall(SYS_setresuid, -1, other_uid, -1), SyscallSucceeds());
+    }
+
+    for (const int64_t key_id : {int64_t{KEY_SPEC_SESSION_KEYRING}, id}) {
+      SCOPED_TRACE(key_id);
+      const auto result = keyctl(KEYCTL_GET_KEYRING_ID, key_id);
+      if (test.searchable) {
+        EXPECT_THAT(result, IsPosixErrorOkAndHolds(id));
+      } else {
+        EXPECT_THAT(result, PosixErrorIs(EACCES));
+      }
+    }
+  }).Join();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    , KeyPermissionTest,
+    ::testing::Values(
+        KeyPermissionTestCase{"Owner", KeyAccessor::kOwner, KEY_USR_SEARCH, true},
+        KeyPermissionTestCase{"OwnerIgnoresGroup", KeyAccessor::kOwner,
+                              KEY_GRP_SEARCH, false},
+        KeyPermissionTestCase{"OwnerIgnoresOther", KeyAccessor::kOwner,
+                              KEY_OTH_SEARCH, false},
+        KeyPermissionTestCase{"OwnerPossessor", KeyAccessor::kOwner,
+                              KEY_POS_SEARCH, true},
+        KeyPermissionTestCase{"Group", KeyAccessor::kGroup, KEY_GRP_SEARCH, true},
+        KeyPermissionTestCase{"GroupIgnoresOther", KeyAccessor::kGroup,
+                              KEY_GRP_VIEW | KEY_OTH_SEARCH, false},
+        KeyPermissionTestCase{"EmptyGroupUsesOther", KeyAccessor::kGroup,
+                              KEY_OTH_SEARCH, true},
+        KeyPermissionTestCase{"GroupPossessor", KeyAccessor::kGroup,
+                              KEY_GRP_VIEW | KEY_POS_SEARCH, true},
+        KeyPermissionTestCase{"SupplementaryGroup",
+                              KeyAccessor::kSupplementaryGroup, KEY_GRP_SEARCH,
+                              true},
+        KeyPermissionTestCase{"SupplementaryGroupIgnoresOther",
+                              KeyAccessor::kSupplementaryGroup,
+                              KEY_GRP_VIEW | KEY_OTH_SEARCH, false},
+        KeyPermissionTestCase{"EmptySupplementaryGroupUsesOther",
+                              KeyAccessor::kSupplementaryGroup, KEY_OTH_SEARCH,
+                              true},
+        KeyPermissionTestCase{"Other", KeyAccessor::kOther, KEY_OTH_SEARCH, true},
+        KeyPermissionTestCase{"OtherIgnoresOwnerAndGroup", KeyAccessor::kOther,
+                              KEY_USR_SEARCH | KEY_GRP_SEARCH, false},
+        KeyPermissionTestCase{"OtherPossessor", KeyAccessor::kOther,
+                              KEY_POS_SEARCH, true}),
+    [](const ::testing::TestParamInfo<KeyPermissionTestCase>& info) {
+      return info.param.name;
+    });
 
 // JoiningNonSearchableNamedKeyring verifies what happens when joining an
 // existing named keyring without the search permission.


### PR DESCRIPTION
Key checks accumulate permissions from owner, group, and other classes and ignore supplementary groups. This can grant access that Linux denies or deny a group member access. Select one class using Linux's precedence, including fallback to other when the group mask is empty, then add possessor permissions.

KEYCTL_GET_KEYRING_ID returns positive IDs without validating them, and KEYCTL_SETPERM cannot find a retained session keyring by numeric ID after a user-namespace change. Share key resolution across lookup and permission changes, resolving the session keyring before the current namespace's key map. Keep the permission check for each operation, allowing SETPERM with SETATTR even when SEARCH is absent.

Exercise permission selection, both ID forms, and lookup and permission changes after a user-namespace transition through syscall tests shared by Linux and gVisor.

Assisted-by: Codex