### PR TITLE
Honor errnoRet in OCI seccomp profiles

### DIFF
--- a/runsc/container/container_test.go
+++ b/runsc/container/container_test.go
@@ -4096,6 +4096,85 @@ func TestUserLog(t *testing.T) {
 	}
 }
 
+// TestOCISeccompErrnoRet checks that an OCI seccomp profile's `errnoRet` is
+// honored end-to-end: the errno the application observes must be the one
+// named in the profile, and a rule that omits `errnoRet` must still default
+// to EPERM. This is the pattern glibc >= 2.34 relies on to fall back from
+// clone3(2) to clone(2): it only does so when clone3 fails with ENOSYS.
+// See gvisor.dev/issue/14688.
+func TestOCISeccompErrnoRet(t *testing.T) {
+	app, err := testutil.FindFile("test/cmd/test_app/test_app")
+	if err != nil {
+		t.Fatal("error finding test_app:", err)
+	}
+
+	spec, conf := sleepSpecConf(t)
+	conf.OCISeccomp = true
+
+	// getsid(2) and getpgid(2) are both fully implemented by the sentry and
+	// are not on the Go runtime's startup path, so the only way test_app can
+	// observe a failure for either is through the seccomp filter below.
+	enosys := uint(unix.ENOSYS)
+	spec.Linux = &specs.Linux{
+		Seccomp: &specs.LinuxSeccomp{
+			DefaultAction: specs.ActAllow,
+			Syscalls: []specs.LinuxSyscall{
+				{
+					Names:    []string{"getsid"},
+					Action:   specs.ActErrno,
+					ErrnoRet: &enosys,
+				},
+				{
+					// No ErrnoRet: must default to EPERM, like runc.
+					Names:  []string{"getpgid"},
+					Action: specs.ActErrno,
+				},
+			},
+		},
+	}
+
+	_, bundleDir, cleanup, err := testutil.SetupContainer(spec, conf)
+	if err != nil {
+		t.Fatalf("error setting up container: %v", err)
+	}
+	defer cleanup()
+
+	args := Args{
+		ID:        testutil.RandomContainerID(),
+		Spec:      spec,
+		BundleDir: bundleDir,
+	}
+	cont, err := New(conf, args)
+	if err != nil {
+		t.Fatalf("error creating container: %v", err)
+	}
+	defer cont.Destroy()
+	if err := cont.Start(conf); err != nil {
+		t.Fatalf("error starting container: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name  string
+		sysno int
+		want  error
+	}{
+		{name: "errno_ret_honored", sysno: unix.SYS_GETSID, want: unix.ENOSYS},
+		{name: "no_errno_ret_defaults_to_eperm", sysno: unix.SYS_GETPGID, want: unix.EPERM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// test_app's "syscall" subcommand always exits 0; it prints the
+			// errno it observed, which is what we assert on.
+			out, err := executeCombinedOutput(conf, cont, nil, app, "syscall", "--syscall="+strconv.Itoa(tc.sysno))
+			if err != nil {
+				t.Fatalf("error executing test_app: %v", err)
+			}
+			if want := fmt.Sprintf("failed: %v", tc.want); !strings.Contains(string(out), want) {
+				t.Errorf("syscall(%d) output %q does not contain %q", tc.sysno, out, want)
+			}
+		})
+	}
+}
+
 func TestWaitOnExitedSandbox(t *testing.T) {
 	for name, conf := range configs(t, false /* noOverlay */) {
 		t.Run(name, func(t *testing.T) {

--- a/runsc/specutils/seccomp/seccomp.go
+++ b/runsc/specutils/seccomp/seccomp.go
@@ -18,6 +18,7 @@ package seccomp
 
 import (
 	"fmt"
+	"math"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
@@ -32,9 +33,13 @@ import (
 var (
 	killThreadAction = seccomp.KillThread
 	trapAction       = seccomp.Trap
-	// runc always returns EPERM as the errorcode for SECCOMP_RET_ERRNO
+	// errnoAction is the default errno returned for SCMP_ACT_ERRNO when the
+	// rule (or the profile's defaultErrnoRet) does not request a specific one,
+	// matching runc's default.
 	errnoAction = seccomp.ReturnError.Code(uint16(unix.EPERM))
-	// runc always returns EPERM as the errorcode for SECCOMP_RET_TRACE
+	// traceAction is the default code returned for SCMP_ACT_TRACE when the
+	// rule (or the profile's defaultErrnoRet) does not request a specific one,
+	// matching runc's default.
 	traceAction = seccomp.Trace.Code(uint16(unix.EPERM))
 	allowAction = seccomp.Allow
 )
@@ -42,9 +47,9 @@ var (
 // BuildProgram generates a bpf program based on the given OCI seccomp
 // config.
 func BuildProgram(s *specs.LinuxSeccomp) (bpf.Program, error) {
-	defaultAction, err := convertAction(s.DefaultAction)
+	defaultAction, err := convertAction(s.DefaultAction, s.DefaultErrnoRet)
 	if err != nil {
-		return bpf.Program{}, fmt.Errorf("secomp default action: %w", err)
+		return bpf.Program{}, fmt.Errorf("seccomp default action: %w", err)
 	}
 	ruleset, err := convertRules(s)
 	if err != nil {
@@ -93,8 +98,11 @@ func lookupSyscallNo(arch uint32, name string) (uint32, error) {
 	return uint32(n), nil
 }
 
-// convertAction converts a LinuxSeccompAction to BPFAction
-func convertAction(act specs.LinuxSeccompAction) (seccomp.Action, error) {
+// convertAction converts a LinuxSeccompAction to BPFAction. errnoRet is the
+// errnoRet (or defaultErrnoRet) requested by the OCI profile for this action,
+// or nil if it requested none. It is only meaningful for ActErrno and
+// ActTrace and, as in runc, is silently ignored for every other action.
+func convertAction(act specs.LinuxSeccompAction, errnoRet *uint) (seccomp.Action, error) {
 	// TODO(gvisor.dev/issue/3124): Update specs package to include ActLog and ActKillProcess.
 	// LINT.IfChange
 	switch act {
@@ -103,15 +111,31 @@ func convertAction(act specs.LinuxSeccompAction) (seccomp.Action, error) {
 	case specs.ActTrap:
 		return trapAction, nil
 	case specs.ActErrno:
-		return errnoAction, nil
+		return withErrnoRet(errnoAction, errnoRet)
 	case specs.ActTrace:
-		return traceAction, nil
+		return withErrnoRet(traceAction, errnoRet)
 	case specs.ActAllow:
 		return allowAction, nil
 	default:
 		return seccomp.Default, fmt.Errorf("invalid action: %v", act)
 	}
 	// LINT.ThenChange(:KnownActions)
+}
+
+// withErrnoRet overrides the return code of act with errnoRet, if set. act
+// must be errnoAction or traceAction (or another action already carrying a
+// return code); Action.Code replaces any code already present. errnoRet is
+// only meaningful for SCMP_ACT_ERRNO and SCMP_ACT_TRACE — passing it for any
+// other action would panic deep in the BPF encoder, since gVisor's BPF
+// action only carries a return code for those two actions.
+func withErrnoRet(act seccomp.Action, errnoRet *uint) (seccomp.Action, error) {
+	if errnoRet == nil {
+		return act, nil
+	}
+	if *errnoRet > math.MaxUint16 {
+		return seccomp.Default, fmt.Errorf("errnoRet %d does not fit in 16 bits", *errnoRet)
+	}
+	return act.Code(uint16(*errnoRet)), nil
 }
 
 // convertRules converts OCI linux seccomp rules into RuleSets that can be used by
@@ -126,7 +150,7 @@ func convertRules(s *specs.LinuxSeccomp) ([]seccomp.RuleSet, error) {
 	for _, syscall := range s.Syscalls {
 		sysRules := seccomp.NewSyscallRules()
 
-		action, err := convertAction(syscall.Action)
+		action, err := convertAction(syscall.Action, syscall.ErrnoRet)
 		if err != nil {
 			return nil, err
 		}

--- a/runsc/specutils/seccomp/seccomp_test.go
+++ b/runsc/specutils/seccomp/seccomp_test.go
@@ -16,6 +16,7 @@ package seccomp
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -44,6 +45,12 @@ func testInput(arch uint32, syscallName string, args *[6]uint64) bpf.Input {
 		Args: *args,
 	}
 	return seccomp.DataAsBPFInput(&data, make([]byte, data.SizeBytes()))
+}
+
+// errnoRetPtr returns a pointer to errno, for use as an OCI errnoRet or
+// defaultErrnoRet field.
+func errnoRetPtr(errno uint) *uint {
+	return &errno
 }
 
 // testCase holds a seccomp test case.
@@ -367,8 +374,214 @@ var (
 			input:    testInput(nativeArchAuditNo, "clone", &[6]uint64{0x50f00}),
 			expected: uint32(linux.SECCOMP_RET_ALLOW),
 		},
+		{
+			name: "default_errno_ret",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.ENOSYS))),
+		},
+		{
+			// errnoRet: 0 is distinct from an unset errnoRet: it means
+			// "return 0", not "use the EPERM default".
+			name: "default_errno_ret_zero",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: errnoRetPtr(0),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(0)),
+		},
+		{
+			// defaultErrnoRet is meaningless for SCMP_ACT_ALLOW; applying it
+			// anyway would panic in BPFAction.WithReturnCode.
+			name: "default_errno_ret_ignored_for_allow",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActAllow,
+				DefaultErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ALLOW),
+		},
+		{
+			// Likewise for SCMP_ACT_KILL.
+			name: "default_errno_ret_ignored_for_kill",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActKill,
+				DefaultErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_KILL_THREAD),
+		},
+		{
+			// This is the glibc >= 2.34 clone3 fallback pattern: clone3 must
+			// return ENOSYS (not EPERM) or glibc will not fall back to
+			// clone(2). See gvisor.dev/issue/14688.
+			name: "match_name_errno_ret",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"clone3"},
+						Action:   specs.ActErrno,
+						ErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+					},
+					{
+						// No ErrnoRet: must fall back to EPERM, not
+						// whatever the other rule in this profile requested.
+						Names:  []string{"getcwd"},
+						Action: specs.ActErrno,
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "clone3", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.ENOSYS))),
+		},
+		{
+			// Same profile as match_name_errno_ret: proves errnoRet is
+			// plumbed per rule (per RuleSet), not shared across the profile.
+			name: "match_name_errno_ret_default_eperm",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"clone3"},
+						Action:   specs.ActErrno,
+						ErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+					},
+					{
+						Names:  []string{"getcwd"},
+						Action: specs.ActErrno,
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "getcwd", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.EPERM))),
+		},
+		{
+			name: "match_name_errno_ret_zero",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"clone3"},
+						Action:   specs.ActErrno,
+						ErrnoRet: errnoRetPtr(0),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "clone3", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(0)),
+		},
+		{
+			name: "match_name_trace_ret",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"write"},
+						Action:   specs.ActTrace,
+						ErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "write", nil),
+			expected: uint32(linux.SECCOMP_RET_TRACE.WithReturnCode(uint16(unix.ENOSYS))),
+		},
+		{
+			// errnoRet is meaningless for SCMP_ACT_ALLOW; applying it anyway
+			// would panic in BPFAction.WithReturnCode.
+			name: "errno_ret_ignored_for_allow",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"getcwd"},
+						Action:   specs.ActAllow,
+						ErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "getcwd", nil),
+			expected: uint32(linux.SECCOMP_RET_ALLOW),
+		},
+		{
+			// Likewise for SCMP_ACT_TRAP.
+			name: "errno_ret_ignored_for_trap",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"getcwd"},
+						Action:   specs.ActTrap,
+						ErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "getcwd", nil),
+			expected: uint32(linux.SECCOMP_RET_TRAP),
+		},
+		{
+			// defaultErrnoRet must not leak into a per-rule action that
+			// doesn't set its own errnoRet.
+			name: "default_errno_ret_does_not_leak_to_rules",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActAllow,
+				DefaultErrnoRet: errnoRetPtr(uint(unix.ENOSYS)),
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:  []string{"getcwd"},
+						Action: specs.ActErrno,
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "getcwd", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.EPERM))),
+		},
 	}
 )
