### PR TITLE
overlay, gofer: defer dentry drop when Notify removes the last watch

### DIFF
--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -513,7 +513,7 @@ func (fs *filesystem) doCreateAt(ctx context.Context, rp *vfs.ResolvingPath, dir
 		if dir {
 			ev |= linux.IN_ISDIR
 		}
-		parent.inode.watches.Notify(ctx, name, uint32(ev), 0, vfs.InodeEvent, false /* unlinked */)
+		parent.inode.watches.Notify(withCheckCachingList(ctx, &ds), name, uint32(ev), 0, vfs.InodeEvent, false /* unlinked */)
 		return nil
 	}
 	// No cached dentry exists; however, in InteropModeShared there might still be
@@ -545,7 +545,7 @@ func (fs *filesystem) doCreateAt(ctx context.Context, rp *vfs.ResolvingPath, dir
 	if dir {
 		ev |= linux.IN_ISDIR
 	}
-	parent.inode.watches.Notify(ctx, name, uint32(ev), 0, vfs.InodeEvent, false /* unlinked */)
+	parent.inode.watches.Notify(withCheckCachingList(ctx, &ds), name, uint32(ev), 0, vfs.InodeEvent, false /* unlinked */)
 	return nil
 }
 
@@ -708,12 +708,13 @@ func (fs *filesystem) unlinkAt(ctx context.Context, rp *vfs.ResolvingPath, dir b
 		}
 	}
 
+	nctx := withCheckCachingList(ctx, &ds)
 	if !dir {
 		var cw *vfs.Watches
 		if child != nil {
 			cw = &child.inode.watches
 		}
-		vfs.InotifyRemoveChild(ctx, cw, &parent.inode.watches, name)
+		vfs.InotifyRemoveChild(nctx, cw, &parent.inode.watches, name)
 	}
 
 	parent.childrenMu.Lock()
@@ -741,12 +742,12 @@ func (fs *filesystem) unlinkAt(ctx context.Context, rp *vfs.ResolvingPath, dir b
 			// last reference is dropped. refs==0 means no extra refs
 			// remain, so emit the child notifications now. Otherwise
 			// defer to destroyLocked(). HandleDeletion() is idempotent.
-			child.inode.watches.HandleDeletion(ctx)
+			child.inode.watches.HandleDeletion(nctx)
 		}
 		ds = appendDentry(ds, child)
 	}
 	if dir {
-		parent.inode.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
+		parent.inode.watches.Notify(nctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0, vfs.InodeEvent, true /* unlinked */)
 	}
 	parent.cacheNegativeLookupLocked(name)
 	if parent.inode.cachedMetadataAuthoritative() {
@@ -1386,7 +1387,7 @@ func (d *dentry) createAndOpenChildLocked(ctx context.Context, rp *vfs.Resolving
 		}
 		childVFSFD = &fd.vfsfd
 	}
-	d.inode.watches.Notify(ctx, name, linux.IN_CREATE, 0, vfs.PathEvent, false /* unlinked */)
+	d.inode.watches.Notify(withCheckCachingList(ctx, ds), name, linux.IN_CREATE, 0, vfs.PathEvent, false /* unlinked */)
 	childVFSFD.SetCreated()
 	return childVFSFD, nil
 }
@@ -1660,8 +1661,9 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 			}
 		}
 		// Sends notifications for both the renamed and replaced dentries.
-		vfs.InotifyRename(ctx, &renamed.inode.watches, &oldParent.inode.watches, &newParent.inode.watches, oldName, newName, renamed.isDir())
-		vfs.InotifyRename(ctx, &replaced.inode.watches, &newParent.inode.watches, &oldParent.inode.watches, newName, oldName, replaced.isDir())
+		nctx := withCheckCachingList(ctx, &ds)
+		vfs.InotifyRename(nctx, &renamed.inode.watches, &oldParent.inode.watches, &newParent.inode.watches, oldName, newName, renamed.isDir())
+		vfs.InotifyRename(nctx, &replaced.inode.watches, &newParent.inode.watches, &oldParent.inode.watches, newName, oldName, replaced.isDir())
 		return nil
 	}
 	if replaced != nil {
@@ -1714,7 +1716,7 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 			newParent.incLinks()
 		}
 	}
