### PR TITLE
netfilter: add MARK target, RuleContinue verdict, and full mangle table hook support

### DIFF
--- a/pkg/sentry/socket/netfilter/BUILD
+++ b/pkg/sentry/socket/netfilter/BUILD
@@ -14,6 +14,7 @@ go_library(
         "ipv4.go",
         "ipv6.go",
         "mark_matcher.go",
+        "mark_target.go",
         "multiport_matcher.go",
         "multiport_matcher_v1.go",
         "netfilter.go",

--- a/pkg/sentry/socket/netfilter/mark_target.go
+++ b/pkg/sentry/socket/netfilter/mark_target.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netfilter
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/marshal"
+	"gvisor.dev/gvisor/pkg/syserr"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// MarkTargetName is the name of the MARK target, which sets the packet's
+// netfilter mark. kube-proxy uses it (revision 2, set-xmark semantics) for its
+// masquerade/drop marks, e.g. `-j MARK --or-mark 0x4000`.
+const MarkTargetName = "MARK"
+
+// markTargetRevision is the xt_mark_tginfo2 revision. iptables negotiates the
+// highest supported revision; 2 is what modern iptables/kube-proxy use.
+const markTargetRevision = 2
+
+// markTargetV2Size is sizeof(xt_entry_target) + sizeof(xt_mark_tginfo2{u32,u32}).
+const markTargetV2Size = linux.SizeOfXTEntryTarget + 8
+
+// xtMarkTargetV2 corresponds to xt_entry_target + struct xt_mark_tginfo2
+// {__u32 mark, mask}. set-xmark semantics: mark = (mark &^ mask) ^ value.
+//
+// +marshal
+type xtMarkTargetV2 struct {
+	Target linux.XTEntryTarget
+	Mark   uint32
+	Mask   uint32
+}
+
+func init() {
+	registerTargetMaker(&markTargetMaker{NetworkProtocol: header.IPv4ProtocolNumber})
+	registerTargetMaker(&markTargetMaker{NetworkProtocol: header.IPv6ProtocolNumber})
+}
+
+// markTarget sets pkt.Mark. It is non-terminating: after setting the mark,
+// traversal continues to the next rule (RuleContinue), matching Linux's -j MARK.
+//
+// +stateify savable
+type markTarget struct {
+	mark            uint32
+	mask            uint32
+	networkProtocol tcpip.NetworkProtocolNumber
+}
+
+func (mt *markTarget) id() targetID {
+	return targetID{
+		name:            MarkTargetName,
+		networkProtocol: mt.networkProtocol,
+		revision:        markTargetRevision,
+	}
+}
+
+// Action implements stack.Target.Action.
+func (mt *markTarget) Action(pkt *stack.PacketBuffer, _ stack.Hook, _ *stack.Route, _ stack.AddressableEndpoint) (stack.RuleVerdict, int) {
+	pkt.Mark = (pkt.Mark &^ mt.mask) ^ mt.mark
+	return stack.RuleContinue, 0
+}
+
+// markTargetMaker implements targetMaker for the MARK target (revision 2).
+//
+// +stateify savable
+type markTargetMaker struct {
+	NetworkProtocol tcpip.NetworkProtocolNumber
+}
+
+func (mm *markTargetMaker) id() targetID {
+	return targetID{
+		name:            MarkTargetName,
+		networkProtocol: mm.NetworkProtocol,
+		revision:        markTargetRevision,
+	}
+}
+
+func (*markTargetMaker) marshal(target target) []byte {
+	mt := target.(*markTarget)
+	xt := xtMarkTargetV2{
+		Target: linux.XTEntryTarget{
+			TargetSize: uint16(markTargetV2Size),
+			Revision:   markTargetRevision,
+		},
+		Mark: mt.mark,
+		Mask: mt.mask,
+	}
+	copy(xt.Target.Name[:], MarkTargetName)
+	return marshal.Marshal(&xt)
+}
+
+func (mm *markTargetMaker) unmarshal(buf []byte, filter stack.IPHeaderFilter) (target, *syserr.Error) {
+	if len(buf) < markTargetV2Size {
+		nflog("markTargetMaker: buf has insufficient size for MARK target %d", len(buf))
+		return nil, syserr.ErrInvalidArgument
+	}
+	var xt xtMarkTargetV2
+	xt.UnmarshalUnsafe(buf)
+	return &markTarget{
+		mark:            xt.Mark,
+		mask:            xt.Mask,
+		networkProtocol: filter.NetworkProtocol(),
+	}, nil
+}

--- a/pkg/sentry/socket/netfilter/netfilter.go
+++ b/pkg/sentry/socket/netfilter/netfilter.go
@@ -196,6 +196,8 @@ func SetEntries(mapper IDMapper, stk *stack.Stack, optVal []byte, ipv6 bool) *sy
 		table = stack.EmptyFilterTable()
 	case natTable:
 		table = stack.EmptyNATTable()
+	case mangleTable:
+		table = stack.EmptyMangleTable()
 	case rawTable:
 		table = stack.EmptyRawTable()
 	default:
@@ -295,6 +297,7 @@ func SetEntries(mapper IDMapper, stk *stack.Stack, optVal []byte, ipv6 bool) *sy
 	}
 
 	if err := checkLoopsAndChains(table, ipv6); err != nil {
+		nflog("checkLoopsAndChains failed for table %q (validHooks=%#x, rules=%d): %v", replace.Name.String(), table.ValidHooks(), len(table.Rules), err)
 		return err
 	}
 
