### PR TITLE
fix(cpuid): calculate CPU family by adding extended family on x86 (fixes #14631)

### DIFF
--- a/pkg/cpuid/cpuid_amd64.go
+++ b/pkg/cpuid/cpuid_amd64.go
@@ -337,10 +337,10 @@ func (fs FeatureSet) WriteCPUInfoTo(cpu, numCPU uint, w io.Writer) {
 		family += uint32(ef)
 	}
 	model := uint32(m)
+	// AMD64 Architecture Programmer's Manual, Vol 3, E.3.2:
+	// "Model is an 8-bit value and is defined as: Model[7:0] = {ExtModel[3:0],BaseModel[3:0]}.
+	// If BaseFamily[3:0] is less than 0Fh, then ExtModel is reserved and Model is equal to BaseModel[3:0]."
 	if fs.AMD() {
-		// AMD manuals (AMD64 Architecture Programmer's Manual, Vol 3, E.3.2):
-		// "If BaseFamily[3:0] is less than 0Fh, then ExtModel is reserved and
-		// Model is equal to BaseModel[3:0]."
 		if f == 0xf {
 			model |= uint32(em) << 4
 		}

--- a/pkg/cpuid/cpuid_amd64.go
+++ b/pkg/cpuid/cpuid_amd64.go
@@ -332,10 +332,18 @@ func (fs FeatureSet) WriteCPUInfoTo(cpu, numCPU uint, w io.Writer) {
 	ax, _, _, _ := fs.query(featureInfo)
 	ef, em, _, f, m, _ := signatureSplit(ax)
 	vendor := fs.VendorID()
+	family := uint32(f)
+	if f == 0xf {
+		family += uint32(ef)
+	}
+	model := uint32(m)
+	if f == 0x6 || f == 0xf {
+		model |= uint32(em) << 4
+	}
 	fmt.Fprintf(w, "processor\t: %d\n", cpu)
 	fmt.Fprintf(w, "vendor_id\t: %s\n", string(vendor[:]))
-	fmt.Fprintf(w, "cpu family\t: %d\n", ((ef<<4)&0xff)|f)
-	fmt.Fprintf(w, "model\t\t: %d\n", ((em<<4)&0xff)|m)
+	fmt.Fprintf(w, "cpu family\t: %d\n", family)
+	fmt.Fprintf(w, "model\t\t: %d\n", model)
 	fmt.Fprintf(w, "model name\t: %s\n", "unknown") // Unknown for now.
 	fmt.Fprintf(w, "stepping\t: %s\n", "unknown")   // Unknown for now.
 	fmt.Fprintf(w, "cpu MHz\t\t: %.3f\n", cpuFreqMHz)

--- a/pkg/cpuid/cpuid_amd64.go
+++ b/pkg/cpuid/cpuid_amd64.go
@@ -337,7 +337,16 @@ func (fs FeatureSet) WriteCPUInfoTo(cpu, numCPU uint, w io.Writer) {
 		family += uint32(ef)
 	}
 	model := uint32(m)
-	if f == 0x6 || f == 0xf {
+	if fs.AMD() {
+		// AMD manuals (AMD64 Architecture Programmer's Manual, Vol 3, E.3.2):
+		// "If BaseFamily[3:0] is less than 0Fh, then ExtModel is reserved and
+		// Model is equal to BaseModel[3:0]."
+		if f == 0xf {
+			model |= uint32(em) << 4
+		}
+	} else if f == 0x6 || f == 0xf {
+		// Intel manuals:
+		// Extended model is used if BaseFamily is 0x6 or 0xf.
 		model |= uint32(em) << 4
 	}
 	fmt.Fprintf(w, "processor\t: %d\n", cpu)

--- a/pkg/cpuid/cpuid_amd64_test.go
+++ b/pkg/cpuid/cpuid_amd64_test.go
@@ -18,6 +18,8 @@
 package cpuid
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -108,5 +110,52 @@ func TestRemove(t *testing.T) {
 	testFeatures.Function.(Static).Remove(X86FeatureRDRAND)
 	if !testFeatures.HasFeature(X86FeatureFPU) {
 		t.Errorf("Remove failed, got %q want %q", testFeatures.FlagString(), justFPU.FlagString())
+	}
+}
+
+func TestWriteCPUInfoFamilyAndModel(t *testing.T) {
+	testCases := []struct {
+		name       string
+		eax        uint32
+		wantFamily string
+		wantModel  string
+	}{
+		{
+			// AMD EPYC 7R13 (Zen 3):
+			// Base family = 0xf, Extended family = 0x0a -> cpu family = 25 (0x19).
+			// Base model = 0x1, Extended model = 0x0 -> model = 1.
+			// (0x0a << 20) | (0x0 << 16) | (0xf << 8) | (0x1 << 4) | 0x1 = 0x00a00f11
+			name:       "AMD EPYC Zen 3",
+			eax:        0x00a00f11,
+			wantFamily: "cpu family\t: 25\n",
+			wantModel:  "model\t\t: 1\n",
+		},
+		{
+			// Intel Skylake:
+			// Base family = 6, Extended family = 0 -> cpu family = 6.
+			// Base model = 5, Extended model = 5 -> model = 85 (0x55).
+			// (0x0 << 20) | (0x5 << 16) | (0x6 << 8) | (0x5 << 4) | 0x4 = 0x00050654
+			name:       "Intel Skylake",
+			eax:        0x00050654,
+			wantFamily: "cpu family\t: 6\n",
+			wantModel:  "model\t\t: 85\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := make(Static)
+			s[In{Eax: uint32(featureInfo)}] = Out{Eax: tc.eax}
+			fs := FeatureSet{Function: s}
+			var buf bytes.Buffer
+			fs.WriteCPUInfoTo(0, 1, &buf)
+			got := buf.String()
+			if !strings.Contains(got, tc.wantFamily) {
+				t.Errorf("WriteCPUInfoTo() missing %q; got:\n%s", tc.wantFamily, got)
+			}
+			if !strings.Contains(got, tc.wantModel) {
+				t.Errorf("WriteCPUInfoTo() missing %q; got:\n%s", tc.wantModel, got)
+			}
+		})
 	}
 }

--- a/pkg/cpuid/cpuid_amd64_test.go
+++ b/pkg/cpuid/cpuid_amd64_test.go
@@ -116,6 +116,7 @@ func TestRemove(t *testing.T) {
 func TestWriteCPUInfoFamilyAndModel(t *testing.T) {
 	testCases := []struct {
 		name       string
+		vendor     [12]byte
 		eax        uint32
 		wantFamily string
 		wantModel  string
@@ -126,9 +127,22 @@ func TestWriteCPUInfoFamilyAndModel(t *testing.T) {
 			// Base model = 0x1, Extended model = 0x0 -> model = 1.
 			// (0x0a << 20) | (0x0 << 16) | (0xf << 8) | (0x1 << 4) | 0x1 = 0x00a00f11
 			name:       "AMD EPYC Zen 3",
+			vendor:     authenticAMD,
 			eax:        0x00a00f11,
 			wantFamily: "cpu family\t: 25\n",
 			wantModel:  "model\t\t: 1\n",
+		},
+		{
+			// AMD Athlon/K7:
+			// Base family = 6, Extended family = 0 -> cpu family = 6.
+			// Base model = 2, Extended model = 1 -> for AMD, ExtModel is reserved
+			// when BaseFamily < 0x0f, so model = 2 (not 18).
+			// (0x0 << 20) | (0x1 << 16) | (0x6 << 8) | (0x2 << 4) | 0x0 = 0x00010620
+			name:       "AMD K7",
+			vendor:     authenticAMD,
+			eax:        0x00010620,
+			wantFamily: "cpu family\t: 6\n",
+			wantModel:  "model\t\t: 2\n",
 		},
 		{
 			// Intel Skylake:
@@ -136,6 +150,7 @@ func TestWriteCPUInfoFamilyAndModel(t *testing.T) {
 			// Base model = 5, Extended model = 5 -> model = 85 (0x55).
 			// (0x0 << 20) | (0x5 << 16) | (0x6 << 8) | (0x5 << 4) | 0x4 = 0x00050654
 			name:       "Intel Skylake",
+			vendor:     genuineIntel,
 			eax:        0x00050654,
 			wantFamily: "cpu family\t: 6\n",
 			wantModel:  "model\t\t: 85\n",
@@ -145,6 +160,10 @@ func TestWriteCPUInfoFamilyAndModel(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			s := make(Static)
+			if tc.vendor != [12]byte{} {
+				bx, cx, dx := regsFromVendorID(tc.vendor)
+				s[In{Eax: uint32(vendorID)}] = Out{Ebx: bx, Ecx: cx, Edx: dx}
+			}
 			s[In{Eax: uint32(featureInfo)}] = Out{Eax: tc.eax}
 			fs := FeatureSet{Function: s}
 			var buf bytes.Buffer


### PR DESCRIPTION
Fixes #14631

### Problem Description
On x86 architectures (especially modern AMD processors like AMD EPYC 7R13 / Zen 3), `/proc/cpuinfo` inside gVisor reported an incorrect `cpu family` of `175` instead of `25`.

The previous calculation in `pkg/cpuid/cpuid_amd64.go`:
```go
fmt.Fprintf(w, "cpu family\t: %d\n", ((ef<<4)&0xff)|f)
```
performed bitwise concatenation (`(ef << 4) | f`). For an AMD Zen 3 CPU with Base Family `f = 15` (`0x0f`) and Extended Family `ef = 10` (`0x0a`), this resulted in `(10 << 4) | 15 = 175` (`0xaf`).

### Solution
According to AMD Architecture Programmer's Manual (APM Vol 3) and Intel 64 and IA-32 Architectures Software Developer's Manual:
- If Base Family is `0x0f`, the Display Family is computed by addition: `Base Family + Extended Family` (i.e. `15 + 10 = 25`). Otherwise, Display Family is `Base Family`.
- If Base Family is `0x06` or `0x0f`, Display Model is `(Extended Model << 4) | Base Model`. Otherwise, Display Model is `Base Model`.

### Changes
1. Updated `WriteCPUInfoTo` in `pkg/cpuid/cpuid_amd64.go` to compute `family` and `model` in accordance with the x86 specifications and Linux kernel `/proc/cpuinfo` behavior.
2. Added unit test `TestWriteCPUInfoFamilyAndModel` in `pkg/cpuid/cpuid_amd64_test.go` verifying CPU family and model generation for AMD Zen 3 and Intel architectures.
