### PR TITLE
Name the staged release tag release-<name>-staging.

### DIFF
--- a/.buildkite/release.yaml
+++ b/.buildkite/release.yaml
@@ -48,7 +48,7 @@ steps:
       queue: "release"
   - <<: *common
     label: ":ship: Release"
-    if: build.branch == "master" || build.tag != null
+    if: build.branch == "master" || (build.tag != null && build.tag =~ /-staging/)
     commands:
       # Stamps the binaries below with release-<name>.
       - ./.buildkite/scripts/release/tag.sh stage

--- a/.buildkite/scripts/release/tag.sh
+++ b/.buildkite/scripts/release/tag.sh
@@ -39,11 +39,11 @@ if [[ "$#" -ne 1 ]]; then
 fi
 
 declare -r staging_tag="${BUILDKITE_TAG:-}"
-if [[ "${staging_tag}" != staging-release-* ]]; then
+if [[ "${staging_tag}" != release-*-staging ]]; then
   echo "Not a staged release build; nothing to do." >&2
   exit 0
 fi
-declare -r tag="${staging_tag#staging-}"
+declare -r tag="${staging_tag%-staging}"
 
 # The object "${tag}" names in the remote; empty if it does not exist.
 published_object() {

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -94,7 +94,7 @@ else
       fi
       # LINT.ThenChange(../.buildkite/hooks/pre-command)
       # A staging tag names a release that is still being built.
-      if [[ "$tag" == staging-release-* ]]; then
+      if [[ "$tag" == release-*-staging ]]; then
         continue
       fi
       name=$(echo "${tag}" | cut -d'-' -f2)

--- a/tools/tag_release.sh
+++ b/tools/tag_release.sh
@@ -83,7 +83,7 @@ git tag -f -F "${message_file}" -a "${tag}" "${commit}"
 
 # Push under a staging name; the release pipeline publishes the real tag once
 # the artifacts are uploaded. A failed release leaves no tag behind.
-git push --force origin "refs/tags/${tag}:refs/tags/staging-${tag}"
+git push --force origin "refs/tags/${tag}:refs/tags/${tag}-staging"
 git tag -d "${tag}" # Not published yet.
 
 set +x
@@ -92,5 +92,5 @@ cat <<EOF
 Staged ${tag}. The release pipeline publishes it once the artifacts are in
 gs://gvisor/releases/:
 
-  https://buildkite.com/gvisor/release/builds?branch=staging-${tag}
+  https://buildkite.com/gvisor/release/builds?branch=${tag}-staging
 EOF

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # The STABLE_ prefix will trigger a re-link if it changes.
-echo STABLE_VERSION "$(git describe --always --tags --abbrev=12 --dirty 2>/dev/null || echo 0.0.0)"
+echo STABLE_VERSION "$(git describe --always --tags --exclude 'release-*-staging' --abbrev=12 --dirty 2>/dev/null || echo 0.0.0)"


### PR DESCRIPTION
The Release pipeline's branch filter is "master release-*", so staging-release-20260907.0 never triggered a build and the release silently produced nothing. The new name matches that filter, the Release step now skips published release-<name> tags so a release is not built and uploaded twice, and git describe ignores staged tags left behind by failed builds.