-	vfs.InotifyRename(ctx, &renamed.inode.watches, &oldParent.inode.watches, &newParent.inode.watches, oldName, newName, renamed.isDir())
+	vfs.InotifyRename(withCheckCachingList(ctx, &ds), &renamed.inode.watches, &oldParent.inode.watches, &newParent.inode.watches, oldName, newName, renamed.isDir())
 	return nil
 }
 
@@ -1733,15 +1735,13 @@ func (fs *filesystem) SetStatAt(ctx context.Context, rp *vfs.ResolvingPath, opts
 		return err
 	}
 	err = d.setStat(ctx, rp.Credentials(), &opts, rp.Mount())
+	if err == nil {
+		if ev := vfs.InotifyEventFromStatMask(opts.Stat.Mask); ev != 0 {
+			d.InotifyWithParent(withCheckCachingList(ctx, &ds), ev, 0, vfs.InodeEvent)
+		}
+	}
 	fs.renameMuRUnlockAndCheckCaching(ctx, &ds)
-	if err != nil {
-		return err
-	}
-
-	if ev := vfs.InotifyEventFromStatMask(opts.Stat.Mask); ev != 0 {
-		d.InotifyWithParent(ctx, ev, 0, vfs.InodeEvent)
-	}
-	return nil
+	return err
 }
 
 // StatAt implements vfs.FilesystemImpl.StatAt.
@@ -1882,13 +1882,11 @@ func (fs *filesystem) SetXattrAt(ctx context.Context, rp *vfs.ResolvingPath, opt
 		return err
 	}
 	err = d.setXattr(ctx, rp.Credentials(), &opts)
-	fs.renameMuRUnlockAndCheckCaching(ctx, &ds)
-	if err != nil {
-		return err
+	if err == nil {
+		d.InotifyWithParent(withCheckCachingList(ctx, &ds), linux.IN_ATTRIB, 0, vfs.InodeEvent)
 	}
-
-	d.InotifyWithParent(ctx, linux.IN_ATTRIB, 0, vfs.InodeEvent)
-	return nil
+	fs.renameMuRUnlockAndCheckCaching(ctx, &ds)
+	return err
 }
 
 // RemoveXattrAt implements vfs.FilesystemImpl.RemoveXattrAt.
@@ -1901,13 +1899,11 @@ func (fs *filesystem) RemoveXattrAt(ctx context.Context, rp *vfs.ResolvingPath, 
 		return err
 	}
 	err = d.removeXattr(ctx, rp.Credentials(), name)
-	fs.renameMuRUnlockAndCheckCaching(ctx, &ds)
-	if err != nil {
-		return err
+	if err == nil {
+		d.InotifyWithParent(withCheckCachingList(ctx, &ds), linux.IN_ATTRIB, 0, vfs.InodeEvent)
 	}
-
-	d.InotifyWithParent(ctx, linux.IN_ATTRIB, 0, vfs.InodeEvent)
-	return nil
+	fs.renameMuRUnlockAndCheckCaching(ctx, &ds)
+	return err
 }
 
 // GetPosixACLAt implements vfs.FilesystemImpl.GetPosixACLAt.

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -1701,10 +1701,36 @@ func (d *dentry) Watches() *vfs.Watches {
 	return &d.inode.watches
 }
 
+// checkCachingListKey is the context key under which withCheckCachingList
+// publishes an operation's list of dentries to check for caching to
+// dentry.OnZeroWatches.
+type checkCachingListKey struct{}
+
+// withCheckCachingList returns ctx carrying ds, the list that the calling
+// operation will pass to renameMuRUnlockAndCheckCaching or
+// renameMuUnlockAndCheckCaching. Use it for Watches.Notify and the
+// vfs.Inotify* helpers while fs.renameMu is held: Notify removes watches the
+// notification expired (IN_ONESHOT) and calls OnZeroWatches on the notifying
+// goroutine, whose checkCachingLocked locks d.vfsd for IsDead() (held by
+// unlinkAt between PrepareDeleteDentry and CommitDeleteDentry) and takes
+// fs.renameMu for writing to destroy a deleted dentry or to evict from a full
+// cache, deadlocking against the caller. OnZeroWatches appends the dentry to
+// ds instead and the caller checks it after the unlock.
+//
+// Preconditions: fs.renameMu must be locked.
+func withCheckCachingList(ctx context.Context, ds **[]*dentry) context.Context {
+	return context.WithValue(ctx, checkCachingListKey{}, ds)
+}
+
 // OnZeroWatches implements vfs.DentryImpl.OnZeroWatches.
 //
 // If no watches are left on this dentry and it has no references, cache it.
 func (d *dentry) OnZeroWatches(ctx context.Context) {
+	if ds, ok := ctx.Value(checkCachingListKey{}).(**[]*dentry); ok {
+		// The caller holds fs.renameMu; see withCheckCachingList.
+		*ds = appendDentry(*ds, d)
+		return
+	}
 	d.checkCachingLocked(ctx, false /* renameMuWriteLocked */)
 }
 

