### PR TITLE
nvproxy: return ENOTTY for unsupported ioctl numbers

### DIFF
--- a/pkg/sentry/devices/nvproxy/frontend.go
+++ b/pkg/sentry/devices/nvproxy/frontend.go
@@ -245,7 +245,12 @@ func (fd *frontendFD) Ioctl(ctx context.Context, uio usermem.IO, sysno uintptr, 
 	// - Add symbol and parameter type definitions to //pkg/abi/nvgpu.
 	// - Add filter to seccomp_filters.go.
 	// - Add handling below.
-	result, err := fd.dev.nvp.abi.frontendIoctl[nr].handle(&fi)
+	handler, ok := fd.dev.nvp.abi.frontendIoctl[nr]
+	if !ok {
+		fi.ctx.Warningf("nvproxy: %s for frontend ioctl %d == %#x (argSize=%d, cmd=%#x)", errUndefinedHandler.Error(), nr, nr, argSize, cmd)
+		return 0, linuxerr.EINVAL
+	}
+	result, err := handler.handle(&fi)
 	if err != nil {
 		if handleErr, ok := err.(*errHandler); ok {
 			fi.ctx.Warningf("nvproxy: %v for frontend ioctl %d == %#x (argSize=%d, cmd=%#x)", handleErr, nr, nr, argSize, cmd)

--- a/pkg/sentry/devices/nvproxy/uvm.go
+++ b/pkg/sentry/devices/nvproxy/uvm.go
@@ -140,7 +140,12 @@ func (fd *uvmFD) Ioctl(ctx context.Context, uio usermem.IO, sysno uintptr, args 
 		cmd:             cmd,
 		ioctlParamsAddr: argPtr,
 	}
-	result, err := fd.dev.nvp.abi.uvmIoctl[cmd].handle(&ui)
+	handler, ok := fd.dev.nvp.abi.uvmIoctl[cmd]
+	if !ok {
+		ctx.Warningf("nvproxy: %s for uvm ioctl %d == %#x", errUndefinedHandler.Error(), cmd, cmd)
+		return 0, linuxerr.EINVAL
+	}
+	result, err := handler.handle(&ui)
 	if err != nil {
 		if handleErr, ok := err.(*errHandler); ok {
 			ctx.Warningf("nvproxy: %v for uvm ioctl %d = %#x", handleErr, cmd, cmd)


### PR DESCRIPTION
The frontend and UVM ioctl dispatch sites indexed the per-driver-version handler maps directly and called the returned handler without a presence check. An ioctl number absent from the map (e.g. one not supported by the current driver version) yields the zero value, so the dispatch called a nil function and panicked the Sentry.

An unknown ioctl number against the real NVIDIA driver returns ENOTTY, so reject it the same way at both dispatch sites.

Added a regression test covering the frontend and UVM dispatch paths with unregistered ioctl numbers.