@@ -553,11 +556,13 @@ func MatchRevision(t *kernel.Task, revPtr hostarch.Addr) (linux.XTGetRevision, *
 
 	maxSupported, ok := matchMakerRevision(rev.Name.String(), rev.Revision)
 	if !ok {
+		nflog("MatchRevision: no registered matcher named %q (iptables requested rev %d)", rev.Name.String(), rev.Revision)
 		// Return ENOENT if there's no matcher with that name.
 		return linux.XTGetRevision{}, syserr.ErrNoFileOrDir
 	}
 
 	if maxSupported < rev.Revision {
+		nflog("MatchRevision: matcher %q requested rev %d > max supported %d", rev.Name.String(), rev.Revision, maxSupported)
 		// Return EPROTONOSUPPORT if we have an insufficient revision.
 		return linux.XTGetRevision{}, syserr.ErrProtocolNotSupported
 	}
@@ -576,10 +581,12 @@ func TargetRevision(t *kernel.Task, revPtr hostarch.Addr, netProto tcpip.Network
 	}
 	maxSupported, ok := targetRevision(rev.Name.String(), netProto, rev.Revision)
 	if !ok {
+		nflog("TargetRevision: no registered target named %q (iptables requested rev %d)", rev.Name.String(), rev.Revision)
 		// Return ENOENT if there's no target with that name.
 		return linux.XTGetRevision{}, syserr.ErrNoFileOrDir
 	}
 	if maxSupported < rev.Revision {
+		nflog("TargetRevision: target %q requested rev %d > max supported %d", rev.Name.String(), rev.Revision, maxSupported)
 		// Return EPROTONOSUPPORT if we have an insufficient revision.
 		return linux.XTGetRevision{}, syserr.ErrProtocolNotSupported
 	}

--- a/pkg/tcpip/stack/iptables.go
+++ b/pkg/tcpip/stack/iptables.go
@@ -259,6 +259,20 @@ func EmptyNATTable() Table {
 	}
 }
 