--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -571,7 +571,7 @@ func (fs *filesystem) doCreateAt(ctx context.Context, rp *vfs.ResolvingPath, ct 
 	if ct != createNonDirectory {
 		ev |= linux.IN_ISDIR
 	}
-	parent.watches.Notify(ctx, name, uint32(ev), 0 /* cookie */, vfs.InodeEvent, false /* unlinked */)
+	parent.watches.Notify(withDropList(ctx, &ds), name, uint32(ev), 0 /* cookie */, vfs.InodeEvent, false /* unlinked */)
 	return nil
 }
 
@@ -1050,7 +1050,7 @@ func (fs *filesystem) createAndOpenLocked(ctx context.Context, rp *vfs.Resolving
 		upperFD.DecRef(ctx)
 		return nil, err
 	}
-	parent.watches.Notify(ctx, childName, linux.IN_CREATE, 0 /* cookie */, vfs.PathEvent, false /* unlinked */)
+	parent.watches.Notify(withDropList(ctx, ds), childName, linux.IN_CREATE, 0 /* cookie */, vfs.PathEvent, false /* unlinked */)
 	fd.vfsfd.SetCreated()
 	return &fd.vfsfd, nil
 }
@@ -1378,8 +1378,9 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 			}
 		}
 
-		vfs.InotifyRename(ctx, &renamed.watches, &oldParent.watches, &newParent.watches, oldName, newName, renamed.isDir())
-		vfs.InotifyRename(ctx, &replaced.watches, &newParent.watches, &oldParent.watches, newName, oldName, replaced.isDir())
+		nctx := withDropList(ctx, &ds)
+		vfs.InotifyRename(nctx, &renamed.watches, &oldParent.watches, &newParent.watches, oldName, newName, renamed.isDir())
+		vfs.InotifyRename(nctx, &replaced.watches, &newParent.watches, &oldParent.watches, newName, oldName, replaced.isDir())
 		return nil
 	}
 
@@ -1425,7 +1426,7 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 		}
 	}
 
-	vfs.InotifyRename(ctx, &renamed.watches, &oldParent.watches, &newParent.watches, oldName, newName, renamed.isDir())
+	vfs.InotifyRename(withDropList(ctx, &ds), &renamed.watches, &oldParent.watches, &newParent.watches, oldName, newName, renamed.isDir())
 	return nil
 }
 
@@ -1568,14 +1569,15 @@ func (fs *filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 	fs.releaseDirIno(child.dirInoHash)
 	ds = appendDentry(ds, child)
 	parent.dirents = nil
+	nctx := withDropList(ctx, &ds)
 	// Linux sends the parent's IN_DELETE|IN_ISDIR at rmdir() time, but
 	// defers the child's IN_DELETE_SELF/IN_IGNORED until the last ref is
 	// dropped. Emit the child notifications now only when no extra refs
 	// remain; otherwise defer to destroyLocked().
 	if child.refs.Load() == 0 {
-		child.watches.HandleDeletion(ctx)
+		child.watches.HandleDeletion(nctx)
 	}
-	parent.watches.Notify(ctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0 /* cookie */, vfs.InodeEvent, true /* unlinked */)
+	parent.watches.Notify(nctx, name, linux.IN_DELETE|linux.IN_ISDIR, 0 /* cookie */, vfs.InodeEvent, true /* unlinked */)
 	return nil
 }
 
@@ -1589,15 +1591,13 @@ func (fs *filesystem) SetStatAt(ctx context.Context, rp *vfs.ResolvingPath, opts
 		return err
 	}
 	err = d.setStatLocked(ctx, rp, opts)
+	if err == nil {
+		if ev := vfs.InotifyEventFromStatMask(opts.Stat.Mask); ev != 0 {
+			d.InotifyWithParent(withDropList(ctx, &ds), ev, 0 /* cookie */, vfs.InodeEvent)
+		}
+	}
 	fs.renameMuRUnlockAndCheckDrop(ctx, &ds)
