### PR TITLE
specutils/seccomp: support custom errnoRet and defaultErrnoRet in OCI converter (fixes #14688)

### DIFF
--- a/runsc/specutils/seccomp/seccomp.go
+++ b/runsc/specutils/seccomp/seccomp.go
@@ -18,6 +18,7 @@ package seccomp
 
 import (
 	"fmt"
+	"math"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
@@ -32,19 +33,15 @@ import (
 var (
 	killThreadAction = seccomp.KillThread
 	trapAction       = seccomp.Trap
-	// runc always returns EPERM as the errorcode for SECCOMP_RET_ERRNO
-	errnoAction = seccomp.ReturnError.Code(uint16(unix.EPERM))
-	// runc always returns EPERM as the errorcode for SECCOMP_RET_TRACE
-	traceAction = seccomp.Trace.Code(uint16(unix.EPERM))
-	allowAction = seccomp.Allow
+	allowAction      = seccomp.Allow
 )
 
 // BuildProgram generates a bpf program based on the given OCI seccomp
 // config.
 func BuildProgram(s *specs.LinuxSeccomp) (bpf.Program, error) {
-	defaultAction, err := convertAction(s.DefaultAction)
+	defaultAction, err := convertAction(s.DefaultAction, s.DefaultErrnoRet)
 	if err != nil {
-		return bpf.Program{}, fmt.Errorf("secomp default action: %w", err)
+		return bpf.Program{}, fmt.Errorf("seccomp default action: %w", err)
 	}
 	ruleset, err := convertRules(s)
 	if err != nil {
@@ -93,8 +90,8 @@ func lookupSyscallNo(arch uint32, name string) (uint32, error) {
 	return uint32(n), nil
 }
 
-// convertAction converts a LinuxSeccompAction to BPFAction
-func convertAction(act specs.LinuxSeccompAction) (seccomp.Action, error) {
+// convertAction converts a LinuxSeccompAction to BPFAction, respecting custom errnoRet if specified.
+func convertAction(act specs.LinuxSeccompAction, errnoRet *uint) (seccomp.Action, error) {
 	// TODO(gvisor.dev/issue/3124): Update specs package to include ActLog and ActKillProcess.
 	// LINT.IfChange
 	switch act {
@@ -102,12 +99,20 @@ func convertAction(act specs.LinuxSeccompAction) (seccomp.Action, error) {
 		return killThreadAction, nil
 	case specs.ActTrap:
 		return trapAction, nil
-	case specs.ActErrno:
-		return errnoAction, nil
-	case specs.ActTrace:
-		return traceAction, nil
 	case specs.ActAllow:
 		return allowAction, nil
+	case specs.ActErrno, specs.ActTrace:
+		if errnoRet != nil && *errnoRet > math.MaxUint16 {
+			return seccomp.Default, fmt.Errorf("invalid errnoRet: %d exceeds maximum 16-bit value", *errnoRet)
+		}
+		code := uint16(unix.EPERM)
+		if errnoRet != nil {
+			code = uint16(*errnoRet)
+		}
+		if act == specs.ActErrno {
+			return seccomp.ReturnError.Code(code), nil
+		}
+		return seccomp.Trace.Code(code), nil
 	default:
 		return seccomp.Default, fmt.Errorf("invalid action: %v", act)
 	}
@@ -126,9 +131,9 @@ func convertRules(s *specs.LinuxSeccomp) ([]seccomp.RuleSet, error) {
 	for _, syscall := range s.Syscalls {
 		sysRules := seccomp.NewSyscallRules()
 
-		action, err := convertAction(syscall.Action)
+		action, err := convertAction(syscall.Action, syscall.ErrnoRet)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("seccomp syscall names %v action %q: %w", syscall.Names, syscall.Action, err)
 		}
 
 		// Args

--- a/runsc/specutils/seccomp/seccomp_test.go
+++ b/runsc/specutils/seccomp/seccomp_test.go
@@ -16,6 +16,8 @@ package seccomp
 
 import (
 	"fmt"
+	"math"
+	"strings"
 	"testing"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -46,6 +48,10 @@ func testInput(arch uint32, syscallName string, args *[6]uint64) bpf.Input {
 	return seccomp.DataAsBPFInput(&data, make([]byte, data.SizeBytes()))
 }
 
+func uintPtr(u uint) *uint {
+	return &u
+}
+
 // testCase holds a seccomp test case.
 type testCase struct {
 	name     string
@@ -72,6 +78,63 @@ var (
 			},
 			input:    testInput(nativeArchAuditNo, "read", nil),
 			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.EPERM))),
+		},
+		{
+			name: "default_deny_custom_errno",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(uint(unix.ENOSYS)),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.ENOSYS))),
+		},
+		{
+			name: "default_deny_custom_errno_zero",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(0),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(0)),
+		},
+		{
+			name: "default_trace_custom_errno",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActTrace,
+				DefaultErrnoRet: uintPtr(42),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_TRACE.WithReturnCode(42)),
+		},
+		{
+			// runc compatibility: errnoRet is ignored for actions that do not support DATA (e.g. ActAllow).
+			name: "default_allow_with_errno_ret",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActAllow,
+				DefaultErrnoRet: uintPtr(1),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ALLOW),
+		},
+		{
+			// runc compatibility: errnoRet overflow is ignored for actions that do not support DATA.
+			name: "default_allow_with_errno_ret_overflow",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActAllow,
+				DefaultErrnoRet: uintPtr(0x10000),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ALLOW),
+		},
+		{
+			// runc compatibility: errnoRet overflow is ignored for ActTrap.
+			name: "default_trap_with_errno_ret_overflow",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActTrap,
+				DefaultErrnoRet: uintPtr(math.MaxUint),
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_TRAP),
 		},
 		{
 			name: "deny_arch",
@@ -139,6 +202,263 @@ var (
 			},
 			input:    testInput(nativeArchAuditNo, "write", nil),
 			expected: uint32(linux.SECCOMP_RET_TRACE.WithReturnCode(uint16(unix.EPERM))),
+		},
+		{
+			// runc compatibility: per-rule errnoRet is ignored for ActAllow.
+			name: "syscall_allow_with_errno_ret",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"read"},
+						Action:   specs.ActAllow,
+						ErrnoRet: uintPtr(0),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ALLOW),
+		},
+		{
+			// runc compatibility: per-rule errnoRet is ignored for ActKill.
+			name: "syscall_kill_with_errno_ret",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"read"},
+						Action:   specs.ActKill,
+						ErrnoRet: uintPtr(1),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_KILL_THREAD),
+		},
+		{
+			// runc compatibility: per-rule errnoRet overflow is ignored for ActKill.
+			name: "syscall_kill_with_errno_ret_overflow",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"read"},
+						Action:   specs.ActKill,
+						ErrnoRet: uintPtr(0x10000),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_KILL_THREAD),
+		},
+		{
+			name: "match_name_custom_errno",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"clone3",
+						},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(uint(unix.ENOSYS)),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "clone3", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.ENOSYS))),
+		},
+		{
+			// Note: OCI runtime-spec defines errnoRet as uint. In Linux seccomp BPF ABI,
+			// SECCOMP_RET_ERRNO | 0 is legal and returned as-is (not coerced to EPERM).
+			name: "errno_ret_zero",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"clone3",
+						},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(0),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "clone3", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(0)),
+		},
+		{
+			name: "errno_ret_signed_max",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"clone3",
+						},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(0x7fff),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "clone3", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(0x7fff)),
+		},
+		{
+			// Verify that 0x8000 (high bit set) is accepted as unsigned 16-bit DATA,
+			// rather than being rejected or treated as negative errno.
+			name: "errno_ret_high_bit",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"clone3",
+						},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(0x8000),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "clone3", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(0x8000)),
+		},
+		{
+			name: "errno_ret_max",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"clone3",
+						},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(0xffff),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "clone3", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(0xffff)),
+		},
+		{
+			name: "default_errno_matched_allow",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(uint(unix.ENOSYS)),
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"read",
+						},
+						Action: specs.ActAllow,
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ALLOW),
+		},
+		{
+			name: "default_errno_unmatched_syscall",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(uint(unix.ENOSYS)),
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"read",
+						},
+						Action: specs.ActAllow,
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "write", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.ENOSYS))),
+		},
+		{
+			name: "match_name_custom_trace",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"write",
+						},
+						Action:   specs.ActTrace,
+						ErrnoRet: uintPtr(42),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "write", nil),
+			expected: uint32(linux.SECCOMP_RET_TRACE.WithReturnCode(42)),
+		},
+		{
+			name: "trace_errno_ret_zero",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"write",
+						},
+						Action:   specs.ActTrace,
+						ErrnoRet: uintPtr(0),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "write", nil),
+			expected: uint32(linux.SECCOMP_RET_TRACE.WithReturnCode(0)),
+		},
+		{
+			name: "trace_errno_ret_max",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"write",
+						},
+						Action:   specs.ActTrace,
+						ErrnoRet: uintPtr(0xffff),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "write", nil),
+			expected: uint32(linux.SECCOMP_RET_TRACE.WithReturnCode(0xffff)),
+		},
+		{
+			name: "syscall_without_errno_ret_defaults_to_eperm_even_with_default_errno_ret",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(uint(unix.ENOSYS)),
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"read",
+						},
+						Action: specs.ActErrno,
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.EPERM))),
+		},
+		{
+			name: "syscall_custom_errno_overrides_default_errno",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(uint(unix.ENOSYS)),
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names: []string{
+							"read",
+						},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(uint(unix.EAGAIN)),
+					},
+				},
+			},
+			input:    testInput(nativeArchAuditNo, "read", nil),
+			expected: uint32(linux.SECCOMP_RET_ERRNO.WithReturnCode(uint16(unix.EAGAIN))),
 		},
 		{
 			name: "no_match_name_allow",
@@ -403,3 +723,157 @@ func checkProgram(p bpf.Program, in bpf.Input, expected uint32) error {
 
 	return nil
 }
+
+// TestInvalidErrnoRet verifies that BuildProgram returns an error when errnoRet
+// exceeds the 16-bit range or when an unsupported action is supplied.
+func TestInvalidErrnoRet(t *testing.T) {
+	testCases := []struct {
+		name              string
+		config            specs.LinuxSeccomp
+		expectedErrSubstr string
+	}{
+		{
+			name: "default_errno_ret_overflow_errno",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(0x10000),
+			},
+			expectedErrSubstr: "exceeds maximum 16-bit value",
+		},
+		{
+			name: "default_errno_ret_overflow_trace",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActTrace,
+				DefaultErrnoRet: uintPtr(0x10000),
+			},
+			expectedErrSubstr: "exceeds maximum 16-bit value",
+		},
+		{
+			name: "default_errno_ret_overflow_max_uint",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.ActErrno,
+				DefaultErrnoRet: uintPtr(math.MaxUint),
+			},
+			expectedErrSubstr: "exceeds maximum 16-bit value",
+		},
+		{
+			name: "syscall_errno_ret_overflow_errno",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"read"},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(0x10000),
+					},
+				},
+			},
+			expectedErrSubstr: "exceeds maximum 16-bit value",
+		},
+		{
+			name: "syscall_errno_ret_overflow_trace",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"read"},
+						Action:   specs.ActTrace,
+						ErrnoRet: uintPtr(0x10000),
+					},
+				},
+			},
+			expectedErrSubstr: "exceeds maximum 16-bit value",
+		},
+		{
+			name: "syscall_errno_ret_overflow_max_uint",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"read"},
+						Action:   specs.ActTrace,
+						ErrnoRet: uintPtr(math.MaxUint),
+					},
+				},
+			},
+			expectedErrSubstr: "exceeds maximum 16-bit value",
+		},
+		{
+			name: "default_action_unsupported_log_no_errno",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.LinuxSeccompAction("SCMP_ACT_LOG"),
+			},
+			expectedErrSubstr: "invalid action",
+		},
+		{
+			name: "default_action_unsupported_log_with_overflow",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.LinuxSeccompAction("SCMP_ACT_LOG"),
+				DefaultErrnoRet: uintPtr(0x10000),
+			},
+			expectedErrSubstr: "invalid action",
+		},
+		{
+			name: "default_errno_ret_on_unsupported_log",
+			config: specs.LinuxSeccomp{
+				DefaultAction:   specs.LinuxSeccompAction("SCMP_ACT_LOG"),
+				DefaultErrnoRet: uintPtr(1),
+			},
+			expectedErrSubstr: "invalid action",
+		},
+		{
+			name: "syscall_action_unsupported_kill_process",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:  []string{"read"},
+						Action: specs.LinuxSeccompAction("SCMP_ACT_KILL_PROCESS"),
+					},
+				},
+			},
+			expectedErrSubstr: "invalid action",
+		},
+		{
+			name: "syscall_errno_ret_on_unsupported_notify",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"read"},
+						Action:   specs.LinuxSeccompAction("SCMP_ACT_NOTIFY"),
+						ErrnoRet: uintPtr(1),
+					},
+				},
+			},
+			expectedErrSubstr: "invalid action",
+		},
+		{
+			name: "syscall_action_error_wrapped",
+			config: specs.LinuxSeccomp{
+				DefaultAction: specs.ActAllow,
+				Syscalls: []specs.LinuxSyscall{
+					{
+						Names:    []string{"clone3"},
+						Action:   specs.ActErrno,
+						ErrnoRet: uintPtr(0x10000),
+					},
+				},
+			},
+			expectedErrSubstr: "seccomp syscall names [clone3] action \"SCMP_ACT_ERRNO\"",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := BuildProgram(&tc.config)
+			if err == nil {
+				t.Fatalf("BuildProgram(%+v) succeeded, expected error", tc.config)
+			}
+			if tc.expectedErrSubstr != "" && !strings.Contains(err.Error(), tc.expectedErrSubstr) {
+				t.Errorf("BuildProgram error %q does not contain expected substring %q", err.Error(), tc.expectedErrSubstr)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
### Problem Description
Currently, `runsc/specutils/seccomp/seccomp.go` hardcodes `unix.EPERM` for both `SECCOMP_RET_ERRNO` and `SECCOMP_RET_TRACE`:
```go
errnoAction = seccomp.ReturnError.Code(uint16(unix.EPERM))
traceAction = seccomp.Trace.Code(uint16(unix.EPERM))
```
Any custom `errnoRet` specified on individual `specs.LinuxSyscall` rules or `defaultErrnoRet` on `specs.LinuxSeccomp` is silently ignored and discarded.

This breaks container workloads that rely on specific errno returns, most notably **glibc >= 2.34**:
- On `pthread_create()`, modern glibc tries `clone3()` first.
- If `clone3()` returns `-ENOSYS`, glibc falls back cleanly to legacy `clone()`.
- When run under `runsc` with standard container seccomp profiles blocking `clone3` with `SCMP_ACT_ERRNO` and `errnoRet: 38 (ENOSYS)`, `runsc` returns `EPERM` instead of `ENOSYS`.
- glibc treats `EPERM` as a hard failure and aborts thread creation.

### Proposed Changes
1. **Pass `defaultErrnoRet` & `errnoRet`**:
   - `s.DefaultErrnoRet` is passed to `convertAction` in `BuildProgram`.
   - `syscall.ErrnoRet` is passed to `convertAction` in `convertRules`.
2. **Support custom errno / trace return code**:
   - For `specs.ActErrno` and `specs.ActTrace`, construct `seccomp.ReturnError.Code(code)` and `seccomp.Trace.Code(code)`.
   - If `errnoRet` is nil, maintain existing behavior by defaulting to `unix.EPERM`.
3. **16-bit `SECCOMP_RET_DATA` validation**:
   - Validates that `*errnoRet <= math.MaxUint16` (0..65535).
   - Values exceeding 16 bits fail cleanly with an informative error rather than silently truncating or wrapping.
4. **runc Compatibility**:
   - In accordance with runc behavior (`getAction` in libcontainer), `errnoRet` is ignored on actions that do not consume return data (`ActAllow`, `ActKill`, `ActTrap`), avoiding container startup failures on profiles with leftover generator metadata.
5. **Syscall rule diagnostic wrapping**:
   - Wraps syscall rule conversion errors with `seccomp syscall names %v action %q: %w` to include the syscall names for easier debugging.
6. **Comprehensive Test Suite**:
   - Added unit tests in `seccomp_test.go`:
     - Default deny with custom errno (`unix.ENOSYS`) and zero (`0`).
     - Default trace with custom trace code (`42`).
     - Syscall rule matching `clone3` with custom errno `unix.ENOSYS`.
     - Boundary values: `0`, `0x7fff` (signed max), `0x8000` (unsigned 16-bit high bit), `0xffff` (16-bit max).
     - Rule independence: verifying that `defaultErrnoRet` applies only to unmatched default syscalls and does not accidentally leak onto per-syscall `ActErrno` rules with nil `ErrnoRet` (preserving runc/OCI contract).
     - Full negative testing in `TestInvalidErrnoRet`: verifying clean rejection of `errnoRet > 0xffff` (including `0x10000` and `math.MaxUint`), unsupported actions (`SCMP_ACT_LOG`, `SCMP_ACT_NOTIFY`, `SCMP_ACT_KILL_PROCESS`), and verification of error message wrapping with syscall names.

Fixes #14688