+
+// errnoRetOutOfRangeTests are OCI seccomp profiles with an errnoRet that
+// does not fit in the 16-bit SECCOMP_RET_DATA field, which BuildProgram
+// must reject rather than silently truncate.
+var errnoRetOutOfRangeTests = []testCase{
+	{
+		name: "default",
+		config: specs.LinuxSeccomp{
+			DefaultAction:   specs.ActErrno,
+			DefaultErrnoRet: errnoRetPtr(math.MaxUint16 + 1),
+		},
+	},
+	{
+		name: "rule",
+		config: specs.LinuxSeccomp{
+			DefaultAction: specs.ActAllow,
+			Syscalls: []specs.LinuxSyscall{
+				{
+					Names:    []string{"getcwd"},
+					Action:   specs.ActErrno,
+					ErrnoRet: errnoRetPtr(math.MaxUint16 + 1),
+				},
+			},
+		},
+	},
+}
+
+// TestErrnoRetOutOfRange checks that an errnoRet that does not fit in the
+// 16-bit SECCOMP_RET_DATA field is rejected by BuildProgram rather than
+// silently truncated, which would otherwise reinterpret the rule (e.g.
+// errnoRet: 0x10000 truncates to 0, turning a deny rule into an allow rule).
+func TestErrnoRetOutOfRange(t *testing.T) {
+	for _, tc := range errnoRetOutOfRangeTests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := BuildProgram(&tc.config); err == nil {
+				t.Errorf("BuildProgram(%+v) succeeded, want error", tc.config)
+			}
+		})
+	}
+}
 
 // TestRunscSeccomp generates seccomp programs from OCI config and executes
 // them using runsc's library, comparing against expected results.


