### PR TITLE
overlay: do not panic on whiteout creation failure during UnlinkAt/RmdirAt

### DIFF
--- a/pkg/sentry/fsimpl/overlay/filesystem.go
+++ b/pkg/sentry/fsimpl/overlay/filesystem.go
@@ -590,7 +590,7 @@ func CreateWhiteout(ctx context.Context, vfsObj *vfs.VirtualFilesystem, creds *a
 
 func (fs *filesystem) cleanupRecreateWhiteout(ctx context.Context, vfsObj *vfs.VirtualFilesystem, pop *vfs.PathOperation) {
 	if err := CreateWhiteout(ctx, vfsObj, fs.creds, pop); err != nil {
-		panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to recreate whiteout after failed file creation: %v", err))
+		log.Warningf("overlay: failed to recreate whiteout after failed file creation: %v", err)
 	}
 }
 
@@ -1299,7 +1299,7 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 				Start: replaced.upperVD,
 				Path:  fspath.Parse(whiteoutName),
 			}); err != nil && !linuxerr.Equals(linuxerr.EEXIST, err) {
-				panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to recreate deleted whiteout after RenameAt failure: %v", err))
+				log.Warningf("overlay: failed to recreate deleted whiteout after RenameAt failure: %v", err)
 			}
 		}
 	}
@@ -1421,7 +1421,7 @@ func (fs *filesystem) RenameAt(ctx context.Context, rp *vfs.ResolvingPath, oldPa
 	toDecRef = vfsObj.CommitRenameReplaceDentry(ctx, &handle, &renamed.vfsd, replacedVFSD)
 
 	if err := CreateWhiteout(ctx, vfsObj, fs.creds, &oldpop); err != nil {
-		panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to create whiteout at origin after RenameAt: %v", err))
+		log.Warningf("overlay: failed to create whiteout at origin after RenameAt: %v", err)
 	}
 	if renamed.isDir() {
 		if err := vfsObj.SetXattrAt(ctx, fs.creds, &newpop, &vfs.SetXattrOptions{
@@ -1524,7 +1524,7 @@ func (fs *filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 					Start: child.upperVD,
 					Path:  fspath.Parse(whiteoutName),
 				}); err != nil && !linuxerr.Equals(linuxerr.EEXIST, err) {
-					panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to recreate deleted whiteout after RmdirAt failure: %v", err))
+					log.Warningf("overlay: failed to recreate deleted whiteout after RmdirAt failure: %v", err)
 				}
 			}
 		}
@@ -1564,7 +1564,7 @@ func (fs *filesystem) RmdirAt(ctx context.Context, rp *vfs.ResolvingPath) error 
 				// Don't attempt to recover from this: the original directory is
 				// already gone, so any dentries representing it are invalid, and
 				// creating a new directory won't undo that.
-				panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to create whiteout after removing upper layer directory during RmdirAt: %v", err))
+				log.Warningf("overlay: failed to create whiteout after removing upper layer directory during RmdirAt: %v", err)
 			}
 			return err
 		}
@@ -1802,7 +1802,7 @@ func (fs *filesystem) UnlinkAt(ctx context.Context, rp *vfs.ResolvingPath) error
 		if err := CreateWhiteout(ctx, vfsObj, fs.creds, &pop); err != nil {
 			vfsObj.AbortDeleteDentry(&child.vfsd)
 			if childLayer == lookupLayerUpper {
-				panic(fmt.Sprintf("unrecoverable overlayfs inconsistency: failed to create whiteout after unlinking upper layer file during UnlinkAt: %v", err))
+				log.Warningf("overlay: failed to create whiteout after unlinking upper layer file during UnlinkAt: %v", err)
 			}
 			return err
 		}

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -35,6 +35,7 @@
 #include <unistd.h>
 
 #include <array>
+#include <atomic>
 #include <cerrno>
 #include <cmath>
 #include <cstdint>
@@ -3239,6 +3240,77 @@ TEST(MountTest, OverlayfsOnGoferBehavior) {
                          sizeof(xattr_buf)),
                 SyscallSucceeds());
     EXPECT_STREQ(xattr_buf, "value");
