### PR TITLE
netfilter: add iptables MASQUERADE target with strict hook validation and tests

### DIFF
--- a/pkg/sentry/socket/netfilter/BUILD
+++ b/pkg/sentry/socket/netfilter/BUILD
@@ -14,6 +14,7 @@ go_library(
         "ipv4.go",
         "ipv6.go",
         "mark_matcher.go",
+        "masquerade.go",
         "multiport_matcher.go",
         "multiport_matcher_v1.go",
         "netfilter.go",

--- a/pkg/sentry/socket/netfilter/ipv4.go
+++ b/pkg/sentry/socket/netfilter/ipv4.go
@@ -200,6 +200,12 @@ func modifyEntries4(mapper IDMapper, stk *stack.Stack, optVal []byte, replace *l
 				}
 				rejectTarget.Handler = handler
 			}
+			if _, ok := target.(*masqueradeTarget); ok {
+				if replace.Name.String() != natTable {
+					nflog("MASQUERADE target is only supported in the nat table")
+					return nil, syserr.ErrInvalidArgument
+				}
+			}
 			rule.Target = target
 		}
 		optVal = optVal[targetSize:]

--- a/pkg/sentry/socket/netfilter/ipv6.go
+++ b/pkg/sentry/socket/netfilter/ipv6.go
@@ -203,6 +203,12 @@ func modifyEntries6(mapper IDMapper, stk *stack.Stack, optVal []byte, replace *l
 				}
 				rejectTarget.Handler = handler
 			}
+			if _, ok := target.(*masqueradeTarget); ok {
+				if replace.Name.String() != natTable {
+					nflog("MASQUERADE target is only supported in the nat table")
+					return nil, syserr.ErrInvalidArgument
+				}
+			}
 			rule.Target = target
 		}
 		optVal = optVal[targetSize:]

