### PR TITLE
fix: preserve short receives and release SCM_RIGHTS on errors

### DIFF
--- a/pkg/sentry/mm/io.go
+++ b/pkg/sentry/mm/io.go
@@ -623,8 +623,9 @@ func (mm *MemoryManager) withInternalMappings(ctx context.Context, ar hostarch.A
 	n := int64(un)
 
 	// Return the first error in order of progress through ar.
-	if err != nil {
-		// Do not convert errors returned by f to EFAULT.
+	if err != nil || un < imbs.NumBytes() {
+		// Do not convert errors returned by f to EFAULT, or report mapping
+		// errors beyond the end of a successful short I/O.
 		return n, err
 	}
 	if imerr != nil {
@@ -691,8 +692,9 @@ func (mm *MemoryManager) withVecInternalMappings(ctx context.Context, ars hostar
 	n := int64(un)
 
 	// Return the first error in order of progress through ars.
-	if err != nil {
-		// Do not convert errors from f to EFAULT.
+	if err != nil || un < imbs.NumBytes() {
+		// Do not convert errors returned by f to EFAULT, or report mapping
+		// errors beyond the end of a successful short I/O.
 		return n, err
 	}
 	if imerr != nil {

--- a/pkg/sentry/syscalls/linux/sys_socket.go
+++ b/pkg/sentry/syscalls/linux/sys_socket.go
@@ -815,12 +815,12 @@ func recvSingleMsg(t *kernel.Task, s socket.Socket, msgPtr hostarch.Addr, flags 
 	// Fast path when no control message nor name buffers are provided.
 	if msg.ControlLen == 0 && msg.NameLen == 0 {
 		n, mflags, _, _, cms, err := s.RecvMsg(t, dst, int(flags), haveDeadline, deadline, false, 0)
-		if err != nil {
-			return 0, linuxerr.ConvertIntr(err.ToError(), linuxerr.ERESTARTSYS)
-		}
 		if !cms.Unix.Empty() {
 			mflags |= linux.MSG_CTRUNC
 			cms.Release(t)
+		}
+		if err != nil {
+			return 0, linuxerr.ConvertIntr(err.ToError(), linuxerr.ERESTARTSYS)
 		}
 
 		if int(msg.Flags) != mflags {
@@ -837,10 +837,11 @@ func recvSingleMsg(t *kernel.Task, s socket.Socket, msgPtr hostarch.Addr, flags 
 		return 0, linuxerr.ENOBUFS
 	}
 	n, mflags, sender, senderLen, cms, e := s.RecvMsg(t, dst, int(flags), haveDeadline, deadline, msg.NameLen != 0, msg.ControlLen)
+	// Control messages may have been dequeued even if copying the data failed.
+	defer cms.Release(t)
 	if e != nil {
 		return 0, linuxerr.ConvertIntr(e.ToError(), linuxerr.ERESTARTSYS)
 	}
-	defer cms.Release(t)
 
 	controlData := make([]byte, 0, msg.ControlLen)
 	controlData = control.PackControlMessages(t, cms, controlData)

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -4030,6 +4030,8 @@ cc_library(
         ":unix_domain_socket_test_util",
         "//test/util:capability_util",
         "//test/util:cleanup",
+        "//test/util:file_descriptor",
+        "//test/util:memory_util",
         "//test/util:socket_util",
         "//test/util:test_util",
         "//test/util:thread_util",

--- a/test/syscalls/linux/socket_unix_cmsg.cc
+++ b/test/syscalls/linux/socket_unix_cmsg.cc
@@ -15,6 +15,7 @@
 #include "test/syscalls/linux/socket_unix_cmsg.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
@@ -28,7 +29,9 @@
 #include "gtest/gtest.h"
 #include "test/syscalls/linux/unix_domain_socket_test_util.h"
 #include "test/util/cleanup.h"
+#include "test/util/file_descriptor.h"
 #include "test/util/linux_capability_util.h"
+#include "test/util/memory_util.h"
 #include "test/util/socket_util.h"
 #include "test/util/test_util.h"
 #include "test/util/thread_util.h"
@@ -63,6 +66,88 @@ TEST_P(UnixSocketPairCmsgTest, BasicFDPass) {
   EXPECT_EQ(0, memcmp(sent_data, received_data, sizeof(sent_data)));
 
   ASSERT_NO_FATAL_FAILURE(TransferTest(fd, pair->first_fd()));
+}
+
+TEST_P(UnixSocketPairCmsgTest, FDPassWithInaccessibleBufferTail) {
+  for (bool vectored : {false, true}) {
+    SCOPED_TRACE(vectored);
+    auto sockets = ASSERT_NO_ERRNO_AND_VALUE(NewSocketPair());
+    auto pair = ASSERT_NO_ERRNO_AND_VALUE(
+        UnixDomainSocketPair(SOCK_SEQPACKET).Create());
+
+    // The unused tail of a large receive buffer need not be accessible.
+    constexpr size_t kBufferSize = 1 << 20;
+    auto mapping = ASSERT_NO_ERRNO_AND_VALUE(
+        MmapAnon(kBufferSize, PROT_NONE, MAP_PRIVATE));
+    ASSERT_THAT(mprotect(mapping.ptr(), kPageSize, PROT_READ | PROT_WRITE),
+                SyscallSucceeds());
+    char sent_data[] = "hello";
+    ASSERT_NO_FATAL_FAILURE(SendSingleFD(sockets->first_fd(), pair->second_fd(),
+                                         sent_data, sizeof(sent_data)));
+
+    struct iovec iov[2] = {};
+    iov[0].iov_base = mapping.ptr();
+    iov[0].iov_len = vectored ? kPageSize : kBufferSize;
+    iov[1].iov_base = reinterpret_cast<void*>(mapping.addr() + kPageSize);
+    iov[1].iov_len = kBufferSize - kPageSize;
+    char control[CMSG_SPACE(sizeof(int))] = {};
+    struct msghdr msg = {};
+    msg.msg_iov = iov;
+    msg.msg_iovlen = vectored ? 2 : 1;
+    msg.msg_control = control;
+    msg.msg_controllen = sizeof(control);
+    ASSERT_THAT(RetryEINTR(recvmsg)(sockets->second_fd(), &msg, 0),
+                SyscallSucceedsWithValue(sizeof(sent_data)));
+    struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+    ASSERT_NE(cmsg, nullptr);
+    ASSERT_EQ(cmsg->cmsg_level, SOL_SOCKET);
+    ASSERT_EQ(cmsg->cmsg_type, SCM_RIGHTS);
+    ASSERT_EQ(cmsg->cmsg_len, CMSG_LEN(sizeof(int)));
+    int received_fd;
+    memcpy(&received_fd, CMSG_DATA(cmsg), sizeof(received_fd));
+    FileDescriptor fd(received_fd);
+    EXPECT_EQ(msg.msg_flags & MSG_CTRUNC, 0);
+    EXPECT_EQ(memcmp(mapping.ptr(), sent_data, sizeof(sent_data)), 0);
+    ASSERT_NO_FATAL_FAILURE(TransferTest(fd.get(), pair->first_fd()));
+  }
+}
+
+TEST_P(UnixSocketPairCmsgTest, ReceiveFaultReleasesFD) {
+  auto sockets = ASSERT_NO_ERRNO_AND_VALUE(NewSocketPair());
+  int pipe_fds[2];
+  ASSERT_THAT(pipe2(pipe_fds, O_NONBLOCK), SyscallSucceeds());
+  FileDescriptor read_end(pipe_fds[0]);
+  FileDescriptor write_end(pipe_fds[1]);
+
+  // This payload reaches the inaccessible page. Receiving it must fail, and
+  // the in-flight write FD must be released.
+  auto mapping = ASSERT_NO_ERRNO_AND_VALUE(
+      MmapAnon(2 * kPageSize, PROT_NONE, MAP_PRIVATE));
+  ASSERT_THAT(mprotect(mapping.ptr(), kPageSize, PROT_READ | PROT_WRITE),
+              SyscallSucceeds());
+  std::vector<char> sent_data(2 * kPageSize, 'a');
+  ASSERT_NO_FATAL_FAILURE(SendSingleFD(sockets->first_fd(), write_end.get(),
+                                       sent_data.data(), sent_data.size()));
+  write_end.reset();
+
+  struct iovec iov = {};
+  iov.iov_base = mapping.ptr();
+  iov.iov_len = mapping.len();
+  char control[CMSG_SPACE(sizeof(int))] = {};
+  struct msghdr msg = {};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = control;
+  msg.msg_controllen = sizeof(control);
+  ASSERT_THAT(RetryEINTR(recvmsg)(sockets->second_fd(), &msg, 0),
+              SyscallFailsWithErrno(EFAULT));
+
+  // Drop any data still queued on stream sockets. No write FD is installed in
+  // the receiving process, so closing the sockets must leave no pipe writers.
+  sockets.reset();
+  char byte;
+  EXPECT_THAT(RetryEINTR(read)(read_end.get(), &byte, sizeof(byte)),
+              SyscallSucceedsWithValue(0));
 }
 
 TEST_P(UnixSocketPairCmsgTest, BasicTwoFDPass) {


### PR DESCRIPTION
A short Unix socket receive can return `EFAULT` when an unused tail of its destination buffer is inaccessible. The memory manager prepares the entire buffer, completes the short read, then reports the later mapping error. If that read dequeued `SCM_RIGHTS`, `recvSingleMsg` returns before releasing the control messages, leaving file references alive even after both transport sockets are closed.

Ignore mapping errors beyond successful short I/O in both scalar and vector internal-mapping paths, while preserving errors when the copy reaches the inaccessible region. Release received control messages on error paths as well. Add syscall regressions for short receives with one or two iovecs and for FD cleanup after a real receive fault, across stream, datagram, seqpacket, blocking, nonblocking, and reversed socket pairs.

Related to #14497. The regression reproduces the `EFAULT` and retained-FD failure mechanism; the original HAProxy reload workload has not been rerun.

Validation:

- Bazel build of `//runsc` and `//test/syscalls/linux:socket_unix_pair_test` passed.
- `bazel test //test/syscalls:socket_unix_pair_test_native --test_env='GTEST_FILTER=*UnixSocketPairCmsgTest*'` passed.
- All 24 new regression cases pass on native Linux. On both KVM and systrap, all 24 fail before the fix and pass after it.
- Ran the full 648-case control-message suite under both KVM and systrap: 626 passed, 10 skipped, and 12 pre-existing `BasicFDPassNullControlMsgCtrunc` failures. Baseline comparison confirmed those same 12 failures and no new failures after the fix.
- `git diff --check`, `gofmt`, and Google-style `clang-format` checks passed. Linux validation used LF-normalized source copies in dedicated containers.

Assisted-by: Codex
