### PR TITLE
netlink/route: report IFLA_OPERSTATE in RTM_GETLINK

### DIFF
--- a/pkg/abi/linux/netlink_route.go
+++ b/pkg/abi/linux/netlink_route.go
@@ -183,6 +183,17 @@ const (
 	IFLA_INFO_SLAVE_DATA = 5
 )
 
+// Interface operational states (RFC 2863), from uapi/linux/if_link.h.
+const (
+	IF_OPER_UNKNOWN        = 0
+	IF_OPER_NOTPRESENT     = 1
+	IF_OPER_DOWN           = 2
+	IF_OPER_LOWERLAYERDOWN = 3
+	IF_OPER_TESTING        = 4
+	IF_OPER_DORMANT        = 5
+	IF_OPER_UP             = 6
+)
+
 // Virtuall ethernet attributes, from uapi/linux/veth.h.
 const (
 	VETH_INFO_PEER = 1

--- a/pkg/sentry/socket/netlink/route/protocol.go
+++ b/pkg/sentry/socket/netlink/route/protocol.go
@@ -251,6 +251,15 @@ func writeLinkInfo(m *nlmsg.Message, idx int32, i inet.Interface) {
 	m.PutAttrString(linux.IFLA_IFNAME, i.Name)
 	m.PutAttr(linux.IFLA_MTU, primitive.AllocateUint32(i.MTU))
 
+	// Report operational state so consumers that poll for a port coming up
+	// (e.g. the CNI bridge plugin's OperState==UP check) succeed. Netstack
+	// interfaces are effectively always up once IFF_UP is set.
+	operState := uint8(linux.IF_OPER_DOWN)
+	if i.Flags&linux.IFF_UP != 0 {
+		operState = linux.IF_OPER_UP
+	}
+	m.PutAttr(linux.IFLA_OPERSTATE, primitive.AllocateUint8(operState))
+
 	mac := make([]byte, 6)
 	brd := mac
 	if len(i.Addr) > 0 {

--- a/test/syscalls/linux/socket_netlink_route.cc
+++ b/test/syscalls/linux/socket_netlink_route.cc
@@ -284,6 +284,12 @@ void CheckLinkMsg(const struct nlmsghdr* hdr, const Link& link) {
     std::string address(reinterpret_cast<const char*>(RTA_DATA(rta_address)));
     EXPECT_EQ(address, link.address);
   }
+  const struct rtattr* rta_operstate = FindRtAttr(hdr, msg, IFLA_OPERSTATE);
+  EXPECT_NE(nullptr, rta_operstate) << "IFLA_OPERSTATE not found in message.";
+  if (rta_operstate != nullptr) {
+    const auto operstate = *(uint8_t*)(RTA_DATA(rta_operstate));
+    EXPECT_EQ(operstate, IF_OPER_UP);
+  }
   EXPECT_EQ(ASSERT_NO_ERRNO_AND_VALUE(LinkKind(hdr, msg)), link.kind);
 }
 


### PR DESCRIPTION
## Summary
- Defines `IF_OPER_*` constants in `pkg/abi/linux/netlink_route.go` according to RFC 2863 / `uapi/linux/if_link.h`.
- Updates `writeLinkInfo` in `pkg/sentry/socket/netlink/route/protocol.go` to emit `IFLA_OPERSTATE` as `IF_OPER_UP` when `IFF_UP` is set (or `IF_OPER_DOWN`).
- Updates `test/syscalls/linux/socket_netlink_route.cc` to assert `IFLA_OPERSTATE == IF_OPER_UP`.

## Motivation & Context
Previously, `writeLinkInfo` did not emit `IFLA_OPERSTATE`, causing netlink consumers to default an interface's operational state to `IF_OPER_UNKNOWN`. When CNI bridge plugins attach a host-side `veth` to a bridge and poll for `OperState == UP`, the missing attribute caused it to fail fatally with `"bridge port in error state: unknown"`, blocking pod networking setup.

## Test Plan
- Unit tests: `bazel build //pkg/sentry/socket/netlink/route:route //pkg/abi/linux:linux`
- Syscall tests: `test/syscalls/linux/socket_netlink_route.cc`