### PR TITLE
nvproxy: preserve GPU identities for restored processes

### DIFF
--- a/pkg/abi/nvgpu/ctrl.go
+++ b/pkg/abi/nvgpu/ctrl.go
@@ -81,9 +81,11 @@ const (
 	NV0000_CTRL_CMD_GPU_ASYNC_ATTACH_ID       = 0x289
 	NV0000_CTRL_CMD_GPU_WAIT_ATTACH_ID        = 0x290
 
-	NV0000_CTRL_GPU_INVALID_ID      = 0xffffffff
-	NV0000_CTRL_GPU_MAX_PROBED_GPUS = NV_MAX_DEVICES
-	NV0000_GPU_MAX_GID_LENGTH       = 0x100
+	NV0000_CTRL_GPU_INVALID_ID         = 0xffffffff
+	NV0000_CTRL_GPU_MAX_PROBED_GPUS    = NV_MAX_DEVICES
+	NV0000_CTRL_GPU_MAX_ATTACHED_GPUS  = 32
+	NV0000_CTRL_GPU_MAX_ACTIVE_DEVICES = 256
+	NV0000_GPU_MAX_GID_LENGTH          = 0x100
 )
 
 // From src/common/sdk/nvidia/inc/ctrl/ctrl0000/ctrl0000gpuacct.h:
@@ -145,6 +147,8 @@ const (
 	NV0000_CTRL_CMD_SYSTEM_GET_FEATURES                     = 0x1f0
 	NV0000_CTRL_SYSTEM_GET_BUILD_VERSION_V2_MAX_STRING_SIZE = 256
 	NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS                    = 32
+	NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS_SQUARED            = 1024
+	NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS                   = 8
 	NV0000_CTRL_P2P_CAPS_INDEX_TABLE_SIZE                   = 9
 )
 
@@ -186,6 +190,15 @@ const (
 	NV0000_CTRL_OS_UNIX_IMPORT_OBJECTS_TO_FD_MAX_OBJECTS = 128
 )
 
+// HasDeviceInstance is implemented by control parameter structs that report a
+// device instance number (NV0080_ALLOC_PARAMETERS::deviceId) back to the
+// caller. nvproxy must translate such a value from the host's device instances
+// to the guest's after a restore that remapped devices.
+type HasDeviceInstance interface {
+	GetDeviceInstance() uint32
+	SetDeviceInstance(uint32)
+}
+
 // +marshal
 type NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS struct {
 	_              structs.HostLayout
@@ -204,6 +217,16 @@ func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS) GetFrontendFD() int3
 // SetFrontendFD implements HasFrontendFD.SetFrontendFD.
 func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS) SetFrontendFD(fd int32) {
 	p.FD = fd
+}
+
+// GetDeviceInstance implements HasDeviceInstance.GetDeviceInstance.
+func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS) GetDeviceInstance() uint32 {
+	return p.DeviceInstance
+}
+
+// SetDeviceInstance implements HasDeviceInstance.SetDeviceInstance.
+func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS) SetDeviceInstance(devInst uint32) {
+	p.DeviceInstance = devInst
 }
 
 // +marshal
@@ -225,6 +248,19 @@ func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS_V545) GetFrontendFD()
 // SetFrontendFD implements HasFrontendFD.SetFrontendFD.
 func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS_V545) SetFrontendFD(fd int32) {
 	p.FD = fd
+}
+
+// GetDeviceInstance implements HasDeviceInstance.GetDeviceInstance.
+func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS_V545) GetDeviceInstance() uint32 {
+	return p.DeviceInstance
+}
+
+// SetDeviceInstance implements HasDeviceInstance.SetDeviceInstance.
+//
+// GpuInstanceID is deliberately not translated: it identifies a MIG instance
+// within a GPU, not a device.
+func (p *NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS_V545) SetDeviceInstance(devInst uint32) {
+	p.DeviceInstance = devInst
 }
 
 // +marshal
