### PR TITLE
Report container running while any init task is alive

### DIFF
--- a/pkg/sentry/kernel/task_exit.go
+++ b/pkg/sentry/kernel/task_exit.go
@@ -495,6 +495,14 @@ func (tg *ThreadGroup) anyNonExitingTaskLocked() *Task {
 	return nil
 }
 
+// HasNonExitingTasks returns true if any task in tg has not yet begun
+// exiting.
+func (tg *ThreadGroup) HasNonExitingTasks() bool {
+	tg.pidns.owner.mu.RLock()
+	defer tg.pidns.owner.mu.RUnlock()
+	return tg.anyNonExitingTaskLocked() != nil
+}
+
 // reparentLocked changes t's parent. The new parent may be nil.
 //
 // Preconditions: The TaskSet mutex must be locked for writing.

--- a/runsc/boot/loader.go
+++ b/runsc/boot/loader.go
@@ -2472,8 +2472,8 @@ func (l *Loader) containerRuntimeState(cid string) ContainerRuntimeState {
 		// Container has no thread group assigned, so it has not started yet.
 		return RuntimeStateCreating
 	}
-	if exec.tg.Leader().ExitState() == kernel.TaskExitNone {
-		// Init process is still running.
+	if exec.tg.HasNonExitingTasks() {
+		// Init process thread group is still running.
 		return RuntimeStateRunning
 	}
 	// Init process has stopped, but no one has called wait on it yet.

--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -3724,6 +3724,54 @@ func TestSignalCreated(t *testing.T) {
 	}
 }
 
+// TestStateNonLeaderExec verifies that a container whose init process
+// continuously execs from non-leader threads is never reported Stopped.
+// During such an execve the old thread group leader exits before the execing
+// thread is promoted in its place; the leader alone must not be used as a
+// liveness signal. A single transient "stopped" answer from `runsc state` is
+// treated as terminal by container shims, permanently wedging teardown.
+func TestStateNonLeaderExec(t *testing.T) {
+	app, err := testutil.FindFile("test/cmd/test_app/test_app")
+	if err != nil {
+		t.Fatal("error finding test_app:", err)
+	}
+	spec := testutil.NewSpecWithArgs(app, "exec-from-thread")
+	conf := testutil.TestConfig(t)
+	_, bundleDir, cleanup, err := testutil.SetupContainer(spec, conf)
+	if err != nil {
+		t.Fatalf("error setting up container: %v", err)
+	}
+	defer cleanup()
+
+	args := Args{
+		ID:        testutil.RandomContainerID(),
+		Spec:      spec,
+		BundleDir: bundleDir,
+	}
+	c, err := New(conf, args)
+	if err != nil {
+		t.Fatalf("error creating container: %v", err)
+	}
+	defer c.Destroy()
+	if err := c.Start(conf); err != nil {
+		t.Fatalf("error starting container: %v", err)
+	}
+
+	// Poll state the same way `runsc state` does (Load + CheckStopped) while
+	// init re-execs from non-leader threads, and verify the container is
+	// never reported Stopped.
+	polls := 0
+	for start := time.Now(); time.Since(start) < 10*time.Second; polls++ {
+		cLoaded, err := Load(conf.RootDir, FullID{ContainerID: args.ID}, LoadOpts{})
+		if err != nil {
+			t.Fatalf("error loading container after %d polls: %v", polls, err)
+		}
+		if cLoaded.Status == Stopped {
+			t.Fatalf("container transiently reported Stopped after %d polls while init is alive", polls)
+		}
+	}
+}
+
 // TestDestroyStarting attempts to force a race between start and destroy.
 func TestDestroyStarting(t *testing.T) {
 	for i := 0; i < 10; i++ {

--- a/test/cmd/test_app/BUILD
+++ b/test/cmd/test_app/BUILD
@@ -10,6 +10,7 @@ go_binary(
     testonly = 1,
     srcs = [
         "chardev.go",
+        "exec_thread.go",
         "fds.go",
         "hostinet_sr.go",
         "main.go",

--- a/test/cmd/test_app/exec_thread.go
+++ b/test/cmd/test_app/exec_thread.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+	"runtime"
+
+	"github.com/google/subcommands"
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/runsc/flag"
+)
+
+// execFromThread re-execs itself in a loop, always from a thread that is not
+// the thread group leader. Each execve enters the window in which the old
+// leader has exited but the execing thread has not yet been promoted in its
+// place, which is the window in which container state must not be misreported
+// as stopped.
+type execFromThread struct{}
+
+// Name implements subcommands.Command.Name.
+func (*execFromThread) Name() string {
+	return "exec-from-thread"
+}
+
+// Synopsis implements subcommands.Command.Synopsis.
+func (*execFromThread) Synopsis() string {
+	return "re-execs itself in a loop from a non-thread-group-leader thread"
+}
+
+// Usage implements subcommands.Command.Usage.
+func (*execFromThread) Usage() string {
+	return "exec-from-thread"
+}
+
+// SetFlags implements subcommands.Command.SetFlags.
+func (*execFromThread) SetFlags(*flag.FlagSet) {}
+
+// Execute implements subcommands.Command.Execute.
+func (*execFromThread) Execute(context.Context, *flag.FlagSet, ...any) subcommands.ExitStatus {
+	errCh := make(chan error, 1)
+	go execWhenNotLeader(errCh)
+	// On success this process is replaced and we never get here.
+	fatalf("exec-from-thread: %v", <-errCh)
+	return subcommands.ExitFailure
+}
+
+// execWhenNotLeader re-execs the current binary from the calling goroutine's
+// thread if it is not the thread group leader. Otherwise it parks itself,
+// keeping the leader thread pinned, and hands off to a new goroutine, which
+// the runtime must schedule on a different thread.
+func execWhenNotLeader(errCh chan error) {
+	runtime.LockOSThread()
+	if unix.Gettid() == unix.Getpid() {
+		go execWhenNotLeader(errCh)
+		select {} // Hold the leader thread parked until the exec.
+	}
+	errCh <- unix.Exec("/proc/self/exe", []string{os.Args[0], "exec-from-thread"}, os.Environ())
+}

--- a/test/cmd/test_app/main.go
+++ b/test/cmd/test_app/main.go
@@ -46,6 +46,7 @@ func main() {
 	subcommands.Register(subcommands.FlagsCommand(), "")
 	subcommands.Register(new(capability), "")
 	subcommands.Register(new(chardevCheck), "")
+	subcommands.Register(new(execFromThread), "")
 	subcommands.Register(new(fdReceiver), "")
 	subcommands.Register(new(fdSender), "")
 	subcommands.Register(new(forkBomb), "")


### PR DESCRIPTION
containerRuntimeState judged a container by its init thread group leader's exit state alone. During execve from a non-leader thread the old leader exits before the execing task is promoted in its place, so `runsc state` transiently reported "stopped" for a live container.

A single transient "stopped" answer is treated as terminal by container shims: kills are then silently dropped and no exit event is published, leaving pods stuck terminating forever.