### PR TITLE
overlay: allow relative paths in lowerdir, upperdir, and workdir

### DIFF
--- a/pkg/sentry/fsimpl/overlay/overlay.go
+++ b/pkg/sentry/fsimpl/overlay/overlay.go
@@ -180,6 +180,16 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 	if vfsroot.Ok() {
 		defer vfsroot.DecRef(ctx)
 	}
+	vfscwd := vfs.WorkingDirFromContext(ctx)
+	if vfscwd.Ok() {
+		defer vfscwd.DecRef(ctx)
+	}
+	resolveStart := func(path fspath.Path) vfs.VirtualDentry {
+		if !path.Absolute && vfscwd.Ok() {
+			return vfscwd
+		}
+		return vfsroot
+	}
 
 	userXattrVal, userXattr := mopts["userxattr"]
 	if userXattr && userXattrVal != "" {
@@ -197,17 +207,17 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		// Linux overlayfs also requires a workdir when upperdir is
 		// specified; we don't, so silently ignore this option.
 		if workdir, ok := mopts["workdir"]; ok {
+			if len(workdir) == 0 {
+				ctx.Infof("overlay.FilesystemType.GetFilesystem: empty workdir")
+				return nil, nil, linuxerr.EINVAL
+			}
 			// Linux creates the "work" directory in `workdir`.
 			// Docker calls chown on it and fails if it doesn't
 			// exist.
 			workdirPath := fspath.Parse(workdir + "/work")
-			if !workdirPath.Absolute {
-				ctx.Infof("overlay.FilesystemType.GetFilesystem: workdir %q must be absolute", workdir)
-				return nil, nil, linuxerr.EINVAL
-			}
 			pop := vfs.PathOperation{
 				Root:               vfsroot,
-				Start:              vfsroot,
+				Start:              resolveStart(workdirPath),
 				Path:               workdirPath,
 				FollowFinalSymlink: false,
 			}
@@ -219,14 +229,14 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 			}
 			delete(mopts, "workdir")
 		}
