### PR TITLE
fix(shm): check ownership before destroying SysV shared memory segment (fixes #14191)

### DIFF
--- a/pkg/sentry/kernel/shm/shm.go
+++ b/pkg/sentry/kernel/shm/shm.go
@@ -651,13 +651,18 @@ func (s *Shm) Set(ctx context.Context, ds *linux.ShmidDS) error {
 // destroyed once it has no references. MarkDestroyed may be called multiple
 // times, and is safe to call after a segment has already been destroyed. See
 // shmctl(IPC_RMID).
-func (s *Shm) MarkDestroyed(ctx context.Context) {
+func (s *Shm) MarkDestroyed(ctx context.Context) error {
+	creds := auth.CredentialsFromContext(ctx)
+	if !s.obj.CheckOwnership(creds) {
+		return linuxerr.EPERM
+	}
+
 	s.registry.dissociateKey(s)
 
 	s.mu.Lock()
 	if s.pendingDestruction {
 		s.mu.Unlock()
-		return
+		return nil
 	}
 	s.pendingDestruction = true
 	s.mu.Unlock()
@@ -668,4 +673,5 @@ func (s *Shm) MarkDestroyed(ctx context.Context) {
 	// N.B. This cannot be the final DecRef, as the caller also
 	// holds a reference.
 	s.DecRef(ctx)
+	return nil
 }

--- a/pkg/sentry/syscalls/linux/sys_shm.go
+++ b/pkg/sentry/syscalls/linux/sys_shm.go
@@ -145,7 +145,9 @@ func Shmctl(t *kernel.Task, sysno uintptr, args arch.SyscallArguments) (uintptr,
 		return 0, nil, err
 
 	case linux.IPC_RMID:
-		segment.MarkDestroyed(t)
+		if err := segment.MarkDestroyed(t); err != nil {
+			return 0, nil, err
+		}
 		return 0, nil, nil
 
 	case linux.SHM_LOCK, linux.SHM_UNLOCK:

--- a/test/syscalls/linux/shm.cc
+++ b/test/syscalls/linux/shm.cc
@@ -21,6 +21,7 @@
 
 #include "gmock/gmock.h"
 #include "absl/time/clock.h"
+#include "test/util/capability_util.h"
 #include "test/util/multiprocess_util.h"
 #include "test/util/posix_error.h"
 #include "test/util/temp_path.h"
@@ -537,6 +538,21 @@ TEST(ShmTest, MprotectWriteOnWritableSegmentSucceeds) {
   EXPECT_EQ(addr[0], 'y');
 
   ASSERT_NO_ERRNO(Shmdt(addr));
+}
+
+TEST(ShmTest, RmidPermissionCheck) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  const ShmSegment shm = ASSERT_NO_ERRNO_AND_VALUE(
+      Shmget(IPC_PRIVATE, kAllocSize, IPC_CREAT | 0600));
+
+  auto child = [&] {
+    TEST_CHECK_SUCCESS(syscall(SYS_setuid, 1000));
+    TEST_CHECK_ERRNO(Shmctl<void>(shm.id(), IPC_RMID, nullptr), EPERM);
+    return 0;
+  };
+
+  EXPECT_THAT(InForkedProcess(child), IsPosixErrorOkAndHolds(0));
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes #14191

### Problem Description
Previously, `shmctl(IPC_RMID)` did not check caller ownership or privileges before marking a shared memory segment for destruction (`segment.MarkDestroyed(t)` returned unconditionally). Consequently, unprivileged processes without ownership (and without `CAP_SYS_ADMIN`) could destroy SysV shared memory segments created by root or other users in the same IPC namespace.

### Solution
In Linux (`ipc/shm.c:shmctl_down` and `ipc/util.c:ipcctl_obtain_check`), `IPC_RMID` requires that the caller is the creator (`shm_perm.cuid`), owner (`shm_perm.uid`), or has `CAP_SYS_ADMIN`.

1. Added ownership verification via `s.obj.CheckOwnership(creds)` in `Shm.MarkDestroyed(ctx)` and returned `linuxerr.EPERM` if unauthorized.
2. Propagated errors from `segment.MarkDestroyed(t)` in `Shmctl(cmd == linux.IPC_RMID)` in `pkg/sentry/syscalls/linux/sys_shm.go`.
3. Added `TEST(ShmTest, RmidPermissionCheck)` in `test/syscalls/linux/shm.cc` verifying that non-owners cannot destroy segments with `IPC_RMID`.