@@ -636,6 +672,10 @@ const (
 	NV2080_CTRL_CMD_GPU_RELEASE_COMPUTE_MODE_RESERVATION = 0x20800146 // undocumented; paramSize == 0
 	NV2080_CTRL_CMD_GPU_GET_ENGINE_PARTNERLIST           = 0x20800147
 	NV2080_CTRL_CMD_GPU_GET_GID_INFO                     = 0x2080014a
+	NV2080_GPU_MAX_GID_LENGTH                            = 0x100
+	NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT_MASK         = 0x3
+	NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT_ASCII        = 0x0
+	NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT_BINARY       = 0x2
 	NV2080_CTRL_CMD_GPU_GET_INFOROM_OBJECT_VERSION       = 0x2080014b
 	NV2080_CTRL_CMD_GPU_GET_INFOROM_IMAGE_VERSION        = 0x20800156
 	NV2080_CTRL_CMD_GPU_QUERY_INFOROM_ECC_SUPPORT        = 0x20800157

--- a/pkg/sentry/devices/nvproxy/BUILD
+++ b/pkg/sentry/devices/nvproxy/BUILD
@@ -48,6 +48,11 @@ go_library(
         "frontend_mmap_mutex.go",
         "frontend_mmap_unsafe.go",
         "frontend_unsafe.go",
+        "gpuid.go",
+        "gpuid_frontend.go",
+        "ioctl_log.go",
+        "pciaddr.go",
+        "uuid.go",
         "handlers.go",
         "nvproxy.go",
         "nvproxy_unsafe.go",
@@ -102,9 +107,11 @@ go_library(
 
 go_test(
     name = "nvproxy_test",
-    srcs = ["nvproxy_test.go"],
+    srcs = ["nvproxy_test.go", "save_restore_test.go", "uuid_test.go", "pciaddr_test.go"],
+    data = ["frontend.go", "frontend_unsafe.go", "gpuid_frontend.go", "pciaddr.go", "uvm_unsafe.go"],
     library = ":nvproxy",
     deps = [
+        "//pkg/hostarch",
         "//pkg/abi/nvgpu",
         "//pkg/seccomp",
         "//pkg/sentry/devices/nvproxy/nvconf",

--- a/pkg/sentry/devices/nvproxy/frontend.go
+++ b/pkg/sentry/devices/nvproxy/frontend.go
@@ -60,10 +60,10 @@ func (dev *frontendDevice) basename() string {
 // Open implements vfs.Device.Open.
 func (dev *frontendDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.Dentry, opts vfs.OpenOptions) (*vfs.FileDescription, error) {
 	fd := &frontendFD{
-		dev: dev,
+		dev: dev.forOpeningTask(ctx),
 	}
 	var err error
-	fd.hostFD, fd.containerName, err = openHostDevFile(ctx, dev.basename(), dev.nvp.useDevGofer, opts.Flags)
+	fd.hostFD, fd.containerName, err = openHostDevFile(ctx, fd.dev.basename(), dev.nvp.useDevGofer, opts.Flags)
 	if err != nil {
 		return nil, err
 	}
@@ -85,6 +85,49 @@ func (dev *frontendDevice) Open(ctx context.Context, mnt *vfs.Mount, vfsd *vfs.D
 	defer fd.dev.nvp.fdsMu.Unlock()
 	fd.dev.nvp.frontendFDs[fd] = struct{}{}
 	return &fd.vfsfd, nil
+}
+
+// forOpeningTask returns the device that an open of dev by the calling task
+// should actually be served by.
+//
+// After a restore that remapped devices, a process that existed at checkpoint
+// time still derives the device file to open from the device instances its
+// user-mode driver recorded then, so it opens the old minor -- /dev/nvidia2
+// when the sandbox now holds nvidia4 and nvidia6. The old device file still
+// exists in the sandbox (runsc/boot/nvproxy.go:createRemappedNvproxyDeviceFiles
+// creates the new ones and leaves the old ones alone), so the open reaches
+// here, and forwarding it to host minor 2 fails: that device is not in this
+// container's device gofer.
+//
+// This mirrors what nvproxy.afterLoad() already does for frontendFDs that were
+// themselves restored -- it repoints fd.dev at the new device -- for the case
+// of a restored process opening a device file afresh.
+//
+// A task that did not exist at checkpoint time initialised its driver against
+// the devices that are present and means the minor it named, so it is served
+// unchanged.
+func (dev *frontendDevice) forOpeningTask(ctx context.Context) *frontendDevice {
+	if dev.isCtlDevice() {
+		return dev
+	}
+	nvp := dev.nvp
+	if len(nvp.guestToHostMinor) == 0 {
+		return dev
+	}
+	scope := scopeFor(kernel.TaskFromContext(ctx))
+	if !scope.Restored {
+		return dev
+	}
+	newMinor, ok := nvp.guestToHostMinor[dev.minor]
+	if !ok || newMinor == dev.minor {
+		return dev
+	}
+	if newMinor > nvgpu.NV_MINOR_DEVICE_NUMBER_REGULAR_MAX {
+		log.Warningf("nvproxy: refusing to remap an open of nvidia%d to out-of-range minor %d", dev.minor, newMinor)
+		return dev
+	}
+	log.Infof("nvproxy: remapped open of nvidia%d to nvidia%d for restored tg %d", dev.minor, newMinor, scope.TGID)
+	return nvp.regularDevs[newMinor]
 }
 
 // frontendFD implements vfs.FileDescriptionImpl for /dev/nvidia# and
@@ -966,6 +1009,21 @@ func rmControlSimple(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETER
 func ctrlHasFrontendFD[Params any, PtrParams hasFrontendFDPtr[Params]](fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
 	var ctrlParamsValue Params
 	ctrlParams := PtrParams(&ctrlParamsValue)
+	n, err := ctrlHasFrontendFDInvoke[Params, PtrParams](fi, ioctlParams, ctrlParams)
+	if err != nil {
+		return n, err
+	}
+	if _, err := ctrlParams.CopyOut(fi.t, addrFromP64(ioctlParams.Params)); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// ctrlHasFrontendFDInvoke copies in ctrlParams, replaces the application FD it
+// carries with the corresponding host FD for the duration of the ioctl, and
+// invokes it. It does not copy ctrlParams back out, so that callers can amend
+// the returned parameters first.
+func ctrlHasFrontendFDInvoke[Params any, PtrParams hasFrontendFDPtr[Params]](fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS, ctrlParams PtrParams) (uintptr, error) {
 	if ctrlParams.SizeBytes() != int(ioctlParams.ParamsSize) {
 		return 0, linuxerr.EINVAL
 	}
@@ -987,8 +1045,25 @@ func ctrlHasFrontendFD[Params any, PtrParams hasFrontendFDPtr[Params]](fi *front
 	ctrlParams.SetFrontendFD(ctlFile.hostFD)
 	n, err := rmControlInvoke(fi, ioctlParams, ctrlParams)
 	ctrlParams.SetFrontendFD(origFD)
+	return n, err
+}
+
+// ctrlGetExportObjectInfo implements
+// NV0000_CTRL_CMD_OS_UNIX_GET_EXPORT_OBJECT_INFO. It is ctrlHasFrontendFD plus
+// translation of the device instance the driver reports: after a restore that
+// remapped devices, the host device instance owning the exported memory no
+// longer matches the device instance that the application's user-mode driver
+// recorded before the checkpoint, and returning it untranslated makes
+// cuMemImportFromShareableHandle() fail with CUDA_ERROR_INVALID_DEVICE.
+func ctrlGetExportObjectInfo[Params any, PtrParams hasFrontendFDAndDeviceInstancePtr[Params]](fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	var ctrlParamsValue Params
+	ctrlParams := PtrParams(&ctrlParamsValue)
+	n, err := ctrlHasFrontendFDInvoke[Params, PtrParams](fi, ioctlParams, ctrlParams)
 	if err != nil {
 		return n, err
+	}
+	if scope := scopeFor(fi.t); ioctlParams.Status == nvgpu.NV_OK && scope.Restored {
+		fi.fd.dev.nvp.translateDeviceInstanceToGuest(ctrlParams, scope)
 	}
 	if _, err := ctrlParams.CopyOut(fi.t, addrFromP64(ioctlParams.Params)); err != nil {
 		return n, err

--- a/pkg/sentry/devices/nvproxy/frontend_unsafe.go
+++ b/pkg/sentry/devices/nvproxy/frontend_unsafe.go
@@ -15,6 +15,7 @@
 package nvproxy
 
 import (
+	"fmt"
 	"runtime"
 	"unsafe"
 
@@ -27,9 +28,9 @@ import (
 
 func frontendIoctlInvoke[Params any, PtrParams hasStatusPtr[Params]](fi *frontendIoctlState, ioctlParams PtrParams) (uintptr, error) {
 	n, err := frontendIoctlInvokeNoStatus(fi, ioctlParams)
-	if err == nil && log.IsLogging(log.Debug) {
+	if err == nil {
 		if status := ioctlParams.GetStatus(); status != nvgpu.NV_OK {
-			fi.ctx.Debugf("nvproxy: frontend ioctl failed: status=%#x", status)
+			logFrontendIoctlStatus(fi, status, any(ioctlParams))
 		}
 	}
 	return n, err
@@ -52,6 +53,7 @@ func rmControlInvoke[Params any](fi *frontendIoctlState, ioctlParams *nvgpu.NVOS
 	if err != nil {
 		return n, err
 	}
+	logRMControlStatus(fi, ioctlParams)
 	if _, err := ioctlParams.CopyOut(fi.t, fi.ioctlParamsAddr); err != nil {
 		return n, err
 	}
@@ -351,8 +353,11 @@ func ctrlClientSystemGetP2PCaps(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS5
 	}
 	ctrlParams.BusPeerIDs = busPeerIDs
 
+	origGPUIDs := translateP2PGpuIDsToHost(fi, ctrlParams.GpuIDs[:], ctrlParams.GpuCount)
+
 	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams)
 	ctrlParams.BusPeerIDs = origBusPeerIDs
+	ctrlParams.GpuIDs = origGPUIDs
 	if err != nil {
 		return n, err
 	}
@@ -363,6 +368,34 @@ func ctrlClientSystemGetP2PCaps(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS5
 
 	_, err = ctrlParams.CopyOut(fi.t, addrFromP64(ioctlParams.Params))
 	return n, err
+}
+
+// translateP2PGpuIDsToHost resolves the guest gpuIds an application passed to
+// NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS to the host gpuIds the driver knows,
+// returning the original array so the caller can put it back before copying
+// out. NCCL asks this to decide whether two GPUs can reach each other, so a
+// stale gpuId here makes peer access look unavailable.
+func translateP2PGpuIDsToHost(fi *frontendIoctlState, gpuIDs []uint32, gpuCount uint32) [nvgpu.NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS]uint32 {
+	var orig [nvgpu.NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS]uint32
+	copy(orig[:], gpuIDs)
+	m := fi.fd.dev.nvp.guestToHostGPUID
+	scope := scopeFor(fi.t)
+	if len(m) == 0 || !scope.Restored {
+		return orig
+	}
+	n := int(gpuCount)
+	if n > len(gpuIDs) {
+		n = len(gpuIDs)
+	}
+	for i := 0; i < n; i++ {
+		if host, ok := translateID(gpuIDs[i], m); ok {
+			if log.IsLogging(log.Debug) {
+				fi.ctx.Debugf("nvproxy: NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS: translated gpuId %d (guest) to %d (host) [%v]", gpuIDs[i], host, scope)
+			}
+			gpuIDs[i] = host
+		}
+	}
+	return orig
 }
 
 func ctrlClientSystemGetP2PCapsV550(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
@@ -388,9 +421,12 @@ func ctrlClientSystemGetP2PCapsV550(fi *frontendIoctlState, ioctlParams *nvgpu.N
 	}
 	ctrlParams.BusEgmPeerIDs = busEgmPeerIDs
 
+	origGPUIDs := translateP2PGpuIDsToHost(fi, ctrlParams.GpuIDs[:], ctrlParams.GpuCount)
+
 	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams)
 	ctrlParams.BusPeerIDs = origBusPeerIDs
 	ctrlParams.BusEgmPeerIDs = origBusEgmPeerIDs
+	ctrlParams.GpuIDs = origGPUIDs
 	if err != nil {
 		return n, err
 	}
@@ -441,8 +477,14 @@ func rmAllocInvoke[Params any](fi *frontendIoctlState, ioctlParams *nvgpu.NVOS64
 	fi.ioctlParamsSize = nvgpu.SizeofNVOS64Parameters
 	n, err := frontendIoctlInvoke(fi, ioctlParams)
 	fi.ioctlParamsSize = origParamsSize
-	if err == nil && ioctlParams.Status == nvgpu.NV_OK {
-		addObjLocked(fi, client, ioctlParams, rightsRequested, allocParams)
+	if err == nil {
+		if ioctlParams.Status == nvgpu.NV_OK {
+			addObjLocked(fi, client, ioctlParams, rightsRequested, allocParams)
+		} else if log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: rm alloc failed: hClass=%v hRoot=%v hObjectParent=%v hObjectNew=%v paramsSize=%d%s status=%#x (%s) [%v]",
+				ioctlParams.HClass, ioctlParams.HRoot, ioctlParams.HObjectParent, ioctlParams.HObjectNew, ioctlParams.ParamsSize,
+				allocParamsNote(ioctlParams.HClass, allocParams), ioctlParams.Status, statusName(ioctlParams.Status), scopeFor(fi.t))
+		}
 	}
 	unlock()
 	ioctlParams.PAllocParms = origPAllocParms
@@ -463,6 +505,35 @@ func rmAllocInvoke[Params any](fi *frontendIoctlState, ioctlParams *nvgpu.NVOS64
 		return n, err
 	}
 	return n, nil
+}
+
+// allocParamsNote renders the identifying field of an allocation's parameters
+// for the failure line, for the classes where it decides whether the call can
+// succeed. allocParams is a typed pointer that may be nil, which for
+// NV01_DEVICE_0 means the application passed none and RM will read the request
+// as naming device instance 0.
+func allocParamsNote(hClass nvgpu.ClassID, allocParams any) string {
+	switch hClass {
+	case nvgpu.NV01_DEVICE_0:
+		p, ok := allocParams.(*nvgpu.NV0080_ALLOC_PARAMETERS)
+		if !ok || p == nil {
+			return " deviceId=null"
+		}
+		return fmt.Sprintf(" deviceId=%d", p.DeviceID)
+	case nvgpu.NV20_SUBDEVICE_0:
+		p, ok := allocParams.(*nvgpu.NV2080_ALLOC_PARAMETERS)
+		if !ok || p == nil {
+			return " subDeviceId=null"
+		}
+		return fmt.Sprintf(" subDeviceId=%d", p.SubDeviceID)
+	case nvgpu.NV_MEMORY_EXPORT:
+		p, ok := allocParams.(*nvgpu.NV00E0_ALLOCATION_PARAMETERS)
+		if !ok || p == nil {
+			return " deviceInstanceMask=null"
+		}
+		return fmt.Sprintf(" deviceInstanceMask=%#x", p.DeviceInstanceMask)
+	}
+	return ""
 }
 
 func rmIdleChannelsInvoke(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS30_PARAMETERS, clientsBuf, devicesBuf, channelsBuf *byte) (uintptr, error) {

--- a/pkg/sentry/devices/nvproxy/gpuid.go
+++ b/pkg/sentry/devices/nvproxy/gpuid.go
@@ -1,0 +1,727 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/log"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
+)
+
+// Translation of device identifiers across a restore that remapped devices.
+//
+// Two families of identifier cross the nvproxy boundary and are properties of
+// the host rather than of the sandbox:
+//
+//   - the "device instance", NV0080_ALLOC_PARAMETERS::deviceId, remapped in
+//     saved objects by nvproxy.afterLoad();
+//   - the "gpuId", nv_state_t::gpu_id, which the driver generates from PCI
+//     information and which therefore differs on a different physical GPU.
+//
+// The application's user-mode driver caches both from before the checkpoint,
+// so an untranslated one reaching it is read as naming a device it does not
+// have. Identifiers travel in both directions: outward, where a host value
+// must be reported as the guest value the application remembers, and inward,
+// where a guest value must be resolved to the host value the driver expects.
+
+// idMaps bundles the translation tables for one nvproxy. The tables
+// themselves are saved fields of nvproxy; this is only a value bundle so that
+// the pure helpers below can be tested without a sandbox.
+//
+// The guestToHost maps are the inverses of the hostToGuest maps. They are
+// stored rather than inverted on demand so that a restore with no remapping
+// (which does not run the composition) still has them.
+type idMaps struct {
+	// HostToGuestDeviceInstance maps a host device instance to the device
+	// instance the application saw before the most recent checkpoint.
+	HostToGuestDeviceInstance map[uint32]uint32
+
+	// GuestToHostDeviceInstance is the inverse of HostToGuestDeviceInstance.
+	GuestToHostDeviceInstance map[uint32]uint32
+
+	// HostToGuestGPUID maps a host gpuId to the gpuId the application saw
+	// before the most recent checkpoint.
+	HostToGuestGPUID map[uint32]uint32
+
+	// GuestToHostGPUID is the inverse of HostToGuestGPUID.
+	GuestToHostGPUID map[uint32]uint32
+
+	// HostToGuestUUID maps a host GPU UUID string, "GPU-" prefix included, to
+	// the UUID the application saw before the most recent checkpoint.
+	HostToGuestUUID map[string]string
+
+	// HostToGuestPCIAddr and GuestToHostPCIAddr map packed PCI addresses; see
+	// PackPCIAddr.
+	HostToGuestPCIAddr map[uint64]uint64
+	GuestToHostPCIAddr map[uint64]uint64
+}
+
+// empty returns true if no restore has established any translation.
+func (m idMaps) empty() bool {
+	return len(m.HostToGuestDeviceInstance) == 0 && len(m.HostToGuestGPUID) == 0
+}
+
+// composeIDMap returns the host-to-guest mapping produced by applying the
+// old-to-new pairs in remap on top of prev, where prev is the mapping
+// established by a previous restore (nil if there was none).
+//
+// It is pure. Each remapping is composed with the one before it rather than
+// replacing it, so that a sandbox restored twice still reports the identifiers
+// of its original boot. An old identifier absent from prev was never remapped
+// and is therefore its own guest identifier.
+func composeIDMap(prev map[uint32]uint32, remap [][2]uint32) map[uint32]uint32 {
+	return composeMap(prev, remap)
+}
+
+// composeMap is composeIDMap for any identifier type. Every family of
+// identifier composes the same way, so they share one implementation.
+func composeMap[T comparable](prev map[T]T, remap [][2]T) map[T]T {
+	next := make(map[T]T, len(remap))
+	for _, pair := range remap {
+		oldID, newID := pair[0], pair[1]
+		guest := oldID
+		if g, ok := prev[oldID]; ok {
+			guest = g
+		}
+		next[newID] = guest
+	}
+	return next
+}
+
+// invertMap is invertIDMap for any identifier type.
+func invertMap[T comparable](m map[T]T, what string) map[T]T {
+	inv := make(map[T]T, len(m))
+	collided := make(map[T]struct{})
+	for host, guest := range m {
+		if prevHost, ok := inv[guest]; ok {
+			log.Warningf("nvproxy: %s mapping is not injective: guest %v is the image of both host %v and host %v; neither will be translated inward", what, guest, prevHost, host)
+			collided[guest] = struct{}{}
+			continue
+		}
+		inv[guest] = host
+	}
+	for guest := range collided {
+		delete(inv, guest)
+	}
+	return inv
+}
+
+// PackPCIAddr encodes a PCI address as one value: domain in bits 63:24, bus in
+// 23:16, slot (device) in 15:8 and function in 7:0. Exported because
+// runsc/boot fills DeviceRemapIDs.
+func PackPCIAddr(domain uint32, bus, slot, function uint8) uint64 {
+	return uint64(domain)<<24 | uint64(bus)<<16 | uint64(slot)<<8 | uint64(function)
+}
+
+// UnpackPCIAddr is the inverse of PackPCIAddr.
+func UnpackPCIAddr(v uint64) (domain uint32, bus, slot, function uint8) {
+	return uint32(v >> 24), uint8(v >> 16), uint8(v >> 8), uint8(v)
+}
+
+// formatPCIAddrMap renders a PCI address mapping in ascending key order.
+func formatPCIAddrMap(m map[uint64]uint64) string {
+	keys := make([]uint64, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s -> %s", formatPCIAddr(k), formatPCIAddr(m[k]))
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// formatPCIAddr renders a packed PCI address conventionally.
+func formatPCIAddr(v uint64) string {
+	domain, bus, slot, function := UnpackPCIAddr(v)
+	return fmt.Sprintf("%04x:%02x:%02x.%x", domain, bus, slot, function)
+}
+
+// invertIDMap returns the inverse of m. A host identifier that is not the
+// image of exactly one guest identifier is dropped with a warning rather than
+// silently overwriting a sibling: an ambiguous inverse would resolve a guest
+// identifier to the wrong device, which is worse than not resolving it.
+func invertIDMap(m map[uint32]uint32, what string) map[uint32]uint32 {
+	return invertMap(m, what)
+}
+
+// formatIDMap renders m in ascending key order, since Go map iteration order
+// would otherwise vary from one log line to the next.
+func formatIDMap(m map[uint32]uint32) string {
+	keys := make([]uint32, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%d -> %d", k, m[k])
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// permuteDeviceInstanceMask translates a bitmask whose set bits are device
+// instances, using m. A set bit whose device instance is not in m is carried
+// through unchanged, matching the scalar translations.
+func permuteDeviceInstanceMask(mask uint32, m map[uint32]uint32) uint32 {
+	if len(m) == 0 {
+		return mask
+	}
+	var out uint32
+	for bit := uint32(0); bit < 32; bit++ {
+		if mask&(1<<bit) == 0 {
+			continue
+		}
+		to := bit
+		if t, ok := m[bit]; ok {
+			if t >= 32 {
+				// Cannot be represented in the mask. Keep the original bit
+				// rather than dropping the device entirely.
+				log.Warningf("nvproxy: device instance %d translates to %d, which does not fit in a 32-bit device mask", bit, t)
+				to = bit
+			} else {
+				to = t
+			}
+		}
+		out |= 1 << to
+	}
+	return out
+}
+
+// translateID returns the translation of id under m, and whether one was
+// found. NV0000_CTRL_GPU_INVALID_ID is never translated: it is the terminator
+// of every gpuId array the driver fills.
+func translateID(id uint32, m map[uint32]uint32) (uint32, bool) {
+	if id == nvgpu.NV0000_CTRL_GPU_INVALID_ID {
+		return id, false
+	}
+	to, ok := m[id]
+	return to, ok
+}
+
+// idDirection says which way a translated field moves.
+type idDirection int
+
+const (
+	// idIn is a field the application supplies: a guest identifier that must
+	// be resolved to a host identifier before the ioctl, and put back
+	// afterwards so that the application reads its own value again.
+	idIn idDirection = iota
+
+	// idOut is a field the driver fills: a host identifier that must be
+	// reported as a guest identifier after the ioctl.
+	idOut
+)
+
+// idKind says which family of identifier a field holds.
+type idKind int
+
+const (
+	idGPUID idKind = iota
+	idDeviceInstance
+	idDeviceInstanceMask
+)
+
+// rawIDField describes one run of NvU32 identifiers inside a control's
+// parameter buffer, by byte offset rather than by a Go struct. These controls
+// are proxied as opaque bytes by rmControlSimple, and modelling them as
+// marshallable structs would make a driver whose layout differs by a field
+// fail outright; addressing them by offset lets a size check fall back to
+// passing the buffer through untouched.
+type rawIDField struct {
+	// Kind and Dir say what the field holds and which way it moves.
+	Kind idKind
+	Dir  idDirection
+
+	// Offset is the byte offset of the first element.
+	Offset int
+
+	// Count is the number of elements.
+	Count int
+
+	// Stride is the byte distance between elements. Zero means 4, i.e. a
+	// contiguous NvU32 array.
+	Stride int
+
+	// CountAt, if non-negative, is the byte offset of an NvU32 that bounds
+	// Count: only the first that many elements are translated.
+	CountAt int
+}
+
+// stride returns f.Stride, defaulting to the size of an NvU32.
+func (f rawIDField) stride() int {
+	if f.Stride == 0 {
+		return 4
+	}
+	return f.Stride
+}
+
+// end returns the byte offset one past the last element of f.
+func (f rawIDField) end() int {
+	return f.Offset + (f.Count-1)*f.stride() + 4
+}
+
+// rawIDSpec describes every identifier field in one control's parameters.
+type rawIDSpec struct {
+	// Name is the control's NV0000_CTRL_CMD_* name, for logging.
+	Name string
+
+	// Size is the parameter size this layout was modelled from. A control
+	// whose ParamsSize differs is passed through untranslated: the layout on
+	// that driver is not the one described here.
+	Size int
+
+	Fields []rawIDField
+}
+
+// minSize returns the smallest buffer every field of s fits in.
+func (s *rawIDSpec) minSize() int {
+	n := 0
+	for _, f := range s.Fields {
+		if e := f.end(); e > n {
+			n = e
+		}
+	}
+	return n
+}
+
+// rawIDSpecs describes the controls that carry identifiers in a parameter
+// layout nvproxy does not otherwise model. Offsets and sizes are from
+// src/common/sdk/nvidia/inc/ctrl/ctrl0000/{ctrl0000gpu.h,ctrl0000system.h} at
+// driver 610.
+var rawIDSpecs = map[uint32]*rawIDSpec{
+	// NV0000_CTRL_GPU_GET_ATTACHED_IDS_PARAMS{gpuIds[32]}.
+	nvgpu.NV0000_CTRL_CMD_GPU_GET_ATTACHED_IDS: {
+		Name: "NV0000_CTRL_CMD_GPU_GET_ATTACHED_IDS",
+		Size: 4 * nvgpu.NV0000_CTRL_GPU_MAX_ATTACHED_GPUS,
+		Fields: []rawIDField{
+			{Kind: idGPUID, Dir: idOut, Offset: 0, Count: nvgpu.NV0000_CTRL_GPU_MAX_ATTACHED_GPUS, CountAt: -1},
+		},
+	},
+
+	// NV0000_CTRL_GPU_GET_PROBED_IDS_PARAMS{gpuIds[32], excludedGpuIds[32],
+	// gpuFlags[32]}.
+	nvgpu.NV0000_CTRL_CMD_GPU_GET_PROBED_IDS: {
+		Name: "NV0000_CTRL_CMD_GPU_GET_PROBED_IDS",
+		Size: 3 * 4 * nvgpu.NV0000_CTRL_GPU_MAX_PROBED_GPUS,
+		Fields: []rawIDField{
+			{Kind: idGPUID, Dir: idOut, Offset: 0, Count: nvgpu.NV0000_CTRL_GPU_MAX_PROBED_GPUS, CountAt: -1},
+			{Kind: idGPUID, Dir: idOut, Offset: 4 * nvgpu.NV0000_CTRL_GPU_MAX_PROBED_GPUS, Count: nvgpu.NV0000_CTRL_GPU_MAX_PROBED_GPUS, CountAt: -1},
+		},
+	},
+
+	// NV0000_CTRL_GPU_GET_DEVICE_IDS_PARAMS{deviceIds}, a bitmask of device
+	// instances rather than a list of gpuIds despite the name.
+	nvgpu.NV0000_CTRL_CMD_GPU_GET_DEVICE_IDS: {
+		Name: "NV0000_CTRL_CMD_GPU_GET_DEVICE_IDS",
+		Size: 4,
+		Fields: []rawIDField{
+			{Kind: idDeviceInstanceMask, Dir: idOut, Offset: 0, Count: 1, CountAt: -1},
+		},
+	},
+
+	// NV0000_CTRL_GPU_GET_ACTIVE_DEVICE_IDS_PARAMS{numDevices,
+	// NV0000_CTRL_GPU_ACTIVE_DEVICE devices[256]}, each device being
+	// {gpuId, gpuInstanceId, computeInstanceId}. The latter two are MIG
+	// instance ids and are not translated.
+	nvgpu.NV0000_CTRL_CMD_GPU_GET_ACTIVE_DEVICE_IDS: {
+		Name: "NV0000_CTRL_CMD_GPU_GET_ACTIVE_DEVICE_IDS",
+		Size: 4 + 12*nvgpu.NV0000_CTRL_GPU_MAX_ACTIVE_DEVICES,
+		Fields: []rawIDField{
+			{Kind: idGPUID, Dir: idOut, Offset: 4, Count: nvgpu.NV0000_CTRL_GPU_MAX_ACTIVE_DEVICES, Stride: 12, CountAt: 0},
+		},
+	},
+
+	// NV0000_CTRL_SYSTEM_GET_P2P_CAPS_V2_PARAMS{gpuIds[32], gpuCount,
+	// p2pCaps, p2pOptimalReadCEs, p2pOptimalWriteCEs, p2pCapsStatus[9],
+	// busPeerIds[1024], busEgmPeerIds[1024]}. The peer id arrays hold peer
+	// indices, not gpuIds.
+	nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_V2: {
+		Name: "NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_V2",
+		Size: 4*nvgpu.NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS + 4 + 4 + 4 + 4 + nvgpu.NV0000_CTRL_P2P_CAPS_INDEX_TABLE_SIZE + 3 +
+			4*nvgpu.NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS_SQUARED + 4*nvgpu.NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS_SQUARED,
+		Fields: []rawIDField{
+			{Kind: idGPUID, Dir: idIn, Offset: 0, Count: nvgpu.NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS, CountAt: 4 * nvgpu.NV0000_CTRL_SYSTEM_MAX_ATTACHED_GPUS},
+		},
+	},
+
+	// NV0000_CTRL_SYSTEM_GET_P2P_CAPS_MATRIX_PARAMS{grpACount, grpBCount,
+	// gpuIdGrpA[8], gpuIdGrpB[8], then five [8][8] NvU32 matrices}.
+	nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_MATRIX: {
+		Name: "NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_MATRIX",
+		Size: 4 + 4 + 4*nvgpu.NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS + 4*nvgpu.NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS +
+			5*4*nvgpu.NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS*nvgpu.NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS,
+		Fields: []rawIDField{
+			{Kind: idGPUID, Dir: idIn, Offset: 8, Count: nvgpu.NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS, CountAt: 0},
+			{Kind: idGPUID, Dir: idIn, Offset: 8 + 4*nvgpu.NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS, Count: nvgpu.NV0000_CTRL_SYSTEM_MAX_P2P_GROUP_GPUS, CountAt: 4},
+		},
+	},
+}
+
+// applyRawIDFields translates every field of spec whose direction is dir,
+// in place in buf, using maps. It returns the number of values it changed.
+//
+// buf is the raw control parameter buffer. Preconditions: len(buf) == spec.Size.
+// If inverse is true the opposite map is used, which is how an inbound field
+// is put back to the value the application passed after the ioctl has read it.
+func applyRawIDFields(buf []byte, spec *rawIDSpec, dir idDirection, inverse bool, maps idMaps, onTranslate func(kind idKind, from, to uint32)) int {
+	changed := 0
+	for _, f := range spec.Fields {
+		if f.Dir != dir {
+			continue
+		}
+		count := f.Count
+		if f.CountAt >= 0 {
+			if n := int(hostarch.ByteOrder.Uint32(buf[f.CountAt:])); n < count {
+				count = n
+			}
+		}
+		guestToHost := (dir == idIn) != inverse
+		var m map[uint32]uint32
+		switch f.Kind {
+		case idGPUID:
+			if guestToHost {
+				m = maps.GuestToHostGPUID
+			} else {
+				m = maps.HostToGuestGPUID
+			}
+		case idDeviceInstance, idDeviceInstanceMask:
+			if guestToHost {
+				m = maps.GuestToHostDeviceInstance
+			} else {
+				m = maps.HostToGuestDeviceInstance
+			}
+		}
+		if len(m) == 0 {
+			continue
+		}
+		stride := f.stride()
+		for i := 0; i < count; i++ {
+			off := f.Offset + i*stride
+			from := hostarch.ByteOrder.Uint32(buf[off:])
+			var to uint32
+			if f.Kind == idDeviceInstanceMask {
+				to = permuteDeviceInstanceMask(from, m)
+				if to == from {
+					continue
+				}
+			} else {
+				var ok bool
+				to, ok = translateID(from, m)
+				if !ok {
+					continue
+				}
+			}
+			hostarch.ByteOrder.PutUint32(buf[off:], to)
+			changed++
+			if onTranslate != nil {
+				onTranslate(f.Kind, from, to)
+			}
+		}
+	}
+	return changed
+}
+
+// composeUUIDMap is composeIDMap for UUID strings.
+func composeUUIDMap(prev map[string]string, remap [][2]string) map[string]string {
+	return composeMap(prev, remap)
+}
+
+// formatUUIDMap renders m in ascending key order.
+func formatUUIDMap(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%s -> %s", k, m[k])
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// uuidBinary parses a "GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" UUID string
+// into the 16 raw bytes the driver reports in binary format, as produced by
+// src/nvidia/src/kernel/gpu/gpu.c:gpuGetGidInfo_IMPL().
+func uuidBinary(s string) ([16]byte, bool) {
+	var out [16]byte
+	hex := strings.TrimPrefix(s, "GPU-")
+	hex = strings.ReplaceAll(hex, "-", "")
+	if len(hex) != 32 {
+		return out, false
+	}
+	for i := 0; i < 16; i++ {
+		hi, ok := hexNibble(hex[2*i])
+		if !ok {
+			return out, false
+		}
+		lo, ok := hexNibble(hex[2*i+1])
+		if !ok {
+			return out, false
+		}
+		out[i] = hi<<4 | lo
+	}
+	return out, true
+}
+
+func hexNibble(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}
+
+// translateUUIDBytes rewrites a GPU UUID held in buf, in either the ASCII or
+// the binary representation, from the host's to the guest's. It reports
+// whether it changed anything.
+//
+// asciiLen bounds the ASCII form; pass 0 to use the whole of buf up to the
+// first NUL.
+func translateUUIDBytes(buf []byte, binary bool, m map[string]string) (from, to string, ok bool) {
+	if len(m) == 0 {
+		return "", "", false
+	}
+	if binary {
+		if len(buf) < 16 {
+			return "", "", false
+		}
+		for hostStr, guestStr := range m {
+			hostBin, hostOK := uuidBinary(hostStr)
+			guestBin, guestOK := uuidBinary(guestStr)
+			if !hostOK || !guestOK {
+				continue
+			}
+			if string(hostBin[:]) == string(buf[:16]) {
+				copy(buf[:16], guestBin[:])
+				return hostStr, guestStr, true
+			}
+		}
+		return "", "", false
+	}
+	// ASCII: the driver writes a NUL-terminated string.
+	end := len(buf)
+	if i := indexByte(buf, 0); i >= 0 {
+		end = i
+	}
+	hostStr := string(buf[:end])
+	guestStr, found := m[hostStr]
+	if !found {
+		return "", "", false
+	}
+	if len(guestStr) > len(buf) {
+		// Cannot happen with well-formed UUIDs, which are all the same
+		// length, but refuse rather than truncate.
+		log.Warningf("nvproxy: guest UUID %q does not fit in a %d-byte buffer", guestStr, len(buf))
+		return "", "", false
+	}
+	copy(buf, guestStr)
+	for i := len(guestStr); i < end; i++ {
+		buf[i] = 0
+	}
+	return hostStr, guestStr, true
+}
+
+func indexByte(b []byte, c byte) int {
+	for i := range b {
+		if b[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// invertUUIDMap returns the inverse of m, dropping any guest UUID that is the
+// image of more than one host UUID for the same reason invertIDMap does.
+func invertUUIDMap(m map[string]string) map[string]string {
+	return invertMap(m, "UUID")
+}
+
+// Identifier translation applies only to processes that were restored from the
+// checkpoint. Those hold a user-mode driver whose tables are keyed by the
+// identities the sandbox had before the checkpoint. A process created after
+// the restore -- a forked child, an exec'd image, or a helper the checkpointer
+// runs inside the sandbox after the restore, such as cuda-checkpoint --
+// initialises CUDA against the devices that are actually present, so it must
+// see the host's identities and the device files that exist. Translating for
+// it hands it a device instance and a /dev/nvidia# that do not.
+//
+// Threads created later inside a restored process share its thread group, and
+// so stay translated. That is intended: NCCL's proxy threads run against the
+// driver state the process already had.
+
+// translationScope is the answer to "should this ioctl be translated", plus
+// the thread group it was decided for, which the Debug lines report so that
+// the scoping can be checked against a log.
+type translationScope struct {
+	// Restored is true if the calling thread group existed at checkpoint time.
+	Restored bool
+
+	// TGID is the calling thread group's ID, or 0 if there is no task.
+	TGID int32
+}
+
+// String implements fmt.Stringer.String.
+func (s translationScope) String() string {
+	return fmt.Sprintf("tgid=%d restored=%t", s.TGID, s.Restored)
+}
+
+// scopeFor returns the translation scope for a task. A nil task -- which
+// happens on no current path, since object re-creation during restore issues
+// its ioctls directly rather than through a handler -- is treated as not
+// restored, the conservative answer: it passes host identities through
+// unchanged, which is what nvproxy did before any of this existed.
+func scopeFor(t *kernel.Task) translationScope {
+	if t == nil {
+		return translationScope{}
+	}
+	tg := t.ThreadGroup()
+	if tg == nil {
+		return translationScope{}
+	}
+	return translationScope{
+		Restored: tg.ExistedAtCheckpoint(),
+		TGID:     int32(tg.ID()),
+	}
+}
+
+// permuteByDeviceInstance returns arr with each element moved from the index
+// it occupied under one device-instance numbering to the index it occupies
+// under the other. An index with no translation keeps its element.
+func permuteByDeviceInstance(arr [nvgpu.NV_MAX_DEVICES]uint32, m map[uint32]uint32) [nvgpu.NV_MAX_DEVICES]uint32 {
+	if len(m) == 0 {
+		return arr
+	}
+	var out [nvgpu.NV_MAX_DEVICES]uint32
+	moved := make(map[uint32]struct{}, len(m))
+	for from, to := range m {
+		if from >= uint32(len(arr)) || to >= uint32(len(arr)) {
+			continue
+		}
+		out[to] = arr[from]
+		moved[from] = struct{}{}
+		moved[to] = struct{}{}
+	}
+	// Indices that no translation names, in either direction, keep what they
+	// had.
+	for i := range arr {
+		if _, ok := moved[uint32(i)]; !ok {
+			out[i] = arr[i]
+		}
+	}
+	return out
+}
+
+// describeRawIDField renders the live values of one identifier field, bounded
+// by its count field where it has one and stopping at the array terminator.
+// It is for the Debug line that shows what a restored process actually
+// enumerated: the identifiers it sees are what it keys its device table on.
+func describeRawIDField(buf []byte, f rawIDField) string {
+	count := f.Count
+	if f.CountAt >= 0 && f.CountAt+4 <= len(buf) {
+		if n := int(hostarch.ByteOrder.Uint32(buf[f.CountAt:])); n < count {
+			count = n
+		}
+	}
+	stride := f.stride()
+	var b strings.Builder
+	b.WriteByte('[')
+	shown := 0
+	for i := 0; i < count; i++ {
+		off := f.Offset + i*stride
+		if off+4 > len(buf) {
+			break
+		}
+		v := hostarch.ByteOrder.Uint32(buf[off:])
+		if f.Kind == idGPUID && v == nvgpu.NV0000_CTRL_GPU_INVALID_ID {
+			// The terminator: nothing beyond it is meaningful.
+			break
+		}
+		if shown != 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "%d", v)
+		shown++
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// removeShadowedGPUIDs removes physical GPUs whose identifiers now name a
+// different, remapped GPU in the guest. The remaining entries are still host
+// IDs; translate them only after compacting the list and its parallel flags.
+func removeShadowedGPUIDs(buf []byte, cmd uint32, maps idMaps) {
+	switch cmd {
+	case nvgpu.NV0000_CTRL_CMD_GPU_GET_ATTACHED_IDS:
+		compactGPUIDList(buf, 0, nvgpu.NV0000_CTRL_GPU_MAX_ATTACHED_GPUS, -1, maps)
+	case nvgpu.NV0000_CTRL_CMD_GPU_GET_PROBED_IDS:
+		count := int(nvgpu.NV0000_CTRL_GPU_MAX_PROBED_GPUS)
+		compactGPUIDList(buf, 0, count, 8*count, maps)
+		compactGPUIDList(buf, 4*count, count, -1, maps)
+	}
+}
+
+func compactGPUIDList(buf []byte, offset, count, flagsOffset int, maps idMaps) {
+	dst := 0
+	for src := 0; src < count; src++ {
+		id := hostarch.ByteOrder.Uint32(buf[offset+4*src:])
+		if id == nvgpu.NV0000_CTRL_GPU_INVALID_ID {
+			break
+		}
+		_, mapped := maps.HostToGuestGPUID[id]
+		_, shadowed := maps.GuestToHostGPUID[id]
+		if shadowed && !mapped {
+			continue
+		}
+		hostarch.ByteOrder.PutUint32(buf[offset+4*dst:], id)
+		if flagsOffset >= 0 {
+			flags := hostarch.ByteOrder.Uint32(buf[flagsOffset+4*src:])
+			hostarch.ByteOrder.PutUint32(buf[flagsOffset+4*dst:], flags)
+		}
+		dst++
+	}
+	for ; dst < count; dst++ {
+		hostarch.ByteOrder.PutUint32(buf[offset+4*dst:], nvgpu.NV0000_CTRL_GPU_INVALID_ID)
+		if flagsOffset >= 0 {
+			hostarch.ByteOrder.PutUint32(buf[flagsOffset+4*dst:], 0)
+		}
+	}
+}

--- a/pkg/sentry/devices/nvproxy/gpuid_frontend.go
+++ b/pkg/sentry/devices/nvproxy/gpuid_frontend.go
@@ -1,0 +1,461 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/log"
+)
+
+// RM control handlers that translate device identifiers across a restore that
+// remapped devices. See gpuid.go for the identifier families and the tables.
+
+// ctrlTranslateRawIDs proxies a control whose parameters nvproxy does not
+// model as a marshallable struct, translating the identifier fields named by
+// rawIDSpecs at fixed byte offsets.
+//
+// A control whose ParamsSize does not match the modelled layout is passed
+// through untranslated rather than rejected: the driver in the sandbox may not
+// be the one the layout was taken from, and passing it through is exactly the
+// behaviour before this handler existed.
+func ctrlTranslateRawIDs(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	spec := rawIDSpecs[ioctlParams.Cmd]
+	ids := nvp.ids()
+	scope := scopeFor(fi.t)
+	if spec == nil || ids.empty() || !scope.Restored || int(ioctlParams.ParamsSize) != spec.Size {
+		if spec != nil && scope.Restored && int(ioctlParams.ParamsSize) != spec.Size && !ids.empty() {
+			log.Warningf("nvproxy: %s params are %d bytes, not the %d this build models; passing identifiers through untranslated",
+				spec.Name, ioctlParams.ParamsSize, spec.Size)
+		}
+		return rmControlSimple(fi, ioctlParams)
+	}
+	if ioctlParams.Params == 0 {
+		return 0, linuxerr.EINVAL
+	}
+
+	ctrlParams := make([]byte, ioctlParams.ParamsSize)
+	if _, err := fi.t.CopyInBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return 0, err
+	}
+
+	onTranslate := func(dir string) func(kind idKind, from, to uint32) {
+		return func(kind idKind, from, to uint32) {
+			if log.IsLogging(log.Debug) {
+				fi.ctx.Debugf("nvproxy: %s: translated %s %d to %d (%s) [%v]", spec.Name, idKindName(kind), from, to, dir, scope)
+			}
+		}
+	}
+
+	applyRawIDFields(ctrlParams, spec, idIn, false, ids, onTranslate("guest->host"))
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams[0])
+	if err != nil {
+		return n, err
+	}
+	// Put the inbound identifiers back to what the application passed, then
+	// translate the ones the driver filled.
+	applyRawIDFields(ctrlParams, spec, idIn, true, ids, nil)
+	if ioctlParams.Status == nvgpu.NV_OK {
+		removeShadowedGPUIDs(ctrlParams, ioctlParams.Cmd, ids)
+		applyRawIDFields(ctrlParams, spec, idOut, false, ids, onTranslate("host->guest"))
+		if log.IsLogging(log.Debug) {
+			for _, f := range spec.Fields {
+				if f.Dir != idOut {
+					continue
+				}
+				fi.ctx.Debugf("nvproxy: %s: %s out (guest) at +%d: %s [%v]",
+					spec.Name, idKindName(f.Kind), f.Offset, describeRawIDField(ctrlParams, f), scope)
+			}
+		}
+	}
+	if _, err := fi.t.CopyOutBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// idKindName names an idKind for a log line.
+func idKindName(kind idKind) string {
+	switch kind {
+	case idGPUID:
+		return "gpuId"
+	case idDeviceInstance:
+		return "device instance"
+	case idDeviceInstanceMask:
+		return "device instance mask"
+	}
+	return "identifier"
+}
+
+// ctrlGpuGetIDInfoTranslate is ctrlGpuGetIDInfo plus translation: the
+// application supplies a guest gpuId and the driver answers with a host device
+// instance.
+func ctrlGpuGetIDInfoTranslate(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	scope := scopeFor(fi.t)
+	var ctrlParams nvgpu.NV0000_CTRL_GPU_GET_ID_INFO_PARAMS
+	if ctrlParams.SizeBytes() != int(ioctlParams.ParamsSize) {
+		return 0, linuxerr.EINVAL
+	}
+	if !scope.Restored {
+		return ctrlGpuGetIDInfo(fi, ioctlParams)
+	}
+	if _, err := ctrlParams.CopyIn(fi.t, addrFromP64(ioctlParams.Params)); err != nil {
+		return 0, err
+	}
+
+	// szName is not used anywhere in the driver, so we explicitly set it to null.
+	// See src/nvidia/src/kernel/gpu_mgr/gpu_mgr.c::gpumgrGetGpuIdInfo().
+	ctrlParams.SzName = 0
+
+	guestGPUID := ctrlParams.GpuID
+	if hostGPUID, ok := translateID(guestGPUID, nvp.guestToHostGPUID); ok {
+		ctrlParams.GpuID = hostGPUID
+		if log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: NV0000_CTRL_CMD_GPU_GET_ID_INFO: translated gpuId %d (guest) to %d (host) [%v]", guestGPUID, hostGPUID, scope)
+		}
+	}
+
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams)
+	hostGPUIDUsed := ctrlParams.GpuID
+	// The application must read back the gpuId it passed, not the host one it
+	// was resolved to; this control echoes the field.
+	ctrlParams.GpuID = guestGPUID
+	if err != nil {
+		return n, err
+	}
+	if ioctlParams.Status == nvgpu.NV_OK {
+		hostDevInst, hostGPUInst, hostSubDevInst := ctrlParams.DeviceInstance, ctrlParams.GpuInstance, ctrlParams.SubDeviceInstance
+		ctrlParams.DeviceInstance, ctrlParams.GpuInstance = translateIDInfoIdentity(fi, "NV0000_CTRL_CMD_GPU_GET_ID_INFO", nvp, scope, hostDevInst, hostGPUInst, hostSubDevInst)
+		if log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: NV0000_CTRL_CMD_GPU_GET_ID_INFO: gpuIdIn=%d(guest)/%d(host) gpuIdOut=%d deviceInstance=%d(host)->%d(guest) gpuInstance=%d(host)->%d(guest) subDeviceInstance=%d [%v]",
+				guestGPUID, hostGPUIDUsed, ctrlParams.GpuID, hostDevInst, ctrlParams.DeviceInstance, hostGPUInst, ctrlParams.GpuInstance, hostSubDevInst, scope)
+		}
+	}
+	_, err = ctrlParams.CopyOut(fi.t, addrFromP64(ioctlParams.Params))
+	return n, err
+}
+
+// Byte offsets within NV0000_CTRL_GPU_GET_ID_INFO_V2_PARAMS{gpuId, gpuFlags,
+// deviceInstance, subDeviceInstance, sliStatus, boardId, gpuInstance, numaId},
+// from src/common/sdk/nvidia/inc/ctrl/ctrl0000/ctrl0000gpu.h. Unlike the
+// non-V2 struct this one has no embedded szName pointer, so every field is a
+// bare NvU32 and the struct is 32 bytes.
+const (
+	idInfoV2GpuID             = 0
+	idInfoV2DeviceInstance    = 8
+	idInfoV2SubDeviceInstance = 12
+	idInfoV2GpuInstance       = 24
+	idInfoV2ParamsSize        = 32
+)
+
+// ctrlGpuGetIDInfoV2 implements NV0000_CTRL_CMD_GPU_GET_ID_INFO_V2. nvproxy
+// models no Go struct for it, so its fields are addressed by offset; a params
+// size that does not match the modelled layout is passed through untranslated.
+func ctrlGpuGetIDInfoV2(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	scope := scopeFor(fi.t)
+	if !scope.Restored || nvp.ids().empty() || int(ioctlParams.ParamsSize) != idInfoV2ParamsSize || ioctlParams.Params == 0 {
+		if scope.Restored && !nvp.ids().empty() && int(ioctlParams.ParamsSize) != idInfoV2ParamsSize {
+			log.Warningf("nvproxy: NV0000_CTRL_CMD_GPU_GET_ID_INFO_V2 params are %d bytes, not the %d this build models; passing identifiers through untranslated",
+				ioctlParams.ParamsSize, idInfoV2ParamsSize)
+		}
+		return rmControlSimple(fi, ioctlParams)
+	}
+
+	ctrlParams := make([]byte, ioctlParams.ParamsSize)
+	if _, err := fi.t.CopyInBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return 0, err
+	}
+
+	guestGPUID := hostarch.ByteOrder.Uint32(ctrlParams[idInfoV2GpuID:])
+	hostGPUIDUsed := guestGPUID
+	if host, ok := translateID(guestGPUID, nvp.guestToHostGPUID); ok {
+		hostGPUIDUsed = host
+		hostarch.ByteOrder.PutUint32(ctrlParams[idInfoV2GpuID:], host)
+	}
+
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams[0])
+	// Put back the gpuId the application passed; this control echoes it, and
+	// the user-mode driver keys its device table on what it reads back.
+	hostarch.ByteOrder.PutUint32(ctrlParams[idInfoV2GpuID:], guestGPUID)
+	if err != nil {
+		return n, err
+	}
+	if ioctlParams.Status == nvgpu.NV_OK {
+		hostDevInst := hostarch.ByteOrder.Uint32(ctrlParams[idInfoV2DeviceInstance:])
+		hostGPUInst := hostarch.ByteOrder.Uint32(ctrlParams[idInfoV2GpuInstance:])
+		hostSubDevInst := hostarch.ByteOrder.Uint32(ctrlParams[idInfoV2SubDeviceInstance:])
+		guestDevInst, guestGPUInst := translateIDInfoIdentity(fi, "NV0000_CTRL_CMD_GPU_GET_ID_INFO_V2", nvp, scope, hostDevInst, hostGPUInst, hostSubDevInst)
+		hostarch.ByteOrder.PutUint32(ctrlParams[idInfoV2DeviceInstance:], guestDevInst)
+		hostarch.ByteOrder.PutUint32(ctrlParams[idInfoV2GpuInstance:], guestGPUInst)
+		if log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: NV0000_CTRL_CMD_GPU_GET_ID_INFO_V2: gpuIdIn=%d(guest)/%d(host) gpuIdOut=%d deviceInstance=%d(host)->%d(guest) gpuInstance=%d(host)->%d(guest) subDeviceInstance=%d [%v]",
+				guestGPUID, hostGPUIDUsed, guestGPUID, hostDevInst, guestDevInst, hostGPUInst, guestGPUInst, hostSubDevInst, scope)
+		}
+	}
+	if _, err := fi.t.CopyOutBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// translateIDInfoIdentity translates the identity a GET_ID_INFO answer
+// carries, returning the guest device instance and gpu instance.
+//
+// gpuInstance is gpuGetInstance(pGpu), an index into the GPU manager's table
+// rather than into the device-group table, so it is a host identifier of its
+// own family and DeviceRemapID carries no mapping for it. It is translated
+// only where the driver reports it as equal to the device instance, which is
+// the case on a system where each device has exactly one subdevice -- the
+// property CheckDevicesRemappable() already requires in order to save at all.
+// Where the two differ nvproxy leaves gpuInstance alone and says so, rather
+// than guessing a mapping.
+func translateIDInfoIdentity(fi *frontendIoctlState, name string, nvp *nvproxy, scope translationScope, hostDevInst, hostGPUInst, hostSubDevInst uint32) (guestDevInst, guestGPUInst uint32) {
+	guestDevInst, guestGPUInst = hostDevInst, hostGPUInst
+	if g, ok := translateID(hostDevInst, nvp.hostToGuestDeviceInstance); ok {
+		guestDevInst = g
+		if hostGPUInst == hostDevInst {
+			guestGPUInst = g
+		} else {
+			log.Warningf("nvproxy: %s reports gpuInstance %d != deviceInstance %d; leaving gpuInstance untranslated", name, hostGPUInst, hostDevInst)
+		}
+	}
+	if hostSubDevInst != 0 {
+		log.Warningf("nvproxy: %s reports subDeviceInstance %d, but remapping requires it to be 0", name, hostSubDevInst)
+	}
+	return guestDevInst, guestGPUInst
+}
+
+// ctrlGpuAttachIDs implements NV0000_CTRL_CMD_GPU_ATTACH_IDS, whose gpuId
+// array is an input and whose FailedID is an output.
+func ctrlGpuAttachIDs(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	var ctrlParams nvgpu.NV0000_CTRL_GPU_ATTACH_IDS_PARAMS
+	if ctrlParams.SizeBytes() != int(ioctlParams.ParamsSize) || nvp.ids().empty() || !scopeFor(fi.t).Restored {
+		return rmControlSimple(fi, ioctlParams)
+	}
+	if _, err := ctrlParams.CopyIn(fi.t, addrFromP64(ioctlParams.Params)); err != nil {
+		return 0, err
+	}
+
+	origGPUIDs := ctrlParams.GPUIDs
+	for i := range ctrlParams.GPUIDs {
+		if host, ok := translateID(ctrlParams.GPUIDs[i], nvp.guestToHostGPUID); ok {
+			ctrlParams.GPUIDs[i] = host
+		}
+	}
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams)
+	ctrlParams.GPUIDs = origGPUIDs
+	if err != nil {
+		return n, err
+	}
+	if guest, ok := translateID(ctrlParams.FailedID, nvp.hostToGuestGPUID); ok {
+		ctrlParams.FailedID = guest
+	}
+	_, err = ctrlParams.CopyOut(fi.t, addrFromP64(ioctlParams.Params))
+	return n, err
+}
+
+// ctrlGpuGetUUIDFromGPUID implements NV0000_CTRL_CMD_GPU_GET_UUID_FROM_GPU_ID:
+// a guest gpuId in, a host UUID out.
+func ctrlGpuGetUUIDFromGPUID(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	var ctrlParams nvgpu.NV0000_CTRL_GPU_GET_UUID_FROM_GPU_ID_PARAMS
+	if ctrlParams.SizeBytes() != int(ioctlParams.ParamsSize) || nvp.ids().empty() || !scopeFor(fi.t).Restored {
+		return rmControlSimple(fi, ioctlParams)
+	}
+	if _, err := ctrlParams.CopyIn(fi.t, addrFromP64(ioctlParams.Params)); err != nil {
+		return 0, err
+	}
+
+	guestGPUID := ctrlParams.GPUID
+	if host, ok := translateID(guestGPUID, nvp.guestToHostGPUID); ok {
+		ctrlParams.GPUID = host
+	}
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams)
+	ctrlParams.GPUID = guestGPUID
+	if err != nil {
+		return n, err
+	}
+	if ioctlParams.Status == nvgpu.NV_OK {
+		// NV0000_CTRL_GPU_GET_UUID_FROM_GPU_ID_FLAGS_FORMAT_BINARY is bit 0 of
+		// Flags, matching NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT.
+		binary := ctrlParams.Flags&nvgpu.NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT_MASK == nvgpu.NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT_BINARY
+		if from, to, ok := translateUUIDBytes(ctrlParams.GPUUUID[:], binary, nvp.hostToGuestUUID); ok && log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: NV0000_CTRL_CMD_GPU_GET_UUID_FROM_GPU_ID: translated UUID %s (host) to %s (guest)", from, to)
+		}
+	}
+	_, err = ctrlParams.CopyOut(fi.t, addrFromP64(ioctlParams.Params))
+	return n, err
+}
+
+// gidInfoParamsSize is the size of NV2080_CTRL_GPU_GET_GID_INFO_PARAMS
+// {index, flags, length, data[256]}.
+const gidInfoParamsSize = 4 + 4 + 4 + nvgpu.NV2080_GPU_MAX_GID_LENGTH
+
+// ctrlGpuGetGidInfo implements NV2080_CTRL_CMD_GPU_GET_GID_INFO, which returns
+// a host GPU UUID through a subdevice handle in either ASCII or binary form.
+func ctrlGpuGetGidInfo(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	if int(ioctlParams.ParamsSize) != gidInfoParamsSize || len(nvp.hostToGuestUUID) == 0 || ioctlParams.Params == 0 || !scopeFor(fi.t).Restored {
+		return rmControlSimple(fi, ioctlParams)
+	}
+	ctrlParams := make([]byte, ioctlParams.ParamsSize)
+	if _, err := fi.t.CopyInBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return 0, err
+	}
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams[0])
+	if err != nil {
+		return n, err
+	}
+	if ioctlParams.Status == nvgpu.NV_OK {
+		flags := hostarch.ByteOrder.Uint32(ctrlParams[4:])
+		length := hostarch.ByteOrder.Uint32(ctrlParams[8:])
+		data := ctrlParams[12:]
+		if int(length) < len(data) && length != 0 {
+			data = data[:length]
+		}
+		binary := flags&nvgpu.NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT_MASK == nvgpu.NV2080_GPU_CMD_GPU_GET_GID_FLAGS_FORMAT_BINARY
+		if from, to, ok := translateUUIDBytes(data, binary, nvp.hostToGuestUUID); ok && log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: NV2080_CTRL_CMD_GPU_GET_GID_INFO: translated UUID %s (host) to %s (guest)", from, to)
+		}
+	}
+	if _, err := fi.t.CopyOutBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// rmAllocDevice implements NV01_DEVICE_0 allocation.
+//
+// NV0080_ALLOC_PARAMETERS.DeviceID is a device instance, and a process
+// restored from a checkpoint supplies the one it recorded then.
+// nvproxy.afterLoad() rewrites this field in the objects that already existed
+// at checkpoint time, but a restored process that allocates a *new*
+// NV01_DEVICE_0 -- which is what a CUDA restore leg does, on a fresh RM client
+// -- was passing the guest instance straight through, and RM answered
+// NV_ERR_INSUFFICIENT_PERMISSIONS because that client has no access to a
+// device by that number.
+func rmAllocDevice(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS64_PARAMETERS, isNVOS64 bool) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	scope := scopeFor(fi.t)
+	if !scope.Restored || len(nvp.guestToHostDeviceInstance) == 0 {
+		return rmAllocSimple[nvgpu.NV0080_ALLOC_PARAMETERS](fi, ioctlParams, isNVOS64)
+	}
+
+	// src/nvidia/src/kernel/gpu/device.c:deviceConstruct_IMPL() treats NULL
+	// allocParams for NV01_DEVICE_0 as the zero value, so an application that
+	// passes none is asking for device instance 0. If guest instance 0 needs
+	// translating we have to materialise the parameters to say so.
+	var allocParams nvgpu.NV0080_ALLOC_PARAMETERS
+	appPassedParams := ioctlParams.PAllocParms != 0
+	if appPassedParams {
+		if _, err := allocParams.CopyIn(fi.t, addrFromP64(ioctlParams.PAllocParms)); err != nil {
+			return 0, err
+		}
+	}
+
+	guestDevInst := allocParams.DeviceID
+	hostDevInst, translate := nvp.guestToHostDeviceInstance[guestDevInst]
+	if !translate {
+		// Nothing to do; take the ordinary path so that behaviour is
+		// bit-identical for a device instance we know nothing about.
+		if log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: NV01_DEVICE_0 alloc: device instance %d has no translation, passing through [%v]", guestDevInst, scope)
+		}
+		return rmAllocSimple[nvgpu.NV0080_ALLOC_PARAMETERS](fi, ioctlParams, isNVOS64)
+	}
+
+	allocParams.DeviceID = hostDevInst
+	if log.IsLogging(log.Debug) {
+		fi.ctx.Debugf("nvproxy: NV01_DEVICE_0 alloc: translated device instance %d (guest) to %d (host)%s hRoot=%v hObjectNew=%v [%v]",
+			guestDevInst, hostDevInst, nullParamsNote(appPassedParams), ioctlParams.HRoot, ioctlParams.HObjectNew, scope)
+	}
+
+	// rmAllocInvoke() points PAllocParms at allocParams for the duration of
+	// the ioctl and restores the application's value afterwards, so passing
+	// parameters the application did not is invisible to it. ParamsSize is
+	// deliberately left alone: the driver derives the size from the class and
+	// ignores it (see rmAllocSimpleParams), and it is copied back out to the
+	// application.
+	n, err := rmAllocInvoke(fi, ioctlParams, &allocParams, isNVOS64, addSimpleObjDepParentLocked)
+	// The object captured for a future checkpoint holds the host device
+	// instance, which is what nvproxy.afterLoad() expects to remap; restore
+	// the application's value only after that capture has happened.
+	allocParams.DeviceID = guestDevInst
+	if err != nil {
+		return n, err
+	}
+	if appPassedParams {
+		if _, err := allocParams.CopyOut(fi.t, addrFromP64(ioctlParams.PAllocParms)); err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+// nullParamsNote annotates a log line for the case where the application
+// passed no allocation parameters at all.
+func nullParamsNote(appPassedParams bool) string {
+	if appPassedParams {
+		return ""
+	}
+	return " (materialised from null allocParams)"
+}
+
+// rmAllocMemoryExport implements NV_MEMORY_EXPORT allocation.
+//
+// NV00E0_ALLOCATION_PARAMETERS.DeviceInstanceMask is a bitmask of device
+// instances and GIIDMasks is indexed by device instance, so both are the
+// guest's numbering when a restored process supplies them.
+//
+// This path is reachable only with the fabric IMEX management capability
+// enabled, so it is untested here; it is translated for the same reason as
+// NV01_DEVICE_0 rather than left as a second instance of the same bug.
+func rmAllocMemoryExport(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS64_PARAMETERS, isNVOS64 bool) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	scope := scopeFor(fi.t)
+	if !scope.Restored || len(nvp.guestToHostDeviceInstance) == 0 || ioctlParams.PAllocParms == 0 {
+		return rmAllocSimple[nvgpu.NV00E0_ALLOCATION_PARAMETERS](fi, ioctlParams, isNVOS64)
+	}
+
+	var allocParams nvgpu.NV00E0_ALLOCATION_PARAMETERS
+	if _, err := allocParams.CopyIn(fi.t, addrFromP64(ioctlParams.PAllocParms)); err != nil {
+		return 0, err
+	}
+
+	origMask := allocParams.DeviceInstanceMask
+	origGIIDMasks := allocParams.GIIDMasks
+	allocParams.DeviceInstanceMask = permuteDeviceInstanceMask(origMask, nvp.guestToHostDeviceInstance)
+	allocParams.GIIDMasks = permuteByDeviceInstance(origGIIDMasks, nvp.guestToHostDeviceInstance)
+	if log.IsLogging(log.Debug) && allocParams.DeviceInstanceMask != origMask {
+		fi.ctx.Debugf("nvproxy: NV_MEMORY_EXPORT alloc: translated device instance mask %#x (guest) to %#x (host) [%v]",
+			origMask, allocParams.DeviceInstanceMask, scope)
+	}
+
+	n, err := rmAllocInvoke(fi, ioctlParams, &allocParams, isNVOS64, addSimpleObjDepParentLocked)
+	allocParams.DeviceInstanceMask = origMask
+	allocParams.GIIDMasks = origGIIDMasks
+	if err != nil {
+		return n, err
+	}
+	if _, err := allocParams.CopyOut(fi.t, addrFromP64(ioctlParams.PAllocParms)); err != nil {
+		return n, err
+	}
+	return n, nil
+}

--- a/pkg/sentry/devices/nvproxy/ioctl_log.go
+++ b/pkg/sentry/devices/nvproxy/ioctl_log.go
@@ -1,0 +1,378 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"fmt"
+	"strings"
+
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/log"
+)
+
+// Diagnostics for GPU checkpoint/restore. Every driver call that reports a
+// non-NV_OK status is logged at Debug from the choke point it passes through,
+// so that a failure inside the CUDA or NCCL user-mode driver -- which reports
+// only a CUDA error code -- can be traced to the RM call that produced it.
+
+// statusName returns the NV_* name of an RM status code, from
+// src/common/sdk/nvidia/inc/nvstatuscodes.h.
+func statusName(status uint32) string {
+	if name, ok := statusNames[status]; ok {
+		return name
+	}
+	return fmt.Sprintf("NV_ERR_?(%#x)", status)
+}
+
+var statusNames = map[uint32]string{
+	0x00000000: "NV_OK",
+	0x0000FFFF: "NV_ERR_GENERIC",
+	0x00000001: "NV_ERR_BROKEN_FB",
+	0x00000002: "NV_ERR_BUFFER_TOO_SMALL",
+	0x00000003: "NV_ERR_BUSY_RETRY",
+	0x00000004: "NV_ERR_CALLBACK_NOT_SCHEDULED",
+	0x00000005: "NV_ERR_CARD_NOT_PRESENT",
+	0x00000006: "NV_ERR_CYCLE_DETECTED",
+	0x00000007: "NV_ERR_DMA_IN_USE",
+	0x00000008: "NV_ERR_DMA_MEM_NOT_LOCKED",
+	0x00000009: "NV_ERR_DMA_MEM_NOT_UNLOCKED",
+	0x0000000A: "NV_ERR_DUAL_LINK_INUSE",
+	0x0000000B: "NV_ERR_ECC_ERROR",
+	0x0000000C: "NV_ERR_FIFO_BAD_ACCESS",
+	0x0000000D: "NV_ERR_FREQ_NOT_SUPPORTED",
+	0x0000000E: "NV_ERR_GPU_DMA_NOT_INITIALIZED",
+	0x0000000F: "NV_ERR_GPU_IS_LOST",
+	0x00000010: "NV_ERR_GPU_IN_FULLCHIP_RESET",
+	0x00000011: "NV_ERR_GPU_NOT_FULL_POWER",
+	0x00000012: "NV_ERR_GPU_UUID_NOT_FOUND",
+	0x00000013: "NV_ERR_HOT_SWITCH",
+	0x00000014: "NV_ERR_I2C_ERROR",
+	0x00000015: "NV_ERR_I2C_SPEED_TOO_HIGH",
+	0x00000016: "NV_ERR_ILLEGAL_ACTION",
+	0x00000017: "NV_ERR_IN_USE",
+	0x00000018: "NV_ERR_INFLATE_COMPRESSED_DATA_FAILED",
+	0x00000019: "NV_ERR_INSERT_DUPLICATE_NAME",
+	0x0000001A: "NV_ERR_INSUFFICIENT_RESOURCES",
+	0x0000001B: "NV_ERR_INSUFFICIENT_PERMISSIONS",
+	0x0000001C: "NV_ERR_INSUFFICIENT_POWER",
+	0x0000001D: "NV_ERR_INVALID_ACCESS_TYPE",
+	0x0000001E: "NV_ERR_INVALID_ADDRESS",
+	0x0000001F: "NV_ERR_INVALID_ARGUMENT",
+	0x00000020: "NV_ERR_INVALID_BASE",
+	0x00000021: "NV_ERR_INVALID_CHANNEL",
+	0x00000022: "NV_ERR_INVALID_CLASS",
+	0x00000023: "NV_ERR_INVALID_CLIENT",
+	0x00000024: "NV_ERR_INVALID_COMMAND",
+	0x00000025: "NV_ERR_INVALID_DATA",
+	0x00000026: "NV_ERR_INVALID_DEVICE",
+	0x00000027: "NV_ERR_INVALID_DMA_SPECIFIER",
+	0x00000028: "NV_ERR_INVALID_EVENT",
+	0x00000029: "NV_ERR_INVALID_FLAGS",
+	0x0000002A: "NV_ERR_INVALID_FUNCTION",
+	0x0000002B: "NV_ERR_INVALID_HEAP",
+	0x0000002C: "NV_ERR_INVALID_INDEX",
+	0x0000002D: "NV_ERR_INVALID_IRQ_LEVEL",
+	0x0000002E: "NV_ERR_INVALID_LIMIT",
+	0x0000002F: "NV_ERR_INVALID_LOCK_STATE",
+	0x00000030: "NV_ERR_INVALID_METHOD",
+	0x00000031: "NV_ERR_INVALID_OBJECT",
+	0x00000032: "NV_ERR_INVALID_OBJECT_BUFFER",
+	0x00000033: "NV_ERR_INVALID_OBJECT_HANDLE",
+	0x00000034: "NV_ERR_INVALID_OBJECT_NEW",
+	0x00000035: "NV_ERR_INVALID_OBJECT_OLD",
+	0x00000036: "NV_ERR_INVALID_OBJECT_PARENT",
+	0x00000037: "NV_ERR_INVALID_OFFSET",
+	0x00000038: "NV_ERR_INVALID_OPERATION",
+	0x00000039: "NV_ERR_INVALID_OWNER",
+	0x0000003A: "NV_ERR_INVALID_PARAM_STRUCT",
+	0x0000003B: "NV_ERR_INVALID_PARAMETER",
+	0x0000003C: "NV_ERR_INVALID_PATH",
+	0x0000003D: "NV_ERR_INVALID_POINTER",
+	0x0000003E: "NV_ERR_INVALID_REGISTRY_KEY",
+	0x0000003F: "NV_ERR_INVALID_REQUEST",
+	0x00000040: "NV_ERR_INVALID_STATE",
+	0x00000041: "NV_ERR_INVALID_STRING_LENGTH",
+	0x00000042: "NV_ERR_INVALID_READ",
+	0x00000043: "NV_ERR_INVALID_WRITE",
+	0x00000044: "NV_ERR_INVALID_XLATE",
+	0x00000045: "NV_ERR_IRQ_NOT_FIRING",
+	0x00000046: "NV_ERR_IRQ_EDGE_TRIGGERED",
+	0x00000047: "NV_ERR_MEMORY_TRAINING_FAILED",
+	0x00000048: "NV_ERR_MISMATCHED_SLAVE",
+	0x00000049: "NV_ERR_MISMATCHED_TARGET",
+	0x0000004A: "NV_ERR_MISSING_TABLE_ENTRY",
+	0x0000004B: "NV_ERR_MODULE_LOAD_FAILED",
+	0x0000004C: "NV_ERR_MORE_DATA_AVAILABLE",
+	0x0000004D: "NV_ERR_MORE_PROCESSING_REQUIRED",
+	0x0000004E: "NV_ERR_MULTIPLE_MEMORY_TYPES",
+	0x0000004F: "NV_ERR_NO_FREE_FIFOS",
+	0x00000050: "NV_ERR_NO_INTR_PENDING",
+	0x00000051: "NV_ERR_NO_MEMORY",
+	0x00000052: "NV_ERR_NO_SUCH_DOMAIN",
+	0x00000053: "NV_ERR_NO_VALID_PATH",
+	0x00000054: "NV_ERR_NOT_COMPATIBLE",
+	0x00000055: "NV_ERR_NOT_READY",
+	0x00000056: "NV_ERR_NOT_SUPPORTED",
+	0x00000057: "NV_ERR_OBJECT_NOT_FOUND",
+	0x00000058: "NV_ERR_OBJECT_TYPE_MISMATCH",
+	0x00000059: "NV_ERR_OPERATING_SYSTEM",
+	0x0000005A: "NV_ERR_OTHER_DEVICE_FOUND",
+	0x0000005B: "NV_ERR_OUT_OF_RANGE",
+	0x0000005C: "NV_ERR_OVERLAPPING_UVM_COMMIT",
+	0x0000005D: "NV_ERR_PAGE_TABLE_NOT_AVAIL",
+	0x0000005E: "NV_ERR_PID_NOT_FOUND",
+	0x0000005F: "NV_ERR_PROTECTION_FAULT",
+	0x00000060: "NV_ERR_RC_ERROR",
+	0x00000061: "NV_ERR_REJECTED_VBIOS",
+	0x00000062: "NV_ERR_RESET_REQUIRED",
+	0x00000063: "NV_ERR_STATE_IN_USE",
+	0x00000064: "NV_ERR_SIGNAL_PENDING",
+	0x00000065: "NV_ERR_TIMEOUT",
+	0x00000066: "NV_ERR_TIMEOUT_RETRY",
+	0x00000067: "NV_ERR_TOO_MANY_PRIMARIES",
+	0x00000068: "NV_ERR_UVM_ADDRESS_IN_USE",
+	0x00000069: "NV_ERR_MAX_SESSION_LIMIT_REACHED",
+	0x0000006A: "NV_ERR_LIB_RM_VERSION_MISMATCH",
+	0x0000006B: "NV_ERR_PRIV_SEC_VIOLATION",
+	0x0000006C: "NV_ERR_GPU_IN_DEBUG_MODE",
+	0x0000006D: "NV_ERR_FEATURE_NOT_ENABLED",
+	0x0000006E: "NV_ERR_RESOURCE_LOST",
+	0x0000006F: "NV_ERR_PMU_NOT_READY",
+	0x00000070: "NV_ERR_FLCN_ERROR",
+	0x00000071: "NV_ERR_FATAL_ERROR",
+	0x00000072: "NV_ERR_MEMORY_ERROR",
+	0x00000073: "NV_ERR_INVALID_LICENSE",
+	0x00000074: "NV_ERR_NVLINK_INIT_ERROR",
+	0x00000075: "NV_ERR_NVLINK_MINION_ERROR",
+	0x00000076: "NV_ERR_NVLINK_CLOCK_ERROR",
+	0x00000077: "NV_ERR_NVLINK_TRAINING_ERROR",
+	0x00000078: "NV_ERR_NVLINK_CONFIGURATION_ERROR",
+	0x00000079: "NV_ERR_RISCV_ERROR",
+	0x0000007A: "NV_ERR_FABRIC_MANAGER_NOT_PRESENT",
+	0x0000007B: "NV_ERR_ALREADY_SIGNALLED",
+	0x0000007C: "NV_ERR_QUEUE_TASK_SLOT_NOT_AVAILABLE",
+	0x0000007D: "NV_ERR_KEY_ROTATION_IN_PROGRESS",
+	0x0000007E: "NV_ERR_TEST_ONLY_CODE_NOT_ENABLED",
+	0x0000007F: "NV_ERR_SECURE_BOOT_FAILED",
+	0x00000080: "NV_ERR_INSUFFICIENT_ZBC_ENTRY",
+	0x00000081: "NV_ERR_NVLINK_FABRIC_NOT_READY",
+	0x00000082: "NV_ERR_NVLINK_FABRIC_FAILURE",
+	0x00000083: "NV_ERR_GPU_MEMORY_ONLINING_FAILURE",
+	0x00000084: "NV_ERR_REDUCTION_MANAGER_NOT_AVAILABLE",
+	0x00000085: "NV_ERR_THRESHOLD_CROSSED",
+	0x00000086: "NV_ERR_RESOURCE_RETIREMENT_ERROR",
+	0x00000087: "NV_ERR_FABRIC_STATE_OUT_OF_SYNC",
+	0x00000088: "NV_ERR_BUFFER_FULL",
+	0x00000089: "NV_ERR_BUFFER_EMPTY",
+	0x0000008A: "NV_ERR_MC_FLA_OFFSET_TABLE_FULL",
+	0x0000008B: "NV_ERR_OPERATION_ABORTED",
+	0x0000008C: "NV_ERR_DMA_XFER_FAILED",
+	0x0000008D: "NV_ERR_RESOURCE_ACCOUNTING_HARD_LIMIT_EXCEEDED",
+	0x00010001: "NV_WARN_HOT_SWITCH",
+	0x00010002: "NV_WARN_INCORRECT_PERFMON_DATA",
+	0x00010003: "NV_WARN_MISMATCHED_SLAVE",
+	0x00010004: "NV_WARN_MISMATCHED_TARGET",
+	0x00010005: "NV_WARN_MORE_PROCESSING_REQUIRED",
+	0x00010006: "NV_WARN_NOTHING_TO_DO",
+	0x00010007: "NV_WARN_NULL_OBJECT",
+	0x00010008: "NV_WARN_OUT_OF_RANGE",
+	0x00010009: "NV_WARN_THRESHOLD_CROSSED",
+	0x0001000A: "NV_WARN_RESOURCE_ACCOUNTING_SOFT_LIMIT_EXCEEDED",
+}
+
+// frontendIoctlName returns the NV_ESC_* name of a frontend ioctl number.
+func frontendIoctlName(nr uint32) string {
+	if name, ok := frontendIoctlNames[nr]; ok {
+		return name
+	}
+	return fmt.Sprintf("NV_ESC_?(%#x)", nr)
+}
+
+var frontendIoctlNames = map[uint32]string{
+	nvgpu.NV_ESC_CARD_INFO:                     "NV_ESC_CARD_INFO",
+	nvgpu.NV_ESC_REGISTER_FD:                   "NV_ESC_REGISTER_FD",
+	nvgpu.NV_ESC_ALLOC_OS_EVENT:                "NV_ESC_ALLOC_OS_EVENT",
+	nvgpu.NV_ESC_FREE_OS_EVENT:                 "NV_ESC_FREE_OS_EVENT",
+	nvgpu.NV_ESC_CHECK_VERSION_STR:             "NV_ESC_CHECK_VERSION_STR",
+	nvgpu.NV_ESC_ATTACH_GPUS_TO_FD:             "NV_ESC_ATTACH_GPUS_TO_FD",
+	nvgpu.NV_ESC_SYS_PARAMS:                    "NV_ESC_SYS_PARAMS",
+	nvgpu.NV_ESC_NUMA_INFO:                     "NV_ESC_NUMA_INFO",
+	nvgpu.NV_ESC_EXPORT_TO_DMABUF_FD:           "NV_ESC_EXPORT_TO_DMABUF_FD",
+	nvgpu.NV_ESC_WAIT_OPEN_COMPLETE:            "NV_ESC_WAIT_OPEN_COMPLETE",
+	nvgpu.NV_ESC_RM_ALLOC_MEMORY:               "NV_ESC_RM_ALLOC_MEMORY",
+	nvgpu.NV_ESC_RM_FREE:                       "NV_ESC_RM_FREE",
+	nvgpu.NV_ESC_RM_CONTROL:                    "NV_ESC_RM_CONTROL",
+	nvgpu.NV_ESC_RM_ALLOC:                      "NV_ESC_RM_ALLOC",
+	nvgpu.NV_ESC_RM_DUP_OBJECT:                 "NV_ESC_RM_DUP_OBJECT",
+	nvgpu.NV_ESC_RM_SHARE:                      "NV_ESC_RM_SHARE",
+	nvgpu.NV_ESC_RM_IDLE_CHANNELS:              "NV_ESC_RM_IDLE_CHANNELS",
+	nvgpu.NV_ESC_RM_VID_HEAP_CONTROL:           "NV_ESC_RM_VID_HEAP_CONTROL",
+	nvgpu.NV_ESC_RM_MAP_MEMORY:                 "NV_ESC_RM_MAP_MEMORY",
+	nvgpu.NV_ESC_RM_UNMAP_MEMORY:               "NV_ESC_RM_UNMAP_MEMORY",
+	nvgpu.NV_ESC_RM_ALLOC_CONTEXT_DMA2:         "NV_ESC_RM_ALLOC_CONTEXT_DMA2",
+	nvgpu.NV_ESC_RM_MAP_MEMORY_DMA:             "NV_ESC_RM_MAP_MEMORY_DMA",
+	nvgpu.NV_ESC_RM_UNMAP_MEMORY_DMA:           "NV_ESC_RM_UNMAP_MEMORY_DMA",
+	nvgpu.NV_ESC_RM_UPDATE_DEVICE_MAPPING_INFO: "NV_ESC_RM_UPDATE_DEVICE_MAPPING_INFO",
+}
+
+// uvmIoctlName returns the UVM_* name of a UVM ioctl command.
+func uvmIoctlName(cmd uint32) string {
+	if name, ok := uvmIoctlNames[cmd]; ok {
+		return name
+	}
+	return fmt.Sprintf("UVM_?(%d)", cmd)
+}
+
+var uvmIoctlNames = map[uint32]string{
+	nvgpu.UVM_INITIALIZE:                     "UVM_INITIALIZE",
+	nvgpu.UVM_DEINITIALIZE:                   "UVM_DEINITIALIZE",
+	nvgpu.UVM_CREATE_RANGE_GROUP:             "UVM_CREATE_RANGE_GROUP",
+	nvgpu.UVM_DESTROY_RANGE_GROUP:            "UVM_DESTROY_RANGE_GROUP",
+	nvgpu.UVM_REGISTER_GPU_VASPACE:           "UVM_REGISTER_GPU_VASPACE",
+	nvgpu.UVM_UNREGISTER_GPU_VASPACE:         "UVM_UNREGISTER_GPU_VASPACE",
+	nvgpu.UVM_REGISTER_CHANNEL:               "UVM_REGISTER_CHANNEL",
+	nvgpu.UVM_UNREGISTER_CHANNEL:             "UVM_UNREGISTER_CHANNEL",
+	nvgpu.UVM_ENABLE_PEER_ACCESS:             "UVM_ENABLE_PEER_ACCESS",
+	nvgpu.UVM_DISABLE_PEER_ACCESS:            "UVM_DISABLE_PEER_ACCESS",
+	nvgpu.UVM_SET_RANGE_GROUP:                "UVM_SET_RANGE_GROUP",
+	nvgpu.UVM_MAP_EXTERNAL_ALLOCATION:        "UVM_MAP_EXTERNAL_ALLOCATION",
+	nvgpu.UVM_FREE:                           "UVM_FREE",
+	nvgpu.UVM_REGISTER_GPU:                   "UVM_REGISTER_GPU",
+	nvgpu.UVM_UNREGISTER_GPU:                 "UVM_UNREGISTER_GPU",
+	nvgpu.UVM_PAGEABLE_MEM_ACCESS:            "UVM_PAGEABLE_MEM_ACCESS",
+	nvgpu.UVM_SET_PREFERRED_LOCATION:         "UVM_SET_PREFERRED_LOCATION",
+	nvgpu.UVM_UNSET_PREFERRED_LOCATION:       "UVM_UNSET_PREFERRED_LOCATION",
+	nvgpu.UVM_ENABLE_READ_DUPLICATION:        "UVM_ENABLE_READ_DUPLICATION",
+	nvgpu.UVM_DISABLE_READ_DUPLICATION:       "UVM_DISABLE_READ_DUPLICATION",
+	nvgpu.UVM_SET_ACCESSED_BY:                "UVM_SET_ACCESSED_BY",
+	nvgpu.UVM_UNSET_ACCESSED_BY:              "UVM_UNSET_ACCESSED_BY",
+	nvgpu.UVM_MIGRATE:                        "UVM_MIGRATE",
+	nvgpu.UVM_MIGRATE_RANGE_GROUP:            "UVM_MIGRATE_RANGE_GROUP",
+	nvgpu.UVM_TOOLS_READ_PROCESS_MEMORY:      "UVM_TOOLS_READ_PROCESS_MEMORY",
+	nvgpu.UVM_TOOLS_WRITE_PROCESS_MEMORY:     "UVM_TOOLS_WRITE_PROCESS_MEMORY",
+	nvgpu.UVM_MAP_DYNAMIC_PARALLELISM_REGION: "UVM_MAP_DYNAMIC_PARALLELISM_REGION",
+	nvgpu.UVM_UNMAP_EXTERNAL:                 "UVM_UNMAP_EXTERNAL",
+	nvgpu.UVM_ALLOC_SEMAPHORE_POOL:           "UVM_ALLOC_SEMAPHORE_POOL",
+	nvgpu.UVM_PAGEABLE_MEM_ACCESS_ON_GPU:     "UVM_PAGEABLE_MEM_ACCESS_ON_GPU",
+	nvgpu.UVM_VALIDATE_VA_RANGE:              "UVM_VALIDATE_VA_RANGE",
+	nvgpu.UVM_CREATE_EXTERNAL_RANGE:          "UVM_CREATE_EXTERNAL_RANGE",
+	nvgpu.UVM_MM_INITIALIZE:                  "UVM_MM_INITIALIZE",
+}
+
+// logFrontendIoctlStatus logs a frontend ioctl that the driver answered with a
+// non-NV_OK status. It is called from frontendIoctlInvoke(), the single choke
+// point every status-bearing frontend ioctl passes through, so no handler can
+// be missed. ioctlParams is passed as any so that the handful of parameter
+// types worth naming their handles can be recognised; everything else gets the
+// generic line.
+func logFrontendIoctlStatus(fi *frontendIoctlState, status uint32, ioctlParams any) {
+	name := frontendIoctlName(fi.nr)
+	switch p := ioctlParams.(type) {
+	case *nvgpu.NVOS54_PARAMETERS:
+		// Also logged by logRMControlStatus() with the control command; this
+		// branch keeps the two lines consistent when a control fails.
+		fi.ctx.Debugf("nvproxy: %s failed: cmd=%#x hClient=%v hObject=%v paramsSize=%d status=%#x (%s)",
+			name, p.Cmd, p.HClient, p.HObject, p.ParamsSize, status, statusName(status))
+	case *nvgpu.NVOS64_PARAMETERS:
+		fi.ctx.Debugf("nvproxy: %s failed: hClass=%v hRoot=%v hObjectParent=%v hObjectNew=%v paramsSize=%d status=%#x (%s)",
+			name, p.HClass, p.HRoot, p.HObjectParent, p.HObjectNew, p.ParamsSize, status, statusName(status))
+	case *nvgpu.NVOS21_PARAMETERS:
+		fi.ctx.Debugf("nvproxy: %s failed: hClass=%v hRoot=%v hObjectParent=%v hObjectNew=%v paramsSize=%d status=%#x (%s)",
+			name, p.HClass, p.HRoot, p.HObjectParent, p.HObjectNew, p.ParamsSize, status, statusName(status))
+	case *nvgpu.NVOS55_PARAMETERS:
+		fi.ctx.Debugf("nvproxy: %s failed: hClient=%v hParent=%v hObject=%v hClientSrc=%v hObjectSrc=%v flags=%#x status=%#x (%s)",
+			name, p.HClient, p.HParent, p.HObject, p.HClientSrc, p.HObjectSrc, p.Flags, status, statusName(status))
+	case *nvgpu.NVOS46_PARAMETERS:
+		fi.ctx.Debugf("nvproxy: %s failed: hClient=%v hDevice=%v hDma=%v hMemory=%v offset=%#x length=%#x flags=%#x status=%#x (%s)",
+			name, p.Client, p.Device, p.Dma, p.Memory, p.Offset, p.Length, p.Flags, status, statusName(status))
+	case *nvgpu.NVOS33_PARAMETERS:
+		fi.ctx.Debugf("nvproxy: %s failed: hClient=%v hDevice=%v hMemory=%v offset=%#x length=%#x flags=%#x status=%#x (%s)",
+			name, p.HClient, p.HDevice, p.HMemory, p.Offset, p.Length, p.Flags, status, statusName(status))
+	case *nvgpu.IoctlNVOS02ParametersWithFD:
+		fi.ctx.Debugf("nvproxy: %s failed: hRoot=%v hObjectParent=%v hObjectNew=%v hClass=%v flags=%#x limit=%#x status=%#x (%s)",
+			name, p.Params.HRoot, p.Params.HObjectParent, p.Params.HObjectNew, p.Params.HClass, p.Params.Flags, p.Params.Limit, status, statusName(status))
+	default:
+		fi.ctx.Debugf("nvproxy: %s failed: paramsSize=%d status=%#x (%s)",
+			name, fi.ioctlParamsSize, status, statusName(status))
+	}
+}
+
+// logRMControlStatus logs the outcome of an NV_ESC_RM_CONTROL: every control at
+// Debug, and any control the driver answered with a non-NV_OK status at Debug.
+// It is called from rmControlInvoke(), which every control handler funnels
+// through.
+func logRMControlStatus(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) {
+	if ioctlParams.Status != nvgpu.NV_OK {
+		fi.ctx.Debugf("nvproxy: rm control failed: cmd=%#x hClient=%v hObject=%v paramsSize=%d status=%#x (%s)",
+			ioctlParams.Cmd, ioctlParams.HClient, ioctlParams.HObject, ioctlParams.ParamsSize, ioctlParams.Status, statusName(ioctlParams.Status))
+		return
+	}
+	if log.IsLogging(log.Debug) {
+		fi.ctx.Debugf("nvproxy: rm control: cmd=%#x hClient=%v hObject=%v paramsSize=%d status=%#x%s",
+			ioctlParams.Cmd, ioctlParams.HClient, ioctlParams.HObject, ioctlParams.ParamsSize, ioctlParams.Status,
+			ctrlParamsPreview(fi, ioctlParams))
+	}
+}
+
+// ctrlParamsPreviewLen is how much of a control's parameters the Debug line
+// shows.
+const ctrlParamsPreviewLen = 32
+
+// ctrlParamsPreview renders the first bytes of a control's parameters as
+// NvU32s, for the NV0000 gpu (0x2xx) and system (0x1xx) controls whose
+// parameters begin with gpuIds. Those are the controls by which an application
+// discovers which GPUs exist, so seeing the identifiers flow is what tells us
+// whether a translation is reaching them.
+//
+// It returns "" for every other command, and never reads more than the
+// application said it passed.
+func ctrlParamsPreview(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) string {
+	if ioctlParams.Cmd&^0xff != 0x100 && ioctlParams.Cmd&^0xff != 0x200 {
+		return ""
+	}
+	if ioctlParams.Params == 0 || ioctlParams.ParamsSize == 0 {
+		return ""
+	}
+	n := int(ioctlParams.ParamsSize)
+	if n > ctrlParamsPreviewLen {
+		n = ctrlParamsPreviewLen
+	}
+	n -= n % 4
+	if n == 0 {
+		return ""
+	}
+	buf := make([]byte, n)
+	if _, err := fi.t.CopyInBytes(addrFromP64(ioctlParams.Params), buf); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(" params=[")
+	for i := 0; i+4 <= n; i += 4 {
+		if i != 0 {
+			b.WriteByte(' ')
+		}
+		fmt.Fprintf(&b, "%#010x", hostarch.ByteOrder.Uint32(buf[i:]))
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// logUVMIoctlStatus logs a UVM ioctl that the driver answered with a non-NV_OK
+// rmStatus. It is called from uvmIoctlInvoke(), the single choke point for UVM
+// ioctls that carry a status.
+func logUVMIoctlStatus(ui *uvmIoctlState, status uint32) {
+	ui.ctx.Debugf("nvproxy: uvm ioctl %s failed: rmStatus=%#x (%s)", uvmIoctlName(ui.cmd), status, statusName(status))
+}

--- a/pkg/sentry/devices/nvproxy/nvproxy.go
+++ b/pkg/sentry/devices/nvproxy/nvproxy.go
@@ -219,6 +219,28 @@ type nvproxy struct {
 
 	clientsMu sync.RWMutex `state:"nosave"`
 	clients   map[nvgpu.Handle]*rootClient
+
+	// The identifier translation tables established by restores that remapped
+	// devices; empty if this sandbox has never been restored onto a different
+	// set of devices. See gpuid.go and uuid.go.
+	//
+	// They are saved rather than recomputed on each restore: a restored
+	// sandbox can be checkpointed again and restored onto a third set of
+	// devices, and the identifiers the application remembers are still those
+	// of its original boot.
+	//
+	// These are only mutated by nvproxy.afterLoad(), which runs while the
+	// sandbox is paused, so they need no lock.
+	hostToGuestDeviceInstance map[uint32]uint32
+	guestToHostDeviceInstance map[uint32]uint32
+	hostToGuestGPUID          map[uint32]uint32
+	guestToHostGPUID          map[uint32]uint32
+	hostToGuestUUID           map[string]string
+	guestToHostUUID           map[string]string
+	hostToGuestMinor          map[uint32]uint32
+	guestToHostMinor          map[uint32]uint32
+	hostToGuestPCIAddr        map[uint64]uint64
+	guestToHostPCIAddr        map[uint64]uint64
 }
 
 func nvproxyFromVFS(vfsObj *vfs.VirtualFilesystem) *nvproxy {
@@ -234,6 +256,19 @@ func nvproxyFromVFS(vfsObj *vfs.VirtualFilesystem) *nvproxy {
 		return nil
 	}
 	return ctlDevice.nvp
+}
+
+// ids returns nvp's identifier translation tables.
+func (nvp *nvproxy) ids() idMaps {
+	return idMaps{
+		HostToGuestDeviceInstance: nvp.hostToGuestDeviceInstance,
+		GuestToHostDeviceInstance: nvp.guestToHostDeviceInstance,
+		HostToGuestGPUID:          nvp.hostToGuestGPUID,
+		GuestToHostGPUID:          nvp.guestToHostGPUID,
+		HostToGuestUUID:           nvp.hostToGuestUUID,
+		HostToGuestPCIAddr:        nvp.hostToGuestPCIAddr,
+		GuestToHostPCIAddr:        nvp.guestToHostPCIAddr,
+	}
 }
 
 type marshalPtr[T any] interface {
@@ -259,6 +294,12 @@ type hasFrontendFDAndStatusPtr[T any] interface {
 	marshalPtr[T]
 	nvgpu.HasFrontendFD
 	nvgpu.HasStatus
+}
+
+type hasFrontendFDAndDeviceInstancePtr[T any] interface {
+	marshalPtr[T]
+	nvgpu.HasFrontendFD
+	nvgpu.HasDeviceInstance
 }
 
 type hasCtrlInfoListPtr[T any] interface {

--- a/pkg/sentry/devices/nvproxy/pciaddr.go
+++ b/pkg/sentry/devices/nvproxy/pciaddr.go
@@ -1,0 +1,321 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+	"gvisor.dev/gvisor/pkg/errors/linuxerr"
+	"gvisor.dev/gvisor/pkg/hostarch"
+	"gvisor.dev/gvisor/pkg/log"
+)
+
+// translatePCIAddrToGuest translates a host PCI address to the one the
+// application saw before the checkpoint, reporting whether it did.
+func (nvp *nvproxy) translatePCIAddrToGuest(domain uint32, bus, slot, function uint8) (uint32, uint8, uint8, uint8, bool) {
+	if len(nvp.hostToGuestPCIAddr) == 0 {
+		return domain, bus, slot, function, false
+	}
+	guest, ok := nvp.hostToGuestPCIAddr[PackPCIAddr(domain, bus, slot, function)]
+	if !ok {
+		return domain, bus, slot, function, false
+	}
+	d, b, s, f := UnpackPCIAddr(guest)
+	return d, b, s, f, true
+}
+
+// frontendIoctlCardInfo implements NV_ESC_CARD_INFO, which reports an array of
+// nv_ioctl_card_info_t: one entry per card, each naming the card by gpuId, by
+// PCI address and by device file minor number. All three are host identities,
+// and a restored process matches its own recorded state against them.
+//
+// This is frontendIoctlBytes plus that translation. A parameter buffer that is
+// not a whole number of entries is passed through untouched.
+func frontendIoctlCardInfo(fi *frontendIoctlState) (uintptr, error) {
+	if fi.ioctlParamsSize == 0 {
+		return frontendIoctlInvokeNoStatus[byte](fi, nil)
+	}
+
+	ioctlParams := make([]byte, fi.ioctlParamsSize)
+	if _, err := fi.t.CopyInBytes(fi.ioctlParamsAddr, ioctlParams); err != nil {
+		return 0, err
+	}
+	n, err := frontendIoctlInvokeNoStatus(fi, &ioctlParams[0])
+	if err != nil {
+		return n, err
+	}
+	translateCardInfo(fi, ioctlParams)
+	if _, err := fi.t.CopyOutBytes(fi.ioctlParamsAddr, ioctlParams); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// translateCardInfo rewrites, in place, every host identity in an
+// NV_ESC_CARD_INFO reply.
+func translateCardInfo(fi *frontendIoctlState, buf []byte) {
+	nvp := fi.fd.dev.nvp
+	scope := scopeFor(fi.t)
+	if !scope.Restored || nvp.ids().empty() {
+		return
+	}
+	var one nvgpu.IoctlCardInfo
+	stride := one.SizeBytes()
+	if stride == 0 || len(buf)%stride != 0 {
+		log.Warningf("nvproxy: NV_ESC_CARD_INFO reply is %d bytes, not a multiple of the %d-byte entry this build models; passing identities through untranslated", len(buf), stride)
+		return
+	}
+	for off := 0; off+stride <= len(buf); off += stride {
+		var ci nvgpu.IoctlCardInfo
+		ci.UnmarshalBytes(buf[off : off+stride])
+		if ci.Valid == 0 {
+			continue
+		}
+		changed := false
+		if guest, ok := translateID(ci.GPUID, nvp.hostToGuestGPUID); ok {
+			if log.IsLogging(log.Debug) {
+				fi.ctx.Debugf("nvproxy: NV_ESC_CARD_INFO: translated gpuId %d (host) to %d (guest) [%v]", ci.GPUID, guest, scope)
+			}
+			ci.GPUID = guest
+			changed = true
+		}
+		if guest, ok := nvp.hostToGuestMinor[ci.MinorNumber]; ok {
+			if log.IsLogging(log.Debug) {
+				fi.ctx.Debugf("nvproxy: NV_ESC_CARD_INFO: translated minor %d (host) to %d (guest) [%v]", ci.MinorNumber, guest, scope)
+			}
+			ci.MinorNumber = guest
+			changed = true
+		}
+		if d, b, sl, f, ok := nvp.translatePCIAddrToGuest(ci.PCIInfo.Domain, ci.PCIInfo.Bus, ci.PCIInfo.Slot, ci.PCIInfo.Function); ok {
+			if log.IsLogging(log.Debug) {
+				fi.ctx.Debugf("nvproxy: NV_ESC_CARD_INFO: translated PCI address %s (host) to %s (guest) [%v]",
+					formatPCIAddr(PackPCIAddr(ci.PCIInfo.Domain, ci.PCIInfo.Bus, ci.PCIInfo.Slot, ci.PCIInfo.Function)),
+					formatPCIAddr(PackPCIAddr(d, b, sl, f)), scope)
+			}
+			ci.PCIInfo.Domain, ci.PCIInfo.Bus, ci.PCIInfo.Slot, ci.PCIInfo.Function = d, b, sl, f
+			changed = true
+		}
+		if changed {
+			ci.MarshalBytes(buf[off : off+stride])
+		}
+	}
+}
+
+// Byte offsets within NV0000_CTRL_GPU_GET_PCI_INFO_PARAMS{NvU32 gpuId, NvU32
+// domain, NvU16 bus, NvU16 slot}, from
+// src/common/sdk/nvidia/inc/ctrl/ctrl0000/ctrl0000gpu.h. Note that bus and
+// slot are 16-bit here, unlike the 8-bit fields of nv_pci_info_t, and that
+// there is no function field.
+const (
+	pciInfoGpuID      = 0
+	pciInfoDomain     = 4
+	pciInfoBus        = 8
+	pciInfoSlot       = 10
+	pciInfoParamsSize = 12
+)
+
+// ctrlGpuGetPCIInfo implements NV0000_CTRL_CMD_GPU_GET_PCI_INFO: a guest gpuId
+// in, a host PCI address out.
+func ctrlGpuGetPCIInfo(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	scope := scopeFor(fi.t)
+	if !scope.Restored || nvp.ids().empty() || int(ioctlParams.ParamsSize) != pciInfoParamsSize || ioctlParams.Params == 0 {
+		if scope.Restored && !nvp.ids().empty() && int(ioctlParams.ParamsSize) != pciInfoParamsSize {
+			log.Warningf("nvproxy: NV0000_CTRL_CMD_GPU_GET_PCI_INFO params are %d bytes, not the %d this build models; passing identifiers through untranslated",
+				ioctlParams.ParamsSize, pciInfoParamsSize)
+		}
+		return rmControlSimple(fi, ioctlParams)
+	}
+
+	ctrlParams := make([]byte, ioctlParams.ParamsSize)
+	if _, err := fi.t.CopyInBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return 0, err
+	}
+
+	guestGPUID := hostarch.ByteOrder.Uint32(ctrlParams[pciInfoGpuID:])
+	if host, ok := translateID(guestGPUID, nvp.guestToHostGPUID); ok {
+		hostarch.ByteOrder.PutUint32(ctrlParams[pciInfoGpuID:], host)
+		if log.IsLogging(log.Debug) {
+			fi.ctx.Debugf("nvproxy: NV0000_CTRL_CMD_GPU_GET_PCI_INFO: translated gpuId %d (guest) to %d (host) [%v]", guestGPUID, host, scope)
+		}
+	}
+
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams[0])
+	// The application must read back the gpuId it passed.
+	hostarch.ByteOrder.PutUint32(ctrlParams[pciInfoGpuID:], guestGPUID)
+	if err != nil {
+		return n, err
+	}
+	if ioctlParams.Status == nvgpu.NV_OK {
+		hostDomain := hostarch.ByteOrder.Uint32(ctrlParams[pciInfoDomain:])
+		hostBus := hostarch.ByteOrder.Uint16(ctrlParams[pciInfoBus:])
+		hostSlot := hostarch.ByteOrder.Uint16(ctrlParams[pciInfoSlot:])
+		// The function is not reported by this control, so translate against
+		// function 0, which is what every GPU uses.
+		if d, b, sl, _, ok := nvp.translatePCIAddrToGuest(hostDomain, uint8(hostBus), uint8(hostSlot), 0); ok {
+			hostarch.ByteOrder.PutUint32(ctrlParams[pciInfoDomain:], d)
+			hostarch.ByteOrder.PutUint16(ctrlParams[pciInfoBus:], uint16(b))
+			hostarch.ByteOrder.PutUint16(ctrlParams[pciInfoSlot:], uint16(sl))
+			if log.IsLogging(log.Debug) {
+				fi.ctx.Debugf("nvproxy: NV0000_CTRL_CMD_GPU_GET_PCI_INFO: gpuId=%d translated PCI address %s (host) to %s (guest) [%v]",
+					guestGPUID, formatPCIAddr(PackPCIAddr(hostDomain, uint8(hostBus), uint8(hostSlot), 0)),
+					formatPCIAddr(PackPCIAddr(d, b, sl, 0)), scope)
+			}
+		}
+	}
+	if _, err := fi.t.CopyOutBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// NV2080_CTRL_BUS_GET_INFO_V2_PARAMS{NvU32 busInfoListSize,
+// NV2080_CTRL_BUS_INFO busInfoList[NV2080_CTRL_BUS_INFO_MAX_LIST_SIZE]}, each
+// entry being NVXXXX_CTRL_XXX_INFO{NvU32 index, NvU32 data}. From
+// src/common/sdk/nvidia/inc/ctrl/ctrl2080/ctrl2080bus.h.
+const (
+	busInfoListSizeOff       = 0
+	busInfoListOff           = 4
+	busInfoMaxListSize       = 0x34
+	busInfoIndexBusNumber    = 0x0000000f
+	busInfoIndexDeviceNumber = 0x00000010
+	busInfoIndexDomainNumber = 0x0000002c
+)
+
+// busGetInfoV2ParamsSize is the size of the modelled layout.
+var busGetInfoV2ParamsSize = busInfoListOff + busInfoMaxListSize*int(nvgpu.CtrlXxxInfoSize)
+
+// ctrlBusGetInfoV2 implements NV2080_CTRL_CMD_BUS_GET_INFO_V2, an
+// index/value list in which three indices report the GPU's PCI address one
+// component at a time.
+//
+// The components are translated together: a bus number translated without the
+// domain and device it belongs to would name a device that does not exist. The
+// application asks for them in separate entries of one list, so this handler
+// resolves whichever components the list requests against the one host address
+// they must all belong to.
+func ctrlBusGetInfoV2(fi *frontendIoctlState, ioctlParams *nvgpu.NVOS54_PARAMETERS) (uintptr, error) {
+	nvp := fi.fd.dev.nvp
+	scope := scopeFor(fi.t)
+	if !scope.Restored || len(nvp.hostToGuestPCIAddr) == 0 || int(ioctlParams.ParamsSize) != busGetInfoV2ParamsSize || ioctlParams.Params == 0 {
+		if scope.Restored && len(nvp.hostToGuestPCIAddr) != 0 && int(ioctlParams.ParamsSize) != busGetInfoV2ParamsSize {
+			log.Warningf("nvproxy: NV2080_CTRL_CMD_BUS_GET_INFO_V2 params are %d bytes, not the %d this build models; passing PCI identifiers through untranslated",
+				ioctlParams.ParamsSize, busGetInfoV2ParamsSize)
+		}
+		return rmControlSimple(fi, ioctlParams)
+	}
+	if ioctlParams.ParamsSize > nvgpu.RMAPI_PARAM_COPY_MAX_PARAMS_SIZE {
+		return 0, linuxerr.EINVAL
+	}
+
+	ctrlParams := make([]byte, ioctlParams.ParamsSize)
+	if _, err := fi.t.CopyInBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return 0, err
+	}
+	n, err := rmControlInvoke(fi, ioctlParams, &ctrlParams[0])
+	if err != nil {
+		return n, err
+	}
+	if ioctlParams.Status == nvgpu.NV_OK {
+		translateBusInfoPCIAddr(fi, ctrlParams, scope)
+	}
+	if _, err := fi.t.CopyOutBytes(addrFromP64(ioctlParams.Params), ctrlParams); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
+// translateBusInfoPCIAddr rewrites the PCI address components of a
+// NV2080_CTRL_BUS_GET_INFO_V2 reply.
+func translateBusInfoPCIAddr(fi *frontendIoctlState, buf []byte, scope translationScope) {
+	nvp := fi.fd.dev.nvp
+	stride := int(nvgpu.CtrlXxxInfoSize)
+	count := int(hostarch.ByteOrder.Uint32(buf[busInfoListSizeOff:]))
+	if count > busInfoMaxListSize {
+		count = busInfoMaxListSize
+	}
+
+	// First pass: find which components the list asks for, and their offsets.
+	var (
+		hostDomain, hostBus, hostSlot uint32
+		offDomain, offBus, offSlot    = -1, -1, -1
+		haveDomain, haveBus, haveSlot bool
+	)
+	for i := 0; i < count; i++ {
+		off := busInfoListOff + i*stride
+		if off+stride > len(buf) {
+			break
+		}
+		index := hostarch.ByteOrder.Uint32(buf[off:])
+		dataOff := off + 4
+		switch index {
+		case busInfoIndexDomainNumber:
+			hostDomain, offDomain, haveDomain = hostarch.ByteOrder.Uint32(buf[dataOff:]), dataOff, true
+		case busInfoIndexBusNumber:
+			hostBus, offBus, haveBus = hostarch.ByteOrder.Uint32(buf[dataOff:]), dataOff, true
+		case busInfoIndexDeviceNumber:
+			hostSlot, offSlot, haveSlot = hostarch.ByteOrder.Uint32(buf[dataOff:]), dataOff, true
+		}
+	}
+	if !haveDomain && !haveBus && !haveSlot {
+		return
+	}
+
+	// The list may request only some components, so complete the host address
+	// from the mapping: exactly one host device can match the components that
+	// were asked for.
+	hostAddr, ok := matchHostPCIAddr(nvp.hostToGuestPCIAddr, hostDomain, haveDomain, hostBus, haveBus, hostSlot, haveSlot)
+	if !ok {
+		return
+	}
+	guestAddr := nvp.hostToGuestPCIAddr[hostAddr]
+	guestDomain, guestBus, guestSlot, _ := UnpackPCIAddr(guestAddr)
+	if offDomain >= 0 {
+		hostarch.ByteOrder.PutUint32(buf[offDomain:], guestDomain)
+	}
+	if offBus >= 0 {
+		hostarch.ByteOrder.PutUint32(buf[offBus:], uint32(guestBus))
+	}
+	if offSlot >= 0 {
+		hostarch.ByteOrder.PutUint32(buf[offSlot:], uint32(guestSlot))
+	}
+	if log.IsLogging(log.Debug) {
+		fi.ctx.Debugf("nvproxy: NV2080_CTRL_CMD_BUS_GET_INFO_V2: translated PCI address %s (host) to %s (guest) [%v]",
+			formatPCIAddr(hostAddr), formatPCIAddr(guestAddr), scope)
+	}
+}
+
+// matchHostPCIAddr returns the single host PCI address in m consistent with
+// the components that were reported, and whether there is exactly one. A
+// request that names components matching no device, or more than one, is left
+// alone: guessing which device was meant is how the wrong GPU gets picked.
+func matchHostPCIAddr(m map[uint64]uint64, domain uint32, haveDomain bool, bus uint32, haveBus bool, slot uint32, haveSlot bool) (uint64, bool) {
+	var found uint64
+	n := 0
+	for host := range m {
+		hDomain, hBus, hSlot, _ := UnpackPCIAddr(host)
+		if haveDomain && hDomain != domain {
+			continue
+		}
+		if haveBus && uint32(hBus) != bus {
+			continue
+		}
+		if haveSlot && uint32(hSlot) != slot {
+			continue
+		}
+		found = host
+		n++
+	}
+	return found, n == 1
+}

--- a/pkg/sentry/devices/nvproxy/pciaddr_test.go
+++ b/pkg/sentry/devices/nvproxy/pciaddr_test.go
@@ -1,0 +1,207 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"testing"
+
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+)
+
+func TestPackPCIAddrRoundTrip(t *testing.T) {
+	for _, test := range []struct {
+		domain             uint32
+		bus, slot, funcNum uint8
+		want               string
+	}{
+		{0x0000, 0x07, 0x00, 0x0, "0000:07:00.0"},
+		{0x0000, 0xca, 0x00, 0x0, "0000:ca:00.0"},
+		{0x1234, 0xff, 0x1f, 0x7, "1234:ff:1f.7"},
+		{0, 0, 0, 0, "0000:00:00.0"},
+	} {
+		v := PackPCIAddr(test.domain, test.bus, test.slot, test.funcNum)
+		d, b, s, f := UnpackPCIAddr(v)
+		if d != test.domain || b != test.bus || s != test.slot || f != test.funcNum {
+			t.Errorf("UnpackPCIAddr(PackPCIAddr(%#x,%#x,%#x,%#x)) = (%#x,%#x,%#x,%#x)", test.domain, test.bus, test.slot, test.funcNum, d, b, s, f)
+		}
+		if got := formatPCIAddr(v); got != test.want {
+			t.Errorf("formatPCIAddr() = %q, want %q", got, test.want)
+		}
+	}
+	// Distinct addresses must pack distinctly, or one GPU's address would map
+	// onto another's.
+	seen := make(map[uint64]struct{})
+	for _, v := range []uint64{
+		PackPCIAddr(0, 0x07, 0, 0),
+		PackPCIAddr(0, 0x08, 0, 0),
+		PackPCIAddr(0, 0, 0x07, 0),
+		PackPCIAddr(1, 0, 0, 0),
+	} {
+		if _, ok := seen[v]; ok {
+			t.Errorf("two distinct PCI addresses pack to %#x", v)
+		}
+		seen[v] = struct{}{}
+	}
+}
+
+func TestMatchHostPCIAddr(t *testing.T) {
+	a := PackPCIAddr(0, 0x07, 0x00, 0)
+	b := PackPCIAddr(0, 0x0b, 0x00, 0)
+	m := map[uint64]uint64{a: PackPCIAddr(0, 0x03, 0x00, 0), b: PackPCIAddr(0, 0x04, 0x00, 0)}
+
+	// All three components, exact.
+	if got, ok := matchHostPCIAddr(m, 0, true, 0x07, true, 0x00, true); !ok || got != a {
+		t.Errorf("matchHostPCIAddr(full) = (%#x, %v), want (%#x, true)", got, ok, a)
+	}
+	// Bus alone is enough to pick one out here.
+	if got, ok := matchHostPCIAddr(m, 0, false, 0x0b, true, 0, false); !ok || got != b {
+		t.Errorf("matchHostPCIAddr(bus only) = (%#x, %v), want (%#x, true)", got, ok, b)
+	}
+	// Domain alone matches both: ambiguous, so no translation rather than a
+	// guess at which GPU was meant.
+	if _, ok := matchHostPCIAddr(m, 0, true, 0, false, 0, false); ok {
+		t.Errorf("matchHostPCIAddr(ambiguous) reported a match")
+	}
+	// A device that is not ours matches nothing.
+	if _, ok := matchHostPCIAddr(m, 0, true, 0x99, true, 0, true); ok {
+		t.Errorf("matchHostPCIAddr(absent) reported a match")
+	}
+	// An empty map never matches.
+	if _, ok := matchHostPCIAddr(nil, 0, true, 0x07, true, 0x00, true); ok {
+		t.Errorf("matchHostPCIAddr(nil map) reported a match")
+	}
+}
+
+// TestCardInfoFieldsSurviveRoundTrip pins that translateCardInfo edits the
+// fields it means to: an entry is unmarshalled, three identities are changed,
+// and everything else must come back unchanged.
+func TestCardInfoFieldsSurviveRoundTrip(t *testing.T) {
+	var ci nvgpu.IoctlCardInfo
+	ci.Valid = 1
+	ci.GPUID = 0xc400
+	ci.MinorNumber = 5
+	ci.PCIInfo.Domain = 0
+	ci.PCIInfo.Bus = 0x0b
+	ci.PCIInfo.Slot = 0x00
+	ci.PCIInfo.Function = 0
+	ci.PCIInfo.VendorID = 0x10de
+	ci.PCIInfo.DeviceID = 0x2330
+	ci.RegAddress = 0xdeadbeef00000000
+	ci.FBSize = 0x123456789
+	ci.InterruptLine = 0x42
+
+	buf := make([]byte, ci.SizeBytes())
+	ci.MarshalBytes(buf)
+
+	var back nvgpu.IoctlCardInfo
+	back.UnmarshalBytes(buf)
+	back.GPUID = 0x400
+	back.MinorNumber = 3
+	back.PCIInfo.Bus = 0x07
+	back.MarshalBytes(buf)
+
+	var final nvgpu.IoctlCardInfo
+	final.UnmarshalBytes(buf)
+	if final.GPUID != 0x400 || final.MinorNumber != 3 || final.PCIInfo.Bus != 0x07 {
+		t.Errorf("translated fields did not survive: gpuId=%#x minor=%d bus=%#x", final.GPUID, final.MinorNumber, final.PCIInfo.Bus)
+	}
+	if final.PCIInfo.VendorID != 0x10de || final.PCIInfo.DeviceID != 0x2330 {
+		t.Errorf("PCI vendor/device ids were disturbed: %#x/%#x", final.PCIInfo.VendorID, final.PCIInfo.DeviceID)
+	}
+	if final.RegAddress != ci.RegAddress || final.FBSize != ci.FBSize || final.InterruptLine != ci.InterruptLine {
+		t.Errorf("unrelated card info fields were disturbed")
+	}
+	if final.Valid != 1 {
+		t.Errorf("Valid was disturbed")
+	}
+}
+
+// TestBusGetInfoV2ParamsSize pins the modelled layout of
+// NV2080_CTRL_BUS_GET_INFO_V2_PARAMS against the entry size nvgpu computes.
+func TestBusGetInfoV2ParamsSize(t *testing.T) {
+	if got, want := int(nvgpu.CtrlXxxInfoSize), 8; got != want {
+		t.Fatalf("NVXXXX_CTRL_XXX_INFO is %d bytes, want %d ({NvU32 index, NvU32 data})", got, want)
+	}
+	if got, want := busGetInfoV2ParamsSize, 4+0x34*8; got != want {
+		t.Errorf("busGetInfoV2ParamsSize = %d, want %d", got, want)
+	}
+	// The three PCI indices, from ctrl2080bus.h.
+	if busInfoIndexBusNumber != 0x0f || busInfoIndexDeviceNumber != 0x10 || busInfoIndexDomainNumber != 0x2c {
+		t.Errorf("bus info indices are %#x/%#x/%#x, want 0xf/0x10/0x2c", busInfoIndexBusNumber, busInfoIndexDeviceNumber, busInfoIndexDomainNumber)
+	}
+}
+
+// TestRemapPairsSkipsUnrecordedPCIAddrs pins backward compatibility: a
+// checkpoint written before nvproxy recorded PCI addresses yields no PCI
+// mapping at all, rather than a mapping onto 0000:00:00.0.
+func TestRemapPairsSkipsUnrecordedPCIAddrs(t *testing.T) {
+	dr := &DeviceRemapping{NewDeviceByOld: map[*DeviceRemapID]*DeviceRemapID{}}
+	oldDev := &DeviceRemapID{DeviceInstance: 1, Minor: 2} // no PCIAddrValid
+	newDev := &DeviceRemapID{DeviceInstance: 6, Minor: 5, PCIBus: 0x0b, PCIAddrValid: true}
+	dr.NewDeviceByOld[oldDev] = newDev
+
+	_, _, _, _, pciAddrs := remapPairs(dr)
+	if len(pciAddrs) != 0 {
+		t.Errorf("remapPairs() produced %d PCI address pairs from an old checkpoint, want 0", len(pciAddrs))
+	}
+
+	// With both sides recorded, the pair appears.
+	oldDev.PCIBus = 0x07
+	oldDev.PCIAddrValid = true
+	_, _, _, _, pciAddrs = remapPairs(dr)
+	if len(pciAddrs) != 1 {
+		t.Fatalf("remapPairs() produced %d PCI address pairs, want 1", len(pciAddrs))
+	}
+	if pciAddrs[0][0] != PackPCIAddr(0, 0x07, 0, 0) || pciAddrs[0][1] != PackPCIAddr(0, 0x0b, 0, 0) {
+		t.Errorf("remapPairs() PCI pair = %s -> %s", formatPCIAddr(pciAddrs[0][0]), formatPCIAddr(pciAddrs[0][1]))
+	}
+}
+
+// TestPCIAddrMapComposesAcrossRestores pins that a process restored twice
+// still sees the PCI address of its original boot.
+func TestPCIAddrMapComposesAcrossRestores(t *testing.T) {
+	boot := PackPCIAddr(0, 0x07, 0, 0)
+	first := PackPCIAddr(0, 0x0b, 0, 0)
+	second := PackPCIAddr(0, 0x4e, 0, 0)
+
+	m := composeMap[uint64](nil, [][2]uint64{{boot, first}})
+	if m[first] != boot {
+		t.Fatalf("after one restore %s maps to %s, want %s", formatPCIAddr(first), formatPCIAddr(m[first]), formatPCIAddr(boot))
+	}
+	m = composeMap(m, [][2]uint64{{first, second}})
+	if m[second] != boot {
+		t.Errorf("after two restores %s maps to %s, want %s", formatPCIAddr(second), formatPCIAddr(m[second]), formatPCIAddr(boot))
+	}
+	if _, ok := m[first]; ok {
+		t.Errorf("a stale intermediate PCI address was kept: %v", m)
+	}
+	inv := invertMap(m, "PCI address")
+	if inv[boot] != second {
+		t.Errorf("guest-to-host PCI address = %s, want %s", formatPCIAddr(inv[boot]), formatPCIAddr(second))
+	}
+}
+
+// TestDeviceRemapIDPCIAddrString pins how an unrecorded address is reported,
+// so a log line cannot be read as "domain 0, bus 0".
+func TestDeviceRemapIDPCIAddrString(t *testing.T) {
+	id := &DeviceRemapID{}
+	if got, want := id.PCIAddrString(), "<unrecorded>"; got != want {
+		t.Errorf("PCIAddrString() = %q, want %q", got, want)
+	}
+	id = &DeviceRemapID{PCIDomain: 0, PCIBus: 0x0b, PCISlot: 0, PCIFunction: 0, PCIAddrValid: true}
+	if got, want := id.PCIAddrString(), "0000:0b:00.0"; got != want {
+		t.Errorf("PCIAddrString() = %q, want %q", got, want)
+	}
+}

--- a/pkg/sentry/devices/nvproxy/procfs.go
+++ b/pkg/sentry/devices/nvproxy/procfs.go
@@ -17,6 +17,8 @@ package nvproxy
 import (
 	"fmt"
 
+	"gvisor.dev/gvisor/pkg/context"
+	"gvisor.dev/gvisor/pkg/sentry/kernel"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 )
 
@@ -58,4 +60,24 @@ func procfsCapability(devMinor, mode uint32) string {
 	// consistent with our treatment of ModifyDeviceFiles in
 	// /proc/driver/nvidia/params.
 	return fmt.Sprintf("DeviceFileMinor: %d\nDeviceFileMode: %d\nDeviceFileModify: 0\n", devMinor, mode)
+}
+
+// GPUUUIDMapFromContext returns the restored caller's CUDA UUIDs mapped to
+// physical host UUIDs. External resource admission needs physical identities,
+// while CUDA and NCCL must retain the checkpointed identities. Fresh processes
+// use host identities already and receive an empty map. The result is a copy.
+func GPUUUIDMapFromContext(ctx context.Context) map[string]string {
+	nvp := nvproxyFromVFS(kernel.KernelFromContext(ctx).VFS())
+	return nvp.gpuUUIDMap(scopeFor(kernel.TaskFromContext(ctx)))
+}
+
+func (nvp *nvproxy) gpuUUIDMap(scope translationScope) map[string]string {
+	out := make(map[string]string)
+	if nvp == nil || !scope.Restored {
+		return out
+	}
+	for guest, host := range nvp.guestToHostUUID {
+		out[guest] = host
+	}
+	return out
 }

--- a/pkg/sentry/devices/nvproxy/save_restore.go
+++ b/pkg/sentry/devices/nvproxy/save_restore.go
@@ -87,6 +87,17 @@ type DeviceRemapID struct {
 	// invocation of NV2080_CTRL_CMD_GPU_SET_SDM.
 	SubDeviceInstance uint32 `json:"subdevice_instance"`
 
+	// PCIDomain, PCIBus, PCISlot and PCIFunction are the device's PCI address,
+	// from nv_pci_info_t as reported by NV_ESC_CARD_INFO. PCIAddrValid says
+	// whether they were recorded: a checkpoint written before nvproxy recorded
+	// them decodes with all four zero, which is indistinguishable from a
+	// legitimate 0000:00:00.0, so the flag is what the restore checks.
+	PCIDomain    uint32 `json:"pci_domain"`
+	PCIBus       uint8  `json:"pci_bus"`
+	PCISlot      uint8  `json:"pci_slot"`
+	PCIFunction  uint8  `json:"pci_function"`
+	PCIAddrValid bool   `json:"pci_addr_valid"`
+
 	// UUID is the "UUID", including the "GPU-" prefix, as printed by
 	// `nvidia-smi -L`. This is provided by the GSP, and retrieved and
 	// stringified by src/nvidia/src/kernel/gpu/gpu.c:gpuGetGidInfo_IMPL().
@@ -99,7 +110,17 @@ type DeviceRemapID struct {
 
 // String implements fmt.Stringer.String.
 func (id *DeviceRemapID) String() string {
-	return fmt.Sprintf("{Minor:%d PCIVendorID:0x%04x PCIDeviceID:0x%04x GPUID:%#x DeviceInstance:%d SubDeviceInstance:%d UUID:%s}", id.Minor, id.PCIVendorID, id.PCIDeviceID, id.GPUID, id.DeviceInstance, id.SubDeviceInstance, id.UUID)
+	return fmt.Sprintf("{Minor:%d PCIVendorID:0x%04x PCIDeviceID:0x%04x PCIAddr:%s GPUID:%#x DeviceInstance:%d SubDeviceInstance:%d UUID:%s}", id.Minor, id.PCIVendorID, id.PCIDeviceID, id.PCIAddrString(), id.GPUID, id.DeviceInstance, id.SubDeviceInstance, id.UUID)
+}
+
+// PCIAddrString renders the device's PCI address in the conventional
+// domain:bus:slot.function form, or "<unrecorded>" for a device saved before
+// nvproxy recorded it.
+func (id *DeviceRemapID) PCIAddrString() string {
+	if !id.PCIAddrValid {
+		return "<unrecorded>"
+	}
+	return fmt.Sprintf("%04x:%02x:%02x.%x", id.PCIDomain, id.PCIBus, id.PCISlot, id.PCIFunction)
 }
 
 // CheckDevicesRemappable checks that the set of devices in ids can be saved.

--- a/pkg/sentry/devices/nvproxy/save_restore.go
+++ b/pkg/sentry/devices/nvproxy/save_restore.go
@@ -18,6 +18,7 @@ import (
 	goContext "context"
 	"fmt"
 	"path/filepath"
+	"sort"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/abi/nvgpu"
@@ -263,6 +264,11 @@ func (nvp *nvproxy) afterLoad(ctx goContext.Context) {
 				}
 			}
 		}
+		// Applications keep their own tables keyed by the identifiers they saw
+		// before the checkpoint, so remember how to translate each family of
+		// identifier in both directions. All three come from the same
+		// DeviceRemapID pairs.
+		nvp.composeIDMaps(dr)
 	}
 
 	// Ensure that frontendFDs have host FDs before restoring objects that may
@@ -319,6 +325,89 @@ func (nvp *nvproxy) afterLoad(ctx goContext.Context) {
 		}
 		// Reuse slice across iterations.
 		depHs = depHs[:0]
+	}
+}
+
+// remapPairs returns dr's old->new pairs for each family of identifier, in a
+// deterministic order so that logging and composition do not vary run to run.
+// It is separated from composeIDMaps() so that the composition can be tested
+// without constructing a DeviceRemapping.
+func remapPairs(dr *DeviceRemapping) (devInsts [][2]uint32, gpuIDs [][2]uint32, uuids [][2]string, minors [][2]uint32, pciAddrs [][2]uint64) {
+	olds := make([]*DeviceRemapID, 0, len(dr.NewDeviceByOld))
+	for oldDev := range dr.NewDeviceByOld {
+		olds = append(olds, oldDev)
+	}
+	sort.Slice(olds, func(i, j int) bool { return olds[i].DeviceInstance < olds[j].DeviceInstance })
+	for _, oldDev := range olds {
+		newDev := dr.NewDeviceByOld[oldDev]
+		devInsts = append(devInsts, [2]uint32{oldDev.DeviceInstance, newDev.DeviceInstance})
+		gpuIDs = append(gpuIDs, [2]uint32{oldDev.GPUID, newDev.GPUID})
+		uuids = append(uuids, [2]string{oldDev.UUID, newDev.UUID})
+		minors = append(minors, [2]uint32{oldDev.Minor, newDev.Minor})
+		if oldDev.PCIAddrValid && newDev.PCIAddrValid {
+			pciAddrs = append(pciAddrs, [2]uint64{packPCIAddr(oldDev), packPCIAddr(newDev)})
+		}
+	}
+	return devInsts, gpuIDs, uuids, minors, pciAddrs
+}
+
+// packPCIAddr encodes a device's PCI address as one value, so that it can be
+// mapped with the same machinery as every other identifier.
+func packPCIAddr(id *DeviceRemapID) uint64 {
+	return PackPCIAddr(id.PCIDomain, id.PCIBus, id.PCISlot, id.PCIFunction)
+}
+
+// composeIDMaps folds dr into nvp's identifier translation tables. It runs
+// while the sandbox is paused, so it takes no lock.
+func (nvp *nvproxy) composeIDMaps(dr *DeviceRemapping) {
+	devInsts, gpuIDs, uuids, minors, pciAddrs := remapPairs(dr)
+
+	nvp.hostToGuestDeviceInstance = composeIDMap(nvp.hostToGuestDeviceInstance, devInsts)
+	nvp.guestToHostDeviceInstance = invertIDMap(nvp.hostToGuestDeviceInstance, "device instance")
+	nvp.hostToGuestGPUID = composeIDMap(nvp.hostToGuestGPUID, gpuIDs)
+	nvp.guestToHostGPUID = invertIDMap(nvp.hostToGuestGPUID, "gpuId")
+	nvp.hostToGuestUUID = composeUUIDMap(nvp.hostToGuestUUID, uuids)
+	nvp.guestToHostUUID = invertUUIDMap(nvp.hostToGuestUUID)
+	nvp.hostToGuestMinor = composeIDMap(nvp.hostToGuestMinor, minors)
+	nvp.guestToHostMinor = invertIDMap(nvp.hostToGuestMinor, "device minor")
+	if len(pciAddrs) == len(dr.NewDeviceByOld) {
+		nvp.hostToGuestPCIAddr = composeMap(nvp.hostToGuestPCIAddr, pciAddrs)
+		nvp.guestToHostPCIAddr = invertMap(nvp.hostToGuestPCIAddr, "PCI address")
+	} else {
+		// A checkpoint written before nvproxy recorded PCI addresses. Leave
+		// whatever a previous restore established rather than composing a
+		// partial mapping: a stale PCI address reaching a restored process is
+		// the failure this translation exists to prevent, but a wrong one is
+		// worse.
+		log.Warningf("nvproxy: %d of %d remapped devices have no recorded PCI address, so PCI addresses will not be translated; re-checkpoint with this build to enable it",
+			len(dr.NewDeviceByOld)-len(pciAddrs), len(dr.NewDeviceByOld))
+	}
+
+	if log.IsLogging(log.Debug) {
+		log.Debugf("nvproxy: host-to-guest device instance mapping after restore: %s", formatIDMap(nvp.hostToGuestDeviceInstance))
+		log.Debugf("nvproxy: host-to-guest gpuId mapping after restore: %s", formatIDMap(nvp.hostToGuestGPUID))
+		log.Debugf("nvproxy: host-to-guest UUID mapping after restore: %s", formatUUIDMap(nvp.hostToGuestUUID))
+		log.Debugf("nvproxy: guest-to-host device minor mapping after restore: %s", formatIDMap(nvp.guestToHostMinor))
+		log.Debugf("nvproxy: host-to-guest PCI address mapping after restore: %s", formatPCIAddrMap(nvp.hostToGuestPCIAddr))
+	}
+}
+
+// translateDeviceInstanceToGuest rewrites the device instance reported by
+// ctrlParams from a host device instance to the device instance that the
+// application saw before the most recent checkpoint. It is a no-op if this
+// sandbox has never been restored onto a different set of devices.
+func (nvp *nvproxy) translateDeviceInstanceToGuest(ctrlParams nvgpu.HasDeviceInstance, scope translationScope) {
+	if len(nvp.hostToGuestDeviceInstance) == 0 {
+		return
+	}
+	hostDevInst := ctrlParams.GetDeviceInstance()
+	guestDevInst, ok := nvp.hostToGuestDeviceInstance[hostDevInst]
+	if !ok {
+		return
+	}
+	ctrlParams.SetDeviceInstance(guestDevInst)
+	if log.IsLogging(log.Debug) {
+		log.Debugf("nvproxy: translated device instance %d (host) to %d (guest) [%v]", hostDevInst, guestDevInst, scope)
 	}
 }
 

--- a/pkg/sentry/devices/nvproxy/save_restore_test.go
+++ b/pkg/sentry/devices/nvproxy/save_restore_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"testing"
+)
+
+// remappingFromDeviceInstances builds a DeviceRemapping that maps each old
+// device instance in pairs to the new one beside it. Only DeviceInstance
+// matters to composeIDMap().
+func remappingFromDeviceInstances(pairs [][2]uint32) *DeviceRemapping {
+	dr := &DeviceRemapping{
+		NewDeviceByOld:            make(map[*DeviceRemapID]*DeviceRemapID),
+		OldDeviceByMinor:          make(map[uint32]*DeviceRemapID),
+		OldDeviceByDeviceInstance: make(map[uint32]*DeviceRemapID),
+	}
+	for _, pair := range pairs {
+		oldID := &DeviceRemapID{DeviceInstance: pair[0]}
+		newID := &DeviceRemapID{DeviceInstance: pair[1]}
+		dr.NewDeviceByOld[oldID] = newID
+		dr.OldDeviceByDeviceInstance[oldID.DeviceInstance] = oldID
+	}
+	return dr
+}
+
+func TestComposeIDMap(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		prev  map[uint32]uint32
+		pairs [][2]uint32
+		want  map[uint32]uint32
+	}{
+		{
+			name:  "first restore",
+			prev:  nil,
+			pairs: [][2]uint32{{0, 4}, {1, 7}},
+			want:  map[uint32]uint32{4: 0, 7: 1},
+		},
+		{
+			name:  "identity remapping still recorded",
+			prev:  nil,
+			pairs: [][2]uint32{{0, 0}, {1, 1}},
+			want:  map[uint32]uint32{0: 0, 1: 1},
+		},
+		{
+			// A sandbox booted on 0,1 was restored onto 4,7 and is now
+			// restored onto 2,3: it must still report 0,1.
+			name:  "second restore composes with the first",
+			prev:  map[uint32]uint32{4: 0, 7: 1},
+			pairs: [][2]uint32{{4, 2}, {7, 3}},
+			want:  map[uint32]uint32{2: 0, 3: 1},
+		},
+		{
+			// Overlapping old and new sets: the entry for the device that
+			// kept its instance must not be clobbered by the one that took it.
+			name:  "overlapping sets",
+			prev:  map[uint32]uint32{2: 0, 3: 1},
+			pairs: [][2]uint32{{2, 3}, {3, 5}},
+			want:  map[uint32]uint32{3: 0, 5: 1},
+		},
+		{
+			// An old device instance absent from prev was never remapped, so
+			// it is its own guest instance.
+			name:  "old instance missing from prev maps to itself",
+			prev:  map[uint32]uint32{4: 0},
+			pairs: [][2]uint32{{4, 6}, {9, 8}},
+			want:  map[uint32]uint32{6: 0, 8: 9},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := composeIDMap(test.prev, test.pairs)
+			if len(got) != len(test.want) {
+				t.Fatalf("composeIDMap() = %v, want %v", got, test.want)
+			}
+			for host, wantGuest := range test.want {
+				gotGuest, ok := got[host]
+				if !ok {
+					t.Errorf("composeIDMap() = %v, missing host device instance %d", got, host)
+					continue
+				}
+				if gotGuest != wantGuest {
+					t.Errorf("composeIDMap()[%d] = %d, want %d", host, gotGuest, wantGuest)
+				}
+			}
+			// The input must not be mutated: it is the saved state of a
+			// sandbox that may still be read by a concurrent log line.
+			if test.prev != nil {
+				if _, ok := test.prev[0xdead]; ok {
+					t.Errorf("prev was mutated")
+				}
+			}
+		})
+	}
+}
+
+func TestFormatIDMapIsOrdered(t *testing.T) {
+	m := map[uint32]uint32{7: 1, 2: 3, 4: 0}
+	const want = "{2 -> 3, 4 -> 0, 7 -> 1}"
+	for i := 0; i < 16; i++ {
+		if got := formatIDMap(m); got != want {
+			t.Fatalf("formatIDMap() = %q, want %q", got, want)
+		}
+	}
+	if got, want := formatIDMap(nil), "{}"; got != want {
+		t.Errorf("formatIDMap(nil) = %q, want %q", got, want)
+	}
+}
+
+// TestRemapPairsCoversAllThreeIdentifiers pins that the device instance, gpuId
+// and UUID mappings all come from the same DeviceRemapID pairs, in the same
+// order.
+func TestRemapPairsCoversAllThreeIdentifiers(t *testing.T) {
+	dr := &DeviceRemapping{NewDeviceByOld: map[*DeviceRemapID]*DeviceRemapID{}}
+	old0 := &DeviceRemapID{DeviceInstance: 0, GPUID: 0x1111, Minor: 2, UUID: "GPU-00000000-0000-0000-0000-000000000000"}
+	new0 := &DeviceRemapID{DeviceInstance: 4, GPUID: 0x4444, Minor: 4, UUID: "GPU-44444444-0000-0000-0000-000000000000"}
+	old1 := &DeviceRemapID{DeviceInstance: 1, GPUID: 0x2222, Minor: 3, UUID: "GPU-11111111-0000-0000-0000-000000000000"}
+	new1 := &DeviceRemapID{DeviceInstance: 7, GPUID: 0x7777, Minor: 6, UUID: "GPU-77777777-0000-0000-0000-000000000000"}
+	dr.NewDeviceByOld[old0] = new0
+	dr.NewDeviceByOld[old1] = new1
+
+	// Ordered by old device instance, so the result does not vary with map
+	// iteration order.
+	for i := 0; i < 16; i++ {
+		devInsts, gpuIDs, uuids, minors, _ := remapPairs(dr)
+		if want := [][2]uint32{{0, 4}, {1, 7}}; !equalPairs(devInsts, want) {
+			t.Fatalf("remapPairs() device instances = %v, want %v", devInsts, want)
+		}
+		if want := [][2]uint32{{0x1111, 0x4444}, {0x2222, 0x7777}}; !equalPairs(gpuIDs, want) {
+			t.Fatalf("remapPairs() gpuIds = %v, want %v", gpuIDs, want)
+		}
+		if len(uuids) != 2 || uuids[0][0] != old0.UUID || uuids[0][1] != new0.UUID {
+			t.Fatalf("remapPairs() uuids = %v", uuids)
+		}
+		if want := [][2]uint32{{2, 4}, {3, 6}}; !equalPairs(minors, want) {
+			t.Fatalf("remapPairs() minors = %v, want %v", minors, want)
+		}
+	}
+}
+
+func equalPairs(got, want [][2]uint32) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestInvertIDMapDropsAmbiguousEntries(t *testing.T) {
+	inv := invertIDMap(map[uint32]uint32{4: 0, 7: 1}, "test")
+	if len(inv) != 2 || inv[0] != 4 || inv[1] != 7 {
+		t.Errorf("invertIDMap() = %v, want {0:4, 1:7}", inv)
+	}
+	// Two hosts claiming the same guest: neither may be resolved inward.
+	inv = invertIDMap(map[uint32]uint32{4: 0, 7: 0, 9: 3}, "test")
+	if _, ok := inv[0]; ok {
+		t.Errorf("invertIDMap() kept an ambiguous entry: %v", inv)
+	}
+	if inv[3] != 9 {
+		t.Errorf("invertIDMap() dropped an unambiguous entry: %v", inv)
+	}
+}
+
+func TestPermuteDeviceInstanceMask(t *testing.T) {
+	m := map[uint32]uint32{4: 0, 7: 1}
+	// Bits 4 and 7 set -> bits 0 and 1 set.
+	if got, want := permuteDeviceInstanceMask(1<<4|1<<7, m), uint32(1<<0|1<<1); got != want {
+		t.Errorf("permuteDeviceInstanceMask(0x90) = %#x, want %#x", got, want)
+	}
+	// A bit with no translation is carried through.
+	if got, want := permuteDeviceInstanceMask(1<<4|1<<9, m), uint32(1<<0|1<<9); got != want {
+		t.Errorf("permuteDeviceInstanceMask() = %#x, want %#x", got, want)
+	}
+	// An empty map is the identity.
+	if got, want := permuteDeviceInstanceMask(0xdeadbeef, nil), uint32(0xdeadbeef); got != want {
+		t.Errorf("permuteDeviceInstanceMask() = %#x, want %#x", got, want)
+	}
+	if got, want := permuteDeviceInstanceMask(0, m), uint32(0); got != want {
+		t.Errorf("permuteDeviceInstanceMask(0) = %#x, want %#x", got, want)
+	}
+}
+
+func TestComposeUUIDMap(t *testing.T) {
+	const (
+		a = "GPU-aaaaaaaa-0000-0000-0000-000000000000"
+		b = "GPU-bbbbbbbb-0000-0000-0000-000000000000"
+		c = "GPU-cccccccc-0000-0000-0000-000000000000"
+	)
+	first := composeUUIDMap(nil, [][2]string{{a, b}})
+	if first[b] != a {
+		t.Fatalf("composeUUIDMap() = %v, want {%s: %s}", first, b, a)
+	}
+	// Restored again onto a third device: still reports the original.
+	second := composeUUIDMap(first, [][2]string{{b, c}})
+	if second[c] != a {
+		t.Errorf("composeUUIDMap() = %v, want {%s: %s}", second, c, a)
+	}
+	if _, ok := second[b]; ok {
+		t.Errorf("composeUUIDMap() kept a stale host UUID: %v", second)
+	}
+}
+
+func TestUUIDBinaryRoundTrip(t *testing.T) {
+	const s = "GPU-0123456789abcdef-fedc-ba98-7654-3210deadbeef"
+	if _, ok := uuidBinary(s); ok {
+		t.Errorf("uuidBinary(%q) accepted a malformed UUID", s)
+	}
+	const good = "GPU-01234567-89ab-cdef-fedc-ba9876543210"
+	bin, ok := uuidBinary(good)
+	if !ok {
+		t.Fatalf("uuidBinary(%q) failed", good)
+	}
+	if got := formatUUID(bin[:]); got != good {
+		t.Errorf("formatUUID(uuidBinary(%q)) = %q", good, got)
+	}
+	if _, ok := uuidBinary("not a uuid"); ok {
+		t.Errorf("uuidBinary() accepted junk")
+	}
+}
+
+func TestFormatUUIDZero(t *testing.T) {
+	var zero [16]byte
+	if got := formatUUID(zero[:]); got != "<zero>" {
+		t.Errorf("formatUUID(zero) = %q, want <zero>", got)
+	}
+	if got := formatUUID([]byte{1, 2}); got != "<short>" {
+		t.Errorf("formatUUID(short) = %q, want <short>", got)
+	}
+}
+
+// TestMinorMapComposesAcrossRestores pins the map that decides where a
+// restored process's open of an old /dev/nvidia# is sent. A process restored
+// twice still names the minor it saw on its original boot.
+func TestMinorMapComposesAcrossRestores(t *testing.T) {
+	// Booted on minors 2,3; restored onto 4,6.
+	hostToGuest := composeIDMap(nil, [][2]uint32{{2, 4}, {3, 6}})
+	guestToHost := invertIDMap(hostToGuest, "device minor")
+	if guestToHost[2] != 4 || guestToHost[3] != 6 {
+		t.Fatalf("after one restore guestToHostMinor = %v, want {2:4, 3:6}", guestToHost)
+	}
+	// Checkpointed again and restored onto 0,1. The process still opens
+	// /dev/nvidia2 and /dev/nvidia3, which must now reach 0 and 1.
+	hostToGuest = composeIDMap(hostToGuest, [][2]uint32{{4, 0}, {6, 1}})
+	guestToHost = invertIDMap(hostToGuest, "device minor")
+	if guestToHost[2] != 0 || guestToHost[3] != 1 {
+		t.Errorf("after two restores guestToHostMinor = %v, want {2:0, 3:1}", guestToHost)
+	}
+	if _, ok := guestToHost[4]; ok {
+		t.Errorf("guestToHostMinor kept a stale intermediate minor: %v", guestToHost)
+	}
+}
+
+// TestMinorMapIdentityRemapIsHarmless pins that a restore onto the same minors
+// leaves an open pointing at the minor the caller named.
+func TestMinorMapIdentityRemapIsHarmless(t *testing.T) {
+	hostToGuest := composeIDMap(nil, [][2]uint32{{2, 2}, {3, 3}})
+	guestToHost := invertIDMap(hostToGuest, "device minor")
+	if guestToHost[2] != 2 || guestToHost[3] != 3 {
+		t.Errorf("guestToHostMinor = %v, want the identity", guestToHost)
+	}
+}

--- a/pkg/sentry/devices/nvproxy/save_restore_unsafe.go
+++ b/pkg/sentry/devices/nvproxy/save_restore_unsafe.go
@@ -70,6 +70,11 @@ func FillDeviceRemapIDsFromMinor(ctx context.Context, ctlDevClient *devutil.Gofe
 		}
 		id.PCIVendorID = ci.PCIInfo.VendorID
 		id.PCIDeviceID = ci.PCIInfo.DeviceID
+		id.PCIDomain = ci.PCIInfo.Domain
+		id.PCIBus = ci.PCIInfo.Bus
+		id.PCISlot = ci.PCIInfo.Slot
+		id.PCIFunction = ci.PCIInfo.Function
+		id.PCIAddrValid = true
 		id.GPUID = ci.GPUID
 	}
 

--- a/pkg/sentry/devices/nvproxy/uuid.go
+++ b/pkg/sentry/devices/nvproxy/uuid.go
@@ -1,0 +1,196 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+)
+
+// UVM identifies GPUs by UUID rather than by device instance or gpuId: every
+// UVM ioctl parameter struct that names a GPU carries an NvProcessorUuid,
+// modelled here as nvgpu.NvUUID. After a restore that remapped devices, the
+// application passes the UUIDs of the GPUs it had before the checkpoint, which
+// the host driver does not recognise -- UVM_MAP_EXTERNAL_ALLOCATION then fails
+// with NV_ERR_INVALID_DEVICE, which CUDA reports out of cuMemSetAccess() as
+// CUDA_ERROR_INVALID_DEVICE.
+//
+// Rather than enumerate the parameter types that carry one, nvproxy finds
+// every NvUUID inside a parameter struct by walking its type once and caching
+// the byte offsets. That cannot miss a parameter type, including the array of
+// per-GPU attributes in UVM_MAP_EXTERNAL_ALLOCATION_PARAMS, and it needs no
+// per-type method.
+
+// uuidSize is the width of an NvProcessorUuid.
+const uuidSize = 16
+
+// uuidOffsetCache memoises uuidOffsetsOf by type.
+var uuidOffsetCache sync.Map // reflect.Type -> []int
+
+var nvUUIDType = reflect.TypeOf(nvgpu.NvUUID{})
+
+// uuidOffsetsFor returns the byte offset of every NvUUID inside the type of v,
+// computing and caching it on first use.
+func uuidOffsetsFor(t reflect.Type) []int {
+	if cached, ok := uuidOffsetCache.Load(t); ok {
+		return cached.([]int)
+	}
+	offs := uuidOffsetsOf(t, 0, nil)
+	uuidOffsetCache.Store(t, offs)
+	return offs
+}
+
+// uuidOffsetsOf appends the byte offset of every NvUUID inside t, which itself
+// begins at base, to offs.
+func uuidOffsetsOf(t reflect.Type, base int, offs []int) []int {
+	if t == nvUUIDType {
+		return append(offs, base)
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			offs = uuidOffsetsOf(f.Type, base+int(f.Offset), offs)
+		}
+	case reflect.Array:
+		elem := t.Elem()
+		// Skip arrays that cannot contain a UUID, which is most of them.
+		if !typeMayContainUUID(elem) {
+			return offs
+		}
+		stride := int(elem.Size())
+		for i := 0; i < t.Len(); i++ {
+			offs = uuidOffsetsOf(elem, base+i*stride, offs)
+		}
+	}
+	return offs
+}
+
+// typeMayContainUUID reports whether t is, or transitively contains, an
+// NvUUID. It exists so that uuidOffsetsOf does not walk every element of a
+// large array of scalars.
+func typeMayContainUUID(t reflect.Type) bool {
+	if t == nvUUIDType {
+		return true
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			if typeMayContainUUID(t.Field(i).Type) {
+				return true
+			}
+		}
+	case reflect.Array:
+		return typeMayContainUUID(t.Elem())
+	}
+	return false
+}
+
+// formatUUID renders a raw 16-byte processor UUID the way `nvidia-smi -L` and
+// nvproxy's DeviceRemapID.UUID do.
+func formatUUID(b []byte) string {
+	if len(b) < uuidSize {
+		return "<short>"
+	}
+	var zero bool = true
+	for _, c := range b[:uuidSize] {
+		if c != 0 {
+			zero = false
+			break
+		}
+	}
+	if zero {
+		// The CPU's processor UUID, and the value of an unused slot.
+		return "<zero>"
+	}
+	return fmt.Sprintf("GPU-%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+		b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+		b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15])
+}
+
+// translateUUIDsInBuf rewrites every UUID at the given offsets in buf using m,
+// which is keyed and valued by the "GPU-..." string form. It returns the
+// translations it made, for logging.
+func translateUUIDsInBuf(buf []byte, offs []int, m map[string]string) [][2]string {
+	if len(m) == 0 || len(offs) == 0 {
+		return nil
+	}
+	var done [][2]string
+	for _, off := range offs {
+		if off+uuidSize > len(buf) {
+			continue
+		}
+		from := formatUUID(buf[off:])
+		to, ok := m[from]
+		if !ok {
+			continue
+		}
+		toBin, ok := uuidBinary(to)
+		if !ok {
+			continue
+		}
+		copy(buf[off:off+uuidSize], toBin[:])
+		done = append(done, [2]string{from, to})
+	}
+	return done
+}
+
+// describeUUIDsInBuf renders every non-zero UUID at the given offsets, for a
+// log line.
+func describeUUIDsInBuf(buf []byte, offs []int) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	n := 0
+	for _, off := range offs {
+		if off+uuidSize > len(buf) {
+			continue
+		}
+		s := formatUUID(buf[off:])
+		if s == "<zero>" {
+			continue
+		}
+		if n != 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(s)
+		n++
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+// uvmIoctlLogsUUIDs reports whether a UVM ioctl's UUIDs are worth an Info line.
+// These are the ioctls by which the application builds its view of which GPUs
+// exist and which may reach which memory -- the ones a wrong UUID breaks.
+var uvmIoctlLogsUUIDs = map[uint32]struct{}{
+	nvgpu.UVM_REGISTER_GPU:                   {},
+	nvgpu.UVM_UNREGISTER_GPU:                 {},
+	nvgpu.UVM_REGISTER_GPU_VASPACE:           {},
+	nvgpu.UVM_UNREGISTER_GPU_VASPACE:         {},
+	nvgpu.UVM_ENABLE_PEER_ACCESS:             {},
+	nvgpu.UVM_DISABLE_PEER_ACCESS:            {},
+	nvgpu.UVM_MAP_EXTERNAL_ALLOCATION:        {},
+	nvgpu.UVM_ALLOC_SEMAPHORE_POOL:           {},
+	nvgpu.UVM_SET_PREFERRED_LOCATION:         {},
+	nvgpu.UVM_SET_ACCESSED_BY:                {},
+	nvgpu.UVM_MIGRATE:                        {},
+	nvgpu.UVM_MAP_DYNAMIC_PARALLELISM_REGION: {},
+	nvgpu.UVM_REGISTER_CHANNEL:               {},
+	nvgpu.UVM_PAGEABLE_MEM_ACCESS_ON_GPU:     {},
+}

--- a/pkg/sentry/devices/nvproxy/uuid_test.go
+++ b/pkg/sentry/devices/nvproxy/uuid_test.go
@@ -1,0 +1,521 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvproxy
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"gvisor.dev/gvisor/pkg/abi/nvgpu"
+	"gvisor.dev/gvisor/pkg/hostarch"
+)
+
+const (
+	guestUUID = "GPU-01234567-89ab-cdef-fedc-ba9876543210"
+	hostUUID  = "GPU-fedcba98-7654-3210-0123-456789abcdef"
+)
+
+// TestUUIDOffsetsFindEveryGPUUUID pins that the reflective walk finds the UUID
+// in each UVM parameter type that carries one, including every element of
+// UVM_MAP_EXTERNAL_ALLOCATION_PARAMS.PerGPUAttributes -- the ioctl whose stale
+// UUID makes cuMemSetAccess() fail with CUDA_ERROR_INVALID_DEVICE.
+func TestUUIDOffsetsFindEveryGPUUUID(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		typ   reflect.Type
+		count int
+		first int
+	}{
+		{"UVM_REGISTER_GPU", reflect.TypeOf(nvgpu.UVM_REGISTER_GPU_PARAMS{}), 1, 0},
+		{"UVM_UNREGISTER_GPU", reflect.TypeOf(nvgpu.UVM_UNREGISTER_GPU_PARAMS{}), 1, 0},
+		{"UVM_REGISTER_GPU_VASPACE", reflect.TypeOf(nvgpu.UVM_REGISTER_GPU_VASPACE_PARAMS{}), 1, 0},
+		{"UVM_ENABLE_PEER_ACCESS", reflect.TypeOf(nvgpu.UVM_ENABLE_PEER_ACCESS_PARAMS{}), 2, 0},
+		{"UVM_DISABLE_PEER_ACCESS", reflect.TypeOf(nvgpu.UVM_DISABLE_PEER_ACCESS_PARAMS{}), 2, 0},
+		{"UVM_MAP_EXTERNAL_ALLOCATION", reflect.TypeOf(nvgpu.UVM_MAP_EXTERNAL_ALLOCATION_PARAMS{}), nvgpu.UVM_MAX_GPUS, 24},
+		{"UVM_MAP_EXTERNAL_ALLOCATION_V550", reflect.TypeOf(nvgpu.UVM_MAP_EXTERNAL_ALLOCATION_PARAMS_V550{}), nvgpu.UVM_MAX_GPUS_V2, 24},
+		{"UVM_SET_PREFERRED_LOCATION", reflect.TypeOf(nvgpu.UVM_SET_PREFERRED_LOCATION_PARAMS{}), 1, -1},
+		{"UVM_SET_ACCESSED_BY", reflect.TypeOf(nvgpu.UVM_SET_ACCESSED_BY_PARAMS{}), 1, -1},
+		{"UVM_MIGRATE", reflect.TypeOf(nvgpu.UVM_MIGRATE_PARAMS{}), 1, -1},
+		{"UVM_ALLOC_SEMAPHORE_POOL", reflect.TypeOf(nvgpu.UVM_ALLOC_SEMAPHORE_POOL_PARAMS{}), nvgpu.UVM_MAX_GPUS, -1},
+		{"UVM_REGISTER_CHANNEL", reflect.TypeOf(nvgpu.UVM_REGISTER_CHANNEL_PARAMS{}), 1, 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			offs := uuidOffsetsFor(test.typ)
+			if len(offs) != test.count {
+				t.Fatalf("uuidOffsetsFor(%s) found %d UUIDs, want %d (offsets %v)", test.name, len(offs), test.count, offs)
+			}
+			if test.first >= 0 && offs[0] != test.first {
+				t.Errorf("uuidOffsetsFor(%s)[0] = %d, want %d", test.name, offs[0], test.first)
+			}
+			// Every offset must be inside the struct.
+			for _, off := range offs {
+				if off < 0 || off+uuidSize > int(test.typ.Size()) {
+					t.Errorf("uuidOffsetsFor(%s) offset %d is outside a %d-byte struct", test.name, off, test.typ.Size())
+				}
+			}
+		})
+	}
+}
+
+// TestMapExternalAllocationUUIDRoundTrip drives the exact path that fails on a
+// remapped restore: the application passes the UUID it had before the
+// checkpoint, nvproxy resolves it to the host's for the driver, and puts the
+// application's back before the application reads the struct again.
+func TestMapExternalAllocationUUIDRoundTrip(t *testing.T) {
+	guestBin, ok := uuidBinary(guestUUID)
+	if !ok {
+		t.Fatalf("uuidBinary(%q) failed", guestUUID)
+	}
+	hostBin, ok := uuidBinary(hostUUID)
+	if !ok {
+		t.Fatalf("uuidBinary(%q) failed", hostUUID)
+	}
+
+	var params nvgpu.UVM_MAP_EXTERNAL_ALLOCATION_PARAMS
+	params.GPUAttributesCount = 1
+	params.PerGPUAttributes[0].GPUUUID = nvgpu.NvUUID(guestBin)
+
+	typ := reflect.TypeOf(&params).Elem()
+	offs := uuidOffsetsFor(typ)
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(&params)), int(typ.Size()))
+
+	guestToHost := map[string]string{guestUUID: hostUUID}
+	hostToGuest := map[string]string{hostUUID: guestUUID}
+
+	// Inward: the driver must see the host's UUID.
+	if done := translateUUIDsInBuf(buf, offs, guestToHost); len(done) != 1 {
+		t.Fatalf("translateUUIDsInBuf() made %d translations, want 1", len(done))
+	}
+	if params.PerGPUAttributes[0].GPUUUID != nvgpu.NvUUID(hostBin) {
+		t.Fatalf("inward translation produced %s, want %s", formatUUID(params.PerGPUAttributes[0].GPUUUID[:]), hostUUID)
+	}
+	// Untouched slots must stay zero rather than being given a device.
+	if params.PerGPUAttributes[1].GPUUUID != (nvgpu.NvUUID{}) {
+		t.Errorf("an unused per-GPU slot was written: %s", formatUUID(params.PerGPUAttributes[1].GPUUUID[:]))
+	}
+
+	// Outward: the application must read back its own UUID.
+	translateUUIDsInBuf(buf, offs, hostToGuest)
+	if params.PerGPUAttributes[0].GPUUUID != nvgpu.NvUUID(guestBin) {
+		t.Fatalf("outward translation produced %s, want %s", formatUUID(params.PerGPUAttributes[0].GPUUUID[:]), guestUUID)
+	}
+}
+
+// TestUUIDTranslationLeavesUnknownDevicesAlone pins that a UUID the sandbox
+// does not own is passed through rather than mapped onto some other device.
+func TestUUIDTranslationLeavesUnknownDevicesAlone(t *testing.T) {
+	const otherUUID = "GPU-99999999-9999-9999-9999-999999999999"
+	otherBin, ok := uuidBinary(otherUUID)
+	if !ok {
+		t.Fatal("uuidBinary failed")
+	}
+	var params nvgpu.UVM_REGISTER_GPU_PARAMS
+	params.GPUUUID = nvgpu.NvUUID(otherBin)
+	typ := reflect.TypeOf(&params).Elem()
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(&params)), int(typ.Size()))
+	if done := translateUUIDsInBuf(buf, uuidOffsetsFor(typ), map[string]string{guestUUID: hostUUID}); len(done) != 0 {
+		t.Errorf("translateUUIDsInBuf() translated an unknown UUID: %v", done)
+	}
+	if params.GPUUUID != nvgpu.NvUUID(otherBin) {
+		t.Errorf("an unknown UUID was modified")
+	}
+}
+
+// TestNoUUIDMapIsANoOp pins that a sandbox that was never restored onto other
+// devices pays nothing and changes nothing.
+func TestNoUUIDMapIsANoOp(t *testing.T) {
+	var params nvgpu.UVM_REGISTER_GPU_PARAMS
+	guestBin, _ := uuidBinary(guestUUID)
+	params.GPUUUID = nvgpu.NvUUID(guestBin)
+	typ := reflect.TypeOf(&params).Elem()
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(&params)), int(typ.Size()))
+	if done := translateUUIDsInBuf(buf, uuidOffsetsFor(typ), nil); done != nil {
+		t.Errorf("translateUUIDsInBuf() with no map made translations: %v", done)
+	}
+	if params.GPUUUID != nvgpu.NvUUID(guestBin) {
+		t.Errorf("params were modified with no map")
+	}
+}
+
+// TestRawIDSpecsFitTheirParams pins that every modelled field lies inside the
+// parameter size it was modelled from, so a translation cannot run off the end
+// of the buffer.
+func TestRawIDSpecsFitTheirParams(t *testing.T) {
+	for cmd, spec := range rawIDSpecs {
+		if got := spec.minSize(); got > spec.Size {
+			t.Errorf("%s (cmd %#x): fields need %d bytes but the layout is %d", spec.Name, cmd, got, spec.Size)
+		}
+		for _, f := range spec.Fields {
+			if f.CountAt >= 0 && f.CountAt+4 > spec.Size {
+				t.Errorf("%s: CountAt %d is outside a %d-byte layout", spec.Name, f.CountAt, spec.Size)
+			}
+			if f.Count <= 0 {
+				t.Errorf("%s: field has Count %d", spec.Name, f.Count)
+			}
+		}
+	}
+}
+
+// TestApplyRawIDFieldsRoundTrip drives an inbound gpuId array through the
+// translate/restore pair the raw handler uses.
+func TestApplyRawIDFieldsRoundTrip(t *testing.T) {
+	spec := rawIDSpecs[nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_MATRIX]
+	if spec == nil {
+		t.Fatal("no spec for GET_P2P_CAPS_MATRIX")
+	}
+	buf := make([]byte, spec.Size)
+	// grpACount = 2, grpBCount = 0; gpuIdGrpA = [0x1111, 0x2222, 0x3333, ...].
+	putU32(buf, 0, 2)
+	putU32(buf, 8, 0x1111)
+	putU32(buf, 12, 0x2222)
+	putU32(buf, 16, 0x3333)
+
+	maps := idMaps{
+		GuestToHostGPUID: map[uint32]uint32{0x1111: 0xaaaa, 0x2222: 0xbbbb, 0x3333: 0xcccc},
+		HostToGuestGPUID: map[uint32]uint32{0xaaaa: 0x1111, 0xbbbb: 0x2222, 0xcccc: 0x3333},
+	}
+	if n := applyRawIDFields(buf, spec, idIn, false, maps, nil); n != 2 {
+		t.Fatalf("applyRawIDFields() translated %d values, want 2 (grpACount bounds it)", n)
+	}
+	if got := getU32(buf, 8); got != 0xaaaa {
+		t.Errorf("gpuIdGrpA[0] = %#x, want 0xaaaa", got)
+	}
+	if got := getU32(buf, 16); got != 0x3333 {
+		t.Errorf("gpuIdGrpA[2] = %#x, want 0x3333 (beyond grpACount, must be untouched)", got)
+	}
+	if n := applyRawIDFields(buf, spec, idIn, true, maps, nil); n != 2 {
+		t.Fatalf("restore translated %d values, want 2", n)
+	}
+	if got := getU32(buf, 8); got != 0x1111 {
+		t.Errorf("after restore gpuIdGrpA[0] = %#x, want 0x1111", got)
+	}
+}
+
+// TestApplyRawIDFieldsStride drives the strided gpuId field of
+// GET_ACTIVE_DEVICE_IDS, whose entries are 12 bytes apart.
+func TestApplyRawIDFieldsStride(t *testing.T) {
+	spec := rawIDSpecs[nvgpu.NV0000_CTRL_CMD_GPU_GET_ACTIVE_DEVICE_IDS]
+	if spec == nil {
+		t.Fatal("no spec for GET_ACTIVE_DEVICE_IDS")
+	}
+	buf := make([]byte, spec.Size)
+	putU32(buf, 0, 2) // numDevices
+	putU32(buf, 4, 0xaaaa)
+	putU32(buf, 8, 7) // gpuInstanceId, a MIG id: must not be translated
+	putU32(buf, 16, 0xbbbb)
+	maps := idMaps{HostToGuestGPUID: map[uint32]uint32{0xaaaa: 0x1111, 0xbbbb: 0x2222, 7: 0xdead}}
+	if n := applyRawIDFields(buf, spec, idOut, false, maps, nil); n != 2 {
+		t.Fatalf("applyRawIDFields() translated %d values, want 2", n)
+	}
+	if got := getU32(buf, 4); got != 0x1111 {
+		t.Errorf("devices[0].gpuId = %#x, want 0x1111", got)
+	}
+	if got := getU32(buf, 16); got != 0x2222 {
+		t.Errorf("devices[1].gpuId = %#x, want 0x2222", got)
+	}
+	if got := getU32(buf, 8); got != 7 {
+		t.Errorf("devices[0].gpuInstanceId = %#x, want 7 (a MIG id, never translated)", got)
+	}
+}
+
+// TestTranslateIDNeverTouchesInvalidID pins that the terminator of a gpuId
+// array is left alone even if it somehow appears in a map.
+func TestTranslateIDNeverTouchesInvalidID(t *testing.T) {
+	m := map[uint32]uint32{nvgpu.NV0000_CTRL_GPU_INVALID_ID: 3}
+	if got, ok := translateID(nvgpu.NV0000_CTRL_GPU_INVALID_ID, m); ok || got != nvgpu.NV0000_CTRL_GPU_INVALID_ID {
+		t.Errorf("translateID(INVALID_ID) = (%#x, %v), want (INVALID_ID, false)", got, ok)
+	}
+}
+
+func putU32(b []byte, off int, v uint32) {
+	b[off] = byte(v)
+	b[off+1] = byte(v >> 8)
+	b[off+2] = byte(v >> 16)
+	b[off+3] = byte(v >> 24)
+}
+
+func getU32(b []byte, off int) uint32 {
+	return uint32(b[off]) | uint32(b[off+1])<<8 | uint32(b[off+2])<<16 | uint32(b[off+3])<<24
+}
+
+// TestScopeForNilTaskIsConservative pins that with no task to ask, nvproxy
+// does not translate: passing host identities through unchanged is what it did
+// before any translation existed, and is always safe.
+func TestScopeForNilTaskIsConservative(t *testing.T) {
+	scope := scopeFor(nil)
+	if scope.Restored {
+		t.Errorf("scopeFor(nil).Restored = true, want false")
+	}
+	if scope.TGID != 0 {
+		t.Errorf("scopeFor(nil).TGID = %d, want 0", scope.TGID)
+	}
+}
+
+func TestTranslationScopeString(t *testing.T) {
+	if got, want := (translationScope{Restored: true, TGID: 42}).String(), "tgid=42 restored=true"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+	if got, want := (translationScope{}).String(), "tgid=0 restored=false"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+// TestEveryTranslationIsScoped reads the source and requires that each handler
+// which translates an identifier also consults the translation scope. A
+// translation that is not scoped hands a process created after the restore an
+// identity, and a device file name, that does not exist -- which is how the
+// unscoped version killed the sandbox on restore.
+func TestEveryTranslationIsScoped(t *testing.T) {
+	for _, test := range []struct {
+		file  string
+		funcs []string
+	}{
+		{"gpuid_frontend.go", []string{
+			"func rmAllocDevice(",
+			"func rmAllocMemoryExport(",
+			"func ctrlTranslateRawIDs(",
+			"func ctrlGpuGetIDInfoTranslate(",
+			"func ctrlGpuGetIDInfoV2(",
+			"func ctrlGpuAttachIDs(",
+			"func ctrlGpuGetUUIDFromGPUID(",
+			"func ctrlGpuGetGidInfo(",
+		}},
+		{"frontend.go", []string{"func ctrlGetExportObjectInfo[", "func (dev *frontendDevice) forOpeningTask("}},
+		{"frontend_unsafe.go", []string{"func translateP2PGpuIDsToHost("}},
+		{"uvm_unsafe.go", []string{"func uvmIoctlInvoke["}},
+		{"pciaddr.go", []string{
+			"func translateCardInfo(",
+			"func ctrlGpuGetPCIInfo(",
+			"func ctrlBusGetInfoV2(",
+		}},
+	} {
+		src, err := os.ReadFile(test.file)
+		if err != nil {
+			t.Fatalf("reading %s: %v", test.file, err)
+		}
+		for _, fn := range test.funcs {
+			body, ok := funcBody(string(src), fn)
+			if !ok {
+				t.Errorf("%s: could not find %q; if it was renamed, rename it here too", test.file, fn)
+				continue
+			}
+			if !strings.Contains(body, "scope") {
+				t.Errorf("%s: %q translates identifiers but never consults the translation scope", test.file, fn)
+			}
+		}
+	}
+}
+
+// funcBody returns the text of the function whose declaration begins with
+// decl, up to the closing brace in column 0.
+func funcBody(src, decl string) (string, bool) {
+	i := strings.Index(src, decl)
+	if i < 0 {
+		return "", false
+	}
+	rest := src[i:]
+	if j := strings.Index(rest, "\n}\n"); j >= 0 {
+		return rest[:j], true
+	}
+	return rest, true
+}
+
+// TestPermuteByDeviceInstance covers the array whose indices are device
+// instances (NV00E0_ALLOCATION_PARAMETERS.GIIDMasks).
+func TestPermuteByDeviceInstance(t *testing.T) {
+	var arr [nvgpu.NV_MAX_DEVICES]uint32
+	arr[0] = 0xaa
+	arr[1] = 0xbb
+	arr[9] = 0xcc
+	// Guest instances 0,1 live at host instances 4,6.
+	out := permuteByDeviceInstance(arr, map[uint32]uint32{0: 4, 1: 6})
+	if out[4] != 0xaa || out[6] != 0xbb {
+		t.Errorf("permuteByDeviceInstance() = [4]=%#x [6]=%#x, want 0xaa, 0xbb", out[4], out[6])
+	}
+	// An index named as a source, but not as a destination, is vacated.
+	if out[0] != 0 || out[1] != 0 {
+		t.Errorf("permuteByDeviceInstance() left [0]=%#x [1]=%#x, want both vacated", out[0], out[1])
+	}
+	// An index no translation names keeps its element.
+	if out[9] != 0xcc {
+		t.Errorf("permuteByDeviceInstance()[9] = %#x, want 0xcc", out[9])
+	}
+	// An empty map is the identity.
+	if permuteByDeviceInstance(arr, nil) != arr {
+		t.Errorf("permuteByDeviceInstance() with no map changed the array")
+	}
+}
+
+// TestAllocParamsNoteNullDevice pins that the failure line distinguishes "the
+// application passed no allocation parameters" from "it asked for device 0",
+// which is the distinction the NV01_DEVICE_0 failure turned on.
+func TestAllocParamsNoteNullDevice(t *testing.T) {
+	if got, want := allocParamsNote(nvgpu.NV01_DEVICE_0, (*nvgpu.NV0080_ALLOC_PARAMETERS)(nil)), " deviceId=null"; got != want {
+		t.Errorf("allocParamsNote(nil) = %q, want %q", got, want)
+	}
+	p := &nvgpu.NV0080_ALLOC_PARAMETERS{DeviceID: 3}
+	if got, want := allocParamsNote(nvgpu.NV01_DEVICE_0, p), " deviceId=3"; got != want {
+		t.Errorf("allocParamsNote() = %q, want %q", got, want)
+	}
+	if got := allocParamsNote(nvgpu.NV01_ROOT_CLIENT, nil); got != "" {
+		t.Errorf("allocParamsNote() for an unremarkable class = %q, want empty", got)
+	}
+}
+
+// TestNV0080AllocParamsDeviceIDOffset settles, against the real marshaller,
+// that DeviceID is the first NvU32 of NV0080_ALLOC_PARAMETERS and that
+// rmAllocDevice therefore reads and writes the field it means to. A
+// mis-addressed read here would make every restored device object land on the
+// wrong GPU while logging a plausible number.
+func TestNV0080AllocParamsDeviceIDOffset(t *testing.T) {
+	var p nvgpu.NV0080_ALLOC_PARAMETERS
+	p.DeviceID = 0xa1a2a3a4
+	p.HClientShare = nvgpu.Handle{Val: 0xb1b2b3b4}
+	buf := make([]byte, p.SizeBytes())
+	p.MarshalBytes(buf)
+
+	if got := hostarch.ByteOrder.Uint32(buf[0:]); got != 0xa1a2a3a4 {
+		t.Errorf("DeviceID marshalled to offset 0 as %#x, want 0xa1a2a3a4 (buf=%x)", got, buf[:16])
+	}
+	if got := hostarch.ByteOrder.Uint32(buf[4:]); got != 0xb1b2b3b4 {
+		t.Errorf("HClientShare is not the second NvU32: got %#x (buf=%x)", got, buf[:16])
+	}
+
+	// Round-trip: what rmAllocDevice copies in is what the application wrote.
+	var back nvgpu.NV0080_ALLOC_PARAMETERS
+	back.UnmarshalBytes(buf)
+	if back.DeviceID != p.DeviceID {
+		t.Errorf("round-tripped DeviceID = %#x, want %#x", back.DeviceID, p.DeviceID)
+	}
+
+	// A zero value, which is what rmAllocDevice starts from when the
+	// application passes no parameters at all, means device instance 0.
+	var zero nvgpu.NV0080_ALLOC_PARAMETERS
+	if zero.DeviceID != 0 {
+		t.Errorf("the zero NV0080_ALLOC_PARAMETERS has DeviceID %d, want 0", zero.DeviceID)
+	}
+}
+
+// TestIDInfoV2Offsets pins the byte offsets ctrlGpuGetIDInfoV2 addresses
+// against the field order of NV0000_CTRL_GPU_GET_ID_INFO_V2_PARAMS
+// {gpuId, gpuFlags, deviceInstance, subDeviceInstance, sliStatus, boardId,
+// gpuInstance, numaId}, all bare NvU32.
+func TestIDInfoV2Offsets(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		off   int
+		index int
+	}{
+		{"gpuId", idInfoV2GpuID, 0},
+		{"deviceInstance", idInfoV2DeviceInstance, 2},
+		{"subDeviceInstance", idInfoV2SubDeviceInstance, 3},
+		{"gpuInstance", idInfoV2GpuInstance, 6},
+	} {
+		if want := test.index * 4; test.off != want {
+			t.Errorf("%s is at offset %d, want %d (field %d of a flat NvU32 struct)", test.name, test.off, want, test.index)
+		}
+	}
+	if idInfoV2ParamsSize != 8*4 {
+		t.Errorf("idInfoV2ParamsSize = %d, want %d", idInfoV2ParamsSize, 8*4)
+	}
+	// The non-V2 struct is a different shape: it has an 8-byte szName pointer
+	// in the middle, so these offsets must never be used for it.
+	var v1 nvgpu.NV0000_CTRL_GPU_GET_ID_INFO_PARAMS
+	if v1.SizeBytes() == idInfoV2ParamsSize {
+		t.Errorf("NV0000_CTRL_GPU_GET_ID_INFO_PARAMS is %d bytes, the same as the V2 layout; the two handlers can no longer be told apart by size", v1.SizeBytes())
+	}
+}
+
+// TestDescribeRawIDFieldStopsAtTerminator pins that the enumeration Debug line
+// reports what the application will actually read, not the whole fixed array.
+func TestDescribeRawIDFieldStopsAtTerminator(t *testing.T) {
+	buf := make([]byte, 128)
+	putU32(buf, 0, 0x4400)
+	putU32(buf, 4, 0x300)
+	putU32(buf, 8, nvgpu.NV0000_CTRL_GPU_INVALID_ID)
+	putU32(buf, 12, 0x999)
+	f := rawIDField{Kind: idGPUID, Dir: idOut, Offset: 0, Count: 32, CountAt: -1}
+	if got, want := describeRawIDField(buf, f), "[17408, 768]"; got != want {
+		t.Errorf("describeRawIDField() = %q, want %q", got, want)
+	}
+}
+
+func TestEnumerationDoesNotAliasSourceAndDestinationGPUs(t *testing.T) {
+	for _, cmd := range []uint32{nvgpu.NV0000_CTRL_CMD_GPU_GET_ATTACHED_IDS, nvgpu.NV0000_CTRL_CMD_GPU_GET_PROBED_IDS} {
+		spec := rawIDSpecs[cmd]
+		buf := make([]byte, spec.Size)
+		for off := 0; off < len(buf); off += 4 {
+			hostarch.ByteOrder.PutUint32(buf[off:], nvgpu.NV0000_CTRL_GPU_INVALID_ID)
+		}
+		input := []uint32{0x4400, 0x300, 0x400, 0x8300, 0xc400}
+		for i, id := range input {
+			hostarch.ByteOrder.PutUint32(buf[4*i:], id)
+			if cmd == nvgpu.NV0000_CTRL_CMD_GPU_GET_PROBED_IDS {
+				hostarch.ByteOrder.PutUint32(buf[256+4*i:], uint32(i+10))
+			}
+		}
+		maps := idMaps{HostToGuestGPUID: map[uint32]uint32{0x8300: 0x400, 0xc400: 0x300}, GuestToHostGPUID: map[uint32]uint32{0x400: 0x8300, 0x300: 0xc400}}
+		removeShadowedGPUIDs(buf, cmd, maps)
+		applyRawIDFields(buf, spec, idOut, false, maps, nil)
+		for i, want := range []uint32{0x4400, 0x400, 0x300, nvgpu.NV0000_CTRL_GPU_INVALID_ID} {
+			if got := hostarch.ByteOrder.Uint32(buf[4*i:]); got != want {
+				t.Fatalf("cmd=%#x entry %d=%#x, want %#x", cmd, i, got, want)
+			}
+		}
+		if cmd == nvgpu.NV0000_CTRL_CMD_GPU_GET_PROBED_IDS {
+			for i, want := range []uint32{10, 13, 14, 0} {
+				if got := hostarch.ByteOrder.Uint32(buf[256+4*i:]); got != want {
+					t.Fatalf("flags[%d]=%d, want %d", i, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestEnumerationPreservesOverlappingAndIdentityMappings(t *testing.T) {
+	for _, hostToGuest := range []map[uint32]uint32{{1: 1, 2: 2}, {2: 1, 3: 2}, {2: 1, 1: 2}} {
+		maps := idMaps{HostToGuestGPUID: hostToGuest, GuestToHostGPUID: make(map[uint32]uint32)}
+		for host, guest := range hostToGuest {
+			maps.GuestToHostGPUID[guest] = host
+		}
+		buf := make([]byte, 20)
+		for i, id := range []uint32{1, 2, 3, 4, nvgpu.NV0000_CTRL_GPU_INVALID_ID} {
+			hostarch.ByteOrder.PutUint32(buf[4*i:], id)
+		}
+		compactGPUIDList(buf, 0, 5, -1, maps)
+		seen := make(map[uint32]bool)
+		for i := 0; i < 5; i++ {
+			id := hostarch.ByteOrder.Uint32(buf[4*i:])
+			if id == nvgpu.NV0000_CTRL_GPU_INVALID_ID {
+				break
+			}
+			if guest, ok := hostToGuest[id]; ok {
+				id = guest
+			}
+			if seen[id] {
+				t.Fatalf("mapping %v enumerates guest %d twice", hostToGuest, id)
+			}
+			seen[id] = true
+		}
+		for guest := range maps.GuestToHostGPUID {
+			if !seen[guest] {
+				t.Fatalf("mapping %v lost guest %d", hostToGuest, guest)
+			}
+		}
+	}
+}

--- a/pkg/sentry/devices/nvproxy/uuid_test.go
+++ b/pkg/sentry/devices/nvproxy/uuid_test.go
@@ -519,3 +519,28 @@ func TestEnumerationPreservesOverlappingAndIdentityMappings(t *testing.T) {
 		}
 	}
 }
+
+// Admission needs the current composed map, scoped to the caller's CUDA identity.
+func TestAdmissionGPUUUIDMap(t *testing.T) {
+	nvp := &nvproxy{guestToHostUUID: map[string]string{guestUUID: hostUUID}}
+	if got := nvp.gpuUUIDMap(translationScope{}); len(got) != 0 {
+		t.Fatalf("fresh process map = %v, want empty", got)
+	}
+	restored := translationScope{Restored: true}
+	got := nvp.gpuUUIDMap(restored)
+	if got[guestUUID] != hostUUID {
+		t.Fatalf("restored map = %v", got)
+	}
+	got[guestUUID] = "changed"
+	if nvp.guestToHostUUID[guestUUID] != hostUUID {
+		t.Fatal("caller mutated runtime mapping")
+	}
+	nvp.guestToHostUUID[guestUUID] = guestUUID
+	if got := nvp.gpuUUIDMap(restored); got[guestUUID] != guestUUID {
+		t.Fatalf("second migration map = %v", got)
+	}
+	var absent *nvproxy
+	if got := absent.gpuUUIDMap(restored); len(got) != 0 {
+		t.Fatalf("absent nvproxy map = %v", got)
+	}
+}

--- a/pkg/sentry/devices/nvproxy/uvm_unsafe.go
+++ b/pkg/sentry/devices/nvproxy/uvm_unsafe.go
@@ -15,6 +15,7 @@
 package nvproxy
 
 import (
+	"reflect"
 	"runtime"
 	"unsafe"
 
@@ -25,16 +26,77 @@ import (
 )
 
 func uvmIoctlInvoke[Params any, PtrParams hasStatusPtr[Params]](ui *uvmIoctlState, ioctlParams PtrParams) (uintptr, error) {
+	// UVM names GPUs by UUID. After a restore that remapped devices the
+	// application still holds the UUIDs of the GPUs it had before the
+	// checkpoint, so resolve them to the host's on the way in and report the
+	// host's as the application's on the way out. uvmIoctlInvoke() is the
+	// single choke point every UVM ioctl passes through, so no handler can be
+	// missed.
+	nvp := ui.fd.dev.nvp
+	scope := scopeFor(ui.t)
+	var (
+		uuidOffs []int
+		buf      []byte
+	)
+	if len(nvp.hostToGuestUUID) != 0 && scope.Restored {
+		typ := reflect.TypeOf(ioctlParams).Elem()
+		uuidOffs = uuidOffsetsFor(typ)
+		if len(uuidOffs) != 0 {
+			buf = unsafe.Slice((*byte)(unsafe.Pointer(ioctlParams)), int(typ.Size()))
+			if in := translateUUIDsInBuf(buf, uuidOffs, nvp.guestToHostUUID); len(in) != 0 && log.IsLogging(log.Debug) {
+				for _, pair := range in {
+					ui.ctx.Debugf("nvproxy: uvm %s: translated UUID %s (guest) to %s (host) [%v]", uvmIoctlName(ui.cmd), pair[0], pair[1], scope)
+				}
+			}
+		}
+	}
+
 	n, _, errno := unix.RawSyscall(unix.SYS_IOCTL, uintptr(ui.fd.hostFD), uintptr(ui.cmd), uintptr(unsafe.Pointer(ioctlParams)))
+
+	if buf != nil {
+		// Both restores the inbound UUIDs the application passed and
+		// translates any the driver returned, since the two maps are inverses.
+		translateUUIDsInBuf(buf, uuidOffs, nvp.hostToGuestUUID)
+	}
 	if errno != 0 {
 		return n, errno
 	}
-	if log.IsLogging(log.Debug) {
-		if status := ioctlParams.GetStatus(); status != nvgpu.NV_OK {
-			ui.ctx.Debugf("nvproxy: uvm ioctl failed: status=%#x", status)
-		}
+	logUVMIoctl(ui, ioctlParams, scope)
+	if status := ioctlParams.GetStatus(); status != nvgpu.NV_OK {
+		logUVMIoctlStatus(ui, status)
 	}
 	return n, nil
+}
+
+// logUVMIoctl writes the Debug line for the UVM ioctls by which an application
+// builds its view of which GPUs exist and which may reach which memory. Those
+// are the ones a stale UUID breaks, and the UUIDs shown are the guest's, since
+// this runs after the outbound translation.
+func logUVMIoctl[Params any, PtrParams hasStatusPtr[Params]](ui *uvmIoctlState, ioctlParams PtrParams, scope translationScope) {
+	if !log.IsLogging(log.Debug) {
+		return
+	}
+	if _, ok := uvmIoctlLogsUUIDs[ui.cmd]; !ok {
+		return
+	}
+	typ := reflect.TypeOf(ioctlParams).Elem()
+	offs := uuidOffsetsFor(typ)
+	if len(offs) == 0 {
+		return
+	}
+	buf := unsafe.Slice((*byte)(unsafe.Pointer(ioctlParams)), int(typ.Size()))
+	status := ioctlParams.GetStatus()
+	switch p := any(ioctlParams).(type) {
+	case *nvgpu.UVM_MAP_EXTERNAL_ALLOCATION_PARAMS:
+		ui.ctx.Debugf("nvproxy: uvm %s: gpuAttributesCount=%d hClient=%#x hMemory=%#x base=%#x length=%#x uuids=%s rmStatus=%#x (%s) [%v]",
+			uvmIoctlName(ui.cmd), p.GPUAttributesCount, p.HClient, p.HMemory, p.Base, p.Length, describeUUIDsInBuf(buf, offs), status, statusName(status), scope)
+	case *nvgpu.UVM_MAP_EXTERNAL_ALLOCATION_PARAMS_V550:
+		ui.ctx.Debugf("nvproxy: uvm %s: gpuAttributesCount=%d hClient=%#x hMemory=%#x base=%#x length=%#x uuids=%s rmStatus=%#x (%s) [%v]",
+			uvmIoctlName(ui.cmd), p.GPUAttributesCount, p.HClient, p.HMemory, p.Base, p.Length, describeUUIDsInBuf(buf, offs), status, statusName(status), scope)
+	default:
+		ui.ctx.Debugf("nvproxy: uvm %s: uuids=%s rmStatus=%#x (%s) [%v]",
+			uvmIoctlName(ui.cmd), describeUUIDsInBuf(buf, offs), status, statusName(status), scope)
+	}
 }
 
 // BufferReadAt implements memmap.File.BufferReadAt.

--- a/pkg/sentry/devices/nvproxy/version.go
+++ b/pkg/sentry/devices/nvproxy/version.go
@@ -161,7 +161,7 @@ func Init() {
 			// constructed with the entirety of the nvproxy functionality.
 			return &driverABI{
 				frontendIoctl: map[uint32]frontendIoctlHandler{
-					nvgpu.NV_ESC_CARD_INFO:                     feHandler(frontendIoctlBytes, compUtil), // nv_ioctl_card_info_t array
+					nvgpu.NV_ESC_CARD_INFO:                     feHandler(frontendIoctlCardInfo, compUtil), // nv_ioctl_card_info_t array
 					nvgpu.NV_ESC_CHECK_VERSION_STR:             feHandler(frontendIoctlSimpleNoStatus[nvgpu.RMAPIVersion], compUtil),
 					nvgpu.NV_ESC_ATTACH_GPUS_TO_FD:             feHandler(frontendIoctlBytes, compUtil), // NvU32 array containing GPU IDs
 					nvgpu.NV_ESC_SYS_PARAMS:                    feHandler(frontendIoctlSimpleNoStatus[nvgpu.IoctlSysParams], compUtil),
@@ -221,22 +221,22 @@ func Init() {
 				controlCmd: map[uint32]controlCmdHandler{
 					nvgpu.NV0000_CTRL_CMD_CLIENT_GET_ADDR_SPACE_TYPE:                       ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV0000_CTRL_CMD_CLIENT_SET_INHERITED_SHARE_POLICY:                ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_GPU_GET_ATTACHED_IDS:                             ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_GPU_GET_DEVICE_IDS:                               ctrlHandler(rmControlSimple, compUtil|nvconf.CapGraphics),
-					nvgpu.NV0000_CTRL_CMD_GPU_GET_ID_INFO_V2:                               ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_GPU_GET_PROBED_IDS:                               ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_GPU_ATTACH_IDS:                                   ctrlHandler(rmControlSimple, compUtil),
+					nvgpu.NV0000_CTRL_CMD_GPU_GET_ATTACHED_IDS:                             ctrlHandler(ctrlTranslateRawIDs, compUtil),
+					nvgpu.NV0000_CTRL_CMD_GPU_GET_DEVICE_IDS:                               ctrlHandler(ctrlTranslateRawIDs, compUtil|nvconf.CapGraphics),
+					nvgpu.NV0000_CTRL_CMD_GPU_GET_ID_INFO_V2:                               ctrlHandler(ctrlGpuGetIDInfoV2, compUtil),
+					nvgpu.NV0000_CTRL_CMD_GPU_GET_PROBED_IDS:                               ctrlHandler(ctrlTranslateRawIDs, compUtil),
+					nvgpu.NV0000_CTRL_CMD_GPU_ATTACH_IDS:                                   ctrlHandler(ctrlGpuAttachIDs, compUtil),
 					nvgpu.NV0000_CTRL_CMD_GPU_DETACH_IDS:                                   ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_GPU_GET_PCI_INFO:                                 ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_GPU_GET_UUID_FROM_GPU_ID:                         ctrlHandler(rmControlSimple, compUtil|nvconf.CapGraphics),
+					nvgpu.NV0000_CTRL_CMD_GPU_GET_PCI_INFO:                                 ctrlHandler(ctrlGpuGetPCIInfo, compUtil),
+					nvgpu.NV0000_CTRL_CMD_GPU_GET_UUID_FROM_GPU_ID:                         ctrlHandler(ctrlGpuGetUUIDFromGPUID, compUtil|nvconf.CapGraphics),
 					nvgpu.NV0000_CTRL_CMD_GPU_QUERY_DRAIN_STATE:                            ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV0000_CTRL_CMD_GPU_GET_MEMOP_ENABLE:                             ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV0000_CTRL_CMD_GSYNC_GET_ATTACHED_IDS:                           ctrlHandler(rmControlSimple, nvconf.CapGraphics),
 					nvgpu.NV0000_CTRL_CMD_SYNC_GPU_BOOST_GROUP_INFO:                        ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_CPU_INFO:                              ctrlHandler(rmControlSimple, compUtil|nvconf.CapGraphics),
-					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_V2:                           ctrlHandler(rmControlSimple, compUtil),
+					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_V2:                           ctrlHandler(ctrlTranslateRawIDs, compUtil),
 					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_FABRIC_STATUS:                         ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_MATRIX:                       ctrlHandler(rmControlSimple, compUtil),
+					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS_MATRIX:                       ctrlHandler(ctrlTranslateRawIDs, compUtil),
 					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_FEATURES:                              ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV0080_CTRL_CMD_DMA_ADV_SCHED_GET_VA_CAPS:                        ctrlHandler(rmControlSimple, compUtil|nvconf.CapGraphics),
 					nvgpu.NV0080_CTRL_CMD_DMA_GET_CAPS:                                     ctrlHandler(rmControlSimple, compUtil|nvconf.CapGraphics),
@@ -259,7 +259,7 @@ func Init() {
 					nvgpu.NV2080_CTRL_CMD_BUS_GET_PCI_INFO:                                 ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_BUS_GET_PCI_BAR_INFO:                             ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_BUS_GET_INFO:                                     ctrlHandler(ctrlIoctlHasInfoList[nvgpu.NvxxxCtrlXxxGetInfoParams], compUtil|nvconf.CapVideo),
-					nvgpu.NV2080_CTRL_CMD_BUS_GET_INFO_V2:                                  ctrlHandler(rmControlSimple, compUtil),
+					nvgpu.NV2080_CTRL_CMD_BUS_GET_INFO_V2:                                  ctrlHandler(ctrlBusGetInfoV2, compUtil),
 					nvgpu.NV2080_CTRL_CMD_BUS_GET_PCIE_SUPPORTED_GPU_ATOMICS:               ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_BUS_GET_C2C_INFO:                                 ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_CE_GET_CE_PCE_MASK:                               ctrlHandler(rmControlSimple, nvconf.CapGraphics),
@@ -285,7 +285,7 @@ func Init() {
 					nvgpu.NV2080_CTRL_CMD_GPU_ACQUIRE_COMPUTE_MODE_RESERVATION:             ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_GPU_RELEASE_COMPUTE_MODE_RESERVATION:             ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_GPU_GET_ENGINE_PARTNERLIST:                       ctrlHandler(rmControlSimple, nvconf.CapGraphics),
-					nvgpu.NV2080_CTRL_CMD_GPU_GET_GID_INFO:                                 ctrlHandler(rmControlSimple, compUtil),
+					nvgpu.NV2080_CTRL_CMD_GPU_GET_GID_INFO:                                 ctrlHandler(ctrlGpuGetGidInfo, compUtil),
 					nvgpu.NV2080_CTRL_CMD_GPU_GET_INFOROM_OBJECT_VERSION:                   ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_GPU_GET_INFOROM_IMAGE_VERSION:                    ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NV2080_CTRL_CMD_GPU_QUERY_INFOROM_ECC_SUPPORT:                    ctrlHandler(rmControlSimple, compUtil),
@@ -377,7 +377,7 @@ func Init() {
 					nvgpu.NVA06F_CTRL_CMD_GPFIFO_SCHEDULE:                                  ctrlHandler(rmControlSimple, compUtil),
 					nvgpu.NVA06F_CTRL_CMD_BIND:                                             ctrlHandler(rmControlSimple, nvconf.CapGraphics|nvconf.CapVideo),
 					nvgpu.NVC56F_CTRL_CMD_GET_KMB:                                          ctrlHandler(rmControlSimple, compUtil),
-					nvgpu.NV0000_CTRL_CMD_GPU_GET_ID_INFO:                                  ctrlHandler(ctrlGpuGetIDInfo, compUtil),
+					nvgpu.NV0000_CTRL_CMD_GPU_GET_ID_INFO:                                  ctrlHandler(ctrlGpuGetIDInfoTranslate, compUtil),
 					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_BUILD_VERSION:                         ctrlHandler(ctrlClientSystemGetBuildVersion, compUtil),
 					nvgpu.NV0080_CTRL_CMD_GPU_GET_CLASSLIST:                                ctrlHandler(ctrlGetNvU32List, compUtil),
 					nvgpu.NV0080_CTRL_CMD_GR_GET_CAPS:                                      ctrlHandler(ctrlDevGetCaps, nvconf.CapGraphics),
@@ -392,7 +392,7 @@ func Init() {
 					nvgpu.NV0000_CTRL_CMD_SYSTEM_GET_P2P_CAPS:                              ctrlHandler(ctrlClientSystemGetP2PCaps, compUtil),
 					nvgpu.NV0000_CTRL_CMD_OS_UNIX_EXPORT_OBJECT_TO_FD:                      ctrlHandler(ctrlHasFrontendFD[nvgpu.NV0000_CTRL_OS_UNIX_EXPORT_OBJECT_TO_FD_PARAMS], compUtil),
 					nvgpu.NV0000_CTRL_CMD_OS_UNIX_IMPORT_OBJECT_FROM_FD:                    ctrlHandler(ctrlHasFrontendFD[nvgpu.NV0000_CTRL_OS_UNIX_IMPORT_OBJECT_FROM_FD_PARAMS], compUtil),
-					nvgpu.NV0000_CTRL_CMD_OS_UNIX_GET_EXPORT_OBJECT_INFO:                   ctrlHandler(ctrlHasFrontendFD[nvgpu.NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS], compUtil),
+					nvgpu.NV0000_CTRL_CMD_OS_UNIX_GET_EXPORT_OBJECT_INFO:                   ctrlHandler(ctrlGetExportObjectInfo[nvgpu.NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS], compUtil),
 					nvgpu.NV0000_CTRL_CMD_OS_UNIX_EXPORT_OBJECTS_TO_FD:                     ctrlHandler(ctrlHasFrontendFD[nvgpu.NV0000_CTRL_OS_UNIX_EXPORT_OBJECTS_TO_FD_PARAMS], compUtil),
 					nvgpu.NV0000_CTRL_CMD_OS_UNIX_IMPORT_OBJECTS_FROM_FD:                   ctrlHandler(ctrlHasFrontendFD[nvgpu.NV0000_CTRL_OS_UNIX_IMPORT_OBJECTS_FROM_FD_PARAMS], compUtil),
 					nvgpu.NV0041_CTRL_CMD_GET_SURFACE_INFO:                                 ctrlHandler(ctrlIoctlHasInfoList[nvgpu.NvxxxCtrlXxxGetInfoParams], compUtil),
@@ -421,7 +421,7 @@ func Init() {
 					nvgpu.NV01_EVENT_OS_EVENT:        allocHandler(rmAllocEventOSEvent, compUtil),
 					nvgpu.NV_EVENT_BUFFER:            allocHandler(rmAllocEventBuffer, nvconf.CapProfiling),
 					nvgpu.NV01_MEMORY_VIRTUAL:        allocHandler(rmAllocMemoryVirtual, nvconf.CapGraphics|nvconf.CapVideo),
-					nvgpu.NV01_DEVICE_0:              allocHandler(rmAllocSimple[nvgpu.NV0080_ALLOC_PARAMETERS], compUtil),
+					nvgpu.NV01_DEVICE_0:              allocHandler(rmAllocDevice, compUtil),
 					nvgpu.NV_SEMAPHORE_SURFACE:       allocHandler(rmAllocSimple[nvgpu.NV_SEMAPHORE_SURFACE_ALLOC_PARAMETERS], nvconf.CapGraphics),
 					nvgpu.RM_USER_SHARED_DATA:        allocHandler(rmAllocSimple[nvgpu.NV00DE_ALLOC_PARAMETERS], compUtil),
 					nvgpu.NV_MEMORY_FABRIC:           allocHandler(rmAllocSimple[nvgpu.NV00F8_ALLOCATION_PARAMETERS], compUtil),
@@ -834,11 +834,11 @@ func Init() {
 		// 545.23.06 is an intermediate unqualified version from the main branch.
 		v545_23_06 := addUnsupportedDriverABI(545, 23, 06, func() *driverABI {
 			abi := v535_113_01()
-			abi.controlCmd[nvgpu.NV0000_CTRL_CMD_OS_UNIX_GET_EXPORT_OBJECT_INFO] = ctrlHandler(ctrlHasFrontendFD[nvgpu.NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS_V545], compUtil)
-			abi.controlCmd[nvgpu.NV0000_CTRL_CMD_GPU_GET_ACTIVE_DEVICE_IDS] = ctrlHandler(rmControlSimple, compUtil)
+			abi.controlCmd[nvgpu.NV0000_CTRL_CMD_OS_UNIX_GET_EXPORT_OBJECT_INFO] = ctrlHandler(ctrlGetExportObjectInfo[nvgpu.NV0000_CTRL_OS_UNIX_GET_EXPORT_OBJECT_INFO_PARAMS_V545], compUtil)
+			abi.controlCmd[nvgpu.NV0000_CTRL_CMD_GPU_GET_ACTIVE_DEVICE_IDS] = ctrlHandler(ctrlTranslateRawIDs, compUtil)
 			abi.controlCmd[nvgpu.NV00DE_CTRL_CMD_REQUEST_DATA_POLL] = ctrlHandler(rmControlSimple, compUtil)
 			abi.allocationClass[nvgpu.RM_USER_SHARED_DATA] = allocHandler(rmAllocSimple[nvgpu.NV00DE_ALLOC_PARAMETERS_V545], compUtil)
-			abi.allocationClass[nvgpu.NV_MEMORY_EXPORT] = allocHandler(rmAllocSimple[nvgpu.NV00E0_ALLOCATION_PARAMETERS], nvconf.CapFabricIMEXManagement)
+			abi.allocationClass[nvgpu.NV_MEMORY_EXPORT] = allocHandler(rmAllocMemoryExport, nvconf.CapFabricIMEXManagement)
 			abi.allocationClass[nvgpu.NV_MEMORY_MULTICAST_FABRIC] = allocHandler(rmAllocMulticastFabric[nvgpu.NV00FD_ALLOCATION_PARAMETERS_V545], compUtil)
 			abi.allocationClass[nvgpu.NV01_MEMORY_SYSTEM] = allocHandler(rmAllocSimple[nvgpu.NV_MEMORY_ALLOCATION_PARAMS_V545], compUtil)
 			abi.allocationClass[nvgpu.NV01_MEMORY_LOCAL_USER] = allocHandler(rmAllocSimple[nvgpu.NV_MEMORY_ALLOCATION_PARAMS_V545], compUtil)

--- a/pkg/sentry/fsimpl/proc/checkpoint.go
+++ b/pkg/sentry/fsimpl/proc/checkpoint.go
@@ -45,6 +45,7 @@ func (fs *filesystem) newGvisorInode(ctx context.Context, root *auth.Credentials
 		return nil, err
 	}
 	gvisorFiles["checkpoint"] = checkpoint
+	gvisorFiles["gpu_uuid_map"] = fs.newInode(ctx, root, 0444, &gpuUUIDMapData{})
 	gvisorFiles["spec_environ"] = fs.newInode(ctx, root, 0444, &specEnvironData{k: k})
 	if internalData.FSCheckpointEnabled {
 		log.Infof("Setting up fscheckpoint files under [procfs]/gvisor")

--- a/pkg/sentry/fsimpl/proc/nvproxy.go
+++ b/pkg/sentry/fsimpl/proc/nvproxy.go
@@ -15,6 +15,8 @@
 package proc
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"path"
 
@@ -103,4 +105,17 @@ func (fs *filesystem) addNvproxyFiles(ctx context.Context, root *auth.Credential
 	contents["driver"] = fs.newStaticDir(ctx, root, map[string]kernfs.Inode{
 		"nvidia": inodeFromNode(nvidiaDir),
 	})
+}
+
+// gpuUUIDMapData exposes physical identity for external GPU resource admission.
+// It is evaluated on every read, so a second migration cannot retain a stale map.
+//
+// +stateify savable
+type gpuUUIDMapData struct{ dynamicBytesFileSetAttr }
+
+var _ dynamicInode = (*gpuUUIDMapData)(nil)
+
+// Generate implements vfs.DynamicBytesSource.Generate.
+func (*gpuUUIDMapData) Generate(ctx context.Context, buf *bytes.Buffer) error {
+	return json.NewEncoder(buf).Encode(nvproxy.GPUUUIDMapFromContext(ctx))
 }

--- a/pkg/sentry/kernel/BUILD
+++ b/pkg/sentry/kernel/BUILD
@@ -438,6 +438,7 @@ go_test(
         "table_test.go",
         "task_syscall_benchmark_test.go",
         "task_test.go",
+        "thread_group_checkpoint_test.go",
         "timekeeper_test.go",
     ],
     library = ":kernel",

--- a/pkg/sentry/kernel/kernel_state.go
+++ b/pkg/sentry/kernel/kernel_state.go
@@ -116,3 +116,8 @@ func (p *pid) saveT() *Task {
 func (p *pid) loadT(_ context.Context, t *Task) {
 	p.t.Store(t)
 }
+
+// afterLoad is invoked by stateify.
+func (tg *ThreadGroup) afterLoad(context.Context) {
+	tg.markExistedAtCheckpoint()
+}

--- a/pkg/sentry/kernel/task_exec.go
+++ b/pkg/sentry/kernel/task_exec.go
@@ -290,6 +290,9 @@ func (r *runExecveAfterSiblingExitStop) execute(t *Task) taskRunState {
 		oldTID = tracer.tg.pidns.tids[t]
 	}
 	t.promoteLocked()
+	// The new image initialises its own GPU driver state, so this thread group
+	// no longer holds device identities from before a checkpoint.
+	t.tg.clearExistedAtCheckpoint()
 	// "POSIX timers are not preserved (timer_create(2))." - execve(2). Handle
 	// this first since POSIX timers are protected by the signal mutex, which
 	// we're about to change. Note that we have to stop and destroy timers

--- a/pkg/sentry/kernel/thread_group.go
+++ b/pkg/sentry/kernel/thread_group.go
@@ -292,6 +292,18 @@ type ThreadGroup struct {
 	// sigsegvLockCount to 0 requires that the signal mutex is locked.
 	sigsegvLockCount atomicbitops.Int32
 
+	// existedAtCheckpoint is true if this thread group was loaded from a
+	// checkpoint rather than created after the sandbox was restored. It is not
+	// saved: StateLoad() sets it on every load, so a thread group that
+	// survives two checkpoints stays marked, and one created after a restore
+	// and then itself checkpointed is marked on the next restore -- which is
+	// correct, since by then it does hold identities from a checkpoint.
+	//
+	// StateLoad writes while the sandbox is paused. Exec clears it only
+	// after all sibling tasks have exited. Readers are syscalls of this
+	// thread group, so neither write can race a reader.
+	existedAtCheckpoint bool `state:"nosave"`
+
 	// coredumpFilter is used to track which memory regions the process requests to be
 	// saved on core dump. It can be accessed from userspace as /proc/[pid]/coredump_filter.
 	//

--- a/pkg/sentry/kernel/thread_group_checkpoint_test.go
+++ b/pkg/sentry/kernel/thread_group_checkpoint_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kernel
+
+import (
+	"testing"
+)
+
+// TestExistedAtCheckpointDefaultsFalse pins the property nvproxy's scoping
+// rests on: a thread group that was not loaded from a state file -- a child
+// forked after a restore, or a helper the checkpointer runs inside the sandbox
+// -- must not be treated as holding pre-checkpoint device identities.
+func TestExistedAtCheckpointDefaultsFalse(t *testing.T) {
+	var tg ThreadGroup
+	if tg.ExistedAtCheckpoint() {
+		t.Errorf("a freshly constructed ThreadGroup reports ExistedAtCheckpoint() == true")
+	}
+}
+
+func TestExistedAtCheckpointMarkAndClear(t *testing.T) {
+	var tg ThreadGroup
+	// StateLoad() marks every thread group it loads.
+	tg.markExistedAtCheckpoint()
+	if !tg.ExistedAtCheckpoint() {
+		t.Fatalf("markExistedAtCheckpoint() did not take effect")
+	}
+	// Marking twice, as a second restore would, is idempotent.
+	tg.markExistedAtCheckpoint()
+	if !tg.ExistedAtCheckpoint() {
+		t.Fatalf("marking twice cleared the mark")
+	}
+	// execve() replaces the image, and with it the user-mode driver state that
+	// held the old identities.
+	tg.clearExistedAtCheckpoint()
+	if tg.ExistedAtCheckpoint() {
+		t.Errorf("clearExistedAtCheckpoint() did not take effect")
+	}
+	// A thread group created after a restore and then itself checkpointed is
+	// marked on the next restore.
+	tg.markExistedAtCheckpoint()
+	if !tg.ExistedAtCheckpoint() {
+		t.Errorf("a cleared thread group could not be marked again")
+	}
+}

--- a/pkg/sentry/kernel/threads.go
+++ b/pkg/sentry/kernel/threads.go
@@ -634,6 +634,38 @@ func (tg *ThreadGroup) ID() ThreadID {
 	return ThreadID(tg.pidWithinNS.Load())
 }
 
+// ExistedAtCheckpoint returns true if tg was loaded from a checkpoint rather
+// than created after the sandbox was restored.
+//
+// nvproxy uses this to decide whether a process holds device identities from
+// before the checkpoint. A process restored from a checkpoint has a user-mode
+// GPU driver whose tables are keyed by the device instances, gpuIds and UUIDs
+// of the devices the sandbox had then, so nvproxy must translate for it. A
+// process created after the restore -- a forked child, or a helper the
+// checkpointer runs inside the sandbox -- initialises its driver from scratch
+// against the devices that are actually present, so translating for it would
+// hand it identities, and device file names, that do not exist.
+func (tg *ThreadGroup) ExistedAtCheckpoint() bool {
+	return tg.existedAtCheckpoint
+}
+
+// markExistedAtCheckpoint is called by ThreadGroup.StateLoad(). Every thread
+// group loaded from a state file existed when that state file was written, and
+// one created afterwards is constructed with the field unset, so no walk of
+// the task set is needed and no ordering between this and the rest of the
+// restore matters.
+func (tg *ThreadGroup) markExistedAtCheckpoint() {
+	tg.existedAtCheckpoint = true
+}
+
+// clearExistedAtCheckpoint is called when tg execs a new image. execve()
+// replaces the address space, so whatever user-mode driver state held the old
+// device identities is gone, and the new image initialises its own against the
+// devices that are present.
+func (tg *ThreadGroup) clearExistedAtCheckpoint() {
+	tg.existedAtCheckpoint = false
+}
+
 // A taskNode defines the relationship between a task and the rest of the
 // system. The comments on threadGroupNode also apply to taskNode.
 //


### PR DESCRIPTION
NCCL P2P/cuMem communicators retain GPU identities in the CUDA user-mode driver across checkpoint. After nvproxy remaps their RM objects to different physical GPUs, untranslated device instances, GPU IDs, UUIDs and PCI addresses can make cuMem imports resolve to the wrong device. Enumeration also contains both the still-attached source GPU and a destination translated to that source identity, so the restored driver registers one saved GPU twice.

This patch records PCI addresses in remap metadata, tracks thread groups loaded from checkpoint, and translates GPU identities in both directions for those restored thread groups. New processes and exec images use current host identities. Enumeration compaction removes source identities shadowed by remapped destinations and preserves aligned per-GPU flags. Maps compose across subsequent restores. Diagnostic logging is gated by debug. A read-only dynamic `/proc/gvisor/gpu_uuid_map` exposes the restored caller's composed CUDA-to-physical UUID mapping for external resource admission; fresh callers receive an empty mapping. CUDA identities themselves remain stable.

Validation:

- Current master nvproxy/proc Bazel tests also pass for the admission mapping interface.
- Current master: `make test DOCKER_BUILD=false TARGETS='//pkg/sentry/devices/nvproxy:nvproxy_test //pkg/sentry/kernel:kernel_test'` passes using Bazel 8.3.1.
- Equivalent patch on generated Go branch 24533f4896ef07746c799c89c3f0b75611c8ab44: real two-rank NVIDIA L40S experiments with torch 2.14.0+cu130 and NCCL 2.30.7, default P2P/CUMEM transport.
- Cross-GPU cuMem FD import/map/access/readback passes. The original NCCL ranks pass barrier, checked all-reduce, all-gather, five 4 MiB all-reduces and repeated live requests after migration.
- Reverse migration, same-GPU restore, and checkpointing the migrated ranks again followed by a second migration pass without replacing the ranks or process group.
- An unsuspended-communicator negative control fails. An additional cuda-checkpoint `--device-map` conflicts with nvproxy's identity mapping and is not used by the passing runs.

The final pinned shipping runtime also passed single-GPU migration and two-rank dev requests through memory admission across GPU pairs in both directions, with the original rank PIDs. Admission translates UUIDs at its external boundary instead of changing the CUDA identities needed by NCCL.

Saved nvproxy fields change; deployment must segregate dumps by runtime build. This is a draft pending broader GPU/driver coverage and review of the scope policy, including processes that fork with inherited CUDA state and mixed process generations across checkpoints. Real GPU tests above use the generated Go branch; current-master validation is the Bazel unit suite.