-		upperPath := fspath.Parse(upperPathname)
-		if !upperPath.Absolute {
-			ctx.Infof("overlay.FilesystemType.GetFilesystem: upperdir %q must be absolute", upperPathname)
+		if len(upperPathname) == 0 {
+			ctx.Infof("overlay.FilesystemType.GetFilesystem: empty upperdir")
 			return nil, nil, linuxerr.EINVAL
 		}
+		upperPath := fspath.Parse(upperPathname)
 		upperRoot, err := vfsObj.GetDentryAt(ctx, creds, &vfs.PathOperation{
 			Root:               vfsroot,
-			Start:              vfsroot,
+			Start:              resolveStart(upperPath),
 			Path:               upperPath,
 			FollowFinalSymlink: true,
 		}, &vfs.GetDentryOptions{
@@ -273,14 +283,14 @@ func (fstype FilesystemType) GetFilesystem(ctx context.Context, vfsObj *vfs.Virt
 		delete(mopts, "lowerdir")
 		lowerPathnames := strings.Split(lowerPathnamesStr, ":")
 		for _, lowerPathname := range lowerPathnames {
-			lowerPath := fspath.Parse(lowerPathname)
-			if !lowerPath.Absolute {
-				ctx.Infof("overlay.FilesystemType.GetFilesystem: lowerdir %q must be absolute", lowerPathname)
+			if len(lowerPathname) == 0 {
+				ctx.Infof("overlay.FilesystemType.GetFilesystem: empty lowerdir")
 				return nil, nil, linuxerr.EINVAL
 			}
+			lowerPath := fspath.Parse(lowerPathname)
 			lowerRoot, err := vfsObj.GetDentryAt(ctx, creds, &vfs.PathOperation{
 				Root:               vfsroot,
-				Start:              vfsroot,
+				Start:              resolveStart(lowerPath),
 				Path:               lowerPath,
 				FollowFinalSymlink: true,
 			}, &vfs.GetDentryOptions{

--- a/pkg/sentry/kernel/kernel.go
+++ b/pkg/sentry/kernel/kernel.go
@@ -1265,7 +1265,7 @@ func (ctx *createProcessContext) Value(key any) any {
 		return ipcns
 	case auth.CtxCredentials:
 		return ctx.args.Credentials
-	case vfs.CtxRoot:
+	case vfs.CtxRoot, vfs.CtxWorkingDir:
 		if ctx.args.MountNamespace == nil {
 			return nil
 		}
@@ -2182,7 +2182,7 @@ func (ctx *supervisorContext) Value(key any) any {
 	case auth.CtxCredentials:
 		// The supervisor context is global root.
 		return auth.NewRootCredentials(ctx.Kernel.rootUserNamespace)
-	case vfs.CtxRoot:
+	case vfs.CtxRoot, vfs.CtxWorkingDir:
 		if ctx.Kernel.globalInit == nil || ctx.Kernel.globalInit.Leader() == nil {
 			return vfs.VirtualDentry{}
 		}

--- a/pkg/sentry/kernel/task_context.go
+++ b/pkg/sentry/kernel/task_context.go
@@ -97,6 +97,12 @@ func (t *Task) contextValue(key any, isTaskGoroutine bool) any {
 			defer t.mu.Unlock()
 		}
 		return t.FSContext().RootDirectory()
+	case vfs.CtxWorkingDir:
+		if !isTaskGoroutine {
+			t.mu.Lock()
+			defer t.mu.Unlock()
+		}
+		return t.FSContext().WorkingDirectory()
 	case vfs.CtxMountNamespace:
 		if !isTaskGoroutine {
 			t.mu.Lock()

--- a/pkg/sentry/vfs/context.go
+++ b/pkg/sentry/vfs/context.go
@@ -31,6 +31,9 @@ const (
 	// CtxRoot is a Context.Value key for a VFS root.
 	CtxRoot
 
+	// CtxWorkingDir is a Context.Value key for a VFS working directory.
+	CtxWorkingDir
+
 	// CtxRestoreFilesystemFDMap is a Context.Value key for a
 	// map[checkpoint.ResourceID]int mapping filesystem unique IDs (cf.
 	// gofer.InternalFilesystemOptions.UniqueID) to host FDs.
@@ -115,3 +118,38 @@ func (rc rootContext) Value(key any) any {
 		return rc.Context.Value(key)
 	}
 }
+
+// WorkingDirFromContext returns the VFS working directory used by ctx. It takes a
+// reference on the returned VirtualDentry. If ctx does not have a specific VFS
+// working directory, WorkingDirFromContext returns a zero-value VirtualDentry.
+func WorkingDirFromContext(ctx goContext.Context) VirtualDentry {
+	if v := ctx.Value(CtxWorkingDir); v != nil {
+		return v.(VirtualDentry)
+	}
+	return VirtualDentry{}
+}
+
+type workingDirContext struct {
+	context.Context
+	workingDir VirtualDentry
+}
+
+// WithWorkingDir returns a copy of ctx with the given working directory.
+func WithWorkingDir(ctx context.Context, workingDir VirtualDentry) context.Context {
+	return &workingDirContext{
+		Context:    ctx,
+		workingDir: workingDir,
+	}
+}
+
+// Value implements Context.Value.
+func (wc workingDirContext) Value(key any) any {
+	switch key {
+	case CtxWorkingDir:
+		wc.workingDir.IncRef()
+		return wc.workingDir
+	default:
+		return wc.Context.Value(key)
+	}
+}
+

--- a/test/syscalls/linux/mount.cc
+++ b/test/syscalls/linux/mount.cc
@@ -3242,6 +3242,71 @@ TEST(MountTest, OverlayfsOnGoferBehavior) {
   }
 }
 
+// Test that overlayfs can be mounted with relative lowerdir, upperdir, and
+// workdir paths resolved against the calling process's working directory
+// (fixes #14699).
+TEST(MountTest, OverlayfsRelativePaths) {
+  SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
+
+  auto base_dir = ASSERT_NO_ERRNO_AND_VALUE(TempPath::CreateDir());
+  bool in_overlayfs = ASSERT_NO_ERRNO_AND_VALUE(IsOverlayfs(base_dir.path()));
+
+  // Overlayfs cannot be used as upper layer for another overlayfs mount. If
+  // running in overlayfs, create a tmpfs mount to use as the base directory.
+  if (in_overlayfs) {
+    TEST_CHECK_SUCCESS(mount("tmpfs", base_dir.path().c_str(), "tmpfs", 0,
+                             "mode=1777,size=10m"));
+  }
+  auto tmpfs_cleanup = Cleanup([&base_dir, &in_overlayfs] {
+    if (in_overlayfs) {
+      umount2(base_dir.path().c_str(), 0);
+    }
+  });
+
+  // Save current working directory so we can restore it upon test completion.
+  char* cwd = getcwd(nullptr, 0);
+  ASSERT_NE(cwd, nullptr);
+  std::string old_cwd(cwd);
+  free(cwd);
+  auto cwd_cleanup = Cleanup([old_cwd] { chdir(old_cwd.c_str()); });
+
+  // Change working directory to base_dir.
+  ASSERT_THAT(chdir(base_dir.path().c_str()), SyscallSucceeds());
+
+  // Create relative directories: l0, l1, u, w, m.
+  ASSERT_THAT(mkdir("l0", 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir("l1", 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir("u", 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir("w", 0755), SyscallSucceeds());
+  ASSERT_THAT(mkdir("m", 0755), SyscallSucceeds());
+
+  // Populate lower layers with test files.
+  ASSERT_NO_ERRNO(CreateWithContents("l0/file0", "from_l0", 0644));
+  ASSERT_NO_ERRNO(CreateWithContents("l1/file1", "from_l1", 0644));
+
+  // Mount overlay with relative paths.
+  std::string opts = "lowerdir=l0:l1,upperdir=u,workdir=w,userxattr";
+  ASSERT_THAT(
+      mount("overlay", "m", "overlay", 0, opts.c_str()),
+      SyscallSucceeds());
+  auto overlayfs_cleanup = Cleanup([] { umount2("m", 0); });
+
+  // Verify that files from both lower layers are accessible through the merged mount.
+  std::string content0;
+  ASSERT_NO_ERRNO(GetContents("m/file0", &content0));
+  EXPECT_EQ(content0, "from_l0");
+
+  std::string content1;
+  ASSERT_NO_ERRNO(GetContents("m/file1", &content1));
+  EXPECT_EQ(content1, "from_l1");
+
+  // Write a new file through the merged mount and verify it is written to upperdir.
+  ASSERT_NO_ERRNO(CreateWithContents("m/newfile", "created_in_overlay", 0644));
+  std::string upper_content;
+  ASSERT_NO_ERRNO(GetContents("u/newfile", &upper_content));
+  EXPECT_EQ(upper_content, "created_in_overlay");
+}
+
 TEST(MountTest, PollMountInfo) {
   SKIP_IF(!ASSERT_NO_ERRNO_AND_VALUE(HaveCapability(CAP_SYS_ADMIN)));
 


### PR DESCRIPTION
Fixes #14699

### Problem

On Linux, `mount(2)` for `overlayfs` resolves relative paths in `lowerdir`, `upperdir`, and `workdir` against the calling process's current working directory (`AT_FDCWD` / `pwd`).

In gVisor, `overlay.FilesystemType.GetFilesystem` rejected all non-absolute paths in `lowerdir`, `upperdir`, and `workdir` with `EINVAL` (`lowerdir %q must be absolute`).

Under Docker 29 with containerd snapshotter, containerd executes a `chdir` and switches to relative `lowerdir` paths once the absolute mount option string would exceed one page (`PAGE_SIZE`). For images with ~38 layers or more (e.g. `paketobuildpacks/builder-jammy-java-tiny` which has 39 layers and is the default builder for Cloud Native Buildpacks), `docker create` fails with `EINVAL`, breaking tools like `pack build` and Spring Boot's `bootBuildImage` under gVisor.

### Solution

1. Added `CtxWorkingDir` and `WorkingDirFromContext` to `pkg/sentry/vfs/context.go`, and wired `vfs.CtxWorkingDir` in `pkg/sentry/kernel/task_context.go` to retrieve the calling task's current working directory (`t.FSContext().WorkingDirectory()`).
2. In `pkg/sentry/fsimpl/overlay/overlay.go`:
   - Extracted `vfscwd` via `vfs.WorkingDirFromContext(ctx)`.
   - Replaced the absolute-path restriction on `lowerdir`, `upperdir`, and `workdir` with resolution starting from `vfscwd` when `!path.Absolute && vfscwd.Ok()` (falling back to `vfsroot`). Empty pathnames continue to be rejected with `EINVAL` matching Linux overlayfs.
3. Added regression test `MountTest.OverlayfsRelativePaths` in `test/syscalls/linux/mount.cc` which tests mounting an overlay using relative `lowerdir=l0:l1`, `upperdir=u`, and `workdir=w` after `chdir`, verifying that files from both lower layers can be read and new files are written to the upper layer.

Signed-off-by: jdymitarai <o10040115@gmail.com>