--- a/pkg/sentry/socket/netfilter/masquerade.go
+++ b/pkg/sentry/socket/netfilter/masquerade.go
@@ -1,0 +1,105 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netfilter
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/linux"
+	"gvisor.dev/gvisor/pkg/marshal"
+	"gvisor.dev/gvisor/pkg/syserr"
+	"gvisor.dev/gvisor/pkg/tcpip"
+	"gvisor.dev/gvisor/pkg/tcpip/header"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+)
+
+// MasqueradeTargetName is used to mark targets as masquerade targets. Masquerade
+// targets should be reached for only the NAT table. These targets change the
+// source IP to the outgoing interface's primary address (computed at action
+// time); only valid in the POSTROUTING chain. The underlying rewrite is already
+// implemented by stack.MasqueradeTarget -- this maker just translates the
+// iptables MASQUERADE target to/from it.
+const MasqueradeTargetName = "MASQUERADE"
+
+type masqueradeTarget struct {
+	stack.MasqueradeTarget
+	// raw is the original marshalled xt_entry_target (header + NAT range payload)
+	// as received from iptables. MASQUERADE has several on-wire layouts across
+	// revisions -- rev0 nf_nat_ipv4_multi_range_compat (56B) and rev1/2 nf_nat_range
+	// (72B, as emitted by kube-proxy's `--random-fully` rules). We never interpret
+	// the range (the source address comes from the egress interface), so we retain
+	// the raw bytes to marshal them back verbatim for a faithful iptables-save.
+	raw []byte
+}
+
+func (mt *masqueradeTarget) id() targetID {
+	return targetID{
+		name:            MasqueradeTargetName,
+		networkProtocol: mt.NetworkProtocol,
+	}
+}
+
+type masqueradeTargetMaker struct {
+	NetworkProtocol tcpip.NetworkProtocolNumber
+}
+
+func (mm *masqueradeTargetMaker) id() targetID {
+	return targetID{
+		name:            MasqueradeTargetName,
+		networkProtocol: mm.NetworkProtocol,
+	}
+}
+
+func (*masqueradeTargetMaker) marshal(target target) []byte {
+	// Round-trip the exact bytes we received (preserves the revision/layout that
+	// iptables negotiated) so iptables-save/kube-proxy see their own rule back.
+	if mt, ok := target.(*masqueradeTarget); ok && len(mt.raw) > 0 {
+		return append([]byte(nil), mt.raw...)
+	}
+	// Fallback for internally-constructed targets: the legacy
+	// nf_nat_ipv4_multi_range_compat layout (same as SNAT revision 0).
+	xt := linux.XTNATTargetV0{
+		Target: linux.XTEntryTarget{
+			TargetSize: linux.SizeOfXTNATTargetV0,
+		},
+	}
+	copy(xt.Target.Name[:], MasqueradeTargetName)
+	xt.NfRange.RangeSize = 1
+	return marshal.Marshal(&xt)
+}
+
+func (*masqueradeTargetMaker) unmarshal(buf []byte, filter stack.IPHeaderFilter) (target, *syserr.Error) {
+	// MASQUERADE is valid only for IPv4 and IPv6 in the nat table's POSTROUTING hook.
+	netProto := filter.NetworkProtocol()
+	if netProto != header.IPv4ProtocolNumber && netProto != header.IPv6ProtocolNumber {
+		nflog("masqueradeTargetMaker: unsupported network protocol: %d", netProto)
+		return nil, syserr.ErrNotSupported
+	}
+
+	// MASQUERADE ignores the NAT address range entirely -- the source address is
+	// the egress interface's, derived at action time by stack.MasqueradeTarget.
+	// iptables sends several range layouts across revisions (rev0
+	// nf_nat_ipv4_multi_range_compat, rev1/2 nf_nat_range, the latter carrying
+	// kube-proxy's --random-fully flag), so we do NOT parse or validate the range;
+	// we only require the fixed xt_entry_target header and retain the raw bytes.
+	if len(buf) < linux.SizeOfXTEntryTarget {
+		nflog("masqueradeTargetMaker: buf too small for masquerade target: %d", len(buf))
+		return nil, syserr.ErrInvalidArgument
+	}
+	return &masqueradeTarget{
+		MasqueradeTarget: stack.MasqueradeTarget{
+			NetworkProtocol: netProto,
+		},
+		raw: append([]byte(nil), buf...),
+	}, nil
+}

--- a/pkg/sentry/socket/netfilter/netfilter.go
+++ b/pkg/sentry/socket/netfilter/netfilter.go
@@ -455,7 +455,7 @@ const (
 	visited
 )
 
