### PR TITLE
proc, tcpip: add writable net.ipv4.conf.all.route_localnet

### DIFF
--- a/pkg/sentry/fsimpl/proc/tasks_sys.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys.go
@@ -108,6 +108,18 @@ func (fs *filesystem) newSysNetDir(ctx context.Context, root *auth.Credentials, 
 				"tcp_sack":            fs.newInode(ctx, root, 0644, &tcpSackData{stack: stack}),
 				"tcp_wmem":            fs.newInode(ctx, root, 0644, &tcpMemData{stack: stack, dir: tcpWMem}),
 
+				// conf/{all,default}/route_localnet toggles acceptance of martian
+				// loopback packets on non-loopback NICs (kube-proxy enables this). It
+				// is backed by the IPv4 protocol's AllowExternalLoopbackTraffic option.
+				"conf": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
+					"all": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
+						"route_localnet": fs.newInode(ctx, root, 0644, &routeLocalnetData{stack: stack}),
+					}),
+					"default": fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
+						"route_localnet": fs.newInode(ctx, root, 0644, &routeLocalnetData{stack: stack}),
+					}),
+				}),
+
 				// The following files are simple stubs until they are implemented in
 				// netstack, most of these files are configuration related. We use the
 				// value closest to the actual netstack behavior or any empty file, all
@@ -480,6 +492,51 @@ func (ipf *ipForwarding) Write(ctx context.Context, _ *vfs.FileDescription, src 
 		return 0, err
 	}
 	ipf.enabled = enabled
+	return n, nil
+}
+
+// routeLocalnetData implements vfs.WritableDynamicBytesSource for
+// /proc/sys/net/ipv4/conf/{all,default}/route_localnet. Enabling it accepts
+// martian loopback packets (IPv4 AllowExternalLoopbackTraffic), matching
+// Linux's net.ipv4.conf.*.route_localnet.
+//
+// +stateify savable
+type routeLocalnetData struct {
+	kernfs.DynamicBytesFile
+
+	stack inet.Stack `state:"wait"`
+}
+
+var _ vfs.WritableDynamicBytesSource = (*routeLocalnetData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (rl *routeLocalnetData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	enabled, err := rl.stack.GetAllowExternalLoopbackTraffic(ipv4.ProtocolNumber)
+	if err != nil {
+		return err
+	}
+	val := "0\n"
+	if enabled {
+		val = "1\n"
+	}
+	buf.WriteString(val)
+	return nil
+}
+
+// Write implements vfs.WritableDynamicBytesSource.Write.
+func (rl *routeLocalnetData) Write(ctx context.Context, _ *vfs.FileDescription, src usermem.IOSequence, offset int64) (int64, error) {
+	if offset != 0 {
+		// No need to handle partial writes thus far.
+		return 0, linuxerr.EINVAL
+	}
+	buf := make([]int32, 1)
+	n, err := ParseInt32Vec(ctx, src, buf)
+	if err != nil || n == 0 {
+		return 0, err
+	}
+	if err := rl.stack.SetAllowExternalLoopbackTraffic(ipv4.ProtocolNumber, buf[0] != 0); err != nil {
+		return 0, err
+	}
 	return n, nil
 }
 

--- a/pkg/sentry/fsimpl/proc/tasks_sys_test.go
+++ b/pkg/sentry/fsimpl/proc/tasks_sys_test.go
@@ -318,6 +318,66 @@ func TestPortRangeSharedStack(t *testing.T) {
 	}
 }
 