-	if err != nil {
-		return err
-	}
-
-	if ev := vfs.InotifyEventFromStatMask(opts.Stat.Mask); ev != 0 {
-		d.InotifyWithParent(ctx, ev, 0 /* cookie */, vfs.InodeEvent)
-	}
-	return nil
+	return err
 }
 
 // Precondition: d.fs.renameMu must be held for reading.
@@ -1804,7 +1804,7 @@ func (fs *filesystem) UnlinkAt(ctx context.Context, rp *vfs.ResolvingPath) error
 		}
 	}
 	ds = appendDentry(ds, child)
-	vfs.InotifyRemoveChild(ctx, &child.watches, &parent.watches, name)
+	vfs.InotifyRemoveChild(withDropList(ctx, &ds), &child.watches, &parent.watches, name)
 	parent.dirents = nil
 	return nil
 }
@@ -1895,13 +1895,11 @@ func (fs *filesystem) SetXattrAt(ctx context.Context, rp *vfs.ResolvingPath, opt
 	}
 
 	err = fs.setXattrLocked(ctx, d, rp.Mount(), rp.Credentials(), &opts)
-	fs.renameMuRUnlockAndCheckDrop(ctx, &ds)
-	if err != nil {
-		return err
+	if err == nil {
+		d.InotifyWithParent(withDropList(ctx, &ds), linux.IN_ATTRIB, 0 /* cookie */, vfs.InodeEvent)
 	}
-
-	d.InotifyWithParent(ctx, linux.IN_ATTRIB, 0 /* cookie */, vfs.InodeEvent)
-	return nil
+	fs.renameMuRUnlockAndCheckDrop(ctx, &ds)
+	return err
 }
 
 // Precondition: fs.renameMu must be locked, d.copyMu must be unlocked.
@@ -1951,13 +1949,11 @@ func (fs *filesystem) RemoveXattrAt(ctx context.Context, rp *vfs.ResolvingPath, 
 	}
 
 	err = fs.removeXattrLocked(ctx, d, rp.Mount(), rp.Credentials(), name)
-	fs.renameMuRUnlockAndCheckDrop(ctx, &ds)
-	if err != nil {
-		return err
+	if err == nil {
+		d.InotifyWithParent(withDropList(ctx, &ds), linux.IN_ATTRIB, 0 /* cookie */, vfs.InodeEvent)
 	}
-
-	d.InotifyWithParent(ctx, linux.IN_ATTRIB, 0 /* cookie */, vfs.InodeEvent)
-	return nil
+	fs.renameMuRUnlockAndCheckDrop(ctx, &ds)
+	return err
 }
 
 // Precondition: fs.renameMu must be locked, d.copyMu must be unlocked.

--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -843,13 +843,39 @@ func (d *dentry) Watches() *vfs.Watches {
 	return &d.watches
 }
 
+// dropListKey is the context key under which withDropList publishes an
+// operation's drop list to dentry.OnZeroWatches.
+type dropListKey struct{}
+
+// withDropList returns ctx carrying ds, the drop list that the calling
+// operation will pass to renameMuRUnlockAndCheckDrop or
+// renameMuUnlockAndCheckDrop. Use it for Watches.Notify and the
+// vfs.Inotify* helpers while fs.renameMu is held: Notify removes watches the
+// notification expired (IN_ONESHOT) and calls OnZeroWatches on the notifying
+// goroutine, which would otherwise take fs.renameMu for writing and deadlock.
+// The notified dentry is often not on ds already, since a dentry kept alive
+// by its watches is found in its parent's children map rather than
+// instantiated by the walk, so OnZeroWatches appends it to ds and the caller
+// drops it after the unlock.
+//
+// Preconditions: fs.renameMu must be locked.
+func withDropList(ctx context.Context, ds **[]*dentry) context.Context {
+	return context.WithValue(ctx, dropListKey{}, ds)
+}
+
 // OnZeroWatches implements vfs.DentryImpl.OnZeroWatches.
 func (d *dentry) OnZeroWatches(ctx context.Context) {
-	if d.refs.Load() == 0 {
-		d.fs.renameMu.Lock()
-		d.checkDropLocked(ctx)
-		d.fs.renameMu.Unlock()
+	if d.refs.Load() != 0 {
+		return
 	}
+	if ds, ok := ctx.Value(dropListKey{}).(**[]*dentry); ok {
+		// The caller holds fs.renameMu; see withDropList.
+		*ds = appendDentry(*ds, d)
+		return
+	}
+	d.fs.renameMu.Lock()
+	d.checkDropLocked(ctx)
+	d.fs.renameMu.Unlock()
 }
 
 // iterLayers invokes yield on each layer comprising d, from top to bottom. If

--- a/pkg/sentry/vfs/dentry.go
+++ b/pkg/sentry/vfs/dentry.go
@@ -139,6 +139,13 @@ type DentryImpl interface {
 	// The caller does not need to hold a reference on the dentry. OnZeroWatches
 	// may acquire inotify locks, so to prevent deadlock, no inotify locks should
 	// be held by the caller.
+	//
+	// Watches.Notify calls OnZeroWatches on the notifying goroutine when the
+	// notification expires the dentry's last watch (IN_ONESHOT). Since
+	// FilesystemImpls call Notify while holding their own locks, an
+	// implementation that needs such a lock in OnZeroWatches must arrange for
+	// the notifying operation to do the work after it releases the lock; see
+	// overlay.withDropList and gofer.withCheckCachingList.
 	OnZeroWatches(ctx context.Context)
 }
 

--- a/test/syscalls/linux/inotify.cc
+++ b/test/syscalls/linux/inotify.cc
@@ -2348,6 +2348,97 @@ TEST(Inotify, OneShot) {
               SyscallFailsWithErrno(EINVAL));
 }
 
