### PR TITLE
fdchannel, lisafs: check MSG_CTRUNC and mark channel dead on FD exhaustion (fixes #14697)

### DIFF
--- a/pkg/fdchannel/fdchannel_test.go
+++ b/pkg/fdchannel/fdchannel_test.go
@@ -130,3 +130,58 @@ func TestRecvFDThenShutdown(t *testing.T) {
 	time.Sleep(time.Second) // to ensure recvEP.RecvFD() has blocked
 	recvEP.Shutdown()
 }
+
+func TestRecvFDTruncatedUnderExhaustion(t *testing.T) {
+	sendFile, err := os.CreateTemp("", "fdchannel_test_")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %v", err)
+	}
+	defer sendFile.Close()
+
+	chanFDs, err := NewConnectedSockets()
+	if err != nil {
+		t.Fatalf("failed to create fdchannel sockets: %v", err)
+	}
+	sendEP := NewEndpoint(chanFDs[0])
+	defer sendEP.Destroy()
+	recvEP := NewEndpoint(chanFDs[1])
+	defer recvEP.Destroy()
+
+	// 1. Prime the receiver buffer with a successful send and receive.
+	if err := sendEP.SendFD(int(sendFile.Fd())); err != nil {
+		t.Fatalf("SendFD failed: %v", err)
+	}
+	firstFD, err := recvEP.RecvFD()
+	if err != nil {
+		t.Fatalf("RecvFD failed: %v", err)
+	}
+	defer unix.Close(firstFD)
+
+	// 2. Query and lower RLIMIT_NOFILE to prevent allocation of subsequent FDs.
+	var origRlim unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &origRlim); err != nil {
+		t.Skipf("cannot get rlimit: %v", err)
+	}
+	lowRlim := origRlim
+	lowRlim.Cur = uint64(firstFD + 1)
+	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &lowRlim); err != nil {
+		t.Skipf("cannot lower RLIMIT_NOFILE: %v", err)
+	}
+	defer unix.Setrlimit(unix.RLIMIT_NOFILE, &origRlim)
+
+	// 3. Send another FD from sendEP.
+	if err := sendEP.SendFD(int(sendFile.Fd())); err != nil {
+		t.Fatalf("SendFD failed: %v", err)
+	}
+
+	// 4. RecvFD must fail and must never return the stale firstFD.
+	secondFD, err := recvEP.RecvFD()
+	if err == nil {
+		unix.Close(secondFD)
+		t.Fatalf("RecvFD succeeded unexpectedly under FD exhaustion: got %d, want error", secondFD)
+	}
+	if secondFD == firstFD {
+		t.Fatalf("RecvFD returned stale FD %d from previous receive under FD exhaustion", secondFD)
+	}
+}
+

--- a/pkg/fdchannel/fdchannel_unsafe.go
+++ b/pkg/fdchannel/fdchannel_unsafe.go
@@ -119,6 +119,12 @@ func (ep *Endpoint) RecvFDNonblock() (int, error) {
 func (ep *Endpoint) recvFD(nonblock bool) (int, error) {
 	cmsgLen := unix.CmsgLen(sizeofInt32)
 	ep.msghdr.SetControllen(cmsgLen)
+	ep.msghdr.Flags = 0
+	ep.cmsg.Level = 0
+	ep.cmsg.Type = 0
+	ep.cmsg.SetLen(0)
+	*ep.cmsgData() = -1
+
 	var e unix.Errno
 	if nonblock {
 		_, _, e = unix.RawSyscall(unix.SYS_RECVMSG, uintptr(ep.sockfd), uintptr(unsafe.Pointer(&ep.msghdr)), unix.MSG_TRUNC|unix.MSG_DONTWAIT)
@@ -127,6 +133,9 @@ func (ep *Endpoint) recvFD(nonblock bool) (int, error) {
 	}
 	if e != 0 {
 		return -1, e
+	}
+	if int(ep.msghdr.Flags)&unix.MSG_CTRUNC != 0 {
+		return -1, unix.EMFILE
 	}
 	if int(ep.msghdr.Controllen) != cmsgLen {
 		return -1, fmt.Errorf("received control message has incorrect length: got %d, wanted %d", ep.msghdr.Controllen, cmsgLen)

--- a/pkg/lisafs/channel.go
+++ b/pkg/lisafs/channel.go
@@ -190,8 +190,10 @@ func (ch *channel) rcvMsg(dataLen uint32) (MID, uint32, error) {
 	for i := 0; i < int(header.numFDs); i++ {
 		fd, err := ch.fdChan.RecvFDNonblock()
 		if err != nil {
+			ch.dead = true
+			closeFDs(ch.ReleaseFDs())
 			log.Warningf("expected %d FDs, received %d successfully, got err after that: %v", header.numFDs, i, err)
-			break
+			return 0, 0, unix.EIO
 		}
 		ch.TrackFD(fd)
 	}


### PR DESCRIPTION
<!--
Please thoroughly read the contributing guide before submitting a pull request.
https://github.com/google/gvisor/blob/master/CONTRIBUTING.md
-->

### Description

In `fdchannel.recvFD`, when the receiver process is at its file descriptor limit (`RLIMIT_NOFILE`), the Linux kernel's `scm_detach_fds` fails to allocate an FD, drops the in-flight donated file, sets `MSG_CTRUNC` on `msghdr.msg_flags`, leaves `msg_controllen` untouched at the requested size, and returns 0 (`success`) from `recvmsg(2)`.

Previously:
1. `recvFD` never inspected `msghdr.Flags & unix.MSG_CTRUNC`.
2. `ep.cmsg` was not cleared prior to `recvmsg`.

Under FD exhaustion, `recvFD` verified that `Controllen` matched, and read back the previous receive's `SOL_SOCKET`/`SCM_RIGHTS` level and type from the dirty control buffer, returning the previous receive's FD number as a valid FD while the newly donated file was silently closed.

Additionally, in `pkg/lisafs/channel.go:rcvMsg`, when `RecvFDNonblock()` failed, it logged a warning, broke out of the loop, and returned success without marking the channel dead. The corrupted channel was then returned to the pool with an inconsistent FD queue.

### Changes

1. In `pkg/fdchannel/fdchannel_unsafe.go`:
   - Reset `ep.msghdr.Flags = 0`, `ep.cmsg.Level = 0`, `ep.cmsg.Type = 0`, `ep.cmsg.SetLen(0)`, and `*ep.cmsgData() = -1` before each `recvmsg` call.
   - Check `ep.msghdr.Flags & unix.MSG_CTRUNC != 0` after `recvmsg` and return `unix.EMFILE`.
2. In `pkg/lisafs/channel.go`:
   - When `ch.fdChan.RecvFDNonblock()` fails in `rcvMsg`, set `ch.dead = true`, close any partially received FDs via `closeFDs(ch.ReleaseFDs())`, and return `unix.EIO` so the broken channel is retired and the RPC fails cleanly.
3. In `pkg/fdchannel/fdchannel_test.go`:
   - Added `TestRecvFDTruncatedUnderExhaustion` to verify that under `RLIMIT_NOFILE` exhaustion, `RecvFD()` returns an error and never returns a stale FD.

Fixes #14697