+  }
+}
+
+// Deleting an upper layer file when whiteout creation fails (e.g. concurrent
+// removal of the parent directory on the underlying filesystem) should not
+// cause the sandbox to panic (fixes #14726).
+TEST(MountTest, OverlayfsUnlinkWhiteoutFailureDoesNotPanic) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  bool in_overlayfs = ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(base_dir.path()));
+
+  // Overlayfs cannot be used as upper layer for another overlayfs mount. If
+  // running in overlayfs, create a tmpfs mount to use as the base directory.
+  if (in_overlayfs) {
+    TEST_CHECK_SUCCESS(mount("tmpfs", base_dir.path().c_str(), "tmpfs", 0,
+                             "mode=1777,size=10m"));
+  }
+  auto tmpfs_cleanup = Cleanup([&base_dir, &in_overlayfs] {
+    if (in_overlayfs) {
+      umount2(base_dir.path().c_str(), 0);
+    }
+  });
+
+  auto lower = JoinPath(base_dir.path(), "lower");
+  auto upper = JoinPath(base_dir.path(), "upper");
+  auto work = JoinPath(base_dir.path(), "work");
+  auto merged = JoinPath(base_dir.path(), "merged");
+  ASSERT_THAT(mkdir(lower.c_str(), 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir(upper.c_str(), 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir(work.c_str(), 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir(merged.c_str(), 0755), SyscallSucceeds());
+
+  std::string opts = "lowerdir=" + lower + ",upperdir=" + upper +
+                     ",workdir=" + work + ",userxattr";
+  ASSERT_THAT(
+      mount("overlay", merged.c_str(), "overlay", 0, opts.c_str()),
+      SyscallSucceeds());
+  auto overlayfs_cleanup =
+      Cleanup([&merged] { umount2(merged.c_str(), 0); });
+
+  // Repeat the race a few times to ensure unlink does not panic when the
+  // parent upper directory is concurrently removed.
+  for (int i = 0; i < 20; ++i) {
+    std::string dname = absl::StrCat("d", i);
+    std::string lower_d = JoinPath(lower, dname);
+    ASSERT_THAT(mkdir(lower_d.c_str(), 0755), SyscallSucceeds());
+    std::string lower_f = JoinPath(lower_d, "f");
+    ASSERT_NO_ERRNO(CreateWithContents(lower_f, "x", 0644));
+
+    // Modify via merged to copy up to upper layer.
+    std::string merged_f = JoinPath(JoinPath(merged, dname), "f");
+    ASSERT_NO_ERRNO(SetContents(merged_f, "xy"));
+
+    std::string upper_d = JoinPath(upper, dname);
+    std::atomic<bool> stop(false);
+    std::vector<std::unique_ptr<ScopedThread>> threads;
+    for (int t = 0; t < 2; ++t) {
+      threads.push_back(std::make_unique<ScopedThread>([&upper_d, &stop] {
+        while (!stop.load()) {
+          rmdir(upper_d.c_str());
+        }
+      }));
+    }
+
+    // Attempt unlink through merged overlay. Whether it succeeds or fails
+    // with an errno (e.g. ENOENT), the sandbox MUST NOT panic.
+    unlink(merged_f.c_str());
+
+    stop.store(true);
+    threads.clear();
   }
 }
 


### PR DESCRIPTION
Fixes #14726

### Problem

In `pkg/sentry/fsimpl/overlay/filesystem.go`, when `UnlinkAt` or `RmdirAt` removes an entry from the upper layer and creates a whiteout (character device `0:0`) to obscure lower layer entries, `CreateWhiteout` can fail if the parent directory has been concurrently removed on the underlying filesystem (e.g. returning `ENOENT`).

Unlike Linux overlayfs (which creates whiteouts in the workdir and renames them atomically), gVisor performs deletion followed by `mknod(0, 0)`. When `CreateWhiteout` failed, gVisor called `panic("unrecoverable overlayfs inconsistency: failed to create whiteout ...")`, causing a fatal Sentry kernel panic that abruptly terminates the entire container/sandbox (denial of service).

Similarly, failures during cleanup recreation of deleted whiteouts (`cleanupRecreateWhiteouts` in `RenameAt`, `RmdirAt`, and `cleanupRecreateWhiteout`) also panicked.

*(Note: PR #14073 was suggested in comments on #14726, but PR #14073 strictly addresses directory `RenameAt` and opaque xattrs in user namespaces; it does not touch `UnlinkAt`, `RmdirAt`, or whiteout creation failures).*

### Solution

1. In `pkg/sentry/fsimpl/overlay/filesystem.go`:
   - In `UnlinkAt` and `RmdirAt`: Replace `panic` when `CreateWhiteout` fails with `log.Warningf` and gracefully return `err` to the caller.
   - In `cleanupRecreateWhiteouts` (`RenameAt`, `RmdirAt`) and `cleanupRecreateWhiteout`: Replace `panic` on whiteout recreation failure with `log.Warningf`.
   - In `RenameAt`: Replace `panic` on origin whiteout creation failure with `log.Warningf`.
2. In `test/syscalls/linux/mount.cc`:
   - Added regression test `MountTest.OverlayfsUnlinkWhiteoutFailureDoesNotPanic` that reproduces racing `unlink` of an upper copy-up file against concurrent removal of its parent on the raw upper layer, verifying that the sandbox stays alive and does not panic.

Signed-off-by: jdymitarai <o10040115@gmail.com>
