### PR TITLE
portforward: retry I/O after registering readiness waiter

### DIFF
--- a/runsc/boot/portforward/portforward_netstack.go
+++ b/runsc/boot/portforward/portforward_netstack.go
@@ -106,6 +106,8 @@ func (n *netstackConn) Read(ctx context.Context, buf []byte, cancel <-chan struc
 			e, ch = waiter.NewChannelEntry(waiter.ReadableEvents | waiter.EventIn | waiter.EventHUp | waiter.EventErr)
 			n.wq.EventRegister(&e)
 			defer n.wq.EventUnregister(&e)
+			res, tcpErr = n.ep.Read(b, tcpip.ReadOptions{})
+			continue
 		}
 		select {
 		case <-ch:
@@ -134,6 +136,8 @@ func (n *netstackConn) Write(ctx context.Context, buf []byte, cancel <-chan stru
 			e, ch = waiter.NewChannelEntry(waiter.WritableEvents | waiter.EventIn | waiter.EventHUp | waiter.EventErr)
 			n.wq.EventRegister(&e)
 			defer n.wq.EventUnregister(&e)
+			res, tcpErr = n.ep.Write(&b, tcpip.WriteOptions{Atomic: true})
+			continue
 		}
 		select {
 		case <-ch:

--- a/runsc/boot/portforward/portforward_netstack_test.go
+++ b/runsc/boot/portforward/portforward_netstack_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"sync"
 	"testing"
+	"testing/synctest"
 
 	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/context"
@@ -391,5 +392,51 @@ func TestDoCopyDrainsLargeRead(t *testing.T) {
 	}
 	if !bytes.Equal(got, payload) {
 		t.Fatalf("copied data mismatch")
+	}
+}
+
+type readinessRaceEndpoint struct {
+	tcpip.Endpoint
+	impl tcpErrImpl
+	wq   waiter.Queue
+}
+
+func (e *readinessRaceEndpoint) Read(dst io.Writer, opts tcpip.ReadOptions) (tcpip.ReadResult, tcpip.Error) {
+	res, err := e.impl.Read(dst, opts)
+	e.wq.Notify(waiter.ReadableEvents)
+	return res, err
+}
+
+func (e *readinessRaceEndpoint) Write(src tcpip.Payloader, opts tcpip.WriteOptions) (int64, tcpip.Error) {
+	res, err := e.impl.Write(src, opts)
+	e.wq.Notify(waiter.WritableEvents)
+	return res, err
+}
+
+func TestNetstackConnReadinessBeforeRegistration(t *testing.T) {
+	for _, operation := range []string{"Read", "Write"} {
+		t.Run(operation, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ep := &readinessRaceEndpoint{}
+				conn := &netstackConn{ep: ep, wq: &ep.wq}
+				call := conn.Read
+				if operation == "Write" {
+					call = conn.Write
+				}
+				cancel := make(chan struct{})
+				defer close(cancel)
+				done := false
+				go func() {
+					if _, err := call(context.Background(), nil, cancel); err != io.EOF {
+						t.Errorf("%s error = %v, want EOF", operation, err)
+					}
+					done = true
+				}()
+				synctest.Wait()
+				if !done {
+					t.Fatal("operation blocks with readiness pending")
+				}
+			})
+		})
 	}
 }


### PR DESCRIPTION
`netstackConn.Read` and `Write` can miss a readiness notification between the initial operation returning `ErrWouldBlock` and registration of the waiter. Registration does not replay readiness, so port forwarding can wait indefinitely despite pending input or available output capacity.

Retry the operation immediately after registering the waiter, before waiting for another notification. This preserves the existing fast path.

Add a deterministic `synctest` regression covering both Read and Write. It verifies completion after readiness changes before registration, without a real-time timeout.

Validation:

- Both regression cases fail immediately before the fix and pass afterward.
- Full port-forward unit target passes.
- 100 repetitions of each regression case pass.
- `gofmt` and `git diff --check`.