### PR DESCRIPTION
The OCI spec lets a seccomp rule request a specific errno via LinuxSyscall.ErrnoRet (and a default via LinuxSeccomp.DefaultErrnoRet), but runsc's converter never read either field and hardcoded EPERM for every SCMP_ACT_ERRNO and SCMP_ACT_TRACE result.

This silently breaks the standard clone3 compatibility pattern: glibc >= 2.34 attempts clone3 first and only falls back to clone() when clone3 fails with ENOSYS, so profiles that must block clone3 set "errnoRet": 38 to preserve that fallback. Under runsc the requested errno was accepted and then discarded, and a modern-glibc workload failed to create threads instead.

Thread the profile's errnoRet through convertAction, mirroring runc's getAction(): it applies to SCMP_ACT_ERRNO and SCMP_ACT_TRACE and is ignored for other actions, and rules that do not set it keep defaulting to EPERM. A value that does not fit in SECCOMP_RET_DATA is rejected rather than silently truncated, since truncation could turn a deny rule into an allow rule (e.g. errnoRet: 0x10000 truncates to 0).

Adds unit test coverage in seccomp_test.go (including the out-of-range rejection and that errnoRet/defaultErrnoRet are correctly scoped and ignored where the OCI spec says they should be) and an end-to-end container test that exercises the fix through an actual OCI seccomp profile and asserts on the errno the application observes.

Fixes #14688

Assisted-by: Claude Code