### PR TITLE
state: bound decoder object-table growth

### DIFF
--- a/pkg/state/BUILD
+++ b/pkg/state/BUILD
@@ -1,4 +1,4 @@
-load("//tools:defs.bzl", "go_library")
+load("//tools:defs.bzl", "go_library", "go_test")
 load("//tools/go_generics:defs.bzl", "go_template_instance")
 
 package(
@@ -87,4 +87,10 @@ go_library(
         "//pkg/gohacks",
         "//pkg/state/wire",
     ],
+)
+
+go_test(
+    name = "state_test",
+    srcs = ["decode_test.go"],
+    library = ":state",
 )

--- a/pkg/state/decode.go
+++ b/pkg/state/decode.go
@@ -290,7 +290,15 @@ func walkChild(path []wire.Dot, obj reflect.Value) reflect.Value {
 	return obj
 }
 
+// maxDecodedObjects bounds the number of objects a single decoded state
+// stream may reference. Real streams are orders of magnitude below this; a
+// value near it almost certainly indicates corruption or a crafted file.
+const maxDecodedObjects = 1 << 24 // ~16.7M objects (~134MB of table)
+
 func (ds *decodeState) growObjectsByID(id objectID) {
+	if id > maxDecodedObjects {
+		Failf("object ID %d exceeds maximum supported object count %d", id, maxDecodedObjects)
+	}
 	if len(ds.objectsByID) < int(id) {
 		ds.objectsByID = append(ds.objectsByID, make([]*objectDecodeState, int(id)-len(ds.objectsByID))...)
 	}

--- a/pkg/state/decode_test.go
+++ b/pkg/state/decode_test.go
@@ -1,0 +1,34 @@
+// Copyright 2026 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import "testing"
+
+// TestGrowObjectsByIDRejectsHugeID verifies that an object ID beyond the
+// supported maximum fails the decode (via Failf) rather than attempting an
+// enormous allocation, which would terminate the process with an
+// unrecoverable out-of-memory panic. A corrupted or crafted state file can
+// contain arbitrary wire-derived object IDs.
+func TestGrowObjectsByIDRejectsHugeID(t *testing.T) {
+    ds := &decodeState{}
+    defer func() {
+        r := recover()
+        if r == nil {
+            t.Fatalf("growObjectsByID(1<<31) did not fail; huge allocation was attempted")
+        }
+    }()
+    // Must not reach the allocation; Failf panics.
+    ds.growObjectsByID(1 << 31)
+}


### PR DESCRIPTION
decodeState.growObjectsByID sized its object table directly from a wire-derived object ID (uint32) with no cap. A corrupted or crafted state file containing a single large object ID drove a make([]*objectDecodeState, ~4e9) — an attempted ~34GB allocation that terminated the decoding process with the Go runtime's unrecoverable out-of-memory panic instead of a decode error.

Bound the table at maxDecodedObjects (1<<24, ~16.7M objects, ~134MB of table — orders of magnitude above real streams). IDs beyond the bound fail via Failf with a descriptive message, consistent with the decoder's existing error discipline.

Also adds the package's first test target (state_test) with a regression test asserting the Failf path.