+// EmptyMangleTable returns a Table with no rules. The mangle table is valid at
+// all five hooks (like Linux, whose mangle table always defines PREROUTING,
+// INPUT, FORWARD, OUTPUT and POSTROUTING builtin chains); SetEntries populates
+// them from the replace request. All hooks must stay non-HookUnset so the
+// dataplane, which checks the mangle table at multiple hooks (incl. Postrouting),
+// never indexes Rules with HookUnset (-1).
+func EmptyMangleTable() Table {
+	return Table{
+		Rules:         []Rule{},
+		BuiltinChains: [NumHooks]int{},
+		Underflows:    [NumHooks]int{},
+	}
+}
+
 // EmptyRawTable returns a Table with no rules and only the Prerouting and
 // Output hooks set, matching the Linux raw table's valid hooks.
 func EmptyRawTable() Table {
@@ -443,6 +457,10 @@ func (it *IPTables) CheckPrerouting(pkt *PacketBuffer, addressEP AddressableEndp
 func (it *IPTables) CheckInput(pkt *PacketBuffer, inNicName string) bool {
 	tables := [...]checkTable{ // escapes: on arm this causes an allocation.
 		{
+			fn:      check,
+			tableID: MangleID,
+		},
+		{
 			fn:      checkNAT,
 			tableID: NATID,
 		},
@@ -482,6 +500,10 @@ func (it *IPTables) CheckInput(pkt *PacketBuffer, inNicName string) bool {
 // +checkescape
 func (it *IPTables) CheckForward(pkt *PacketBuffer, inNicName, outNicName string) bool {
 	tables := [...]checkTable{ // escapes: on arm this causes an allocation.
+		{
+			fn:      check,
+			tableID: MangleID,
+		},
 		{
 			fn:      check,
 			tableID: FilterID,
@@ -721,6 +743,11 @@ func (it *IPTables) checkChain(hook Hook, pkt *PacketBuffer, table Table, ruleId
 
 		case RuleReturn:
 			return chainReturn
+
+		case RuleContinue:
+			// A non-terminating target (e.g. MARK) ran; move to the next rule.
+			ruleIdx++
+			continue
 
 		case RuleJump:
 			// "Jumping" to the next rule just means we're

--- a/pkg/tcpip/stack/iptables_types.go
+++ b/pkg/tcpip/stack/iptables_types.go
@@ -74,6 +74,10 @@ const (
 
 	// RuleReturn indicates the packet should return to the previous chain.
 	RuleReturn
+
+	// RuleContinue indicates that a non-terminating target ran (e.g. MARK) and
+	// traversal should continue to the next rule in the current chain.
+	RuleContinue
 )
 
 // IPTables holds all the tables for a netstack.

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -629,3 +629,15 @@ func TestFilterInputRejectTCPReset(t *testing.T) {
 func TestFilterInputRejectTCPResetUnmatched(t *testing.T) {
 	singleTest(t, &FilterInputRejectTCPResetUnmatched{})
 }
+
+func TestManglePreroutingRuleContinue(t *testing.T) {
+	singleTest(t, &ManglePreroutingRuleContinue{})
+}
+
+func TestMangleMarkPropagateToFilter(t *testing.T) {
+	singleTest(t, &MangleMarkPropagateToFilter{})
+}
+
+func TestMangleInputDrop(t *testing.T) {
+	singleTest(t, &MangleInputDrop{})
+}

--- a/test/iptables/mangle.go
+++ b/test/iptables/mangle.go
@@ -1,0 +1,133 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"gvisor.dev/gvisor/test/netutils"
+)
+
+func init() {
+	RegisterTestCase(&ManglePreroutingRuleContinue{})
+	RegisterTestCase(&MangleMarkPropagateToFilter{})
+	RegisterTestCase(&MangleInputDrop{})
+}
+
+func mangleTable(ipv6 bool, args ...string) error {
+	return run(append([]string{"-t", "mangle"}, args...), ipv6)
+}
+
+// ManglePreroutingRuleContinue tests that the MARK target executes non-terminating
+// (RuleContinue) semantics in the mangle table.
+type ManglePreroutingRuleContinue struct{ containerCase }
+
+var _ TestCase = (*ManglePreroutingRuleContinue)(nil)
+
+func (*ManglePreroutingRuleContinue) Name() string {
+	return "ManglePreroutingRuleContinue"
+}
+
+func (*ManglePreroutingRuleContinue) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	// Rule 1: Set mark 0x42
+	if err := mangleTable(ipv6, "-A", "PREROUTING", "-p", "udp", "--destination-port", fmt.Sprintf("%d", dropPort), "-j", "MARK", "--set-mark", "0x42"); err != nil {
+		return err
+	}
+	// Rule 2: If mark 0x42, DROP. If RuleContinue works, this rule runs and drops the packet.
+	if err := mangleTable(ipv6, "-A", "PREROUTING", "-p", "udp", "-m", "mark", "--mark", "0x42", "--destination-port", fmt.Sprintf("%d", dropPort), "-j", "DROP"); err != nil {
+		return err
+	}
+
+	timedCtx, cancel := context.WithTimeout(ctx, NegativeTimeout)
+	defer cancel()
+	if err := netutils.ListenUDP(timedCtx, dropPort, ipv6); err == nil {
+		return fmt.Errorf("packets on port %d should have been dropped, but got a packet", dropPort)
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("error reading: %v", err)
+	}
+
+	return nil
+}
+
+func (*ManglePreroutingRuleContinue) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, dropPort, sendloopDuration)
+}
+
+// MangleMarkPropagateToFilter tests that a mark applied in mangle PREROUTING persists
+// and is matched by filter INPUT.
+type MangleMarkPropagateToFilter struct{ containerCase }
+
+var _ TestCase = (*MangleMarkPropagateToFilter)(nil)
+
+func (*MangleMarkPropagateToFilter) Name() string {
+	return "MangleMarkPropagateToFilter"
+}
+
+func (*MangleMarkPropagateToFilter) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	// Mark in mangle PREROUTING
+	if err := mangleTable(ipv6, "-A", "PREROUTING", "-p", "udp", "--destination-port", fmt.Sprintf("%d", dropPort), "-j", "MARK", "--set-mark", "0x10"); err != nil {
+		return err
+	}
+	// Drop in filter INPUT on mark match
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-m", "mark", "--mark", "0x10", "--destination-port", fmt.Sprintf("%d", dropPort), "-j", "DROP"); err != nil {
+		return err
+	}
+
+	timedCtx, cancel := context.WithTimeout(ctx, NegativeTimeout)
+	defer cancel()
+	if err := netutils.ListenUDP(timedCtx, dropPort, ipv6); err == nil {
+		return fmt.Errorf("packets on port %d should have been dropped, but got a packet", dropPort)
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("error reading: %v", err)
+	}
+
+	return nil
+}
+
+func (*MangleMarkPropagateToFilter) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, dropPort, sendloopDuration)
+}
+
+// MangleInputDrop tests dropping packets in mangle table INPUT chain.
+type MangleInputDrop struct{ containerCase }
+
+var _ TestCase = (*MangleInputDrop)(nil)
+
+func (*MangleInputDrop) Name() string {
+	return "MangleInputDrop"
+}
+
+func (*MangleInputDrop) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	if err := mangleTable(ipv6, "-A", "INPUT", "-p", "udp", "--destination-port", fmt.Sprintf("%d", dropPort), "-j", "DROP"); err != nil {
+		return err
+	}
+
+	timedCtx, cancel := context.WithTimeout(ctx, NegativeTimeout)
+	defer cancel()
+	if err := netutils.ListenUDP(timedCtx, dropPort, ipv6); err == nil {
+		return fmt.Errorf("packets on port %d should have been dropped in mangle INPUT, but got packet", dropPort)
+	} else if !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("error reading: %v", err)
+	}
+
+	return nil
+}
+
+func (*MangleInputDrop) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return netutils.SendUDPLoop(ctx, ip, dropPort, sendloopDuration)
+}


