### PR TITLE
netfilter: add iptables comment match extension

### DIFF
--- a/pkg/sentry/socket/netfilter/BUILD
+++ b/pkg/sentry/socket/netfilter/BUILD
@@ -8,6 +8,7 @@ package(
 go_library(
     name = "netfilter",
     srcs = [
+        "comment_matcher.go",
         "ct_target.go",
         "dnat.go",
         "extensions.go",

--- a/pkg/sentry/socket/netfilter/comment_matcher.go
+++ b/pkg/sentry/socket/netfilter/comment_matcher.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netfilter
+
+import (
+	"fmt"
+
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+const (
+	matcherNameComment = "comment"
+	commentRevision    = 0
+	// xtCommentInfoSize is sizeof(struct xt_comment_info) == [256]char.
+	xtCommentInfoSize = 256
+)
+
+func init() {
+	registerMatchMaker(commentMarshaler{})
+}
+
+// commentMarshaler implements matchMaker for the "comment" match. A comment is
+// a pure annotation with no effect on matching; it always matches.
+type commentMarshaler struct{}
+
+func (commentMarshaler) name() string {
+	return matcherNameComment
+}
+
+func (commentMarshaler) revision() uint8 {
+	return commentRevision
+}
+
+func (commentMarshaler) marshal(mr matcher) []byte {
+	m := mr.(*commentMatcher)
+	var buf [xtCommentInfoSize]byte
+	copy(buf[:], m.comment)
+	return marshalEntryMatch(matcherNameComment, buf[:])
+}
+
+func (commentMarshaler) unmarshal(_ IDMapper, buf []byte, _ stack.IPHeaderFilter) (stack.Matcher, error) {
+	if len(buf) < xtCommentInfoSize {
+		return nil, fmt.Errorf("buf has insufficient size for comment match: %d", len(buf))
+	}
+	n := 0
+	for n < xtCommentInfoSize && buf[n] != 0 {
+		n++
+	}
+	return &commentMatcher{comment: string(buf[:n])}, nil
+}
+
+// commentMatcher is a no-op matcher carrying a comment string.
+type commentMatcher struct {
+	comment string
+}
+
+func (*commentMatcher) name() string {
+	return matcherNameComment
+}
+
+func (*commentMatcher) revision() uint8 {
+	return commentRevision
+}
+
+// Match implements stack.Matcher.Match: a comment always matches.
+func (*commentMatcher) Match(stack.Hook, *stack.PacketBuffer, string, string) (bool, bool) {
+	return true, false
+}

--- a/test/iptables/filter_input.go
+++ b/test/iptables/filter_input.go
@@ -63,6 +63,7 @@ func init() {
 	RegisterTestCase(&FilterInputInvertDportDrop{})
 	RegisterTestCase(&FilterInputDropAllSrcPorts{})
 	RegisterTestCase(&FilterInputDropAllExceptOneDstPort{})
+	RegisterTestCase(&FilterInputCommentMatch{})
 }
 
 // FilterInputDropUDP tests that we can drop UDP traffic.
@@ -1241,4 +1242,36 @@ func (*FilterInputDropAllExceptOneDstPort) LocalAction(ctx context.Context, ip n
 	}
 
 	return nil
+}
+
+// FilterInputCommentMatch tests matching with the comment extension.
+type FilterInputCommentMatch struct{ containerCase }
+
+var _ TestCase = (*FilterInputCommentMatch)(nil)
+
+// Name implements TestCase.Name.
+func (*FilterInputCommentMatch) Name() string {
+	return "FilterInputCommentMatch"
+}
+
+// ContainerAction implements TestCase.ContainerAction.
+func (*FilterInputCommentMatch) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-m", "udp", "--destination-port", fmt.Sprintf("%d", dropPort), "-m", "comment", "--comment", "drop test port", "-j", "DROP"); err != nil {
+		return err
+	}
+
+	timedCtx, cancel := context.WithTimeout(ctx, NegativeTimeout)
+	defer cancel()
+	if err := netutils.ListenUDP(timedCtx, dropPort, ipv6); err == nil {
+		return fmt.Errorf("packets on port %d should have been dropped, but got a packet", dropPort)
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("error reading: %v", err)
+	}
+
+	return nil
+}
+
+// LocalAction implements TestCase.LocalAction.
+func (*FilterInputCommentMatch) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, dropPort, sendloopDuration)
 }

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -629,3 +629,7 @@ func TestFilterInputRejectTCPReset(t *testing.T) {
 func TestFilterInputRejectTCPResetUnmatched(t *testing.T) {
 	singleTest(t, &FilterInputRejectTCPResetUnmatched{})
 }
+
+func TestFilterInputCommentMatch(t *testing.T) {
+	singleTest(t, &FilterInputCommentMatch{})
+}


### PR DESCRIPTION
## Summary
- Implements the `comment` match extension (revision 0) in `pkg/sentry/socket/netfilter/comment_matcher.go`.
- Evaluates as an unconditional match during packet filtering while round-tripping the 256-byte `struct xt_comment_info` buffer for `iptables-save`.
- Adds `FilterInputCommentMatch` in `test/iptables/filter_input.go`.

## Motivation & Context
In Linux netfilter, `xt_comment` attaches human-readable annotations to rules. Network orchestrators like Kubernetes `kube-proxy` attach comments to nearly every generated rule (e.g. Service names and endpoint mappings). Without a registered matchMaker in gVisor, `iptables-restore` rejected the extension with `"Extension comment revision 0 not supported"`, rolling back the entire ruleset transaction.

## Test Plan
- Unit tests: `bazel test //pkg/sentry/socket/netfilter:netfilter_test`
- Integration tests: `test/iptables:iptables_test` (`FilterInputCommentMatch`)