+// The event that fires an IN_ONESHOT watch also removes the watch, while the
+// filesystem is still inside the operation that generated the event. The tests
+// below cover the operations whose notifications used to deadlock the overlay
+// and gofer filesystems when the watched dentry had no other users
+// (github.com/google/gvisor/issues/14680).
+TEST(Inotify, OneShotDirWatchRemovedByMkdir) {
+  const TempPath root = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  const std::string dir = NewTempAbsPathInDir(root.path());
+  ASSERT_THAT(mkdir(dir.c_str(), 0755), SyscallSucceeds());
+  const FileDescriptor inotify_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+  const int wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(inotify_fd.get(), dir, IN_CREATE | IN_ONESHOT));
+
+  const std::string child = JoinPath(dir, "child");
+  ASSERT_THAT(mkdir(child.c_str(), 0755), SyscallSucceeds());
+
+  const std::vector<Event> events =
+      ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(inotify_fd.get()));
+  EXPECT_THAT(events, Are({
+                          Event(IN_CREATE | IN_ISDIR, wd, "child"),
+                          Event(IN_IGNORED, wd),
+                      }));
+  EXPECT_THAT(inotify_rm_watch(inotify_fd.get(), wd),
+              SyscallFailsWithErrno(EINVAL));
+}
+
+TEST(Inotify, OneShotDirWatchRemovedByRename) {
+  const TempPath root = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  const std::string dir = NewTempAbsPathInDir(root.path());
+  ASSERT_THAT(mkdir(dir.c_str(), 0755), SyscallSucceeds());
+  const FileDescriptor inotify_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+  const int wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(inotify_fd.get(), dir, IN_MOVE_SELF | IN_ONESHOT));
+
+  const std::string new_dir = NewTempAbsPathInDir(root.path());
+  ASSERT_THAT(rename(dir.c_str(), new_dir.c_str()), SyscallSucceeds());
+
+  const std::vector<Event> events =
+      ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(inotify_fd.get()));
+  EXPECT_THAT(events, Are({
+                          Event(IN_MOVE_SELF, wd),
+                          Event(IN_IGNORED, wd),
+                      }));
+  EXPECT_THAT(inotify_rm_watch(inotify_fd.get(), wd),
+              SyscallFailsWithErrno(EINVAL));
+}
+
+TEST(Inotify, OneShotDirWatchRemovedByRmdir) {
+  const TempPath root = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  const std::string dir = NewTempAbsPathInDir(root.path());
+  ASSERT_THAT(mkdir(dir.c_str(), 0755), SyscallSucceeds());
+  const FileDescriptor inotify_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+  const int wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(inotify_fd.get(), dir, IN_DELETE_SELF | IN_ONESHOT));
+
+  ASSERT_THAT(rmdir(dir.c_str()), SyscallSucceeds());
+
+  const std::vector<Event> events =
+      ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(inotify_fd.get()));
+  EXPECT_THAT(events, Are({
+                          Event(IN_DELETE_SELF, wd),
+                          Event(IN_IGNORED, wd),
+                      }));
+  EXPECT_THAT(inotify_rm_watch(inotify_fd.get(), wd),
+              SyscallFailsWithErrno(EINVAL));
+}
+
+TEST(Inotify, OneShotFileWatchRemovedByUnlink) {
+  const TempPath root = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  TempPath file =
+      ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateFileIn(root.path()));
+  const FileDescriptor inotify_fd =
+      ASSERT_NO_ERRNO_AND_VALUE(InotifyInit1(IN_NONBLOCK));
+  const int wd = ASSERT_NO_ERRNO_AND_VALUE(
+      InotifyAddWatch(inotify_fd.get(), file.path(), IN_ATTRIB | IN_ONESHOT));
+
+  file.reset();
+
+  const std::vector<Event> events =
+      ASSERT_NO_ERRNO_AND_VALUE(DrainEvents(inotify_fd.get()));
+  EXPECT_THAT(events, Are({
+                          Event(IN_ATTRIB, wd),
+                          Event(IN_IGNORED, wd),
+                      }));
+  EXPECT_THAT(inotify_rm_watch(inotify_fd.get(), wd),
+              SyscallFailsWithErrno(EINVAL));
+}
+
 // This test helps verify that the lock order of filesystem and inotify locks
 // is respected when inotify instances and watch targets are concurrently being
 // destroyed.