-func checkChainDFS(table stack.Table, ruleIdx int, state []visitState, ipv6 bool) *syserr.Error {
+func checkChainDFS(table stack.Table, ruleIdx int, state []visitState, ipv6 bool, hook stack.Hook) *syserr.Error {
 	if state[ruleIdx] == visiting {
 		nflog("jump loop detected at rule %d", ruleIdx)
 		return syserr.ErrInvalidArgument
@@ -466,6 +466,10 @@ func checkChainDFS(table stack.Table, ruleIdx int, state []visitState, ipv6 bool
 	state[ruleIdx] = visiting
 
 	rule := table.Rules[ruleIdx]
+	if _, ok := rule.Target.(*masqueradeTarget); ok && hook != stack.Postrouting {
+		nflog("MASQUERADE target is only supported in POSTROUTING, rule %d is in hook %v", ruleIdx, hook)
+		return syserr.ErrInvalidArgument
+	}
 	if jump, ok := rule.Target.(*JumpTarget); ok {
 		jumpTo := jump.RuleNum
 		if jumpTo <= 0 || jumpTo >= len(table.Rules) {
@@ -476,7 +480,7 @@ func checkChainDFS(table stack.Table, ruleIdx int, state []visitState, ipv6 bool
 			nflog("jump target %d is not a user chain (rule %d-1 target is %T)", jumpTo, jumpTo, table.Rules[jumpTo-1].Target)
 			return syserr.ErrInvalidArgument
 		}
-		if err := checkChainDFS(table, jumpTo, state, ipv6); err != nil {
+		if err := checkChainDFS(table, jumpTo, state, ipv6, hook); err != nil {
 			return err
 		}
 	}
@@ -495,7 +499,7 @@ func checkChainDFS(table stack.Table, ruleIdx int, state []visitState, ipv6 bool
 		nflog("chain fell through into a user chain without an unconditional final rule at rule %d (next target is %T)", ruleIdx, table.Rules[nextIdx].Target)
 		return syserr.ErrInvalidArgument
 	}
-	if err := checkChainDFS(table, nextIdx, state, ipv6); err != nil {
+	if err := checkChainDFS(table, nextIdx, state, ipv6, hook); err != nil {
 		return err
 	}
 	state[ruleIdx] = visited
@@ -507,7 +511,7 @@ func checkLoopsAndChains(table stack.Table, ipv6 bool) *syserr.Error {
 
 	for hook, ruleIdx := range table.BuiltinChains {
 		if table.ValidHooks()&(1<<hook) != 0 {
-			if err := checkChainDFS(table, ruleIdx, state, ipv6); err != nil {
+			if err := checkChainDFS(table, ruleIdx, state, ipv6, hookFromLinux(hook)); err != nil {
 				return err
 			}
 		}
@@ -515,7 +519,7 @@ func checkLoopsAndChains(table stack.Table, ipv6 bool) *syserr.Error {
 
 	for ruleIdx, rule := range table.Rules {
 		if isUserChainTarget(rule.Target) && ruleIdx+1 < len(table.Rules) {
-			if err := checkChainDFS(table, ruleIdx+1, state, ipv6); err != nil {
+			if err := checkChainDFS(table, ruleIdx+1, state, ipv6, stack.Postrouting); err != nil {
 				return err
 			}
 		}

--- a/pkg/sentry/socket/netfilter/netfilter_test.go
+++ b/pkg/sentry/socket/netfilter/netfilter_test.go
@@ -139,3 +139,43 @@ func TestCheckLoopsAndChainsValid(t *testing.T) {
 		t.Fatalf("checkLoopsAndChains expected nil for valid table, got %v", err)
 	}
 }
+
+func TestCheckLoopsAndChainsMasqueradeInvalidHook(t *testing.T) {
+	// MASQUERADE target placed in Prerouting hook; must be rejected.
+	table := stack.Table{
+		Rules: []stack.Rule{
+			makeRule(&masqueradeTarget{}),
+		},
+		BuiltinChains: makeBuiltinChains(0),
+		Underflows:    makeUnderflows(0),
+	}
+	if err := checkLoopsAndChains(table, false); err != syserr.ErrInvalidArgument {
+		t.Fatalf("checkLoopsAndChains expected %v for masquerade in Prerouting, got %v", syserr.ErrInvalidArgument, err)
+	}
+}
+
+func TestCheckLoopsAndChainsMasqueradeValidPostrouting(t *testing.T) {
+	// MASQUERADE target placed in Postrouting hook; must be accepted.
+	table := stack.Table{
+		Rules: []stack.Rule{
+			makeRule(&masqueradeTarget{}),
+		},
+		BuiltinChains: [stack.NumHooks]int{
+			stack.Prerouting:  stack.HookUnset,
+			stack.Input:       stack.HookUnset,
+			stack.Forward:     stack.HookUnset,
+			stack.Output:      stack.HookUnset,
+			stack.Postrouting: 0,
+		},
+		Underflows: [stack.NumHooks]int{
+			stack.Prerouting:  stack.HookUnset,
+			stack.Input:       stack.HookUnset,
+			stack.Forward:     stack.HookUnset,
+			stack.Output:      stack.HookUnset,
+			stack.Postrouting: 0,
+		},
+	}
+	if err := checkLoopsAndChains(table, false); err != nil {
+		t.Fatalf("checkLoopsAndChains expected nil for masquerade in Postrouting, got %v", err)
+	}
+}

--- a/pkg/sentry/socket/netfilter/targets.go
+++ b/pkg/sentry/socket/netfilter/targets.go
@@ -80,6 +80,14 @@ func init() {
 		NetworkProtocol: header.IPv6ProtocolNumber,
 	})
 
+	// MASQUERADE targets (source NAT to the outgoing interface's address).
+	registerTargetMaker(&masqueradeTargetMaker{
+		NetworkProtocol: header.IPv4ProtocolNumber,
+	})
+	registerTargetMaker(&masqueradeTargetMaker{
+		NetworkProtocol: header.IPv6ProtocolNumber,
+	})
+
 	// CT targets (used in the raw table for conntrack zone assignment).
 	registerTargetMaker(&ctTargetMaker{
 		NetworkProtocol: header.IPv4ProtocolNumber,

--- a/test/iptables/iptables_test.go
+++ b/test/iptables/iptables_test.go
@@ -629,3 +629,15 @@ func TestFilterInputRejectTCPReset(t *testing.T) {
 func TestFilterInputRejectTCPResetUnmatched(t *testing.T) {
 	singleTest(t, &FilterInputRejectTCPResetUnmatched{})
 }
+
+func TestNATPostMasqueradeUDP(t *testing.T) {
+	singleTest(t, &NATPostMasqueradeUDP{})
+}
+
+func TestNATPostMasqueradeTCP(t *testing.T) {
+	singleTest(t, &NATPostMasqueradeTCP{})
+}
+
+func TestNATMasqueradeInvalidHookReject(t *testing.T) {
+	singleTest(t, &NATMasqueradeInvalidHookReject{})
+}

--- a/test/iptables/nat.go
+++ b/test/iptables/nat.go
@@ -57,6 +57,9 @@ func init() {
 	RegisterTestCase(&NATOutDNAT{})
 	RegisterTestCase(&NATOutDNATAddrOnly{})
 	RegisterTestCase(&NATOutDNATPortOnly{})
+	RegisterTestCase(&NATPostMasqueradeUDP{})
+	RegisterTestCase(&NATPostMasqueradeTCP{})
+	RegisterTestCase(&NATMasqueradeInvalidHookReject{})
 }
 
 // NATPreRedirectUDPPort tests that packets are redirected to different port.
@@ -1159,5 +1162,85 @@ func (*NATOutDNATPortOnly) ContainerAction(ctx context.Context, ip net.IP, ipv6 
 
 // LocalAction implements TestCase.LocalAction.
 func (*NATOutDNATPortOnly) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	return nil
+}
+
+// NATPostMasqueradeUDP tests that MASQUERADE rewrites the source IP on UDP packets.
+type NATPostMasqueradeUDP struct{ localCase }
+
+var _ TestCase = (*NATPostMasqueradeUDP)(nil)
+
+func (*NATPostMasqueradeUDP) Name() string {
+	return "NATPostMasqueradeUDP"
+}
+
+func (*NATPostMasqueradeUDP) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	if err := natTable(ipv6, "-A", "POSTROUTING", "-p", "udp", "-j", "MASQUERADE"); err != nil {
+		return err
+	}
+	return netutils.SendUDPLoop(ctx, ip, acceptPort, ipv6)
+}
+
+func (*NATPostMasqueradeUDP) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	remote, err := netutils.ListenUDPFrom(ctx, acceptPort, ipv6)
+	if err != nil {
+		return err
+	}
+	if remote.IP == nil || remote.IP.IsUnspecified() {
+		return fmt.Errorf("expected valid remote address from masquerade, got %v", remote.IP)
+	}
+	return nil
+}
+
+// NATPostMasqueradeTCP tests that MASQUERADE rewrites source IP on TCP connections.
+type NATPostMasqueradeTCP struct{ localCase }
+
+var _ TestCase = (*NATPostMasqueradeTCP)(nil)
+
+func (*NATPostMasqueradeTCP) Name() string {
+	return "NATPostMasqueradeTCP"
+}
+
+func (*NATPostMasqueradeTCP) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	if err := natTable(ipv6, "-A", "POSTROUTING", "-p", "tcp", "-j", "MASQUERADE"); err != nil {
+		return err
+	}
+	return netutils.ConnectTCP(ctx, ip, acceptPort, ipv6)
+}
+
+func (*NATPostMasqueradeTCP) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	remote, err := netutils.ListenTCPFrom(ctx, acceptPort, ipv6)
+	if err != nil {
+		return err
+	}
+	if remote.IP == nil || remote.IP.IsUnspecified() {
+		return fmt.Errorf("expected valid remote address from masquerade, got %v", remote.IP)
+	}
+	return nil
+}
+
+// NATMasqueradeInvalidHookReject tests that installing MASQUERADE in hooks
+// other than POSTROUTING (e.g. PREROUTING or non-nat tables) is rejected.
+type NATMasqueradeInvalidHookReject struct{ containerCase }
+
+var _ TestCase = (*NATMasqueradeInvalidHookReject)(nil)
+
+func (*NATMasqueradeInvalidHookReject) Name() string {
+	return "NATMasqueradeInvalidHookReject"
+}
+
+func (*NATMasqueradeInvalidHookReject) ContainerAction(ctx context.Context, ip net.IP, ipv6 bool) error {
+	// MASQUERADE in nat PREROUTING must be rejected.
+	if err := natTable(ipv6, "-A", "PREROUTING", "-p", "udp", "-j", "MASQUERADE"); err == nil {
+		return fmt.Errorf("expected error installing MASQUERADE target in PREROUTING, but succeeded")
+	}
+	// MASQUERADE in filter table must be rejected.
+	if err := filterTable(ipv6, "-A", "INPUT", "-p", "udp", "-j", "MASQUERADE"); err == nil {
+		return fmt.Errorf("expected error installing MASQUERADE target in filter table, but succeeded")
+	}
+	return nil
+}
+
+func (*NATMasqueradeInvalidHookReject) LocalAction(ctx context.Context, ip net.IP, ipv6 bool) error {
 	return nil
 }


### PR DESCRIPTION
## Summary
- Implements `masqueradeTargetMaker` in `pkg/sentry/socket/netfilter/masquerade.go` for IPv4 and IPv6, translating the iptables target to `stack.MasqueradeTarget`.
- Validates network protocols and target buffer size during unmarshal.
- Strictly validates tables and hooks: enforces that `MASQUERADE` is only installed in the `nat` table on the `POSTROUTING` hook. Any rule placing `MASQUERADE` in other tables (filter/mangle/raw) or other hooks (PREROUTING, INPUT, FORWARD, OUTPUT) is rejected with `EINVAL`.
- Adds unit tests in `pkg/sentry/socket/netfilter/netfilter_test.go` and integration tests in `test/iptables/nat.go` (including `NATMasqueradeInvalidHookReject`).

## Motivation & Context
Kubernetes `kube-proxy` configures `MASQUERADE` in `KUBE-POSTROUTING` for traffic leaving the node or traversing virtual bridge hairpin paths. Although netstack had `stack.MasqueradeTarget`, netfilter had no targetMaker for `"MASQUERADE"`, causing `iptables-restore` to fail ("MASQUERADE revision 0 not supported") and aborting ruleset synchronization.

## Test Plan
- Unit tests: `bazel test //pkg/sentry/socket/netfilter:netfilter_test //pkg/tcpip/stack:stack_test`
- Integration tests: `test/iptables:iptables_test` (`NATPostMasquerade*`, `NATMasqueradeInvalidHookReject`)