### PR TITLE
Allow execve of execute-only (--x) binaries

### DIFF
--- a/pkg/sentry/fsimpl/gofer/filesystem.go
+++ b/pkg/sentry/fsimpl/gofer/filesystem.go
@@ -1120,7 +1120,9 @@ func (d *dentry) open(ctx context.Context, rp *vfs.ResolvingPath, opts *vfs.Open
 	switch d.inode.fileType() {
 	case linux.S_IFREG:
 		if !d.inode.fs.opts.regularFilesUseSpecialFileFD {
-			if err := d.ensureSharedHandle(ctx, ats.MayRead(), ats.MayWrite(), trunc); err != nil {
+			// Exec opens need a readable handle even without read permission;
+			// the sentry must read the executable to load it.
+			if err := d.ensureSharedHandle(ctx, ats.MayRead() || opts.FileExec, ats.MayWrite(), trunc); err != nil {
 				return nil, err
 			}
 			fd, err := newRegularFileFD(mnt, d, opts.Flags, rp.Credentials())
@@ -1270,7 +1272,9 @@ func (d *dentry) openSpecialFile(ctx context.Context, mnt *vfs.Mount, opts *vfs.
 	// since closed its end.
 	isBlockingOpenOfNamedPipe := d.inode.fileType() == linux.S_IFIFO && opts.Flags&linux.O_NONBLOCK == 0
 retry:
-	h, err := d.openHandle(ctx, ats.MayRead(), ats.MayWrite(), opts.Flags&linux.O_TRUNC != 0)
+	// Exec opens need a readable handle even without read permission; the
+	// sentry must read the executable to load it.
+	h, err := d.openHandle(ctx, ats.MayRead() || opts.FileExec, ats.MayWrite(), opts.Flags&linux.O_TRUNC != 0)
 	if err != nil {
 		if isBlockingOpenOfNamedPipe && ats == vfs.MayWrite && linuxerr.Equals(linuxerr.ENXIO, err) {
 			// An attempt to open a named pipe with O_WRONLY|O_NONBLOCK fails

--- a/pkg/sentry/fsimpl/gofer/gofer.go
+++ b/pkg/sentry/fsimpl/gofer/gofer.go
@@ -1586,8 +1586,12 @@ func (d *dentry) checkXattrPermissions(creds *auth.Credentials, name string, ats
 	mode := linux.FileMode(d.inode.mode.RacyLoad())
 	kuid := auth.KUID(d.inode.uid.RacyLoad())
 	kgid := auth.KGID(d.inode.gid.RacyLoad())
-	if err := vfs.GenericCheckPermissions(creds, ats, mode, nil, kuid, kgid); err != nil {
-		return err
+	// Linux only skips the read permission check for reads of security.*,
+	// system.*, and trusted.* xattrs, see fs/xattr.c:xattr_permission().
+	if ats.MayWrite() || vfs.XattrReadNeedsFilePermission(name) {
+		if err := vfs.GenericCheckPermissions(creds, ats, mode, nil, kuid, kgid); err != nil {
+			return err
+		}
 	}
 	return vfs.CheckXattrPermissions(creds, ats, mode, kuid, name)
 }

--- a/pkg/sentry/fsimpl/kernfs/filesystem.go
+++ b/pkg/sentry/fsimpl/kernfs/filesystem.go
@@ -1132,8 +1132,12 @@ func (fs *Filesystem) GetXattrAt(ctx context.Context, rp *vfs.ResolvingPath, opt
 		mode := d.inode.Mode()
 		kuid := d.inode.UID()
 		kgid := d.inode.GID()
-		if err := vfs.GenericCheckPermissions(creds, vfs.MayRead, mode, nil, kuid, kgid); err != nil {
-			return "", err
+		// Linux only skips the read permission check for reads of security.*,
+		// system.*, and trusted.* xattrs, see fs/xattr.c:xattr_permission().
+		if vfs.XattrReadNeedsFilePermission(opts.Name) {
+			if err := vfs.GenericCheckPermissions(creds, vfs.MayRead, mode, nil, kuid, kgid); err != nil {
+				return "", err
+			}
 		}
 		if err := vfs.CheckXattrPermissions(creds, vfs.MayRead, mode, kuid, opts.Name); err != nil {
 			return "", err

--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -894,8 +894,12 @@ func (d *dentry) checkXattrPermissions(creds *auth.Credentials, name string, ats
 	mode := linux.FileMode(d.mode.Load())
 	kuid := auth.KUID(d.uid.Load())
 	kgid := auth.KGID(d.gid.Load())
-	if err := vfs.GenericCheckPermissions(creds, ats, mode, d.accessACL.Load(), kuid, kgid); err != nil {
-		return err
+	// Linux only skips the read permission check for reads of security.*,
+	// system.*, and trusted.* xattrs, see fs/xattr.c:xattr_permission().
+	if ats.MayWrite() || vfs.XattrReadNeedsFilePermission(name) {
+		if err := vfs.GenericCheckPermissions(creds, ats, mode, d.accessACL.Load(), kuid, kgid); err != nil {
+			return err
+		}
 	}
 	return vfs.CheckXattrPermissions(creds, ats, mode, kuid, name)
 }

--- a/pkg/sentry/fsimpl/tmpfs/tmpfs.go
+++ b/pkg/sentry/fsimpl/tmpfs/tmpfs.go
@@ -1078,22 +1078,27 @@ func (i *inode) listXattr(creds *auth.Credentials, size uint64) ([]string, error
 }
 
 func (i *inode) getXattr(creds *auth.Credentials, opts *vfs.GetXattrOptions) (string, error) {
-	if err := i.checkXattrPrefix(opts.Name); err != nil {
-		return "", err
-	}
 	mode := linux.FileMode(i.mode.Load())
 	kuid := auth.KUID(i.uid.Load())
 	kgid := auth.KGID(i.gid.Load())
+
+	// Linux requires read permission for xattr reads outside the security.*,
+	// system.*, and trusted.* namespaces, and applies the check before any
+	// handler-specific rejection; see fs/xattr.c:xattr_permission().
+	if vfs.XattrReadNeedsFilePermission(opts.Name) {
+		acl := i.accessACL.Load()
+		if err := vfs.GenericCheckPermissions(creds, vfs.MayRead, mode, acl, kuid, kgid); err != nil {
+			return "", err
+		}
+	}
+	if err := i.checkXattrPrefix(opts.Name); err != nil {
+		return "", err
+	}
 
 	if strings.HasPrefix(opts.Name, linux.XATTR_SYSTEM_PREFIX) {
 		// Handle POSIX ACL xattrs
 		xattr, err := vfs.ACLGetXattr(creds, opts, mode, i.accessACL.Load(), i.defaultACL.Load())
 		return xattr, err
-	}
-
-	acl := i.accessACL.Load()
-	if err := vfs.GenericCheckPermissions(creds, vfs.MayRead, mode, acl, kuid, kgid); err != nil {
-		return "", err
 	}
 
 	return i.xattrs.GetXattr(creds, mode, kuid, opts)

--- a/pkg/sentry/kernel/auth/user_namespace.go
+++ b/pkg/sentry/kernel/auth/user_namespace.go
@@ -104,6 +104,16 @@ func (ns *UserNamespace) Root() *UserNamespace {
 	return ns
 }
 
+// AncestorPrivilegedWrtIDs returns the closest ancestor of ns (possibly ns
+// itself) into which both kuid and kgid are mapped, per Linux's
+// fs/exec.c:privileged_wrt_inode_uidgid().
+func (ns *UserNamespace) AncestorPrivilegedWrtIDs(kuid KUID, kgid KGID) *UserNamespace {
+	for ns.parent != nil && (!kuid.In(ns).Ok() || !kgid.In(ns).Ok()) {
+		ns = ns.parent
+	}
+	return ns
+}
+
 // Type implements vfs.Namespace.Type.
 func (ns *UserNamespace) Type() string {
 	return "user"

--- a/pkg/sentry/kernel/ptrace.go
+++ b/pkg/sentry/kernel/ptrace.go
@@ -21,6 +21,7 @@ import (
 	"gvisor.dev/gvisor/pkg/errors/linuxerr"
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/marshal/primitive"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/mm"
 	"gvisor.dev/gvisor/pkg/usermem"
 )
@@ -202,14 +203,14 @@ func (t *Task) canTraceStandard(target *Task, attach bool) bool {
 	// """
 	callerCreds := t.Credentials()
 	targetCreds := target.Credentials()
-	if callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace) {
-		return true
-	}
-	if cuid := callerCreds.RealKUID; cuid != targetCreds.RealKUID || cuid != targetCreds.EffectiveKUID || cuid != targetCreds.SavedKUID {
-		return false
-	}
-	if cgid := callerCreds.RealKGID; cgid != targetCreds.RealKGID || cgid != targetCreds.EffectiveKGID || cgid != targetCreds.SavedKGID {
-		return false
+	hasPtraceCapInTargetNS := callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, targetCreds.UserNamespace)
+	if !hasPtraceCapInTargetNS {
+		if cuid := callerCreds.RealKUID; cuid != targetCreds.RealKUID || cuid != targetCreds.EffectiveKUID || cuid != targetCreds.SavedKUID {
+			return false
+		}
+		if cgid := callerCreds.RealKGID; cgid != targetCreds.RealKGID || cgid != targetCreds.EffectiveKGID || cgid != targetCreds.SavedKGID {
+			return false
+		}
 	}
 	var targetMM *mm.MemoryManager
 	var targetUserDumpable bool
@@ -218,7 +219,12 @@ func (t *Task) canTraceStandard(target *Task, attach bool) bool {
 		targetUserDumpable = t.userDumpable
 	})
 	if targetMM != nil {
-		if targetMM.Dumpability() != mm.UserDumpable {
+		// The capability against non-dumpable targets must be held in the
+		// MemoryManager's user namespace (Linux: mm_struct::user_ns), which
+		// fs/exec.c:would_dump() may have lowered to an ancestor of the
+		// target's namespace at execve.
+		if targetMM.Dumpability() != mm.UserDumpable &&
+			!callerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, mmUserNamespace(targetMM, targetCreds)) {
 			return false
 		}
 	} else {
@@ -226,13 +232,52 @@ func (t *Task) canTraceStandard(target *Task, attach bool) bool {
 			return false
 		}
 	}
-	if callerCreds.UserNamespace != targetCreds.UserNamespace {
-		return false
-	}
-	if targetCreds.PermittedCaps&^callerCreds.PermittedCaps != 0 {
-		return false
+	if !hasPtraceCapInTargetNS {
+		if callerCreds.UserNamespace != targetCreds.UserNamespace {
+			return false
+		}
+		if targetCreds.PermittedCaps&^callerCreds.PermittedCaps != 0 {
+			return false
+		}
 	}
 	return true
+}
+
+// mmUserNamespace returns m's user namespace, falling back to the given
+// credentials' user namespace for MemoryManagers restored from saved states
+// that predate mm_struct::user_ns tracking.
+func mmUserNamespace(m *mm.MemoryManager, creds *auth.Credentials) *auth.UserNamespace {
+	if ns := m.UserNamespace(); ns != nil {
+		return ns
+	}
+	return creds.UserNamespace
+}
+
+// ptraceAccessVM returns whether t, which must be target's tracer, may access
+// target's memory via ptrace requests such as PTRACE_PEEKDATA, per Linux's
+// kernel/ptrace.c:ptrace_access_vm().
+func (t *Task) ptraceAccessVM(target *Task) bool {
+	var targetMM *mm.MemoryManager
+	var tracerCreds *auth.Credentials
+	ts := t.tg.pidns.owner
+	ts.mu.RLock()
+	tracerCreds = target.ptracerCreds
+	target.WithMuLocked(func(t *Task) {
+		targetMM = t.MemoryManager()
+	})
+	ts.mu.RUnlock()
+	if targetMM == nil {
+		return false
+	}
+	if targetMM.Dumpability() == mm.UserDumpable {
+		return true
+	}
+	if tracerCreds == nil {
+		// Tracing relationships restored from older saved states have no
+		// credential snapshot; fall back to the tracer's current credentials.
+		tracerCreds = t.Credentials()
+	}
+	return tracerCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, mmUserNamespace(targetMM, target.Credentials()))
 }
 
 // canTraceYAMALocked performs ptrace access checks as defined by the YAMA LSM
@@ -474,6 +519,23 @@ func (t *Task) ptraceUnstop(mode ptraceSyscallMode, singlestep bool, sig linux.S
 	return nil
 }
 
+// canTracemeLocked returns true if t's parent may trace t via PTRACE_TRACEME.
+// Unlike attachment, Linux's kernel/ptrace.c:ptrace_traceme() performs no
+// __ptrace_may_access() check (so the target's dumpability is irrelevant);
+// authorization is security_ptrace_traceme(), implemented by
+// security/commoncap.c:cap_ptrace_traceme().
+//
+// Preconditions: t.parent != nil. The TaskSet mutex must be locked.
+func (t *Task) canTracemeLocked() bool {
+	parentCreds := t.parent.Credentials()
+	childCreds := t.Credentials()
+	if parentCreds.UserNamespace == childCreds.UserNamespace &&
+		childCreds.PermittedCaps&^parentCreds.PermittedCaps == 0 {
+		return true
+	}
+	return parentCreds.HasCapabilityIn(linux.CAP_SYS_PTRACE, childCreds.UserNamespace)
+}
+
 func (t *Task) ptraceTraceme() error {
 	t.tg.pidns.owner.mu.Lock()
 	defer t.tg.pidns.owner.mu.Unlock()
@@ -493,7 +555,7 @@ func (t *Task) ptraceTraceme() error {
 		// returning nil here is correct.
 		return nil
 	}
-	if !t.parent.canTraceLocked(t, true) {
+	if !t.canTracemeLocked() {
 		return linuxerr.EPERM
 	}
 	if t.parent.exitStateLocked() != TaskExitNone {
@@ -502,6 +564,9 @@ func (t *Task) ptraceTraceme() error {
 		return nil
 	}
 	t.ptraceTracer.Store(t.parent)
+	// Linux's ptrace_traceme() => ptrace_link() snapshots the caller's (i.e.
+	// the tracee's own) credentials.
+	t.ptracerCreds = t.Credentials()
 	t.parent.ptraceTracees[t] = struct{}{}
 	return nil
 }
@@ -529,6 +594,7 @@ func (t *Task) ptraceAttach(target *Task, seize bool, opts uintptr) error {
 		}
 	}
 	target.ptraceTracer.Store(t)
+	target.ptracerCreds = t.Credentials()
 	t.ptraceTracees[target] = struct{}{}
 	target.tg.signalHandlers.mu.Lock()
 	target.ptraceSeized = seize
@@ -610,6 +676,7 @@ func (t *Task) forgetTracerLocked() {
 	t.ptraceSyscallMode = ptraceSyscallNone
 	t.ptraceSinglestep = false
 	t.ptraceTracer.Store(nil)
+	t.ptracerCreds = nil
 	if t.exitTracerNotified && !t.exitTracerAcked {
 		t.exitTracerAcked = true
 		// Don't hold signalHandlers.mu while calling exitNotifyLocked,
@@ -809,6 +876,10 @@ func (t *Task) ptraceClone(kind ptraceCloneKind, child *Task, args *linux.CloneA
 		tracer := t.Tracer()
 		if tracer != nil {
 			child.ptraceTracer.Store(tracer)
+			// Automatically attached children inherit the forking tracee's
+			// tracer credential snapshot, as in Linux's
+			// include/linux/ptrace.h:ptrace_init_task().
+			child.ptracerCreds = t.ptracerCreds
 			tracer.ptraceTracees[child] = struct{}{}
 			child.tg.signalHandlers.mu.Lock()
 			// "The "seized" behavior ... is inherited by children that are
@@ -1178,6 +1249,9 @@ func (t *Task) Ptrace(req int64, pid ThreadID, addr, data hostarch.Addr) error {
 
 	switch req {
 	case linux.PTRACE_PEEKTEXT, linux.PTRACE_PEEKDATA:
+		if !t.ptraceAccessVM(target) {
+			return linuxerr.EIO
+		}
 		// "At the system call level, the PTRACE_PEEKTEXT, PTRACE_PEEKDATA, and
 		// PTRACE_PEEKUSER requests have a different API: they store the result
 		// at the address specified by the data parameter, and the return value
@@ -1190,6 +1264,9 @@ func (t *Task) Ptrace(req int64, pid ThreadID, addr, data hostarch.Addr) error {
 		return err
 
 	case linux.PTRACE_POKETEXT, linux.PTRACE_POKEDATA:
+		if !t.ptraceAccessVM(target) {
+			return linuxerr.EIO
+		}
 		word := t.Arch().Native(uintptr(data))
 		_, err := word.CopyOut(target.CopyContext(t, usermem.IOOpts{IgnorePermissions: true}), addr)
 		return err

--- a/pkg/sentry/kernel/task.go
+++ b/pkg/sentry/kernel/task.go
@@ -364,6 +364,14 @@ type Task struct {
 	// additional synchronization.
 	ptraceTracer atomic.Pointer[Task] `state:".(*Task)"`
 
+	// ptracerCreds is a snapshot of this task's tracer's credentials,
+	// captured when the tracing relationship was established, analogous to
+	// Linux's task_struct::ptracer_cred. It is nil if the task is not being
+	// traced (and may be nil for tasks restored from older saved states).
+	//
+	// ptracerCreds is protected by the TaskSet mutex.
+	ptracerCreds *auth.Credentials
+
 	// ptraceTracees is the set of tasks that this task is ptrace-attached to.
 	//
 	// ptraceTracees is protected by the TaskSet mutex.

--- a/pkg/sentry/kernel/task_exec.go
+++ b/pkg/sentry/kernel/task_exec.go
@@ -363,9 +363,9 @@ func (r *runExecveAfterSiblingExitStop) execute(t *Task) taskRunState {
 	}
 
 	// Update dumpability using just the old creds, see fs/exec.c:begin_new_exec().
-	// FIXME: Account for executables that may not be read when setting dumpability below.
 	oldCreds := t.creds.Load()
-	if oldCreds.EffectiveKUID != oldCreds.RealKUID ||
+	if r.image.NotDumpable ||
+		oldCreds.EffectiveKUID != oldCreds.RealKUID ||
 		oldCreds.EffectiveKGID != oldCreds.RealKGID {
 		r.image.MemoryManager.SetDumpability(mm.NotDumpable) // suid_dumpable is not implemented
 	} else {

--- a/pkg/sentry/kernel/task_exit.go
+++ b/pkg/sentry/kernel/task_exit.go
@@ -1222,6 +1222,7 @@ func (t *Task) waitCollectZombieLocked(target *Task, opts *WaitOptions, asPtrace
 	if tracer := target.Tracer(); tracer != nil && tracer.tg == t.tg && target.exitTracerNotified {
 		target.exitTracerAcked = true
 		target.ptraceTracer.Store(nil)
+		target.ptracerCreds = nil
 		delete(t.ptraceTracees, target)
 	}
 	if target.parent != nil && target.parent.tg == t.tg && target.exitParentNotified {

--- a/pkg/sentry/kernel/task_image.go
+++ b/pkg/sentry/kernel/task_image.go
@@ -50,6 +50,10 @@ type TaskImage struct {
 
 	// st is the task's syscall table.
 	st *SyscallTable `state:".(syscallTableInfo)"`
+
+	// NotDumpable is true if the task must be made non-dumpable, see
+	// fs/exec.c:would_dump().
+	NotDumpable bool
 }
 
 // release releases all resources held by the TaskImage. release is called by
@@ -71,9 +75,10 @@ func (image *TaskImage) release(ctx context.Context) {
 // of the original's.
 func (image *TaskImage) Fork(ctx context.Context, k *Kernel, shareAddressSpace bool) (*TaskImage, error) {
 	newImage := &TaskImage{
-		Name: image.Name,
-		Arch: image.Arch.Fork(),
-		st:   image.st,
+		Name:        image.Name,
+		Arch:        image.Arch.Fork(),
+		st:          image.st,
+		NotDumpable: image.NotDumpable,
 	}
 	if shareAddressSpace {
 		newImage.MemoryManager = image.MemoryManager
@@ -162,6 +167,14 @@ func (k *Kernel) LoadTaskImage(ctx context.Context, args loader.LoadArgs) (*Task
 		return nil, nil, false, errNoSyscalls
 	}
 
+	// Apply non-dumpability here as well as in execve (which recomputes
+	// dumpability from the old and new creds): this is the only place it can
+	// be applied for directly created processes.
+	if info.NotDumpable {
+		m.SetDumpability(mm.NotDumpable)
+	}
+	m.SetUserNamespace(info.UserNamespace)
+
 	if !m.IncUsers() {
 		panic("Failed to increment users count on new MM")
 	}
@@ -171,5 +184,6 @@ func (k *Kernel) LoadTaskImage(ctx context.Context, args loader.LoadArgs) (*Task
 		MemoryManager: m,
 		fu:            k.futexes.Fork(),
 		st:            st,
+		NotDumpable:   info.NotDumpable,
 	}, creds, secureExec, nil
 }

--- a/pkg/sentry/loader/elf.go
+++ b/pkg/sentry/loader/elf.go
@@ -645,7 +645,7 @@ func loadInterpreterELF(ctx context.Context, m *mm.MemoryManager, fd *vfs.FileDe
 // path and argv.
 //
 // Preconditions: args.File is an ELF file.
-func loadELF(ctx context.Context, args LoadArgs) (loadedELF, *arch.Context64, error) {
+func loadELF(ctx context.Context, args LoadArgs, wds *wouldDumpState) (loadedELF, *arch.Context64, error) {
 	bin, ac, err := loadInitialELF(ctx, args.MemoryManager, args.Features, args.File)
 	if err != nil {
 		ctx.Infof("Error loading binary: %v", err)
@@ -667,6 +667,8 @@ func loadELF(ctx context.Context, args LoadArgs) (loadedELF, *arch.Context64, er
 			return loadedELF{}, nil, err
 		}
 		defer intFile.DecRef(ctx)
+
+		wouldDump(ctx, intFile, wds)
 
 		interp, err = loadInterpreterELF(ctx, args.MemoryManager, intFile, bin)
 		if err != nil {

--- a/pkg/sentry/loader/loader.go
+++ b/pkg/sentry/loader/loader.go
@@ -108,18 +108,14 @@ type LoadArgs struct {
 // openPath returns an *fs.Dirent and *fs.File for args.Filename, which is not
 // installed in the Task FDTable. The caller takes ownership of both.
 //
-// args.Filename must be a readable, executable, regular file.
+// args.Filename must be an executable, regular file. As on Linux, read
+// permission is not required.
 func openPath(ctx context.Context, args LoadArgs) (*vfs.FileDescription, error) {
 	if args.Filename == "" {
 		ctx.Infof("cannot open empty name")
 		return nil, linuxerr.ENOENT
 	}
 
-	// TODO(gvisor.dev/issue/160): Linux requires only execute permission,
-	// not read. However, our backing filesystems may prevent us from reading
-	// the file without read permission. Additionally, a task with a
-	// non-readable executable has additional constraints on access via
-	// ptrace and procfs.
 	opts := vfs.OpenOptions{
 		Flags:    linux.O_RDONLY,
 		FileExec: true,
@@ -144,6 +140,45 @@ func openPath(ctx context.Context, args LoadArgs) (*vfs.FileDescription, error) 
 		args.AfterOpen(fd)
 	}
 	return fd, nil
+}
+
+// wouldDumpState tracks the effect of Linux's fs/exec.c:would_dump() across
+// the files opened while loading a single image.
+type wouldDumpState struct {
+	// notDumpable is true if some file in the executable/interpreter chain
+	// was not readable by the caller, requiring the task to be made
+	// non-dumpable.
+	notDumpable bool
+
+	// userNS is the value for the image's mm_struct::user_ns: the caller's
+	// user namespace, lowered to the nearest ancestor privileged with respect
+	// to the owner of each non-readable file.
+	userNS *auth.UserNamespace
+}
+
+// wouldDump applies Linux's fs/exec.c:would_dump() for fd: if the credentials
+// in ctx may not read fd, the task must be made non-dumpable and wds.userNS
+// must contain fd's owner.
+func wouldDump(ctx context.Context, fd *vfs.FileDescription, wds *wouldDumpState) {
+	stat, err := fd.Stat(ctx, vfs.StatOptions{
+		Mask: linux.STATX_TYPE | linux.STATX_MODE | linux.STATX_UID | linux.STATX_GID,
+	})
+	if err != nil {
+		wds.notDumpable = true
+		wds.userNS = wds.userNS.Root()
+		return
+	}
+	kuid := auth.KUID(stat.UID)
+	kgid := auth.KGID(stat.GID)
+	acl, err := fd.GetPosixACL(ctx, vfs.AccessACL)
+	if err == nil {
+		creds := auth.CredentialsFromContext(ctx)
+		if vfs.GenericCheckPermissions(creds, vfs.MayRead, linux.FileMode(stat.Mode), acl, kuid, kgid) == nil {
+			return
+		}
+	}
+	wds.notDumpable = true
+	wds.userNS = wds.userNS.AncestorPrivilegedWrtIDs(kuid, kgid)
 }
 
 // checkIsRegularFile prevents us from trying to execute a directory, pipe, etc.
@@ -187,7 +222,7 @@ const (
 //   - arch.Context64 matching the binary arch
 //   - fs.Dirent of the binary file
 //   - Possibly updated args.Argv
-func loadExecutable(ctx context.Context, args LoadArgs) (loadedELF, *arch.Context64, *vfs.FileDescription, []string, error) {
+func loadExecutable(ctx context.Context, args LoadArgs, wds *wouldDumpState) (loadedELF, *arch.Context64, *vfs.FileDescription, []string, error) {
 	for i := 0; i < maxLoaderAttempts; i++ {
 		if args.File == nil {
 			var err error
@@ -223,7 +258,10 @@ func loadExecutable(ctx context.Context, args LoadArgs) (loadedELF, *arch.Contex
 
 		switch {
 		case bytes.Equal(hdr[:], []byte(elfMagic)):
-			loaded, ac, err := loadELF(ctx, args)
+			// Linux applies would_dump() to the terminal binprm file, see
+			// fs/exec.c:begin_new_exec().
+			wouldDump(ctx, args.File, wds)
+			loaded, ac, err := loadELF(ctx, args, wds)
 			if err != nil {
 				ctx.Infof("Error loading ELF: %v", err)
 				return loadedELF{}, nil, nil, nil, err
@@ -263,6 +301,12 @@ type ImageInfo struct {
 	Arch *arch.Context64
 	// The base name of the binary.
 	Name string
+	// NotDumpable is true if the task must be made non-dumpable, see
+	// fs/exec.c:would_dump().
+	NotDumpable bool
+	// UserNamespace is the value for the image's mm_struct::user_ns, see
+	// fs/exec.c:would_dump().
+	UserNamespace *auth.UserNamespace
 }
 
 // Load loads args.File into a MemoryManager. If args.File is nil, the path
@@ -278,7 +322,8 @@ type ImageInfo struct {
 //   - Load is called on the Task goroutine.
 func Load(ctx context.Context, args LoadArgs, extraAuxv []arch.AuxEntry, vdso *VDSO) (ImageInfo, *auth.Credentials, bool, *syserr.Error) {
 	// Load the executable itself.
-	loaded, ac, file, newArgv, err := loadExecutable(ctx, args)
+	wds := wouldDumpState{userNS: auth.CredentialsFromContext(ctx).UserNamespace}
+	loaded, ac, file, newArgv, err := loadExecutable(ctx, args, &wds)
 	if err != nil {
 		return ImageInfo{}, nil, false, syserr.NewDynamic(fmt.Sprintf("failed to load %s: %v", args.Filename, err), syserr.FromError(err).ToLinux())
 	}
@@ -378,8 +423,10 @@ func Load(ctx context.Context, args LoadArgs, extraAuxv []arch.AuxEntry, vdso *V
 	}
 
 	return ImageInfo{
-		OS:   loaded.os,
-		Arch: ac,
-		Name: name,
+		OS:            loaded.os,
+		Arch:          ac,
+		Name:          name,
+		NotDumpable:   wds.notDumpable,
+		UserNamespace: wds.userNS,
 	}, c, secureExec, nil
 }

--- a/pkg/sentry/mm/lifecycle.go
+++ b/pkg/sentry/mm/lifecycle.go
@@ -105,6 +105,7 @@ func (mm *MemoryManager) Fork(ctx context.Context) (*MemoryManager, error) {
 		// IncRef'd below, once we know that there isn't an error.
 		executable:        mm.executable,
 		dumpability:       atomicbitops.FromInt32(mm.dumpability.Load()),
+		userNS:            mm.userNS,
 		aioManager:        aioManager{contexts: make(map[uint64]*AIOContext)},
 		vdsoSigReturnAddr: mm.vdsoSigReturnAddr,
 	}

--- a/pkg/sentry/mm/metadata.go
+++ b/pkg/sentry/mm/metadata.go
@@ -18,6 +18,7 @@ import (
 	"gvisor.dev/gvisor/pkg/context"
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/vfs"
 )
 
@@ -45,6 +46,20 @@ func (mm *MemoryManager) Dumpability() Dumpability {
 // SetDumpability sets the dumpability.
 func (mm *MemoryManager) SetDumpability(d Dumpability) {
 	mm.dumpability.Store(int32(d))
+}
+
+// UserNamespace returns the user namespace in which CAP_SYS_PTRACE grants
+// access to this MemoryManager when it is not dumpable, analogous to Linux's
+// mm_struct::user_ns. May be nil; see MemoryManager.userNS.
+func (mm *MemoryManager) UserNamespace() *auth.UserNamespace {
+	return mm.userNS
+}
+
+// SetUserNamespace sets the user namespace returned by UserNamespace.
+//
+// Preconditions: The MemoryManager is not yet visible to other tasks.
+func (mm *MemoryManager) SetUserNamespace(ns *auth.UserNamespace) {
+	mm.userNS = ns
 }
 
 // ArgvStart returns the start of the application argument vector.

--- a/pkg/sentry/mm/mm.go
+++ b/pkg/sentry/mm/mm.go
@@ -43,6 +43,7 @@ import (
 	"gvisor.dev/gvisor/pkg/hostarch"
 	"gvisor.dev/gvisor/pkg/safemem"
 	"gvisor.dev/gvisor/pkg/sentry/arch"
+	"gvisor.dev/gvisor/pkg/sentry/kernel/auth"
 	"gvisor.dev/gvisor/pkg/sentry/memmap"
 	"gvisor.dev/gvisor/pkg/sentry/pgalloc"
 	"gvisor.dev/gvisor/pkg/sentry/platform"
@@ -184,6 +185,14 @@ type MemoryManager struct {
 	// userspace. This is read under kernel.TaskSet.mu, so it can't be protected
 	// by metadataMu.
 	dumpability atomicbitops.Int32
+
+	// userNS is Linux's mm_struct::user_ns: the user namespace in which
+	// CAP_SYS_PTRACE grants access to this MemoryManager when it is not
+	// dumpable. It is set by the loader before the MemoryManager becomes
+	// visible to other tasks and is immutable thereafter. May be nil for
+	// MemoryManagers restored from older saved states, in which case callers
+	// should fall back to the owning task's user namespace.
+	userNS *auth.UserNamespace
 
 	metadataMu metadataMutex `state:"nosave"`
 

--- a/pkg/sentry/vfs/permissions.go
+++ b/pkg/sentry/vfs/permissions.go
@@ -158,6 +158,12 @@ func AccessTypesForOpenFlags(opts *OpenOptions) AccessTypes {
 		if opts.Flags&linux.O_TRUNC != 0 {
 			return ats | MayRead | MayWrite
 		}
+		if opts.FileExec {
+			// Linux only requires execute permission for execve, see
+			// fs/exec.c:do_open_execat(). Tasks executing non-readable files
+			// are made non-dumpable by the loader.
+			return ats
+		}
 		return ats | MayRead
 	case linux.O_WRONLY:
 		return ats | MayWrite
@@ -294,6 +300,16 @@ func CheckLimit(ctx context.Context, offset, size int64) (int64, error) {
 		return remaining, nil
 	}
 	return size, nil
+}
+
+// XattrReadNeedsFilePermission returns whether getxattr of name requires read
+// permission on the file, per Linux's fs/xattr.c:xattr_permission(): the
+// security.*, system.*, and trusted.* namespaces are exempt from the DAC
+// check; user.* and unrecognized prefixes are not.
+func XattrReadNeedsFilePermission(name string) bool {
+	return !strings.HasPrefix(name, linux.XATTR_SECURITY_PREFIX) &&
+		!strings.HasPrefix(name, linux.XATTR_SYSTEM_PREFIX) &&
+		!strings.HasPrefix(name, linux.XATTR_TRUSTED_PREFIX)
 }
 
 // CheckXattrPermissions checks permissions for extended attribute access.

--- a/test/syscalls/linux/BUILD
+++ b/test/syscalls/linux/BUILD
@@ -846,6 +846,7 @@ cc_binary(
     linkstatic = 1,
     malloc = "//test/util:errno_safe_allocator",
     deps = select_gtest() + [
+        "//test/util:capability_util",
         "//test/util:cleanup",
         "//test/util:file_descriptor",
         "//test/util:fs_util",
@@ -855,6 +856,7 @@ cc_binary(
         "//test/util:temp_path",
         "//test/util:test_main",
         "//test/util:test_util",
+        "//test/util:thread_util",
         "@com_google_absl//absl/strings",
     ],
 )
@@ -2399,6 +2401,7 @@ cc_binary(
     malloc = "//test/util:errno_safe_allocator",
     deps = select_gtest() + [
         "//test/util:capability_util",
+        "//test/util:cleanup",
         "//test/util:file_descriptor",
         "//test/util:fs_util",
         "//test/util:logging",

--- a/test/syscalls/linux/exec.cc
+++ b/test/syscalls/linux/exec.cc
@@ -24,6 +24,7 @@
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <sys/xattr.h>
 #include <unistd.h>
 
 #include <cassert>
@@ -913,6 +914,14 @@ PosixErrorOr<TempPath> CreateSgidExecutable(std::string path) {
   return TempPath::CreateFileWith(GetShortTestTmpdir(), exec_blob, mode);
 }
 
+PosixErrorOr<TempPath> CreateExecuteOnlyExecutable(std::string path) {
+  std::string exec_blob;
+  PosixError perr = GetContents(path, &exec_blob);
+  RETURN_IF_ERRNO(perr);
+
+  return TempPath::CreateFileWith(GetShortTestTmpdir(), exec_blob, 0111);
+}
+
 constexpr int kUnprivilegedUid = 12345;
 constexpr int kUnprivilegedGid = 12345;
 
@@ -970,6 +979,137 @@ TEST(ExecTest, SGIDExecGainsGID) {
         /*want_egid=*/absl::StrCat(privilegedGid),  // gained back original gid
         /*want_dumpability=*/absl::StrCat(SUID_DUMP_DISABLE)};  // but lost this
     CheckExec(suid_exe.path(), argv, /*envv=*/{}, /*expect_status=*/0,
+              /*expect_stderr=*/"");
+  });
+}
+
+// Returns the expected dumpability of a task after an exec that enforces
+// non-dumpability: gVisor hardcodes SUID_DUMP_DISABLE, while Linux uses the
+// value of the fs.suid_dumpable sysctl (fs/exec.c:begin_new_exec() =>
+// set_dumpable(current->mm, suid_dumpable)).
+PosixErrorOr<int> WantNonDumpable() {
+  if (IsRunningOnGvisor()) {
+    return SUID_DUMP_DISABLE;
+  }
+  std::string contents;
+  RETURN_IF_ERRNO(GetContents("/proc/sys/fs/suid_dumpable", &contents));
+  return atoi(contents.c_str());
+}
+
+// Mirrors struct posix_acl_xattr_entry.
+struct ACLEntry {
+  uint16_t tag;
+  uint16_t perm;
+  uint32_t id;
+};
+
+// BuildACL builds the raw xattr representation for a POSIX ACL.
+std::string BuildACL(const std::vector<ACLEntry>& entries) {
+  uint32_t version = 2;
+  std::string buf(reinterpret_cast<const char*>(&version), sizeof(version));
+  for (const ACLEntry& e : entries) {
+    buf.append(reinterpret_cast<const char*>(&e), sizeof(e));
+  }
+  return buf;
+}
+
+// A binary whose mode bits permit reading but whose ACL denies it to the
+// executing user must still make the task non-dumpable.
+TEST(ExecTest, ACLExecuteOnlyBinary) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  std::string exec_blob;
+  ASSERT_NO_ERRNO(GetContents(RunfilePath(kCheckEuidProgram), &exec_blob));
+  TempPath exe = ASSERT_NO_ERRNO_AND_VALUE(
+      TempPath::CreateFileWith(GetShortTestTmpdir(), exec_blob, 0755));
+
+  // ACL: named user kUnprivilegedUid gets --x, so the named-user entry (not
+  // the readable "other" class) governs its access.
+  constexpr uint16_t kTagUserObj = 0x01, kTagUser = 0x02, kTagGroupObj = 0x04,
+                     kTagMask = 0x10, kTagOther = 0x20;
+  constexpr uint32_t kIdUndef = 0xffffffff;
+  const std::string acl = BuildACL({
+      {kTagUserObj, 7, kIdUndef},
+      {kTagUser, 1, kUnprivilegedUid},
+      {kTagGroupObj, 5, kIdUndef},
+      {kTagMask, 1, kIdUndef},
+      {kTagOther, 5, kIdUndef},
+  });
+  int ret = setxattr(exe.path().c_str(), "system.posix_acl_access", acl.data(),
+                     acl.size(), 0);
+  SKIP_IF(ret < 0 && (errno == ENOTSUP || errno == EOPNOTSUPP));
+  ASSERT_THAT(ret, SyscallSucceeds());
+
+  // Use a separate thread so as to not pollute the other tests with the
+  // unprivileged uid/gid we're about to set. The gid must also leave the
+  // file's group class so that only the named-user ACL entry (and not the
+  // group bits, which mirror the ACL mask) denies reading.
+  bool acl_enforced = true;
+  ScopedThread([&] {
+    ASSERT_THAT(syscall(SYS_setgroups, 0, nullptr), SyscallSucceeds());
+    ASSERT_THAT(syscall(SYS_setresgid, kUnprivilegedGid, kUnprivilegedGid,
+                        kUnprivilegedGid),
+                SyscallSucceeds());
+    ASSERT_THAT(syscall(SYS_setresuid, kUnprivilegedUid, kUnprivilegedUid,
+                        kUnprivilegedUid),
+                SyscallSucceeds());
+
+    // The ACL must deny reading. Some filesystems (e.g. gVisor's overlay)
+    // accept the ACL xattr but do not enforce ACLs; skip on those.
+    int fd = open(exe.path().c_str(), O_RDONLY);
+    if (fd >= 0) {
+      close(fd);
+      acl_enforced = false;
+      return;
+    }
+    EXPECT_THAT(open(exe.path().c_str(), O_RDONLY),
+                SyscallFailsWithErrno(EACCES));
+
+    // ...but the ACL must permit executing, and the resulting task must be
+    // non-dumpable.
+    const int want_dumpability = ASSERT_NO_ERRNO_AND_VALUE(WantNonDumpable());
+    const ExecveArray argv = {
+        exe.path(),
+        /*want_euid=*/absl::StrCat(kUnprivilegedUid),
+        /*want_egid=*/absl::StrCat(kUnprivilegedGid),
+        /*want_dumpability=*/absl::StrCat(want_dumpability)};
+    CheckExec(exe.path(), argv, /*envv=*/{}, /*expect_status=*/0,
+              /*expect_stderr=*/"");
+  });
+  if (!acl_enforced) {
+    GTEST_SKIP() << "filesystem does not enforce POSIX ACLs";
+  }
+}
+
+// Linux requires only execute permission (not read) to execve a binary, but
+// marks the resulting task non-dumpable so that the binary's contents cannot
+// be recovered via ptrace or procfs. See gvisor.dev/issue/160.
+TEST(ExecTest, ExecuteOnlyBinary) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+  TempPath exec_only_exe = ASSERT_NO_ERRNO_AND_VALUE(
+      CreateExecuteOnlyExecutable(RunfilePath(kCheckEuidProgram)));
+
+  // Use a separate thread so as to not pollute the other tests with the
+  // unprivileged uid we're about to set.
+  ScopedThread([&] {
+    ASSERT_THAT(syscall(SYS_setresuid, kUnprivilegedUid, kUnprivilegedUid,
+                        kUnprivilegedUid),
+                SyscallSucceeds());
+    ASSERT_EQ(geteuid(), kUnprivilegedUid);
+
+    // The binary must not be readable...
+    EXPECT_THAT(open(exec_only_exe.path().c_str(), O_RDONLY),
+                SyscallFailsWithErrno(EACCES));
+
+    // ...but must still be executable, and the resulting task must be
+    // non-dumpable.
+    const int want_dumpability = ASSERT_NO_ERRNO_AND_VALUE(WantNonDumpable());
+    const ExecveArray argv = {
+        exec_only_exe.path(),
+        /*want_euid=*/absl::StrCat(kUnprivilegedUid),
+        /*want_egid=*/absl::StrCat(getegid()),
+        /*want_dumpability=*/absl::StrCat(want_dumpability)};
+    CheckExec(exec_only_exe.path(), argv, /*envv=*/{}, /*expect_status=*/0,
               /*expect_stderr=*/"");
   });
 }

--- a/test/syscalls/linux/exec_binary.cc
+++ b/test/syscalls/linux/exec_binary.cc
@@ -14,8 +14,13 @@
 
 #include <elf.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <sched.h>
 #include <signal.h>
+#include <sys/prctl.h>
 #include <sys/ptrace.h>
+#include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/user.h>
@@ -32,6 +37,7 @@
 #include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
+#include "test/util/capability_util.h"
 #include "test/util/cleanup.h"
 #include "test/util/file_descriptor.h"
 #include "test/util/fs_util.h"
@@ -40,6 +46,7 @@
 #include "test/util/proc_util.h"
 #include "test/util/temp_path.h"
 #include "test/util/test_util.h"
+#include "test/util/thread_util.h"
 
 namespace gvisor {
 namespace testing {
@@ -1060,6 +1067,313 @@ TEST(ElfTest, ELFInterpreter) {
              })));
 }
 
+// An ELF interpreter requires only execute permission, and executing a binary
+// whose interpreter is not readable makes the task non-dumpable, as with a
+// non-readable binary. See gvisor.dev/issue/160.
+TEST(ElfTest, ExecuteOnlyELFInterpreter) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  ElfBinary<64> interpreter = StandardElf();
+  interpreter.header.e_type = ET_DYN;
+  interpreter.header.e_entry = 0x0;
+  interpreter.UpdateOffsets();
+
+  // See ElfTest.ELFInterpreter above for the rationale.
+  uint64_t const offset = interpreter.phdrs[1].p_offset;
+  interpreter.phdrs[1].p_flags = PF_R | PF_W | PF_X;
+  interpreter.phdrs[1].p_offset = 0x0;
+  interpreter.phdrs[1].p_vaddr = 0x0;
+  interpreter.phdrs[1].p_filesz += offset;
+  interpreter.phdrs[1].p_memsz += offset;
+
+  // Use /tmp: an unprivileged host gofer cannot read an execute-only backing
+  // file, which is not what this test exercises.
+  TempPath interpreter_file =
+      ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith("/tmp", interpreter));
+  ASSERT_THAT(chmod(interpreter_file.path().c_str(), 0111), SyscallSucceeds());
+
+  ElfBinary<64> binary = StandardElf();
+
+  // Append the interpreter path.
+  int const interp_data_start = binary.data.size();
+  for (char const c : interpreter_file.path()) {
+    binary.data.push_back(c);
+  }
+  // NUL-terminate.
+  binary.data.push_back(0);
+  int const interp_data_size = binary.data.size() - interp_data_start;
+
+  decltype(binary)::ElfPhdr phdr = {};
+  phdr.p_type = PT_INTERP;
+  phdr.p_offset = interp_data_start;
+  phdr.p_filesz = interp_data_size;
+  phdr.p_memsz = interp_data_size;
+  binary.phdrs.push_back(phdr);
+
+  binary.UpdateOffsets();
+
+  // /tmp is also traversable by the unprivileged uid below, unlike the test
+  // tmpdir.
+  TempPath binary_file =
+      ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith("/tmp", binary));
+
+  // Use a separate thread so as to not pollute the other tests with the
+  // unprivileged uid we're about to set.
+  ScopedThread([&] {
+    constexpr int kUnprivilegedUid = 12345;
+    ASSERT_THAT(syscall(SYS_setresuid, kUnprivilegedUid, kUnprivilegedUid,
+                        kUnprivilegedUid),
+                SyscallSucceeds());
+
+    // The interpreter must not be readable...
+    EXPECT_THAT(open(interpreter_file.path().c_str(), O_RDONLY),
+                SyscallFailsWithErrno(EACCES));
+
+    // ...but the binary must still be executable.
+    pid_t child;
+    int execve_errno;
+    auto cleanup = ASSERT_NO_ERRNO_AND_VALUE(ForkAndExec(
+        binary_file.path(), {binary_file.path()}, {}, &child, &execve_errno));
+    ASSERT_EQ(execve_errno, 0);
+
+    // WUNTRACED, unlike WaitStopped, also observes the group stop that occurs
+    // if the child's PTRACE_TRACEME was denied for the non-dumpable child.
+    int status;
+    ASSERT_THAT(RetryEINTR(waitpid)(child, &status, WUNTRACED),
+                SyscallSucceedsWithValue(child));
+    ASSERT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) << status;
+
+    // The task must be non-dumpable: even the same-uid parent cannot access
+    // /proc/<pid>/mem.
+    EXPECT_THAT(open(absl::StrCat("/proc/", child, "/mem").c_str(), O_RDONLY),
+                SyscallFailsWithErrno(AnyOf(Eq(EACCES), Eq(EPERM))));
+  });
+}
+
+// An existing tracer must not be able to access the memory of a task that
+// exec'd a non-readable binary, matching Linux's
+// kernel/ptrace.c:ptrace_access_vm().
+TEST(ElfTest, PtraceExecuteOnlyBinary) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  ElfBinary<64> elf = StandardElf();
+  elf.UpdateOffsets();
+
+  // /tmp is also traversable by the unprivileged uid below, unlike the test
+  // tmpdir.
+  TempPath exec_only = ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith("/tmp", elf));
+  ASSERT_THAT(chmod(exec_only.path().c_str(), 0111), SyscallSucceeds());
+  TempPath readable = ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith("/tmp", elf));
+
+  // Use a separate thread so as to not pollute the other tests with the
+  // unprivileged uid we're about to set.
+  ScopedThread([&] {
+    constexpr int kUnprivilegedUid = 12345;
+    ASSERT_THAT(syscall(SYS_setresuid, kUnprivilegedUid, kUnprivilegedUid,
+                        kUnprivilegedUid),
+                SyscallSucceeds());
+    // Restore dumpability, cleared by the uid change, so that the forked
+    // children below start out traceable.
+    ASSERT_THAT(prctl(PR_SET_DUMPABLE, 1), SyscallSucceeds());
+
+    // Trace a child across execve and try to read its memory. The first
+    // segment of StandardElf is loaded at 0x40000.
+    const auto peek_after_exec = [](const std::string& path, long* peeked,
+                                    long* poked) {
+      pid_t child = fork();
+      if (child == 0) {
+        if (ptrace(PTRACE_TRACEME, 0, 0, 0) != 0) {
+          _exit(40);
+        }
+        raise(SIGSTOP);
+        execl(path.c_str(), path.c_str(), nullptr);
+        _exit(41);
+      }
+      MaybeSave();
+      ASSERT_GT(child, 0);
+      int status;
+      ASSERT_THAT(RetryEINTR(waitpid)(child, &status, 0),
+                  SyscallSucceedsWithValue(child));
+      ASSERT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) << status;
+      ASSERT_THAT(ptrace(PTRACE_CONT, child, 0, 0), SyscallSucceeds());
+      // The traced child stops with SIGTRAP after execve.
+      ASSERT_THAT(RetryEINTR(waitpid)(child, &status, 0),
+                  SyscallSucceedsWithValue(child));
+      ASSERT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGTRAP) << status;
+
+      errno = 0;
+      *peeked = ptrace(PTRACE_PEEKDATA, child, 0x40000, 0);
+      *peeked = (*peeked == -1) ? -errno : 0;
+      errno = 0;
+      *poked = ptrace(PTRACE_POKEDATA, child, 0x40000, 0x11223344);
+      *poked = (*poked == -1) ? -errno : 0;
+
+      kill(child, SIGKILL);
+      RetryEINTR(waitpid)(child, nullptr, 0);
+    };
+
+    long peeked, poked;
+    // Control: a readable binary's memory is accessible to the tracer.
+    ASSERT_NO_FATAL_FAILURE(peek_after_exec(readable.path(), &peeked, &poked));
+    EXPECT_EQ(peeked, 0);
+    EXPECT_EQ(poked, 0);
+    // An execute-only binary's memory is not.
+    ASSERT_NO_FATAL_FAILURE(peek_after_exec(exec_only.path(), &peeked, &poked));
+    EXPECT_EQ(peeked, -EIO);
+    EXPECT_EQ(poked, -EIO);
+  });
+}
+
+// CAP_SYS_PTRACE in a user namespace that does not contain the executable's
+// owner must not permit tracing a task that exec'd that non-readable binary;
+// Linux checks the capability in mm->user_ns, which fs/exec.c:would_dump()
+// lowers to an ancestor namespace containing the executable's owner.
+TEST(ElfTest, UsernsAttachExecuteOnlyBinary) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  ElfBinary<64> elf = StandardElf();
+  elf.UpdateOffsets();
+  TempPath exec_only = ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith("/tmp", elf));
+  ASSERT_THAT(chmod(exec_only.path().c_str(), 0111), SyscallSucceeds());
+
+  // The helper must be single-threaded to unshare a user namespace, so fork
+  // before dropping privileges.
+  pid_t helper = fork();
+  if (helper == 0) {
+    if (setgroups(0, nullptr) != 0) _exit(20);
+    if (setresgid(12345, 12345, 12345) != 0) _exit(21);
+    if (setresuid(12345, 12345, 12345) != 0) _exit(22);
+    if (prctl(PR_SET_DUMPABLE, 1) != 0) _exit(23);
+    // The helper holds all capabilities in the new user namespace, but the
+    // executable's owner (root) is not mapped into it.
+    if (unshare(CLONE_NEWUSER) != 0) _exit(24);
+    pid_t child = fork();
+    if (child == 0) {
+      execl(exec_only.path().c_str(), exec_only.path().c_str(), nullptr);
+      _exit(25);
+    }
+    int status;
+    if (waitpid(child, &status, WUNTRACED) != child) _exit(26);
+    if (!WIFSTOPPED(status)) _exit(27);
+    // The stub PTRACE_TRACEMEs; detach (ignoring failure, in case the traceme
+    // was denied) so that PTRACE_ATTACH performs a fresh access check.
+    ptrace(PTRACE_DETACH, child, 0, SIGSTOP);
+    errno = 0;
+    long ret = ptrace(PTRACE_ATTACH, child, 0, 0);
+    int attach_errno = errno;
+    kill(child, SIGKILL);
+    waitpid(child, nullptr, 0);
+    if (ret == 0) _exit(1);  // Attach must be denied.
+    _exit(attach_errno == EPERM ? 0 : 2);
+  }
+  ASSERT_GT(helper, 0);
+  int status;
+  ASSERT_THAT(RetryEINTR(waitpid)(helper, &status, 0),
+              SyscallSucceedsWithValue(helper));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "helper status: " << status;
+}
+
+// How CheckExecuteOnlyScriptStaysDumpable launches the script.
+enum class ScriptExecMode {
+  kPath,          // execve(path)
+  kEmptyPathFd,   // execveat(fd, "", AT_EMPTY_PATH), fd opened O_PATH
+  kRelativeDirfd  // execveat(dirfd, "name", 0)
+};
+
+// An interpreter script that is itself execute-only does not make the task
+// non-dumpable when its interpreter is readable: fs/exec.c:begin_new_exec()
+// applies would_dump() to the final binprm file (the interpreter binary), not
+// to the script, for both by-path and by-fd execution.
+void CheckExecuteOnlyScriptStaysDumpable(ScriptExecMode mode) {
+  ElfBinary<64> elf = StandardElf();
+  elf.UpdateOffsets();
+  // /tmp is also traversable by the unprivileged uid below, unlike the test
+  // tmpdir.
+  TempPath interpreter_file =
+      ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith("/tmp", elf));
+  TempPath script = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateFileWith(
+      "/tmp", absl::StrCat("#!", interpreter_file.path()), 0111));
+
+  // Use a separate thread so as to not pollute the other tests with the
+  // unprivileged uid we're about to set.
+  ScopedThread([&] {
+    constexpr int kUnprivilegedUid = 12345;
+    ASSERT_THAT(syscall(SYS_setresuid, kUnprivilegedUid, kUnprivilegedUid,
+                        kUnprivilegedUid),
+                SyscallSucceeds());
+    // Restore dumpability, cleared by the uid change.
+    ASSERT_THAT(prctl(PR_SET_DUMPABLE, 1), SyscallSucceeds());
+
+    pid_t child = fork();
+    if (child == 0) {
+      if (ptrace(PTRACE_TRACEME, 0, 0, 0) != 0) {
+        _exit(40);
+      }
+      raise(SIGSTOP);
+      char* const argv[] = {const_cast<char*>(script.path().c_str()), nullptr};
+      char* const envv[] = {nullptr};
+      switch (mode) {
+        case ScriptExecMode::kPath:
+          execve(script.path().c_str(), argv, envv);
+          break;
+        case ScriptExecMode::kEmptyPathFd: {
+          int fd = open(script.path().c_str(), O_PATH);
+          if (fd < 0) {
+            _exit(42);
+          }
+          syscall(SYS_execveat, fd, "", argv, envv, AT_EMPTY_PATH);
+          break;
+        }
+        case ScriptExecMode::kRelativeDirfd: {
+          int dirfd = open(std::string(Dirname(script.path())).c_str(),
+                           O_RDONLY | O_DIRECTORY);
+          if (dirfd < 0) {
+            _exit(43);
+          }
+          syscall(SYS_execveat, dirfd,
+                  std::string(Basename(script.path())).c_str(), argv, envv, 0);
+          break;
+        }
+      }
+      _exit(41);
+    }
+    MaybeSave();
+    ASSERT_GT(child, 0);
+    int status;
+    ASSERT_THAT(RetryEINTR(waitpid)(child, &status, 0),
+                SyscallSucceedsWithValue(child));
+    ASSERT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) << status;
+    ASSERT_THAT(ptrace(PTRACE_CONT, child, 0, 0), SyscallSucceeds());
+    ASSERT_THAT(RetryEINTR(waitpid)(child, &status, 0),
+                SyscallSucceedsWithValue(child));
+    ASSERT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGTRAP) << status;
+
+    // The task must remain dumpable: its tracer can read its memory.
+    errno = 0;
+    ptrace(PTRACE_PEEKDATA, child, 0x40000, 0);
+    EXPECT_EQ(errno, 0);
+
+    kill(child, SIGKILL);
+    RetryEINTR(waitpid)(child, nullptr, 0);
+  });
+}
+
+TEST(ElfTest, ExecuteOnlyScriptReadableInterpreter) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+  CheckExecuteOnlyScriptStaysDumpable(ScriptExecMode::kPath);
+}
+
+TEST(ElfTest, ExecuteOnlyScriptReadableInterpreterEmptyPathFd) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+  CheckExecuteOnlyScriptStaysDumpable(ScriptExecMode::kEmptyPathFd);
+}
+
+TEST(ElfTest, ExecuteOnlyScriptReadableInterpreterRelativeDirfd) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+  CheckExecuteOnlyScriptStaysDumpable(ScriptExecMode::kRelativeDirfd);
+}
+
 // Test parameter to ElfInterpterStaticTest cases. The first item is a suffix to
 // add to the end of the interpreter path in the PT_INTERP segment and the
 // second is the expected execve(2) errno.
@@ -1305,14 +1619,12 @@ TEST(ElfTest, NoExecute) {
 
 // Execute, but no read permissions on the binary works just fine.
 TEST(ElfTest, NoRead) {
-  // TODO(gvisor.dev/issue/160): gVisor's backing filesystem may prevent the
-  // sentry from reading the executable.
-  SKIP_IF(IsRunningOnGvisor());
-
   ElfBinary<64> elf = StandardElf();
   elf.UpdateOffsets();
 
-  TempPath file = ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith(elf));
+  // Use /tmp: an unprivileged host gofer cannot read an execute-only backing
+  // file.
+  TempPath file = ASSERT_NO_ERRNO_AND_VALUE(CreateElfWith("/tmp", elf));
 
   ASSERT_THAT(chmod(file.path().c_str(), 0111), SyscallSucceeds());
 
@@ -1324,9 +1636,10 @@ TEST(ElfTest, NoRead) {
 
   ASSERT_NO_ERRNO(WaitStopped(child));
 
-  // TODO(gvisor.dev/issue/160): A task with a non-readable executable is marked
-  // non-dumpable, preventing access to proc files. gVisor does not implement
-  // this behavior.
+  // A task whose credentials cannot read its executable is marked
+  // non-dumpable; see ExecuteOnlyBinary and PtraceExecuteOnlyBinary. This test
+  // runs with CAP_DAC_OVERRIDE, so the executable remains readable to it and
+  // the task stays dumpable.
 }
 
 // No execute permissions on the ELF interpreter.

--- a/test/syscalls/linux/ptrace.cc
+++ b/test/syscalls/linux/ptrace.cc
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include <elf.h>
+#include <fcntl.h>
+#include <grp.h>
+#include <sched.h>
 #include <signal.h>
 #include <stddef.h>
 #include <sys/prctl.h>
@@ -44,6 +47,7 @@
 #include "test/util/save_util.h"
 #include "test/util/signal_util.h"
 #include "test/util/temp_path.h"
+#include "test/util/cleanup.h"
 #include "test/util/test_util.h"
 #include "test/util/thread_util.h"
 #include "test/util/time_util.h"
@@ -248,6 +252,131 @@ TEST(PtraceTest, AttachSameThreadGroup) {
   ScopedThread([&] {
     EXPECT_THAT(ptrace(PTRACE_ATTACH, tid, 0, 0), SyscallFailsWithErrno(EPERM));
   });
+}
+
+// Memory access to a tracee that became non-dumpable after attach is governed
+// by the tracer credentials captured when tracing began, not the tracer's
+// current credentials; see Linux's kernel/ptrace.c:ptrace_access_vm().
+volatile long ptrace_access_vm_marker = 0x123456789abcdef;
+
+void CheckPeekAfterEffectiveCapChange(bool cap_at_attach) {
+  int fds[2];
+  ASSERT_THAT(pipe2(fds, O_NONBLOCK), SyscallSucceeds());
+
+  pid_t const child_pid = fork();
+  if (child_pid == 0) {
+    close(fds[0]);
+    raise(SIGSTOP);
+    // Resumed by the (now attached) tracer.
+    if (prctl(PR_SET_DUMPABLE, 0) != 0) {
+      _exit(30);
+    }
+    if (write(fds[1], "r", 1) != 1) {
+      _exit(31);
+    }
+    close(fds[1]);
+    raise(SIGSTOP);
+    _exit(0);
+  }
+  ASSERT_THAT(child_pid, SyscallSucceeds());
+  close(fds[1]);
+  auto cleanup = Cleanup([child_pid, &fds] {
+    close(fds[0]);
+    kill(child_pid, SIGKILL);
+    RetryEINTR(waitpid)(child_pid, nullptr, 0);
+  });
+
+  int status;
+  ASSERT_THAT(RetryEINTR(waitpid)(child_pid, &status, WUNTRACED),
+              SyscallSucceedsWithValue(child_pid));
+  ASSERT_TRUE(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) << status;
+
+  {
+    AutoCapability cap(CAP_SYS_PTRACE, cap_at_attach);
+    ASSERT_THAT(ptrace(PTRACE_ATTACH, child_pid, 0, 0), SyscallSucceeds());
+    ASSERT_THAT(RetryEINTR(waitpid)(child_pid, &status, 0),
+                SyscallSucceedsWithValue(child_pid));
+    ASSERT_TRUE(WIFSTOPPED(status)) << status;
+
+    // Resume the tracee until it has made itself non-dumpable and stopped
+    // again. It may stop several times first to have pending SIGSTOPs
+    // delivered.
+    bool ready = false;
+    for (int i = 0; i < 5 && !ready; i++) {
+      ASSERT_THAT(ptrace(PTRACE_CONT, child_pid, 0, 0), SyscallSucceeds());
+      ASSERT_THAT(RetryEINTR(waitpid)(child_pid, &status, 0),
+                  SyscallSucceedsWithValue(child_pid));
+      ASSERT_TRUE(WIFSTOPPED(status)) << status;
+      char b;
+      ready = ReadFd(fds[0], &b, 1) == 1;
+    }
+    ASSERT_TRUE(ready) << "tracee never became non-dumpable";
+  }
+
+  {
+    AutoCapability cap(CAP_SYS_PTRACE, !cap_at_attach);
+    errno = 0;
+    long const peeked = ptrace(PTRACE_PEEKDATA, child_pid,
+                               &ptrace_access_vm_marker, 0);
+    long const peek_errno = (peeked == -1) ? errno : 0;
+    errno = 0;
+    long const poked = ptrace(PTRACE_POKEDATA, child_pid,
+                              &ptrace_access_vm_marker, 0x11223344);
+    long const poke_errno = (poked == -1) ? errno : 0;
+    if (cap_at_attach) {
+      EXPECT_EQ(peek_errno, 0);
+      EXPECT_EQ(poke_errno, 0);
+    } else {
+      EXPECT_EQ(peek_errno, EIO);
+      EXPECT_EQ(poke_errno, EIO);
+    }
+  }
+}
+
+TEST(PtraceTest, AccessVmUsesAttachCreds_CapDroppedAfterAttach) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_PTRACE)));
+  SKIP_IF(ASSERT_NO_ERRNO_AND_VALUE(YamaPtraceScope()) > 2);
+  CheckPeekAfterEffectiveCapChange(/*cap_at_attach=*/true);
+}
+
+TEST(PtraceTest, AccessVmUsesAttachCreds_CapGainedAfterAttach) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_PTRACE)));
+  // The attach happens without effective CAP_SYS_PTRACE, which Yama scope 2
+  // forbids.
+  SKIP_IF(ASSERT_NO_ERRNO_AND_VALUE(YamaPtraceScope()) > 1);
+  CheckPeekAfterEffectiveCapChange(/*cap_at_attach=*/false);
+}
+
+// PTRACE_TRACEME performs no dumpability check: Linux authorizes it via
+// security_ptrace_traceme() (commoncap.c:cap_ptrace_traceme()), not
+// __ptrace_may_access(), so it succeeds even for a non-dumpable child whose mm
+// belongs to an outer user namespace.
+TEST(PtraceTest, TracemeNonDumpableInUserns) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SETUID)));
+
+  // The helper must be single-threaded to unshare a user namespace, so fork
+  // before dropping privileges.
+  pid_t helper = fork();
+  if (helper == 0) {
+    if (setgroups(0, nullptr) != 0) _exit(20);
+    if (setresgid(12345, 12345, 12345) != 0) _exit(21);
+    if (setresuid(12345, 12345, 12345) != 0) _exit(22);
+    if (unshare(CLONE_NEWUSER) != 0) _exit(23);
+    if (prctl(PR_SET_DUMPABLE, 0) != 0) _exit(24);
+    pid_t child = fork();
+    if (child == 0) {
+      _exit(ptrace(PTRACE_TRACEME, 0, 0, 0) == 0 ? 0 : 1);
+    }
+    int status;
+    if (waitpid(child, &status, 0) != child) _exit(25);
+    _exit(WIFEXITED(status) ? WEXITSTATUS(status) : 26);
+  }
+  ASSERT_GT(helper, 0);
+  int status;
+  ASSERT_THAT(RetryEINTR(waitpid)(helper, &status, 0),
+              SyscallSucceedsWithValue(helper));
+  EXPECT_TRUE(WIFEXITED(status) && WEXITSTATUS(status) == 0)
+      << "helper status: " << status;
 }
 
 TEST(PtraceTest, TraceParentNotAllowed) {

--- a/test/syscalls/linux/xattr.cc
+++ b/test/syscalls/linux/xattr.cc
@@ -117,6 +117,21 @@ TEST_F(XattrTest, XattrInvalidPrefix) {
               SyscallFailsWithErrno(EOPNOTSUPP));
 }
 
+// getxattr of a name outside the security/system/trusted namespaces requires
+// read permission on the file, per Linux's fs/xattr.c:xattr_permission().
+TEST_F(XattrTest, UnknownPrefixRequiresReadPermission) {
+  // A caller-owned mode-0000 file is unreadable even to its owner once the
+  // DAC-bypassing capabilities are dropped, without requiring an ownership
+  // change (which an unprivileged host gofer cannot perform).
+  const char* path = test_file_name_.c_str();
+  ASSERT_THAT(chmod(path, 0000), SyscallSucceeds());
+
+  AutoCapability cap_override(CAP_DAC_OVERRIDE, false);
+  AutoCapability cap_read_search(CAP_DAC_READ_SEARCH, false);
+  EXPECT_THAT(getxattr(path, "ceph.file.layout", nullptr, 0),
+              SyscallFailsWithErrno(EACCES));
+}
+
 TEST_F(XattrTest, SecurityCapacityXattr) {
   SKIP_IF(!IsRunningOnGvisor());
   const char* path = test_file_name_.c_str();


### PR DESCRIPTION
Linux requires only execute permission to execve a binary (fs/exec.c:do_open_execat() passes MAY_EXEC as the sole acc_mode), but gVisor's loader required read permission as well, so executing a mode-0111 binary as a non-root user failed with EACCES.

Fix this by:

- Not requiring MayRead for FileExec opens in vfs.AccessTypesForOpenFlags(), matching Linux.
- Still acquiring readable host handles in the gofer client for exec opens, since the sentry must read the executable to load it (the gofer process is privileged, as the host kernel is on Linux).
- Mirroring Linux's fs/exec.c:would_dump() so that a non-readable file's contents cannot be recovered from the task that exec'd it: tasks whose credentials cannot read (including via POSIX ACLs) the terminal binary or its PT_INTERP interpreter are made non-dumpable. Interpreter scripts are exempt, as on Linux, for path, AT_EMPTY_PATH, and relative-dirfd execution. The MemoryManager tracks Linux's mm_struct::user_ns, lowered to the nearest ancestor namespace privileged with respect to each non-readable file's owner. CAP_SYS_PTRACE grants access to a non-dumpable task only in that namespace (kernel/ptrace.c:__ptrace_may_access()), memory access by an already-attached tracer rechecks it against the credentials saved when tracing began (kernel/ptrace.c:ptrace_access_vm()), and PTRACE_TRACEME keeps its separate credential-based authorization (security/commoncap.c:cap_ptrace_traceme()). This also resolves the corresponding FIXME in Task.promoteLocked.
- Only applying the file-read DAC check to xattr reads outside the security.*, system.*, and trusted.* namespaces, before any handler-specific rejection, per Linux's fs/xattr.c:xattr_permission(), in tmpfs, gofer, overlay, and kernfs. The blanket check previously made execve fail while reading security.capability off a non-readable binary.

Also re-enable ElfTest.NoRead under gVisor and add regression tests for execute-only ELF/interpreter loading, ACL-based read denial, ptrace and user-namespace protection, saved tracer credentials, script launch modes, TRACEME, and unknown-prefix xattr permissions.

Validation (Linux amd64, systrap):

- Full exec, ELF, ptrace, xattr, proc, prctl, and process_vm suites on tmpfs: 389 passed, 3 pre-existing skips.
- All 13 new/changed tests pass natively (verified against the host kernel first) and with save/restore.
- directfs/shared/overlay gofer matrix: 11 targets passed; the overlay ACL test runs and passes with upstream's overlay ACL support.
- mm, auth, kernel, vfs, and tmpfs unit-test targets passed.
- Initial OCI launches of a root-owned 0111 ELF as UID/GID 12345 (directfs and RPC): dumpability 0, ordinary read denied.
- End-to-end Docker comparison against runc: identical exec/read/ dumpability behavior, plus C reproducers for each ptrace/dumpability scenario run against both native Linux and runsc.

Disclosure: this change was developed with AI assistance -- implementation by Anthropic's Claude, with iterative adversarial review by OpenAI's Codex. Every behavioral claim was validated against native Linux with the tests and reproducers above.

Updates #160