### PR DESCRIPTION
Fixes #14680.

A sandbox on an overlay rootfs stops responding to SIGKILL after a process
mkdirs in, renames or rmdirs a directory carrying an IN_ONESHOT inotify
watch, or unlinks a watched file. The task never returns from the syscall,
every later dentry release (task exit included) queues behind it, `runsc
kill` returns without effect, the shim's Wait never completes and the
kubelet retries the stop until the sentry is killed by hand. Stacks in the
issue.

Watches.Notify removes the watches the notification expired before it
returns and calls OnZeroWatches on the notifying goroutine when the last
one goes. Overlay and gofer notify with filesystem locks held, and their
OnZeroWatches take locks the caller holds:

  - overlay: renameMu for writing, while doCreateAt, createAndOpenLocked,
    RmdirAt and UnlinkAt hold it for reading and RenameAt for writing.
  - gofer: checkCachingLocked locks the vfs.Dentry for IsDead() (held by
    unlinkAt from PrepareDeleteDentry to CommitDeleteDentry) and takes
    renameMu for writing to destroy a deleted dentry (rmdir) or to evict
    from a full dentry cache (rename and unlink with > dcache entries).

Skipping the drop in OnZeroWatches is not enough: the notified dentry is
usually not on the operation's drop list, because a dentry kept alive only
by its watches stays in its parent's children map and getChildLocked
appends only dentries it instantiates. It would leak once its last watch
is gone.

Both filesystems now pass the operation's drop list in the context given
to Watches.Notify and the vfs.Inotify* helpers (overlay.withDropList,
gofer.withCheckCachingList); OnZeroWatches appends the dentry to it and
the existing renameMu(R)UnlockAndCheck{Drop,Caching} does the work after
the unlock. inotify_rm_watch and inotify fd release are unchanged.
SetStatAt, SetXattrAt and RemoveXattrAt now notify before the unlock:
after it, OnZeroWatches took renameMu under InotifyWithParent's
ancestryMu, against the lock order, and in overlay ran on a dentry the
drop check may already have destroyed.

Tested on x86_64, systrap, no KVM:

  - Issue reproducer vs unpatched runsc from the go branch head (master
    9072dc843; the 6 later commits touch nothing under pkg/), alpine
    rootfs, one-shot watch held by a second process. Overlay
    (--overlay2=root:self): mkdir, rename, rmdir, unlink all hang. Gofer
    (--overlay2=none): rmdir and unlink hang cold, rename with a full
    dcache; mkdir completes (the new child pins the parent). tmpfs:
    nothing hangs. Patched: every case completes in 10-20 ms, event then
    IN_IGNORED.
  - bazel test inotify_test_{native,runsc_systrap_directfs,
    runsc_systrap_overlay,runsc_systrap_shared,
    runsc_systrap_directfs_save,runsc_systrap_overlay_save}: all pass.
    Only the 4 new tests on master: native passes (Linux 6.8), directfs
    and overlay time out (overlay in the mkdir test, gofer in rmdir).
