### PR TITLE
syscalls/linux: raise setsockopt maxOptLen to 1MB

### DIFF
--- a/pkg/sentry/syscalls/linux/sys_socket.go
+++ b/pkg/sentry/syscalls/linux/sys_socket.go
@@ -44,11 +44,16 @@ const maxAddrLen = 200
 
 // maxOptLen is the maximum sockopt parameter length we're willing to accept.
 // Linux limits this to INT_MAX (net/socket.c: do_sock_setsockopt), but we use
-// a conservative 32KB here to balance compatibility with resource protection.
-// The previous limit of 8KB broke real-world workloads such as iptables-restore
-// with large rulesets (e.g. Istio service mesh) where IPT_SO_SET_REPLACE
-// payloads commonly exceed 8KB.
-const maxOptLen = 32 * 1024
+// a bounded value here to balance compatibility with resource protection.
+// This must be large enough for iptables-restore's IPT_SO_SET_REPLACE payload:
+// the entire table (all chains + rules, encoded as ipt_entry structs) is passed
+// in a single setsockopt. kube-proxy's nat table alone exceeds 32KB once a
+// handful of multi-port ClusterIP Services exist (each Service adds several
+// KUBE-SVC/KUBE-SEP chains with DNAT/MARK/comment rules), and a rejected
+// SET_REPLACE surfaces only as an opaque "iptables-restore: line N failed" at
+// the table's COMMIT. A 1MB cap comfortably fits realistic kube-proxy/Istio
+// rulesets while staying well under maxControlLen.
+const maxOptLen = 1024 * 1024
 
 // maxControlLen is the maximum length of the msghdr.msg_control buffer we're
 // willing to accept. Note that this limit is smaller than Linux, which allows

--- a/test/syscalls/linux/socket_ip_unbound.cc
+++ b/test/syscalls/linux/socket_ip_unbound.cc
@@ -307,6 +307,16 @@ TEST_P(IPUnboundSocketTest, LargeTOSOptionSize) {
   }
 }
 
+TEST_P(IPUnboundSocketTest, LargeOptLenAbove32KB) {
+  auto socket = ASSERT_NO_ERRNO_AND_VALUE(NewSocket());
+  std::vector<char> buf(64 * 1024, 0);
+  int* set = reinterpret_cast<int*>(buf.data());
+  *set = 0xC0;
+  TOSOption t = GetTOSOption(GetParam().domain);
+  EXPECT_THAT(setsockopt(socket->get(), t.level, t.option, buf.data(), buf.size()),
+              SyscallSucceedsWithValue(0));
+}
+
 TEST_P(IPUnboundSocketTest, NegativeTOS) {
   auto socket = ASSERT_NO_ERRNO_AND_VALUE(NewSocket());
 


### PR DESCRIPTION
## Summary
- Raises `maxOptLen` in `pkg/sentry/syscalls/linux/sys_socket.go` from 32KB to 1MB.
- Adds `TEST_P(IPUnboundSocketTest, LargeOptLenAbove32KB)` in `test/syscalls/linux/socket_ip_unbound.cc` verifying that sockopt payloads > 32KB succeed.

## Motivation & Context
`IPT_SO_SET_REPLACE` passes an entire iptables table (all chains + rules) in a single `setsockopt` call. Previously, gVisor capped `maxOptLen` at 32KB, causing `iptables-restore` with multi-port Kubernetes `ClusterIP` Services to abort at the syscall layer with an opaque `"iptables-restore: line N failed"` error at the table's `COMMIT` line before netfilter ever evaluated it. Raising this limit to 1MB accommodates realistic `kube-proxy` and Istio rulesets while staying well below `maxControlLen` (10MB).

## Test Plan
- Unit tests: `bazel build //pkg/sentry/syscalls/linux:linux`
- Syscall tests: `test/syscalls/linux/socket_ip_unbound.cc`