### PR DESCRIPTION
## Summary
- Adds `RuleContinue` verdict to netstack's iptables engine (`pkg/tcpip/stack/iptables.go` and `iptables_types.go`) to support non-terminating targets (`XT_CONTINUE`).
- Implements the `MARK` target maker (revision 2) in `pkg/sentry/socket/netfilter/mark_target.go` with set-xmark semantics (`pkt.Mark = (pkt.Mark &^ mask) ^ mark`) returning `RuleContinue`.
- Wires `MangleID` into all 5 hooks (`PREROUTING`, `INPUT`, `FORWARD`, `OUTPUT`, `POSTROUTING`) in `pkg/tcpip/stack/iptables.go`.
- Adds integration tests in `test/iptables/mangle.go`.

## Motivation & Context
Kubernetes `kube-proxy` relies heavily on packet marking for masquerading and tracking (`-A KUBE-MARK-MASQ -j MARK --or-mark 0x4000` and mid-chain `-j MARK --xor-mark 0x4000` followed by `MASQUERADE`). gVisor previously had no `MARK` target and only supported terminating rule verdicts (`Accept`/`Drop`), preventing chained rules from evaluating after setting a mark.

## Test Plan
- Unit tests: `bazel test //pkg/sentry/socket/netfilter:netfilter_test //pkg/tcpip/stack:stack_test`
- Integration tests: `test/iptables:iptables_test` (`Mangle*`)