### PR TITLE
netfilter: add iptables addrtype match extension with strict validation

### DIFF
--- a/pkg/abi/linux/netfilter.go
+++ b/pkg/abi/linux/netfilter.go
@@ -1057,6 +1057,12 @@ const (
 	XT_ADDRTYPE_XRESOLVE    = 1 << 11
 )
 
+// SizeOfXTAddrtypeInfoV1 is the size of struct xt_addrtype_info_v1.
+const SizeOfXTAddrtypeInfoV1 = 8
+
+// SizeOfXTAddrtypeInfo is the size of struct xt_addrtype_info.
+const SizeOfXTAddrtypeInfo = 12
+
 // XTAddrtypeInfoV1 corresponds to struct xt_addrtype_info_v1 in
 // include/uapi/linux/netfilter/xt_addrtype.h.
 //

--- a/pkg/sentry/socket/netfilter/BUILD
+++ b/pkg/sentry/socket/netfilter/BUILD
@@ -8,6 +8,7 @@ package(
 go_library(
     name = "netfilter",
     srcs = [
+        "addrtype_matcher.go",
         "ct_target.go",
         "dnat.go",
         "extensions.go",

--- a/pkg/sentry/socket/netfilter/addrtype_matcher.go
+++ b/pkg/sentry/socket/netfilter/addrtype_matcher.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netfilter
+
+import (
+	"fmt"
+
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+const (
+	matcherNameAddrType = "addrtype"
+	addrTypeRevision    = 1
+
+	offAddrTypeSource = 0
+	offAddrTypeDest   = 2
+	offAddrTypeFlags  = 4
+)
+
+// supportedAddrTypes contains address types that can be classified without full
+// FIB routing tables. Other types (ANYCAST, BLACKHOLE, UNREACHABLE, PROHIBIT)
+// are explicitly rejected during unmarshal.
+const supportedAddrTypes = linux.XT_ADDRTYPE_UNSPEC |
+	linux.XT_ADDRTYPE_UNICAST |
+	linux.XT_ADDRTYPE_LOCAL |
+	linux.XT_ADDRTYPE_BROADCAST |
+	linux.XT_ADDRTYPE_MULTICAST
+
+const supportedAddrTypeFlags = linux.XT_ADDRTYPE_INVERT_SOURCE | linux.XT_ADDRTYPE_INVERT_DEST
+
+func init() {
+	registerMatchMaker(addrTypeMarshaler{})
+}
+
+// addrTypeMarshaler implements matchMaker for the "addrtype" match (revision 1).
+// kube-proxy uses `-m addrtype --dst-type LOCAL -j KUBE-NODEPORTS`.
+type addrTypeMarshaler struct{}
+
+func (addrTypeMarshaler) name() string {
+	return matcherNameAddrType
+}
+
+func (addrTypeMarshaler) revision() uint8 {
+	return addrTypeRevision
+}
+
+func (addrTypeMarshaler) marshal(mr matcher) []byte {
+	m := mr.(*addrTypeMatcher)
+	return marshalEntryMatch(matcherNameAddrType, m.raw)
+}
+
+func (addrTypeMarshaler) unmarshal(_ IDMapper, buf []byte, _ stack.IPHeaderFilter) (stack.Matcher, error) {
+	if len(buf) < linux.SizeOfXTAddrtypeInfoV1 {
+		return nil, fmt.Errorf("buf has insufficient size for addrtype match: %d", len(buf))
+	}
+	raw := make([]byte, linux.SizeOfXTAddrtypeInfoV1)
+	copy(raw, buf[:linux.SizeOfXTAddrtypeInfoV1])
+
+	source := hostarch.ByteOrder.Uint16(buf[offAddrTypeSource:])
+	dest := hostarch.ByteOrder.Uint16(buf[offAddrTypeDest:])
+	flags := hostarch.ByteOrder.Uint32(buf[offAddrTypeFlags:])
+
+	if (source|dest)&^supportedAddrTypes != 0 {
+		return nil, fmt.Errorf("addrtype: unsupported address type mask (source=0x%x, dest=0x%x); FIB routing types are not supported", source, dest)
+	}
+	if flags&^supportedAddrTypeFlags != 0 {
+		return nil, fmt.Errorf("addrtype: unsupported flags 0x%x; interface limits are not supported", flags)
+	}
+
+	return &addrTypeMatcher{
+		source: source,
+		dest:   dest,
+		flags:  flags,
+		raw:    raw,
+	}, nil
+}
+
+// addrTypeMatcher matches on the address type of the packet's source/dest.
+type addrTypeMatcher struct {
+	source uint16
+	dest   uint16
+	flags  uint32
+	raw    []byte
+}
+
+func (*addrTypeMatcher) name() string {
+	return matcherNameAddrType
+}
+
+func (*addrTypeMatcher) revision() uint8 {
+	return addrTypeRevision
+}
+
+// Match implements stack.Matcher.Match. Address types are derived from the
+// packet address itself (multicast/broadcast/unicast).
+func (m *addrTypeMatcher) Match(_ stack.Hook, pkt *stack.PacketBuffer, _, _ string) (bool, bool) {
+	netHdr := pkt.Network()
+	if netHdr == nil {
+		return false, false
+	}
+	if m.dest != linux.XT_ADDRTYPE_UNSPEC {
+		matched := addrTypeOf(netHdr.DestinationAddress())&m.dest != 0
+		if m.flags&linux.XT_ADDRTYPE_INVERT_DEST != 0 {
+			matched = !matched
+		}
+		if !matched {
+			return false, false
+		}
+	}
+	if m.source != linux.XT_ADDRTYPE_UNSPEC {
+		matched := addrTypeOf(netHdr.SourceAddress())&m.source != 0
+		if m.flags&linux.XT_ADDRTYPE_INVERT_SOURCE != 0 {
+			matched = !matched
+		}
+		if !matched {
+			return false, false
+		}
+	}
+	return true, false
+}
+
+// addrTypeOf classifies an address into XT_ADDRTYPE_* bits using only the
+// address value (no routing-table lookup).
+func addrTypeOf(addr tcpip.Address) uint16 {
+	switch addr.Len() {
+	case header.IPv4AddressSize:
+		if header.IsV4MulticastAddress(addr) {
+			return linux.XT_ADDRTYPE_MULTICAST
+		}
+		if addr == header.IPv4Broadcast {
+			return linux.XT_ADDRTYPE_BROADCAST
+		}
+	case header.IPv6AddressSize:
+		if header.IsV6MulticastAddress(addr) {
+			return linux.XT_ADDRTYPE_MULTICAST
+		}
+	}
+	return linux.XT_ADDRTYPE_UNICAST
+}

--- a/test/iptables/addrtype.go
+++ b/test/iptables/addrtype.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"gvisor.dev/gvisor/test/netutils"
+)
+
+func init() {
+	RegisterTestCase(&FilterInputAddrTypeUnicastDrop{})
+	RegisterTestCase(&FilterInputAddrTypeBroadcastDrop{})
+	RegisterTestCase(&FilterInputAddrTypeMulticastDrop{})
+	RegisterTestCase(&FilterInputAddrTypeInvertBroadcastDrop{})
+	RegisterTestCase(&FilterInputAddrTypeFIBReject{})
+}
+
+// FilterInputAddrTypeUnicastDrop tests dropping packets matching --dst-type UNICAST.
+type FilterInputAddrTypeUnicastDrop struct{ containerCase }
+
+var _ TestCase = (*FilterInputAddrTypeUnicastDrop)(nil)
+
+func (*FilterInputAddrTypeUnicastDrop) Name() string {
+	return "FilterInputAddrTypeUnicastDrop"
+}
+
+func (*FilterInputAddrTypeUnicastDrop) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-m", "addrtype", "--dst-type", "UNICAST", "--destination-port", fmt.Sprintf("%d", dropPort), "-j", "DROP"); err != nil {
+		return err
+	}
+
+	timedCtx, cancel := context.WithTimeout(ctx, NegativeTimeout)
+	defer cancel()
+	if err := netutils.ListenUDP(timedCtx, dropPort, ipv6); err == nil {
+		return fmt.Errorf("packets on port %d should have been dropped, but got a packet", dropPort)
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("error reading: %v", err)
+	}
+
+	return nil
+}
+
+func (*FilterInputAddrTypeUnicastDrop) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, dropPort, sendloopDuration)
+}
+
+// FilterInputAddrTypeBroadcastDrop tests matching with --dst-type BROADCAST.
+type FilterInputAddrTypeBroadcastDrop struct{ localCase }
+
+var _ TestCase = (*FilterInputAddrTypeBroadcastDrop)(nil)
+
+func (*FilterInputAddrTypeBroadcastDrop) Name() string {
+	return "FilterInputAddrTypeBroadcastDrop"
+}
+
+func (*FilterInputAddrTypeBroadcastDrop) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	// Drop broadcast packets, but unicast should pass through to acceptPort.
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-m", "addrtype", "--dst-type", "BROADCAST", "-j", "DROP"); err != nil {
+		return err
+	}
+	return netutils.ListenUDP(ctx, acceptPort, ipv6)
+}
+
+func (*FilterInputAddrTypeBroadcastDrop) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, acceptPort, sendloopDuration)
+}
+
+// FilterInputAddrTypeMulticastDrop tests matching with --dst-type MULTICAST.
+type FilterInputAddrTypeMulticastDrop struct{ localCase }
+
+var _ TestCase = (*FilterInputAddrTypeMulticastDrop)(nil)
+
+func (*FilterInputAddrTypeMulticastDrop) Name() string {
+	return "FilterInputAddrTypeMulticastDrop"
+}
+
+func (*FilterInputAddrTypeMulticastDrop) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	// Drop multicast packets, but unicast should pass through.
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-m", "addrtype", "--dst-type", "MULTICAST", "-j", "DROP"); err != nil {
+		return err
+	}
+	return netutils.ListenUDP(ctx, acceptPort, ipv6)
+}
+
+func (*FilterInputAddrTypeMulticastDrop) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, acceptPort, sendloopDuration)
+}
+
+// FilterInputAddrTypeInvertBroadcastDrop tests inverted match ! --dst-type BROADCAST.
+type FilterInputAddrTypeInvertBroadcastDrop struct{ containerCase }
+
+var _ TestCase = (*FilterInputAddrTypeInvertBroadcastDrop)(nil)
+
+func (*FilterInputAddrTypeInvertBroadcastDrop) Name() string {
+	return "FilterInputAddrTypeInvertBroadcastDrop"
+}
+
+func (*FilterInputAddrTypeInvertBroadcastDrop) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	// Drop anything that is NOT broadcast (i.e. unicast) destined for dropPort.
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-m", "addrtype", "!", "--dst-type", "BROADCAST", "--destination-port", fmt.Sprintf("%d", dropPort), "-j", "DROP"); err != nil {
+		return err
+	}
+
+	timedCtx, cancel := context.WithTimeout(ctx, NegativeTimeout)
+	defer cancel()
+	if err := netutils.ListenUDP(timedCtx, dropPort, ipv6); err == nil {
+		return fmt.Errorf("packets on port %d should have been dropped, but got a packet", dropPort)
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("error reading: %v", err)
+	}
+
+	return nil
+}
+
+func (*FilterInputAddrTypeInvertBroadcastDrop) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, dropPort, sendloopDuration)
+}
+
+// FilterInputAddrTypeFIBReject tests that unsupported FIB routing address types
+// (such as BLACKHOLE, UNREACHABLE, PROHIBIT) are explicitly rejected during rule load.
+type FilterInputAddrTypeFIBReject struct{ containerCase }
+
+var _ TestCase = (*FilterInputAddrTypeFIBReject)(nil)
+
+func (*FilterInputAddrTypeFIBReject) Name() string {
+	return "FilterInputAddrTypeFIBReject"
+}
+
+func (*FilterInputAddrTypeFIBReject) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-m", "addrtype", "--dst-type", "BLACKHOLE", "-j", "DROP"); err == nil {
+		return fmt.Errorf("expected error installing addrtype rule with unsupported BLACKHOLE type, but succeeded")
+	}
+	return nil
+}
+
+func (*FilterInputAddrTypeFIBReject) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return nil
+}

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -629,3 +629,23 @@ func TestFilterInputRejectTCPReset(t *testing.T) {
 func TestFilterInputRejectTCPResetUnmatched(t *testing.T) {
 	singleTest(t, &FilterInputRejectTCPResetUnmatched{})
 }
+
+func TestFilterInputAddrTypeUnicastDrop(t *testing.T) {
+	singleTest(t, &FilterInputAddrTypeUnicastDrop{})
+}
+
+func TestFilterInputAddrTypeBroadcastDrop(t *testing.T) {
+	singleTest(t, &FilterInputAddrTypeBroadcastDrop{})
+}
+
+func TestFilterInputAddrTypeMulticastDrop(t *testing.T) {
+	singleTest(t, &FilterInputAddrTypeMulticastDrop{})
+}
+
+func TestFilterInputAddrTypeInvertBroadcastDrop(t *testing.T) {
+	singleTest(t, &FilterInputAddrTypeInvertBroadcastDrop{})
+}
+
+func TestFilterInputAddrTypeFIBReject(t *testing.T) {
+	singleTest(t, &FilterInputAddrTypeFIBReject{})
+}


### PR DESCRIPTION
## Summary
- Defines `XT_ADDRTYPE_*` constants, flags, and sizes in `pkg/abi/linux/netfilter.go` from `uapi/linux/netfilter/xt_addrtype.h`.
- Implements the `addrtype` match extension (revision 1) in `pkg/sentry/socket/netfilter/addrtype_matcher.go`.
- Evaluates `UNICAST`, `LOCAL`, `BROADCAST`, and `MULTICAST` destination and source address filters with inversion (`!`) support.
- Strictly rejects unsupported FIB routing types (`ANYCAST`, `BLACKHOLE`, `UNREACHABLE`, `PROHIBIT`) and unsupported interface flags during unmarshal.
- Adds integration tests in `test/iptables/addrtype.go` including a test verifying explicit rejection of unsupported FIB types (`FilterInputAddrTypeFIBReject`).

## Motivation & Context
Kubernetes `kube-proxy` terminates its `KUBE-SERVICES` chain with `-m addrtype --dst-type LOCAL -j KUBE-NODEPORTS`. Without an `addrtype` matchMaker registered in gVisor, `iptables-restore` aborted with `"Couldn't load match 'addrtype'"`, rolling back the entire ruleset synchronization.

## Test Plan
- Unit tests: `bazel test //pkg/sentry/socket/netfilter:netfilter_test //pkg/tcpip/stack:stack_test`
- Integration tests: `test/iptables:iptables_test` (`FilterInputAddrType*`)