+// TestConfigureRouteLocalnet tests the implementation of
+// /proc/sys/net/ipv4/conf/{all,default}/route_localnet.
+func TestConfigureRouteLocalnet(t *testing.T) {
+	ctx := context.Background()
+	s := inet.NewTestStack()
+
+	var cases = []struct {
+		comment string
+		initial bool
+		str     string
+		final   bool
+	}{
+		{comment: `disabled; write 1 enables`, initial: false, str: "1", final: true},
+		{comment: `disabled; write 0 stays disabled`, initial: false, str: "0", final: false},
+		{comment: `enabled; write 0 disables`, initial: true, str: "0", final: false},
+		{comment: `enabled; write 1 stays enabled`, initial: true, str: "1", final: true},
+		{comment: `disabled; nonzero enables`, initial: false, str: "2404", final: true},
+	}
+	for _, c := range cases {
+		t.Run(c.comment, func(t *testing.T) {
+			s.AllowExternalLoopbackTraffic = c.initial
+
+			file := &routeLocalnetData{stack: s}
+
+			var initialBuf bytes.Buffer
+			if err := file.Generate(ctx, &initialBuf); err != nil {
+				t.Fatalf("file.Generate(ctx, &initialBuf) = %v, want nil", err)
+			}
+			initialWant := "0\n"
+			if c.initial {
+				initialWant = "1\n"
+			}
+			if got := initialBuf.String(); got != initialWant {
+				t.Errorf("file.Generate initial got %q, want %q", got, initialWant)
+			}
+
+			src := usermem.BytesIOSequence([]byte(c.str))
+			if n, err := file.Write(ctx, nil, src, 0); n != int64(len(c.str)) || err != nil {
+				t.Errorf("file.Write(ctx, nil, %q, 0) = (%d, %v); want (%d, nil)", c.str, n, err, len(c.str))
+			}
+
+			if got, want := s.AllowExternalLoopbackTraffic, c.final; got != want {
+				t.Errorf("s.AllowExternalLoopbackTraffic incorrect; got: %v, want: %v", got, want)
+			}
+
+			var finalBuf bytes.Buffer
+			if err := file.Generate(ctx, &finalBuf); err != nil {
+				t.Fatalf("file.Generate(ctx, &finalBuf) = %v, want nil", err)
+			}
+			finalWant := "0\n"
+			if c.final {
+				finalWant = "1\n"
+			}
+			if got := finalBuf.String(); got != finalWant {
+				t.Errorf("file.Generate final got %q, want %q", got, finalWant)
+			}
+		})
+	}
+}
+
 func TestParseInt32Vec(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {

--- a/pkg/sentry/inet/inet.go
+++ b/pkg/sentry/inet/inet.go
@@ -125,6 +125,15 @@ type Stack interface {
 	// SetForwarding enables or disables packet forwarding between NICs.
 	SetForwarding(protocol tcpip.NetworkProtocolNumber, enable bool) error
 
+	// GetAllowExternalLoopbackTraffic returns whether acceptance of martian
+	// loopback packets (Linux net.ipv4.conf.*.route_localnet) is enabled for the
+	// protocol.
+	GetAllowExternalLoopbackTraffic(protocol tcpip.NetworkProtocolNumber) (bool, error)
+
+	// SetAllowExternalLoopbackTraffic enables or disables acceptance of martian
+	// loopback packets (Linux net.ipv4.conf.*.route_localnet) for the protocol.
+	SetAllowExternalLoopbackTraffic(protocol tcpip.NetworkProtocolNumber, enable bool) error
+
 	// PortRange returns the UDP and TCP inclusive range of ephemeral ports
 	// used in both IPv4 and IPv6.
 	PortRange() (uint16, uint16)

--- a/pkg/sentry/inet/test_stack.go
+++ b/pkg/sentry/inet/test_stack.go
@@ -32,15 +32,16 @@ var _ Stack = (*TestStack)(nil)
 
 // TestStack is a dummy implementation of Stack for tests.
 type TestStack struct {
-	InterfacesMap     map[int32]Interface
-	InterfaceAddrsMap map[int32][]InterfaceAddr
-	RouteList         []Route
-	SupportsIPv6Flag  bool
-	TCPRecvBufSize    TCPBufferSize
-	TCPSendBufSize    TCPBufferSize
-	TCPSACKFlag       bool
-	Recovery          TCPLossRecovery
-	IPForwarding      bool
+	InterfacesMap                map[int32]Interface
+	InterfaceAddrsMap            map[int32][]InterfaceAddr
+	RouteList                    []Route
+	SupportsIPv6Flag             bool
+	TCPRecvBufSize               TCPBufferSize
+	TCPSendBufSize               TCPBufferSize
+	TCPSACKFlag                  bool
+	Recovery                     TCPLossRecovery
+	IPForwarding                 bool
+	AllowExternalLoopbackTraffic bool
 }
 
 // NewTestStack returns a TestStack with no network interfaces. The value of
@@ -210,6 +211,17 @@ func (s *TestStack) RestoreCleanupEndpoints([]stack.TransportEndpoint) {}
 // SetForwarding implements Stack.
 func (s *TestStack) SetForwarding(protocol tcpip.NetworkProtocolNumber, enable bool) error {
 	s.IPForwarding = enable
+	return nil
+}
+
+// GetAllowExternalLoopbackTraffic implements Stack.
+func (s *TestStack) GetAllowExternalLoopbackTraffic(protocol tcpip.NetworkProtocolNumber) (bool, error) {
+	return s.AllowExternalLoopbackTraffic, nil
+}
+
+// SetAllowExternalLoopbackTraffic implements Stack.
+func (s *TestStack) SetAllowExternalLoopbackTraffic(protocol tcpip.NetworkProtocolNumber, enable bool) error {
+	s.AllowExternalLoopbackTraffic = enable
 	return nil
 }
 

--- a/pkg/sentry/socket/hostinet/stack.go
+++ b/pkg/sentry/socket/hostinet/stack.go
@@ -469,6 +469,16 @@ func (*Stack) SetForwarding(tcpip.NetworkProtocolNumber, bool) error {
 	return linuxerr.EACCES
 }
 
+// GetAllowExternalLoopbackTraffic implements inet.Stack.GetAllowExternalLoopbackTraffic.
+func (*Stack) GetAllowExternalLoopbackTraffic(tcpip.NetworkProtocolNumber) (bool, error) {
+	return false, nil
+}
+
+// SetAllowExternalLoopbackTraffic implements inet.Stack.SetAllowExternalLoopbackTraffic.
+func (*Stack) SetAllowExternalLoopbackTraffic(tcpip.NetworkProtocolNumber, bool) error {
+	return linuxerr.EACCES
+}
+
 // PortRange implements inet.Stack.PortRange.
 func (*Stack) PortRange() (uint16, uint16) {
 	// Use the default Linux values per net/ipv4/af_inet.c:inet_init_net().

--- a/pkg/sentry/socket/netstack/stack.go
+++ b/pkg/sentry/socket/netstack/stack.go
@@ -1157,6 +1157,24 @@ func (s *Stack) SetForwarding(protocol tcpip.NetworkProtocolNumber, enable bool)
 	return nil
 }
 
+// GetAllowExternalLoopbackTraffic implements inet.Stack.GetAllowExternalLoopbackTraffic.
+func (s *Stack) GetAllowExternalLoopbackTraffic(protocol tcpip.NetworkProtocolNumber) (bool, error) {
+	var opt tcpip.AllowExternalLoopbackTrafficOption
+	if err := s.Stack.NetworkProtocolOption(protocol, &opt); err != nil {
+		return false, fmt.Errorf("NetworkProtocolOption(%d, ...): %s", protocol, err)
+	}
+	return bool(opt), nil
+}
+
+// SetAllowExternalLoopbackTraffic implements inet.Stack.SetAllowExternalLoopbackTraffic.
+func (s *Stack) SetAllowExternalLoopbackTraffic(protocol tcpip.NetworkProtocolNumber, enable bool) error {
+	opt := tcpip.AllowExternalLoopbackTrafficOption(enable)
+	if err := s.Stack.SetNetworkProtocolOption(protocol, &opt); err != nil {
+		return fmt.Errorf("SetNetworkProtocolOption(%d, &%t): %s", protocol, enable, err)
+	}
+	return nil
+}
+
 // PortRange implements inet.Stack.PortRange.
 func (s *Stack) PortRange() (uint16, uint16) {
 	return s.Stack.PortRange()

--- a/pkg/tcpip/network/ipv4/ipv4.go
+++ b/pkg/tcpip/network/ipv4/ipv4.go
@@ -960,7 +960,7 @@ func (e *endpoint) HandlePacket(pkt *stack.PacketBuffer) {
 	defer hView.Release()
 
 	if !e.nic.IsLoopback() {
-		if !e.protocol.options.AllowExternalLoopbackTraffic {
+		if !e.protocol.allowExternalLoopbackTraffic.Load() {
 			if header.IsV4LoopbackAddress(h.SourceAddress()) {
 				martianPacketLogger.Infof("Martian packet dropped with loopback source address. If your traffic is unexpectedly dropped, you may want to allow martian packets.")
 				stats.InvalidSourceAddressesReceived.Increment()
@@ -1666,6 +1666,11 @@ type protocol struct {
 
 	options Options
 
+	// allowExternalLoopbackTraffic mirrors options.AllowExternalLoopbackTraffic
+	// but is runtime-settable (via SetOption / the route_localnet sysctl). It is
+	// read lock-free on the packet path, so it is stored atomically.
+	allowExternalLoopbackTraffic atomicbitops.Bool
+
 	multicastRouteTable multicast.RouteTable
 	// multicastForwardingDisp is the multicast forwarding event dispatcher that
 	// an integrator can provide to receive multicast forwarding events. Note
@@ -1696,6 +1701,9 @@ func (p *protocol) SetOption(option tcpip.SettableNetworkProtocolOption) tcpip.E
 	case *tcpip.DefaultTTLOption:
 		p.SetDefaultTTL(uint8(*v))
 		return nil
+	case *tcpip.AllowExternalLoopbackTrafficOption:
+		p.allowExternalLoopbackTraffic.Store(bool(*v))
+		return nil
 	default:
 		return &tcpip.ErrUnknownProtocolOption{}
 	}
@@ -1706,6 +1714,9 @@ func (p *protocol) Option(option tcpip.GettableNetworkProtocolOption) tcpip.Erro
 	switch v := option.(type) {
 	case *tcpip.DefaultTTLOption:
 		*v = tcpip.DefaultTTLOption(p.DefaultTTL())
+		return nil
+	case *tcpip.AllowExternalLoopbackTrafficOption:
+		*v = tcpip.AllowExternalLoopbackTrafficOption(p.allowExternalLoopbackTraffic.Load())
 		return nil
 	default:
 		return &tcpip.ErrUnknownProtocolOption{}
@@ -2077,6 +2088,7 @@ func NewProtocolWithOptions(opts Options) stack.NetworkProtocolFactory {
 			defaultTTL: atomicbitops.FromUint32(DefaultTTL),
 			options:    opts,
 		}
+		p.allowExternalLoopbackTraffic.Store(opts.AllowExternalLoopbackTraffic)
 		p.fragmentation = fragmentation.NewFragmentation(fragmentblockSize, fragmentation.HighFragThreshold, fragmentation.LowFragThreshold, ReassembleTimeout, s.Clock(), p)
 		p.eps = make(map[tcpip.NICID]*endpoint)
 		// Set ICMP rate limiting to Linux defaults.

--- a/pkg/tcpip/tcpip.go
+++ b/pkg/tcpip/tcpip.go
@@ -1067,6 +1067,16 @@ func (*DefaultTTLOption) isGettableNetworkProtocolOption() {}
 
 func (*DefaultTTLOption) isSettableNetworkProtocolOption() {}
 
+// AllowExternalLoopbackTrafficOption enables or disables acceptance of martian
+// loopback packets (packets with a loopback source or destination address
+// arriving on a non-loopback NIC). It mirrors Linux's
+// net.ipv4.conf.*.route_localnet.
+type AllowExternalLoopbackTrafficOption bool
+
+func (*AllowExternalLoopbackTrafficOption) isGettableNetworkProtocolOption() {}
+
+func (*AllowExternalLoopbackTrafficOption) isSettableNetworkProtocolOption() {}
+
 // GettableTransportProtocolOption is a marker interface for transport protocol
 // options that may be queried.
 type GettableTransportProtocolOption interface {

--- a/pkg/tcpip/tests/integration/loopback_test.go
+++ b/pkg/tcpip/tests/integration/loopback_test.go
@@ -791,3 +791,94 @@ func TestExternalLoopbackTraffic(t *testing.T) {
 		})
 	}
 }
+
+// TestExternalLoopbackTrafficRuntimeToggle verifies that flipping the
+// AllowExternalLoopbackTraffic option at runtime (the path exercised by the
+// /proc/sys/net/ipv4/conf/all/route_localnet sysctl, as opposed to setting it
+// once at protocol construction) actually changes whether martian
+// loopback-sourced packets are accepted on a non-loopback NIC. This mirrors
+// Linux, where writing net.ipv4.conf.all.route_localnet takes effect on
+// subsequently received packets without restarting the stack.
+func TestExternalLoopbackTrafficRuntimeToggle(t *testing.T) {
+	const (
+		nicID1 = 1
+		nicID2 = 2
+		ttl    = 64
+	)
+	ipv4Loopback := testutil.MustParse4("127.0.0.1")
+
+	// Start with the option disabled (Linux's default route_localnet=0).
+	s := stack.New(stack.Options{
+		NetworkProtocols: []stack.NetworkProtocolFactory{
+			ipv4.NewProtocolWithOptions(ipv4.Options{AllowExternalLoopbackTraffic: false}),
+		},
+		TransportProtocols: []stack.TransportProtocolFactory{icmp.NewProtocol4},
+	})
+	defer s.Destroy()
+
+	e := channel.New(1, header.IPv6MinimumMTU, "")
+	if err := s.CreateNIC(nicID1, e); err != nil {
+		t.Fatalf("CreateNIC(%d, _): %s", nicID1, err)
+	}
+	v4Addr := tcpip.ProtocolAddress{Protocol: ipv4.ProtocolNumber, AddressWithPrefix: utils.Ipv4Addr}
+	if err := s.AddProtocolAddress(nicID1, v4Addr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("AddProtocolAddress(%d, %+v, {}): %s", nicID1, v4Addr, err)
+	}
+	if err := s.CreateNIC(nicID2, loopback.New()); err != nil {
+		t.Fatalf("CreateNIC(%d, _): %s", nicID2, err)
+	}
+	loopbackAddr := tcpip.ProtocolAddress{
+		Protocol:          ipv4.ProtocolNumber,
+		AddressWithPrefix: tcpip.AddressWithPrefix{Address: ipv4Loopback, PrefixLen: 8},
+	}
+	if err := s.AddProtocolAddress(nicID2, loopbackAddr, stack.AddressProperties{}); err != nil {
+		t.Fatalf("AddProtocolAddress(%d, %+v, {}): %s", nicID2, loopbackAddr, err)
+	}
+	s.SetRouteTable([]tcpip.Route{
+		{Destination: header.IPv4EmptySubnet, NIC: nicID1},
+		{Destination: ipv4Loopback.WithPrefix().Subnet(), NIC: nicID2},
+	})
+
+	stats := s.Stats().IP
+	invalidSrc := stats.InvalidSourceAddressesReceived
+	delivered := stats.PacketsDelivered
+
+	rxMartian := func() {
+		utils.RxICMPv4EchoRequest(e, ipv4Loopback, utils.Ipv4Addr.Address, ttl)
+	}
+	setOption := func(enable bool) {
+		opt := tcpip.AllowExternalLoopbackTrafficOption(enable)
+		if err := s.SetNetworkProtocolOption(ipv4.ProtocolNumber, &opt); err != nil {
+			t.Fatalf("SetNetworkProtocolOption(ipv4, AllowExternalLoopbackTraffic=%t): %s", enable, err)
+		}
+	}
+
+	// Disabled: the martian loopback-sourced packet is dropped.
+	rxMartian()
+	if got, want := invalidSrc.Value(), uint64(1); got != want {
+		t.Errorf("with option disabled: InvalidSourceAddressesReceived = %d, want %d", got, want)
+	}
+	if got, want := delivered.Value(), uint64(0); got != want {
+		t.Errorf("with option disabled: PacketsDelivered = %d, want %d", got, want)
+	}
+
+	// Enable at runtime (the sysctl path): the next packet is accepted.
+	setOption(true)
+	rxMartian()
+	if got, want := invalidSrc.Value(), uint64(1); got != want {
+		t.Errorf("after enabling: InvalidSourceAddressesReceived = %d, want %d (unchanged)", got, want)
+	}
+	if got, want := delivered.Value(), uint64(1); got != want {
+		t.Errorf("after enabling: PacketsDelivered = %d, want %d", got, want)
+	}
+
+	// Disable again at runtime: subsequent packets are dropped once more.
+	setOption(false)
+	rxMartian()
+	if got, want := invalidSrc.Value(), uint64(2); got != want {
+		t.Errorf("after re-disabling: InvalidSourceAddressesReceived = %d, want %d", got, want)
+	}
+	if got, want := delivered.Value(), uint64(1); got != want {
+		t.Errorf("after re-disabling: PacketsDelivered = %d, want %d (unchanged)", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Adds support for the `net.ipv4.conf.all.route_localnet` sysctl and wires it to a runtime-configurable `AllowExternalLoopbackTrafficOption` in netstack.

When enabled (e.g. by `kube-proxy` for NodePort/hairpin NAT paths), netstack accepts "martian" loopback traffic (`127.0.0.0/8` source or destination) arriving on non-loopback NICs instead of dropping it.

## Linux Fidelity
- **Faithful behavior:** Mirrors Linux `net.ipv4.conf.*.route_localnet` (Linux `net/ipv4/fib_frontend.c` / `IN_DEV_ROUTE_LOCALNET`), allowing routing of `127.0.0.0/8` across external interfaces.
- **Divergences:** 
  - Linux implements `route_localnet` per-interface (`conf/all`, `conf/default`, `conf/<if>`), taking the logical OR of `all` and `<if>`. This PR only exposes `conf/all/route_localnet` backed by a single global IPv4 protocol option.
  - Per-interface configuration and IPv6 loopback route toggling are not implemented.

## Tests
- `TestConfigureRouteLocalnet` (`pkg/sentry/fsimpl/proc/tasks_sys_test.go`): verifies the `/proc` write parser and sysctl toggle.
- `TestExternalLoopbackTrafficRuntimeToggle` (`pkg/tcpip/tests/integration/loopback_test.go`): verifies that toggling the option at runtime dynamically flips packet acceptance on non-loopback endpoints.

Assisted-by: Cortex Code